### PR TITLE
Fix backtick typo in PHP memcached extension array

### DIFF
--- a/guides/v2.0/config-guide/memcache/memcache_magento.md
+++ b/guides/v2.0/config-guide/memcache/memcache_magento.md
@@ -34,7 +34,7 @@ To configure Magento to use memcache:
 
             'session' =>
                array (
-                  'save' => 'memcached’,
+                  'save' => 'memcached',
                   'save_path' => '<memcache ip or host>:<memcache port>'
             ),
             


### PR DESCRIPTION
Then:
 'save' => 'memcached`,

Now:
 'save' => 'memcached',