### PR TITLE
Fixed incorrect callable type hints.

### DIFF
--- a/guides/v2.0/extension-dev-guide/plugins.md
+++ b/guides/v2.0/extension-dev-guide/plugins.md
@@ -116,7 +116,7 @@ namespace My\Module\Plugin;
 
 class ProductPlugin
 {
-    public function aroundSave(\Magento\Catalog\Model\Product $subject, \callable $proceed)
+    public function aroundSave(\Magento\Catalog\Model\Product $subject, callable $proceed)
     {
         $this->doSmthBeforeProductIsSaved();
         $returnValue = $proceed();
@@ -156,7 +156,7 @@ namespace My\Module\Plugin;
 
 class MyUtilityPlugin
 {
-    public function aroundSave(\My\Module\Model\MyUtility $subject, \callable $proceed, SomeType $obj)
+    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, SomeType $obj)
     {
       //do something
     }
@@ -174,7 +174,7 @@ namespace My\Module\Plugin;
 
 class MyUtilityPlugin
 {
-    public function aroundSave(\My\Module\Model\MyUtility $subject, \callable $proceed, ...$args)
+    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, ...$args)
     {
       //do something
       $proceed(...$args);

--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -177,7 +177,7 @@ namespace My\Module\Plugin;
 
 class ProductPlugin
 {
-    public function aroundSave(\Magento\Catalog\Model\Product $subject, \callable $proceed)
+    public function aroundSave(\Magento\Catalog\Model\Product $subject, callable $proceed)
     {
         $this->doSmthBeforeProductIsSaved();
         $returnValue = $proceed();
@@ -217,7 +217,7 @@ namespace My\Module\Plugin;
 
 class MyUtilityPlugin
 {
-    public function aroundSave(\My\Module\Model\MyUtility $subject, \callable $proceed, SomeType $obj)
+    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, SomeType $obj)
     {
       //do something
     }
@@ -235,7 +235,7 @@ namespace My\Module\Plugin;
 
 class MyUtilityPlugin
 {
-    public function aroundSave(\My\Module\Model\MyUtility $subject, \callable $proceed, ...$args)
+    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, ...$args)
     {
       //do something
       $proceed(...$args);


### PR DESCRIPTION
The `callable` type hint shouldn't have a `\` prefix, otherwise you get errors like:
```
PHP Parse error:  syntax error, unexpected 'callable' (T_CALLABLE), expecting identifier (T_STRING)
```