### PR TITLE
Comment skip_scd=yes in example of build_options.ini

### DIFF
--- a/guides/v2.2/cloud/env/environment-vars_magento.md
+++ b/guides/v2.2/cloud/env/environment-vars_magento.md
@@ -99,7 +99,7 @@ scd_threads=2
 scd_strategy=standard
 
 ; Skips static content deployment during the build phase.
-skip_scd=yes
+;skip_scd=yes
 ```
 
 <table>


### PR DESCRIPTION
Some our clients copy an example of build_options.ini from our article. It would be better to have the "skip_scd=yes" commented out.