### PR TITLE
Remove warning about redis session lock troubles

### DIFF
--- a/guides/v2.0/config-guide/memcache/memcache.md
+++ b/guides/v2.0/config-guide/memcache/memcache.md
@@ -17,11 +17,10 @@ memcache provides a very large hash table that can be distributed across multipl
 
 Magento uses memcached for session storage but not for page caching. For page caching, we recommend <a href="{{page.baseurl}}config-guide/redis/config-redis.html">Redis</a> or <a href="{{page.baseurl}}config-guide/varnish/config-varnish.html">Varnish</a>.
 
-<div class="bs-callout bs-callout-info" id="info">
-   <span class="glyphicon-class">
-   <p>We recommend you use memcached for session storage. The Redis session handler in the <code>phpredis</code> {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} {% glossarytooltip 55774db9-bf9d-40f3-83db-b10cc5ae3b68 %}extension{% endglossarytooltip %} does not support session locking, which might cause issues with distributed systems and applications that rely on Ajax.</p></span>
-</div>
-
 #### Next step
 *   <a href="{{page.baseurl}}config-guide/memcache/memcache_ubuntu.html">Install, configure, verify memcached on Ubuntu</a>
 *   <a href="{{page.baseurl}}config-guide/memcache/memcache_centos.html">Install, configure, verify memcached on CentOS</a>
+
+<h2 id="related">Related topics</h2>
+<a href="{{page.baseurl}}config-guide/redis/config-redis.html#why-redis-is-better">Why Redis is better</a>
+ 

--- a/guides/v2.0/config-guide/memcache/memcache.md
+++ b/guides/v2.0/config-guide/memcache/memcache.md
@@ -1,26 +1,21 @@
 ---
 layout: default
 group: config-guide
-subgroup: 10_mem
 title: Use memcached for session storage
-menu_title: Use memcached for session storage
-menu_order: 1
-menu_node: parent
 version: 2.0
 github_link: config-guide/memcache/memcache.md
 ---
 
-<h2 id="config-memcache-over">Overview of memcached session storage</h2>
-memcached is a general-purpose distributed memory caching system. It is often used to speed up dynamic database-driven websites by caching data and objects in RAM to reduce the number of times an external data source (such as a database or API) must be read. (Source: <a href="https://en.wikipedia.org/wiki/Memcached" target="_blank">Wikipedia</a>)
+Memcached is a general-purpose, distributed memory caching system. It is often used to speed up dynamic database-driven websites by caching data and objects in RAM to reduce the number of times an external data source (such as a database or API) must be read. (Source: [Wikipedia](https://en.wikipedia.org/wiki/Memcached){:target="_blank"})
 
-memcache provides a very large hash table that can be distributed across multiple machines. When the table is full, subsequent inserts cause older data to be purged in least recently used (LRU) order. The size of this hash table is often very large. (Source: <a href="http://memcached.org/" target="_blank">memcached.org</a>)
+Memcache provides a very large hash table that can be distributed across multiple machines. When the table is full, subsequent inserts cause older data to be purged in least recently used (LRU) order. The size of this hash table is often very large. (Source: [memcached.org](http://memcached.org/){:target="_blank})
 
-Magento uses memcached for session storage but not for page caching. For page caching, we recommend <a href="{{page.baseurl}}config-guide/redis/config-redis.html">Redis</a> or <a href="{{page.baseurl}}config-guide/varnish/config-varnish.html">Varnish</a>.
+Magento uses memcached for session storage but not for page caching. For page caching, we recommend [Redis]({{page.baseurl}}config-guide/redis/config-redis.html) or [Varnish]({{page.baseurl}}config-guide/varnish/config-varnish.html). 
+
+<div class="bs-callout bs-callout-info" id="info" markdown="1">
+Refer to [Why Redis is better]({{page.baseurl}}config-guide/redis/config-redis.html#why-redis-is-better) for a list of advantages to using Redis.
+</div>
 
 #### Next step
-*   <a href="{{page.baseurl}}config-guide/memcache/memcache_ubuntu.html">Install, configure, verify memcached on Ubuntu</a>
-*   <a href="{{page.baseurl}}config-guide/memcache/memcache_centos.html">Install, configure, verify memcached on CentOS</a>
-
-<h2 id="related">Related topics</h2>
-<a href="{{page.baseurl}}config-guide/redis/config-redis.html#why-redis-is-better">Why Redis is better</a>
- 
+*   [Install, configure, verify memcached on Ubuntu]({{page.baseurl}}config-guide/memcache/memcache_ubuntu.html)
+*   [Install, configure, verify memcached on CentOS]({{page.baseurl}}config-guide/memcache/memcache_centos.html)


### PR DESCRIPTION
Also link to the why redis is better section of redis guide. The same guide also mentions that the session locking problem has been fixed since Magento 2.0.6