### PR TITLE
Fixed typo in PHP Version requirements

### DIFF
--- a/guides/v2.0/install-gde/system-requirements.md
+++ b/guides/v2.0/install-gde/system-requirements.md
@@ -37,7 +37,7 @@ MariaDB and Percona are compatible with Magento because we support MySQL 5.6 API
 
 *	5.6.x
 *	5.5.x, where x is 22 or greater
-*	7.0.2 up to 7.0.10, except for 7.0.5
+*	7.0.2 up to 7.0.11, except for 7.0.5
 
 	There is a [known PHP 7.0.5 issue](https://bugs.php.net/bug.php?id=71914){:target="_blank"} that affects our [code compiler]({{page.baseurl}}config-guide/cli/config-cli-subcommands-compiler.html); to avoid the issue, do not use PHP 7.0.5. 
 

--- a/guides/v2.0/install-gde/system-requirements.md
+++ b/guides/v2.0/install-gde/system-requirements.md
@@ -37,7 +37,7 @@ MariaDB and Percona are compatible with Magento because we support MySQL 5.6 API
 
 *	5.6.x
 *	5.5.x, where x is 22 or greater
-*	7.0.2 up to 7.1.0, except for 7.0.5
+*	7.0.2 up to 7.0.10, except for 7.0.5
 
 	There is a [known PHP 7.0.5 issue](https://bugs.php.net/bug.php?id=71914){:target="_blank"} that affects our [code compiler]({{page.baseurl}}config-guide/cli/config-cli-subcommands-compiler.html); to avoid the issue, do not use PHP 7.0.5. 
 


### PR DESCRIPTION
I think the install guide has a typo in which PHP 7.1.0 and PHP 7.0.10 were confused by the previous author. Officially, PHP 7.1.0 is not supported yet, at least not when doing a composer install without --ignore-platform-reqs.