### PR TITLE
Database and media dump transferring update

### DIFF
--- a/guides/v2.0/cloud/live/stage-prod-migrate.md
+++ b/guides/v2.0/cloud/live/stage-prod-migrate.md
@@ -115,15 +115,26 @@ Options:
 
 For additional options, see the [rsync man page](http://linux.die.net/man/1/rsync){:target="\_blank"}.
 
-To migrate static files:
 
-1.	Copy media folder to your local environment:
+To migrate static files from your local machine:
 
-		rsync -azvP <environment_ssh_link@ssh.region.magento.cloud>:pub/media/ /local_machine/pub/media/ 
-
-2.	rsync the `pub/media` directory from your local Magento server to staging or production:
+	*	rsync the `pub/media` directory from your local Magento server to staging or production:
 
 		rsync -azvP local_machine/pub/media/ <environment_ssh_link@ssh.region.magento.cloud>:pub/media/ 
+						
+To migrate static files from remote-to-remote environments directly (fast approach):
+
+**Note** In order to transfer media from remote-to-remote environments directly you need to enable ssh agent forwarding, please refer to this [github guidance](https://developer.github.com/v3/guides/using-ssh-agent-forwarding/)
+
+1.	SSH into the environment you want to transfer from (you can find ssh link in your Cloud UI -> select the branch -> Access Site -> SSH access):
+
+		 ssh -A <environment_ssh_link@ssh.region.magento.cloud>
+
+2.	rsync the `pub/media` directory from your environment you have logged into on step #1 to another remote environment:
+
+		rsync -azvP pub/media/ <destination_environment_ssh_link@ssh.region.magento.cloud>:pub/media/
+
+**Note**: You can find ssh link of the evnrionment in your Cloud UI -> select the branch -> Access Site -> SSH access.
 
 ## Migrate the database {#cloud-live-migrate-db}
 
@@ -135,15 +146,14 @@ For continuous integration deployments, we **do not recommend** migrating data f
 
 We **do recommend** migrating data from Production into Staging to fully test your site and store(s) in a near-production environment with all services and settings.
 
+**Note** In order to transfer media from remote-to-remote environments directly you need to enable ssh agent forwarding, please refer to this [github guidance](https://developer.github.com/v3/guides/using-ssh-agent-forwarding/)
+
 To migrate a database:
 
 1.	SSH into the environment you want to create a database dump from:
 
-	*	Staging: `ssh -A <project ID>_stg@<project ID>.ent.magento.cloud`
-	*	Production: `ssh -A <project ID>@<project ID>.ent.magento.cloud`
-	* To SSH into the `master` branch of your Integration environment:
-
-			magento-cloud environment:ssh
+			ssh -A <environment_ssh_link@ssh.region.magento.cloud>
+			
 2.	Find the database login information with the following command:
 
     ```
@@ -160,30 +170,24 @@ To migrate a database:
 
 		mysqldump -h <database host> --user=<database user name> --password=<password> --single-transaction --triggers <database name> | gzip - > /tmp/database.sql.gz
 		
-4. 	Enter `exit` to terminate the SSH connection.
 
-5.	Transfer the database dump to local machine with an `rsync` command:
+4.	Transfer the database dump to another remote emvironment with an `rsync` command:
 
-		rsync -azvP <environment_ssh_link@ssh.region.magento.cloud>:/tmp/database.sql.gz /local_folder/
+		rsync -azvP /tmp/database.sql.gz <destination_environment_ssh_link@ssh.region.magento.cloud>:/tmp
 		
-6. 	Transfer the database dump from local machine to remote cloud environment (staging or production):
+8.	Enter `exit` to terminate the SSH connection.
 
-		rsync  -azvP /local_folder/database.sql.gz <environment_ssh_link@ssh.region.magento.cloud>:/tmp
-	
 7.	Open an SSH connection to the environment you want to migrate the database into:
 
-	*	Staging: `ssh -A <project ID>_stg@<project ID>.ent.magento.cloud`
-	*	Production: `ssh -A <project ID>@<project ID>.ent.magento.cloud`
-	* To SSH into the `master` branch of your Integration environment:
-
-			magento-cloud environment:ssh
+		ssh -A <destination_environment_ssh_link@ssh.region.magento.cloud>
+	
 8.	Import the database dump with the following command:
 
-		zcat database.sql.gz | mysql -h <database_host> -u <username> -p<password> <database name>
+		zcat /tmp/database.sql.gz | mysql -h <database_host> -u <username> -p<password> <database name>
 
 	The following is an example using information from step 2:
 
-		zcat database.sql.gz | mysql -h database.internal -u user main
+		zcat /tmp/database.sql.gz | mysql -h database.internal -u user main
 
 ### Troubleshooting the database migration
 If you encounter the following error, you can try to create a database dump with the DEFINER replaced:


### PR DESCRIPTION
Cloud customers can no longer transfer dumps from one remote environment to another, only via local machine. 

Also, added -h <database.host> for zcat command as required.

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[ ] Content fix or rewrite
[ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will...
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->