### PR TITLE
Proxy syntax correction in es-config-apache.md

### DIFF
--- a/guides/v2.1/config-guide/elasticsearch/es-config-apache.md
+++ b/guides/v2.1/config-guide/elasticsearch/es-config-apache.md
@@ -49,7 +49,7 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 		<VirtualHost *:8080>
 		   ProxyPass "/" "http://localhost:9200/"
-		   ProxyPassReverse "/" http://localhost:9200/"
+		   ProxyPassReverse "/" "http://localhost:9200/"
 		</VirtualHost>
 5.	Restart Apache:
 


### PR DESCRIPTION
Add missing `"` in Apache 2.4 proxy instructions