### PR TITLE
Added listening port configuration for Varnish 4.*

### DIFF
--- a/guides/v2.0/config-guide/varnish/config-varnish-configure.md
+++ b/guides/v2.0/config-guide/varnish/config-varnish-configure.md
@@ -28,25 +28,19 @@ To modify the Varnish system configuration:
 2.	Set the Varnish listen port to 80:
 
 		VARNISH_LISTEN_PORT=80
-
-3.	If necessary, comment out the following:
-
-		## Alternative 1, Minimal configuration, no VCL
-		#DAEMON_OPTS="-a :6081 \
-		#             -T localhost:6082 \
-		#             -b localhost:8080 \
-		#             -u varnish -g varnish \
-		#             -s file,/var/lib/varnish/varnish_storage.bin,1G"
-		## Alternative 2, Configuration with VCL
-		#DAEMON_OPTS="-a :6081 \
-		#             -T localhost:6082 \
-		#             -f /etc/varnish/default.vcl \
-		#             -u varnish -g varnish \
-		#             -S /etc/varnish/secret \
-		#             -s file,/var/lib/varnish/varnish_storage.bin,1G"
+		
+For Varnish 4.* make sure that DAEMON_OPTS have the correct listening port for the `-a` parameter (even if VARNISH_LISTEN_PORT set to the correct one)
+	
+	DAEMON_OPTS="-a :80 \
+             -T localhost:6082 \
+             -f /etc/varnish/default.vcl \
+             -S /etc/varnish/secret \
+             -s malloc,256m"
+	     
+     	
 
 
-4.	Save your changes to `/etc/sysconfig/varnish` (or `/etc/default/varnish` on Debian and Ubuntu) and exit the text editor.
+3.	Save your changes to `/etc/sysconfig/varnish` (or `/etc/default/varnish` on Debian and Ubuntu) and exit the text editor.
 
 <h3 id="config-varnish-config-default">Modify <code>default.vcl</code></h3>
 This section discusses how to provide minimal configuration so Varnish returns HTTP response headers. This enables you to verify Varnish works before you configure Magento to use Varnish.


### PR DESCRIPTION
The previous description "If necessary, comment out the following:" was not clear enough. Moreover, for Varnish 4.* VARNISH_LISTEN_PORT is not actual anymore, you need to edit the daemon parameters for this purpose (https://varnish-cache.org/docs/4.0/tutorial/putting_varnish_on_port_80.html). I've clarified the correct way to set the listening port for varnish 4.*