### PR TITLE
Fixed typo in part 4 of Magento 1.x dev docs

### DIFF
--- a/guides/m1x/magefordev/mage-for-dev-4.html
+++ b/guides/m1x/magefordev/mage-for-dev-4.html
@@ -377,7 +377,7 @@ public function goodbyeAction() {
 
 <pre>http://example.com/helloworld/index/goodbye</pre>
 
-<p>We need to add a Handle for the full action name (<tt>helloworld_index_goodbye</tt>) to our local.xml file.  Rather than specify a new &lt;bloxk /&gt;, lets use the update tag to include the <tt>helloworld_index_index</tt> Handle.</p>
+<p>We need to add a Handle for the full action name (<tt>helloworld_index_goodbye</tt>) to our local.xml file.  Rather than specify a new &lt;block /&gt;, lets use the update tag to include the <tt>helloworld_index_index</tt> Handle.</p>
 
 <pre>
 &lt;layout version="0.1.0">


### PR DESCRIPTION
Just a minor typo fix.  Awesome to have these docs up on Github!