### PR TITLE
Updated varnish version as it was incorrect

### DIFF
--- a/guides/v2.0/install-gde/system-requirements-tech.md
+++ b/guides/v2.0/install-gde/system-requirements-tech.md
@@ -88,7 +88,7 @@ Mail Transfer Agent (MTA) or an SMTP server
 
 ### Magento can utilize the following technologies:
 *	<a href="{{page.baseurl}}config-guide/redis/config-redis.html">Redis</a> version 3.0 for page caching and session storage (the latter supported by Magento version 2.0.6 and later only)
-*	<a href="{{page.baseurl}}config-guide/varnish/config-varnish.html">Varnish</a> version 3.5 or latest stable 4.x version for page caching
+*	<a href="{{page.baseurl}}config-guide/varnish/config-varnish.html">Varnish</a> version 3.0.5 or latest stable 4.x version for page caching
 *	<a href="{{page.baseurl}}config-guide/memcache/memcache.html">memcached</a> latest stable version for session storage with either `memcache` or `memcached` PHP extensions (latest stable version)
 
 *	Magento Enterprise Edition (EE) only <img src="{{ site.baseurl }}common/images/ee-only_small.png">


### PR DESCRIPTION
Varnish 3.5 is not a Varnish 3 version, this should be 3.0.5 in accordance with the VCL file produced in the admin panel.