### PR TITLE
Added missing closing li tag.

### DIFF
--- a/guides/v2.0/frontend-dev-guide/css-guide/css_quick_guide_mode.md
+++ b/guides/v2.0/frontend-dev-guide/css-guide/css_quick_guide_mode.md
@@ -10,12 +10,12 @@ github_link: frontend-dev-guide/css-guide/css_quick_guide_mode.md
 ---
 <h2> What's in this topic </h2>
 
-After you <a href="{{page.baseurl}}frontend-dev-guide/themes/theme-create.html" target="_blank">create a theme</a>, before starting to change the styles, is deciding, which LESS compilation mode you will use. There are <a href="{{page.baseurl}}frontend-dev-guide/css-topics/css-preprocess.html#LESS compilation modes" target="_blank">two modes available in Magento</a>: server-side compilation mode and client-side (recommended for theme development). 
+After you <a href="{{page.baseurl}}frontend-dev-guide/themes/theme-create.html" target="_blank">create a theme</a>, before starting to change the styles, is deciding, which LESS compilation mode you will use. There are <a href="{{page.baseurl}}frontend-dev-guide/css-topics/css-preprocess.html#LESS compilation modes" target="_blank">two modes available in Magento</a>: server-side compilation mode and client-side (recommended for theme development).
 This topic demonstrates on a practical example how the choice of the mode influences the styles development.
 
 The first step, creating and applying a theme is done before the compilation mode is chosen, so it is described only once, but is required whatever compilation mode you will further use.
 
-In the examples in this topic the <a href="{{page.baseurl}}frontend-dev-guide/css-guide/css_quick_guide_approach.html#simple_extend">simplest approach for customizing theme styles</a> is used: changes are done in the `_extend.less` of the new theme. 
+In the examples in this topic the <a href="{{page.baseurl}}frontend-dev-guide/css-guide/css_quick_guide_approach.html#simple_extend">simplest approach for customizing theme styles</a> is used: changes are done in the `_extend.less` of the new theme.
 
 In our examples we will change the color and font of the primary buttons. The default view of the primary buttons can be illustrated by the **Create an Account** button view on the Customer login page:
 
@@ -32,7 +32,7 @@ In our examples we will change the color and font of the primary buttons. The de
 1. Create a new theme as described in the <a href="{{page.baseurl}}frontend-dev-guide/themes/theme-create.html" target="_blank">Create a theme</a> topic. In your `theme.xml` specify Magento Luma or Magento Blank as a parent theme.
 2. <a href="{{page.baseurl}}frontend-dev-guide/themes/theme-apply.html#theme-apply-apply">Apply your theme</a> in the Magento Admin.
 
-Server-side is the default mode for LESS compilation, so if you do not change this, your Magento instance is using server-side compilation mode. 
+Server-side is the default mode for LESS compilation, so if you do not change this, your Magento instance is using server-side compilation mode.
 
 <h2 id="server-side">Making simple style changes in server-side compilation mode</h2>
 
@@ -43,6 +43,7 @@ The following is an illustration of how the process of making simple changes loo
 <li>Change the color of the buttons by adding the following code in <code>_extend.less</code>:
 
 <img src="{{ site.baseurl }}common/images/extend_less_code_1.png" alt="Less code redefining the color of the primary buttons">
+</li>
 <li>Delete all files in the following directories:
 <ul>
 <li><code>pub/static/frontend/&lt;Your_Vendor&gt;/&lt;your_theme&gt;</code></li>
@@ -63,7 +64,7 @@ The following is an illustration of how the process of making simple changes loo
 <li><code>var/view_preprocessed/less</code> </li>
 </ul>
 </li>
-<li>Refresh the page, and view the changes applied. 
+<li>Refresh the page, and view the changes applied.
 
 <img src="{{ site.baseurl }}common/images/extend_less_screenshot2.png" alt="Admin login page where the font of the buttons was changed">
 </li>


### PR DESCRIPTION
This should hopefully fix the `</ol>` tag which shows up:
![screen shot 2016-09-12 at 23 27 26](https://cloud.githubusercontent.com/assets/85479/18453671/b14133f6-7940-11e6-864e-6ac2c13efd1a.png)
