### PR TITLE
MAGEDOC-2979 Remove deprecated [-d|--dry-run]

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -3,10 +3,6 @@ group: config-guide
 title: Deploy static view files
 version: 2.2
 github_link: config-guide/cli/config-cli-subcommands-static-view.md
-functional_areas:
-  - Configuration
-  - System
-  - Setup
 ---
 
 {% include config/cli-intro.md %}

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -1,12 +1,6 @@
 ---
 group: config-guide
-subgroup: 04_CLI
 title: Deploy static view files
-menu_title: Deploy static view files
-menu_node:
-menu_order: 302
-level3_menu_node: level3child
-level3_subgroup: static_deploy
 version: 2.2
 github_link: config-guide/cli/config-cli-subcommands-static-view.md
 functional_areas:
@@ -54,7 +48,7 @@ To deploy static view files:
 
 Command options:
 
-	bin/magento setup:static-content:deploy [<languages>] [-t|--theme[="<theme>"]] [--exclude-theme[="<theme>"]] [-l|--language[="<language>"]] [--exclude-language[="<language>"]] [-a|--area[="<area>"]] [--exclude-area[="<area>"]] [-j|--jobs[="<number>"]]  [--no-javascript] [--no-css] [--no-less] [--no-images] [--no-fonts] [--no-html] [--no-misc] [--no-html-minify] [-d|--dry-run] [-f|--force]
+	bin/magento setup:static-content:deploy [<languages>] [-t|--theme[="<theme>"]] [--exclude-theme[="<theme>"]] [-l|--language[="<language>"]] [--exclude-language[="<language>"]] [-a|--area[="<area>"]] [--exclude-area[="<area>"]] [-j|--jobs[="<number>"]]  [--no-javascript] [--no-css] [--no-less] [--no-images] [--no-fonts] [--no-html] [--no-misc] [--no-html-minify] [-f|--force]
 
 The following table explains this command's parameters and values.
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -3,6 +3,10 @@ group: config-guide
 title: Deploy static view files
 version: 2.2
 github_link: config-guide/cli/config-cli-subcommands-static-view.md
+functional_areas:
+  - Configuration
+  - System
+  - Setup
 ---
 
 {% include config/cli-intro.md %}


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[X] Content fix or rewrite
[ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary

Removed a deprecated command from the command options section: `[-d|--dry-run]`. Deprecated [since 2.2](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Deploy/Console/DeployStaticOptions.php#L108).
 
When this pull request is merged, it will remove a deprecated command.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->