### PR TITLE
Remove extra </tr> on module packaging guide

### DIFF
--- a/guides/v2.0/extension-dev-guide/package/package_module.md
+++ b/guides/v2.0/extension-dev-guide/package/package_module.md
@@ -51,7 +51,6 @@ The `composer.json` uses [Composer's generic schema](https://getcomposer.org/doc
 <td><code>autoload </code></td>
 <td>Specify necessary information to be loaded, such as [registration.php]({{page.baseurl}}extension-dev-guide/build/component-registration.html). For more information, see <a href="https://getcomposer.org/doc/01-basic-usage.md#autoloading">Autoloading</a> from Composer.</td>
 
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
On the page "/guides/v2.2/extension-dev-guide/package/package_module.html" is an extra "</tr>" which is rendered as content instead of html, because there is no matching opening tag.

Exact position of the is beneath the headline "Create a Magento Composer file", right above the table.