### PR TITLE
Expanding file permissions to address servers hosting multiple domains

### DIFF
--- a/_includes/install/file-system-perms.html
+++ b/_includes/install/file-system-perms.html
@@ -1,22 +1,51 @@
 <h2 id="install-perms-import">Why we recommend you set file system permissions</h2>
 <P>Malicious exploits are an unfortunate reality in the internet age. To help prevent exploits that take advantage of the file system, we recommend you set Magento file system ownership and permissions in a particular way. For more information, see <a href="{{ site.gdeurl }}install-gde/prereq/apache-user.html#install-update-depend-user-over">Overview of ownership and permissions</a>.</p>
+<p>On web servers that host multiple domains, it is common practice for each domain to have a different web server user.  This allows some limited protection in that the web user for one domain is not able to create, and more importantly read, files stored in the other domain(such as the server configuration containing the database logon information!).  This means that there are now two web server users that may need to access files for your system, the domain user and the system user.  In general, the system user will require read access to any .htaccess files as well as search access to directories containing static resources.</p>
+
 <p>The important things:</p>
 <ul><li>The owner of the Magento file system:
 <ul><li>Must have full control (read/write/execute) of all files and directories.</li>
 <li>Must <em>not</em> be the web server user; it should be a different user.</li></ul>
 </li>
-<li>The web server user must have write access to the following files and directories:
-<ul><li><code>var</code></li>
-<li><code>app/etc</code></li>
-<li><code>pub</code></li></ul>
+<li>The web server domain user:
+	<ul>
+		<li>Must have write access to the following files and directories:
+			<ul>
+				<li><code>var</code></li>
+				<li><code>app/etc</code></li>
+				<li><code>pub</code></li>
+			</ul>
+		</li>
+		<li>Must have search[execute] access to the following directories[including any subdirectories]:
+			<ul>
+				<li><code>pub</code></li>
+			</ul>
+		</li>
+	</ul>
 </li>
+	<li>The web server system user:
+		<ul><li>Must have search[execute] access to the following directories[including any subdirectories]
+			<ul>
+				<li><code>pub</code></li>
+			</ul>
+		</li>
+			<li>Must have read access to any .htaccess files in the following directories[including any subdirectories]
+				<ul>
+					<li><code>pub</code></li>
+				</ul>
+			</li>
+		</ul>
+    </li>
 </ul>
-<p>In addition, the web server's <em>group</em> must own the Magento file system so that the Magento user (who is in the group) can share access to files with the web server user. (This includes files created by the Magento Admin or other web-based utilities.)</p>
+<p>In addition, the web server domain user's <em>group</em> must own the Magento file system so that the Magento user (who is in the group) can share access to files with the web server user. (This includes files created by the Magento Admin or other web-based utilities.)</p>
 <p>We recommend setting the permissions as follows:</p>
-<ul><li>All directories have 770 permissions.<br>
-770 permissions give full control (that is, read/write/execute) to the owner and to the group and no permissions to anyone else.</li>
-<li>All files have 660 permissions.<br>
-660 permissions mean the owner and the group can read and write but other users have no permissions.</li></ul>
+<ul><li>All directories have 771 permissions.<br>
+771 permissions give full control (that is, read/write/search) to the owner and to the group and search permission to everyone.</li>
+<li>All files except .htaccess have 660 permissions.<br>
+660 permissions mean the owner and the group can read and write but other users have no permissions.</li>
+	<li>All .htaccess have 664 permissions.<br>
+		664 permissions mean the owner and the group can read and write and other users can read only.</li>
+</ul>
 
 <h2 id="install-perms-set">File system permissions and ownership</h2>
 <p>Use the following steps:</p>
@@ -25,14 +54,15 @@
 	The base directory is typically a subdirectory named <code>magento2</code> under your web server's docroot. Need help locating the docroot? Click <a href="{{ site.gdeurl }}install-gde/basics/basics_docroot.html">here</a>.<br>
 
 	Examples:
-	<ul><li>Ubuntu: <code>/var/www/magento2</code>
+	<ul><li>Ubuntu: <code>/var/www/magento2</code></li>
 	<li>CentOS: <code>/var/www/html/magento2</code></li>
+		</ul>
 <li>Set ownership:<br>
-<pre>chown -R :&lt;your web server group name> .</pre>
+<pre>chown -R :&lt;your web server group name&gt; .</pre>
 Typical examples:<br>
 CentOS: <code>chown -R :apache .</code><br>
 Ubuntu: <code>chown -R :www-data .</code></li>
 <li>Set permissions:<br>
-	<pre>find . -type d -exec chmod 770 {} \; && find . -type f -exec chmod 660 {} \; && chmod +x bin/magento</pre>
+	<pre>find . -type d -exec chmod 771 {} \; && find . -type f -exec chmod 660 {} \; && chmod ug+x bin/magento; && find . -type f -name .htaccess -exec chmod o+r {} \</pre>
 	If you must enter the commands as <code>sudo</code>, use:<br>
-	<pre>sudo find . -type d -exec chmod 770 {} \; && sudo find . -type f -exec chmod 660 {} \; && sudo chmod +x bin/magento</pre></li></ol>
+	<pre>sudo find . -type d -exec chmod 771 {} \; && find . -type f -exec chmod 660 {} \; && chmod ug+x bin/magento; && find . -type f -name .htaccess -exec chmod o+r {} \</pre></li></ol>

--- a/_includes/install/file-system-perms1-why.html
+++ b/_includes/install/file-system-perms1-why.html
@@ -1,23 +1,35 @@
 <p>Malicious exploits are an unfortunate reality in the internet age. To help prevent exploits that take advantage of the file system, we recommend you set Magento file system ownership and permissions in a particular way. For more information, see <a href="{{ site.gdeurl }}install-gde/prereq/apache-user.html#install-update-depend-user-over">Overview of ownership and permissions</a>.</p>
 
 <div class="bs-callout bs-callout-info" id="info">
-  <p>This topic covers permissions for a development environment. In production, the web server user should have limited write privileges. To help manage you production and developer modes, we provide the <code><a href="{{ site.gdeurl }}config-guide/cli/config-cli-subcommands-mode.html">magento deploy:mode:set</a></code> command.</p>
-</div> 
+  <p>This topic covers permissions for a development environment. In production, the web server user(s) should have limited write privileges. To help manage you production and developer modes, we provide the <code><a href="{{ site.gdeurl }}config-guide/cli/config-cli-subcommands-mode.html">magento deploy:mode:set</a></code> command.</p>
+  <p>On web servers that host multiple domains, it is common practice for each domain to have a different web server user.  This allows some limited protection in that the web user for one domain is not able to create, and more importantly read, files stored in the other domain(such as the server configuration containing the database logon information!).  This means that there are now two web server users that may need to access files for your system, the domain user and the system user.  In general, the system user will require read access to any .htaccess files as well as search access to directories containing static resources.</p>
+</div>
 
 <p>The important things:</p>
 <ul><li>The owner of the Magento file system:
 <ul><li>Must have full control (read/write/execute) of all files and directories.</li>
-<li>Must <em>not</em> be the web server user; it should be a different user.</li></ul>
+<li>Must <em>not</em> be a web server user; it should be a different user.</li></ul>
 </li>
-<li>The web server user must have write access to the following files and directories:
+<li>The web server domain user must have write access to the following files and directories:
 <ul><li><code>var</code></li>
 <li><code>app/etc</code></li>
 <li><code>pub</code></li></ul>
 </li>
 </ul>
-<p>In addition, the web server's <em>group</em> must own the Magento file system so that the Magento user (who is in the group) can share access to files with the web server user. (This includes files created by the Magento Admin or other web-based utilities.)</p>
+<li>The web server system user must have search[also called execute] access to the following directory:
+  <ul>
+    <li><code>pub</code></li></ul>
+</li>
+<li>The web server system user must have read access to .htaccess files in at least the following directory:
+  <ul>
+    <li><code>pub</code></li></ul>
+</li>
+</ul>
+<p>In addition, the web server domain user's <em>group</em> must own the Magento file system so that the Magento user (who is in the group) can share access to files with the web server domain user. (This includes files created by the Magento Admin or other web-based utilities.)</p>
 <p>We recommend setting the permissions as follows:</p>
-<ul><li>All directories have 770 permissions.<br>
-770 permissions give full control (that is, read/write/execute) to the owner and to the group and no permissions to anyone else.</li>
-<li>All files have 660 permissions.<br>
-660 permissions mean the owner and the group can read and write but other users have no permissions.</li></ul>
+<ul><li>All directories have 771 permissions.<br>
+771 permissions give full control (that is, read/write/search) to the owner and to the group and search permissions to anyone else.</li>
+<li>All files except .htaccess have 660 permissions.<br>
+660 permissions mean the owner and the group can read and write but other users have no permissions.</li>
+  <li>All .htaccess files have 661 permissions.<br>
+    661 permissions mean the owner and the group can read and write but other users may read this file.</li></ul>

--- a/_includes/install/file-system-perms2-how.md
+++ b/_includes/install/file-system-perms2-how.md
@@ -22,11 +22,16 @@ Use the following steps:
 
 	*	CentOS: `chown -R :apache .`
 	*	Ubuntu: `chown -R :www-data .`
+	
+	Multi-Domain Hosting examples:
+    
+    *	mydomain.com: `chown -R :mydomain .`
+    *	mylongdomain.com: `chown -R :mylongdo .`
 
 3.	Set permissions:
 
-		find . -type d -exec chmod 770 {} \; && find . -type f -exec chmod 660 {} \; && chmod u+x bin/magento
+		find . -type d -exec chmod 771 {} \; && find . -type f -exec chmod 660 {} \; && chmod u+x bin/magento; && find . -type f -name .htaccess -exec chmod o+r {} \
 
 	If you must enter the commands as `sudo`, use:
 
-		sudo find . -type d -exec chmod 770 {} \; && sudo find . -type f -exec chmod 660 {} \; && sudo chmod u+x bin/magento
+		sudo find . -type d -exec chmod 771 {} \; && sudo find . -type f -exec chmod 660 {} \; && sudo chmod u+x bin/magento; && find . -type f -name .htaccess -exec chmod o+r {} \


### PR DESCRIPTION
Corrects file permissions when dealing with Virtual Host environments.  In a virtual host environment Apache will be run as 2 different users.  Assuming mydomain.com:

Apache will run as both apache:www-data and mydomain:mydomain

In this case, the closest match to the single server/single domain assumption made in the docs is for the magento user and the mydomain user to share a group which is not shared by the apache user.

This is problematic if the Apache server uses mod_rewrite[and frankly do we expect it ever to NOT use it?].  With mod_rewrite, Apache will scan for .htaccess files before switching to to the mydomain user and after switching to the mydomain user as many other extensions - most notably mod_security2 - need to check for configuration adjustments to global rules.

That means the .htaccess file is an exception to the 660 file permission - it instead must be 664.  Note: Magento actually does set the correct file permission on .htaccess it simply does not document it.

In addition - a frequently missed setting is that in order to perform a recursive check up the directory tree for .htaccess files the apache user will need search/list permissions for the entire directory tree.  
ie an attempt to load the file pub/static/frontend/Magento/luma/en_US/js/theme.js will use the .htaccess file located at pub/static/.htaccess    However, Apache will first check for html/pub/static/frontend/Magento/luma/en_US/js/.htaccess, then html/pub/static/frontend/Magento/luma/en_US/.htaccess, then html/pub/static/frontend/Magento/luma/.htaccess, etc

This requires search permissions - otherwise known as the X bit [for eXtra not eXecute!]

As such, I've modified the documentation with the correct information as well as changing the wording to avoid using the word 'execute' since many people have trouble grasping that it is not possible to execute a directory.

As there is no security implication with enabling the search bit on directories for all users - there really is no need to have a separate set of instructions for the 2 different environments.