### PR TITLE
Add config file to the app:config:dump command

### DIFF
--- a/guides/v2.2/config-guide/prod/config-reference-sens.md
+++ b/guides/v2.2/config-guide/prod/config-reference-sens.md
@@ -14,7 +14,7 @@ github_link: config-guide/prod/config-reference-sens.md
 
 This topic lists configuration paths for system-specific and sensitive settings:
 
-*	The [`magento app:config:dump` command]({{ page.baseurl }}config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control.
+*	The [`magento app:config:dump` command]({{ page.baseurl }}config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.
 *	The [`magento config:sensitive:set` command]({{ page.baseurl }}config-guide/cli/config-cli-subcommands-config-mgmt-set.html) writes sensitive settings to `app/etc/env.php`.
 
 	You can also set sensitive values using configuration variables as discussed in [Use environment variables to override configuration settings]({{ page.baseurl }}config-guide/prod/config-reference-var-name.html).


### PR DESCRIPTION
The current description only mentions the update to app/etc/env.php after running app:config:dump, but it also updates app/etc/config.php with shared configuration for all Magento instances.