### PR TITLE
Correct Code Example

### DIFF
--- a/guides/v2.0/extension-dev-guide/cache/partial-caching/create-cache-type.md
+++ b/guides/v2.0/extension-dev-guide/cache/partial-caching/create-cache-type.md
@@ -21,20 +21,23 @@ The tag *scope* provides a mechanism for a cache type.
 To create a new cache type:
 
 {% highlight php startinline %}
-class %Namespace%_%Module%_Model_Cache_Type extends \Magento\Cache\Frontend\Decorator\TagScope
+class %Namespace%\%Module%\Model\Cache\Type extends \Magento\Framework\Cache\Frontend\Decorator\TagScope
 {
+  const TYPE_IDENTIFIER = '%cache_type_id%';
+  const CACHE_TAG = '%CACHE_TYPE_TAG%';
+  
   public function __construct(\Magento\Framework\App\Cache\Type\FrontendPool $cacheFrontendPool)
   {
-    parent::__construct($cacheFrontendPool->get('%cache_type_id%'), '%cache_type_tag%');
+    parent::__construct($cacheFrontendPool->get(self::TYPE_IDENTIFIER), self::CACHE_TAG);
   }
 }
 {% endhighlight %}
 
 You must specify the following parameters:
 
-*	`Namespace_Module` defines the name of a {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} that uses a cache type. A module can use several cache types and a cache type can be used in several modules.
+*	`Namespace\Module` defines the name of a {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} that uses a cache type. A module can use several cache types and a cache type can be used in several modules.
 *	`%cache_type_id%` defines unique identifier of a cache type.
-*	`%cache_type_tag%` defines unique tag to be used in the cache type scoping.
+*	`%CACHE_TYPE_TAG%` defines unique tag to be used in the cache type scoping.
 
 ## More information about caching
 


### PR DESCRIPTION
This change corrects the parent class name used in the code example. Constants were added, making the example consitent with cache type code used in core modules.