### PR TITLE
Layout xml

### DIFF
--- a/guides/v2.1/coding-standards/layout-coding-standard.md
+++ b/guides/v2.1/coding-standards/layout-coding-standard.md
@@ -8,7 +8,7 @@ menu_order: 100
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
 version: 2.1
-github_link: coding-standards/xml-coding-standard.md
+github_link: coding-standards/layout-coding-standard.md
 ---
 
 # Layout XML Coding Standard
@@ -17,8 +17,8 @@ github_link: coding-standards/xml-coding-standard.md
 
 The `name` attribute should adhere to the guidelines listed below. The `name` attribute should:
 
-- Be unique to the project.
-- Use a namespace approach where each child block's name contains its parent's name as well.
+- Should explain element's purpose rather than its position on the page .
+- Be unique to the module that declares it by prepending it with module's namespace as `<vendor>.<module>`
 - Have segments separated by a `.` (period).
 - Be all lowercase.
 - Never use `_` (underscores).
@@ -26,12 +26,8 @@ The `name` attribute should adhere to the guidelines listed below. The `name` at
 *Example:*
 
 ```xml
-<block name="header">
-  <block name="header.right">
-    <block name="header.right.search">
-      <block name="header.right.search.autocomplete" />
-    </block>
-  </block>
+<block name="magento.catalog.product.preview">
+  <block name="magento.catalog.price"/>
 </block>
 ```
 
@@ -49,11 +45,7 @@ The `as` attribute should follow the guidelines below. The value of `as`:
 *Example:*
 
 ```xml
-<block name="header">
-  <block name="header.right" as="right_actions">
-    <block name="header.right.search" as="search">
-      <block name="header.right.search.autocomplete" as="autocomplete" />
-    </block>
-  </block>
+<block name="magento.catalog.product.preview">
+  <block name="magento.catalog.total.price" as="total_price"/>
 </block>
 ```

--- a/guides/v2.1/coding-standards/xml-coding-standard.md
+++ b/guides/v2.1/coding-standards/xml-coding-standard.md
@@ -1,0 +1,59 @@
+---
+layout: default
+group: coding-standards
+subgroup: Coding standards
+title: XML Coding Standards
+menu_title: XML Coding Standards
+menu_order: 100
+contributor_name: SwiftOtter Studios
+contributor_link: https://swiftotter.com/
+version: 2.1
+github_link: coding-standards/xml-coding-standard.md
+---
+
+# XML Coding Standard
+
+### Name attribute
+
+The `name` attribute should adhere to the guidelines listed below. The `name` attribute should:
+
+- Be unique to the project.
+- Use a namespace approach where each child block's name contains its parent's name as well.
+- Have segments separated by a `.` (period).
+- Be all lowercase.
+- Never use `_` (underscores).
+
+*Example:*
+
+```xml
+<block name="header">
+  <block name="header.right">
+    <block name="header.right.search">
+      <block name="header.right.search.autocomplete" />
+    </block>
+  </block>
+</block>
+```
+
+### As attribute
+
+The `as` attribute should follow the guidelines below. The value of `as`:
+
+- Only needs to be unique to the block that contains it.
+- Should be as concise as possible, but with enough clarity to be understood within the block.
+- Can use an `_` (underscore) as a separator.
+- Should only be added if necessary.
+- Should be all lowercase.
+
+
+*Example:*
+
+```xml
+<block name="header">
+  <block name="header.right" as="right_actions">
+    <block name="header.right.search" as="search">
+      <block name="header.right.search.autocomplete" as="autocomplete" />
+    </block>
+  </block>
+</block>
+```

--- a/guides/v2.1/coding-standards/xml-coding-standard.md
+++ b/guides/v2.1/coding-standards/xml-coding-standard.md
@@ -2,8 +2,8 @@
 layout: default
 group: coding-standards
 subgroup: Coding standards
-title: XML Coding Standards
-menu_title: XML Coding Standards
+title: Layout XML Coding Standards
+menu_title: Layout XML Coding Standards
 menu_order: 100
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
@@ -11,7 +11,7 @@ version: 2.1
 github_link: coding-standards/xml-coding-standard.md
 ---
 
-# XML Coding Standard
+# Layout XML Coding Standard
 
 ### Name attribute
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [x] New topic
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
Original PR - https://github.com/magento/devdocs/pull/1078

> The goal of this is to formalize a standard for writing layout XML. There hasn't been a standard set that the community follows when authoring layout XML. By setting a precedent for layout XML naming conventions, I am hopeful that it will lead to XML declarations that are easier to read and more consistent which could decrease maintenance time.
> Note: this is identical to #982. I found that I did that PR on the wrong branch of my fork and needed to move over to this one to provide flexibility.

 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information
