### PR TITLE
remove dry run from deploy static

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -55,7 +55,7 @@ To deploy static view files:
 
 Command options:
 
-	magento setup:static-content:deploy [<languages>] [-t|--theme[="<theme>"]] [--exclude-theme[="<theme>"]] [-l|--language[="<language>"]] [--exclude-language[="<language>"]] [-a|--area[="<area>"]] [--exclude-area[="<area>"]] [-j|--jobs[="<number>"]]  [--no-javascript] [--no-css] [--no-less] [--no-images] [--no-fonts] [--no-html] [--no-misc] [--no-html-minify] [-d|--dry-run] [-f|--force]
+	magento setup:static-content:deploy [<languages>] [-t|--theme[="<theme>"]] [--exclude-theme[="<theme>"]] [-l|--language[="<language>"]] [--exclude-language[="<language>"]] [-a|--area[="<area>"]] [--exclude-area[="<area>"]] [-j|--jobs[="<number>"]]  [--no-javascript] [--no-css] [--no-less] [--no-images] [--no-fonts] [--no-html] [--no-misc] [--no-html-minify] [-f|--force]
 
 The following table explains this command's parameters and values.
 
@@ -345,22 +345,6 @@ The following table explains this command's parameters and values.
       <td>
         <p>
           Do not minify HTML files.
-        </p>
-      </td>
-      <td>
-        <p>
-          No
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        --dry-run (-d)
-      </td>
-      <td>
-        <p>
-          Include to view the files output by the tool without
-          outputting anything.
         </p>
       </td>
       <td>


### PR DESCRIPTION
I saw in https://github.com/magento/magento2/issues/6545 that dry run was dreprecated and now is not working .
<img width="881" alt="captura de pantalla 2018-04-07 a las 2 28 45" src="https://user-images.githubusercontent.com/31536252/38449145-ab0ed078-3a0b-11e8-9e33-24ac00c1876a.png">

whatsnew
Removed the deprecated `--dry-run` CLI option from the [Deploy static view files topic](http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.html).
