### PR TITLE
Add MAGETWO-69633 to 2.2 Release Notes

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
@@ -419,6 +419,9 @@ This release contains hundreds of fixes and enhancements.
 <!---69868 -->* Static tests run in a Windows environment no longer fail due to file path mismatches. *Fix submitted by community member <a href="https://github.com/barbazul" target="_blank">Barbazul</a> in pull request <a href="https://github.com/magento/magento2/pull/9902" target="_blank">9902</a>.*
 
 
+<!---69633 -->* Configuration paths `persistent_identifier` & `compression_threshold` for Redis Sessions have been corrected. *Fix submitted by community member <a href="https://github.com/LukeHandle" target="_blank">Luke Hanley</a> in pull request <a href="https://github.com/magento/magento2/pull/9368" target="_blank">9368</a>.* 
+
+
 #### Admin framework
 
 <!--- 57805 -->* You can no longer delete a currently logged-in user.


### PR DESCRIPTION
Links in with PR https://github.com/magento/magento2/pull/9368

Appears to be in 2.2 - https://github.com/magento/magento2/blob/2.2/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php#L49-L56

Happy to re-word the message if desired.