### PR TITLE
Remove extra comma in example composer.json

### DIFF
--- a/guides/v2.0/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.0/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -56,7 +56,7 @@ For more information see: [`composer.json`]({{page.baseurl}}extension-dev-guide/
         "AFL-3.0"
       ],
       "require": {
-        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6",
+        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6"
       },
       "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
module:enable fails in tutorial if composer.json is copy/pasted as is.