### PR TITLE
Move Plugin and Dependency injection links

### DIFF
--- a/guides/v1.0/config-guide/bk-config-guide.md
+++ b/guides/v1.0/config-guide/bk-config-guide.md
@@ -15,13 +15,6 @@ github_link: config-guide/bk-config-guide.md
    <li>
       <p><a href="{{ site.gdeurl }}config-guide/config/config-files.html">Configuration files</a></p>
    </li>
-   <li>
-      <p><a href="{{ site.gdeurl }}config-guide/config/plugins.html">Plugins</a></p>
-   </li>
-  
-       <li>
-      <p><a href="{{ site.gdeurl }}config-guide/config/depend-inj.html">Dependency injection</a></p>
-   </li>
     <li>
       <p><a href="{{ site.gdeurl }}config-guide/config/magento-mode.html">Magento modes</a></p>
    </li>

--- a/guides/v1.0/extension-dev-guide/bk-extension-dev-guide.md
+++ b/guides/v1.0/extension-dev-guide/bk-extension-dev-guide.md
@@ -20,6 +20,12 @@ github_link: extension-dev-guide/bk-extension-dev-guide.md
 <dt>
    <p><a href="{{ site.gdeurl }}extension-dev-guide/service-contracts/design-patterns.html">Service contract design patterns</a></p>
 </dt>
+<dt>
+  <p><a href="{{ site.gdeurl }}config-guide/config/plugins.html">Plugins</a></p>
+</dt>
+<dt>
+  <p><a href="{{ site.gdeurl }}config-guide/config/depend-inj.html">Dependency injection</a></p>
+</dt>
 <!--
    <dt>
                        <p><a href="{{ site.gdeurl }}extension-dev-guide/service-contracts/add-later/service-domain-guidelines.html">Guidelines for domain and service layers</a></p>


### PR DESCRIPTION
- Move the links from Configuration to Extension. The topics as written describe
  the details of plugins and dependency injection more than the actual config.
  The information is more useful (and should maybe) only be relevant to
  extension developers (e.g. deployers should not normally need to change
  these configuration files).

This was requested by an extension developer and makes sense. I only moved the links because technically the config files described are part of the configuration while the rest is conceptual and is needed for extension developers.