### PR TITLE
clarified to open PRs on 2.0 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome! This site contains the latest Magento developer documentation for ongoing Magento 2.0 releases.
 
-To contribute, please fork the 2.0 branch. 
+To contribute, please fork the 2.0 branch and submit any PRs to this same branch as well.
 
 # Build this site using Jekyll
 To preview your work before submitting it to us, you can view the site locally using [Jekyll](https://jekyllrb.com){:target="_blank"}.


### PR DESCRIPTION
I had to research which branch you preferred to open PRs on. Seems like `develop` is deprecated, or at least not preferred: https://github.com/magento/devdocs/pull/565#issuecomment-208021411