### PR TITLE
Update system-requirements.md

### DIFF
--- a/guides/v2.0/install-gde/system-requirements.md
+++ b/guides/v2.0/install-gde/system-requirements.md
@@ -31,7 +31,7 @@ MySQL 5.6 (Oracle or Percona)
 
 *	5.6.x
 *	5.5.x, where x is 22 or greater
-*	7.0.2&ndash;7.0.6 except for 2.0.5 (supported by Magento version 2.0.1 and later only)
+*	7.0.2&ndash;7.0.6 except for 7.0.5 (supported by Magento version 2.0.1 and later only)
 
 	There is a [known PHP issue](https://bugs.php.net/bug.php?id=71914){:target="_blank"} that affects our [code compiler]({{ site.gdeurl }}config-guide/cli/config-cli-subcommands-compiler.html) when using PHP 7.0.5. We recommend you *not* use PHP 7.0.5; instead, use PHP 7.0.2&ndash;7.0.4 or 7.0.6.
 


### PR DESCRIPTION
Looks like there was a typo for a Php version number, which could get confusing as there is a Magento version number of 2.0.5. If I'm wrong about this assumption, could that line be rewritten so that it's easier to understand?

Thanks