### PR TITLE
1618: Google fonts

### DIFF
--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -70,7 +70,7 @@ The following file is a sample of a file you must add:
     	<!-- Add external resources -->
 	    <css src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css" src_type="url" />
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" src_type="url" />
-        <link src="http://fonts.googleapis.com/css?family=Montserrat" src_type="url" /> 
+        <link rel="stylesheet" type="text/css" src="http://fonts.googleapis.com/css?family=Montserrat" src_type="url" />
     </head>
 </page>
 {%endhighlight xml%}

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -68,7 +68,7 @@ The following file is a sample of a file you must add:
         <link src="js/sample.js"/>
 		
     	<!-- Add external resources -->
-	    <css src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css" src_type="url" />
+	<css src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css" src_type="url" />
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" src_type="url" />
         <link rel="stylesheet" type="text/css" src="http://fonts.googleapis.com/css?family=Montserrat" src_type="url" />
     </head>


### PR DESCRIPTION
Fixes https://github.com/magento/devdocs/issues/1618

whatsnew
Fixed the code sample showing how to [reference Google fonts](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html#layout_markup_css) in 2.2 theme development.