### PR TITLE
Added Fixes for broken GitHub links

### DIFF
--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -8,7 +8,7 @@ menu_order: 2000
 level3_menu_node:
 level3_subgroup:
 version: 2.2
-github_link: release-candidate/install.md
+github_link: release-notes/release-candidate/install.md
 ---
 
 ## Installation

--- a/guides/v2.2/release-notes/release-candidate/quick-start.md
+++ b/guides/v2.2/release-notes/release-candidate/quick-start.md
@@ -8,7 +8,7 @@ menu_order: 1000
 level3_menu_node:
 level3_subgroup:
 version: 2.2
-github_link: release-candidate/quick-start.md
+github_link: release-notes/release-candidate/quick-start.md
 ---
 
 We are pleased to present the Magento 2.2.0 CE, EE, and B2B Release Candidate 1. This QuickStart guide provides the basic information you need to start participating in our Magento 2.2.0 Release Candidate evaluation program.


### PR DESCRIPTION
Added fixes to the broken links for the section _**Edit this page on GitHub**_ of the pages:
- [2.2 Install](http://devdocs.magento.com/guides/v2.2/release-notes/release-candidate/install.html)
- [2.2 Quickstart](http://devdocs.magento.com/guides/v2.2/release-notes/release-candidate/quick-start.html)