### PR TITLE
Update package_module.md

### DIFF
--- a/guides/v2.0/extension-dev-guide/package/package_module.md
+++ b/guides/v2.0/extension-dev-guide/package/package_module.md
@@ -186,5 +186,6 @@ A private repository can be used for development or private code but installatio
 {% endhighlight %}
 
 All packages on the private repository can now be referenced within the `require` field.
-* Refer to the [official documentation](https://packagist.com/features/private-vcs-packages) for more details on how to configure your project for Private Packagist use.
+
+Refer to the [official documentation](https://packagist.com/features/private-vcs-packages) for more details on how to configure your project to use Private Packagist.
 <!-- ##Submitting your module to Marketplace -->

--- a/guides/v2.0/extension-dev-guide/package/package_module.md
+++ b/guides/v2.0/extension-dev-guide/package/package_module.md
@@ -186,5 +186,5 @@ A private repository can be used for development or private code but installatio
 {% endhighlight %}
 
 All packages on the private repository can now be referenced within the `require` field.
-
+* Refer to the [official documentation](https://packagist.com/features/private-vcs-packages) for more details on how to configure your project for Private Packagist use.
 <!-- ##Submitting your module to Marketplace -->


### PR DESCRIPTION
Included a link to the documentation which does include more steps than simply adding in a repositories entry for private packagist, such as actually running a composer command to configure your local composer with credentials (which are mandatory) to access your private packagist account.

whatsnew
Added a link to the Private Packagist documentation in the [Package a component](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/package/package_module.html) topic.