### PR TITLE
admin-password was wrong in the guide

### DIFF
--- a/guides/v1.0/install-gde/install/install-cli-install.md
+++ b/guides/v1.0/install-gde/install/install-cli-install.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-group: install 
+group: install
 subgroup: T_Command-line installation
-title: Install the Magento software using the command line 
-menu_title: Install the Magento software using the command line 
-menu_node: 
+title: Install the Magento software using the command line
+menu_title: Install the Magento software using the command line
+menu_node:
 menu_order: 4
 github_link: install-gde/install/install-cli-install.md
 ---
 
-  
+
 <h4>Contents</h4>
 
 See one of the following sections:
@@ -83,7 +83,7 @@ You can run the following commands to find values for some required arguments:
   <p>If an error displays when you run these commands, make sure you updated installation dependencies as discussed in <a href="{{ site.gdeurl }}install-gde/install/prepare-install.html">Update installation dependencies</a>.</p></span>
 </div>
 
-	
+
 <h2 id="instgde-install-cli-magento">Install the Magento software from the command line</h2>
 The format of the install command follows:
 
@@ -116,7 +116,7 @@ The following table discusses the meanings of installation option names and valu
 	</tr>
 	<tr>
 		<td><p>--backend-frontname</p></td>
-		<td><p>Path to access the Magento Admin. This path is appended to base URL. Default is <code>admin</code>. 
+		<td><p>Path to access the Magento Admin. This path is appended to base URL. Default is <code>admin</code>.
 For example, if Base URL is http://www.example.com and Admin Path is <code>admin</code>, the Admin Panel's URL is <code>http://www.example.com/admin</code>&mdash;provided you configured your web server for server rewrites.</p></td>
 		<td><p>No</p></td>
 	</tr>
@@ -226,11 +226,11 @@ For example, if Base URL is http://www.example.com and Admin Path is <code>admin
 		<p><code>0</code> disables the use of the key.</p></td>
 		<td><p>No</p></td>
 	</tr>
-	<!-- <tr> 
+	<!-- <tr>
 		<td>enable_modules=&lt;list>}</td>
 		<td><p>Enable modules that are installed but disabled where <code>&lt;list></code> is a comma-separated list of modules (no spaces allowed). Use <code>php index.php help module-list</code> to list enabled and disabled modules.</p>
 		<p>To enable and disable modules after installing Magento, see <a href="{{ site.gdeurl }}install-gde/install/install-cli-subcommands-enable.html">Enable and disable modules</a>.</p>
-		<p>For important information about module dependencies, see <a href="{{ site.gdeurl }}install-gde/install/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-modules">About enabling and disabling modules</a>.</p></td>  
+		<p>For important information about module dependencies, see <a href="{{ site.gdeurl }}install-gde/install/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-modules">About enabling and disabling modules</a>.</p></td>
 		<td>No</td>
 	</tr>
 	<tr>
@@ -350,7 +350,7 @@ The following example installs Magento with the following options:
 		--backend-frontname=admin --db-host=localhost --db-name=magento \
 		--db-user=magento --db-password=magento \
 		--admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
-		--admin-user=admin --admin_password=admin123 --language=en_US \
+		--admin-user=admin --admin-password=admin123 --language=en_US \
 		--currency=USD --timezone=America/Chicago --cleanup-database \
 		--sales-order-increment-prefix="ORD$" --session-save=db
 


### PR DESCRIPTION
In the install snippet there is an error with `admin_password` it should be `admin-password` so that the installer can complete.