### PR TITLE
Fix indentation on 2.0 redis-session conf example

### DIFF
--- a/guides/v2.0/config-guide/redis/redis-session.md
+++ b/guides/v2.0/config-guide/redis/redis-session.md
@@ -22,29 +22,29 @@ Before you continue, [install Redis]({{page.baseurl}}config-guide/redis/config-r
 Following is a sample configuration to add to `<your Magento install dir>app/etc/env.php`:
 
     'session' => 
-       array (
-       'save' => 'redis',
-       'redis' => 
-          array (
-		'host' => '127.0.0.1',
-		'port' => '6379',
-		'password' => '',
-		'timeout' => '2.5',
-		'persistent_identifier' => '',
-		'database' => '2',
-		'compression_threshold' => '2048',
-		'compression_library' => 'gzip',
-		'log_level' => '1',
-		'max_concurrency' => '6',
-		'break_after_frontend' => '5',
-		'break_after_adminhtml' => '30',
-		'first_lifetime' => '600',
-		'bot_first_lifetime' => '60',
-		'bot_lifetime' => '7200',
-		'disable_locking' => '0',
-		'min_lifetime' => '60',
-		'max_lifetime' => '2592000'
-        )
+    array (
+      'save' => 'redis',
+      'redis' => 
+      array (
+        'host' => '127.0.0.1',
+        'port' => '6379',
+        'password' => '',
+        'timeout' => '2.5',
+        'persistent_identifier' => '',
+        'database' => '2',
+        'compression_threshold' => '2048',
+        'compression_library' => 'gzip',
+        'log_level' => '1',
+        'max_concurrency' => '6',
+        'break_after_frontend' => '5',
+        'break_after_adminhtml' => '30',
+        'first_lifetime' => '600',
+        'bot_first_lifetime' => '60',
+        'bot_lifetime' => '7200',
+        'disable_locking' => '0',
+        'min_lifetime' => '60',
+        'max_lifetime' => '2592000'
+      )
     ),
 
 where


### PR DESCRIPTION
The current config example has 2 issues:
1. It uses tabs part way through, this does not format well when copying/pasting.
2. It adds indent to the `array (` declaration, whereas the default `env.php` does not, nor does the `redis-pg-cache` page.