### PR TITLE
Add argument delimiter for php command

### DIFF
--- a/guides/v1.0/install-gde/install/sample-data.md
+++ b/guides/v1.0/install-gde/install/sample-data.md
@@ -48,7 +48,7 @@ This section discusses how to install optional sample data *after* you install t
 
 To install the sample data, enter the following command:
 
-	php dev/tools/Magento/Tools/SampleData/install.php --admin_username=<your Magento admin user name>
+	php dev/tools/Magento/Tools/SampleData/install.php -- --admin_username=<your Magento admin user name>
 
 <h2 id="installgde-install-sample-old">Sample data for earlier Magento versions</h2>
 {% include install/sample-data-note.html %}


### PR DESCRIPTION
Instead of the "--admin_username" belonging as a PHP command argument, it should be an argument to the script itself.