### PR TITLE
Fixing incorrect username example

### DIFF
--- a/guides/v2.0/get-started/authentication/gs-authentication-token.md
+++ b/guides/v2.0/get-started/authentication/gs-authentication-token.md
@@ -71,17 +71,17 @@ redirect_from: /guides/v1.0/get-started/authentication/gs-authentication-token.h
 <p>For example:</p>
 <pre>curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token.xml" \
      -H "Content-Type:application/xml" \
-     -d '&lt;login>&lt;username>test@example.com&lt;/username>&lt;password>123123q&lt;/password>&lt;/login>'</pre>
+     -d '&lt;login>&lt;username>user_example&lt;/username>&lt;password>123123q&lt;/password>&lt;/login>'</pre>
 <a name="auth-request"></a>
 <h2>Authentication token request</h2>
 <p>To request an authentication token for a customer user for the REST web API:</p>
 <pre>curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token" \
      -H "Content-Type:application/json" \
-     -d '{"username":"test@example.com", "password":"123123q"}'</pre>
+     -d '{"username":"user_example", "password":"123123q"}'</pre>
 <p>To request an authentication token for an admin user for the REST web API:</p>
 <pre>curl -X POST "https://magento.host/index.php/rest/V1/integration/admin/token" \
      -H "Content-Type:application/json" \
-     -d '{"username":"test@example.com", "password":"123123q"}'</pre>
+     -d '{"username":"user_example", "password":"123123q"}'</pre>
 <a name="auth-response"></a>
 <h2>Authentication token response</h2>
 <p>A successful request returns a response body with the token, as follows:</p>


### PR DESCRIPTION
The username defined in the example is an email, which is not correct, it must be the username of the account.