### PR TITLE
Update mod_depend.md

### DIFF
--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
@@ -1,1 +1,60 @@
-../../../../../v2.1/architecture/archi_perspectives/components/modules/mod_depend.md
+---
+layout: default
+group: arch-guide
+subgroup: Components
+title: Module dependencies
+menu_title: Module dependencies
+menu_order: 6
+level3_menu_node: level3child
+level3_subgroup: modules
+version: 2.2
+github_link: architecture/archi_perspectives/components/modules/mod_depend.md
+redirect_from:
+  - /guides/v1.0/architecture/modules/mod_depend.html
+  - /guides/v2.0/architecture/modules/mod_depend.html
+---
+
+## Overview {#m2devgde-moddep-intro}
+
+A *software dependency* identifies  one software component's reliance on another for proper functioning. A core principle of Magento architecture is the **minimization of software dependencies**. Instead of being closely interrelated with other modules, modules are optimally designed to be <i>loosely coupled</i>. Loosely coupled modules require little or no knowledge of other modules to perform their tasks.
+
+Each Magento {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} is responsible for a unique feature. In practice, this means that:
+
+* Several modules cannot be responsible for one feature.
+
+* One module cannot be responsible for several features.
+
+* Module dependencies on other modules must be declared explicitly. You must also declare any dependency upon other components (for example, a theme, language package, or library).
+
+* Removing or disabling a module does not result in disabling other modules.
+
+## What components can modules depend upon?
+
+Although Magento architecture favors loosely coupled software components, modules can contain dependencies upon these software components:
+
+* other modules
+
+* {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} extensions
+
+* libraries (either Magento Framework {% glossarytooltip 08968dbb-2eeb-45c7-ae95-ffca228a7575 %}library{% endglossarytooltip %} or third party libraries)
+
+<div class="bs-callout bs-callout-warning" id="warning">
+<p>Note: You can lose the historical information contained in a module if the module is removed or disabled. We recommend alternative storage of module information before you remove or disable a module.</p></div>
+
+## Managing module dependencies
+
+At a high level, there are three main steps for managing module dependencies:
+
+1. Name and declare the module in the `module.xml` file.
+
+2. Declare any dependencies that the module has (whether on other modules or on a different component) in the module's `composer.json` file.
+
+3. (*Optional*) Define the desired load order of config files and `.css` files in the `module.xml` file. More information [here](https://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-load-order.html).
+
+Example: Module A declares a dependency upon Module B. Thus, in Module A's `module.xml` file, Module B is listed in the &lt;sequence> list, so that B's files are loaded before A's. Additionally, you must declare a dependency upon Module B in A's `composer.json` file. Furthermore, in the <a href="{{page.baseurl}}/config-guide/config/config-php.html">deployment configuration</a>, Modules A and B must both be defined as enabled.
+
+## Related topics {#m2arch-module-related}
+
+<a href="{{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html">Module overview</a>
+
+<a href="{{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_depend_types.html">Types of module dependencies</a>


### PR DESCRIPTION
Included a link to a page which provides further details relating to defining the load order of config files in module.xml ... as the previous page content is ambiguous about how this is done, even though there is reference to changing the load order using sequence. The included link to Component load order page is more verbose and clearer as to the how/why of changing the load order of files to the uninitiated.

*Also, I'm not clear on what the "redirect_from" links at the top of this page are ... so if I'm making a mistake by not including one that refers to M2.2, please let me know what action is required to update the file correctly.. I didn't find any mention of this in the devdoc contributor documentation. Thanks