### PR TITLE
Fixed Magneto typos

### DIFF
--- a/guides/v2.0/howdoi/webapi/filter-response.md
+++ b/guides/v2.0/howdoi/webapi/filter-response.md
@@ -12,7 +12,7 @@ github_link: howdoi/webapi/filter-response.md
 ## Retrieving filtered responses
 {:.no_toc}
 
-Some REST calls return dozens or even hundreds of parameters, and parsing through all this data can be unwieldy. In addition, mobile app developers might find the bandwidth needed to process a request to be excessive. To resolve these problems, Magneto provides a query parameter-based syntax for REST {% glossarytooltip 786086f2-622b-4007-97fe-2c19e5283035 %}API{% endglossarytooltip %} requests that return partial responses.
+Some REST calls return dozens or even hundreds of parameters, and parsing through all this data can be unwieldy. In addition, mobile app developers might find the bandwidth needed to process a request to be excessive. To resolve these problems, Magento provides a query parameter-based syntax for REST {% glossarytooltip 786086f2-622b-4007-97fe-2c19e5283035 %}API{% endglossarytooltip %} requests that return partial responses.
 
 <div class="bs-callout bs-callout-info" id="info">
   <p>This feature is not available for SOAP, because SOAP does not allow partial responses. </p>

--- a/guides/v2.0/rest/retrieve-filtered-responses.md
+++ b/guides/v2.0/rest/retrieve-filtered-responses.md
@@ -10,7 +10,7 @@ github_link: rest/retrieve-filtered-responses.md
 redirect_from: /guides/v2.0/howdoi/webapi/filter-response.html
 ---
 
-Some REST calls return dozens or even hundreds of parameters, and parsing through all this data can be unwieldy. In addition, mobile app developers might find the bandwidth needed to process a request to be excessive. To resolve these problems, Magneto provides a query parameter-based syntax for REST {% glossarytooltip 786086f2-622b-4007-97fe-2c19e5283035 %}API{% endglossarytooltip %} requests that return partial responses.
+Some REST calls return dozens or even hundreds of parameters, and parsing through all this data can be unwieldy. In addition, mobile app developers might find the bandwidth needed to process a request to be excessive. To resolve these problems, Magento provides a query parameter-based syntax for REST {% glossarytooltip 786086f2-622b-4007-97fe-2c19e5283035 %}API{% endglossarytooltip %} requests that return partial responses.
 
 <div class="bs-callout bs-callout-info" id="info">
   <p>This feature is not available for SOAP, because SOAP does not allow partial responses. </p>

--- a/guides/v2.2/extension-dev-guide/message-queues/bulk-operations.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/bulk-operations.md
@@ -75,7 +75,7 @@ To send this notification, use `OperationManagementInterface::changeOperationSta
 
 #### Handling Recoverable Exceptions
 
-Magento provides database exception classes to simplify the process of identifying recoverable database errors in client code. In most cases, such errors happen due to some environment issues and can be fixed. The full path to these classes is `Magneto\Framework\DB\Adapter\<class_name>`. These exceptions extend generic `\Zend_Db_Adapter_Exception`.
+Magento provides database exception classes to simplify the process of identifying recoverable database errors in client code. In most cases, such errors happen due to some environment issues and can be fixed. The full path to these classes is `Magento\Framework\DB\Adapter\<class_name>`. These exceptions extend generic `\Zend_Db_Adapter_Exception`.
 
 {% glossarytooltip 53da11f1-d0b8-4a7e-b078-1e099462b409 %}Exception{% endglossarytooltip %} class | Description of database error(s)
 --- | ---


### PR DESCRIPTION
Found several instances of 'Magneto' in the docs. This fixes them.