### PR TITLE
Remove recommendation to use Memcache instead of Redis for session du…

### DIFF
--- a/guides/v2.1/config-guide/memcache/memcache.md
+++ b/guides/v2.1/config-guide/memcache/memcache.md
@@ -1,1 +1,26 @@
-../../../v2.0/config-guide/memcache/memcache.md
+---
+layout: default
+group: config-guide
+subgroup: 10_mem
+title: Use memcached for session storage
+menu_title: Use memcached for session storage
+menu_order: 1
+menu_node: parent
+version: 2.0
+github_link: config-guide/memcache/memcache.md
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+<h2 id="config-memcache-over">Overview of memcached session storage</h2>
+memcached is a general-purpose distributed memory caching system. It is often used to speed up dynamic database-driven websites by caching data and objects in RAM to reduce the number of times an external data source (such as a database or API) must be read. (Source: <a href="https://en.wikipedia.org/wiki/Memcached" target="_blank">Wikipedia</a>)
+
+memcache provides a very large hash table that can be distributed across multiple machines. When the table is full, subsequent inserts cause older data to be purged in least recently used (LRU) order. The size of this hash table is often very large. (Source: <a href="http://memcached.org/" target="_blank">memcached.org</a>)
+
+Magento uses memcached for session storage but not for page caching. For page caching, we recommend <a href="{{page.baseurl}}config-guide/redis/config-redis.html">Redis</a> or <a href="{{page.baseurl}}config-guide/varnish/config-varnish.html">Varnish</a>.
+
+#### Next step
+*   <a href="{{page.baseurl}}config-guide/memcache/memcache_ubuntu.html">Install, configure, verify memcached on Ubuntu</a>
+*   <a href="{{page.baseurl}}config-guide/memcache/memcache_centos.html">Install, configure, verify memcached on CentOS</a>


### PR DESCRIPTION
…e to locking issues

The session locking issue was fixed for the 2.1 release with the updated "colinmollenhour/php-redis-session-abstract" dependency to 1.3.4, containing this fix: https://github.com/colinmollenhour/php-redis-session-abstract/commit/6f005b2c3755e4a96ddad821e2ea15d66fb314ae.

Redis should be used for session over Memcache if available as the better back-end, now with no locking issues.