### PR TITLE
Fixes unsupported Varnish version number in the 2.2RC CE release notes.

### DIFF
--- a/guides/v2.2/release-notes/release-notes-2-2-prerelease1-CE.md
+++ b/guides/v2.2/release-notes/release-notes-2-2-prerelease1-CE.md
@@ -32,7 +32,7 @@ Look for the following highlights in this release:
 
 
 
-* **Upgraded technology stack.**  We've dropped support for PHP 5.6 and Varnish 5.  We now support PHP 7.1, along with Redis 3.2, MySQL 5.7, and Varnish 5 support. All third-party libraries have been upgraded to the latest stable version.
+* **Upgraded technology stack.**  We've dropped support for PHP 5.6 and Varnish 3.  We now support PHP 7.1, along with Redis 3.2, MySQL 5.7, and Varnish 5 support. All third-party libraries have been upgraded to the latest stable version.
 
 
 * **Pipeline deployment**, a new deployment process, enables separate build and deployment stages that can run separately. Resource-intensive processes can run on the build server. Pipeline deployment supports easy management of configuration between environments, too. Read more about pipleine deployment [here]({{page.baseurl}}config-guide/deployment/pipeline/).


### PR DESCRIPTION
Feedback on page: [/guides/v2.2/release-notes/release-notes-2-2-prerelease1-CE.html](http://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-prerelease1-CE.html)

Changes:
> We’ve dropped support for PHP 5.6 and Varnish 5.

To:
> We’ve dropped support for PHP 5.6 and Varnish 3.

This is only incorrect on the Community Edition Release notes, it is correct on the [Enterprise Edition Release notes](http://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-prerelease1-EE.html).