### PR TITLE
Its "themes.js" not "theme.js"

### DIFF
--- a/guides/v2.0/frontend-dev-guide/css-topics/css_debug.md
+++ b/guides/v2.0/frontend-dev-guide/css-topics/css_debug.md
@@ -80,7 +80,7 @@ npm update
 </li>
 
 <li>
-Add your theme to Grunt configuration. To do this, in the <code>dev/tools/grunt/configs/theme.js</code> file, add your theme to <code>module.exports</code> like following:
+Add your theme to Grunt configuration. To do this, in the <code>dev/tools/grunt/configs/themes.js</code> file, add your theme to <code>module.exports</code> like following:
 <pre>
 module.exports = {
     &lt;theme&gt;: {


### PR DESCRIPTION
There does not appear to be any "theme.js" file in "dev/tools/grunt/configs/",
it seems the correct one is "themes.js".