### PR TITLE
Correct indentation on auth.json file example

### DIFF
--- a/guides/v2.0/install-gde/prereq/dev_install.md
+++ b/guides/v2.0/install-gde/prereq/dev_install.md
@@ -57,7 +57,7 @@ To set up authentication:
         {
            "github-oauth": {
              "github.com": "804d4ab968ia8vk0Uar263a1cbd40d82da7464aa7"
-        },
+           },
            "http-basic": {
               "repo.magento.com": {
                  "username": "<username>",


### PR DESCRIPTION
Indentation on the auth.json file example was incorrect and can cause confusion on how to format the file (caught me out earlier)