### PR TITLE
Replaced \Zend\Soap with native \SoapClient

### DIFF
--- a/guides/v2.0/get-started/soap/soap-web-api-calls.md
+++ b/guides/v2.0/get-started/soap/soap-web-api-calls.md
@@ -105,12 +105,9 @@ $opts = array(
         );
 $wsdlUrl = 'http://magento.ll/soap/default?wsdl=1&services=testModule1AllSoapAndRestV1';
 $serviceArgs = array("id"=>1);
- 
-$soapClient = new Zend\Soap\Client($wsdlUrl);
-$soapClient->setSoapVersion(SOAP_1_2);
- 
+
 $context = stream_context_create($opts);
-$soapClient->setStreamContext($context);
+$soapClient = new SoapClient($wsdlUrl, ['version' => SOAP_1_2, 'context' => $context]);
  
 $soapResponse = $soapClient->testModule1AllSoapAndRestV1Item($serviceArgs); ?>
 {% endhighlight %}


### PR DESCRIPTION
It's more general to use the standard `SoapClient` class of php. It's not needed to use the `\Zend\Soap` component.
The example should show us that it's easy to call the Magento 2 SOAP Service without any special components.