### PR TITLE
Run grunt command before ece-build hook

### DIFF
--- a/guides/v2.0/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.0/cloud/project/project-conf-files_magento-app.md
@@ -248,7 +248,11 @@ hooks:
     cd public/profiles/project_name/themes/custom/theme_name
     npm install
     grunt
+    cd
+    php ./bin/magento magento-cloud:build
 ```
+
+Note, that SASS compile should be run before static assets deployment, so you have to put the grunt command before the `m2-ece-build` command.
 
 ## `crons` {#cloud-yaml-platform-cron}
 `crons` describes processes that are triggered on a schedule. We recommend you run cron as the [Magento file system owner]({{ page.baseurl }}cloud/before/before-workspace-file-sys-owner.html). Do not run cron as `root`. We also recommend against running cron as the web server user.

--- a/guides/v2.0/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.0/cloud/project/project-conf-files_magento-app.md
@@ -252,7 +252,7 @@ hooks:
     php ./bin/magento magento-cloud:build
 ```
 
-You must compile SASS files using `grunt` before static content deployment, which happens during the build.
+You must compile SASS files using `grunt` before static content deployment, which happens during the build. Place the `grunt` command before the `build` command.
 
 ## `crons` {#cloud-yaml-platform-cron}
 `crons` describes processes that are triggered on a schedule. We recommend you run cron as the [Magento file system owner]({{ page.baseurl }}cloud/before/before-workspace-file-sys-owner.html). Do not run cron as `root`. We also recommend against running cron as the web server user.

--- a/guides/v2.0/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.0/cloud/project/project-conf-files_magento-app.md
@@ -252,7 +252,7 @@ hooks:
     php ./bin/magento magento-cloud:build
 ```
 
-Note, that SASS compile should be run before static assets deployment, so you have to put the grunt command before the `m2-ece-build` command.
+You must compile SASS files using `grunt` before static content deployment, which happens during the build.
 
 ## `crons` {#cloud-yaml-platform-cron}
 `crons` describes processes that are triggered on a schedule. We recommend you run cron as the [Magento file system owner]({{ page.baseurl }}cloud/before/before-workspace-file-sys-owner.html). Do not run cron as `root`. We also recommend against running cron as the web server user.

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -240,7 +240,11 @@ hooks:
     cd public/profiles/project_name/themes/custom/theme_name
     npm install
     grunt
+    cd
+    php ./vendor/bin/m2-ece-build
 ```
+
+Note, that SASS compile should be run before static assets deployment, so you have to put the grunt command before the `m2-ece-build` command.
 
 ## Environment variables {#variables}
 The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.X.

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -244,7 +244,7 @@ hooks:
     php ./vendor/bin/m2-ece-build
 ```
 
-Note, that SASS compile should be run before static assets deployment, so you have to put the grunt command before the `m2-ece-build` command.
+You must compile SASS files using `grunt` before static content deployment, which happens during the build. Place the `grunt` command before the `build` command.
 
 ## Environment variables {#variables}
 The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.X.


### PR DESCRIPTION
The grunt tasks prepare Magento themes and they should be run before setup:static-content:deploy command. I've added a note that grunt should be placed before our build hook.