### PR TITLE
Updates the Magento 2.1.3 release notes with a link to issue 5101, which was missing.

### DIFF
--- a/guides/v2.1/release-notes/ReleaseNotes2.1.3CE.md
+++ b/guides/v2.1/release-notes/ReleaseNotes2.1.3CE.md
@@ -131,7 +131,7 @@ We've enhanced the performance of configurable products in several ways:
 ### Email
 {:.no_toc}
 
-<!---57496-->* Magento now successfully loads the New Order Email templates. 
+<!---57496-->* Magento now successfully loads the New Order Email templates. <a href="https://github.com/magento/magento2/issues/5101" target="_blank">(GITHUB-5101)</a>
 
 <!---57204 -->* The **Send Welcome Email From** field now identifies the store that the customer is associated with. 
 

--- a/guides/v2.1/release-notes/ReleaseNotes2.1.3EE.md
+++ b/guides/v2.1/release-notes/ReleaseNotes2.1.3EE.md
@@ -128,7 +128,7 @@ We've enhanced the performance of configurable products in several ways:
 ### Email
 {:.no_toc}
 
-<!---57496-->* Magento now successfully loads the New Order Email templates. 
+<!---57496-->* Magento now successfully loads the New Order Email templates. <a href="https://github.com/magento/magento2/issues/5101" target="_blank">(GITHUB-5101)</a>
 
 <!---57204 -->* The **Send Welcome Email From** field now identifies the store that the customer is associated with. 
 


### PR DESCRIPTION
I'm not sure if that number in front is your internal MAGETWO number, but that might be incorrect.
It should probably be 57026 or 54786, mentioned in this PR: https://github.com/magento/magento2/pull/5116#issuecomment-252547488
If you want me to fix that number too, let me know, or you can change it yourself, your choice :)