### PR TITLE
Fix the turorial back link

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -6,14 +6,13 @@
   	<a href="#" data-proofer-ignore class="toc-toggler">Table of Contents</a>
   	<div class="sidebar-wrapper">
 
-      {% assign parent = page.breadcrumbs[0] %}
+
       {% assign steps = site.pages | where: "guide_version", page.guide_version | where: "level3_subgroup", page.level3_subgroup | sort: "menu_order" %}
       {% assign first_step = steps[0] %}
       <ul>
         <li class="level-0">
-          <a href="{{ page.baseurl }}/{{ parent.url }}">
-            <div class="back-link-subtitle">&larr; Return to</div>
-            <div class="back-link-title">{{ parent.title }}</div>
+          <a href="{{ page.baseurl }}/{{ page.return_to.url }}">
+            &larr; {{ page.return_to.title }}
           </a>
         </li>
       {% for step in steps %}

--- a/guides/v2.1/get-started/order-tutorial/order-add-items.md
+++ b/guides/v2.1/get-started/order-tutorial/order-add-items.md
@@ -1,15 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 5. Add items to the cart
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 5
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-add-items.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-admin-token.md
+++ b/guides/v2.1/get-started/order-tutorial/order-admin-token.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 2. Get the admin token
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 2
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-admin-token.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-config-store.md
+++ b/guides/v2.1/get-started/order-tutorial/order-config-store.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 1. Configure the store
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 1
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-config-store.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-create-customer.md
+++ b/guides/v2.1/get-started/order-tutorial/order-create-customer.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 3. Create a customer
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 3
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-create-customer.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-create-invoice.md
+++ b/guides/v2.1/get-started/order-tutorial/order-create-invoice.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 8. Create an invoice
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 8
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-create-invoice.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-create-order.md
+++ b/guides/v2.1/get-started/order-tutorial/order-create-order.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 7. Create an order
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 7
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-create-order.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders
@@ -1575,4 +1574,4 @@ Not applicable
 ### Verify this step {#verify-step}
 
 1. Log in to the Luma store as the customer. The dashboard shows the order.
-2. Log in to {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %}. Click **Sales > Orders**. The order is displayed in the grid. Its status is Pending. 
+2. Log in to {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %}. Click **Sales > Orders**. The order is displayed in the grid. Its status is Pending.

--- a/guides/v2.1/get-started/order-tutorial/order-create-quote.md
+++ b/guides/v2.1/get-started/order-tutorial/order-create-quote.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 4. Create a quote
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 4
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-create-quote.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-create-shipment.md
+++ b/guides/v2.1/get-started/order-tutorial/order-create-shipment.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 9. Create a shipment
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 9
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-create-shipment.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-intro.md
+++ b/guides/v2.1/get-started/order-tutorial/order-intro.md
@@ -1,15 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup: 20_REST
 title: Order Processing with REST APIs Tutorial
 menu_title: Initial tasks
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 0
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-intro.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-issue-refund.md
+++ b/guides/v2.1/get-started/order-tutorial/order-issue-refund.md
@@ -1,16 +1,15 @@
 ---
 layout: tutorial
 group: get-started
-subgroup:
 title: Step 10. Issue a partial refund
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 10
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-issue-refund.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders

--- a/guides/v2.1/get-started/order-tutorial/order-prepare-checkout.md
+++ b/guides/v2.1/get-started/order-tutorial/order-prepare-checkout.md
@@ -4,13 +4,13 @@ group: get-started
 subgroup:
 title: Step 6. Prepare for checkout
 subtitle: Order Processing with REST APIs Tutorial
-menu_title:
+return_to:
+  title: REST APIs
+  url: get-started/rest_front.html
 menu_order: 6
-level3_menu_node:
 level3_subgroup: order-tutorial
 version: 2.1
 github_link: get-started/order-tutorial/order-prepare-checkout.md
-ee_only: False
 functional_areas:
   - Integration
   - Orders


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the `← Back` link in tutorial template.
This introduces another page variable called `return_to`:
```
return_to:
  title: REST APIs
  url: get-started/rest_front.html
```
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
