### PR TITLE
Update to remove reference to sample-data-media

### DIFF
--- a/_includes/install/sample-data.html
+++ b/_includes/install/sample-data.html
@@ -1,5 +1,5 @@
 <p>To enable sample data, you must:</p>
-<ol><li>Decide the version of <code>magento/sample-data</code> and <code>magento/sample-data-media</code> you want as discussed in <a href="{{ site.gdeurl }}install-gde/install/sample-data.html#instgde-prereq-sample-intro">Introduction to Magento sample data</a>.</li>
+<ol><li>Decide the version of <code>magento/sample-data</code> you want as discussed in <a href="{{ site.gdeurl }}install-gde/install/sample-data.html#instgde-prereq-sample-intro">Introduction to Magento sample data</a>.</li>
 <li>Run the <code>composer package</code> and <code>composer require</code> commands to update <code>composer.json</code>.</li></ol>
 
 <p>To update <code>composer.json</code>:</p>


### PR DESCRIPTION
Should  no longer be deciding on which version for both, just sample-data