### PR TITLE
Fixed html markup for h2 tag on REST reference page

### DIFF
--- a/guides/v1.0/rest/bk-rest.md
+++ b/guides/v1.0/rest/bk-rest.md
@@ -10,7 +10,7 @@ github_link: rest/bk-rest.md
 ---
 The format and content of the REST Reference is still being developed. Until this information is available, Magento will periodically publish unprocessed documentation generated from the code.
 
-<h2 id="list"">List of REST APIs</h2>
+<h2 id="list">List of REST APIs</h2>
 
 <h3>Magento/Backend </h3>
 


### PR DESCRIPTION
Removed extra closing double-quote in html markup for h2 tag