### PR TITLE
Added changes for the Memcache Documentation

### DIFF
--- a/guides/v2.0/config-guide/memcache/memcache_centos.md
+++ b/guides/v2.0/config-guide/memcache/memcache_centos.md
@@ -111,11 +111,13 @@ Create `cache-test.php` in your web server's docroot:
 
 {% highlight PHP %}
 <?php
-$meminstance = new Memcache();
-$meminstance->pconnect('<memcache host name or ip>', <memcache port>);
+if (class_exists('Memcache')) {
+    $meminstance = new Memcache();
+} else {
+    $meminstance = new Memcached();
+}
 
-mysql_connect("localhost", "memcache_test", "memcache_test") or die(mysql_error());
-mysql_select_db("memcache_test") or die(mysql_error());
+$meminstance->addServer('<memcache host name or ip>', <memcache port>);
 
 $query = "select id from example where name = 'new_data'";
 $querykey = "KEY" . md5($query);
@@ -123,14 +125,19 @@ $querykey = "KEY" . md5($query);
 $result = $meminstance->get($querykey);
 
 if (!$result) {
-   $result = mysql_fetch_array(mysql_query("select id from example where name = 'new_data'")) or die('mysql error');
-   $meminstance->set($querykey, $result, 0, 600);
-   print "got result from mysql\n";
-   return 0;
+   try {
+        $dbh = new PDO('mysql:host=localhost;dbname=memcache_test','memcache_test','memcache_test');
+        $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $result = $dbh->query("select id from example where name = 'new_data'")->fetch();
+        $meminstance->set($querykey, $result, 0, 600);
+        print "got result from mysql\n";
+        return 0;
+    } catch (PDOException $e) {
+        die($e->getMessage());
+    }
 }
 print "got result from memcached\n";
 return 0;
-
 ?>
 {% endhighlight %}
 

--- a/guides/v2.0/config-guide/memcache/memcache_ubuntu.md
+++ b/guides/v2.0/config-guide/memcache/memcache_ubuntu.md
@@ -84,7 +84,12 @@ Create `cache-test.php` in the web server's docroot with the following contents:
 
 {% highlight php %}
 <?php
-$mem = new Memcache();
+if (class_exists('Memcache')) {
+    $meminstance = new Memcache();
+} else {
+    $meminstance = new Memcached();
+}
+
 $mem->addServer("<memcache host name or ip>", <memcache port>);
 
 $result = $mem->get("test");


### PR DESCRIPTION
Hi,

I have added a couple of changes to the memcache test script for Centos and Ubuntu to handle the `Memcache` v/s `Memcached` class error, also change mysql function to PDO for PHP7 environment testing compatibility.

  