### PR TITLE
removed outdated reference to static file deployer

### DIFF
--- a/guides/v2.0/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.0/config-guide/cli/config-cli-subcommands-static-view.md
@@ -59,7 +59,7 @@ To deploy static view files:
 
 	In a more secure environment, you should make the web server user the owner of the files after running the tool.
 2.	Delete the contents of `<your Magento install dir>/pub/static`.
-3.	Run the static view files deployment tool from the `<your Magento install dir>/dev/tools/Magento/Tools/View` directory.
+3.	Run the static view files deployment tool `<your Magento install dir>/bin/magento setup:static-content:deploy`.
 <!-- 4.	Set read-only file permissions for the `pub/static` directory, its subdirectories, and files. -->
 	
 	<div class="bs-callout bs-callout-info" id="info">


### PR DESCRIPTION
magento setup:static-content:deploy is used instead of dev/tools/Magento/Tools/View/deploy.php