### PR TITLE
Invalid param and align logo mobile / tablet

### DIFF
--- a/scss/partials/_site-header.scss
+++ b/scss/partials/_site-header.scss
@@ -111,7 +111,7 @@
     }
 
     .logo {
-      width: a;
+      margin-top:10px;
     }
 
     .search-btn {


### PR DESCRIPTION
Invalid param is **width:a** and the vertical align is below:

**Before**
![image](https://cloud.githubusercontent.com/assets/610598/21315077/9210906a-c5e1-11e6-860d-5f4acc981724.png)

**After**
![image](https://cloud.githubusercontent.com/assets/610598/21315095/a7c9aaae-c5e1-11e6-9ef8-fed03f10c0bf.png)

