### PR TITLE
Default filename of logo in Magento2 is logo.svg and not logo.png

### DIFF
--- a/guides/v1.0/frontend-dev-guide/themes/theme-create.md
+++ b/guides/v1.0/frontend-dev-guide/themes/theme-create.md
@@ -145,7 +145,7 @@ app/design/frontend/&lt;Vendor&gt;/
 │&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├──&nbsp;view.xml
 │&nbsp;&nbsp;&nbsp;├──&nbsp;web/
 │&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├──&nbsp;images
-│&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├──&nbsp;logo.png
+│&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├──&nbsp;logo.svg
 │&nbsp;&nbsp;&nbsp;├──&nbsp;theme.xml
 │&nbsp;&nbsp;&nbsp;├──&nbsp;composer.json
 </pre>


### PR DESCRIPTION
While reading through the docs and experimenting with Magento2, I noticed my custom logo wouldn't show up in a new theme.
Apparantly it was because Magento2 defaults to an svg logo instead of a png one.
See: https://github.com/magento/magento2/blob/1289e4e08fbf8c5f84a069e2a183595fcd14276f/app/code/Magento/Theme/Block/Html/Header/Logo.php#L102