### PR TITLE
Update php-centos.md

### DIFF
--- a/guides/v2.0/install-gde/prereq/php-centos.md
+++ b/guides/v2.0/install-gde/prereq/php-centos.md
@@ -33,7 +33,8 @@ redirect_from: /guides/v1.0/install-gde/prereq/php-centos.html
 
 Magento requires:
 
-*	PHP 7.0.2 (supported by Magento version 2.0.1 and later only)
+*	7.0.2–7.0.6 except for 7.0.5 (supported by Magento version 2.0.1 and later only)
+	There is a known PHP issue that affects our code compiler when using PHP 7.0.5. We recommend you not use PHP 7.0.5; instead, use PHP 7.0.2–7.0.4 or 7.0.6.
 *	PHP 5.6.x
 *	PHP 5.5.x, where x is 22 or greater 
 


### PR DESCRIPTION
This page should reflect the comments about Php version which are listed here: http://devdocs.magento.com/guides/v2.0/install-gde/system-requirements.html . I have a PR open to possibly clear up some confusion on that page as well: https://github.com/magento/devdocs/pull/664 . If PR 664 is merged, then my edit above to 7.0.5 is accurate...if it's not, then whatever the outcome of that section of System requirements is, should be reflected here as well.