### PR TITLE
Update using_grunt.md

### DIFF
--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -69,7 +69,7 @@ To use a custom file for Grunt configuration:
 
 
        {
-           "themes": "dev/tools/grunt/configs/local-themes"
+           "themes": "dev/tools/grunt/configs/local-themes/themes"
        }
 
 


### PR DESCRIPTION
To prevent:
```
$ grunt clean
Loading "Gruntfile.js" tasks...ERROR
>> Error: Cannot find module 'd:\OSPanel\domains\mg2as/dev/tools/grunt/configs/local-themes'
Warning: Task "clean" not found. Use --force to continue.

Aborted due to warnings.
```