### PR TITLE
Added a related topic

### DIFF
--- a/guides/v2.0/extension-dev-guide/attributes.md
+++ b/guides/v2.0/extension-dev-guide/attributes.md
@@ -217,4 +217,7 @@ However, if an extension similar to the following has been defined, the interfac
 
 
 <h2 id="related">Related topics</h2>
-<a href="{{page.baseurl}}get-started/authentication/gs-authentication.html">Web API authentication overview</a>
+<ul>
+    <li><a href="{{page.baseurl}}get-started/authentication/gs-authentication.html">Web API authentication overview</a></li>
+    <li><a href="{{page.baseurl}}extension-dev-guide/extension_attributes/adding-attributes.html">Adding extension attributes to an entity</a></li>
+</ul>


### PR DESCRIPTION
The "Adding extension attributes to entity" is a relevant guide since it describes one way to persist extension attributes. It also serves as a hint that values set to the extension attributes actually have to be separately persisted.