### PR TITLE
Update zip_install.md

### DIFF
--- a/guides/v2.0/install-gde/prereq/zip_install.md
+++ b/guides/v2.0/install-gde/prereq/zip_install.md
@@ -73,7 +73,7 @@ To transfer the Magento software archive to your server:
 
 	For example,
 
-		cp /var/www/Magento-CE-2.0.0-rc2+Samples.tar.bz2 magento2
+		cp /var/www/Magento-CE-2.0.0+Samples.tar.bz2 magento2
 
 8.	Continue with the next section.
 


### PR DESCRIPTION
Removed reference to release candidate 1, due to the fact that the project is well past that...I can see keeping an example at 2.0.0 as it would probably be too cumbersome to continually search out each portion of the documents that reference an out of date version number....that said, I feel that having an example at least with 2.0.0 is more appropriate than 2.0.0-rc1, especially if the project most likely won't have another version with that kind of naming format.