### PR TITLE
MAGEDOC-2980 Fix version picker label

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ versions:
       name: "2.2"
       url: /guides/v2.2/
    -
-      name: "2.3 Pre-release"
+      name: "2.3"
       url: /guides/v2.3/
 
 # GitHub variables

--- a/_includes/home/intro.html
+++ b/_includes/home/intro.html
@@ -1,7 +1,7 @@
 <section class="home-intro">
   <div class="container">
 
-      <h1>Magento {{ page.guide_version }}{% if page.guide_version == "2.3" %} Pre-release{%endif %} Developer Documentation</h1>
+      <h1>Magento {{ page.guide_version }}{% if page.guide_version == "2.3" %} Alpha{%endif %} Developer Documentation</h1>
 
     <p>Everything you need to build and manage a customized Magento store.</p>
 

--- a/_includes/layout/version-switcher.html
+++ b/_includes/layout/version-switcher.html
@@ -1,12 +1,12 @@
 {% if site.versions %}
 <div class="version-switcher dropdown" data-version="{{ page.guide_version }}">
 	<button id="version-switcher-button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Magento {{ page.guide_version }}{% if page.guide_version == "2.3" %} Pre-release{% endif %}
+    Magento {{ page.guide_version }}{% if page.guide_version == "2.3" %} Alpha{% endif %}
 	</button>
 
 	<ul class="dropdown-menu dropdown-menu-left" aria-labelledby="version-switcher-button">
 	{% for version in site.versions %}
-		<li><a class="dropdown-item" data-proofer-ignore href="{{ site.baseurl }}{{ version.url }}{{ page.github_link | replace: ".md",".html" }}">Magento {{ version.name }}</a></li>
+    <li><a class="dropdown-item" data-proofer-ignore href="{{ site.baseurl }}{{ version.url }}{{ page.github_link | replace: ".md",".html" }}">Magento {{ version.name }}{% if version.url contains "v2.3" %} Alpha{% endif %}</a></li>
 	{% endfor %}
   </ul>
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New topic
[ ] Content fix or rewrite
[X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the 2.3 label in the version picker to say "Alpha" instead of "Pre-release".
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

Fixes MAGEDOC-2980