### PR TITLE
Fix a description of the VERBOSE_COMMANDS variable

### DIFF
--- a/guides/v2.0/cloud/env/environment-vars_magento.md
+++ b/guides/v2.0/cloud/env/environment-vars_magento.md
@@ -108,8 +108,8 @@ The following variables are available during the deploy process of build and dep
 </tr>
 <tr>
 <td><code>VERBOSE_COMMANDS</code></td>
-<td>Enables or disables the <a href="https://symfony.com/doc/current/console/verbosity.html">Symfony</a> debug verbosity level for your logs. Be aware, if you enable this verbosity, the logs will be deeply detailed. This is available in all versions.</td>
-<td>disabled</td>
+<td>Enables or disables the <a href="https://symfony.com/doc/current/console/verbosity.html">Symfony</a> debug verbosity level for your logs. Choose the level of detail provided in the logs: <code>-v</code>, <code>-vv</code>, or <code>-vvv</code>. Be aware, if you enable this verbosity, the logs will be deeply detailed. This is available in all versions.</td>
+<td>Not set</td>
 </tr>
 <tr>
 <td><code>ADMIN_USERNAME</code></td>


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[ ] Content fix or rewrite
[x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix a description of the VERBOSE_COMMANDS variable.

We have a couple of articles where you can see the VERBOSE_COMMANDS variable:
* https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html
* https://devdocs.magento.com/guides/v2.2/cloud/env/variables-build.html

and all of them are correct, but the https://devdocs.magento.com/guides/v2.0/cloud/env/environment-vars_magento.html isn't. The incorrect information confuses users and led to deployment issues on the Magento Cloud.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->