### PR TITLE
Specify magento2ce directory when cloning

### DIFF
--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -66,7 +66,7 @@ There are three Magento code repositories on GitHub where you can find Release C
 
 These instructions assume you have experience working with Github repositories. Refer to Github's documentation if you need help setting up [SSH keys](https://help.github.com/articles/connecting-to-github-with-ssh/){:target="	&#95;blank"} or [cloning repositories](https://help.github.com/articles/cloning-a-repository/){:target="	&#95;blank"}.
 
-1.  Clone the `magento2/` repository to your server's [docroot](http://devdocs.magento.com/guides/v2.1/install-gde/basics/basics_docroot.html):
+1.  Clone the `magento2ce/` repository to your server's [docroot](http://devdocs.magento.com/guides/v2.1/install-gde/basics/basics_docroot.html):
 
     ```
     cd /var/www/html

--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -70,7 +70,7 @@ These instructions assume you have experience working with Github repositories. 
 
     ```
     cd /var/www/html
-    git clone -b develop git@github.com:magento/magento2.git
+    git clone -b develop git@github.com:magento/magento2.git magento2ce
     ```
 
 2.  Clone the `magento2ee/` and `magento2b2b/` repositories inside the `magento2ce/` repository:


### PR DESCRIPTION
Following step 1 from "Clone the Magento Github repositories" gives the user the repository inside a directory "magento2" by default, whereas the rest of the guide describes this as "magento2ce"