### PR TITLE
Correct minor grammatical error and improve usability

### DIFF
--- a/guides/v2.0/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.0/architecture/archi_perspectives/present_layer.md
@@ -36,7 +36,7 @@ One helpful way of understanding the Magento presentation layer components is by
 
 Each theme resides in a unique directory and contains custom page layouts, templates, skins, and language files that work together to create a distinct user experience. 
 
-For an extensive introduction to theme elements and an overview of how to extend and override the default Magento themes, see Frontend Developers Guide.
+For an extensive introduction to theme elements and an overview of how to extend and override the default Magento themes, see the <a href="{{ site.gdeurl }}frontend-dev-guide/bk-frontend-dev-guide.html">Frontend Developer Guide</a>.
 
 
 


### PR DESCRIPTION
Correcte a minor grammatical error and made the phrase Frontend Developer Guide a link to that guide to improve usability of the documentation.

I know these are very minor changes, but I am trying to remember to submit PR's for even the minor improvements I see as I read the documentation. 