### PR TITLE
Update theme-inherit.md

### DIFF
--- a/guides/v1.0/frontend-dev-guide/themes/theme-inherit.md
+++ b/guides/v1.0/frontend-dev-guide/themes/theme-inherit.md
@@ -139,7 +139,7 @@ To add an extending layout file:
 <u>Example</u>:
 
 OrangeCo decided they should remove the “Report bugs” link from the footer, defined in `app/code/Magento/Theme/view/frontend/layout/default.xml`
-To do this, they added an extending layout in `app/design/frontend/OrangeCo/orange/Magento_blank/layout/default.xml` :
+To do this, they added an extending layout in `app/design/frontend/OrangeCo/orange/Magento_Theme/layout/default.xml` :
 
 <pre>
 &lt;page&nbsp;xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&nbsp;xsi:noNamespaceSchemaLocation=&quot;../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd&quot;&gt;


### PR DESCRIPTION
Update example to use `<Vendor>_<Module>` instead of `<Vendor>_<theme>` (or concrete, `Magento_Theme` instead of `Magento_blank`) so it matches the explanation in the line above:

> Put your custom layout file in the `app/design/frontend/<Vendor>/<theme>/<Vendor>_<Module>/layout/ directory`.
