### PR TITLE
Add troubleshooting guide for http_resp_hdr_len

### DIFF
--- a/guides/v2.0/config-guide/varnish/config-varnish.md
+++ b/guides/v2.0/config-guide/varnish/config-varnish.md
@@ -92,6 +92,21 @@ We know of the following issues with Varnish:
 	      .first_byte_timeout = 600s;
 		}
 
+*	Possible error on some pages:
+
+		Error 503 Backend fetch failed
+		Backend fetch failed
+		Guru Meditation:
+		XID: 303394517
+
+	If you experience this error, it is possible that Magento is sending a list of
+	cache tags longer than the default allowed 8192 characters. To fix this, you
+	must edit the `http_resp_hdr_len` launch parameter.
+
+	On CentOS, this can be changed in the `/etc/sysconfig/varnish` file by adding
+	the line:
+
+		-p http_resp_hdr_len=64000 \
 
 #### Next step
 <a href="{{ site.gdeurl }}config-guide/varnish/config-varnish-install.html">Install Varnish</a>


### PR DESCRIPTION
We recently had an issue where Varnish would serve some pages (startlingly quickly), and give a backend fetch error (503) on others. It turns out that it is due to the length of the cache tags list being longer than the maximum header length that varnish expects.

Fortunately, this is configurable.

Attached is a screenshot of what the change looks like once compiled.

![Screenshot](https://cloud.githubusercontent.com/assets/1707318/12943476/7f2febfc-cfd9-11e5-9ad7-1ee032d4395e.png)
