### PR TITLE
Fix broken link

### DIFF
--- a/guides/v2.0/ui-components/ui_components_js.md
+++ b/guides/v2.0/ui-components/ui_components_js.md
@@ -10,7 +10,7 @@ github_link: ui-components/ui_components_js.md
 ---
 
 ## What's in this topic
-This topic is aimed for developers, who need to reuse the [Magento UI Components]({{page.baseurl}}ui-library/ui-library-component.html). 
+This topic is aimed for developers, who need to reuse the [Magento UI Components]({{page.baseurl}}ui_comp_guide/bk-ui_comps.html). 
 
 The topic covers the following:
 


### PR DESCRIPTION
This PR should fix a broken link.

---

I ended up [on this page](http://devdocs.magento.com/guides/v2.1/ui-components/ui_components_js.html) which had a lot of documentation that I hadn't found before. In looking through the site, I'm having trouble finding out where they are. Are they semi-not-public (yet) or am I missing some navigation?
