### PR TITLE
Update config-cli-subcommands.md

### DIFF
--- a/guides/v2.1/config-guide/cli/config-cli-subcommands.md
+++ b/guides/v2.1/config-guide/cli/config-cli-subcommands.md
@@ -53,11 +53,11 @@ Before you run any of these commands, you must either [install the Magento appli
 		</tr>
 
 	<tr>
-		<td><a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html">magento setup:cache:{enable|disable|clean|flush|status}</a></td>
+		<td><a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html">magento cache:{enable|disable|clean|flush|status}</a></td>
 		<td><p>Manages the cache</p></td>
 	</tr>
 	<tr>
-		<td><a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html">magento setup:indexer:{status|show-mode|set-mode|reindex|info}</a></td>
+		<td><a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html">magento indexer:{status|show-mode|set-mode|reindex|info}</a></td>
 		<td><p>Manages the indexers</p></td>
 	</tr>
 


### PR DESCRIPTION
In v2.2 of CLI there is no setup:cache:{command}, and no setup:indexer:{command}, command. Maybe this was the case in 2.1, but the rest of the docs refer it the functional cache:{command} and indexer:{command} commands.

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[x ] Content fix or rewrite
[ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix a broken document reference to nonexistant CLI command setup:cache:{whatever} and setup:indexer:{whatever}
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->