### PR TITLE
Update system-requirements.md

### DIFF
--- a/guides/v2.0/install-gde/system-requirements.md
+++ b/guides/v2.0/install-gde/system-requirements.md
@@ -37,7 +37,7 @@ MariaDB and Percona are compatible with Magento because we support MySQL 5.6 API
 
 *	5.6.x
 *	5.5.x, where x is 22 or greater
-*	7.0.2 up to 7.1.0, except for 7.0.5
+*	7.0.2 up to 7.0.11, except for 7.0.5
 
 	There is a [known PHP 7.0.5 issue](https://bugs.php.net/bug.php?id=71914){:target="_blank"} that affects our [code compiler]({{page.baseurl}}config-guide/cli/config-cli-subcommands-compiler.html); to avoid the issue, do not use PHP 7.0.5. 
 


### PR DESCRIPTION
The current installation rejects php7.1 (currently php7.1rc3), unless there's some special flag(s)/option(s) that need to be set that I'm not aware of.

This is what I get when installing with php7.1rc3:
```Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for magento/product-community-edition 2.1.1 -> satisfiable by magento/product-community-edition[2.1.1].
    - magento/product-community-edition 2.1.1 requires php ~5.6.0|7.0.2|~7.0.6 -> your PHP version (7.1.0RC3) does not satisfy that requirement.
```
I also tested it out with php7.0.11 and it worked just fine.