### PR TITLE
Add getDependencies method name to example.

### DIFF
--- a/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
@@ -16,12 +16,16 @@ The declarative schema approach removes the version from the `setup_module` tabl
 
 The sequnce of installing patches is handled through a dependency-based approach. Patches can either be independent or dependent on other patches. Independent patches can be installed in any sequence. A dependent patch requires a minimal number of patches so that it can be installed successfully.
 
-To define a dependency in a patch, make a static reference to the patch class. The class can be in any module.
+To define a dependency in a patch, add the method `public static function getDependencies()`
+ the patch class and return the class names of the patches this patch is dependent on. The dependency can be in any module.
 
 ``` php
-return [
-  \SomeVendor\SomeModule\Setup\Patch\Data\SomePatch::class
-];
+public static function getDependencies()
+{
+    return [
+        \SomeVendor\SomeModule\Setup\Patch\Data\SomePatch::class
+    ];
+}
 ```
 
 The following code sample defines a data patch class that has a dependency.

--- a/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
@@ -14,10 +14,10 @@ Optionally, if you plan to enable rollback for your patch during module uninstal
 
 The declarative schema approach removes the version from the `setup_module` table (in a backward compatible way), leaving only the Composer version. Therefore, you can create all new patches and modules without specifying a `setup_module` version.
 
-The sequnce of installing patches is handled through a dependency-based approach. Patches can either be independent or dependent on other patches. Independent patches can be installed in any sequence. A dependent patch requires a minimal number of patches so that it can be installed successfully.
+The sequence of installing patches is handled through a dependency-based approach. Patches can either be independent or dependent on other patches. Independent patches can be installed in any sequence. A dependent patch requires a minimal number of patches so that it can be installed successfully.
 
 To define a dependency in a patch, add the method `public static function getDependencies()`
- the patch class and return the class names of the patches this patch is dependent on. The dependency can be in any module.
+to the patch class and return the class names of the patches this patch depends on. The dependency can be in any module.
 
 ``` php
 public static function getDependencies()


### PR DESCRIPTION
Add `getDependencies` method name to section describing patch dependencies.