### PR TITLE
Fix typo: grount to grunt

### DIFF
--- a/_data/toc/frontend-developer-guide.yml
+++ b/_data/toc/frontend-developer-guide.yml
@@ -180,5 +180,5 @@ pages:
       url: frontend-dev-guide/tools/tools_overview.html
       children:
 
-        - label: Using Grount for Magento tasks
+        - label: Using Grunt for Magento tasks
           url: frontend-dev-guide/tools/using_grunt.html


### PR DESCRIPTION
The left sidebar nav currently says

> Using Grount for Magento tasks

It should read:

> Using Grunt for Magento tasks

This fixes it by removing the extraneous "o" in Grount