### PR TITLE
Update cluster storage stats in Pro architecture topic

### DIFF
--- a/guides/v2.1/cloud/architecture/pro-architecture.md
+++ b/guides/v2.1/cloud/architecture/pro-architecture.md
@@ -165,9 +165,13 @@ The following figure shows the technologies used in the Production environment:
 
 ![Production technology stack]({{ site.baseurl }}/common/images/cloud_stack-diagram.png)
 
-{{site.data.var.ee}} scales seamlessly from the smallest 6-CPU cluster with 11.25GB of RAM to the largest 96-CPU cluster with 180GB of RAM. Our triple-redundant architecture means we can offer upscaling without downtime. When upscaling, we rotate each of the three instances to upgrade without downtime of your site.
+{{site.data.var.ee}} can scale seamlessly from the smallest Pro12 cluster to the largest Pro120 cluster.
+-   Pro12 offers a 12-CPU (4 x 3 nodes) and 48GB RAM (16 x 3 nodes)
+-   Pro120 offers 120 CPU (40 x 3 nodes) up to 480GB RAM (160 x 3 nodes)
 
-[//]: # (HG—careful: In addition, you can add extra web servers to an existing cluster should the constriction be at the {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} level rather than the database level. This provides _horizontal scaling_ to complement the vertical scaling provided by extra CPUs on the database level.)
+Our triple-redundant architecture means we can offer upscaling without downtime. When upscaling, we rotate each of the three instances to upgrade capacity without impacting site operation.
+
+<!-- [//]: # (HG—careful: In addition, you can add extra web servers to an existing cluster should the constriction be at the {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} level rather than the database level. This provides _horizontal scaling_ to complement the vertical scaling provided by extra CPUs on the database level.) -->
 
 ## Software versions {#cloud-arch-software}
 {{site.data.var.ece}} uses the Debian GNU/Linux 8 (jessie) operating system and the {% glossarytooltip b14ef3d8-51fd-48fe-94df-ed069afb2cdc %}NGINX{% endglossarytooltip %} 1.8 web server. You cannot upgrade this software, but you can configure versions for the following:


### PR DESCRIPTION
- Updated cluster storage capacity info for upscaling cloud pro architecture
in the Production "Technology Stack" section
- Fixed comment syntax to remove commented text from published docs

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will update the storage capacity information for Magento Commerce Cloud Pro12 and Pro120 offerings described in the Pro Architecture topic.

whatsnew
Updated the storage capacity information for Magento Commerce Cloud Pro architecture information in the [Production Technology Stack](https://devdocs.magento.com/guides/v2.1/cloud/architecture/pro-architecture.html#production-technology-stack) documentation for Magento Cloud [v2.1](https://devdocs.magento.com/guides/v2.1/cloud/architecture/pro-architecture.html#production-technology-stack), [v2.2](https://devdocs.magento.com/guides/v2.2/cloud/architecture/pro-architecture.html#production-technology-stack), and [v2.3](https://devdocs.magento.com/guides/v2.3/cloud/architecture/pro-architecture.html#production-technology-stack).


