### PR TITLE
The "key' attribute is not allowed in "item"

### DIFF
--- a/guides/v2.0/extension-dev-guide/depend-inj.md
+++ b/guides/v2.0/extension-dev-guide/depend-inj.md
@@ -356,7 +356,7 @@ translate="true">{someValue}&lt;/argument></pre></td>
 		</tr>
 	<tr>
 		<td><pre>&lt;argument xsi:type="array">
-&lt;item key="someItem"
+&lt;item name="someItem"
 xsi:type="string">someVal&lt;/item>
 &lt;/argument></pre></td>
 		<td>Array with elements corresponding to the items passed as argument. Array can contain an infinite number of items. Each item can be any type as argument, including an array itself, or an object type.</td>


### PR DESCRIPTION
There are errors if "key' attribute is used for "item" node in "array" arguments:

PHP Fatal error:  Uncaught Magento\Framework\Exception\LocalizedException: Invalid Document 
Element 'item', attribute 'key': The attribute 'key' is not allowed.
Line: 43

Element 'item': The attribute 'name' is required but missing.
Line: 43

Element 'item': Not all fields of key identity-constraint 'argumentItemName' evaluate to a node.
Line: 43