### PR TITLE
Wrong link duplication

### DIFF
--- a/guides/v2.0/cloud/access-acct/first-time-setup_template.md
+++ b/guides/v2.0/cloud/access-acct/first-time-setup_template.md
@@ -45,6 +45,6 @@ To set up a Magento project using a template:
 	
 #### Next steps
 *	[Set up an environment]({{ page.baseurl }}cloud/access-acct/set-up-env.html)
-*	[Set Magento Admin environment variables]({{ page.baseurl }}cloud/access-acct/set-up-env.html)
+*	[Set Magento Admin environment variables]({{ page.baseurl }}cloud/access-acct/admin-env-vars.html)
 
 


### PR DESCRIPTION
"Set Magento Admin" environment variables has the same link as "Set up an environment", i provided the correct one