### PR TITLE
Fix typo in regular expression string

### DIFF
--- a/guides/v2.0/frontend-dev-guide/themes/theme-apply.md
+++ b/guides/v2.0/frontend-dev-guide/themes/theme-apply.md
@@ -34,7 +34,7 @@ To apply a theme:
 
 
 ## Add a design exception {#theme-apply-except}
-Design exceptions enable you to specify an alternative theme for particular user-agents, instead of creating a separate store views for them.
+Design expressions enable you to specify an alternative theme for particular user-agents, instead of creating a separate store views for them.
 To add a design exception:
 
 2. In Admin, go to **Stores** > **Configuration** > **Design**.


### PR DESCRIPTION
It should say "regular expressions" instead of "regular exceptions".