### PR TITLE
Change escapeXssInUrl to escapeUrl

### DIFF
--- a/guides/v2.0/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.0/frontend-dev-guide/templates/template-security.md
@@ -65,10 +65,10 @@ For the following output cases, use the specified function to generate XSS-safe 
 {% endhighlight %}
 
 **Case:** URL output\\
-**Function:** `escapeXssInUrl`
+**Function:** `escapeUrl`
 
 {% highlight html %}
-  <a href="<?php echo $block->escapeXssInUrl($block->getCategoryUrl()) ?>">Some Link</a>
+  <a href="<?php echo $block->escapeUrl($block->getCategoryUrl()) ?>">Some Link</a>
 {% endhighlight %}
 
 **Case:** HTML attributes\\


### PR DESCRIPTION
escapeXssInUrl is not called from any blocks in the Magento 2 Core, esacpeUrl is. escapeUrl calls escapeXssInUrl internally, see https://github.com/magento/magento2/blob/1ade3b769a937f19682bbbe4e51b6c956147952f/lib/internal/Magento/Framework/Escaper.php#L206