### PR TITLE
use 127.0.0.1 instead of localhost for db host parameter

### DIFF
--- a/guides/v1.0/install-gde/install/install-cli.md
+++ b/guides/v1.0/install-gde/install/install-cli.md
@@ -118,7 +118,7 @@ For example, if Base URL is http://www.example.com and Admin Path is <code>admin
 		<td>db_host</td>
 		<td><p>Use any of the following:</p>
 		<ul><li>The database server's fully qualified host name or IP address.</li>
-		<li><code>localhost</code> if your database serve is on the same host as your web server.</li>
+		<li><code>127.0.0.1</code> if your database serve is on the same host as your web server.</li>
 		<li>UNIX socket; for example, <code>/var/run/mysqld/mysqld.sock</code></li></ul>
 		<p><strong>Note</strong>: You can optionally specify the database server port in its host name like <code>www.example.com:9000</code></p>
 </td>
@@ -266,7 +266,7 @@ The following example installs Magento with the following options:
 
 	<pre>php -f index.php install --base_url=http://localhost/magento2/
 		--backend_frontname=admin
-		--db_host=localhost --db_name=magento --db_user=magento --db_pass=magento
+		--db_host=127.0.0.1 --db_name=magento --db_user=magento --db_pass=magento
 		--admin_firstname=Magento --admin_lastname=User --admin_email=user@example.com
 		--admin_username=admin --admin_password=iamtheadmin --language=en_US
 		--currency=USD --timezone=America/Chicago</pre>

--- a/guides/v1.0/install-gde/install/install-web.md
+++ b/guides/v1.0/install-gde/install/install-web.md
@@ -89,7 +89,7 @@ To install the Magento software using the Setup Wizard:
 		</tr>
 	<tr>
 		<td>Database Server Host</td>
-		<td>If the web server and database server are located on the same host, enter <tt>localhost</tt>. If the database server is located on a different host, enter its fully qualified host name or IP address.</td>
+		<td>If the web server and database server are located on the same host, enter <tt>127.0.0.1</tt>. If the database server is located on a different host, enter its fully qualified host name or IP address.</td>
 	</tr>
 	<tr>
 		<td>Database Server Username</td>

--- a/guides/v1.0/install-gde/prereq/mysql.md
+++ b/guides/v1.0/install-gde/prereq/mysql.md
@@ -117,7 +117,7 @@ To configure a MySQL database instance:
 3.	Enter the MySQL `root` user's password when prompted.
 4.	Enter the following commands in the order shown to create a database instance named `magento` with user name `magento`:
 	<pre>create database magento;
-GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';</pre>
+GRANT ALL ON magento.* TO magento@127.0.0.1 IDENTIFIED BY 'magento';</pre>
 
 5.	Enter `exit` to quit the command prompt.
 


### PR DESCRIPTION
localhost means connect via socket, which is in some cases not available
or wrong configured or differs from the place php assumes it.

known Downsides: there may be performance impacts, but I never had something noticeable

Reason: It happens regularly that people have connection problems with localhost, which nearly always got resolved by changing to 127.0.0.1
