### PR TITLE
Moved misplaced text outside of example code block

### DIFF
--- a/guides/v2.0/coding-standards/code-standard-javascript.md
+++ b/guides/v2.0/coding-standards/code-standard-javascript.md
@@ -273,9 +273,9 @@ Foo.prototype = {
     }
 };
 
-Assignment operations to constructor prototypes creating temporal coupling and sometimes other unwanted side effects.
-
 {% endhighlight %}
+
+Assignment operations to constructor prototypes creating temporal coupling and sometimes other unwanted side effects.
 
 ### Closures
 


### PR DESCRIPTION
It looks like the text "Assignment operations to constructor prototypes creating temporal coupling and sometimes other unwanted side effects." should be outside (after) the example code block instead of in the code block