### PR TITLE
fix some documentation typo error

### DIFF
--- a/guides/v2.0/howdoi/checkout/checkout_payment.md
+++ b/guides/v2.0/howdoi/checkout/checkout_payment.md
@@ -182,7 +182,7 @@ A sample DI configuration file of a custom module `<your_module_dir>/etc/di.xml`
 
 {%highlight xml%}
 ...
-<type name="Magento\Checkout\Modерel\CompositeConfigProvider">
+<type name="Magento\Checkout\Model\CompositeConfigProvider">
     <arguments>
         <argument name="configProviders" xsi:type="array">
             ...


### PR DESCRIPTION
fix documentation typo error for name="Magento\Checkout\Modерel\CompositeConfigProvider" to name="Magento\Checkout\Model\CompositeConfigProvider"