### PR TITLE
Remove ES 5.x support reference from Magento CE 2.2.3 release note.

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
@@ -10,10 +10,10 @@ level3_subgroup:
 version: 2.2
 github_link: release-notes/ReleaseNotes2.2.3CE.md
 ---
-*Patch code and release notes published on February 27, 2018.* 
+*Patch code and release notes published on February 27, 2018.*
 
 
-We are pleased to present Magento Commerce 2.2.3. This release includes 35 enhancements to product security, a change to the Magento Admin to support recent USPS shipping changes, and a copyright update. And thanks to our community members, it also includes support for Elasticsearch 5.x and enhancements to ACL control for cache management through Magento Admin.
+We are pleased to present Magento Commerce 2.2.3. This release includes 35 enhancements to product security, a change to the Magento Admin to support recent USPS shipping changes, and a copyright update. And thanks to our community members, it also includes enhancements to ACL control for cache management through Magento Admin.
 
 
 ## Highlights
@@ -22,9 +22,7 @@ Look for the following highlights in this release:
 
 * **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
 
-<!--- MAGETWO-84775 -->* **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch](http://devdocs.magento.com/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a> in pull request <a href="https://github.com/magento/magento2/pull/822" target="_blank">822</a>.*
-
-* **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS  removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace. 
+* **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS  removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
 
 * **New layers of control for  cache management tasks managed through the Magento Admin**. This release introduces finer permissions for cache management tasks such as flushing cache storage, flushing the Magento cache, and refreshing cache types. *Fix submitted by community member <a href="https://github.com/bartoszherba" target="_blank">Bartosz Herba</a> in pull request <a href="https://github.com/magento/magento2/pull/78" target="_blank">78</a>.*
 


### PR DESCRIPTION
Remove reference to ES 5.x support from the Magento Open Source 2.2.3 release note.
Let people think that ES support have been open sourced.