### PR TITLE
Updated naming convention for Plugin classes.

### DIFF
--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -41,7 +41,7 @@ You must specify these elements:
 
 * `type name`. A class or interface which the plugin observes.
 * `plugin name`. An arbitrary plugin name that identifies a plugin. Also used to merge the configurations for the plugin.
-* `plugin type`. The name of a plugin's class or its virtual type. Use the following naming convention when you specify this element: `\Vendor\Module\Plugin\<ModelName>Plugin`.
+* `plugin type`. The name of a plugin's class or its virtual type. Use the following naming convention when you specify this element: `\Vendor\Module\Plugin\<ClassName>`.
 
 The following elements are optional:
 
@@ -63,7 +63,7 @@ Below is an example of a before method modifying the `$name` argument before pas
 {% highlight PHP inline=true %}
 namespace My\Module\Plugin;
 
-class ProductPlugin
+class ProductAttributesUpdater
 {
     public function beforeSetName(\Magento\Catalog\Model\Product $subject, $name)
     {
@@ -83,7 +83,7 @@ Below is an example of an after method modifying the return value `$result` of a
 
 namespace My\Module\Plugin;
 
-class ProductPlugin
+class ProductAttributesUpdater
 {
     public function afterGetName(\Magento\Catalog\Model\Product $subject, $result)
     {
@@ -99,7 +99,7 @@ Below is an example of an after method that accepts the `null` result and argume
 {% highlight PHP inline=true %}
 namespace My\Module\Plugin;
 
-class AuthPlugin
+class AuthLogger
 {
     private $logger
 
@@ -127,7 +127,7 @@ After methods do not need to declare all the arguments of their observed methods
 The following example is a class with an after method for [`\Magento\Catalog\Model\Product\Action::updateWebsites($productIds, $websiteIds, $type)`]({{site.mage2100url}}app/code/Magento/Catalog/Model/Product/Action.php){:target="_blank"}:
 {% highlight PHP %}
 
-class MyPlugin
+class WebsitesLogger
 {
     private $logger
 
@@ -165,7 +165,7 @@ Below is an example of an around method adding behavior before and after an obse
 {% highlight PHP inline=true %}
 namespace My\Module\Plugin;
 
-class ProductPlugin
+class ProductAttributesUpdater
 {
     public function aroundSave(\Magento\Catalog\Model\Product $subject, callable $proceed)
     {
@@ -200,7 +200,7 @@ If you wrapped this method with a plugin like below:
 {% highlight PHP inline=true %}
 namespace My\Module\Plugin;
 
-class MyUtilityPlugin
+class MyUtilityUpdater
 {
     public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, SomeType $obj)
     {
@@ -216,7 +216,7 @@ You are responsible for forwarding the arguments from the plugin to the <code>pr
 {% highlight PHP inline=true %}
 namespace My\Module\Plugin;
 
-class MyUtilityPlugin
+class MyUtilityUpdater
 {
     public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, ...$args)
     {


### PR DESCRIPTION
The "Plugin" word is redundant for a class name because the namespace already contains it. All plugins located in the same folder for each module and it's not necessary naming classes with "Plugin" word.

It's more important to create meaningful names instead `ModelNamePlugin`.