### PR TITLE
Changed the order of "help commands" to match options below

### DIFF
--- a/guides/v1.0/install-gde/install/install-cli-install.md
+++ b/guides/v1.0/install-gde/install/install-cli-install.md
@@ -68,12 +68,12 @@ You can run the following commands to find values for some required arguments:
 	<td><code>php magento info:language:list</code></td>
 </tr>
 <tr>
-	<td>Time zone</td>
-	<td><code>php  magento info:timezone:list</code></td>
-</tr>
-<tr>
 	<td>Currency</td>
 	<td><code>php magento info:currency:list</code></td>
+</tr>
+<tr>
+	<td>Time zone</td>
+	<td><code>php  magento info:timezone:list</code></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This is a trivial change, but the order of the Language/Time Zone/Currency arguments were different in the "Installer help commands" table versus the list of arguments in the table beneath it:

![install_the_magento_software_using_the_command_line](https://cloud.githubusercontent.com/assets/129031/7441268/8bf25334-f0a5-11e4-90c3-d3385ca2d6f9.png)

This pull request swaps the order of the Time Zone and Currency rows in the first table:

![install_the_magento_software_using_the_command_line](https://cloud.githubusercontent.com/assets/129031/7441276/f0c045a0-f0a5-11e4-8314-7802c5f7ad50.png)
