### PR TITLE
Fixed ColumnAction,Column link redirect to 404 page.

### DIFF
--- a/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
@@ -16,7 +16,7 @@ Constructor: [app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js]({{si
 
 ## Configuration options
 
-Extends all [Column]({{page.baseurl}}ui_comp_guide/components/listing/ui-column.md) configuration.
+Extends all Column configuration.
 
 ActionsColumn-specific configuration:
 
@@ -71,7 +71,7 @@ ActionsColumn-specific configuration:
   <tr>
     <td><code>callback</code></td>
     <td>Custom action's handler.</td>
-    <td><a href="{{page.baseurl}}ui_comp_guide/components/listing/ui-column.md#column_action">ColumnAction</a> | Array &lt;ColumnAction&gt;  </td>
+    <td>ColumnAction | Array &lt;ColumnAction&gt;  </td>
     <td>Optional</td>
   </tr>
   <tr>


### PR DESCRIPTION
Fixed ColumnAction and Column link in a page redirect to 404 page. This Might confused to user which contains exist for a link so remove link from above both word.