### PR TITLE
Fix name of PhpStorm

### DIFF
--- a/_includes/install/docker/docker-phpstorm.md
+++ b/_includes/install/docker/docker-phpstorm.md
@@ -1,11 +1,11 @@
 <div markdown="1">
 
 <div class="bs-callout bs-callout-info" markdown="1">
-PhPStorm notes:
+PhpStorm notes:
 
-*	The instructions in this topic are based on PhPStorm version 2016.3.2. If you use a different version, some steps might be different. Consult your PhPStorm documentation for details.
-*	PhPStorm has a commonly used window that has a different name in Windows and Mac OS:
+*	The instructions in this topic are based on PhpStorm version 2016.3.2. If you use a different version, some steps might be different. Consult your PhpStorm documentation for details.
+*	PhpStorm has a commonly used window that has a different name in Windows and Mac OS:
 
 	*	Windows: The window is named Settings and you access it by clicking **File** > **Settings**.
-	*	Mac OS: The window is named Preferences and you access it by clicking **PhPStorm** > **Preferences**.
+	*	Mac OS: The window is named Preferences and you access it by clicking **PhpStorm** > **Preferences**.
 </div>


### PR DESCRIPTION
This blocks is shown on following page:
http://devdocs.magento.com/guides/v2.1/install-gde/docker/docker-phpstorm-debug.html

It looks ugly.