### PR TITLE
Changed parameters order for non-default browser

### DIFF
--- a/guides/v2.0/mtf/mtf_quickstart/mtf_quickstart_environment.md
+++ b/guides/v2.0/mtf/mtf_quickstart/mtf_quickstart_environment.md
@@ -36,7 +36,7 @@ Run the Selenium Server with an additional argument.
 Example for Google Chrome with Selenium 2:
 
 
-    java -jar <path_to_selenium_directory>/selenium-server.jar -Dwebdriver.chrome.driver=<path_to_chrome_driver>/chromedriver.exe
+    java -Dwebdriver.chrome.driver=<path_to_chrome_driver>/chromedriver.exe -jar <path_to_selenium_directory>/selenium-server.jar
     
 <div class="bs-callout bs-callout-info" markdown="1">
 For Selenium 3 add the web driver to the directory where `selenium-server.jar` is located and run tests without additional argument: `java -jar <path_to_selenium_directory>/selenium-server.jar`


### PR DESCRIPTION
It's better to change parameters order, because in some cases this command throws the following error: "Exception in thread "main" com.beust.jcommander.ParameterException: Unknown option: -Dwebdriver.chrome.driver=..."