### PR TITLE
Updated command app:config:dump documentation

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
@@ -18,13 +18,11 @@ functional_areas:
 
 In Magento 2.2 and later [pipeline deployment model]({{ page.baseurl}}/config-guide/deployment/pipeline/), you can maintain a consistent configuration across systems. After you configure settings in the Magento Admin on your development system, export those settings to configuration files using the following command:
 
-    bin/magento app:config:dump
+    bin/magento app:config:dump {config-types}
 
-Command options:
-- config-types (space-separated list of config types or omit to dump all)
+Where:
+- space-separated list of config types or omit to dump all. Example: `bin/magento app:config:dump scopes themes etc`
 
-
-    bin/magento app:config:dump scopes themes etc
 
 As a result of the command execution, the following configuration files are updated:
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
@@ -20,6 +20,12 @@ In Magento 2.2 and later [pipeline deployment model]({{ page.baseurl}}/config-gu
 
     bin/magento app:config:dump
 
+Command options:
+- config-types (space-separated list of config types or omit to dump all)
+
+
+    bin/magento app:config:dump scopes themes etc
+
 As a result of the command execution, the following configuration files are updated:
 
 -   [`app/etc/config.php`](#app-etc-config-php)


### PR DESCRIPTION
Updated documentation for `app:config:dump` command introduced in scope of https://github.com/magento/magento2/pull/12410