### PR TITLE
Fix for #1535: Vault documentation not available anymore

### DIFF
--- a/_data/toc/payments-integrations.yml
+++ b/_data/toc/payments-integrations.yml
@@ -55,7 +55,7 @@ pages:
           url: payments-integrations/base-integration/admin-integration.html
 
     - label: Adding vault integration
-      versions: ["2.1"]
+      versions: ["2.1", "2.2", "2.3"]
       url: payments-integrations/vault/vault-intro.html
       children:
 

--- a/guides/v2.2/payments-integrations/vault/admin-integration.md
+++ b/guides/v2.2/payments-integrations/vault/admin-integration.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/admin-integration.md

--- a/guides/v2.2/payments-integrations/vault/customer-stored-payments.md
+++ b/guides/v2.2/payments-integrations/vault/customer-stored-payments.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/customer-stored-payments.md

--- a/guides/v2.2/payments-integrations/vault/enabler.md
+++ b/guides/v2.2/payments-integrations/vault/enabler.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/enabler.md

--- a/guides/v2.2/payments-integrations/vault/module-configuration.md
+++ b/guides/v2.2/payments-integrations/vault/module-configuration.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/module-configuration.md

--- a/guides/v2.2/payments-integrations/vault/payment-token.md
+++ b/guides/v2.2/payments-integrations/vault/payment-token.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/payment-token.md

--- a/guides/v2.2/payments-integrations/vault/token-ui-component-provider.md
+++ b/guides/v2.2/payments-integrations/vault/token-ui-component-provider.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/token-ui-component-provider.md

--- a/guides/v2.2/payments-integrations/vault/vault-di.md
+++ b/guides/v2.2/payments-integrations/vault/vault-di.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/vault-di.md

--- a/guides/v2.2/payments-integrations/vault/vault-intro.md
+++ b/guides/v2.2/payments-integrations/vault/vault-intro.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/vault-intro.md

--- a/guides/v2.2/payments-integrations/vault/vault-payment-configuration.md
+++ b/guides/v2.2/payments-integrations/vault/vault-payment-configuration.md
@@ -1,0 +1,1 @@
+../../../v2.1/payments-integrations/vault/vault-payment-configuration.md


### PR DESCRIPTION
Fixed missed Vault integration guide for Magento 2.2