### PR TITLE
Add docroot for recent Ubuntu releases and Apache 2.4

### DIFF
--- a/guides/v2.0/install-gde/prereq/dev_install.md
+++ b/guides/v2.0/install-gde/prereq/dev_install.md
@@ -84,7 +84,7 @@ To clone the Magento GitHub repository using the SSH protocol:
 	<p><img src="{{ site.baseurl }}common/images/install_mage2_clone-ssh.png" width="650px" alt="Clone the Magento GitHub repository using SSH"></p>
 
 1.	Change to your web server's docroot directory.
-	Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
+	Typically, for Ubuntu, it's `/var/www` or `/var/www/html` and for CentOS it's `/var/www/html`.
 
 	Need help locating the docroot? Click <a href="{{page.baseurl}}install-gde/basics/basics_docroot.html">here.
 
@@ -130,7 +130,7 @@ To clone the Magento GitHub repository using the HTTPS protocol:
 
 1.	Change to your web server's docroot directory.
 
-	Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
+	Typically, for Ubuntu, it's `/var/www` or `/var/www/html` and for CentOS it's `/var/www/html`.
 
 2.	Enter `git clone` and paste the value you obtained from step 1.
 


### PR DESCRIPTION
On recent Ubuntu releases provided with Apache 2.4, the default web server's document root is _/var/www/html_.