### PR TITLE
Fixed default number of jobs

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -221,9 +221,7 @@ The following table explains this command's parameters and values.
       <td>
         <p>
           Enable parallel processing using the specified number of
-          jobs. The default is 4. To cause the task to run in one
-          process (for example, if your system does not support
-          process forking), use <code>--jobs 1</code>.
+          jobs. The default is 0 (do not run in parallel processes).
         </p>
       </td>
       <td>


### PR DESCRIPTION
Described default number of jobs, "4", is incorrect. It is "0" for the command. Though default number is "4" for `\Magento\Deploy\Process\Queue` which is used by the command.