### PR TITLE
FIX admin_apply_theme logic for EE versions

### DIFF
--- a/guides/v2.0/frontend-dev-guide/themes/admin_theme_apply.md
+++ b/guides/v2.0/frontend-dev-guide/themes/admin_theme_apply.md
@@ -21,6 +21,7 @@ This topic describes how to apply your custom {% glossarytooltip d2093e4a-2b71-4
     <module name="%YourVendor_YourModule%" setup_version="2.0.1"> <!-- Example: "Magento_Backend -->"
         <sequence>
             <module name="Magento_Theme"/>
+            <module name="Magento_Enterprise"/> <!-- For Enterprise versions only -->
         </sequence>
     </module>
 {%endhighlight%}


### PR DESCRIPTION
With last EE versions defining a custom admin theme is override by the `Magento_Enterprise` extension.    
For that we have to load `Magento_Enterprise` extension before the custome one.