### PR TITLE
Correct example crontab configuration

### DIFF
--- a/_includes/config/setup-cron.md
+++ b/_includes/config/setup-cron.md
@@ -35,15 +35,14 @@ For example,
 
 A text editor displays. (You might need to choose a text editor first.)
 
-	*/1 * * * * <path-to-binary> -c <ini-file-path> <your Magento install dir>/bin/magento cron:run [>> <log-file>&]
-	*/1 * * * * <path-to-binary> -c <ini-file-path> <your Magento install dir>/update/cron.php [>> <log-file>&]
-	*/1 * * * * <path-to-binary> -c <ini-file-path> <your Magento install dir>/bin/magento setup:cron:run [>> <log-file>&]
+	* * * * * <path_to_binary> -c <ini_file_path> <magento_dir>/bin/magento cron:run | grep -v "Ran jobs by schedule" >> <magento_dir>/var/log/magento.cron.log
+	* * * * * <path_to_binary> -c <ini_file_path> <magento_dir>/update/cron.php >> <magento_dir>/var/log/update.cron.log
+	* * * * * <path_to_binary> -c <ini_file_path> <magento_dir>/bin/magento setup:cron:run >> <magento_dir>/var/log/setup.cron.log
 
 where 
 
-*	`<path-to-binary>` is the absolute file system path to your PHP binary
-*	`<ini-file-path>` is the path to a `php.ini` file to use for the cron job
-*	`[>> <log-file>&]` is an optional but recommended string that appends cron output to a file. This is particularly useful for troubleshooting errors.
+*	`<path_to_binary>` is the absolute file system path to your PHP binary
+*	`<ini_file_pathy>` is the path to a `php.ini` file to use for the cron job
 
 The first command (`magento cron:run`) reindexes indexers, send automated e-mails, generates the sitemap, and so on. Usually it's associated with the PHP command line `.ini` file. The other two commands are used by the Component Manager and System Upgrade.
 
@@ -51,8 +50,8 @@ For example, if the PHP binary is located in `/usr/bin`, you installed Magento i
 
 Example:
 
-	*/1 * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/bin/magento cron:run >> /var/www/magento2/var/log/magento.cron.log&
-	*/1 * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/update/cron.php >> /var/www/magento2/var/log/update.cron.log&
-	*/1 * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/bin/magento setup:cron:run >> /var/www/magento2/var/log/setup.cron.log&
+	* * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/bin/magento cron:run | grep -v "Ran jobs by schedule" >> /var/www/magento2/var/log/magento.cron.log
+	* * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/update/cron.php >> /var/www/magento2/var/log/update.cron.log
+	* * * * * /usr/bin/php -c /etc/php5/apache2/php.ini /var/www/magento2/bin/magento setup:cron:run >> /var/www/magento2/var/log/setup.cron.log
 
 Save your changes to the crontab and exit the editor.


### PR DESCRIPTION
Updates include used here: http://devdocs.magento.com/guides/v2.0/config-guide/cli/config-cli-subcommands-cron.html

* Removes redundant `*/1` and uses simpler `*` for minute configuration
* Makes use of log files clearer
* Improves readability of placeholders (following typical snake case format)
* Strips unnecessary output from the log (constant, hey we ran!)
* Removes the trailing `&` from the commands. This is not needed because everything run by crontab is already run in the background, so it's redundant.