### PR TITLE
remove leading backslash when importing namespaces

### DIFF
--- a/guides/v2.0/extension-dev-guide/build/component-registration.md
+++ b/guides/v2.0/extension-dev-guide/build/component-registration.md
@@ -26,7 +26,7 @@ where &lt;VendorName> is the name of the company providing the {% glossarytoolti
 Do not use "Ui" for your custom module name because the <code>%Vendor%_Ui</code> notation, required when specifying paths, might cause issues.
 
 ### Example
-    use \Magento\Framework\Component\ComponentRegistrar;
+    use Magento\Framework\Component\ComponentRegistrar;
     ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminNotification', __DIR__);
 
 ## Register themes {#register-themes}
@@ -73,7 +73,7 @@ After you create your `registration.php` file and you are creating [your compone
 {% highlight php startinline=true %}
 <?php
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminNotification', __DIR__);
 {%endhighlight %}


### PR DESCRIPTION
The leading backslashes are unnecessary and not recommended when importing namespaces with use, as they are processed at compilation and are relative to the project root.

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will remove unnecessary leading backslash when importing namespaces.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
