### PR TITLE
1340: Base URL is case sensitive

### DIFF
--- a/guides/v2.0/install-gde/trouble/tshoot_admin.md
+++ b/guides/v2.0/install-gde/trouble/tshoot_admin.md
@@ -1,11 +1,7 @@
 ---
 layout: default
 group: install_trouble
-subgroup: 02_access
 title: Error after logging in to the Magento Admin
-menu_title: Error after logging in to the Magento Admin
-menu_node:
-menu_order: 15
 version: 2.0
 github_link: install-gde/trouble/tshoot_admin.md
 functional_areas:
@@ -14,14 +10,18 @@ functional_areas:
   - Setup
 ---
 
-
 ### Details
 
-	The requested URL /magento2index.php/admin/admin/dashboard/index/key/0c81957145a968b697c32a846598dc2e/ was not found on this server.
+  The requested URL /magento2index.php/admin/admin/dashboard/index/key/0c81957145a968b697c32a846598dc2e/ was not found on this server.
 
-Note the lack of a slash character between <tt>magento2</tt> and <tt>index.php</tt> in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %}.
+Note the lack of a slash character between `magento2` and `index.php` in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %}.
 
 ### Solution
 
-The base URL is not correct. The base URL must start with <tt>http://</tt> or <tt>https://</tt> *and* it must end with a slash (/). Run the installation again with a valid value.
+The base URL is not correct. The base URL must:
 
+* Start with `http://` or `https://`
+* End with a slash (`/`)
+* Match the case of the `web/unsecure/base_url` record in the `core_config_data` database table
+
+Re-run the installation using a valid value.

--- a/guides/v2.1/install-gde/trouble/tshoot_admin.md
+++ b/guides/v2.1/install-gde/trouble/tshoot_admin.md
@@ -1,11 +1,7 @@
 ---
 layout: default
 group: install_trouble
-subgroup: 02_access
 title: Error after logging in to the Magento Admin
-menu_title: Error after logging in to the Magento Admin
-menu_node:
-menu_order: 15
 version: 2.1
 github_link: install-gde/trouble/tshoot_admin.md
 functional_areas:
@@ -14,14 +10,18 @@ functional_areas:
   - Setup
 ---
 
-
 ### Details
 
-	The requested URL /magento2index.php/admin/admin/dashboard/index/key/0c81957145a968b697c32a846598dc2e/ was not found on this server.
+  The requested URL /magento2index.php/admin/admin/dashboard/index/key/0c81957145a968b697c32a846598dc2e/ was not found on this server.
 
-Note the lack of a slash character between <tt>magento2</tt> and <tt>index.php</tt> in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %}.
+Note the lack of a slash character between `magento2` and `index.php` in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %}.
 
 ### Solution
 
-The base URL is not correct. The base URL must start with <tt>http://</tt> or <tt>https://</tt> *and* it must end with a slash (/). Run the installation again with a valid value.
+The base URL is not correct. The base URL must:
 
+* Start with `http://` or `https://`
+* End with a slash (`/`)
+* Match the case of the `web/unsecure/base_url` record in the `core_config_data` database table
+
+Re-run the installation using a valid value.


### PR DESCRIPTION
Fixes #1340 

whatsnew
Added information about the base URL being case sensitive in the [installation troubleshooting](http://devdocs.magento.com/guides/v2.2/install-gde/trouble/tshoot_admin.html) topic.