### PR TITLE
Adding guideline section for events.

### DIFF
--- a/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
+++ b/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
@@ -503,7 +503,7 @@ class SampleEventObserverThatModifiesInputs
 {%endhighlight%}
 {% endcollapsible %}
 
-14.2. Use as specific events as possible. Don't use a `global` event when the area impacted is just `frontend`.
+14.2. Use as specific events as possible. Don't use a `global` subscription to an event when the area impacted is just `frontend`.
 
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 

--- a/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
+++ b/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
@@ -473,7 +473,7 @@ We are reviewing this section and will publish it soon.
 
 ## 14. Events
 
-14.1. All values (including objects) passed to event MUST NOT be modified in the event observer. Use plugins instead for this application.
+14.1. All values (including objects) passed to an event MUST NOT be modified in the event observer. Instead, plugins SHOULD BE used for modifying the input or output of a function.
 
 {% collapsible Examples: %}
 {%highlight php startinline=1%}
@@ -503,7 +503,7 @@ class SampleEventObserverThatModifiesInputs
 {%endhighlight%}
 {% endcollapsible %}
 
-14.2. Use as specific events as possible. Don't use a `global` subscription to an event when the area impacted is just `frontend`.
+14.2. Events used SHOULD be observed as specifically as possible. A `global` subscription to an event SHOULD NOT be used when the area impacted is just `frontend`.
 
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 

--- a/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
+++ b/guides/v2.1/coding-standards/technical-guidelines/technical-guidelines.md
@@ -471,6 +471,39 @@ We are reviewing this section and will publish it soon.
 
 13.4. Exception in a single CLI command SHOULD NOT break the CLI framework; running other commands SHOULD still be possible.
 
+## 14. Events
+
+14.1. All values (including objects) passed to event MUST NOT be modified in the event observer. Use plugins instead for this application.
+
+{% collapsible Examples: %}
+{%highlight php startinline=1%}
+
+```
+class SampleEventObserverThatModifiesInputs
+{
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        /** @var \Magento\Framework\App\DataObject $transport */
+        $transport = $observer->getData('transport');
+        
+        if ($transport->getData('some_value') === true) {
+            /**
+             * Expecting this value to go back to the original event dispatcher violates
+             * this rule. Other observers could change the data, or Magento could make
+             * architectural changes always sending immutable objects.
+             */
+            $transport->setData('output_return_value', true);
+        }
+    }
+}
+```
+{%endhighlight%}
+{% endcollapsible %}
+
+14.2. Use as specific events as possible. Don't use a `global` event when the area impacted is just `frontend`.
 
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 


### PR DESCRIPTION
Two rules for events:

1. Treating all event inputs as immutable. If a value is not modified, this allows for Magento's expansion to using queue-based systems.
2. The second one is pretty easy: specific events.