### PR TITLE
Supported browsers list update

### DIFF
--- a/_includes/browsers/supported-browsers.md
+++ b/_includes/browsers/supported-browsers.md
@@ -1,13 +1,8 @@
 <div markdown="1">
 
-Internet Explorer and Microsoft Edge (Windows)
+Browsers support (both storefront and admin area)
 
-*	Storefront: Internet Explorer 9 or later
-*	Magento Admin: Internet Explorer 11 or later, Microsoft Edge, latest&ndash;1
-
-All other browsers (both storefront and Admin)
-
-*	Magento Admin: Internet Explorer 11 or later, Microsoft Edge, latest&ndash;1
+*	Internet Explorer 11 or later, Microsoft Edge, latest&ndash;1
 *	Firefox latest, latest&ndash;1 (any operating system)
 *	Chrome latest, latest&ndash;1 (any operating system)
 *	Safari latest, latest&ndash;1 (Mac OS)

--- a/_includes/browsers/supported-browsers.md
+++ b/_includes/browsers/supported-browsers.md
@@ -1,6 +1,6 @@
 <div markdown="1">
 
-Browsers support (both storefront and admin area)
+Both storefront and admin area
 
 *	Internet Explorer 11 or later, Microsoft Edge, latest&ndash;1
 *	Firefox latest, latest&ndash;1 (any operating system)


### PR DESCRIPTION
Due to lack of support for IE9 by storefront themes, documentation should inform users about that.
Lack of IE9 support description -> https://github.com/magento/magento2/issues/5126

EOL of IE9 was at February 2016 (same as IE10), so investing time in supporting dead browsers are not so good idea for all of us (Magento team, our teams and clients).
