### PR TITLE
Add information about Elasticsearch index prefix to the ES configuration page

### DIFF
--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -30,7 +30,7 @@ To configure Magento to use Elasticsearch:
 	</tr>
 	<tr>
 		<td>Elasticsearch Index Prefix</td>
-		<td>Enter the Elasticsearch Index Prefix. If you use single Elasticsearch instance for several Magento installations, for example, for Staging and Production environments, you have to specify different prefixes for each Magento installation. Otherwise you can left default prefix <code>magento2</code>.</td>
+		<td>Enter the Elasticsearch index prefix. If you use a single Elasticsearch instance for more than one Magento installation (Staging and Production environments), you must specify a unique prefix for each installation. Otherwise, you can use the default prefix <code>magento2</code>.</td>
 	</tr>
 	<tr>
 		<td>Enable Elasticsearch HTTP Auth</td>

--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -29,6 +29,10 @@ To configure Magento to use Elasticsearch:
 		<p>{{site.data.var.ece}}: <a href="{{ page.baseurl }}cloud/project/project-conf-files_services-elastic.html#cloud-es-config-mg">Get this value</a> from your integration system.</p></td>
 	</tr>
 	<tr>
+		<td>Elasticsearch Index Prefix</td>
+		<td>Enter the Elasticsearch Index Prefix. If you use single Elasticsearch instance for several Magento installations, for example, for Staging and Production environments, you have to specify different prefixes for each Magento installation. Otherwise you can left default prefix <code>magento2</code>.</td>
+	</tr>
+	<tr>
 		<td>Enable Elasticsearch HTTP Auth</td>
 		<td>Click <strong>Yes</strong> only if you enabled authentication for your Elasticsearch server. If so, provide a user name and password in the provided fields.</td>
 	</tr>


### PR DESCRIPTION
I've added information about index prefixes in Elasticsearch configuration. It's very important thing if you share single ES instance, like on the Magento Cloud staging/production environments.

whatsnew
Added information about the index prefix when [configuring Elasticsearch](http://devdocs.magento.com/guides/v2.2/config-guide/elasticsearch/configure-magento.html), which is necessary when using a single Elasticsearch instance with multiple Magento installations, like Staging and Production environments.