### PR TITLE
Fixed URL 404 issue

### DIFF
--- a/guides/v2.0/cloud/bk-cloud.md
+++ b/guides/v2.0/cloud/bk-cloud.md
@@ -81,7 +81,7 @@ To better understand {{site.data.var.ee}}, your plan, architecture, and workflow
 ## Learn more about Magento 2 {#magento2}
 If you would like to learn more about Magento 2, see the following resources:
 
-*	[All documentation home page](https://magento.com/help/documentation){:target="_blank"}
+*	[All documentation home page](https://magento.com/resources/technical){:target="_blank"}
 *	User guides (how to use options in the Magento Admin)
 
 	*	[Magento 2.0.x](http://docs.magento.com/m2/2.0/ee/user_guide/getting-started.html){:target="_blank"}


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
Please go to this page https://devdocs.magento.com/guides/v2.0/cloud/bk-cloud.html
and find *All documentation home page* text which through on 404 error so I have a redirect on https://magento.com/resources/technical URL
