### PR TITLE
Fix minor formatting problems on DataSource tpic

### DIFF
--- a/guides/v2.1/ui_comp_guide/concepts/ui_comp_data_source.md
+++ b/guides/v2.1/ui_comp_guide/concepts/ui_comp_data_source.md
@@ -88,6 +88,7 @@ But, XML is static and while that gets us the name of the data provider componen
 Every Javascript component should extend the core Element class in some way (mapped to [`uiElement`]({{page.baseurl}}ui_comp_guide/concepts/ui_comp_uielement_concept.html) with RequireJS and located in `Magento/Ui/view/base/web/js/lib/core/element/element.js`.  When this class initializes it runs an `initLinks()` method. That method, in turn, passes a few class properties into a method that handles linking components together. This file (`lib/core/element/link.js`) binds the values of those parameters to actual components. 
 
 The properties Magento will parse are: 
+
 - `imports`
 - `exports`
 -  `links`
@@ -100,7 +101,7 @@ imports: {
 }
 ```
 
-When the Element class initializes, it will process the link that was declared in `imports`. Remember that one of the first things Magento does is process string literals, though, so it is actually working with something that looks more like the following (where `example` is the Component Name for clarity):
+When the Element class initializes, it will process the link that was declared in `imports`. Remember that one of the first things Magento does is process string literals, though, so it is actually working with something that looks more like the following (where `example` is the UI Component Name for clarity):
 
 ```
 imports: {
@@ -110,4 +111,4 @@ imports: {
 
 The `:` is a special separator that is used to divide the component name that it is to link to and the values it should access in the returned value. No `:` is necessary, though, and the expression, `$.provider` could be any key that was passed into the javascript configuration. 
 
-In the example above, it will return the `totalRecords` property of the `data` object in the `example.example_data_source` component. As a result of these connections, `{{totalRecords}}` will display the output of `DataProvider::getData()`.
+In the example above, it will return the `totalRecords` property of the `data` object in the `example.example_data_source` component. As a result of these connections, `totalRecords` will display the output of `DataProvider::getData()`.


### PR DESCRIPTION
Jekyll was not displaying `{{totalRecords}}` on the site and there was no line break before an unordered list. This should fix those problems.