### PR TITLE
Replacing 2.2 UI comp guide symlinks with files 

### DIFF
--- a/_data/toc/ui-components-guide.yml
+++ b/_data/toc/ui-components-guide.yml
@@ -221,6 +221,7 @@ pages:
           url: /ui_comp_guide/howto/add_category_attribute.html
 
         - label: Update the page URL type
+          versions: "2.3"
           url: /ui_comp_guide/howto/update-url-type.html
 
     - label: Troubleshoot

--- a/_data/toc/ui-components-guide.yml
+++ b/_data/toc/ui-components-guide.yml
@@ -193,6 +193,9 @@ pages:
         - label: Magento custom Knockout.js bindings
           url: /ui_comp_guide/concepts/knockout-bindings.html
 
+        - label: Magento binding syntax
+          url: /ui_comp_guide/concepts/magento-bindings.html
+
         - label: About the uiClass library
           url: /ui_comp_guide/concepts/ui_comp_uiclass_concept.html
 

--- a/guides/v2.2/ui_comp_guide/bk-ui_comps.md
+++ b/guides/v2.2/ui_comp_guide/bk-ui_comps.md
@@ -5,7 +5,7 @@ title: Overview of UI components
 landing-page: UI Components
 menu_title: Overview of UI components
 menu_order: 1
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/bk-ui_comps.md
 redirect_from:
   - /guides/v2.1/ui-components/ui-component.html

--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -1,0 +1,78 @@
+---
+group: UI_Components_guide
+subgroup: concepts
+title: Magento binding syntax
+version: 2.2
+github_link: ui_comp_guide/concepts/magento-bindings.md
+---
+
+## Magento binding syntax
+Within HTML templates, Magento gives you the option of using a binding syntax that is simpler and easier to read and write than the standard Knockout binding syntax. The following code snippets help make the comparison.
+
+### Knockout syntax
+```html
+<!-- ko if: isVisible-->
+    <div class="someClass">
+        <!-- ko i18n: 'Some translatable message!'--><!-- /ko -->
+        <span data-bind="html: content"></span>
+    </div>
+<!-- /ko -->
+```
+### Magento syntax
+```html
+<if args="isVisible">
+    <div class="someClass">
+        <translate args="'Some translatable message!'"/>
+        <span html="content"></span>
+    </div>
+</if>
+```
+or
+```html
+<div class="someClass" if="isVisible">
+    <span translate="'Some translatable message!'"></span>
+    <span html="content"></span>
+</div>
+```
+
+If you use the Magento syntax, the Magento wrapper replaces the Magento syntax with the matching Knockout comments or `data-bind` attributes during the loading of the HTML template. 
+
+
+
+## Binding map
+
+The table below shows how the Knockout bindings map to their Magento binding counterparts.
+
+|Name| Knockout Syntax | Magento Syntax |
+|--- | -------- | -------|
+|if             |`<!-- ko if: isVisible--><!-- /ko -->`                                         | `<if args="isVisible"></if>`                                          |
+|               |`<div data-bind="if: isVisible"></div>`                                        | `<div if="isVisible"></div>`                                          |
+|ifnot          |`<!-- ko ifnot: isVisible--><!-- /ko -->`                                      | `<ifnot args="isVisible"></ifnot>`                                    |
+|               |`<div data-bind="ifnot: isVisible"></div>`                                     | `<div ifnot="isVisible"></div>`                                       |
+|text           |`<!-- ko text: 'Some text' --><!-- /ko -->`                                    | `<text args="'Some text'">`                                           |
+|               |`<div data-bind="text: 'Some text'"></div>`                                    | `<div text="'Some text'"></div>`                                      |
+|with           |`<!-- ko with: element --><!-- /ko -->`                                        | `<with args="element">`                                               |
+|               |`<div data-bind="with: element"></div>`                                        | `<div with="element"></div>`                                          |
+|foreach        |`<!-- ko foreach: elements --><!-- /ko -->`                                    | `<each args="elements">`                                              |
+|               |`<div data-bind="foreach: elements"></div>`                                    | `<div each="elements"></div>`                                         |
+|component      |`<!-- ko component: 'componentName' --> <!-- /ko -->`                          | `<component args="'componentName'">`                                  |
+|               |`<div data-bind="component: componentName"> </div>`                            | `<div component="'componentName'"> </div>`                            |
+|css            |`<div data-bind="css: {_visible: isVisible}"> </div>`                          | `<div css="_visible: isVisible"> </div>`                              |
+|attr           |`<div data-bind="attr: {title: title}"> </div>`                                | `<div attr="title: title"> </div>`                                    |
+|style          |`<div data-bind="style: {color: redColor}"> </div>`                            | `<div ko-style="color: redColor"> </div>`                             |
+|html           |`<div data-bind="html: '<span/>'"> </div>`                                     | `<div html="'<span/>'"> </div>`                                       |
+|click          |`<div data-bind="click: onClick"> </div>`                                      | `<div click="onClick"> </div>`                                        |
+|event          |`<div data-bind="event: {mouseover: showEl}"> </div>`                          | `<div event="mouseover: showEl"> </div>`                              |
+|template       |`<div data-bind="template: templateUrl"> </div>`                               | `<div template="templateUrl"> </div>`                                 |
+|submit         |`<form data-bind="submit: onSubmit"> </form>`                                  | `<form submit="onSubmit"> </form>`                                    |
+|options        |`<select data-bind="options: optionsList"> </select>`                          | `<select options="optionsList"> </select>`                            |
+|selectedOptions|`<select data-bind="options: optionsList, selectedOptions: value"> </select>`  | `<select options="optionsList" selectedOptions="value"> </select>`    |
+|optionsText    |`<select data-bind="options: optionsList, optionsText: 'label'"> </select>`    | `<select options="optionsList" optionsText="'label'"> </select>`      |
+|optionsText    |`<select data-bind="options: optionsList, optionsValue: 'value'"> </select>`   | `<select options="optionsList" optionsValue="'value'"> </select>`     |
+|enable         |`<input data-bind="enable: isEnabled"/>`                                       | `<input enable="isEnabled"/>`                                         |
+|disable        |`<input data-bind="disable: !isEnabled"/>`                                     | `<input ko-disabled="!isEnabled"/>`                                   |
+|hasFocus       |`<input data-bind="hasFocus: onFocus"/>`                                       | `<input ko-focused="onFocus"/>`                                       |
+|textInput      |`<input data-bind="textInput: value"/>`                                        | `<input textInput="value"/>`                                          |
+|value          |`<input data-bind="value: value"/>`                                            | `<input ko-value="value"/>`                                           |
+|checked        |`<input type="chackbox" data-bind="checked: isChecked"/>`                      | `<input type="chackbox" ko-checked="isChecked"/>`                     |
+|checkedValue   |`<input type="chackbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="chackbox" checkedValue="$data" checked="isChecked"/>`   |

--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -6,6 +6,7 @@ version: 2.2
 github_link: ui_comp_guide/concepts/magento-bindings.md
 ---
 
+## Overview
 Within HTML templates, Magento gives you the option of using a binding syntax that is simpler and easier to read and write than the standard Knockout binding syntax. The following code snippets help make the comparison.
 
 ### Knockout syntax

--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -56,7 +56,7 @@ The table below shows how the Knockout bindings map to their Magento binding cou
 |foreach        |`<!-- ko foreach: elements --><!-- /ko -->`                                    | `<each args="elements">`                                              |
 |               |`<div data-bind="foreach: elements"></div>`                                    | `<div each="elements"></div>`                                         |
 |component      |`<!-- ko component: 'componentName' --> <!-- /ko -->`                          | `<component args="'componentName'">`                                  |
-|               |`<div data-bind="component: componentName"> </div>`                            | `<div component="'componentName'"> </div>`                            |
+|               |`<div data-bind="component: 'componentName'"> </div>`                          | `<div component="'componentName'"> </div>`                            |
 |css            |`<div data-bind="css: {_visible: isVisible}"> </div>`                          | `<div css="_visible: isVisible"> </div>`                              |
 |attr           |`<div data-bind="attr: {title: title}"> </div>`                                | `<div attr="title: title"> </div>`                                    |
 |style          |`<div data-bind="style: {color: redColor}"> </div>`                            | `<div ko-style="color: redColor"> </div>`                             |
@@ -74,6 +74,6 @@ The table below shows how the Knockout bindings map to their Magento binding cou
 |hasFocus       |`<input data-bind="hasFocus: onFocus"/>`                                       | `<input ko-focused="onFocus"/>`                                       |
 |textInput      |`<input data-bind="textInput: value"/>`                                        | `<input textInput="value"/>`                                          |
 |value          |`<input data-bind="value: value"/>`                                            | `<input ko-value="value"/>`                                           |
-|checked        |`<input type="chackbox" data-bind="checked: isChecked"/>`                      | `<input type="chackbox" ko-checked="isChecked"/>`                     |
-|checkedValue   |`<input type="chackbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="chackbox" checkedValue="$data" checked="isChecked"/>`   |
+|checked        |`<input type="checkbox" data-bind="checked: isChecked"/>`                      | `<input type="checkbox" ko-checked="isChecked"/>`                     |
+|checkedValue   |`<input type="checkbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="checkbox" checkedValue="$data" checked="isChecked"/>`   |
 {:style="table-layout:auto"}

--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -6,7 +6,6 @@ version: 2.2
 github_link: ui_comp_guide/concepts/magento-bindings.md
 ---
 
-## Magento binding syntax
 Within HTML templates, Magento gives you the option of using a binding syntax that is simpler and easier to read and write than the standard Knockout binding syntax. The following code snippets help make the comparison.
 
 ### Knockout syntax
@@ -76,3 +75,4 @@ The table below shows how the Knockout bindings map to their Magento binding cou
 |value          |`<input data-bind="value: value"/>`                                            | `<input ko-value="value"/>`                                           |
 |checked        |`<input type="chackbox" data-bind="checked: isChecked"/>`                      | `<input type="chackbox" ko-checked="isChecked"/>`                     |
 |checkedValue   |`<input type="chackbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="chackbox" checkedValue="$data" checked="isChecked"/>`   |
+{:style="table-layout:auto"}

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: Configuration flow of UI components
 menu_title: Configuration flow of UI components
 menu_order: 10
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_config_flow_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
@@ -1,1 +1,58 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: Configuration flow of UI components
+menu_title: Configuration flow of UI components
+menu_order: 10
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_config_flow_concept.md
+---
+
+## Overview
+The following section covers the configuration flow of UI components within the Magento system. Before a {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %} is finally displayed on a web page, its configuration undergoes a series of modifications. Starting from the initial reading of the top-level component instance’s {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} declaration, all the way to the merging of module-specific options.
+
+When the server generates a page response, the configuration of these components in the [`.xml` declaration files]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html) is then modified by the [`.php` modifiers]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html), and then finally this combined configuration is packed into JSON format and added into the HTTP response body.
+
+On the client-side, this JSON is processed by `Magento_Ui/js/core/app` where `Magento_Ui/js/core/app` is an alias for the [`app.js`]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/core/app.js) file. The JSON could be seen in the page source. The `Magento_Ui/js/core/app` creates the UI components instances according to the configuration of the JSON using `uiLayout`.
+
+The Magento {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}JavaScript{% endglossarytooltip %} application bounds these instances to the corresponding `.html` templates, if there are any `.html` templates declared in JSON for that particular component. The top-level UI component is bound to the page by the `scope` Knockout binding.
+
+
+## Implementation details
+
+This section provides more detailed steps about the configuration flow.
+
+Lets consider an example with the top-level UI component, `form`.
+
+Lets imagine we have the following file structure in our {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} <My_Module>:
+
+- {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} `.xml` file of the Module’s page: `my_page.xml`
+- top-level UI Component (form or listing) configuration: `my_form.xml`
+- `.php` modifiers that are specific to the module
+
+Keep in mind that the Magento_UI module contains these important files:
+
+- A general, module-agnostic form definition in the `<form>` node of the `.xml` definition file: `<Magento_Ui_module_dir>/view/base/ui_component/etc/definition.xml`
+
+- Default `.xhtml` template for the form, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/ui_component/templates/form/default.xhtml`
+- The Form class, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/web/js/form/form.js`
+
+When the request for my_page comes, the server does the following:
+
+1. Determines which UI components are used in this particular layout. In the example, the UI components that are used are defined in the `my_form` component’s `.xml` declaration file.
+2. Searches the `.xml` files with name `my_form` among all modules. The server then merges all the `my_form .xml` file(s) into a single configuration object, thus overriding the common properties, so that the latest `my_form .xml` file always has the highest priority.
+1. Merges the resulting configuration (from Step 2 above) with the configuration from the UI module `definition.xml`. The UI module `definition.xml` configuration file has the lowest priority, and is overwritten by the merged configuration of all `my_form.xml` files.
+2. Translates the resulting configuration into JSON format and adds it to response body the following way:
+
+{%highlight html%}
+	<script type="text/x-magento-init">{"*": {"Magento_Ui/js/core/app":{<JSON_configuration>}}}</script>
+{%endhighlight%}
+
+Now it is the client's turn to process this JSON and generate the UI component's instances. The flow is following:
+
+1. RequireJS requires `Magento_Ui/js/core/app` and passes [JSON configuration]({{ page.baseurl }}/javascript-dev-guide/javascript/js_init.html#declarative-notation-using-the-script-typetextx-magento-init--tag-decl_tag) as an parameter.
+2. The `Magento_Ui/js/core/app` calls `layout.js `and passes the UI component’s configuration into the layout: `<Magento_Ui_module_dir>/view/base/web/js/core/renderer/layout.js`.
+3. `layout.js` creates instances of UI components. That means that each UI component’s configuration must have an explicitly declared `component` property in JSON. This property references the `.js` file. For example, our form has the component declared in JSON like this:	`"my_form":{"component":"Magento_Ui/js/form/form"}`
+So the instance of this class is created, and properties from the JSON overwrites the properties from the UI component’s `defaults` property. Then resulting properties become the first-level properties of the newly created UI component's instance, and the original `defaults` property is deleted.
+4. The UI components’ `.html` templates (if there are any) are rendered by Magento `knockout.js` template engine. This means, that [bootstrap.js]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/knockout/bootstrap.js) (required by `app.js`) passes our own [template engine]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/knockout/template/engine.js) for the Knockout.
+5. The `bootstrap.js` binds the component as a Model behind this View (template) using Knockout bindings. The UI components are now displayed on the page, and are fully interactive.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
@@ -6,7 +6,7 @@ menu_title: Providing Data to UI Components
 menu_order: 20
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_data_source.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
@@ -1,1 +1,108 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_data_source.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: The DataSource Component
+menu_title: Providing Data to UI Components
+menu_order: 20
+contributor_name: SwiftOtter Studios
+contributor_link: https://swiftotter.com/
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_data_source.md
+---
+
+## Overview
+Magento provides the DataSource object, which is designed to interact with data in your {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %}. Many of the core UI components use this DataSource component. Many UI components require that this object is included. However, there are specific requirements it has in order for it to work correctly.
+
+In this topic, we will explain how to take advantage of the powerful functionality of the data provider in a UI Component.
+
+### Declaring the XML
+
+The DataSource UI component can be included with the `<dataSource />` node in the component's top-level configuration file. The `name` attribute is recommended and should follow the `%instance_name%_data_source` pattern where `%instance_name%` is the name of the component.
+
+The component's data provider class is declared inside `<dataSource />`. The following provides an example and demonstrates what nodes are required.
+
+{% highlight xml%}
+<argument name="dataProvider" xsi:type="configurableObject">
+    <argument name="class" xsi:type="string">[YourNameSpace]\[YourModule]\Ui\DataProvider\[YourComponentName]DataProvider</argument>
+    <argument name="name" xsi:type="string">[YourComponentName]_data_source</argument>
+    <argument name="primaryFieldName" xsi:type="string">entity_id</argument>
+    <argument name="requestFieldName" xsi:type="string">id</argument>
+</argument>
+{% endhighlight %}
+
+In the block of code above, [YourNameSpace]\[YourModule] would be the directory that contains all of the module's files and directories. [YourComponentName] is the name of this instance of a component, which should be the file name as well.
+
+The main node of interest is `<argument name="class" />.` This references a PHP class that must implement `\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface`. To meet that requirement, it can extend `\Magento\Ui\DataProvider\AbstractDataProvider`. The `AbstractDataProvider` class implements all of the required methods in the `DataProviderInterface`. The DataProvider class is the primary source of any data or {% glossarytooltip 3f0f2ef1-ad38-41c6-bd1e-390daaa71d76 %}metadata{% endglossarytooltip %} that the component needs or will use.
+
+While the {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} tells Magento about the component's data provider, Magento doesn't do anything in particular with that unless you hook it up to the component's main PHP class. To make the data available in javascript, add a `getDataSourceData()` method to the UI component's PHP class and return `$this->getContext()->getDataProvider()->getData()`. This will output the result of the data provider's `getData()` method into the JSON that is sent to the browser along with the rest of the UI component's configuration.
+
+Declare a `getData()` method in the data provider class that was referenced in the XML and return a value. Since that output will be part of the JSON rendered on the page, it is accessible via the {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}javascript{% endglossarytooltip %} class that is associated with the UI component and handles its behavior. Magento's Form Provider javascript class is often a good place to start.
+
+
+<div class="bs-callout bs-callout-info" id="info">
+    <p>A Javascript "component" is actually a Javascript file loaded through RequireJS. It should return a Javascript object that defines a module or function. Do not confuse Javascript components with UI components.</p>
+</div>
+
+Include the Form Provider Javascript component by adding this inside the `<dataSource />` node:
+
+{% highlight xml%}
+<argument name="data" xsi:type="array">
+    <item name="js_config" xsi:type="array">
+        <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+    </item>
+</argument>
+{% endhighlight %}
+
+This will include `Magento/Ui/view/base/web/js/form/provider.js` on the page as part of this DataSource component. The Form Provider javascript can also be extended if the functionality doesn't do what is necessary in your case.
+
+Remember that this data provider is still, technically speaking, a completely separate UI Component. To fully link it to the "base" component, there are a few things that need to happen so that the "base" UI component's javascript can use the data provided by the data provider.
+
+A good way to keep configuration data out of the javascript is to declare a "provider" in the base component's XML so it will be able to find that data provider component. Under the `<argument name="data" />` node, add a node like this (where `[ComponentName]` is the name of the component):
+
+{% highlight xml%}
+<item name="config" xsi:type="array">
+    <item name="provider" xsi:type="string">[ComponentName].[ComponentName]_data_source</item>
+</item>
+{% endhighlight %}
+
+This example declares the name of the data provider class and will be output in the JSON that contains the UI component's configuration. It can then be used to locate the data source component. This is essentially declaring a variable that will be available to a javascript class.
+
+# Javascript Template Literals
+
+Throughout Magento's core Javascript components there are strings like this: `'${ $.provider }:data.totalRecords'`. These are ES2015 [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). The `${ }` surrounds an expression that will be parsed as Javascript. `$.provider` is the expression, in this example.
+
+The template literal is in a single-quote string, however, not the back-ticks which are standard for ES2015. As a result, they would normally be treated as a string. Since Magento needs to support browsers that don't recognize template literals a special interpreter was built for them. If the browser does support standard back-tick template literals, Magento will use that, and if not, it evaluates the value manually.
+
+When the component is initialized, it will automatically evaluate all string literals in properties. In the example above, `$.provider` will become  `[ComponentName].[ComponentName]_data_source`. The value of this `provider` was declared in the `js_config` block in the XML above. It is possible to pass nearly any configuration value this way and access it using template literals.
+
+But, XML is static and while that gets us the name of the data provider component, it still doesn't actually provide data. There is one more important step in providing data to Javascript components.
+
+# Javascript Component Linking
+
+Every Javascript component should extend the core Element class in some way (mapped to [`uiElement`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html) with RequireJS and located in `Magento/Ui/view/base/web/js/lib/core/element/element.js`.  When this class initializes it runs an `initLinks()` method. That method, in turn, passes a few class properties into a method that handles linking components together. This file (`lib/core/element/link.js`) binds the values of those parameters to actual components.
+
+The properties Magento will parse are:
+
+- `imports`
+- `exports`
+-  `links`
+
+The `links` property is the same as duplicating a value in both `imports` and `exports`. Each of those properties expect an object that contains key/value pairs to bind the expression to. In the example above, it would appear in the `defaults` property like this:
+
+```
+imports: {
+    totalRecords: '${ $.provider }:data.totalRecords'
+}
+```
+
+When the Element class initializes, it will process the link that was declared in `imports`. Remember that one of the first things Magento does is process string literals, though, so it is actually working with something that looks more like the following (where `example` is the UI Component Name for clarity):
+
+```
+imports: {
+    totalRecords: 'example.example_data_source:data.totalRecords'
+}
+```
+
+The `:` is a special separator that is used to divide the component name that it is to link to and the values it should access in the returned value. No `:` is necessary, though, and the expression, `$.provider` could be any key that was passed into the javascript configuration.
+
+In the example above, it will return the `totalRecords` property of the `data` object in the `example.example_data_source` component. As a result of these connections, `totalRecords` will display the output of `DataProvider::getData()`.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -1,1 +1,190 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_linking_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: Linking properties of UI components
+menu_title: Linking properties of UI components
+menu_order: 100
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_linking_concept.md
+---
+
+## Linking properties implementation
+
+The following properties are used for linking observable properties and methods of UI components:
+
+- `exports`
+- `imports`
+- `links` 
+- `listens`
+
+These properties are processed by the `initLinks()` method of the [`uiElement` class]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html) which is called at the moment of a component's instantiation.
+
+Linking properties are set in [UI components configuration files]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_config_flow_concept.html): XML, JS or {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %}. 
+
+## List of linking properties 
+
+### `exports`
+
+The `exports` property is used to copy a local value to some external entity. If the external entity property is anything but a function, it will be set to the value of the local property. If the external property is a function, it will be called with the local properties value as an argument.
+If the local value is a ko of io-es5 observable, the external entity will also be updated whenever the local property changes. `exports`'s value is an object, composed of the following:
+
+  - `key`: name of the internal property or method that is tracked for changes.
+  - `value`: name of the property or method that receives the value. Can use [string templates](#string_templ).
+
+Example of setting `exports` in a component's `.js` file:
+
+{% highlight js%}
+{
+  'exports': {
+   'visible': '${ $.provider }:visibility'
+  }
+}
+{% endhighlight js%}
+
+Here `visible` is the `key`, `${ $.provider }:visibility` is the `value`. The value of the local `visible` property is assigned to the `visibility` property of the `provider` component. The latter is changed automatically if the value of `visible` changes if the local `visible` property is observable (which it isn't given only the code example above).
+
+Example of setting `exports` in a component's configuration `.xml` file:
+
+{% highlight xml%}
+<argument name="data" xsi:type="array">
+    <item name="config" xsi:type="array">
+        <item name="exports" xsi:type="array">
+            <item name="visible" xsi:type="string">sample_config.sample_provider:visibility</item>
+        </item>
+    </item>
+</argument>
+{% endhighlight xml%}
+
+For an example of `exports` usage in Magento code see [`product_form.xml`, line 81]({{ site.mage2100url }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L81)
+
+### `imports` 
+The `imports` property is used for tracking changes of an external entity property. `imports`'s value is an object, composed of the following:
+
+  - `key`: name of the internal property or method that receives the value. 
+  - `value`: name of the property or method that is tracked for changes. Can use [string templates](#string_templ).
+
+Example of using `imports` in a component's `.js` file:
+
+{% highlight js%}
+{
+  'imports': {
+   'visible': '${ $.provider }:visibility'
+  }
+}
+{% endhighlight js%}
+
+Here the value of the `visibility` property of the `provider` component is assigned to the local `visible` property. If the latter is a ko or ko-es5 observable, the local property is automatically updated if `visibility` changes.
+
+Example of using `imports` in a component's configuration `.xml` file:
+
+{% highlight xml%}
+<argument name="data" xsi:type="array">
+    <item name="config" xsi:type="array">
+        <item name="imports" xsi:type="array">
+            <item name="visible" xsi:type="string">sample_config.sample_provider:visibility</item>
+        </item>
+    </item>
+</argument>
+{% endhighlight xml%}
+
+For an example of `imports` usage in Magento code see [`product_form.xml`, line 103]({{ site.mage2100url }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L103)
+
+### `links`
+
+The `links` property is used for cross tracking properties changes: both linked properties are tracked and changing of one results in changing the other. `links`'s value is an object, composed of the following:
+
+  - `key`: name of the internal property or method that sends and receives the notifications. 
+  - `value`: name of the property or method that sends and receives the value. Can use [string templates](#string_templ).
+
+Example of using `links` in a component's `.js` file:
+
+{% highlight js%}
+{
+  'links': {
+   'visible': '${ $.provider }:visibility'
+  }
+}
+{% endhighlight js%}
+
+Here the local `visible` property is linked with the `visibility`  property of the provider component. If any of them is a ko or ko-es5 observable and changes, the other is changed automatically. If a non-observable linked property is changed the other is not updated automatically.
+
+Example of using `links` in a component's configuration `.xml` file:
+
+{% highlight xml%}
+<argument name="data" xsi:type="array">
+    <item name="config" xsi:type="array">
+        <item name="links" xsi:type="array">
+            <item name="visible" xsi:type="string">sample_config.sample_provider:visibility</item>
+        </item>
+    </item>
+</argument>
+{% endhighlight xml%}
+
+For an example of `links` usage in Magento code see [`text.js`, line 19]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/form/element/text.js#L19)
+
+### `listens`
+The `listens` property is used to track the changes of a component's property. `listens`'s value is an object, composed of the following:
+
+  - `key`: name of the observable property or method which is tracked for changes. Can use [string templates](#string_templ).
+  - `value`: name of the internal method or property which listens to the changes.
+
+Example of using `listens` in a component's `.js` file :
+
+{% highlight js%}
+{
+  'listens': {
+   '${ $.provider }:visibility': 'visibilityChanged'
+  }
+}
+{% endhighlight js%}
+
+Here the local `visibilityChanged` property is a method that will be called when the `visibility` property of the `provider` component changes. It recieves the new value as an argument. If the local property is not a function, it will be set to the new value.
+The external property has to be an observable in order for `listens` to have any effect.
+
+
+Example of using `listens` in a component's configuration `.xml` file:
+
+{% highlight xml%}
+<argument name="data" xsi:type="array">
+    <item name="config" xsi:type="array">
+        <item name="listens" xsi:type="array">
+            <item name="sample_config.sample_provider:visibility" xsi:type="string">visibilityChanged</item>
+        </item>
+    </item>
+</argument>
+{% endhighlight xml%}
+
+For example of `listens` usage in Magento code see [`new_category_form.xml`, line 92]({{ site.mage2100url }}app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L92)
+
+## Template strings usage {#string_templ}
+
+The options of linking properties can contain template strings in the `'${...}'` format. During the component’s initialization, values in this format are processed as template strings using [ES6 templates](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals). In browsers that do not support ES6 templates, these values are processed as underscore templates.
+
+So if we put a variable name in `'${...}'`, it is processed into a string representation of the variable’s value.
+
+When working with UI components, we often need to use the string representation of a certain property of the {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %}. To address a property of the UI component in the scope of this component, the `$.someProperty` syntax is used.
+
+As a result, if the component's property is the variable for the template string, we get notation similar to the following:
+
+    '${ $.provider }:foo' 
+    
+If the string would be built at runtime it would be equivalent to `this.provider + ':foo'`.
+
+We can also build complex templates strings using this syntax, as follows:
+
+- Using variables from the other component:
+
+    ``` 
+    '${ $.provider }:${ $.dataScope }' // 'provider' is the full name of the other component
+    ```
+- Calling several functions in one string: 
+
+    ```
+    '${ $.provider }:data.overload': 'overload reset validate'// we call 'overload', 'reset', 'validate'
+    ```
+
+- Using inline conditions:
+
+    ```
+    '${ $.provider }:${ $.customScope ? $.customScope + "." : ""}data.validate': 'validate'
+    ``` 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: Linking properties of UI components
 menu_title: Linking properties of UI components
 menu_order: 100
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_linking_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_modifier_concept.md
@@ -1,1 +1,118 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: About PHP modifiers in UI components
+menu_title: About PHP modifiers in UI components
+menu_order: 40
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_modifier_concept.md
+---
+
+## What's in this topic
+
+This topic describes how to use {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} modifiers that are the server-side part of [UI components configuration]({{ page.baseurl }}/ui_comp_guide/concepts//ui_comp_config_flow_concept.html). Using modifiers is optional and might be necessary when [static declaration in XML configuration files]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html) is not suitable for the tasks. For example, in cases when additional data should be loaded from database. Or the other specific example is the [default product creation form]({{ page.baseurl }}/howdoi/customize_product.html), for which the modifier is a place where validations are added to display only certain fields for certain {% glossarytooltip 6e836354-0067-48ac-84ce-a4ab7c0c492e %}product types{% endglossarytooltip %}.
+
+## General implementation overview
+
+`DataProvider()` is a PHP part of a UI component, a class responsible for the component's data and metadata preparation. The pool of modifiers (virtual type) is injected to this data provider using the `__construct()` method. The pool's preference is defined in `di.xml`.
+
+So in runtime, the component structure set in the modifier is merged with the configuration that comes from the {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} configuration.
+
+## Adding a custom PHP modifier
+
+To add a PHP modifier for a UI component, take the following steps:
+
+**Step 1**
+
+In your custom module, add a class that implements [`\Magento\Ui\DataProvider\Modifier\ModifierInterface`]({{ site.mage2100url }}app/code/Magento/Ui/DataProvider/Modifier/ModifierInterface.php) with the following methods:
+
+- `modifyData()`: for modifying UI component's data (for example, the list of options for a select element)
+- `modifyMeta()`: for modifying UI component's {% glossarytooltip 3f0f2ef1-ad38-41c6-bd1e-390daaa71d76 %}metadata{% endglossarytooltip %} (for example, name, label, description, type)
+
+Sample modifier:
+
+{% highlight php%}
+
+<?php
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+
+class Example extends AbstractModifier
+{
+    public function modifyMeta(array $meta)
+    {
+        $meta['test_fieldset_name'] = [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Label For Fieldset'),
+                        'sortOrder' => 50,
+                        'collapsible' => true
+                    ]
+                ]
+            ],
+            'children' => [
+                'test_field_name' => [
+                    'arguments' => [
+                        'data' => [
+                            'config' => [
+                                'formElement' => 'select',
+                                'componentType' => 'field',
+                                'options' => [
+                                    ['value' => 'test_value_1', 'label' => 'Test Value 1'],
+                                    ['value' => 'test_value_2', 'label' => 'Test Value 2'],
+                                    ['value' => 'test_value_3', 'label' => 'Test Value 3'],
+                                ],
+                                'visible' => 1,
+                                'required' => 1,
+                                'label' => __('Label For Element')
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+ return $meta;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function modifyData(array $data)
+    {
+        return $data;
+    }
+}
+{%endhighlight%}
+
+**Step 2**
+
+Declare your modifier in your module Di configuration `<Your_Module_dir>/etc/adminhtml/di.xml`. This declaration looks like the following:
+
+{% highlight xml %}
+<virtualType name="%YourNamespace\YourModule\DataProvider\Modifier\Pool%" type="Magento\Ui\DataProvider\Modifier\Pool">
+     <arguments>
+         <argument name="modifiers" xsi:type="array">
+             <item name="modifier_name" xsi:type="array">
+                 <item name="class" xsi:type="string">%YourNamespce\YourModule\Modifier\YourModifierClass%</item>
+                 <item name="sortOrder" xsi:type="number">10</item>
+             </item>
+         </argument>
+     </arguments>
+</virtualType>
+{% endhighlight %}
+
+, where `YourNamespace\YourModule\DataProvider\Modifier\Pool` is a [virtual class]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#configuring-a-type).
+
+(If you want to use this sample in your `di.xml`, replace the sample values with with the real names of your entities.)
+
+**Step 3**
+
+To use your modifier, add a dependency on [`\Magento\Ui\DataProvider\Modifier\PoolInterface`]({{ site.mage2100url }}app/code/Magento/Ui/DataProvider/Modifier/PoolInterface.php) to your UI component data provider. For illustration see [`\Magento\Catalog\Ui\DataProvider\Product\Form\ProductDataProvider`]({{ site.mage2100url }}app/code/Magento/Catalog/Ui/DataProvider/Product/Form/ProductDataProvider.php)
+
+
+## Related reading
+
+- [Dependency injection]( {{ page.baseurl }}/extension-dev-guide/depend-inj.html)
+- [How Do I: Customize product creation form]({{ page.baseurl }}/howdoi/customize_product.html#modifier)

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_modifier_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: About PHP modifiers in UI components
 menu_title: About PHP modifiers in UI components
 menu_order: 40
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_modifier_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -1,1 +1,101 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_template_literals.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: Template Literals in UI Components
+menu_title: Template Literals
+menu_order: 50
+contributor_name: SwiftOtter Studios
+contributor_link: https://swiftotter.com/
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_template_literals.md
+---
+
+# Template Literals in Magento
+
+Magento provides for the use of template literals in UI components. Template literals are strings that can contain embedded expressions. They were introduced into Javascript with ES2015 and were called "template strings" in early editions of the ES2015 / ES6 specification. Since it is a relatively new part of Javascript, some browsers, such as Internet Explorer 11, do not support the specification. Per the specification standard, back-ticks (`` ` ``) are used instead of a single quote (`'`) or double quote (`"`) to delineate a template string. Due to the lack of browser support, Magento has a Javascript class that will parse certain strings with a single quote (`'`) in the same way a browser that supports the specification would parse one with back-ticks.
+
+Template literals can contain expressions which will be evaluated in the current KnockoutJS context. These expressions can contain nearly any valid {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}Javascript{% endglossarytooltip %}. They must start with a dollar sign and be surrounded with curly braces. **Anything inside the following will be evaluated as an expression**: `${  }`. For example, they can be used—and often are—to access properties of the KnockoutJS context like this: `'${ $.submitUrl }'`. They can be used to call functions (`'${ $.loadForm($.formUrl) }'`), or whatever: `'${ 20 + 13 }'`. These expressions are parsed in `/lib/web/mage/utils/template.js`.
+
+Template literals allow UI Components to easily assign dynamic values to class properties. More specifically, they provide an integration layer between a particular KnockoutJS context and a Javascript class.
+
+### The `defaults` Class Property
+
+UI Components are [associated with Javascript classes](http://devdocs.magento.com/guides/v2.1/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) to handle behavior on the client side. These should extend one of the core classes to provide a base level of functionality. Inside the child class, a `defaults` property can be provided.
+
+The `defaults` property should be an object and is handled in a special way. Each property of `defaults` becomes a class property upon initialization. This happens in the `initConfig()` method of `lib/core/class.js`. Every item in `defaults` is passed through a `template()` function which evaluates template literals.
+
+As a result, every `defaults` child property is handled with what could be viewed as a two step process:
+
+1. Evaluate the value of the property for expressions. For example: `'${ $.submitUrl }'` could become `'https://example.com/contact/form/submit/'` (more on that later).
+2. Assign that property/value to the class itself. As a result `class.defaults.submitUrl` would become `class.submitUrl`.
+
+This part is important because it means that Javascript classes that extend `Class` (`magento/module-ui/view/base/web/js/lib/core/class.js`) can use the `defaults` property to assign properties to the class itself and leverage template literals during that process without any work on your part.
+
+#### The `:` separator
+
+Certain properties of the `defaults` object are processed by an additional core Javascript class: `links.js` (located: `magento/module-ui/view/base/web/js/lib/core/element/links.js`). The object keys in `defaults` are: 
+
+- `links`
+- `imports`
+- `exports`
+
+They can be used to interact with other UI Component Javascript classes. While the full use of them is a separate topic, those values can use a colon (`:`) to separate an expression, which should evaluate to a UI Component's name, from the properties to be accessed in that class. Take this example: `'${ $.provider }:user.theme'`. If the `${ $.provider }` expression evaluates to the name of a UI Component that is currently in the registry, that component will be loaded and the value of its `user.theme` property returned.
+
+As a result, a template literal used in the value of one the objects listed above can be used to succinctly access data from an *entirely different* {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI Component{% endglossarytooltip %} Javascript class.
+
+### Template Literal `$` context
+
+Perhaps the most important part of template literals in Magento is the `$` object that can be used inside expressions. (Remember an expression is anything within `${ }`.) The `$` provides access to the `this` context in the Javascript class where the template literals are. To take it a step further, `this` (and the related `$`) is the KnockoutJS context for the template that can be bound to the UI Component. This object should not be confused with the `$` that marks the beginning of an expression. The `$` object can only appear inside of an expression. Here is an example: `${ $.submitUrl }`: the `$` references the current KnockoutJS context, and `.submitUrl` will return the `provider` property from that object.
+
+
+## Example
+
+Perhaps the most useful aspect of template literals is the ability to access other UI Component Javascript classes in the registry so we will use this as an example. First, there are a few things to explain.
+
+UI Components can have a `<item name="config" xsi:type="array">...</item>` node in the primary XML declaration file ([see an example](http://devdocs.magento.com/guides/v2.1/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html#example-of-a-top-level-configuration-file)). In that file, a `component` element can be added with a path reference to the RequireJS file. That file is loaded into the registry when it runs on the front end and other Javascript files can then access it by the *name* of the UI Component instead of the path to the file itself. The name often will look something like this: `example_component.example_component`.
+
+Names of other registered modules can be added to the {% glossarytooltip ebe2cd14-d6d4-4d75-b3d7-a4f2384e5af9 %}server side{% endglossarytooltip %} configuration (XML or PHP) that is output through JSON. Those names can then be easily accessed in the Javascript on the front end. In the following example, the other UI Component's name will be obtained with a template literal in the `imports` object. When this Javascript file is loaded, it will process the template literal and look up the name in the registry. If found, it will load that class. Because there is a colon (`:`), it will go on to find the property that is accessed in the other Javascript class.
+
+
+```javascript
+return Element.extend({
+    defaults: {
+        template: 'Example_Component/message-list',
+        imports: {
+            messages: '${ $.messageHandler }:data.userMessages'
+        }
+    },
+
+    // ...
+
+    initialize: function() {
+        this._super();
+        this.addHtmlClassesToMessages();
+    },
+
+    addHtmlClassesToMessages: function() {
+        this.messages.forEach(function(currentValue) {
+            currentValue['htmlClass'] = 'message message--' + currentValue['type'];
+        });
+    }
+
+    // ...
+})
+```
+
+Notice how the `addHtmlClassesToMessages()` method accesses the `messages` property of `this`. When the class was initialized, the `data.userMessages` array was obtained from the `$.messageHandler` UI Component and was then assigned to the primary object.
+
+In the template, the messages can be displayed like this:
+
+```html
+<!-- File: app/code/Example/Component/view/frontend/web/template/message-list.html -->
+<div>
+  <ul data-bind="foreach: messages" class="message-list">
+      <li data-bind="text: content, css: htmlClass"></li>
+  </ul>
+</div>
+```
+
+### Conclusion
+
+Template literals provide a simple and concise way to evaluate expressions. In Magento, they facilitate a great way to load data into a Javascript class. They also play a part in interacting with other classes to create a fully interactive front end framework.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -6,7 +6,7 @@ menu_title: Template Literals
 menu_order: 50
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_template_literals.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: About the uiClass library
 menu_title: About the uiClass library
 menu_order: 60
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_uiclass_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
@@ -1,1 +1,78 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: About the uiClass library
+menu_title: About the uiClass library
+menu_order: 60
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_uiclass_concept.md
+---
+
+## What is `uiClass`?
+
+The `uiClass` is an abstract class from which all components are extended. The `uiClass` is a low-level class and is rarely used as direct parent for UI components' classes.
+
+`uiClass` source code is `<UI_Module_dir>/view/base/web/js/lib/core/class.js`, in the {{site.data.var.ce}} github repository: [app/code/Magento/Ui/view/base/web/js/lib/core/class.js]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/core/class.js)
+
+## Commonly used uiClass methods
+The uiClass class introduces the architecture of UI components through the following methods:
+
+*  The `extend()` method implements inheritance of UI components. The `extend()` returns new class. The `extend()` method gets a {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}JavaScript{% endglossarytooltip %} object as a parameter, and then extends the base object with the properties and methods of the argument's object. The properties of the argument's object have higher priority than base object's properties.
+   As an example:
+    %componentName%.extend(%JavaScript_extender_object%);
+
+* The `initConfig()` method processes the UI component's configurations. The `initConfig()` method gets as a parameter the JavaScript configuration object, which is then merged with the default configuration (declared in the UI Component that calls the `initConfig()` method) and in the parent {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %}. This resulting configuration is then set as first level properties in the current UI component instance.
+
+  As an example:
+{%highlight js%}
+	defaults: {
+		myFirstProperty: 0,
+		mySecondProperty: 1
+	}
+
+	Before executing initConfig method:
+	console.log(this.myFirstProperty) // Undefined
+	console.log(this.mySecondProperty) // Undefined
+
+	After executing initConfig method:
+	console.log(this.myFirstProperty) // 0
+	console.log(this.mySecondProperty) // 1
+{%endhighlight%}
+
+* The `initialize()` method is called during instantiation. It can be used to add custom functionality executed only once, during component instance creation.
+
+As an example:
+
+{%highlight js%}
+	initialize: function () {
+		%yourMethodName%();
+
+		return this;
+	}
+{%endhighlight%}
+
+* The `_super()` method calls the parent UI component method with the same name as the `_super()` method's caller; if that method does not exists in the parent UI component, then the method tries to find it higher in the inheritance chain.
+As an example:
+
+{%highlight js%}
+	initialize: function () {
+		this._super(); //_super will call parent's `initialize` method here
+
+		return this;
+	}
+{%endhighlight%}
+
+### Commonly used uiClass properties {#uiclass_properties}
+
+The `defaults` property declares the list of properties of a UI component's instance. Also it declares communications between components if needed.
+
+As an example:
+{%highlight js%}
+	defaults: {
+		%yourCustomProperty%: '',
+		imports: {
+            %yourCustomProperty%: '%anotherComponentLink%',
+            disabled: 'checked'
+        },
+	}
+{%endhighlight%}

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: About the uiCollection class
 menu_title: About the uiCollection class
 menu_order: 80
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_uicollection_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
@@ -1,1 +1,87 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: About the uiCollection class
+menu_title: About the uiCollection class
+menu_order: 80
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+---
+
+## What is `uiCollection`
+
+The `uiCollection` library class should be used as a base class by any components that contain a collection of child UI components.  `uiCollection` inherits from the [uiElement class]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html).
+
+`uiCollection` source code is `<UI_Module_dir>/view/base/web/js/lib/core/collection.js`, in the {{site.data.var.ce}} github repository: [app/code/Magento/Ui/view/base/web/js/lib/core/collection.js]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/core/collection.js).
+
+## Commonly used `uiCollection` methods
+
+The `uiCollection` class implements the following methods:
+
+* The `initElement()` method allows you to add custom functionality to a child UI component or to the current UI component at the moment when the child UI component initializes. The `initElement()` method gets the child {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %} instance as a parameter.
+
+  Example:
+
+  {%highlight js%}
+  initElement: function (childInstance) {
+      childInstance.%customProperty% = 21;
+      this.%currentComponentProperty% = 42;
+  }
+  {%endhighlight%}
+
+* The `destroy()` method removes the following for the child components and itself:
+	* link to the component in `uiRegistry`
+	* link to the component in the parent component
+	* event listeners
+
+
+  Example:
+
+{%highlight js%}
+    this.destroy();
+{%endhighlight%}
+
+* The `getChild()` method returns an element from the collection of child UI components.
+
+  Example:
+{%highlight js%}
+    this.getChild(childIndex)
+{%endhighlight%}
+
+  where `childIndex` is the value of the child element's `index` property.
+
+
+## Commonly used `uiCollection` properties
+
+* `elems` is the observable property that contains the collection of child UI components.
+
+  Example:
+
+{%highlight js%}
+console.log(this.elems());
+
+// [
+//   %uiComponentInstance 1 %,
+//   %uiComponentInstance 2 %,
+//   %uiComponentInstance 3 %,
+//   %uiComponentInstance 4 %
+// ]
+{%endhighlight%}
+
+* `childDefaults` can be used to set the children defaults: properties from `childDefaults` are set into child elements' [`defaults` property]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html#uiclass_properties).
+
+## uiCollection template {#uicollection_template}
+
+The `uiCollection` template is `<UI_Module_dir>/view/base/web/templates/collection.html`, in the {{site.data.var.ce}} github repository: [`app/code/Magento/Ui/view/base/web/templates/collection.html`]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/templates/collection.html).
+
+This template performs only one task: renders child templates if they exist.
+
+It looks like following:
+
+{%highlight html%}
+<each args="data: elems, as: 'element'">
+    <render if="hasTemplate()"/>
+</each>
+{%endhighlight%}
+
+ Here `elems` is the collection of the child elements of `uiCollection`. As far as `elems` is the observable property, the templates of the components added to `elems` in the runtime, are also rendered.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uielement_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uielement_concept.md
@@ -5,7 +5,7 @@ title: About the uiElement class
 menu_title: About the uiElement class
 menu_node:
 menu_order: 70
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_uielement_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uielement_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uielement_concept.md
@@ -1,1 +1,80 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_uielement_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: About the uiElement class
+menu_title: About the uiElement class
+menu_node:
+menu_order: 70
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_uielement_concept.md
+---
+
+## What is the `uiElement` class
+
+The `uiElement` class is a direct successor of the [uiClass library]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html).
+When creating a new component, use the `uiElement` class as a direct parent, if your component will be the last in the components hierarchy chain.
+
+`uiElement` source code is `<UI_Module_dir>/view/base/web/js/lib/core/element/element.js`, in the {{site.data.var.ce}} github repository: [app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js).
+
+
+## Commonly used `uiElement` methods
+
+- The `initLinks()` method implements component communication by using [`links.js`]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/lib/core/element/links.js).  `initLinks()` introduces processing of the [`exports`, `imports`, `links` and `listens` properties](http://devdocs.magento.com/guides/v2.0/ui-components/ui_components_js.html#comp_link).
+
+- The `initObservable()` method allows you to declare observable variables within the same instance.
+
+  Example:
+
+      initObservable: function () {
+          this._super();
+
+          this.track('childTemplate')
+          this.observe([
+              '%myVariable1%',
+              '%myVariable2%'
+          ]);
+
+          return this;
+      }
+
+  , where:
+
+    - the `observe()` method is a wrapper for the `ko.observable()` and `ko.observableArray()` methods. It converts the properties of the current method into the observable properties.
+`observe([{Boolean} isTracked,] {String|Array|Object} listOfProperties)`:
+
+        - `isTracked` - `{Boolean}`, optional, - defines access usage: whether to use observable properties (`isTracked = false`) or property accessors (`isTracked = true`).
+        - `listOfProperties` - `{String}` is treated as space-separated list of properties' names. Initial values will be used from current instance (when corresponding property exist).
+        - `listOfProperties` - `{Array}` a list of properties' names. Initial values will be used from current instance (when corresponding property exist).
+        - `listOfProperties` - `{Object}` a list of properties' names. Initial values will be used from this object.
+    - the `track(listOfProperties)` method is equal to `observe(true, listOfProperties)`.
+      The main difference between `observe()` and `track()` is that `observe()` is mainly used without first boolean argument. So it really converts properties to observable functions. It changes how property can be accessed. Otherwise `track()` uses property accessors. So property access remains the same.
+
+      Example:
+
+          this.observable = 1;
+          this.observe('observable');
+
+          this.observable(2); // setter
+          this.observable();  // getter
+
+
+          this.trackable = 1;
+          this.track('trackable');
+
+          this.trackable = 2; // setter
+          this.trackable;     // getter
+
+- The `initModules()` method initializes external UI components' instances and links them to local variables. This method works with the `modules` section of the configuration, where we define the name of the external instance and the local variable. The `modules` section is an object where each key is the variable's name and each value is the instance's name. A developer does not need to be concerned with the instantiation of the module (external instance), because the `initModules()` method will resolve the variable when the instance is instantiated.
+
+  Example:
+
+      // Config, where the `modules` property is declared
+      defaults: {
+          modules: {
+              '%myProperty%': '%linkToTheComponent%'
+          }
+      }
+
+- The `getTemplate()` method returns a file path to UI component's template.
+
+- The `hasTemplate()` method verifies that the `template` property was specified in the instance configuration.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uilayout_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uilayout_concept.md
@@ -1,7 +1,7 @@
 ---
 group: UI_Components_guide
 title: The uiLayout service object
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_uilayout_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uilayout_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uilayout_concept.md
@@ -1,1 +1,154 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_uilayout_concept.md
+---
+group: UI_Components_guide
+title: The uiLayout service object
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_uilayout_concept.md
+---
+
+The `uiLayout` service object is a JavaScript function object used for initializing and configuring UI components.
+This object is defined in the [`layout.js`](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Ui/view/base/web/js/core/renderer/layout.js) file in the UI module.
+
+## `run()` method
+
+The `run()` method is the class entry point represented by `uiLayout` and has the following signature:
+
+`run(nodes, parent, cached, merge)`
+
+| Parameter | Type    | Description                              |
+| --------- | ------- | ---------------------------------------- |
+| `nodes`   | Object  | Configuration object for a UI component  |
+| `parent`  | Object  | The parent component of the UI component |
+| `cached`  | Boolean | Determines if `nodes` should be cached   |
+| `merge`   | Boolean | Determines if `nodes` should be merged   |
+{:style="table-layout:auto;"}
+
+If `cached` is set to `true`, the key for the cache is constructed from the object keys in the `node` parameter.
+Use the `cached` and `merge` parameters when a UI component needs to be updated during runtime.
+
+### `nodes` configuration object
+
+The `nodes` parameter is a JavaScript object used by the `run()` method to determine how a UI component is created.
+
+This object can have the following properties:
+
+| Property       | Type    | Description                                                                                          |
+| -------------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `name`         | String  | Name of the component.                                                                               |
+| `parent`       | String  | Full name of the component's parent element.                                                         |
+| `template`     | String  | Path to the component's `.html` template.                                                            |
+| `config`       | Object  | Configuration properties for the UI component.                                                       |
+| `children`     | Object  | Configuration nodes for children components.                                                         |
+| `isTemplate`   | Boolean | Whether to save the configuration as a template.                                                     |
+| `nodeTemplate` | String  | The full name of a saved configuration template.                                                     |
+| `provider`     | String  | The full name of the DataSource UI component. This property is inherited from the parent if skipped. |
+{:style="table-layout:auto;"}
+
+#### Naming
+
+The name of the property is the shortened name of the component.
+It is used as the `index` property of the generated instance.
+
+The full name of the created UI component is the concatenation of the parent's `name` property and the component's `name` property.
+If an instance with the same full name already exists, `uiLayout` will skip initialization.
+
+#### Parent initialization
+
+If the parent component is not yet initialized, `uiLayout` waits for it to appear in the `uiRegistry`.
+
+#### Configuration template
+
+When `isTemplate` is set to `true`, `uiLayout` stores the configuration in a private `templates` variable instead of initializing the component.
+
+You can use this stored configuration to create dynamic component instances during runtime by specifying the full name of the configuration in `nodeTemplate`.
+If the configuration is found, `uiLayout` uses that configuration instead of the current values.
+
+
+## Code samples
+
+The example module referenced in the following examples uses `OrangeCo` as its company value and `Sample` as the module name.
+
+It also assumes the existence of the following files:
+
+* `app/code/OrangeCo/Sample/view/base/web/js/my-new-component.js`
+* `app/code/OrangeCo/Sample/view/base/web/templates/my-new-component/main-template.html`
+
+### Create a child component
+
+You can use `uiLayout` to create a UI component instance that is a child of another UI component.
+
+The following example creates an instance of the `my-new-component` component that is a child of the `uiCollection` component.
+
+**Example component file:** `app/code/OrangeCo/Sample/view/base/web/js/sample.js`
+
+``` js
+define([
+    'uiLayout',
+    'uiCollection'
+], function (layout, Collection) {
+    'use strict';
+
+    return Collection.extend({
+        defaults: {
+            myNewComponentConfig: {
+                name: 'myNewComponent',
+                component: 'OrangeCo_Sample/js/my-new-component',
+                nodeTemplate: 'OrangeCo_Sample/my-new-component/main-template',
+                parent: '${ $.name }'
+            }
+        },
+        initialize: function () {
+            this._super();
+            layout([this.myNewComponentConfig]);
+
+            return this;
+        }
+    });
+});
+```
+
+The component instance is created when `myNewComponentConfig` is passed on to the `uiLayout` service object:
+
+`layout([this.myNewComponentConfig]);`
+
+This instance is stored in the `uiRegistry` with other components and rendered using the logic for rendering `uiCollection` children templates.
+
+
+### Use a configuration template
+
+You can use the configuration of one UI component to create another UI component.
+The `isTemplate` configuration for the original UI component must be `true` to save its configuration as a template in `uiLayout`.
+
+In the following example, a custom Table UI component is created using an existing configuration template with the name `my_row_template_component_name`.
+
+The [`mageUtils`](https://github.com/magento/magento2/tree/2.3-develop/lib/web/mage/utils) helper library is also used in this example to create the new component based on `myRowTemplateConfig`.
+
+**Example component file:** `app/code/OrangeCo/Sample/view/base/web/js/table.js`
+
+``` js
+define([
+    'uiLayout',
+    'uiCollection',
+    'mageUtils'
+], function (layout, Collection, utils) {
+    'use strict';
+
+    return Collection.extend({
+        defaults: {
+            myRowTemplateConfig: {
+                parent: '${ $.name }',
+                nodeTemplate: 'my_row_template_component_name'
+        }
+    },
+
+    addRow: function (rowIndex) {
+        var objectFromTemplate,
+            myRowTemplateConfig = this.myRowTemplateConfig;
+
+        myRowTemplateConfig.name = rowIndex;
+        objectFromTemplate = utils.template(myRowTemplateConfig);
+        layout([objectFromTemplate]);
+        }
+    });
+});
+```
+

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiregistry.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiregistry.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: uiRegistry
 menu_title: uiRegistry
 menu_order: 110
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_uiregistry.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiregistry.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_uiregistry.md
@@ -1,1 +1,46 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_uiregistry.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: uiRegistry
+menu_title: uiRegistry
+menu_order: 110
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_uiregistry.md
+---
+
+`uiRegistry` is a in-memory storage, plain storage of entities by keys. Implements the `get()`, `set()`, and `has()` methods.
+
+## JS debugging using uiRegistry {#debug_uiregistry}
+
+To debug the UI component JS, we first need to get a `uiRegistry` instance from the browser console. To do so, use the [RequireJs ID]({{ page.baseurl }}/javascript-dev-guide/javascript/requirejs_concept.html) `uiRegistry`.
+
+In the browser console enter the following:
+
+{%highlight js%}
+var registry = require('uiRegistry');
+{%endhighlight%}
+
+Now we have `uiRegistry` instance in the `registry` variable. We can use it to get an instance of any component.
+
+{%highlight js%}
+var component = registry.get('%componentName%');
+{%endhighlight%}
+
+For example:
+
+{%highlight js%}
+// Admin > Products > Catalog > Add Product
+var fieldName = registry.get('product_form.product_form.product-details.container_name.name');
+{%endhighlight%}
+
+Lets look what we have in component variable. It keeps component context with all properties, we can see component file, component name and so on.
+
+{%highlight js%}
+console.log(fieldName.name); // product_form.product_form.product-details.container_name.name
+
+fieldName.trigger('validate'); // will invoke validation
+fieldName.visible(false); // will hide field from page
+fieldName.visible(true);  // will show field again
+fieldName.value(); // will show current field value
+fieldName.value('New string value'); // will change field value to string 'New string value'
+{%endhighlight%}

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
@@ -1,1 +1,126 @@
-../../../v2.1/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
+---
+group: UI_Components_guide
+subgroup: concepts
+title: About XML сonfiguration of UI сomponents
+menu_title: About XML сonfiguration of UI сomponents
+menu_order: 13
+version: 2.1
+github_link: ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
+---
+
+## Overview
+
+This topic discusses the {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} declaration of UI components.
+
+## About the layout configuration file and UI component declaration
+Every {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} that has view representation contains the directory named `layout`. In this directory, the `.xml` declarations of the pages are stored. These `.xml` declarations are, in fact, the pages' {% glossarytooltip 8f407f13-4350-449b-9dc5-217dcf01bc42 %}markup{% endglossarytooltip %}.
+
+In a typical Magento `.xml` layout file we see a `<head/>` node, `<title/>` node with the name of the page, and sometimes [links to CSS and JS files]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-manage.html#layout_markup_css). There are other nodes as well, the most important for us now is the [`<referenceContainer/>` node]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_ref). (The `name` attribute in this node is responsible for the position of the container on the page.). [Basic]({{ page.baseurl }}/ui_comp_guide/bk-ui_comps.html#general-structure) UI components are declared in this node. All nested components are declared in the basic components' instances configuration files (not in the page layouts).
+
+Example of a basic {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %} declaration:
+
+{%highlight xml%}
+<referenceContainer name="page-container">
+	<uiComponent name="%instance_name%"/>
+</referenceContainer>
+{%endhighlight%}
+
+A UI component is declared using the `<uiComponent/>` node. The `name` attribute in the `<uiComponent/>` node references the XML configuration of the basic UI component's instance. This configuration is a separate `.xml` file. It is stored in the `<module_dir>/view/<area>/ui_component/` directory. For example `<module_dir>/view/<area>/ui_component/%instance_name%.xml`.
+
+
+## About the basic component configuration file
+
+The instance configuration file name is the name of instance (`%instance_name%`). The {% glossarytooltip 621ef86b-7314-4fbc-a80d-ab7fa45a27cb %}namespace{% endglossarytooltip %} of the names is global; meaning that if the file names in different modules are the same, they are merged into a single configuration for the particular instance.
+
+Following are the rules for the instance configuration files:
+
+* The top node must have the name of one of the basic UI components. <!-- need to mention or link what components -->
+* The top node must contain a link to the XSD schema.
+
+In the top node, there can be an `<argument/>` node. The `<argument/>` node contains the configuration for that basic UI component. The `<argument/>` node's `name` attribute value must be `data`. The child nodes of the `<argument>` node will be the argument properties that will be passed in to the component.
+
+The top node can have nested nodes. Every nested node is regarded as a separate UI component (i.e. the toolbar). For example, if you want your listing to have a toolbar, then the top node is for the listing and a nested node represents a toolbar. Nested nodes can also contain the `<argument>` node.
+
+
+## Example of a basic component's configuration file
+
+{%highlight xml%}
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">category_form.category_form_data_source</item>
+            <item name="deps" xsi:type="string">category_form.category_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Category Information</item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+        <item name="buttons" xsi:type="array">
+            <item name="delete" xsi:type="string">Magento\Catalog\Block\Adminhtml\Category\Edit\DeleteButton</item>
+            <item name="save" xsi:type="string">Magento\Catalog\Block\Adminhtml\Category\Edit\SaveButton</item>
+        </item>
+        <item name="config" xsi:type="array">
+            <item name="dataScope" xsi:type="string">data</item>
+            <item name="namespace" xsi:type="string">category_form</item>
+        </item>
+        <item name="reverseMetadataMerge" xsi:type="boolean">true</item>
+    </argument>
+    <dataSource name="category_form_data_source">
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Magento\Catalog\Model\Category\DataProvider</argument>
+            <argument name="name" xsi:type="string">category_form_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">entity_id</argument>
+            <argument name="requestFieldName" xsi:type="string">id</argument>
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="submit_url" xsi:type="url" path="catalog/category/save"/>
+                    <item name="validate_url" xsi:type="url" path="catalog/category/validate"/>
+                </item>
+            </argument>
+        </argument>
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+    </dataSource>
+    <fieldset name="general">
+        <field name="id">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="formElement" xsi:type="string">hidden</item>
+                    <item name="source" xsi:type="string">category</item>
+                </item>
+            </argument>
+        </field>
+    </fieldset>
+</form>
+
+{%endhighlight%}
+
+In the above example, within the top-level `<form>` node the `<fieldset>` node is nested. It declares the Fieldset UI component.
+
+The `name` attribute value must be a unique among the other components on the same hierarchical level of the same parent node. Look at the `<argument>` node which `name` attribute has `data` value. The child nodes of this node are the arguments that will be passed in to the component.
+
+All other child nodes are declared as items. `<item name="config"> ...</item>` contains the children nodes that describe the configuration of the current UI component. Please note that although configuration for all components is different, there are base properties that are mostly the same for different components. For example, we can use `<item name="component">...</item>` to define which JS file will be used as the Model for the  Fieldset UI component in the above example. Reference to this JS file can be either be the full path to this file or the alias which is defined in [`require.js` configuration]({{ page.baseurl }}/javascript-dev-guide/javascript/requirejs_concept.html).
+
+In our example, the `<item name="component">...</item>` node within `<fieldset>` is omitted, because this property of the Fieldset UI component is already defined in `definition.xml`.
+
+In this example we showed only a small part of the possible configuration.
+
+The default configuration of a UI component is declared in one of the following ways:
+
+- inside the UI component itself, in the `.js` file
+- in the [`definition.xml` file]({{ site.mage2100url }}app/code/Magento/Ui/view/base/ui_component/etc/definition.xml)
+- in both places, in which case the configurations merge (the UI component `.js` file has priority).
+
+In the above example, the Fieldset UI component uses a merged configuration from both the `definition.xml` file and from the UI component's `.js` file.
+
+For more information about the configuration flow, refer to  the [Configuration Flow of UI Components]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_config_flow_concept.html) topic.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
@@ -4,7 +4,7 @@ subgroup: concepts
 title: About XML сonfiguration of UI сomponents
 menu_title: About XML сonfiguration of UI сomponents
 menu_order: 13
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/howto/add_category_attribute.md
+++ b/guides/v2.2/ui_comp_guide/howto/add_category_attribute.md
@@ -6,7 +6,7 @@ menu_title: Create and display a category attribute with UI components
 menu_order: 3
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/howto/add_category_attribute.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/howto/add_category_attribute.md
+++ b/guides/v2.2/ui_comp_guide/howto/add_category_attribute.md
@@ -1,1 +1,99 @@
-../../../v2.1/ui_comp_guide/howto/add_category_attribute.md
+---
+group: UI_Components_guide
+subgroup: how tos
+title: Add a category attribute
+menu_title: Create and display a category attribute with UI components
+menu_order: 3
+contributor_name: SwiftOtter Studios
+contributor_link: https://swiftotter.com/
+version: 2.1
+github_link: ui_comp_guide/howto/add_category_attribute.md
+---
+
+Category attributes were automatically displayed in the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}admin{% endglossarytooltip %} panel of Magento 1. In Magento 2, it is necessary to explicitly render it with a {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI Component{% endglossarytooltip %}. This is quite easy to do and provides a great degree of control over the form input. In the code examples below, replace `attribute_id` and `Your Category Attribute Name` with your own values.
+
+## Step #1: Create the Attribute
+
+The following is a full example of an install script that creates a {% glossarytooltip 50e49338-1e6c-4473-8527-9e401d67ea2b %}category{% endglossarytooltip %} attribute. If you already have a category attribute, it is not necessary.
+
+{% highlight php startinline=true %}
+// File: Namespace/Module/Setup/InstallData.php
+
+use Magento\Framework\Setup\{
+    ModuleContextInterface,
+    ModuleDataSetupInterface,
+    InstallDataInterface
+};
+
+use Magento\Eav\Setup\EavSetup;
+use Magento\Eav\Setup\EavSetupFactory;
+
+class InstallData implements InstallDataInterface
+{
+    private $eavSetupFactory;
+
+    public function __construct(EavSetupFactory $eavSetupFactory) {
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+        $eavSetup->addAttribute(\Magento\Catalog\Model\Category::ENTITY, 'attribute_id', [
+            'type'     => 'int',
+            'label'    => 'Your Category Attribute Name',
+            'input'    => 'boolean',
+            'source'   => 'Magento\Eav\Model\Entity\Attribute\Source\Boolean',
+            'visible'  => true,
+            'default'  => '0',
+            'required' => false,
+            'global'   => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_STORE,
+            'group'    => 'Display Settings',
+        ]);
+    }
+}
+{% endhighlight %}
+
+## Step #2: Display the Attribute
+
+The category UI Component is rendered with configuration from the `category_form.xml` file. All files with that name are merged together. As a result, you can add a field by creating a `category_form.xml` file in the `view/adminhtml/ui_component` directory in your {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %}.
+
+Here is a full example of adding a field under the "Display Settings" group. It is important to note that `attribute_id` should match the ID of the attribute that you created in the install script.
+
+{% highlight xml %}
+<!-- Namespace/Module/view/adminhtml/ui_component/category_form.xml -->
+<?xml version="1.0"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="display_settings">
+        <field name="attribute_id">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">boolean</item>
+                    <item name="formElement" xsi:type="string">checkbox</item>
+                    <item name="label" xsi:type="string" translate="true">Your Category Attribute Name</item>
+                    <item name="prefer" xsi:type="string">toggle</item>
+                    <item name="valueMap" xsi:type="array">
+                        <item name="true" xsi:type="string">1</item>
+                        <item name="false" xsi:type="string">0</item>
+                    </item>
+                    <item name="default" xsi:type="number">0</item>
+                </item>
+            </argument>
+        </field>
+    </fieldset>
+</form>
+{% endhighlight %}
+
+## Step #3: Upgrade and Run
+
+[Upgrade the database schema]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db-upgr.html) to install the attribute [and clear your cache]({{ page.baseurl }}/howdoi/php/php_clear-dirs.html#howdoi-clear-how).
+
+## How it works
+
+UI Component configuration is merged. When you add a new file, Magento will merge that with the base UI Component configuration file. In the example above, that is `category_form.xml`. The nodes inside of that reflect the structure of the base file. There are only two nodes necessary in this case before the custom field is added: `<form>` and `<fieldset>`. Inside of that, the `<field>` node is used to add a field with a name that matches the id of the attribute you want to render.
+
+The `<field>` node is declared originally in `vendor/magento/module-ui/view/base/ui_component/etc/definition.xml`. If you open that file and look for `<field>`, you will notice that there is only a PHP class referenced—nothing particularly helpful. This is where the `config` elements in the example above come in important. Notice the value of `<item name="formElement">` (`checkbox`)? Now, if you look in `definition.xml`, you will find a `<checkbox>` node that has some configuration values. In the PHP class that the `<field>` element references, it looks up the `formElement` to use and loads that. As a result, `<checkbox>` is the node. In this case, that has the information that we are looking for.
+
+One of those elements is particularly useful when determining what XML you need to provide for your field: `<item name="component">`. That is a Javascript file that handles the functionality of the field. In our case, it is located in `vendor/magento/module-ui/view/base/web/js/form/element/single-checkbox.js`. If you open that file, there is a `defaults` object which contains values that can be modified through the XML above. For example, notice: `defaults.prefer: 'checkbox'`. In the XML above, we declared `<item name="prefer">toggle</item>`. As a result, the {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} value overrides the default value, and the {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}Javascript{% endglossarytooltip %} renders a toggle instead of a plain checkbox.
+
+This opens up the opportunity for you to customize nearly anything about the UI Component. It also should provide you with a basis of how to determine what configuration is available for you to set through XML.

--- a/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
+++ b/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
@@ -4,7 +4,7 @@ subgroup: troubleshoot
 title: Debug UI components JavaScript
 menu_title: Debug UI components JavaScript
 menu_order: 1
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
+++ b/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
@@ -1,1 +1,71 @@
-../../../v2.1/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
+---
+group: UI_Components_guide
+subgroup: troubleshoot
+title: Debug UI components JavaScript
+menu_title: Debug UI components JavaScript
+menu_order: 1
+version: 2.1
+github_link: ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
+---
+
+## Overview
+
+This article describes how to define what UI components are used on a particular page, their {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}JavaScript{% endglossarytooltip %} components and what data they use.
+
+To define the UI components used on a page, you can use browser built-in developer tools, or install additionally a plugin, for example Knockoutjs context debugger for Google Chrome.
+
+## Debugging using Knockout.js plugin
+
+To install the knockout debugging plugin for Google Chrome, take the following steps:
+
+1. Open your Google Chrome browser.
+2. Expand Google Chrome options drop-down (hamburger in upper right).
+3. Select **Settings**.
+4. In left pane, select **Extensions**.
+5. Scroll to end of the page and click **Get more extensions** link.
+6. In the **Search** field write **Knockoutjs context debugger** and press the **Enter** key.
+7. In the result, find the {% glossarytooltip 55774db9-bf9d-40f3-83db-b10cc5ae3b68 %}extension{% endglossarytooltip %} named **Knockoutjs context debugger** (usually the first result), and click **Add to Chrome**.
+
+To define the {% glossarytooltip 9bcc648c-bd08-4feb-906d-1e24c4f2f422 %}UI component{% endglossarytooltip %} using the plugin:
+
+1. Open the required page in Chrome.
+2. Point to the required element on the page, right-click and select **Inspect**. The developer tools panel opens.
+3. In the right column of the panel, click the **Knockout context** tab. The tab displays the name and the configuration of the UI component instance.
+
+A simple example:
+
+1. Launch {% glossarytooltip 18b930cf-09cc-47c9-a5e5-905f86c43f81 %}Magento Admin{% endglossarytooltip %}.
+2. Navigate to **Products** > **Catalog** and click **Add Product**. The product creation page opens.
+3. Right-click on the **Product Name** field and click **Inspect**. Go to the **Knockout context** tab. Here you can see the full context of the field, where you can find JS component file, component name, etc.
+![Image Example]({{ site.baseurl }}/common/images/ui_comp_troubleshoot_chrome1.png)
+
+## Debugging using pure Knockout
+
+To retrieve the context within markup, you can also use the instance of Knockout:
+
+At first we need to get a Knockout instance from the browser console. To do so, use the [RequireJS ID]({{ page.baseurl }}/javascript-dev-guide/javascript/requirejs_concept.html) `knockout`.
+
+{%highlight js%}
+var ko = require('knockout');
+{%endhighlight%}
+
+Now we have Knockout instance in the `ko` variable. We can use it to get a context of any DOM element.
+
+{%highlight js%}
+var context = ko.contextFor($0);
+{%endhighlight%}
+
+, where `$0` is a [special variable](https://developers.google.com/web/tools/chrome-devtools/debug/command-line/command-line-reference#section-1) in browser console. It contains a link to a DOM element that is last inspected.
+
+For example:
+{%highlight js%}
+// Admin > Products > Catalog > Add Product
+// Inspect "Product Name"
+var fieldName = ko.contextFor($0).$data;
+
+console.log(fieldName.name); // product_form.product_form.product-details.container_name.name
+{%endhighlight%}
+
+## See also
+
+[Debug using uiRegistry]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiregistry.html#debug_uiregistry)

--- a/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
+++ b/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
@@ -5,7 +5,7 @@ title: Troubleshooting UI components
 menu_title: Troubleshooting UI components
 menu_order: 1
 menu_node: parent
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
+++ b/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
@@ -1,1 +1,12 @@
-../../../v2.1/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
+---
+group: UI_Components
+subgroup: troubleshoot
+title: Troubleshooting UI components
+menu_title: Troubleshooting UI components
+menu_order: 1
+menu_node: parent
+version: 2.1
+github_link: ui_comp_guide/troubleshoot/ui_comp_troubleshoot_overview.md
+---
+
+## Overview

--- a/guides/v2.2/ui_comp_guide/ui_comp_conceptual_template.md
+++ b/guides/v2.2/ui_comp_guide/ui_comp_conceptual_template.md
@@ -1,1 +1,95 @@
-../../v2.1/ui_comp_guide/ui_comp_conceptual_template.md
+---
+group: UI Components
+subgroup: Concepts
+title: your page title
+menu_title:
+menu_node:
+menu_order: 1
+version: 2.1
+github_link: ui_comp_guide/ui_comp_conceptual_template.md
+---
+
+<!-- Содержание -->
+
+## Overview
+
+High-level, one or two sentences, describing the functionality.
+
+## Common Usage (if relevant)
+Include one or two examples of how this feature or functionality is used.
+
+## Implementation Details
+
+This topic describes in more detail WHAT this feature is, and provides the reader an understanding of what the feature does, and how it is implemented/works. Explain core concepts, and relevant information about system or application workflows.
+
+When writing a conceptual topic, pretend that you are describing this feature to a new developer who just joined your team, and who will be working with you to further develop it.
+
+## Workflow Diagrams (if relevant)
+Add any diagrams or text that explains core workflows.
+
+
+<!-- форматирование -->
+
+### Formatting reference
+
+
+### Basic Markdown Syntax
+Below are some basic examples of what you can do with {% glossarytooltip a5ef9041-976f-4eb3-826e-bf836027d8c3 %}markdown{% endglossarytooltip %}.
+
+#### Text Effects
+
+*emphasis*
+ **bold**
+ `inline code`
+
+By indenting your content by at least 4 spaces, you can create a code block.
+
+    //This is a code block!
+    print "Hello World!";
+
+For more examples of basic markdown please follow this [link](https://daringfireball.net/projects/markdown/syntax){:target="_self"}.
+
+#### Lists
+Lists are useful for organizing and displaying related items. Below are examples of a bulleted list and an ordered list.
+
+**Bulleted List:**
+
+* List Item 1
+*	List Item 2
+*	List Item 3
+
+**Ordered List:**
+
+1.	First Step
+2.	Second Step
+3.	Third Step
+
+#### Tables
+Tables can be useful for displaying different kinds of data in an organized way.
+
+*Example:*
+
+| Column Heading | Column Heading | Column Heading |
+|----------------|----------------|----------------|
+| Data 1         | Data 2         | Data 3         |
+| Data 4         | Data 5         |                |
+| Data 6         |                |                |
+
+You can read more about table syntax [here](http://kramdown.gettalong.org/syntax.html#tables){:target="_blank"}.
+
+#### Code blocks
+
+Code blocks can also be defined by surrounding the block of code with `~~~` which can be seen in the [table](#tables) example.
+
+For highlighted code blocks use the `highlight` Liquid tag.
+
+*Example:*
+
+{% highlight html %}
+<div class="container">
+  <h4 class="title">Title</h4>
+  <div class="content">
+    <p>Paragraph content.</p>
+  </div>
+</div>
+{% endhighlight %}

--- a/guides/v2.2/ui_comp_guide/ui_comp_conceptual_template.md
+++ b/guides/v2.2/ui_comp_guide/ui_comp_conceptual_template.md
@@ -5,7 +5,7 @@ title: your page title
 menu_title:
 menu_node:
 menu_order: 1
-version: 2.1
+version: 2.2
 github_link: ui_comp_guide/ui_comp_conceptual_template.md
 ---
 

--- a/guides/v2.2/ui_comp_guide/ui_comp_procedures_template.md
+++ b/guides/v2.2/ui_comp_guide/ui_comp_procedures_template.md
@@ -1,1 +1,97 @@
-../../v2.1/ui_comp_guide/ui_comp_procedures_template.md
+---
+group: UI Components
+subgroup:
+title:
+menu_title:
+menu_node:
+menu_order: 1
+version: 2.1
+github_link: contributor-guide/basic_template.md
+---
+
+### Overview
+
+One or two sentences, describing what is the procedure and when the user might need it. High-level workflow.
+
+
+### Prerequisites (if relevant)
+What preparations are required, what a user should be familiar with.
+
+
+## Actual steps
+
+Intro sentence (ex.: To make coffee, take the following steps:)
+1.	First Step
+2.	Second Step
+3.	Third Step
+
+For big steps, add info how to validate that step was successful.
+
+For the whole procedure, add info how to validate that procedure was successful, and what to do if not.
+
+<!-- форматирование -->
+
+### Formatting reference
+
+
+### Basic Markdown Syntax
+Below are some basic examples of what you can do with {% glossarytooltip a5ef9041-976f-4eb3-826e-bf836027d8c3 %}markdown{% endglossarytooltip %}.
+
+For more examples of basic markdown please follow this [link](https://daringfireball.net/projects/markdown/syntax){:target="_self"}.
+
+#### Lists
+Lists are useful for organizing and displaying related items. Below are examples of a bulleted list and an ordered list.
+
+**Bulleted List:**
+
+
+
+~~~
+* List Item 1
+* List Item 2
+* List Item 3
+~~~
+
+*Output:*
+
+* List Item 1
+*	List Item 2
+*	List Item 3
+
+**Ordered List:**
+
+~~~
+1. First Step
+2. Second Step
+3. Third Step
+~~~
+
+*Output:*
+
+1.	First Step
+2.	Second Step
+3.	Third Step
+
+
+
+#### Code blocks
+
+By indenting your content by at least 4 spaces, you can create a code block.
+
+    //This is a code block!
+    print "Hello World!";
+
+Code blocks can also be defined by surrounding the block of code with `~~~` which can be seen in the [table](#tables) example.
+
+For highlighted code blocks use the `highlight` Liquid tag.
+
+*Example:*
+
+{% highlight html %}
+<div class="container">
+  <h4 class="title">Title</h4>
+  <div class="content">
+    <p>Paragraph content.</p>
+  </div>
+</div>
+{% endhighlight %}

--- a/guides/v2.2/ui_comp_guide/ui_comp_procedures_template.md
+++ b/guides/v2.2/ui_comp_guide/ui_comp_procedures_template.md
@@ -5,7 +5,7 @@ title:
 menu_title:
 menu_node:
 menu_order: 1
-version: 2.1
+version: 2.2
 github_link: contributor-guide/basic_template.md
 ---
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will remove all symlinks from the UI component guide so that it can be updated with changes that only apply to version 2.2 and above.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
