### PR TITLE
Add Centos 7 config file location

### DIFF
--- a/guides/v2.0/config-guide/varnish/tshoot-varnish-503.md
+++ b/guides/v2.0/config-guide/varnish/tshoot-varnish-503.md
@@ -20,7 +20,8 @@ To resolve this issue, increase the default value of `http_resp_hdr_len` in your
 
 1.	As a user with `root` privileges, open your Vanish configuration file in a text editor:
 
-	*	CentOS: `/etc/sysconfig/varnish`
+	*	CentOS 6: `/etc/sysconfig/varnish`
+	*	CentOS 7: `/etc/varnish/varnish.params`
 	*	Ubuntu: `/etc/default/varnish`
 
 2.	Search for the `http_resp_hdr_len` parameter.


### PR DESCRIPTION
In Centos 7, the varnish configuration file is in /etc/varnish/varnish.params rather than /etc/sysconfig/varnish