### PR TITLE
add missing php70u-json

### DIFF
--- a/guides/v2.0/install-gde/prereq/php-centos.md
+++ b/guides/v2.0/install-gde/prereq/php-centos.md
@@ -102,7 +102,7 @@ To upgrade to PHP 7.0.2 or later:
 		wget https://centos6.iuscommunity.org/ius-release.rpm
 		rpm -Uvh ius-release*.rpm
 		yum -y update
-		yum -y install php70u php70u-pdo php70u-mysqlnd php70u-opcache php70u-xml php70u-mcrypt php70u-gd php70u-devel php70u-mysql php70u-intl php70u-mbstring php70u-bcmath
+		yum -y install php70u php70u-pdo php70u-mysqlnd php70u-opcache php70u-xml php70u-mcrypt php70u-gd php70u-devel php70u-mysql php70u-intl php70u-mbstring php70u-bcmath php70u-json
 
 	<div class="bs-callout bs-callout-info" id="info">
   		<p>The <code>bcmath</code> extension is required for Magento Enterprise Edition (EE) only.</p>


### PR DESCRIPTION
Without it, run into
[RuntimeException]
PHP's json extension is required to use Monolog's NormalizerFormatter