### PR TITLE
Fixed url to UI Componets guide page

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ redirect_from: /guides/v2.1/index.html
       <p>How to contribute to the Magento 2 codebase and to Magento 2 documentation.</p>
       <h3><a href="{{ site.gdeurl21 }}frontend-dev-guide/bk-frontend-dev-guide.html">Frontend Developer Guide</a></h3>
       <p>Customize your storefront.</p>
-      <h3><a href="{{ site.gdeurl21 }}ui-library/ui-library-component.html">UI Components</a></h3>
+      <h3><a href="{{ site.gdeurl21 }}ui-components/ui-component.html">UI Components</a></h3>
       <p>How to use grids, forms, and other elements of the Magento UI Components.</p>
       <h3><a href="{{ site.gdeurl21 }}javascript-dev-guide/bk-javascript-dev-guide.html">JavaScript Developer Guide</a></h3>
       <p>Everything you need to know about Magento and JavaScript.</p>


### PR DESCRIPTION
We get 404 trying to open UI Components guide page - http://devdocs.magento.com/guides/v2.1/ui-library/ui-library-component.html\