### PR TITLE
Fixed link to "What is an integration?"

### DIFF
--- a/guides/v1.0/config-guide/bk-config-guide.md
+++ b/guides/v1.0/config-guide/bk-config-guide.md
@@ -32,9 +32,7 @@ github_link: config-guide/bk-config-guide.md
 <p>To learn about integration, read these topics:</p>
 <ul>
    <li>
-
-      <p><a href="{{ site.gdeurl }}config-guide/integration/what-is-integration.html">What is an integration?</a></p>
-
+      <p><a href="{{ site.gdeurl }}config-guide/integration/integration-what-is.html">What is an integration?</a></p>
    </li>
    <li>
       <p><a href="{{ site.gdeurl }}get-started/authentication/gs-authentication-oauth.html">Integration authorization</a></p>


### PR DESCRIPTION
The current link is pointing to http://devdocs.magento.com/guides/v1.0/config-guide/integration/what-is-integration.html but the file can be found at http://devdocs.magento.com/guides/v1.0/config-guide/integration/integration-what-is.html.

I hope I edited the markdown file in the correct way.