### PR TITLE
Remove steps for restarting web server

### DIFF
--- a/guides/v2.0/config-guide/secy/secy-cron.md
+++ b/guides/v2.0/config-guide/secy/secy-cron.md
@@ -103,13 +103,8 @@ To add security for cron in Magento's `.htaccess`:
     		Require group <name>
 		</Files>
 4.	Save your changes to `.htaccess` and exit the text editor.
-5.	Restart Apache:
 
-	CentOS: `service httpd restart`
-
-	Ubuntu: `service apache2 restart`
-
-6.	Continue with <a href="#config-cron-secure-apache-verify">Verify cron is secure</a>.
+5.	Continue with <a href="#config-cron-secure-apache-verify">Verify cron is secure</a>.
 
 <h2 id="config-cron-secure-nginx">Secure cron with nginx</h2>
 This section discusses how to secure cron using the nginx web server. You must perform the following tasks:


### PR DESCRIPTION
Assuming that "AllowOverride All" is already properly set so that .htaccess files can be read by Apache on each request, changes to .htaccess files shouldn't require a full restart/reload of the web server.