### PR TITLE
remove reference to partner accounts

### DIFF
--- a/guides/v2.2/release-notes/release-candidate/quick-start.md
+++ b/guides/v2.2/release-notes/release-candidate/quick-start.md
@@ -88,12 +88,7 @@ The Magento 2.2.0 EE Release Candidate evaluation is open to all Solution Partne
 
 * Sign the [Release Candidate Software agreement](https://magento.com/partners/portal/customer/account/login)
 
-* Provide GitHub account information. You can  provide one of the following:
-
-	* your Solution Partner GitHub account, clearly labeled with the name of the Partner, the Partner’s logo, and a link to the Partner’s website.
-
-
-	* an Individual Account for a Solution Partner Employee. The company name field must contain the Partner’s name or @partnername. Alternatively, the user’s profile must show that the developer is a member of the Solution Partner’s GitHub Organization.
+* Provide GitHub account information for an Individual Account for a Solution Partner Employee. The company name field must contain the Partner’s name or @partnername. Alternatively, the user’s profile must show that the developer is a member of the Solution Partner’s GitHub Organization.
 
 
 ## More information?


### PR DESCRIPTION
Updated guide to remove reference to accepting partner accounts. GitHub accounts must be individual accounts to grant access.