### PR TITLE
PHP-table-fix: Fix order of PHP versions in table

### DIFF
--- a/_includes/install/php_2.1.md
+++ b/_includes/install/php_2.1.md
@@ -1,6 +1,6 @@
 <div markdown="1">
 
-| 7.0.0, 7.0.1 | 7.0.2 | 7.0.3 | 7.0.4 | 7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x | 5.5.x | 5.6.0&ndash;5.6.4 | 5.6.5&ndash;5.6.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) |
+| 5.5.x | 5.6.0&ndash;5.6.4 | 5.6.5&ndash;5.6.x | 7.0.0, 7.0.1 | 7.0.2 | 7.0.3 | 7.0.4 | 7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x |
+| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)|
 
 </div>


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the order of PHP versions in the v2.1 includes table.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
