### PR TITLE
Update link to js_init.js file

### DIFF
--- a/guides/v2.0/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.0/javascript-dev-guide/javascript/custom_js.md
@@ -142,7 +142,7 @@ define([
 {% endhighlight %}
 
 
-For information about how to initialize your custom JS component in a `.phtml` template, see the <a href="{{page.baseurl}}frontend-dev-guide/javascript/js_init.html" target="_blank">JavaScript initialization</a> topic.
+For information about how to initialize your custom JS component in a `.phtml` template, see the <a href="{{page.baseurl}}javascript-dev-guide/javascript/js_init.html" target="_blank">JavaScript initialization</a> topic.
 
 <h2 id="disable_default_js">Disable default Magento JS</h2>
 


### PR DESCRIPTION
The correct path for frontend-dev-guide/javascript/js_init.html should be javascript-dev-guide/javascript/js_init.html.

Fixes https://github.com/magento/devdocs/issues/1013