### PR TITLE
Update package_module.md

### DIFF
--- a/guides/v2.0/extension-dev-guide/package/package_module.md
+++ b/guides/v2.0/extension-dev-guide/package/package_module.md
@@ -168,7 +168,7 @@ Prerequisite: git must be set up on your machine.
 A private repository can be used for development or private code but installation must be done with a command line interface (you can install a package that specifies a private repository only with a command line installation).</p></span>
 </div>
 
-1. Set up your own Composer packaging repository using a system such as [Satis](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md) or [Toran](https://toranproxy.com/).
+1. Set up your own Composer packaging repository using a system such as [Satis](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md) or [Privte Packagist](https://packagist.com/).
 2. Create the package in a way similar to the described above.
 3. Submit/register the package on your own repository. For example, it can be hosted as a reference to a code repository or submitted as a zip-archive.
 4. To use the private packaging repository in a project, add the following to your `composer.json`file:


### PR DESCRIPTION
Toran is a service which is being phased out. The creators of Packagist.org have now created another service called "Private Packagist" which offers all the features of Toran Proxy, plus more. To date, the majority of account holders are Magento users. This service is the successor to Toran.