### PR TITLE
Change the ID to be unique from other IDs

### DIFF
--- a/guides/v2.0/extension-dev-guide/service-contracts/design-patterns.md
+++ b/guides/v2.0/extension-dev-guide/service-contracts/design-patterns.md
@@ -33,7 +33,7 @@ redirect_from: /guides/v1.0/extension-dev-guide/service-contracts/design-pattern
 <p>Define data interfaces in the <b>Api/Data</b> subdirectory for a module.</p>
 <p>For example, the data interfaces for the Customer module are in the <b>/app/code/Magento/Customer/Api/Data</b> subdirectory.</p>
 
-<h3 id="search-results">Data search results interfaces</h3>
+<h3 id="search-results-interfaces">Data search results interfaces</h3>
 <p>When you pass search criteria to a <code>getList()</code> call, a search results interface is returned with the search results.</p>
 <p>You must define one interface for each data entity for type hinting purposes. That is, the <code>getItems()</code> function in the
    <code>CustomerSearchResultsInterface</code> returns an array of <code>CustomerInterface</code> data entities.


### PR DESCRIPTION
The `#search-results` ID is already used elsewhere and the id had a style which applied a min-height of 400px causing the rest of the content to shove down below the page.