### PR TITLE
GH #2236 Fix PHP include tables

### DIFF
--- a/_includes/install/php_2.0.md
+++ b/_includes/install/php_2.0.md
@@ -1,15 +1,7 @@
 <div markdown="1">
 
-| 7.0.0, 7.0.1 | 7.0.2 | 7.0.3&ndash;7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) 
+| 5.4.x | 5.5.0&ndash;5.5.21 | 5.5.22&ndash;5.5.x | 5.6.x | 7.0.0, 7.0.1 | 7.0.2 | 7.0.3&ndash;7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x |
+| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) 
 
-| 5.6.x |
-| ![Supported]({{ site.baseurl }}/common/images/green-check.png) |
-
-| 5.5.0&ndash;5.5.21 | 5.5.22&ndash;5.5.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) |
-
-| 5.4.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) |
 
 </div>

--- a/_includes/install/php_2.1.md
+++ b/_includes/install/php_2.1.md
@@ -1,13 +1,6 @@
 <div markdown="1">
 
-| 7.0.0, 7.0.1 | 7.0.2 | 7.0.3 | 7.0.4 | 7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)
-
-
-| 5.6.0&ndash;5.6.4 | 5.6.5&ndash;5.6.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) |
-
-| 5.5.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) |
+| 7.0.0, 7.0.1 | 7.0.2 | 7.0.3 | 7.0.4 | 7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x | 5.5.x | 5.6.0&ndash;5.6.4 | 5.6.5&ndash;5.6.x |
+| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) |
 
 </div>

--- a/guides/v2.1/frontend-dev-guide/css-guide/css_quick_guide_mode.md
+++ b/guides/v2.1/frontend-dev-guide/css-guide/css_quick_guide_mode.md
@@ -44,7 +44,7 @@ The following is an illustration of how the process of making simple changes loo
 
     ![Less code redefining the color of the primary buttons]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {
@@ -94,7 +94,7 @@ If you are using server-side compilation mode, you must [clean generated static 
 
     ![Admin login page where the color of the button was changed]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {
@@ -132,7 +132,7 @@ If you are using server-side compilation mode, you must [clean generated static 
 
     ![Admin login page where the font of the buttons was changed]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {

--- a/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_mode.md
+++ b/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_mode.md
@@ -44,7 +44,7 @@ The following is an illustration of how the process of making simple changes loo
 
     ![Less code redefining the color of the primary buttons]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {
@@ -93,7 +93,7 @@ If you are using server-side compilation mode, you must [clean generated static 
 
     ![Admin login page where the color of the button was changed]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {
@@ -131,7 +131,7 @@ If you are using server-side compilation mode, you must [clean generated static 
 
     ![Admin login page where the font of the buttons was changed]({{ site.baseurl }}/common/images/extend_less_screenshot121.png)
 
-1. Change the button font by adding the following code in the `_extend.less` file:
+1. Change the button font size by adding the following code in the `_extend.less` file:
 
     ```css
     .action {


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the formatting of the PHP includes tables for v2.1 and v2.0.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

Fixes GH issues #2236 

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
