### PR TITLE
Changed text to reflect actual content of error msg

### DIFF
--- a/guides/v2.0/comp-mgr/trouble/cman/were-sorry.md
+++ b/guides/v2.0/comp-mgr/trouble/cman/were-sorry.md
@@ -2,14 +2,14 @@
 layout: default
 group: compman
 subgroup: 50_trouble
-title: "We're sorry, we can't take that action right now"
-menu_title: "We're sorry, we can't take that action right now"
+title: "Sorry, we can't take that action right now"
+menu_title: "Sorry, we can't take that action right now"
 menu_node: 
 menu_order: 2
 github_link: comp-mgr/trouble/cman/were-sorry.md
 ---
 
-<h2 id="trouble-update-were-sorry">"We're sorry, we can't take that action right now"</h2>
+<h2 id="trouble-update-were-sorry">"Sorry, we can't take that action right now"</h2>
 The following error might display at the start of your upgrade:
 
 <img src="{{ site.baseurl }}common/images/upgr-sorry.png" width="600px">


### PR DESCRIPTION
The literal error message (as reflected in the pictures) is "Sorry, we can't take that action right now" (without "we're). In the interest of accuracy and SEO for people searching for the error message verbatim, I removed the word that does not exist in the message being displayed on the platform.