### PR TITLE
Fixed related topic links on javascript-dev-guide/javascript/custom_j…

### DIFF
--- a/guides/v2.0/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.0/javascript-dev-guide/javascript/custom_js.md
@@ -180,8 +180,8 @@ $(mage.apply);
 {% endhighlight %}
 
 
-#### Related topic
+<h2 id="related_topic">Related topic</h2>
 
-- [JavaScript resources in Magento]({{ page.baseurl }}javascript-dev-guide/javascript/js-resources.html)
-- [About AMD modules and RequireJS]({{page.baseurl}}javascript-dev-guide/javascript/requirejs_concept.html)
+- <a href="{{page.baseurl}}javascript-dev-guide/javascript/js-resources.html">JavaScript resources in Magento</a>
+- <a href="{{page.baseurl}}javascript-dev-guide/javascript/requirejs_concept.html">About AMD modules and RequireJS</a>
 


### PR DESCRIPTION
Fixed related topic links on javascript-dev-guide/javascript/custom_js.html

Fix the related topic links at the bottom of the page, Markdown seems to be causing issues (is it even supported on the Dev Docs?) - http://devdocs.magento.com/guides/v2.0/javascript-dev-guide/javascript/custom_js.html