### PR TITLE
Improved clarity of MAJOR and/or MINOR dependency

### DIFF
--- a/guides/v2.0/extension-dev-guide/versioning/dependencies.md
+++ b/guides/v2.0/extension-dev-guide/versioning/dependencies.md
@@ -19,7 +19,7 @@ To achieve this, all third-party modules must obey the following rules:
 
 1. You must specify the dependency on all modules listed in the 'require' section of your module's `composer.json` file.
 2. Do not specify a dependency on meta packages (e.g. 'product-community-edition').
-3. Specify a module's MAJOR and/or MINOR version number if you use any of that module's customization points.
+3. Specify a module's MAJOR and optionally MINOR version number if you use any of that module's customization points.
 4. Specify a module's MAJOR, MINOR, and PATCH versions if you call or customize a module's private code.
 
 ## Service Provider Interfaces


### PR DESCRIPTION
`MAJOR and/or MINOR` suggests that a dependency can be added on the MINOR alone, re-worded this to `MAJOR and optionally MINOR`.