### PR TITLE
Corrected parameters on 137 and 141

### DIFF
--- a/guides/v2.1/config-guide/elasticsearch/es-overview.md
+++ b/guides/v2.1/config-guide/elasticsearch/es-overview.md
@@ -134,11 +134,11 @@ To install Elasticsearch:
 
 	*	Very large catalogs (40,000 SKUs or more)
 
-			index.query.bool.max_clause_count: 10024 
+			indices.query.bool.max_clause_count: 10024 
 
 	*	Catalogs with less than 40,000 SKUs:
 
-			index.query.bool.max_clause_count: 4096
+			indices.query.bool.max_clause_count: 4096
 
 	For more information, see [Setting the BooleanQuery maxClauseCount in Elasticsearch](http://george-stathis.com/2013/10/18/setting-the-booleanquery-maxclausecount-in-elasticsearch){:target="_blank"}.
 6.	Save your changes to `elasticsearch.yml` and exit the text editor.


### PR DESCRIPTION
When I tried the original commands, ES returned an error and suggested "indices" as opposed to "index".