### PR TITLE
Update css_quick_guide_approach.md

### DIFF
--- a/guides/v2.0/frontend-dev-guide/css-guide/css_quick_guide_approach.md
+++ b/guides/v2.0/frontend-dev-guide/css-guide/css_quick_guide_approach.md
@@ -87,7 +87,7 @@ In <code>_extend.less</code> register the <code>_buttons_extend.less</code> by a
 </ol>
 
 <h3 id="structured_override">Override component's styles</h3>
-To extend the parent theme's styles for buttons in your theme:
+To override the parent theme's styles for buttons in your theme:
 <ol>
 <li>In your theme directory, create a <code>web/css/source</code> sub-directory. </li>
 <li>Create a <code>_buttons.less</code> file here. The path to it looks like following: 


### PR DESCRIPTION
The section is about overriding button styles, instead the text says, it's a way to **extend** the parent theme's styles for buttons