### PR TITLE
Fixed ColumnAction with link redirect to 404 page.

### DIFF
--- a/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
@@ -71,7 +71,7 @@ ActionsColumn-specific configuration:
   <tr>
     <td><code>callback</code></td>
     <td>Custom action's handler.</td>
-    <td><a href="{{page.baseurl}}ui_comp_guide/components/listing/ui-column.md#column_action">ColumnAction</a> | Array &lt;ColumnAction&gt;  </td>
+    <td>ColumnAction | Array &lt;ColumnAction&gt;  </td>
     <td>Optional</td>
   </tr>
   <tr>


### PR DESCRIPTION
ColumnAction with link redirect to 404 page so remove link from ColumnAction from the table.