### PR TITLE
Fix incorrect module definition XML and add note about how to manually enable module.

### DIFF
--- a/guides/v1.0/architecture/modules/mod_intro.md
+++ b/guides/v1.0/architecture/modules/mod_intro.md
@@ -53,14 +53,14 @@ Minimal declaration sample:
     To enable a module manually, the following commands can be used.
 </p>
 
-<ol>
-    <li><code>php -f setup/index.php module-enable --modules=Vendor_ModuleName # enable module</code></li>
-    <li><code>php -f setup/index.php update # flush appropriate caches</code></li>
-</ol>  
+<pre><code>
+# Enable Module
+php -f bin/magento module:enable Vendor_ModuleName 
+# Run Enabled Module Setup Scripts
+php -f bin/magento setup:upgrade
+</code></pre>
 
 </div>
-
-
 
 
 <h3 id="arch-modules-working-with">Working with modules</h3>
@@ -75,6 +75,7 @@ For 'How To' topics such as instructions for adding modules, extending modules, 
 * <a href="{{ site.gdeurl }}architecture/modules/mod_depend.html">Module dependencies</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_relationships.html">Module relationships</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_and_areas.html">Modules and areas</a>
+* <a href="{{ site.gdeurl }}guides/v1.0/install-gde/install/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable">Module enable, disable</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_conventions.html">Module location and naming conventions</a>
 * <a href="{{ site.gdeurl }}architecture/arch_libraries.html">Libraries</a>
 * <a href="{{ site.gdeurl }}architecture/arch_themes.html">Themes</a>

--- a/guides/v1.0/architecture/modules/mod_intro.md
+++ b/guides/v1.0/architecture/modules/mod_intro.md
@@ -75,7 +75,7 @@ For 'How To' topics such as instructions for adding modules, extending modules, 
 * <a href="{{ site.gdeurl }}architecture/modules/mod_depend.html">Module dependencies</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_relationships.html">Module relationships</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_and_areas.html">Modules and areas</a>
-* <a href="{{ site.gdeurl }}guides/v1.0/install-gde/install/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable">Module enable, disable</a>
+* <a href="{{ site.gdeurl }}install-gde/install/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable">Module enable, disable</a>
 * <a href="{{ site.gdeurl }}architecture/modules/mod_conventions.html">Module location and naming conventions</a>
 * <a href="{{ site.gdeurl }}architecture/arch_libraries.html">Libraries</a>
 * <a href="{{ site.gdeurl }}architecture/arch_themes.html">Themes</a>

--- a/guides/v1.0/architecture/modules/mod_intro.md
+++ b/guides/v1.0/architecture/modules/mod_intro.md
@@ -41,14 +41,26 @@ Minimal declaration sample:
 
 <pre>
 &lt;config>
-    &lt;module name="Namespace_Module" schema_version="2.0.0">
+    &lt;module name="Namespace_Module" setup_version="2.0.0">
     &lt;/module>
 &lt;/config>
 </pre>
 
 <div class="bs-callout bs-callout-info" id="info">
   <p>The enabled/disabled flag for a module is no longer set within a module; it is controlled by the deployment configuration file, with enabled=1, disabled=0. This is controlled by administrators and integrators, not by module developers.</p>
+  
+<p>
+    To enable a module manually, the following commands can be used.
+</p>
+
+<ol>
+    <li><code>php -f setup/index.php module-enable --modules=Vendor_ModuleName # enable module</code></li>
+    <li><code>php -f setup/index.php update # flush appropriate caches</code></li>
+</ol>  
+
 </div>
+
+
 
 
 <h3 id="arch-modules-working-with">Working with modules</h3>


### PR DESCRIPTION
Page currently has `schema_version` as module attribute for module version, when `setup_version` is correct.

Also added precise instructions for enabling a module. The note above about it no longer being controlled by the module was helpful, but it took me a while to figure out how to actually enable it.