### PR TITLE
Changed the order of "help commands" to match options below

### DIFF
--- a/guides/v1.0/frontend-dev-guide/themes/theme-structure.md
+++ b/guides/v1.0/frontend-dev-guide/themes/theme-structure.md
@@ -68,8 +68,7 @@ Let's have a closer look at each particular sub-directory.
         optional
       </td>
       <td colspan="1">
-        <p>
-          Module-specific styles, layouts, and templates.</p>
+          Module-specific styles, layouts, and templates.
       </td>
     </tr>
     <tr>
@@ -82,8 +81,7 @@ Let's have a closer look at each particular sub-directory.
         optional
       </td>
       <td colspan="1">
-        <p>
-          Module-</span>specific styles (<code>.css</code> and/or <code>.less</code> file). General styles for the module are in the <code>module.less</code> file, and styles for widgets are in <code>widgets.less</code>.</p>
+          Module-</span>specific styles (<code>.css</code> and/or <code>.less</code> file). General styles for the module are in the <code>module.less</code> file, and styles for widgets are in <code>widgets.less</code>.
       </td>
     </tr>
     <tr>
@@ -94,7 +92,7 @@ Let's have a closer look at each particular sub-directory.
         optional
       </td>
       <td colspan="1">
-        <p>Layout files which extend the default module or parent theme layouts. <!--ADDLINK--></p>
+        Layout files which extend the default module or parent theme layouts. <!--ADDLINK-->
       </td>
     </tr>
     <tr>
@@ -105,7 +103,7 @@ Let's have a closer look at each particular sub-directory.
         optional
       </td>
       <td colspan="1">
-        <p>Layouts that override the default module layouts.</p>
+        Layouts that override the default module layouts.
       </td>
     </tr>
     <tr>
@@ -152,8 +150,7 @@ Let's have a closer look at each particular sub-directory.
       </td>
       <td colspan="1">required</td>
       <td colspan="1">
-        <p>This directory contains a theme preview (a screenshot of your theme).
-        </p>
+        This directory contains a theme preview (a screenshot of your theme).
       </td>
     </tr>
     <tr>
@@ -245,8 +242,7 @@ Let's have a closer look at each particular sub-directory.
       </td>
       <td colspan="1">optional</td>
       <td colspan="1">
-        <p>Describes the theme dependencies and some meta-information. Will be here if your theme is a Composer package<!--ADDLINK-->
-        </p>
+        Describes the theme dependencies and some meta-information. Will be here if your theme is a Composer package<!--ADDLINK-->
       </td>
     </tr>
   </tbody>

--- a/guides/v1.0/install-gde/install/install-cli-install.md
+++ b/guides/v1.0/install-gde/install/install-cli-install.md
@@ -68,12 +68,12 @@ You can run the following commands to find values for some required arguments:
 	<td><code>php magento info:language:list</code></td>
 </tr>
 <tr>
-	<td>Time zone</td>
-	<td><code>php  magento info:timezone:list</code></td>
-</tr>
-<tr>
 	<td>Currency</td>
 	<td><code>php magento info:currency:list</code></td>
+</tr>
+<tr>
+	<td>Time zone</td>
+	<td><code>php  magento info:timezone:list</code></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This is a trivial change, but the order of the Language/Time Zone/Currency arguments were different in the "Installer help commands" table versus the list of arguments in the table beneath it:

![install_the_magento_software_using_the_command_line](https://cloud.githubusercontent.com/assets/129031/7441268/8bf25334-f0a5-11e4-90c3-d3385ca2d6f9.png)

This pull request swaps the order of the Time Zone and Currency rows in the first table:

![install_the_magento_software_using_the_command_line](https://cloud.githubusercontent.com/assets/129031/7441276/f0c045a0-f0a5-11e4-8314-7802c5f7ad50.png)
