### PR TITLE
Fix the sed filter in mysqldump command

### DIFF
--- a/guides/v2.0/cloud/live/stage-prod-migrate.md
+++ b/guides/v2.0/cloud/live/stage-prod-migrate.md
@@ -193,7 +193,7 @@ This error occurs because the DEFINER for the triggers in the SQL dump is the pr
 
 To solve the issue, you can generate a new database dump changing or removing the `DEFINER` clause. The following is one example of completing this change:
 
-	mysqldump -h <database host> --user=<database user name> --password=<password> --single-transaction main  | sed -i 's/DEFINER=[^*]**/*/g' | gzip > /tmp/database_no-definer.sql.gz
+	mysqldump -h <database host> --user=<database user name> --password=<password> --single-transaction main  | sed 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/g' | gzip > /tmp/database_no-definer.sql.gz
 
 Use the database dump you just created to [migrate the database](#cloud-live-migrate-db).
 


### PR DESCRIPTION
The actual version of sed filter in mysqldump command doesn't work, it fails with the following error:
```
sed: -e expression #1, char 20: Invalid preceding regular expression 
mysqldump: Got errno 32 on write
```

The suggested fix works fine :)