### PR TITLE
Update Deploy Mode to Developer, in How Do I Docs

### DIFF
--- a/guides/v2.0/howdoi/checkout/checkout_edit_form.md
+++ b/guides/v2.0/howdoi/checkout/checkout_edit_form.md
@@ -30,7 +30,7 @@ There are more details about each step in the following sections.
 
 ## Prerequisites 
 
-[Set Magento to the production mode]({{site.gdeurl}}config-guide/cli/config-cli-subcommands-mode.html) while you perform all customizations and debugging. 
+[Set Magento to the developer mode]({{site.gdeurl}}config-guide/cli/config-cli-subcommands-mode.html) while you perform all customizations and debugging. 
 
 For the sake of compatibility, upgradability, and easy maintenance, do not edit the default Magento code. Instead, add your customizations in a separate module. For your checkout customization to be applied correctly, your custom module should [depend]({{site.gdeurl}}extension-dev-guide/build/composer-integration.html) on the Magento_Checkout module.
 


### PR DESCRIPTION
The mode should be set to developer, not production, when doing development work.