### PR TITLE
Update tshoot-varnish-503.md

### DIFF
--- a/guides/v2.2/config-guide/varnish/tshoot-varnish-503.md
+++ b/guides/v2.2/config-guide/varnish/tshoot-varnish-503.md
@@ -55,6 +55,7 @@ To resolve this issue, increase the default value of the `http_resp_hdr_len` par
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p http_resp_hdr_len=65536 \
              -p http_resp_size=98304 \
+	     -p workspace_backend=98304 \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
 


### PR DESCRIPTION
Then you extends http_resp_size you need to extend workspace_backend, because http_resp_size  used this memory, but default workspace_backend = 64k. 

* The memory for the request is allocated from the backend workspace (param: workspace_backend) and this parameter limits how much of that the request is allowed to take up.

* link: https://varnish-cache.org/docs/4.1/reference/varnishd.html#http-resp-size