### PR TITLE
Update upgrade.md to use correct MySQL dump command

### DIFF
--- a/_includes/cloud/upgrade.md
+++ b/_includes/cloud/upgrade.md
@@ -18,7 +18,7 @@ Back up your integration system database and code:
 
 1.  Enter the following command to make a local backup of the remote database:
 
-        magento-cloud environment:mysql-dump
+        magento-cloud environment:sql-dump
 2.  Enter the following command to back up code and media:
 
         php bin/magento setup:backup --code [--media]


### PR DESCRIPTION
Using Magento Cloud CLI 1.10.1 the command appears to be `environment:sql-dump`