### PR TITLE
Fix ambiguity for `remove` attribute.

### DIFF
--- a/guides/v2.1/frontend-dev-guide/layouts/xml-instructions.md
+++ b/guides/v2.1/frontend-dev-guide/layouts/xml-instructions.md
@@ -333,7 +333,7 @@ To pass parameters to a block use the <a href="#argument"><code>&lt;argument>&lt
 <ul>
 <li>The <code>remove</code> attribute is optional and its default value is false.</li>
 
-    This implementation allows you to cancel removal of a block or container in your layout by setting remove attribute value to <code>true</code>
+    This implementation allows you remove a block or container in your layout by setting remove attribute value to <code>true</code> or to cancel removal of a block or container by setting the value to <code>false</code>.
     
     Example: 
     


### PR DESCRIPTION
This fixes the language ambiguity in the description for the `remove` attribute.

## This PR is a:
[ ] New topic
[x] Content fix or rewrite
[ ] Bug fix or improvement
 
## Summary
 
It will change the syntax to fix the inexactness of the description of the use for the `remove` attribute.