### PR TITLE
Change template link to one that is updated

### DIFF
--- a/guides/v2.0/cloud/discover-deploy.md
+++ b/guides/v2.0/cloud/discover-deploy.md
@@ -37,7 +37,7 @@ Deployment consists of the following phases:
 6.	[Post-deployment: configure routing](#cloud-deploy-over-phases-route)
 
 ### Phase 1: Configuration validation and code retrieval {#cloud-deploy-over-phases-conf}
-The remote server gets your code using Git. When you initially set up a project from a template, we retrieve the code from the [the Magento ECE template](https://github.com/magento-cloud/magento-cloud){:target="_blank"}.
+The remote server gets your code using Git. When you initially set up a project from a template, we retrieve the code from the [the Magento ECE template](https://github.com/magento/magento-cloud){:target="_blank"}.
 
 The built-in Git server checks what you are pushing: if you have a syntax error in a configuration file, our Git server refuses the push.
 


### PR DESCRIPTION
After working through the deploy process guide. There is a section for a template to use [here](http://devdocs.magento.com/guides/v2.0/cloud/discover-deploy.html). However, this template is a fork of the main magento one that gets updated more regular. The linked GitHub repo is very out of data in terms of Magento version etc. I propose we with merge this PR with link to the upstream main template or start to update the forked template. 