### PR TITLE
Fixed name of configuration-parameter for database

### DIFF
--- a/guides/v2.0/config-guide/redis/redis-session.md
+++ b/guides/v2.0/config-guide/redis/redis-session.md
@@ -34,7 +34,7 @@ Following is a sample configuration to add to `<your Magento install dir>app/etc
 		'password' => '',
 		'timeout' => '2.5',
 		'persistent_identifier' => '',
-		'db' => '0',
+		'database' => '0',
 		'compression_threshold' => '2048',
 		'compression_library' => 'gzip',
 		'log_level' => '1',


### PR DESCRIPTION
The originally parameter 'db' is completely ignored, but this is only apparent if the value of the parameter is changed to anything other than '0' (0 is the Redis-internal default-value).
The proper parameter is 'database' which is also used in the table below.