### PR TITLE
Update depend-inj.md

### DIFF
--- a/guides/v1.0/config-guide/config/depend-inj.md
+++ b/guides/v1.0/config-guide/config/depend-inj.md
@@ -54,7 +54,7 @@ Factory
 
 Proxy
 
-:	Auto-generated object that implements the same interface as the original object, but unlike this original object has only one dependency&mdash;the object manager. A proxy is used for lazy loading of optional dependencies.
+:	Auto-generated object that implements the same interface as the original object, but unlike this original object has only one dependency&mdash;the object manager. A proxy is used for lazy loading of optional dependencies. Also, a proxy can be used to break cyclical dependencies.
 
 
 Lifestyle


### PR DESCRIPTION
Proxies can also be used to break cyclical dependencies (where class A depends on class B and class B depends on class A). There's a specific exception that is thrown when the ObjectManager detects a cycle ( https://github.com/magento/magento2/blob/master/lib/internal/Magento/Framework/ObjectManager/Factory/Dynamic/Developer.php#L80 ) in non-production mode. One way to resolve this is to use a Proxy as a constructor argument in the di.xml.