### PR TITLE
Fix incorrect sign of migration timestamp correction

### DIFF
--- a/guides/v2.0/migration/migration-migrate-additional.md
+++ b/guides/v2.0/migration/migration-migrate-additional.md
@@ -29,7 +29,7 @@ Some existing behaviour and logic from Magento 1 was implemented in a different 
             <transform>
                 <field>customer_entity.created_at</field>
                 <handler class="\Migration\Handler\Timezone">
-                    <param name="offset" value="-7" />
+                    <param name="offset" value="+7" />
                 </handler>
             </transform>
         </field_rules>


### PR DESCRIPTION
If the time zone for the database field is `UTC-7`, then it needs to be corrected by *positive* 7 hours to match UTC.