### PR TITLE
Tweak acceptable semantic HTML markup example

### DIFF
--- a/guides/v2.0/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.0/coding-standards/code-standard-demarcation.md
@@ -127,14 +127,14 @@ The following list will help you make a distinction between the actual meaning o
 **Acceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <span class="font-weight-bold">semantically</span> represent documents.</p>
-<p><span class="font-weight-bold">Warning:</span> Following the procedure described below may irreparably damage your equipment.</p>
+<p>HTML has been created to <strong>semantically</strong> represent documents.</p>
+<p><strong>Warning:</strong> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 
 **Unacceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <strong>semantically</strong> represent documents.</p>
+<p>HTML has been created to <b>semantically</b> represent documents.</p>
 <p><b>Warning:</b> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 

--- a/guides/v2.0/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.0/coding-standards/code-standard-demarcation.md
@@ -127,8 +127,8 @@ The following list will help you make a distinction between the actual meaning o
 **Acceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <b>semantically</b> represent documents.</p>
-<p><strong>Warning:</strong> Following the procedure described below may irreparably damage your equipment.</p>
+<p>HTML has been created to <span class="font-weight-bold">semantically</span> represent documents.</p>
+<p><span class="font-weight-bold">Warning:</span> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 
 **Unacceptable**:

--- a/guides/v2.0/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.0/coding-standards/code-standard-demarcation.md
@@ -127,14 +127,14 @@ The following list will help you make a distinction between the actual meaning o
 **Acceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <strong>semantically</strong> represent documents.</p>
+<p>HTML has been created to <em>semantically</em> represent documents.</p>
 <p><strong>Warning:</strong> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 
 **Unacceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <b>semantically</b> represent documents.</p>
+<p>HTML has been created to <i>semantically</i> represent documents.</p>
 <p><b>Warning:</b> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 


### PR DESCRIPTION
The example for:

**You must use semantic HTML markup only, and must not use presentation markup.**

...included presentation markup (`<b>` and `<strong>`) which I believe violates the rule.

I replaced it with `<span class="...">` as an example.