### PR TITLE
Example for model unset magic method is incorrect

### DIFF
--- a/guides/m1x/magefordev/mage-for-dev-5.html
+++ b/guides/m1x/magefordev/mage-for-dev-5.html
@@ -359,7 +359,7 @@ $model->getOrigData('title');
 <pre>
 $model->getBlogpostId();
 $model->setBlogpostId(25);
-$model->unsetBlogpostId();
+$model->unsBlogpostId();
 if($model->hasBlogpostId()){...}
 </pre>
 


### PR DESCRIPTION
Example given in documentation for 'unset' magic method is:

    $model->unsetBlogpostId();

This is incorrect.  The method prefix must be three characters long - so

    $model->unsBlogpostId();

(See lib/Varien/Object.php __call() function for case 'uns' - clearly 'et' would become part of the property to act upon)

Tested experimentally and confirmed that the method as shown has zero effect on the model, whereas $model->unsBlogpostId() achieves the desired result.