### PR TITLE
Removed Community Edition Reference from 2.2

### DIFF
--- a/guides/v2.2/extension-dev-guide/validate/test-module.md
+++ b/guides/v2.2/extension-dev-guide/validate/test-module.md
@@ -22,8 +22,8 @@ For more information see the <a href="{{ page.baseurl }}/test/testing.html">Mage
 For further testing with the Magento functional testing frameworks, see
 [Functional Testing Framework]({{ page.baseurl }}/mtf/mtf_introduction.html).
 
-## Test using Community Edition {#test-comm}
-Test your component by deploying Magento Community Edition and adding the component to the project's <code>composer.json</code>.
+## Test using {{site.data.var.ce}} {#test-comm}
+Test your component by deploying {{site.data.var.ce}} and adding the component to the project's <code>composer.json</code>.
 
 {% highlight JSON %}
 "require": {

--- a/guides/v2.2/rest/list.md
+++ b/guides/v2.2/rest/list.md
@@ -12,7 +12,7 @@ functional_areas:
 
 ## List of REST endpoints for {{site.data.var.ee}} {#listee}
 
-The REST endpoints for {{site.data.var.ee}} (formerly Enterprise Edition (EE)) are available on {{site.data.var.ee}} installations only. Commerce installations automatically have access to all {{site.data.var.ce}} (formerly Community Edition (CE)) REST APIs.
+The REST endpoints for {{site.data.var.ee}} are available on {{site.data.var.ee}} installations only. Commerce installations automatically have access to all {{site.data.var.ce}} REST APIs.
 
 Additions since 2.1 are marked with a single asterisk (*).
 


### PR DESCRIPTION
Removed Community edition reference and used standard variable to display Magento Open Source. At some places I changed Enterprise edition reference also
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [X] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will...
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
