### PR TITLE
Remove tooltip from code block

### DIFF
--- a/guides/v2.0/extension-dev-guide/build/module-file-structure.md
+++ b/guides/v2.0/extension-dev-guide/build/module-file-structure.md
@@ -43,7 +43,7 @@ Additional folders can be added for configuration and other ancillary functions 
 A typical {% glossarytooltip d2093e4a-2b71-48a3-99b7-b32af7158019 %}theme{% endglossarytooltip %} file structure can look like the following:
 
 ~~~
-├── {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}composer{% endglossarytooltip %}.json
+├── composer.json
 ├── etc
 │   └── view.xml
 ├── i18n


### PR DESCRIPTION
The tooltip declaration is causing the code block to mess up and should be removed. Tooltips and plain text don't mix well