### PR TITLE
Add some necessary configuration to let multi size work properly

### DIFF
--- a/guides/v2.0/config-guide/multi-site/ms_nginx.md
+++ b/guides/v2.0/config-guide/multi-site/ms_nginx.md
@@ -89,23 +89,25 @@ This section discusses how to load websites on the {% glossarytooltip 1a70d3ac-6
            include /var/www/html/magento2/nginx.conf;
 		}
 4.	Save your changes to the files and exit the text editor.
-5.      Change `nginx.conf.sample` content 
+5.  Change `nginx.conf.sample` content 
 		
 		location ~ (index|get|static|report|404|503|health_check)\.php$ {
-		    try_files $uri =404;
-		    fastcgi_pass   fastcgi_backend;
-		    fastcgi_buffers 1024 4k;
+			try_files $uri =404;
+			fastcgi_pass   fastcgi_backend;
+			fastcgi_buffers 1024 4k;
 
-		    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-		    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
-		    fastcgi_read_timeout 600s;
-		    fastcgi_connect_timeout 600s;
+			fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+			fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+			fastcgi_read_timeout 600s;
+			fastcgi_connect_timeout 600s;
 
-		    fastcgi_index  index.php;
-		    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-		    include        fastcgi_params;
+			fastcgi_index  index.php;
+			fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+			include        fastcgi_params;
 		}
+		
 	to
+	
 		location ~ (index|get|static|report|404|503|health_check)\.php$ {
 		    try_files $uri =404;
 		    fastcgi_pass   fastcgi_backend;

--- a/guides/v2.0/config-guide/multi-site/ms_nginx.md
+++ b/guides/v2.0/config-guide/multi-site/ms_nginx.md
@@ -26,7 +26,7 @@ We assume the following:
 
 	Additional tasks are required to set up {{site.data.var.ece}}. After you complete the tasks discussed in this topic, see [Set up multiple {{site.data.var.ece}} websites or stores]({{ page.baseurl }}cloud/project/project-multi-sites.html).
 *	You use one virtual host per website; the virtual host configuration files are located in `/etc/nginx/sites-available`
-*	You use `nginx.conf.sample` provided by Magento with only the modifications discussed in this tutorial
+*	You use `nginx.conf.sample` provided by Magento with only the modifications discussed in this tutorial, and two line configurations.
 *	The Magento software is installed in `/var/www/html/magento2`
 *	You have two websites other than the default:
 
@@ -61,6 +61,9 @@ This section discusses how to load websites on the {% glossarytooltip 1a70d3ac-6
 		map $http_host $MAGE_RUN_CODE {
            french.mysite.mg french;
 		}
+		map $http_host $MAGE_RUN_TYPE {
+		    french.mysite.mg store
+		}
 
 		server {
            listen 80;
@@ -74,6 +77,9 @@ This section discusses how to load websites on the {% glossarytooltip 1a70d3ac-6
 		map $http_host $MAGE_RUN_CODE {
            german.mysite.mg german;
 		}
+		map $http_host $MAGE_RUN_TYPE {
+		    german.mysite.mg store
+		}
 
 		server {
            listen 80;
@@ -83,6 +89,39 @@ This section discusses how to load websites on the {% glossarytooltip 1a70d3ac-6
            include /var/www/html/magento2/nginx.conf;
 		}
 4.	Save your changes to the files and exit the text editor.
+5.      Change `nginx.conf.sample` content 
+		
+		location ~ (index|get|static|report|404|503|health_check)\.php$ {
+		    try_files $uri =404;
+		    fastcgi_pass   fastcgi_backend;
+		    fastcgi_buffers 1024 4k;
+
+		    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+		    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+		    fastcgi_read_timeout 600s;
+		    fastcgi_connect_timeout 600s;
+
+		    fastcgi_index  index.php;
+		    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+		    include        fastcgi_params;
+		}
+	to
+		location ~ (index|get|static|report|404|503|health_check)\.php$ {
+		    try_files $uri =404;
+		    fastcgi_pass   fastcgi_backend;
+		    fastcgi_buffers 1024 4k;
+
+		    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+		    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+		    fastcgi_param  MAGE_RUN_TYPE $MAGE_RUN_TYPE;
+    		    fastcgi_param  MAGE_RUN_CODE $MAGE_RUN_CODE;
+		    fastcgi_read_timeout 600s;
+		    fastcgi_connect_timeout 600s;
+
+		    fastcgi_index  index.php;
+		    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+		    include        fastcgi_params;
+		}
 5.	Verify the server configuration:
 
 		nginx -t


### PR DESCRIPTION
whatsnew
Added configuration info for [creating nginx virtual hosts](https://devdocs.magento.com/guides/v2.0/config-guide/multi-site/ms_nginx.html#ms-nginx-vhosts) on Tutorial—Set up multiple websites or stores with nginx page.

When I followed the guide to configure multidomain with multi-sites, it's don't don't work as expected. I have checked the `nginx.conf.sample` file and don't find the place to use the parameters (`$MAGE_TYPE_CODE` and `$MAGE_TYPE_RUN`) which are set in `/etc/nginx/conf.d/*.conf`. I searched a lot and find the solution [here](https://magento.stackexchange.com/questions/125584/magento2-multistore-multiwebsite-setup-on-nginx). 
You could check the configuration carefully. (PS: I am not familiar with nginx configuration) 
Wish I could help other peoples.