### PR TITLE
presentation markup used in acceptable example

### DIFF
--- a/guides/v2.0/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.0/coding-standards/code-standard-demarcation.md
@@ -129,14 +129,14 @@ The following list will help you make a distinction between the actual meaning o
 **Acceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <b>semantically</b> represent documents.</p>
+<p>HTML has been created to <strong>semantically</strong> represent documents.</p>
 <p><strong>Warning:</strong> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 
 **Unacceptable**:
 
 {%highlight html%}
-<p>HTML has been created to <strong>semantically</strong> represent documents.</p>
+<p>HTML has been created to <b>semantically</b> represent documents.</p>
 <p><b>Warning:</b> Following the procedure described below may irreparably damage your equipment.</p>
 {%endhighlight%}
 


### PR DESCRIPTION
"You must use semantic HTML markup only, and must not use presentation markup." 

The acceptable example uses presentation markup `<p>semantically</p>`. Replaced with `<strong>`. Removed `<strong>` in the unacceptable example to make it clear what is, and is not acceptable.