### PR TITLE
Removes superfluous 'a' in the menu title

### DIFF
--- a/guides/v2.0/frontend-dev-guide/themes/theme-install.md
+++ b/guides/v2.0/frontend-dev-guide/themes/theme-install.md
@@ -3,7 +3,7 @@ layout: default
 group: fedg
 subgroup: A_Themes
 title: Install a third-party storefront theme
-menu_title: Install a a third-party storefront theme
+menu_title: Install a third-party storefront theme
 menu_order: 2
 version: 2.0
 github_link: frontend-dev-guide/themes/theme-install.md


### PR DESCRIPTION
Removes a superfluous 'a' in the menu title on the "Install a third-party storefront theme" page.