### PR TITLE
nginx config did not match command

### DIFF
--- a/guides/v2.0/comp-mgr/trouble/cman/maint-mode.md
+++ b/guides/v2.0/comp-mgr/trouble/cman/maint-mode.md
@@ -110,7 +110,7 @@ To redirect traffic to a custom maintenance page:
 
 		set $maintenance off;
 
-		if (-f $MAGE_ROOT/var/.maintenance.flag) {
+		if (-f $MAGE_ROOT/maintenance.enable) {
 		set $maintenance on; 
 		}
 


### PR DESCRIPTION
The doc was checking for $MAGE_ROOT/var/maintenance.flag whereas the command said "touch <your Magento install dir>/maintenance.enable".

Alternatively the command could be changed to match the nginx config. "touch <your Magento install dir>/var/maintenance.flag"