### PR TITLE
Fix wrong Google Webfont include

### DIFF
--- a/guides/v2.0/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.0/frontend-dev-guide/layouts/xml-manage.md
@@ -69,13 +69,15 @@ The following file is a sample of a file you must add:
     	<!-- Add external resources -->
 	<css src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css" src_type="url" />
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" src_type="url" />
-        <link src="http://fonts.googleapis.com/css?family=Montserrat" src_type="url" /> 
+        <link rel="stylesheet" type="text/css" src="http://fonts.googleapis.com/css?family=Montserrat" src_type="url" /> 
     </head>
 </page>
 {%endhighlight xml%}
 
 
 When adding external resources, specifying the <code>src_type="url"</code> argument value is a must.
+
+If you'd like to include a google webfont, you have to add the <code>rel="stylesheet" type="text/css"</code> to the <link> tag, otherwise it won't work.
 
 
 You can use either `<link src="js/sample.js"/>` or `<script src="js/sample.js"/>` instruction to add a locally stored JavaScript file to your theme.


### PR DESCRIPTION
Fix wrong Google Webfont include in default_head_blocks.xml as static ressource, because if you haven't add the rel and type paremeter, it won't work.