### PR TITLE
Incorrect param 'Store'

### DIFF
--- a/guides/m1x/api/soap/checkout/cartShipping/cart_shipping.method.html
+++ b/guides/m1x/api/soap/checkout/cartShipping/cart_shipping.method.html
@@ -45,7 +45,7 @@ title: Shipping Method
 </tr>
 <tr>
 <td> string </td>
-<td> store </td>
+<td> storeId </td>
 <td> Store view ID or code (optional) </td>
 </tr>
 </tbody></table>


### PR DESCRIPTION
Further to previous pull request - it looks as if the API will accept either 'store' or 'storeId' as the param name. However the definition states 'storeId' and thus any system that parses the WSDL will show 'storeId' as the correct param name.
Some SOAP implementations will error out if an incorrect param name is used, regardless of whether the API itself will accept it. Therefore I submit that the param names should always match those in the WSDL.
