### PR TITLE
Fix typo

### DIFF
--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -71,7 +71,7 @@ One of the following displays:
 </table>
 
 ### Reindexing catalog search and refreshing the full page cache {#es-reindex}
-After you change Magento's Elasticsearch configuration, you must reindex the catalog search index and refresh the full page using the Admin or command line.
+After you change Magento's Elasticsearch configuration, you must reindex the catalog search index and refresh the full page cache using the Admin or command line.
 
 To refresh the cache using the Admin:
 


### PR DESCRIPTION
Missing 'cache' in 'full page cache'

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[ ] Content fix or rewrite
[X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary

Fixes a small typo on the Elasticsearch configuration guide.