### PR TITLE
Update lifecycle.md

### DIFF
--- a/guides/v2.1/extension-dev-guide/prepare/lifecycle.md
+++ b/guides/v2.1/extension-dev-guide/prepare/lifecycle.md
@@ -127,7 +127,7 @@ class \VendorName\ModuleName\Setup\InstallData implements \Magento\Framework\Set
 
 ### Data upgrade
 
-Magento executes the data upgrade class when it detects an earlier version in the `schema_version` field for the module in the `setup_module` table.
+Magento executes the data upgrade class when it detects an earlier version in the `data_version` field for the module in the `setup_module` table.
 The purpose of this class is to fix corrupted data or populate a new data field after a schema change.
 
 | **Class name** | `UpgradeData`            |


### PR DESCRIPTION
The `DataUpgrade::upgrade()` function is called only when the `data_version` is lower than the module version, it is not called when the `schema_version` is less than the module version.