### PR TITLE
Change index to indices for parameter

### DIFF
--- a/guides/v2.1/config-guide/elasticsearch/es-overview.md
+++ b/guides/v2.1/config-guide/elasticsearch/es-overview.md
@@ -136,7 +136,7 @@ To install Elasticsearch:
 	For example, it might be located in `/etc/elasticsearch` or `<elasticsearch install dir>/config`.
 5.	Add the following parameter to the `Memory` section:
 
-		index.query.bool.max_clause_count: 10024
+		indices.query.bool.max_clause_count: 10024
 
 	For more information, see [Setting the BooleanQuery maxClauseCount in Elasticsearch](http://george-stathis.com/2013/10/18/setting-the-booleanquery-maxclausecount-in-elasticsearch){:target="_blank"}.
 6.	Save your changes to `elasticsearch.yml` and exit the text editor.


### PR DESCRIPTION
Error with index.  Works with indices.

[2017-12-13T16:00:23,410][ERROR][o.e.b.Bootstrap          ] Exception
java.lang.IllegalArgumentException: unknown setting [index.query.bool.max_clause_count] did you mean [indices.query.bool.max_clause_count]?
        at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:312) ~[elasticsearch-6.1.0.jar:6.1.0]
        at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:276) ~[elasticsearch-6.1.0.jar:6.1.0]
        at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:135) ~[elasticsearch-6.1.0.jar:6.1.0]
        at org.elasticsearch.node.Node.<init>(Node.java:330) ~[elasticsearch-6.1.0.jar:6.1.0]