### PR TITLE
Update mage-dirs.md

### DIFF
--- a/guides/v2.1/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-dirs.md
@@ -33,15 +33,17 @@ You can set `MAGE_DIRS` in any of the following ways:
 	require __DIR__ . '/app/bootstrap.php';
 	$params = $_SERVER;
 	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
-       DirectoryList::CACHE => [DirectoryList::PATH => '/mnt/nfs/cache'],
-       DirectoryList::MEDIA => [DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''],
-	];
-
-	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
 	DirectoryList::PUB => [DirectoryList::URL_PATH => ''],	
 	DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],
 	DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
 	DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
+	];
+	
+	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS][DirectoryList::CACHE] = [
+	    DirectoryList::PATH => '/mnt/nfs/cache'
+	];
+	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS][DirectoryList::MEDIA] = [
+	    DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''
 	];
 	$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);
 	/** @var \Magento\Framework\App\Http $app */

--- a/guides/v2.1/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-dirs.md
@@ -36,7 +36,7 @@ You can set `MAGE_DIRS` in any of the following ways:
  	    DirectoryList::PUB => [DirectoryList::URL_PATH => '',
  	    DirectoryList::MEDIA => [DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''],
  	    DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
- 	    DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
+ 	    DirectoryList::UPLOAD => [DirectoryList::URL_PATH => '/mnt/nfs/media/upload'],
  	    DirectoryList::CACHE => [DirectoryList::PATH => '/mnt/nfs/cache'],
 	];
 	$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);

--- a/guides/v2.1/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-dirs.md
@@ -27,28 +27,24 @@ You can set `MAGE_DIRS` in any of the following ways:
 *	Use a custom entry point script such as the following:
 
 	{% highlight php startinline=true %}
+	```
 	use Magento\Framework\App\Filesystem\DirectoryList;
 	use Magento\Framework\App\Bootstrap;
  
 	require __DIR__ . '/app/bootstrap.php';
 	$params = $_SERVER;
 	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
-	DirectoryList::PUB => [DirectoryList::URL_PATH => ''],	
-	DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],
-	DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
-	DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
-	];
-	
-	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS][DirectoryList::CACHE] = [
-	    DirectoryList::PATH => '/mnt/nfs/cache'
-	];
-	$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS][DirectoryList::MEDIA] = [
-	    DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''
+ 	    DirectoryList::PUB => [DirectoryList::URL_PATH => '',
+ 	    DirectoryList::MEDIA => [DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''],
+ 	    DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
+ 	    DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
+ 	    DirectoryList::CACHE => [DirectoryList::PATH => '/mnt/nfs/cache'],
 	];
 	$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);
 	/** @var \Magento\Framework\App\Http $app */
 	$app = $bootstrap->createApplication('Magento\Framework\App\Http');
 	$bootstrap->run($app);
+	```
 	{% endhighlight %}
-
+	
 The preceding example sets paths for `[cache]` and `[media]` directories to `/mnt/nfs/cache` and `/mnt/nfs/media`, respectively.

--- a/guides/v2.1/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-dirs.md
@@ -26,8 +26,7 @@ You can set `MAGE_DIRS` in any of the following ways:
 *	<a href="{{page.baseurl}}/config-guide/bootstrap/magento-how-to-set.html">Set the value of bootstrap parameters</a>
 *	Use a custom entry point script such as the following:
 
-	{% highlight php startinline=true %}
-	```
+	```php?start_inline=1
 	use Magento\Framework\App\Filesystem\DirectoryList;
 	use Magento\Framework\App\Bootstrap;
  
@@ -45,6 +44,5 @@ You can set `MAGE_DIRS` in any of the following ways:
 	$app = $bootstrap->createApplication('Magento\Framework\App\Http');
 	$bootstrap->run($app);
 	```
-	{% endhighlight %}
 	
 The preceding example sets paths for `[cache]` and `[media]` directories to `/mnt/nfs/cache` and `/mnt/nfs/media`, respectively.


### PR DESCRIPTION
The previous sample configuration doesn't work, as the custom array is overwritten by the default values. In order for this to work, the custom values need to come after the default system values ... and in the above case, since the example wasn't meant to overwrite the entire array, targeted array key/value pairs are required.