### PR TITLE
Fix typo in Attribute Set Create page

### DIFF
--- a/guides/m1x/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html
+++ b/guides/m1x/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html
@@ -117,7 +117,7 @@ $attributeSetName = 'New Attribute Set';
 $skeletonId = 4;
 
 $result = $client-&gt;catalogProductAttributeSetCreate(
-    $session,
+    $sessionId,
     $attributeSetName,
     $skeletonId
 );</pre>


### PR DESCRIPTION
fix $sessionId variable typo
http://devdocs.magento.com/guides/m1x/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html