### PR TITLE
Further documentation on events for modal widget (#1897)

### DIFF
--- a/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
@@ -184,7 +184,7 @@ $('#modal_content').modal({
     &lt;option2&gt;: &lt;value2&gt;,
     ...
 });
-$( "#modal_content" ).on( "close", function() {
+$( "#modal_content" ).on( "modalclosed", function() {
   foo(bar);
 });
 </pre>
@@ -196,7 +196,7 @@ $('#modal_content').modal({
     &lt;option1&gt;: &lt;value1&gt;,
     &lt;option2&gt;: &lt;value2&gt;,
     ...
-    close: function(){
+    closed: function(){
        foo(bar);
     }
 });

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
@@ -176,6 +176,32 @@ The modal widget is subscribed to the following events:
 <li><a href="#modal_opened">opened</a></li>
 </ul>
 
+These can be listened to a couple of different ways, the primary being listening to it with jQuery's [`on`](http://api.jquery.com/on/) function, or creating a property with the name of the event that you want to listen to, like so:
+
+<pre>
+$('#modal_content').modal({
+    &lt;option1&gt;: &lt;value1&gt;,
+    &lt;option2&gt;: &lt;value2&gt;,
+    ...
+});
+$( "#modal_content" ).on( "close", function() {
+  foo(bar);
+});
+</pre>
+
+Which is functionally equivalent to the following:
+
+<pre>
+$('#modal_content').modal({
+    &lt;option1&gt;: &lt;value1&gt;,
+    &lt;option2&gt;: &lt;value2&gt;,
+    ...
+    close: function(){
+       foo(bar);
+    }
+});
+</pre>
+
 <h3 id="modal_closed"><code>closed</code></h3>
 Called when the modal window is closed.
 
@@ -184,6 +210,8 @@ Called when the modal window is opened.
 
 <h3 id="modal_opened"><code>always</code></h3>
 ....
+
+
 
 <h2 id="key_navigation">Keyboard navigation</h2>
 - the ESC key: close the current modal window

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_modal.md
@@ -176,28 +176,23 @@ The modal widget is subscribed to the following events:
 <li><a href="#modal_opened">opened</a></li>
 </ul>
 
-These can be listened to a couple of different ways, the primary being listening to it with jQuery's [`on`](http://api.jquery.com/on/) function, or creating a property with the name of the event that you want to listen to, like so:
+You can listen to these events in two ways:
+
+Use jQuery's [`on`](http://api.jquery.com/on/) function:
 
 <pre>
-$('#modal_content').modal({
-    &lt;option1&gt;: &lt;value1&gt;,
-    &lt;option2&gt;: &lt;value2&gt;,
-    ...
-});
-$( "#modal_content" ).on( "modalclosed", function() {
-  foo(bar);
+var modal = $( "#modal_content").modal({...});
+modal.on( "modalclosed", function() {
+    // Do some action when modal closed
 });
 </pre>
 
-Which is functionally equivalent to the following:
-
+Or assign a callback as a property when creating a modal instance:
 <pre>
 $('#modal_content').modal({
-    &lt;option1&gt;: &lt;value1&gt;,
-    &lt;option2&gt;: &lt;value2&gt;,
     ...
     closed: function(){
-       foo(bar);
+       // Do some action when modal closed
     }
 });
 </pre>


### PR DESCRIPTION


<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[X] Content fix or rewrite
[ ] Bug fix or improvement
 
Changes the modal widget's documentation to give further information on event handling
 
## Additional information
The documentation on modal events is lacking, and the "close" property working as an event handler was undocumented entirely, which isn't ideal.

Not sure if this should be elaborated on elsewhere in the documentation as well, maybe in the future you guys should have a master page on how to hook into events and for each component declare a list of events and link to a page explaining how to handle events on another dedicated page, so the docs on the components don't vary much in that way