### PR TITLE
Use Correct PHP Operators, Not Unicode Arrows

### DIFF
--- a/guides/m1x/api/soap/catalogInventory/Inventory.html
+++ b/guides/m1x/api/soap/catalogInventory/Inventory.html
@@ -50,7 +50,7 @@ title: Catalog Inventory
 
 <p>Change manage_stock setting to ‘off’ in the inventory area.</p>
 
-<p>$attributeSets = $client→call($session, ‘product_stock.update’, array(’SKU’,array(’manage_stock’⇒‘0’,’use_config_manage_stock’⇒‘0’)));</p>
+<p>$attributeSets = $client-&gt;call($session, ‘product_stock.update’, array(’SKU’,array(’manage_stock’=&gt;'0’,’use_config_manage_stock’=&gt;'0’)));</p>
 
 <p>The use_config_manage_stock unchecks the ‘Use Config Settings’ box which allows you to make changes to this product and not to use the global settings that are set by default.</p>
 

--- a/guides/v2.0/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.0/frontend-dev-guide/templates/template-security.md
@@ -15,7 +15,7 @@ To prevent <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">XSS</a> 
 
 * If a method indicates that the contents are escaped, do not escape: `getTitleHtml()`, `getHtmlTitle()` (the title is ready for the HTML output)
 
-* Escape data using the `$block→escapeHtml()`,  `$block→escapeQuote()`,  `$block→escapeUrl()`, `$block→escapeXssInUrl()` methods
+* Escape data using the `$block->escapeHtml()`,  `$block->escapeQuote()`,  `$block->escapeUrl()`, `$block->escapeXssInUrl()` methods
 
 * Type casting and php function `count()` don't need escaping  (for example `echo (int)$var`, `echo (bool)$var`, `echo count($var)`)
 
@@ -23,7 +23,7 @@ To prevent <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">XSS</a> 
 
 * Output in double quotes without variables doesn't need escaping (for example `echo "some text"`)
 
-* Otherwise, escape the data using the `$block→escapeHtml()` method
+* Otherwise, escape the data using the `$block->escapeHtml()` method
 
 The following code sample illustrates the XSS-safe output in templates:
 


### PR DESCRIPTION
I'm not sure why these symbols are appearing – perhaps someone's editor is autoreplacing -> for them. Perhaps they're there to avoid problems with HTML output. In this case, though, they occur in examples of PHP, and as such they wouldn't work as intended.