### PR TITLE
<vendor-name>/module-<component-name> is unnecessary restrictive

### DIFF
--- a/guides/v2.0/extension-dev-guide/package/package_module.md
+++ b/guides/v2.0/extension-dev-guide/package/package_module.md
@@ -42,7 +42,7 @@ The `composer.json` uses [Composer's generic schema](https://getcomposer.org/doc
 </tr>
 <tr>
 <td><code>name</code></td>
-<td>A fully-qualified component name, in the format <code>&lt;vendor-name&gt;/module-&lt;component-name&gt;</code>. All letters must be in lowercase. Use dashes in the <code>&lt;component-name&gt;</code> to separate words.</td>
+<td>A fully-qualified component name, in the format <code>&lt;vendor-name&gt;/&lt;component-name&gt;</code>. All letters must be in lowercase. Use dashes in the <code>&lt;component-name&gt;</code> to separate words.</td>
 </tr>
 <tr>
 <td><code>type</code> </td>


### PR DESCRIPTION
The naming convention `<vendor-name>/module-<component-name>` only makes sense for Magento internal packages as there is some processing happening with it here
https://github.com/magento/magento2/blob/2.0.0/lib/internal/Magento/Framework/Module/PackageInfo.php#L153

For 3rd party module names there is no such processing happening and therefore module- does not need to be part of name.