### PR TITLE
Fix example command for flushing all caches types

### DIFF
--- a/guides/v2.0/config-guide/cli/config-cli-subcommands-cache.md
+++ b/guides/v2.0/config-guide/cli/config-cli-subcommands-cache.md
@@ -186,7 +186,7 @@ where
 
 For example, to flush all cache types, enter
 
-	magento cache:flush --all
+	magento cache:flush
 
 Sample result:
 


### PR DESCRIPTION
Not sure why it had been changed before 
https://github.com/magento/devdocs/commit/d20a332d041c9c32121ccb904ca8f50366ede560#diff-8ee7e4ec4b83364e565d3d5d0a69c5f2
from 
magento:cache:flush 
to 
magento cache:flush --all
