### PR TITLE
Logs

### DIFF
--- a/guides/v2.0/cloud/project/project-start.md
+++ b/guides/v2.0/cloud/project/project-start.md
@@ -88,7 +88,7 @@ You can review these logs via SSH into the environment. Change to the directorie
 
 Logs from the deploy hook are located on the server in the following locations:
 
-*	Integration: `/tmp/log/deploy.log`
+*	Integration: `/var/log/deploy.log`
 *	Staging: `/var/log/platform/<prodject ID>/post_deploy.log`
 *	Production: `/var/log/platform/{1|2|3}.<prodject ID>/post_deploy.log`
 

--- a/guides/v2.0/cloud/trouble/environments-logs.md
+++ b/guides/v2.0/cloud/trouble/environments-logs.md
@@ -27,12 +27,12 @@ You may need to SSH into the environments to locate and view logs. To locate the
 ## Build logs
 After pushing to your environment, you can see the results of the both hooks. Logs from the build hook are redirected to the output stream of `git push`, so you can observe them in the terminal or capture them (along with error messages) with `git push > build.log 2>&1`.
 
-For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that compiles both build and deploy actions into one file.
+For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the Magento application root directory, that compiles both build and deploy actions into one file.
 
 ## Deploy logs {#log-deploy-log}
 You can review these logs via SSH into the environment. Change to the directories listed below to review the logs.
 
-For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that compiles both build and deploy actions into one file.
+For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the Magento application root directory, that compiles both build and deploy actions into one file.
 
 Logs from the deploy hook are located on the server in the following locations:
 

--- a/guides/v2.0/cloud/trouble/environments-logs.md
+++ b/guides/v2.0/cloud/trouble/environments-logs.md
@@ -36,7 +36,7 @@ For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that c
 
 Logs from the deploy hook are located on the server in the following locations:
 
-*	Integration: `/tmp/log/deploy.log`
+*	Integration: `/var/log/deploy.log`
 *	Staging: `/var/log/platform/<prodject ID>_stg/post_deploy.log`
 *	Production: `/var/log/platform/<prodject ID>/post_deploy.log`
 

--- a/guides/v2.2/cloud/composer-packages/ece-tools.md
+++ b/guides/v2.2/cloud/composer-packages/ece-tools.md
@@ -87,7 +87,7 @@ You must [update this package](http://devdocs.magento.com/guides/v2.2/cloud/proj
 ### New features
 <!--- MAGECLOUD-1057 -->* {{site.data.var.ece}} now supports scopes and [static content deployment strategies](http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html). We have added the `–s` parameter with a default setting of `quick` for the static content deployment strategy. You can use the environment variable [SCD_STRATEGY](http://devdocs.magento.com/guides/v2.2/cloud/env/environment-vars_magento.html) to customize and use these strategies with your build and deploy actions. This variable supports the options `standard`, `quick`, or `compact`. If you select `compact`, we override the `STATIC_CONTENT_THREADS` value with `1`, which can slow deployment, especially in production environments.
 
-<!--- MAGECLOUD-1014, 1023 -->* We have created a new log file on environments to capture and compile build and deploy actions. The file name and location is `/app/var/log/cloud.log`.
+<!--- MAGECLOUD-1014, 1023 -->* We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `app/var/log/cloud.log` file inside the Magento root application directory.
 
 ### Fixed issues
 <!-- MAGECLOUD-919 & MAGECLOUD-1030-->* Refactored the `ece-tools` package to make it compatible with {{site.data.var.ece}} 2.2.0 and higher.

--- a/guides/v2.2/cloud/env/setup-notifications.md
+++ b/guides/v2.2/cloud/env/setup-notifications.md
@@ -10,7 +10,7 @@ functional_areas:
   - Configuration
 ---
 
-By default, {{site.data.var.ece}} writes build and deploy actions to a single file called `app/var/log/cloud.log`, but you can also send logs to messaging systems, like Slack and email, if you want to receive real-time notifications.
+By default, {{site.data.var.ece}} writes build and deploy actions to a single file called `app/var/log/cloud.log` inside the Magento root application directory, but you can also send logs to messaging systems, like Slack and email, if you want to receive real-time notifications.
 
 For example, you may want to send a Slack message to a group of people when a deployment fails so someone can immediately start investigating what went wrong.
 

--- a/guides/v2.2/cloud/project/project-start.md
+++ b/guides/v2.2/cloud/project/project-start.md
@@ -87,7 +87,7 @@ You can review these logs via SSH into the environment. Change to the directorie
 
 Logs from the deploy hook are located on the server in the following locations:
 
-*	Integration: `/tmp/log/deploy.log`
+*	Integration: `/var/log/deploy.log`
 *	Staging: `/var/log/platform/<prodject ID>/post_deploy.log`
 *	Production: `/var/log/platform/{1|2|3}.<prodject ID>/post_deploy.log`
 

--- a/guides/v2.2/cloud/release-notes/CloudReleaseNotes2.2.1.md
+++ b/guides/v2.2/cloud/release-notes/CloudReleaseNotes2.2.1.md
@@ -48,7 +48,7 @@ In general, we’ve removed serialize/unserialize from most the code to improve 
 
 * When you create a new project using the 30-day free trial, we automatically provision the project with the latest Magento Commerce (Cloud) code. The steps include cloning the latest code repository, adding an environment variable for `ADMIN_EMAIL` using the Project Owner’s email, setting a default randomized Magento Admin password, and sending emails to the Project Owner to access the project and reset the default Magento Admin password. For details, see [Onboarding tasks](http://devdocs.magento.com/guides/v2.2/cloud/onboarding/onboarding-tasks.html) and [What is autoprovisioning](http://devdocs.magento.com/guides/v2.2/cloud/basic-information/cloud-plans.html#autoprovisioning).
 
-<!--- MAGECLOUD-1014, 1023 -->* We have created a new log file on environments to capture and compile Build and Deploy actions. The file name and location is `/app/var/log/cloud.log`.
+<!--- MAGECLOUD-1014, 1023 -->* We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `app/var/log/cloud.log` file inside the Magento root application directory.
 
 ## Known issues {#known}
 For all known {{site.data.var.ee}} 2.2.1  issues, see [Magento Commerce 2.2.1 Release Notes](http://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.html).

--- a/guides/v2.2/cloud/trouble/environments-logs.md
+++ b/guides/v2.2/cloud/trouble/environments-logs.md
@@ -31,12 +31,12 @@ You can also [set up log-based Slack and email notifications]({{page.baseurl}}cl
 ## Build logs
 After pushing to your environment, you can see the results of the both hooks. Logs from the build hook are redirected to the output stream of `git push`, so you can observe them in the terminal or capture them (along with error messages) with `git push > build.log 2>&1`.
 
-For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that compiles both build and deploy actions into one file.
+For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the Magento application root directory, that compiles both build and deploy actions into one file.
 
 ## Deploy logs {#log-deploy-log}
 You can review these logs via SSH into the environment. Change to the directories listed below to review the logs.
 
-For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that compiles both build and deploy actions into one file.
+For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the Magento application root directory, that compiles both build and deploy actions into one file.
 
 Logs from the deploy hook are located on the server in the following locations:
 

--- a/guides/v2.2/cloud/trouble/environments-logs.md
+++ b/guides/v2.2/cloud/trouble/environments-logs.md
@@ -40,7 +40,7 @@ For 2.1.9 and later and 2.2.X, we include a `/app/var/log/cloud.log` file that c
 
 Logs from the deploy hook are located on the server in the following locations:
 
-*	Integration: `/tmp/log/deploy.log`
+*	Integration: `/var/log/deploy.log`
 *	Staging: `/var/log/platform/<prodject ID>_stg/post_deploy.log`
 *	Production: `/var/log/platform/<prodject ID>/post_deploy.log`
 


### PR DESCRIPTION
I've replaced the location of deploy.log on the Integration environment: /tmp/log/deploy.log => /var/log/deploy.log

Actually this log is located in the /tmp/log directory, it isn't a mistake, and /var/log is a symbolic link to the /tmp/log. I think it less confuses users if they can find logs in a usual UNIX location: /var/log directory. Also it's easier to remember where to find system logs: only in the /var/log.

Second commits unifies the location of var/log/cloud.log: the /app/var/log/cloud.log is a valid path only on the Integration environment.