### PR TITLE
Remove SSH key info from HTTPS section

### DIFF
--- a/guides/v2.0/install-gde/prereq/dev_install.md
+++ b/guides/v2.0/install-gde/prereq/dev_install.md
@@ -139,13 +139,6 @@ To clone the Magento GitHub repository using the HTTPS protocol:
 		git clone https://github.com/magento/magento2.git
 3.	Wait for the repository to clone on your server.
 
-	<div class="bs-callout bs-callout-info" id="info">
-		<p>If the following error displays, make sure you <a href="https://help.github.com/articles/generating-ssh-keys/" target="_blank">shared your SSH key</a> with GitHub: </p>
-			<pre>Cloning into 'magento2'...
-Permission denied (publickey).
-fatal: The remote end hung up unexpectedly</pre>
-	</div>
-
 4.	Optionally switch to a <a href="https://github.com/magento/magento2/tags" target="_blank">release tag</a> as follows:
 
 		git checkout tags/<tag name> [-b <version>]


### PR DESCRIPTION
If we use HTTPS connection to clone git repository, SSH key is not used. I removed misleading information.