### PR TITLE
Update requirements

### DIFF
--- a/guides/v2.2/install-gde/system-requirements-tech.md
+++ b/guides/v2.2/install-gde/system-requirements-tech.md
@@ -56,7 +56,7 @@ The [CentOS]({{page.baseurl}}install-gde/prereq/php-centos.html) and [Ubuntu]({{
 *	<a href="http://php.net/manual/en/book.intl.php" target="&#95;blank">intl</a>
 *	<a href="http://php.net/manual/en/book.mbstring.php" target="&#95;blank">mbstring</a>
 *	<a href="http://php.net/manual/en/book.mcrypt.php" target="&#95;blank">mcrypt</a>
-*	<a href="http://php.net/manual/en/book.mhash.php" target="&#95;blank">mhash</a>
+*	<a href="http://php.net/manual/en/book.hash.php" target="&#95;blank">hash</a>
 *	<a href="http://php.net/manual/en/book.openssl.php" target="&#95;blank">openssl</a>
 *	<a href="http://php.net/manual/en/ref.pdo-mysql.php" target="&#95;blank">PDO/MySQL</a>
 *	<a href="http://php.net/manual/en/book.simplexml.php" target="&#95;blank">SimpleXML</a>


### PR DESCRIPTION
Because mhash is obsolete and since 5.3.0 php emulates mhash functions through the HASH extension I decided to change it in our official requirements.
More that we had an internal ticket MDVA-7831 where the merchant was confused by this fact.
I checked composer.json and also found that ext-hash exists in requirements but ext-mhash is absent.
Thank you.