### PR TITLE
Typo config:set -> setup:config:set

### DIFF
--- a/guides/v2.0/install-gde/install/cli/install-cli-subcommands.md
+++ b/guides/v2.0/install-gde/install/cli/install-cli-subcommands.md
@@ -64,8 +64,8 @@ The following table summarizes the available commands. Commands are shown in sum
 		<td><p>Magento software installed</p></td>
 	</tr>
 	<tr>
-		<td><a href="{{page.baseurl}}install-gde/install/cli/install-cli-subcommands-deployment.html">php magento config:set</a></td>
-		<td><p>Creates the deployment configuration.</p></td>
+		<td><a href="{{page.baseurl}}install-gde/install/cli/install-cli-subcommands-deployment.html">magento setup:config:set</a></td>
+		<td><p>Creates or updates the deployment configuration.</p></td>
 		<td><p>None</p></td>
 	</tr>
 	<tr>


### PR DESCRIPTION
None of the other examples give the `php` prefix either: removed. Slightly adjusted the description.

Error given on 2.1:
```
$ magento config:set

  [InvalidArgumentException]
  There are no commands defined in the "config" namespace.
  Did you mean one of these?
      setup:config
      setup:store-config
```