### PR TITLE
Break on Footer Padding

### DIFF
--- a/common/css/override.css
+++ b/common/css/override.css
@@ -106,7 +106,8 @@ p.q 	{
 
 
 .container {
-    padding-left: 66px
+    padding-left: 66px;
+    padding-right: 66px
 }
 
 .copyright .container {


### PR DESCRIPTION
The same padding in the right and left.

Before:
![image](https://cloud.githubusercontent.com/assets/610598/10397661/37045aae-6e7f-11e5-8b8f-ac9993a65087.png)

After:
![image](https://cloud.githubusercontent.com/assets/610598/10397705/738ca878-6e7f-11e5-9b9d-b378aaded72f.png)
