### PR TITLE
Update ui_comp_template_literals.md

### DIFF
--- a/guides/v2.1/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/guides/v2.1/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -90,7 +90,7 @@ In the template, the messages can be displayed like this:
 
 ```html
 <!-- File: app/code/Example/Component/view/frontend/web/template/message-list.html -->
-<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+<div>
   <ul data-bind="foreach: messages" class="message-list">
       <li data-bind="text: content, css: htmlClass"></li>
   </ul>


### PR DESCRIPTION
According to the XML Scheme (XSD) Standard: https://www.w3.org/standards/xml/schema . It is only for XML, not HTML. In this example there is a HTML node that has an XSD attribute set. I found no examples of HTML files in M2.2.3 core that use this pattern. So either this is something that SwiftOtter is advocating, which the M2 Core Team does not do, or the M2 framework itself is capable of acting upon HTML documents and parsing their nodes for this attribute. I would encourage reaching out to someone in the Core Team for clarification here. If it comes to light that this is either/both against the XML Schema Standard, M2 Core Team practices.

Also, if this *is* valid, then it would appear to me that there should be a section here: http://devdocs.magento.com/guides/v2.2/coding-standards/bk-coding-standards.html which includes the use of XML Schema in HTML documents ... or furthermore, just a section for UI Components... if required, I can open an Issue to address the proposed improvement to the Coding Standards.