### PR TITLE
' " ' written before closing of tag

### DIFF
--- a/guides/v2.0/javascript-dev-guide/javascript/js_init.md
+++ b/guides/v2.0/javascript-dev-guide/javascript/js_init.md
@@ -80,7 +80,7 @@ To initialize a JS component on a HTML element without direct access to the elem
     },
     // components initialized without binding to an element
     &quot;*&quot;: {
-        &quot;&lt;js_component3&quot;&gt;: ...
+        &quot;&lt;js_component3&gt;&quot;: ...
     }
 &lt;/script&gt;
 </pre>


### PR DESCRIPTION
when i m reading documentation i found syntax mistake in code example 