### PR TITLE
Fix reference to Magento 2 CE repository/branch

### DIFF
--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -44,7 +44,7 @@ There are three Magento code repositories on GitHub where you can find Release C
   </tr>
 <tr>
     <td><b>Magento CE</b></td>
-    <td><a href="https://github.com/magento/magento2ce">https://github.com/magento/magento2ce</a></td>
+    <td><a href="https://github.com/magento/magento2">https://github.com/magento/magento2</a></td>
     <td>2.2.0-release-candidate</td>
     <td>Publicly available</td>
 </tr>
@@ -70,7 +70,7 @@ These instructions assume you have experience working with Github repositories. 
 
     ```
     cd /var/www/html
-    git clone -b 2.2.0-release-candidate git@github.com:magento/magento2ce.git magento2
+    git clone -b 2.2.0-preview git@github.com:magento/magento2.git
     ```
 
 2.  Clone the `magento2ee/` and `magento2b2b/` repositories inside the `magento2/` repository:

--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -45,7 +45,7 @@ There are three Magento code repositories on GitHub where you can find Release C
 <tr>
     <td><b>Magento CE</b></td>
     <td><a href="https://github.com/magento/magento2">https://github.com/magento/magento2</a></td>
-    <td>2.2.0-release-candidate</td>
+    <td>2.2.0-preview</td>
     <td>Publicly available</td>
 </tr>
 <tr>

--- a/guides/v2.2/release-notes/release-candidate/install.md
+++ b/guides/v2.2/release-notes/release-candidate/install.md
@@ -44,8 +44,8 @@ There are three Magento code repositories on GitHub where you can find Release C
   </tr>
 <tr>
     <td><b>Magento CE</b></td>
-    <td><a href="https://github.com/magento/magento2">https://github.com/magento/magento2</a></td>
-    <td>develop</td>
+    <td><a href="https://github.com/magento/magento2ce">https://github.com/magento/magento2ce</a></td>
+    <td>2.2.0-release-candidate</td>
     <td>Publicly available</td>
 </tr>
 <tr>
@@ -66,11 +66,11 @@ There are three Magento code repositories on GitHub where you can find Release C
 
 These instructions assume you have experience working with Github repositories. Refer to Github's documentation if you need help setting up [SSH keys](https://help.github.com/articles/connecting-to-github-with-ssh/){:target="	&#95;blank"} or [cloning repositories](https://help.github.com/articles/cloning-a-repository/){:target="	&#95;blank"}.
 
-1.  Clone the `magento2/` repository to your server's [docroot](http://devdocs.magento.com/guides/v2.1/install-gde/basics/basics_docroot.html):
+1.  Clone the `magento2/` repository to your server's [docroot](http://devdocs.magento.com/guides/v2.2/install-gde/basics/basics_docroot.html):
 
     ```
     cd /var/www/html
-    git clone -b develop git@github.com:magento/magento2.git
+    git clone -b 2.2.0-release-candidate git@github.com:magento/magento2ce.git magento2
     ```
 
 2.  Clone the `magento2ee/` and `magento2b2b/` repositories inside the `magento2/` repository:
@@ -132,7 +132,7 @@ From the `magento2/` directory, run Composer to update dependencies:
 composer install
 ```
 
-Refer to [Update installation dependencies](http://devdocs.magento.com/guides/v2.1/install-gde/install/prepare-install.html) for more information.
+Refer to [Update installation dependencies](http://devdocs.magento.com/guides/v2.2/install-gde/install/prepare-install.html) for more information.
 
 ### Complete the installation
 Now that you've cloned all the repositories you need and prepared the files, proceed with the installation:


### PR DESCRIPTION
The old reference (repository: magento/magento2 - branch: develop) causes an error because the autoloader can't find missing file app/etc/NonComposerComponentRegistration.php.
Furthermore, some references to devdocs 2.1 have been fixed to point to 2.2.