### PR TITLE
Use urn instead of path to file for mq documentation

### DIFF
--- a/guides/v2.0/config-guide/mq/config-mq.md
+++ b/guides/v2.0/config-guide/mq/config-mq.md
@@ -137,7 +137,7 @@ The `bind` elements link topics to queues and exchanges, defining the message qu
 
 <h2>Sample `queue.xml` file</h2>
 {% highlight xml %}
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../lib/internal/Magento/Framework/Amqp/etc/queue.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/queue.xsd">
     <publisher name="test-publisher-1" connection="rabbitmq" exchange="magento"/>
     <publisher name="test-publisher-2" connection="db" exchange="magento"/>
     <topic name="customer.created" schema="Magento\Customer\Api\Data\CustomerInterface" publisher="test-publisher-1"/>


### PR DESCRIPTION
In the 2.1 and 2.2 docs this is already done.