### PR TITLE
Updates to environment variables

### DIFF
--- a/_includes/cloud/merge-configuration.md
+++ b/_includes/cloud/merge-configuration.md
@@ -1,0 +1,6 @@
+By default, the deployment process overwrites all settings in the `env.php` file; however, you can choose to merge one or more values for a service configuration without overwriting all of the values.
+
+Set the `_merge` option to one of the following:
+
+-  `true`—**Merge** the configured service values with the environment variable values.
+-  `false`—**Overwrite** the configured service values with the environment variable values.

--- a/guides/v2.1/cloud/env/variables-build.md
+++ b/guides/v2.1/cloud/env/variables-build.md
@@ -40,12 +40,41 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Themes include numerous files. Set this variable to `true` if you want to skip copying over theme files during build. This is helpful when static content deployment occurs during the build phase. Use commas to separate multiple theme locations. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly deploy this theme with your code updates and deployments. To exclude the `magento/luma` theme:
+Themes include numerous files. Set this variable to `true` if you want to skip copying over theme files during build. This is helpful when static content deployment occurs during the build phase. Use commas to separate multiple theme locations. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly build this theme with your code updates and deployments. To exclude the `magento/luma` theme:
 
 ```yaml
 stage:
   build:
     SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
+```
+
+### `SCD_MATRIX`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+You can configure multiple locales per theme as long as the theme is not excluded using the `SCD_EXCLUDE_THEMES` variable during build. This is ideal if you want to speed up the build process by reducing the amount of unnecessary theme files. For example, you can build the _magento/backend_ theme in English and a custom theme in other languages.
+
+The following example builds the `magento/backend` theme with three locales:
+
+```yaml
+stage:
+  build:
+    SCD_MATRIX:
+      "magento/backend":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+```
+
+Also, you can choose to _not_ deploy a theme:
+
+```yaml
+stage:
+  build:
+    SCD_MATRIX:
+      "magento/backend": [ ]
 ```
 
 ### `SCD_THREADS`

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -38,7 +38,23 @@ stage:
           backend: file
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file.
+{% include cloud/merge-configuration.md %}
+
+The following example merges new values to an existing configuration:
+
+```yaml
+stage:
+  deploy:
+    CACHE_CONFIGURATION:
+      _merge: true
+      frontend:
+        default:
+          backend:
+            database: 10
+        page_cache:
+          backend:
+            database: 11
+```
 
 ### `CLEAN_STATIC_FILES`
 
@@ -124,7 +140,25 @@ stage:
         port: 1234
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file.
+{% include cloud/merge-configuration.md %}
+
+The following example merges new values to an existing configuration:
+
+```yaml
+stage:
+  deploy:
+        QUEUE_CONFIGURATION:
+          _merge: true
+          amqp:
+            host: changed1.host
+            port: 5672
+          amqp2:
+            host: changed2.host2
+            port: 12345
+          mq:
+            host: changedmq.host
+            port: 1234
+```
 
 ### `REDIS_USE_SLAVE_CONNECTION`
 
@@ -233,7 +267,18 @@ stage:
       elasticsearch_server_timeout: '15'
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file. 
+{% include cloud/merge-configuration.md %}
+
+The following example merges a new value to the existing configuration:
+
+```yaml
+stage:
+  deploy:
+    SEARCH_CONFIGURATION:
+      engine: elasticsearch
+      elasticsearch_server_port: '1234'
+      _merge: true
+```
 
 ### `SESSION_CONFIGURATION`
 
@@ -259,7 +304,18 @@ stage:
       save: redis
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file. 
+{% include cloud/merge-configuration.md %}
+
+The following example merges a new value to the existing configuration:
+
+```yaml
+stage:
+  deploy:
+    SESSION_CONFIGURATION:
+      _merge: true
+      redis:
+        max_concurrency: 10
+```
 
 ### `SKIP_SCD`
 

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -155,6 +155,35 @@ stage:
     SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
 ```
 
+### `SCD_MATRIX`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+You can configure multiple locales per theme as long as the theme is not excluded using the `SCD_EXCLUDE_THEMES` variable during deployment. This is ideal if you want to speed up the deployment process by reducing the amount of unnecessary theme files. For example, you can deploy the _magento/backend_ theme in English and a custom theme in other languages.
+
+The following example deploys the `magento/backend` theme with three locales:
+
+```yaml
+stage:
+  deploy:
+    SCD_MATRIX:
+      "magento/backend":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+```
+
+Also, you can choose to _not_ deploy a theme:
+
+```yaml
+stage:
+  deploy:
+    SCD_MATRIX:
+      "magento/backend": [ ]
+```
+
 ### `SCD_THREADS`
 
 -  **Default**: 

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -62,6 +62,20 @@ Failure to clear static view files might result in issues if there are multiple 
 
 Use the Project Web UI to set this value. When you move the database from one environment to another without an installation process, you need the corresponding cryptographic information. Magento uses the encryption key value set in the Web UI as the `crypt/key` value in the `env.php` file. This does not overwrite an existing encryption key value in the `env.php` file.
 
+### `DATABASE_CONFIGURATION`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+If you defined a database in the [relationships property](https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_magento-app.html#relationships) of the `.magento.app.yaml` file, you can customize your database connections for deployment.
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      some_config: 'some_value'
+```
+
 ### `GENERATED_CODE_SYMLINK`
 
 -  **Default**—`true`

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -46,12 +46,41 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Themes include numerous files. Set this variable to `true` if you want to skip copying over theme files during build. This is helpful when static content deployment occurs during the build phase. Use commas to separate multiple theme locations. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly deploy this theme with your code updates and deployments. To exclude the `magento/luma` theme:
+Themes include numerous files. Set this variable to `true` if you want to skip copying over theme files during build. This is helpful when static content deployment occurs during the build phase. Use commas to separate multiple theme locations. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly build this theme with your code updates and deployments. To exclude the `magento/luma` theme:
 
 ```yaml
 stage:
   build:
     SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
+```
+
+### `SCD_MATRIX`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+You can configure multiple locales per theme as long as the theme is not excluded using the `SCD_EXCLUDE_THEMES` variable during build. This is ideal if you want to speed up the build process by reducing the amount of unnecessary theme files. For example, you can build the _magento/backend_ theme in English and a custom theme in other languages.
+
+The following example builds the `magento/backend` theme with three locales:
+
+```yaml
+stage:
+  build:
+    SCD_MATRIX:
+      "magento/backend":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+```
+
+Also, you can choose to _not_ deploy a theme:
+
+```yaml
+stage:
+  build:
+    SCD_MATRIX:
+      "magento/backend": [ ]
 ```
 
 ### `SCD_STRATEGY`

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -166,6 +166,35 @@ stage:
     SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
 ```
 
+### `SCD_MATRIX`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+You can configure multiple locales per theme as long as the theme is not excluded using the `SCD_EXCLUDE_THEMES` variable during deployment. This is ideal if you want to speed up the deployment process by reducing the amount of unnecessary theme files. For example, you can deploy the _magento/backend_ theme in English and a custom theme in other languages.
+
+The following example deploys the `magento/backend` theme with three locales:
+
+```yaml
+stage:
+  deploy:
+    SCD_MATRIX:
+      "magento/backend":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+```
+
+Also, you can choose to _not_ deploy a theme:
+
+```yaml
+stage:
+  deploy:
+    SCD_MATRIX:
+      "magento/backend": [ ]
+```
+
 ### `SCD_STRATEGY`
 
 -  **Default**—`quick`

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -38,7 +38,23 @@ stage:
           backend: file
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file.
+{% include cloud/merge-configuration.md %}
+
+The following example merges new values to an existing configuration:
+
+```yaml
+stage:
+  deploy:
+    CACHE_CONFIGURATION:
+      _merge: true
+      frontend:
+        default:
+          backend:
+            database: 10
+        page_cache:
+          backend:
+            database: 11
+```
 
 ### `CLEAN_STATIC_FILES`
 
@@ -135,7 +151,25 @@ stage:
         port: 1234
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file.
+{% include cloud/merge-configuration.md %}
+
+The following example merges new values to an existing configuration:
+
+```yaml
+stage:
+  deploy:
+        QUEUE_CONFIGURATION:
+          _merge: true
+          amqp:
+            host: changed1.host
+            port: 5672
+          amqp2:
+            host: changed2.host2
+            port: 12345
+          mq:
+            host: changedmq.host
+            port: 1234
+```
 
 ### `REDIS_USE_SLAVE_CONNECTION`
 
@@ -263,7 +297,18 @@ stage:
      elasticsearch_server_timeout: '15'
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file. 
+{% include cloud/merge-configuration.md %}
+
+The following example merges a new value to the existing configuration:
+
+```yaml
+stage:
+  deploy:
+    SEARCH_CONFIGURATION:
+      engine: elasticsearch
+      elasticsearch_server_port: '1234'
+      _merge: true
+```
 
 ### `SESSION_CONFIGURATION`
 
@@ -289,7 +334,18 @@ stage:
       save: redis
 ```
 
-By default, the deployment process overwrites all settings in the `env.php` file. 
+{% include cloud/merge-configuration.md %}
+
+The following example merges a new value to the existing configuration:
+
+```yaml
+stage:
+  deploy:
+    SESSION_CONFIGURATION:
+      _merge: true
+      redis:
+        max_concurrency: 10
+```
 
 ### `SKIP_SCD`
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -86,6 +86,20 @@ By default, the deployment process overwrites all settings in the `env.php` file
 
 Use the Project Web UI to set this value. When you move the database from one environment to another without an installation process, you need the corresponding cryptographic information. Magento uses the encryption key value set in the Web UI as the `crypt/key` value in the `env.php` file. This does not overwrite an existing encryption key value in the `env.php` file.
 
+### `DATABASE_CONFIGURATION`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+If you defined a database in the [relationships property](https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_magento-app.html#relationships) of the `.magento.app.yaml` file, you can customize your database connections for deployment.
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      some_config: 'some_value'
+```
+
 ### `MYSQL_USE_SLAVE_CONNECTION`
 
 -  **Default**—`false`


### PR DESCRIPTION
New ENV variables:

-  SCD_MATRIX—configure multiple locales per theme
-  DATABASE_CONFIGURATION—customize your database connections for deployment

New ability to choose to merge or overwrite configuration for services using the `_merge` option in CACHE, SESSION, QUEUE, and SEARCH configurations.

whatsnew
Added the [SCD_MATRIX](https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html#scd-matrix) environment variable to configure multiple locales per theme.
Added the [DATABASE_CONFIGURATION](https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html#database-configuration) environment variable to customize your database connections for deployment.
Added the ability to choose to merge or overwrite configuration for services using the `_merge` option in CACHE, SESSION, QUEUE, and SEARCH configurations.