### PR TITLE
Update magento-modes.md

### DIFF
--- a/guides/v2.0/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.0/config-guide/bootstrap/magento-modes.md
@@ -48,7 +48,12 @@ You can run Magento in any of the following *modes*:
 	</tr>
 	<tr>
 		<td>production</td>
-		<td>Intended for deployment on a production system. Exceptions are not displayed to the user, exceptions are written to logs only, and static view files are served from `pub/static` only. New or updated files are not written to the file system. </td>
+		<td><p>Intended for deployment on a production system, this mode:</p>
+			<ul><li>Does not show exceptions to the user (exceptions are written to logs only).</li>
+				<li>Serves static view files from cache only.</li>
+				<li>Prevents automatic code file compilation. New or updated files are not written to the file system.</li>
+				<li><b>Does not allow you to enable or disable cache types in Magento Admin.</b> <a href="{{ page.baseurl }}config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</li>
+			</ul></td>
 	</tr>
 </tbody>
 </table>

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -47,7 +47,7 @@ You can run Magento in any of the following *modes*:
 	</tr>
 	<tr>
 		<td>production</td>
-		<td>Intended for deployment on a production system. This mode:
+		<td><p>Intended for deployment on a production system, this mode:</p>
 			<ul><li>Does not show exceptions to the user (exceptions are written to logs only).</li>
 				<li>Serves static view files from cache only.</li>
 				<li>Prevents automatic code file compilation. New or updated files are not written to the file system.</li>

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -47,8 +47,12 @@ You can run Magento in any of the following *modes*:
 	</tr>
 	<tr>
 		<td>production</td>
-		<td><p>Intended for deployment on a production system. Exceptions are not displayed to the user, exceptions are written to logs only, and static view files are served from cache only. New or updated files are not written to the file system.</p>
-			<p>In production mode, you cannot enable or disable cache types using the Magento Admin. <a href="{{ page.baseurl }}config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</p></td>
+		<td>Intended for deployment on a production system. This mode:
+			<ul><li>Does not show exceptions to the user (exceptions are written to logs only).</li>
+				<li>Serves static view files from cache only.</li>
+				<li>Prevents automatic code file compilation. New or updated files are not written to the file system.</li>
+				<li><b>Does not allow you to enable or disable cache types in Magento Admin.</b> <a href="{{ page.baseurl }}config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</li>
+			</ul></td>
 	</tr>
 </tbody>
 </table>


### PR DESCRIPTION
When I was reading this file, I noticed that the top two (default and developer) had bullet points, but not production. This reformats the production points to make it inline with the first two.