### PR TITLE
Do not delete .htaccess from pub/static

### DIFF
--- a/guides/v2.0/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.0/config-guide/cli/config-cli-subcommands-static-view.md
@@ -38,7 +38,7 @@ Static view files deployment is affected by Magento modes as follows:
 <div class="bs-callout bs-callout-warning">
   <p><em>Developer mode only</em>: When you install or enable a new module, it might load new JavaScript, CSS, layouts, and so on. To avoid issues with static files, you must clean the old files to make sure you get all the changes for the new module.</p>
   <p>You can clean generated static view files in any of the following ways:</p>
-  <ul><li>Manually by clearing the <code>pub/static</code> and <code>var/view_preprocessed</code> directories and subdirectories.</li>
+  <ul><li>Manually by clearing the <code>pub/static</code> (please note: do not delete the .htaccess file within the pub/static folder) and <code>var/view_preprocessed</code> directories and subdirectories.</li>
   <li>Using the Magento command line. Several commands support an optional parameter <code>--clear-static-content</code>, which cleans <a href="{{ site.gdeurl }}config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview">generated static view files</a>. For example, see <a href="{{ site.gdeurl }}install-gde/install/install-cli-subcommands-enable.html">Enable or disable modules</a>.</li>
 <li>In the Magento Admin. Go to <strong>System</strong> > Tools > <strong>Cache Management</strong> and click <strong>Flush Static Files Cache</strong>.</li></ul>
 </div>


### PR DESCRIPTION
Do not delete .htaccess from pub/static, which is a standard Magento file and will not be rewritten. This file should never be deleted from your installation.