### PR TITLE
replace the extension the extension with the module as it is in v2.0

### DIFF
--- a/guides/v2.1/cloud/howtos/install-components.md
+++ b/guides/v2.1/cloud/howtos/install-components.md
@@ -75,7 +75,7 @@ To update `composer.json`:
 If there are errors, see [extension deployment failure]({{page.baseurl}}cloud/trouble/trouble_comp-deploy-fail.html).
 
 <div class="bs-callout bs-callout-warning" markdown="1">
-When installing and adding the module, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
+When installing and adding the module, you must add the `composer.lock` file to your Git branch for deployment. This ensures that the module loads properly when you use the `composer install` command.
 </div>
 
 ### Step 3: Verify the extension {#verify}

--- a/guides/v2.1/cloud/howtos/install-components.md
+++ b/guides/v2.1/cloud/howtos/install-components.md
@@ -75,7 +75,7 @@ To update `composer.json`:
 If there are errors, see [extension deployment failure]({{page.baseurl}}cloud/trouble/trouble_comp-deploy-fail.html).
 
 <div class="bs-callout bs-callout-warning">
-When installing and adding the extension the extension, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
+When installing and adding the module, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
 </div>
 
 ### Step 3: Verify the extension {#verify}

--- a/guides/v2.1/cloud/howtos/install-components.md
+++ b/guides/v2.1/cloud/howtos/install-components.md
@@ -74,7 +74,7 @@ To update `composer.json`:
 
 If there are errors, see [extension deployment failure]({{page.baseurl}}cloud/trouble/trouble_comp-deploy-fail.html).
 
-<div class="bs-callout bs-callout-warning">
+<div class="bs-callout bs-callout-warning" markdown="1">
 When installing and adding the module, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
 </div>
 

--- a/guides/v2.2/cloud/howtos/install-components.md
+++ b/guides/v2.2/cloud/howtos/install-components.md
@@ -75,7 +75,7 @@ To update `composer.json`:
 If there are errors, see [extension deployment failure]({{page.baseurl}}cloud/trouble/trouble_comp-deploy-fail.html).
 
 <div class="bs-callout bs-callout-warning">
-When installing and adding the extension the extension, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
+When installing and adding the module, you must add the `composer.lock` to your Git branch for deployment. If the extension is not in the file, the extension won't load in {{site.data.var.ece}}. This ensures when the `composer install` command is used, the extension properly loads. This command uses the `composer.lock` file.
 </div>
 
 ### Step 3: Verify the extension {#verify}


### PR DESCRIPTION
Hello , 

There should be "the module" instead of "the extension the extension"
Refer below screenshot.
![install manage and upgrade extensions magento 2 developer documentation](https://user-images.githubusercontent.com/33098216/35511102-b6df9fec-0520-11e8-9a20-a64828b4ac95.png)
