### PR TITLE
Add Github link for "improved the deployment of static assets" to 2.1.1 release notes

### DIFF
--- a/guides/v2.1/release-notes/ReleaseNotes2.1.1CE.md
+++ b/guides/v2.1/release-notes/ReleaseNotes2.1.1CE.md
@@ -68,7 +68,7 @@ We address the following functional issues in this release.
 <!--- 57410-->* You can now quickly generate or preview multiple variations of a configurable product. (Saving these variations to the database can be time-consuming, if you have several thousand product options, and our efforts to improve performance continue.) Previously, Magento threw an Invalid Form key error is thrown while you tried to save a configurable product with variations. 
 
 
-<!--- 52660 -->* We've improved the deployment of static assets. 
+<!--- 52660 -->* We've improved the deployment of static assets. <a href="https://github.com/magento/magento2/pull/4294" target="_blank">(GITHUB-4294)</a>
 
 <!--- 55300, 55620, 54682-->* We've improved storefront performance when creating 2500 or more product variants. 
 


### PR DESCRIPTION
Adding the link will have two benefits:
- Provide more information to developers wanting to know what improvements were made. None of the developers at Classy Llama were aware what the ambiguous "We've improved the deployment of static assets." message meant and only discovered the changes once I stumbled upon the feature.
- Provide attribution to the contributor who created the PR. Thanks @denisristic !