### PR TITLE
Removing Order directive

### DIFF
--- a/guides/v2.0/install-gde/prereq/apache.md
+++ b/guides/v2.0/install-gde/prereq/apache.md
@@ -187,7 +187,6 @@ For example:
 	<Directory /var/www/>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride <value from Apache site>
-		Order allow,deny
 		Require all granted
 	</Directory>
 


### PR DESCRIPTION
Hello,

I have an Ubuntu 14.04 server installed with Apache 2.4.7 and I was trying the following scenarios:

### 1. Scenario - the magento2-doc way

```
<Directory /var/www/>
	Options Indexes FollowSymLinks MultiViews
	AllowOverride All
	Order allow,deny
	Require all granted
</Directory>
```
### 2. Scenario - the Apache 2.2 way

```
<Directory /var/www/>
	Options Indexes FollowSymLinks MultiViews
	AllowOverride All
	Order allow,deny
	Allow from all
</Directory>
```
### 3. Scenario - the Apache 2.4 way

```
<Directory /var/www/>
	Options Indexes FollowSymLinks MultiViews
	AllowOverride All
	Require all granted
</Directory>
```

Scenario 2 and 3 are working. Scenario 1 isn't. But since [this link](Require all granted) is telling me to use the third scenario, I thought it would be better to have this also in the official magento2 docs.


Greets! :)