### PR TITLE
Fix installation instructions

### DIFF
--- a/guides/v1.0/install-gde/install/prepare-install.md
+++ b/guides/v1.0/install-gde/install/prepare-install.md
@@ -17,10 +17,7 @@ Composer is a separate application that manages PHP dependencies. Before you can
 
 1.	<a href="{{ site.gdeurl }}install-gde/install/composer-clone.html">Install the Composer software</a>.
 2.	<a href="#install-update-depend-apache">Switch to the Apache user</a> so Composer writes files to the web server docroot as the correct user.
-2.	Run the <a href="#install-composer-install">`composer install` command</a> from *both* of the following directories:
-
-	<pre>&lt;your Magento install dir>
-	&lt;your Magento install dir>/setup</pre>
+2.	Run the <a href="#install-composer-install">`composer install` command</a> from your Magento install directory.
 
 <div class="bs-callout bs-callout-info" id="info">
 <span class="glyphicon-class">


### PR DESCRIPTION
There is no composer.json file anymore in the `setup` directory since alpha-108
