### PR TITLE
PHP Requirements changed

### DIFF
--- a/guides/v1.0/release-notes/release-notes.md
+++ b/guides/v1.0/release-notes/release-notes.md
@@ -24,8 +24,7 @@ Welcome to Magento 2.0 Developer Beta documentation! And welcome to Magento 2.0!
 For this first release of Magento 2.0, here is a summary of some important
 features of the release.
 
--   PHP and MySQL. Magento 2 supports PHP 5.5, with PHP 5.4 (actually 5.4.11 or
-    later) as the minimum requirement, and MySQL 5.6. See [System
+-   PHP and MySQL. Magento 2 supports PHP 5.5 as the minimum requirement, and MySQL 5.6. See [System
     requirements][1].
 
     [1]: <{{ site.gdeurl }}install-gde/system-requirements.html>


### PR DESCRIPTION
According to https://github.com/magento/devdocs/commit/4bd7817bafc82256eb6d38b281b9d52805a0f538 Magento "no longer supports PHP 5.4". So we will have inconsistency if here we will have PHP 5.4 as a minimum requirement.