### PR TITLE
Prevent bullets from showing up in ordered lists

### DIFF
--- a/common/css/stylesheet.css
+++ b/common/css/stylesheet.css
@@ -165,7 +165,7 @@ ul.level3 li, ul li.level3, ol li ol li ul.level3 li
 	padding-left: 16px;
 	margin-bottom:6px;
 }
-ol li, ul ol li { list-style: decimal outside none; }
+ol li, ul ol li { list-style: decimal outside none; background-image:none; }
 ol li { margin-bottom:8px; }
 li p { margin:2px 0 8px; font-size:14px; }
 


### PR DESCRIPTION
Before:
<img width="525" alt="screenshot 2016-05-07 07 55 42" src="https://cloud.githubusercontent.com/assets/2094614/15091982/cfb29f86-1429-11e6-81e0-b54947cd2295.png">

After:
<img width="542" alt="screenshot 2016-05-07 08 02 52" src="https://cloud.githubusercontent.com/assets/2094614/15091992/204d1656-142a-11e6-8ef0-cc08479cf392.png">
