### PR TITLE
Fixed visibility of image element.

### DIFF
--- a/guides/v1.0/install-gde/basics/basics_magento-installed.md
+++ b/guides/v1.0/install-gde/basics/basics_magento-installed.md
@@ -60,7 +60,7 @@ To use a terminal application to remotely access the Magento server:
 
 Here's what it looks like to log in to a server as the `root` user using Cygwin on Windows.
 
-    <p><img src="{{ site.baseurl }}common/images/install_cygwin.png" alt="Logging in using Cygwin on Windows"></p>
+<p><img src="{{ site.baseurl }}common/images/install_cygwin.png" alt="Logging in using Cygwin on Windows"></p>
 
 <div class="bs-callout bs-callout-info" id="info">
 <span class="glyphicon-class">


### PR DESCRIPTION
The \<img\> was rendered inside a \<code\> block and was not visible because of the markup parsing the indentation.

See the broken image at the bottom of http://devdocs.magento.com/guides/v1.0/install-gde/basics/basics_magento-installed.html#instgde-basics-terminal
