### PR TITLE
Mention redis as an alternative

### DIFF
--- a/guides/v2.0/config-guide/varnish/config-varnish.md
+++ b/guides/v2.0/config-guide/varnish/config-varnish.md
@@ -16,7 +16,7 @@ github_link: config-guide/varnish/config-varnish.md
 Magento 2 supports versions 3.0.5 or later or any Varnish 4.x version.
 
 <div class="bs-callout bs-callout-warning">
-    <p>We <em>strongly recommend</em> you use Varnish in production. The built-in full-page caching (to either the file system or <a href="{{page.baseurl}}config-guide/cache/caching-database.html">database</a>) is much slower than Varnish, and Varnish is designed to accelerate HTTP traffic.</p>
+    <p>We <em>strongly recommend</em> you use Varnish (or <a href="{{page.baseurl}}/config-guide/redis/redis-pg-cache.html">Redis</a>) in production. The built-in full-page caching (to either the file system or <a href="{{page.baseurl}}config-guide/cache/caching-database.html">database</a>) is much slower than Varnish, and Varnish is designed to accelerate HTTP traffic.</p>
 </div>
 
 For more information about Varnish, see:


### PR DESCRIPTION
The strong recommendation to use Varnish over file/db based full page cache gives the impression that Varnish is the only viable option to use as a storage for the fpc.

I added a mention of redis, it's also recommended in the memcache configuration guide at /config-guide/memcache/memcache.html:
"For page caching, we recommend Redis or Varnish."