### PR TITLE
Added provider to layout

### DIFF
--- a/guides/v2.0/howdoi/checkout/checkout_new_step.md
+++ b/guides/v2.0/howdoi/checkout/checkout_new_step.md
@@ -174,6 +174,7 @@ A sample `checkout_index_index.xml` follows:
                                             <!-- The new step you add -->
                                             <item name="my-new-step" xsi:type="array">
                                                 <item name="component" xsi:type="string">%Vendor%_%Module%/js/view/my-step-view</item>
+						<item name="provider" xsi:type="string">checkoutProvider</item>
                                                     <!--To display step content before shipping step "sortOrder" value should be < 1-->
                                                     <!--To display step content between shipping step and payment step  1 < "sortOrder" < 2 -->
                                                     <!--To display step content after payment step "sortOrder" > 2 -->


### PR DESCRIPTION
Without setting a provider for the step, you will not have access to certain properties, such as 'source` which is required for validation. Copying the code above and running it as-is will result in console errors.