### PR TITLE
Fix sample data install tool param

### DIFF
--- a/guides/v1.0/install-gde/install/sample-data.md
+++ b/guides/v1.0/install-gde/install/sample-data.md
@@ -61,7 +61,7 @@ To update `composer.json`:
 
 5.  To optionally install sample data only if the Magento software is already installed, enter:
 
-        php dev/tools/Magento/Tools/SampleData/install.php –admin_username=<user name>
+        php dev/tools/Magento/Tools/SampleData/install.php --admin_username=<user name>
 
 6.  If you haven't already installed, see the following sections:
 


### PR DESCRIPTION
It's just a typo fix for PHP install tool param, previously it was *en dash* as a param prefix, corrected to *two hyphens* as the console usage says:
```
Usage: php -f install.php -- --admin_username= [--bootstrap=]
    --admin_username - store's admin username. Required for installation.
    [--bootstrap] - add or override parameters of the bootstrap
```

It's possible to simply copy-paste the example now.