### PR TITLE
Case sensitivity

### DIFF
--- a/guides/m1x/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html
+++ b/guides/m1x/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html
@@ -59,7 +59,7 @@ title: Media List
 <tr>
 <td> string </td>
 <td> identifierType </td>
-<td> Defines whether the product ID or SKU is passed in the 'product' parameter </td>
+<td> Defines whether the product ID or sku is passed in the 'product' parameter </td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
I have discovered that the identifier type in this context is case sensitive and will only work with a lower case value of 'sku', rather than 'SKU'.
Other API methods that use an 'identifierType' param do not have this issue and will work with 'SKU' in upper case, so I feel this is a bug. I cannot however, find a Github repo for Magento and I'm not sure where I would post an issue.
Ideally, this should be fixed in the API but failing that I think it important to be noted in the documentation.