### PR TITLE
Update to Doc Block standard

### DIFF
--- a/guides/v2.0/coding-standards/docblock-standard-general.md
+++ b/guides/v2.0/coding-standards/docblock-standard-general.md
@@ -284,22 +284,6 @@ Functions and methods must have:
   If there is no such operator, the `@return` tag must have `void` as the return value.
 * Declaration of possibly thrown exception using `@throws` tag, if the actual body of function triggers throwing an exception.
   All occurrences of `@throws` in a DocBlock must be after `@param` and `@return` (if any).
-* Motivation behind @deprecated annotation. For example:
-
-{% highlight php startinline=true %}
-/**
- * Get some object
- *
- * @deprecated Added to not break backward compatibility of the constructor signature 
- *             by injecting the new dependency directly. 
- *             The method can be removed in a future major release, when constructor signature can be changed
- * @return SomeObjectInterface
- */
-protected function getSomeObject()
-{
-    ...
-}
-{% endhighlight %}
 
 Exceptions:
 * Constructors may not have short and/or long description
@@ -604,12 +588,48 @@ A deprecated class or method is one that has been superseded and may cease to ex
  It will be retained to provide backward compatibility until next major component release.
 
 Use the `@deprecated` tag to indicate an element is to be deprecated.
-The text of the `@deprecated` tag should indicate the version the element was deprecated as well as the version it will be removed.
-If applicable, also specify what has replaced the deprecated element.
 
-To maintain backward compatibility, an element should be removed only on major revisions.
+Motivation behind the added `@deprecated` tag MUST be explained.
+`@see` tag MUST be used with reference to new implementation when code is deprecated and there is a new alternative.
 
-Use the `@see` tag to refer to the new implementation when code is deprecated.
+For example:
+
+{% highlight php startinline=true %}
+/**
+ * Get some object
+ *
+ * @deprecated Added to not break backward compatibility of the constructor signature 
+ *             by injecting the new dependency directly. 
+ *             The method can be removed in a future major release, when constructor signature can be changed
+ * @return SomeObjectInterface
+ */
+protected function getSomeObject()
+{
+    ...
+}
+
+/**
+ * Set price
+ *
+ * @deprecated Non-scoped price is not supported anymore
+ * @see setScopedPrice()
+ * @return void
+ */
+public function setPrice($price)
+{
+    ...
+}
+ 
+/**
+ * Set price for specified scope
+ *
+ * @return void
+ */
+public function setScopedPrice($price, $scopeType, $scopeId)
+{
+    ...
+}
+{% endhighlight %}
 
 ### @var inline tag
 {:#var}

--- a/guides/v2.0/coding-standards/docblock-standard-general.md
+++ b/guides/v2.0/coding-standards/docblock-standard-general.md
@@ -273,12 +273,37 @@ class Profiler
 Functions and methods must have:
 
 * Short description
+* Long description that explains the motivation behind the implementation in such cases as:
+   * a workaround/hack is implemented. Explain why it is necessary and include any other details necessary to understand the algorithm
+   * non-obvious implementation: the implementation does not correspond to Technical Vision or other known best practices, it has complicated logic. If you were asked questions from at least one another developer about the implementation, there is something non-obvious in it, so include the explanation in the doc block's description
 * Declaration of all arguments (if any) using `@param` tag.
   Appropriate argument type must be specified.
 * Declaration of return type using `@return` tag.
   If there is no such operator, the `@return` tag must have `void` as the return value.
 * Declaration of possibly thrown exception using `@throws` tag, if the actual body of function triggers throwing an exception.
   All occurrences of `@throws` in a DocBlock must be after `@param` and `@return` (if any).
+* Motivation behind @deprecated annotation. For example:
+
+{% highlight php startinline=true %}
+/**
+ * Get some object
+ *
+ * @deprecated Added to not break backward compatibility of the constructor signature 
+ *             by injecting the new dependency directly. 
+ *             The method can be removed in a future major release, when constructor signature can be changed
+ * @return SomeObjectInterface
+ */
+protected function getSomeObject()
+{
+    ...
+}
+{% endhighlight %}
+
+Exceptions:
+* Constructors may not have short and/or long description
+* Testing methods in Unit tests may not have doc blocks if the test's method name follows the convention (test<MehtodName>)
+   * If the test doesn't follow the convention, it should have a doc block describing which method(s) is covered
+   * Non-testing methods should have doc block with description. It includes data providers and any helper methods
 
 #### Things to include
 
@@ -422,6 +447,68 @@ public function deleteDirectory($path)
 If there is no explicit return statement in a method or function, a `@return void` should be used in the documentation.
 
 If the method returns itself, `return $this` should be used.
+
+<h4 id="inheritdoc">@inheritdoc Tag</h4>
+
+Whenever possible `@inheritdoc` tag MUST be used for child methods, and so avoid duplication of doc blocks.
+
+Though PHPDocumentor understands inheritance and uses parent doc block by default (without `@inheritdoc` tag specified), `@inheritdoc` tag helps ensure that the doc block is not missed at all.
+
+Rules for usage of the tag:
+* Use `@inheritdoc` (notice no braces around) to indicate that the entire doc block should be inherited from the parent method
+* Use inline `{@inheritdoc}` tag (with braces around) in long description to reuse parent's long description. The method MUST have its own short description
+
+**DocBlock for the Intreface**
+{% highlight php startinline=true %}
+/**
+ * Interface for mutable value object for integer values
+ */
+interface MutableInterface
+{
+    /**
+     * Get value
+     *
+     * Returns 0, if no value is available
+     *
+     * @return int
+     */
+    public function getVal();
+ 
+    /**
+     * Set value
+     *
+     * Sets 0 in case a non-integer value is passed
+     *
+     * @param int $value
+     */
+    public function setVal($value);
+}
+{% endhighlight %}
+
+**DocBlock for the implementation**
+{% highlight php startinline=true %}
+/**
+ * Limited mutable value object for integer values
+ */
+class LimitedMutableClass implements MutableInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getVal()
+    {
+    }
+ 
+    /**
+     * Set value
+     *
+     * Sets 0 in case the value is bigger than max allowed value. {@inheritdoc}
+     */
+    public function setVal($value)
+    {
+    }
+}
+{% endhighlight %}
 
 ### Constants
 {:#constants}

--- a/guides/v2.0/coding-standards/docblock-standard-general.md
+++ b/guides/v2.0/coding-standards/docblock-standard-general.md
@@ -206,10 +206,12 @@ Classes and interfaces must have a short description that is a human-understanda
 **Good:**
 
 > Handler for PHP errors/warnings/notices that converts them to exceptions.
+> class ErrorHandler { ... }
 
 **Bad:**
 
-> ErrorHandler -> ErrorHandler
+> Error Handler
+> class ErrorHandler { ... }
 
 If possible, add use cases where developers can or cannot use the class.
 


### PR DESCRIPTION
- expanded requirements to the long description and @deprecated tag
- added requirements to the usage of @inheritdoc tag
- fixed example for class naming