### PR TITLE
M1X catalog_product API documentation

### DIFF
--- a/guides/m1x/api/soap/catalog/catalogProduct/catalog_product.info.html
+++ b/guides/m1x/api/soap/catalog/catalogProduct/catalog_product.info.html
@@ -64,7 +64,7 @@ title: Product Info
 <tr>
 <td> string </td>
 <td> productIdentifierType </td>
-<td> Defines whether the product ID or SKU value is passed in the "product" parameter. </td>
+<td> Defines whether the product ID or SKU value is passed in the "productId" parameter. (optional) </td>
 </tr>
 </tbody></table>
 

--- a/guides/m1x/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html
+++ b/guides/m1x/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html
@@ -49,7 +49,7 @@ title: Set Special Price
 </tr>
 <tr>
 <td> string <br class="atl-forced-newline" /> </td>
-<td> product <br class="atl-forced-newline" /> </td>
+<td> productId <br class="atl-forced-newline" /> </td>
 <td> Product ID or SKU </td>
 </tr>
 <tr>
@@ -75,7 +75,7 @@ title: Set Special Price
 <tr>
 <td> string </td>
 <td> productIdentifierType </td>
-<td> Defines whether the product ID or SKU is passed in the 'product' parameter </td>
+<td> Defines whether the product ID or SKU is passed in the 'productId' parameter (optional) </td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
The `productId` and `productIdentifierType` arguments were misnamed/misdocumented under the catalog_product silo. I didn't look for or test any other issues.