### PR TITLE
Link to Tab widget url model + some typos

### DIFF
--- a/guides/v2.0/javascript-dev-guide/widgets/widget_accordion.md
+++ b/guides/v2.0/javascript-dev-guide/widgets/widget_accordion.md
@@ -92,7 +92,7 @@ For example:
 $("#element").accordion({
     header : "#title-1"
     content : "#content-1",
-    trigger : "#trigger-1,
+    trigger : "#trigger-1",
     ajaxUrlElement: "a"
  });
 </pre>
@@ -103,7 +103,7 @@ The accordion widget can be initialized using the <code>data-mage-init</code> at
 
 
 <h2 id="accordion_options">Options</h2>
-Accordion options coincide with <a href="{{site.gdeurl}}frontend-dev-guide/javascript/jquery-widget-tabs.html#fedg_tabs_options" target="_blank">Magento Tabs options</a>, plus the following custom ones:
+Accordion options coincide with <a href="{{site.gdeurl}}javascript-dev-guide/widgets/widget_tabs.html#fedg_tabs_options" target="_blank">Magento Tabs options</a>, plus the following custom ones:
 <ul>
 <li><a href="#collaps_active">active</a></li>
 <li><a href="#collaps_multi">multipleCollapsible</a></li>
@@ -139,7 +139,7 @@ $("#element").accordion({ multipleCollapsible: false});
 Get or set the <code>multipleCollapsible</code> option, after initialization:
 <pre>
 //getter
-var multipleCollapsible = $("#element).accordion("option","multipleCollapsible");
+var multipleCollapsible = $("#element").accordion("option","multipleCollapsible");
 
 //setter
 $("#element").tabs("option","multipleCollapsible",false);


### PR DESCRIPTION
Probably and older url model, and some forgotten double quotes.