### PR TITLE
updated links and names for Magento\Framework references

### DIFF
--- a/guides/v1.0/config-guide/config/config-files.md
+++ b/guides/v1.0/config-guide/config/config-files.md
@@ -26,9 +26,9 @@ github_link: config-guide/config/config-files.md
    For example, events, which previously would have been configured in <code>config.xml</code> along with all other configurations, are now configured in a separate file called <code>events.xml</code>.
    The <code>events.xml</code> file is validated during loading against the <code>events.xsd</code> schema file.
 </p>
-<h3>Magento\Config</h3>
-<p>All configuration files are processed by the Magento <code>Magento\Config</code> library component, which loads, merges, and validates XML configuration files and converts them to proper array format.
-   During configuration loading, <code>Magento\Config</code> validates configuration files against schemas in XSD format.
+<h3>Magento\Framework\Config</h3>
+<p>All configuration files are processed by the Magento <code>Magento\Framework\Config</code> library component, which loads, merges, and validates XML configuration files and converts them to proper array format.
+   During configuration loading, <code>Magento\Framework\Config</code> validates configuration files against schemas in XSD format.
    Each XML configuration type has its own XSD schema.
 </p>
 <h3>Predefined configuration files</h3>
@@ -73,21 +73,21 @@ github_link: config-guide/config/config-files.md
 <p>The second XML file either supplements or overwrites nodes in the first XML file.</p>
 <p>In the following example, the node contents of the second file overwrite node contents of first file if both files contain nodes with same name and identifier.</p>
 <p>This example shows configuration files and their merge result:</p>
-<h2>The Magento\Config component</h2>
-<p><code>Magento\Config</code> ensures loading, merging, validation, and processing of the configurations. You can change the standard loading procedure by providing your own implementation of its interfaces. Magento\Config should be used to introduce a new configuration type.</p>
-<p><code>Magento\Config</code> provides the following interfaces for extension developers to manage configuration files:</p>
+<h2>The Magento\Framework\Config component</h2>
+<p><code>Magento\Framework\Config</code> ensures loading, merging, validation, and processing of the configurations. You can change the standard loading procedure by providing your own implementation of its interfaces. Magento\Framework\Config should be used to introduce a new configuration type.</p>
+<p><code>Magento\Framework\Config</code> provides the following interfaces for extension developers to manage configuration files:</p>
 <ul>
    <li>
-      <p><code>\Magento\Config\DataInterface</code> retrieves the configuration data within a scope.</p>
+      <p><code>\Magento\Framework\Config\DataInterface</code> retrieves the configuration data within a scope.</p>
    </li>
    <li>
-      <p><code>\Magento\Config\ScopeInterface</code> identifies current application scope and provides information about the scope's data.</p>
+      <p><code>\Magento\Framework\Config\ScopeInterface</code> identifies current application scope and provides information about the scope's data.</p>
    </li>
    <li>
-      <p><code>\Magento\Config\FileResolverInterface</code> identifies the set of files to be read by <code>\Magento\Config\ReaderInterface</code>.</p>
+      <p><code>\Magento\Framework\Config\FileResolverInterface</code> identifies the set of files to be read by <code>\Magento\Framework\Config\ReaderInterface</code>.</p>
    </li>
    <li>
-      <p><code>\Magento\Config\ReaderInterface</code> reads the configuration data from storage, selects the storage from which it reads.</p>
+      <p><code>\Magento\Framework\Config\ReaderInterface</code> reads the configuration data from storage, selects the storage from which it reads.</p>
       <p>That is, the file system, database, other storage merges the configuration files according to the merging rules, and validates the configuration files with the validation schemas.</p>
    </li>
 </ul>
@@ -118,19 +118,19 @@ github_link: config-guide/config/config-files.md
 
 If any other extension declares a <code>search.xml</code> file, it is merged with your file when it loads.</p>
 
-<p>To add a configuration type to the file system, use the default implementation of the <code>\Magento\Config\ReaderInterface</code>, which is <code>Magento\Config\Reader\Filesystem</code>. Extend from the default implementation and provide the following parameters:</p>
+<p>To add a configuration type to the file system, use the default implementation of the <code>\Magento\Framework\Config\ReaderInterface</code>, which is <code>Magento\Framework\Config\Reader\Filesystem</code>. Extend from the default implementation and provide the following parameters:</p>
 <ul>
    <li>
-      <p><code>$fileResolver</code>. Implements <code>\Magento\Config\FileResolverInterface</code>. This parameter lists the files containing the configurations of your custom type.</p>
+      <p><code>$fileResolver</code>. Implements <code>\Magento\Framework\Config\FileResolverInterface</code>. This parameter lists the files containing the configurations of your custom type.</p>
    </li>
    <li>
-      <p><code>$converter</code>. Implements <code>\Magento\Config\ConverterInterface</code>. This parameter is responsible for converting the XML into the internal array representation of the configurations.</p>
+      <p><code>$converter</code>. Implements <code>\Magento\Framework\Config\ConverterInterface</code>. This parameter is responsible for converting the XML into the internal array representation of the configurations.</p>
    </li>
    <li>
-      <p><code>$schemaLocator</code>. Implements <code>\Magento\Config/SchemaLocatorInterface</code>. This parameter provides the full path to file(s) containing schema(s) for validation of the individual and merged configuration files.</p>
+      <p><code>$schemaLocator</code>. Implements <code>\Magento\Framework\Config/SchemaLocatorInterface</code>. This parameter provides the full path to file(s) containing schema(s) for validation of the individual and merged configuration files.</p>
    </li>
    <li>
-      <p><code>$validationState</code>. Implements <code>\Magento\Config\ValidationStateInterface</code>. This parameter defines whether a configuration file should be validated. It is provided by the application by default.</p>
+      <p><code>$validationState</code>. Implements <code>\Magento\Framework\Config\ValidationStateInterface</code>. This parameter defines whether a configuration file should be validated. It is provided by the application by default.</p>
    </li>
    <li>
       <p><code>$fileName</code>. The name of a file containing custom configuration. Reader looks for the file names specified by this parameter in <code>etc</code> directories.</p>
@@ -162,7 +162,7 @@ If any other extension declares a <code>search.xml</code> file, it is merged wit
 <pre>
 &lt;config
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:noNamespaceSchemaLocation="../../../../../lib/Magento/ObjectManager/etc/config.xsd"></pre>
+   xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd"></pre>
 
 
 <p>IDEs can validate your configuration files at both runtime and development time.</p>


### PR DESCRIPTION
The references and names in the docs still had the old values when the subfolder Framework and also internal did not exist yet.
