### PR TITLE
Tweaks to Proxies and Code Generation pages

### DIFF
--- a/guides/v2.0/extension-dev-guide/code-generation.md
+++ b/guides/v2.0/extension-dev-guide/code-generation.md
@@ -28,7 +28,7 @@ In particular,
 
 *	A Factory class creates instances of a type. See <a href="{{ site.gdeurl }}extension-dev-guide/factories.html">Instantiating objects with factories</a> for more information. Factories are directly referenced within application code.
 
-*	You can designate a Proxy to be generated for a type in order to ensure the type is not instantiated until it is needed. See <a href="{{ site.gdeurl }}extension-dev-guide/proxies.html">Proxies</a> for more information. Proxies are directly referenced within application code.
+*	You can designate a Proxy to be generated for a type in order to ensure the type is not instantiated until it is needed. See <a href="{{ site.gdeurl }}extension-dev-guide/proxies.html">Proxies</a> for more information. Proxies are directly referenced within DI configuration.
 
 *   Interceptor classes are automatically generated to facilitate Magento's plugin system. An interceptor class extends a type and is returned by the Object Manager to allow multiple plugin classes to inject logic into different methods. Interceptors work behind the scenes and are _not_ directly referenced in application code.
 

--- a/guides/v2.0/extension-dev-guide/proxies.md
+++ b/guides/v2.0/extension-dev-guide/proxies.md
@@ -57,21 +57,7 @@ Magento has a solution for this situation: proxies.  <a href="http://en.wikipedi
 
 Proxies are generated code and therefore do not need to be manually written.  (See <a href="{{ site.gdeurl }}extension-dev-guide/code-generation.html">Code Generation</a> for more information.) Simply reference a class in the form \Original\Class\Name\Proxy, and the class will be generated if it does not exist.
 
-Using the above example, the constructor signature of FastLoading could be changed as follows:
-
-{% highlight PHP %}
-<?php
-    public function __construct(
-        SlowLoading\Proxy $slowLoading
-    ){
-        $this->slowLoading = slowLoading;
-    }
-?>
-{% endhighlight %}
-
-Now the SlowLoading class will not be instantiated - and therefore the resource intensive constructor operations not performed - until the SlowLoading object is used (i.e., if the getSlowValue method is called).
-
-The above example of directly referencing a proxy in a constructor parameter would function correctly.  However, a better practice would be to leave the original interface or class reference in your constructor signature and specify the proxy via DI configuration instead:
+Using the above example, a proxy can be passed into the constructor arguments instead of the original class, using DI configuration as follows:
 
 {% highlight XML %}
 <type name="FastLoading">
@@ -81,6 +67,8 @@ The above example of directly referencing a proxy in a constructor parameter wou
 </type>
 {% endhighlight %}
 
-In this way, proxies can be dropped in to replace their corresponding classes - or proxy replacements _removed_ - without touching application code.
+With the proxy used in place of SlowLoading, the SlowLoading class will not be instantiated - and therefore the resource intensive constructor operations not performed - until the SlowLoading object is used (i.e., if the getSlowValue method is called).
+
+Since DI configuration is used to inject a proxy, proxies can be dropped in to replace their corresponding classes - or proxy replacements _removed_ - without touching application code.
 
 As a practical example of a proxy, you can see the <a href="{{ site.mage2000url }}app/code/Magento/Store/Model/StoreManager.php" target="_blank">StoreManager</a> class and then see the generated StoreManager Proxy class.


### PR DESCRIPTION
Proxies:  Avoid referencing the use of proxies directly in a constructor

Code Generation:  Correct terminology to "referenced directly in DI config" instead of "application code"