### PR TITLE
GH #2107 Fix variable-pool link

### DIFF
--- a/_data/toc/php-developer-guide.yml
+++ b/_data/toc/php-developer-guide.yml
@@ -223,7 +223,8 @@ pages:
           url: /extension-dev-guide/adapters.html
 
         - label: Variable Pool
-          url: extension-dev-guide/variable-pool/
+          versions: ["2.3"]
+          url: /extension-dev-guide/variable-pool/
 
     - label: Configuration
       versions: ["2.2", "2.3"]


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will prevent the appearance of the variable pool link in non-2.3 TOC.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

This issue fixes #2107 
