### PR TITLE
Recommend launching dump-autoload with APCu enabled

### DIFF
--- a/guides/v2.0/config-guide/prod/prod_perf-optimize.md
+++ b/guides/v2.0/config-guide/prod/prod_perf-optimize.md
@@ -41,7 +41,7 @@ After running `setup:di:compile` to generate classes, use composer to update the
 
 Run the following [composer command][composer-dump-autoload] to generate an optimized composer class map that supports faster auto-loading.
 
-	composer dump-autoload -o
+	composer dump-autoload -o --apcu
 
 ### Server - PHP Configuration
 
@@ -61,6 +61,13 @@ If you are on a low memory machine and you do not have many extensions or custom
 
 	opcache.memory_consumption=64
 	opcache.max_accelerated_files=60000
+
+We recommend enabling PHP APCu extension for maximum performance.
+Edit your `apcu.ini` file to include the following:
+
+	extension=apcu.so
+	[apcu]
+	acp.enabled = 1
 
 ### Server - Redis Configuration & Tuning
 

--- a/guides/v2.1/config-guide/prod/prod_perf-optimize.md
+++ b/guides/v2.1/config-guide/prod/prod_perf-optimize.md
@@ -41,7 +41,7 @@ After running `setup:di:compile` to generate classes, use composer to update the
 
 Run the following [composer command][composer-dump-autoload] to generate an optimized composer class map that supports faster auto-loading.
 
-	composer dump-autoload -o
+	composer dump-autoload -o --apcu
 
 ### Server - PHP Configuration
 
@@ -61,6 +61,13 @@ If you are on a low memory machine and you do not have many extensions or custom
 
 	opcache.memory_consumption=64
 	opcache.max_accelerated_files=60000
+
+We recommend enabling PHP APCu extension for maximum performance.
+Edit your `apcu.ini` file to include the following:
+
+	extension=apcu.so
+	[apcu]
+	acp.enabled = 1
 
 ### Server - Redis Configuration & Tuning
 

--- a/guides/v2.2/config-guide/prod/performance-best-practices.md
+++ b/guides/v2.2/config-guide/prod/performance-best-practices.md
@@ -246,7 +246,7 @@ Through preprocessing/compilation of DI instructions, Magento
 
 After compilation completes, we recommend running the following command:
 
-`composer dump-autoload -o`
+`composer dump-autoload -o --apcu`
 
 This command allows composer to rebuild the mapping to project files so that they load faster.
 

--- a/guides/v2.2/config-guide/prod/prod_perf-optimize.md
+++ b/guides/v2.2/config-guide/prod/prod_perf-optimize.md
@@ -41,7 +41,7 @@ After running `setup:di:compile` to generate classes, use composer to update the
 
 Run the following [composer command][composer-dump-autoload] to generate an optimized composer class map that supports faster auto-loading.
 
-	composer dump-autoload -o
+	composer dump-autoload -o --apcu
 
 ### Server - PHP Configuration
 
@@ -61,6 +61,13 @@ If you are on a low memory machine and you do not have many extensions or custom
 
 	opcache.memory_consumption=64
 	opcache.max_accelerated_files=60000
+
+We recommend enabling PHP APCu extension for maximum performance.
+Edit your `apcu.ini` file to include the following:
+
+	extension=apcu.so
+	[apcu]
+	acp.enabled = 1
 
 ### Server - Redis Configuration & Tuning
 

--- a/guides/v2.2/performance-best-practices/deployment-flow.md
+++ b/guides/v2.2/performance-best-practices/deployment-flow.md
@@ -49,7 +49,7 @@ bin/magento setup:di:compile
 After compilation completes, we recommend running the following command:
 
 ``` bash
-composer dump-autoload -o
+composer dump-autoload -o --apcu
 ```
 
 This command allows Composer to rebuild the mapping to project files so that they load faster.


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary

Composer can use an installed APCu extension to cache file location of already loaded classes.
It makes class loading way much quicker since, along with optimize option, it makes composer autoloader always know where files are for a given class.
It can lead to huge performance improvements during all Magento server calls (pages, ajax calls, endpoints). We noticed in production a gain of 250 ms per call

This PR also recommends installing the APCu extension, even if the `--apcu` extension is harmless if it is not installed.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information
See documentation at https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-b-apcu-cache
<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
