### PR TITLE
2282: Remove collapsible elements ad fix formatting

### DIFF
--- a/guides/v2.1/frontend-dev-guide/layouts/layout-practice.md
+++ b/guides/v2.1/frontend-dev-guide/layouts/layout-practice.md
@@ -79,7 +79,7 @@ The markup required for the drop-down is the following:
 
 ### Step 1: Define the layout blocks
 
-OrangeCo <a href="{{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html" target="_blank">applies the Luma theme</a>. Using the approach described in <a href="{{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html" target="_blank">Locate templates, layouts, and styles</a> they find out that the original block responsible for displaying the header links is defined in 
+OrangeCo <a href="{{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html" target="_blank">applies the Luma theme</a>. Using the approach described in <a href="{{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html" target="_blank">Locate templates, layouts, and styles</a> they find out that the original block responsible for displaying the header links is defined in
 
 `<Magento_Theme_module_dir>/view/frontend/layout/default.xml`:
 
@@ -98,7 +98,7 @@ OrangeCo <a href="{{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html"
 
 (See [app/code/Magento/Theme/view/frontend/layout/default.xml](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Theme/view/frontend/layout/default.xml#L43-L47) on github).
 
-Other modules use this block to add their specific links to the header using the [referenceBlock]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_ref) instruction. For example, see how links are added in the Customer module: [app/code/Magento/Customer/view/frontend/layout/default.xml#L10-L23](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Customer/view/frontend/layout/default.xml#L10-L23) 
+Other modules use this block to add their specific links to the header using the [referenceBlock]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_ref) instruction. For example, see how links are added in the Customer module: [app/code/Magento/Customer/view/frontend/layout/default.xml#L10-L23](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Customer/view/frontend/layout/default.xml#L10-L23)
 
 The Luma theme [moves]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv) the `top.links` block to the new `customer` block in the extending layout file.  
 
@@ -132,7 +132,7 @@ The links that should be in header, but outside the drop-down menu are added in 
 
 ### Step 2: Define the templates
 
-Similar to the way they defined the layout on the previous step, OrangeCo 
+Similar to the way they defined the layout on the previous step, OrangeCo
 defines the template which is used as the drop-down container : `<Magento_Customer_module_dir>/view/frontend/templates/account/customer.phtml`.
 
 {% collapsible Expand to see the code %}
@@ -239,16 +239,13 @@ To add quick basic styling and visual behavior to the "dropdown" menu, OrangeCo 
 * redundant elements are hidden with CSS
 * the `.lib-dropdown()` mixin from [Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html) was applied to the corresponding element
 
+`app/design/frontend/OrangeCo/orange/web/css/source/_extend.less`
 
-{%collapsible Expand to see the code %}
-
-`app/design/frontend/OrangeCo/orange/web/css/source/_extend.less`:
-
-{%highlight css%}
+```css
 //
 //  Common
 //  _____________________________________________
- 
+
 & when (@media-common = true) {
     .header.panel .header.links {
         .customer-welcome + .authorization-link {
@@ -256,11 +253,11 @@ To add quick basic styling and visual behavior to the "dropdown" menu, OrangeCo 
         }
     }
 }
-  
+
 //
 //  Mobile
 //  _____________________________________________
-    
+
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .customer-name,
     .customer-welcome + .authorization-link {
@@ -271,7 +268,7 @@ To add quick basic styling and visual behavior to the "dropdown" menu, OrangeCo 
 //
 //  Desktop
 //  _____________________________________________
-    
+
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .customer-welcome {
         .lib-dropdown(
@@ -288,10 +285,7 @@ To add quick basic styling and visual behavior to the "dropdown" menu, OrangeCo 
         );
     }
 }
-{%endhighlight css%}
-
-{% endcollapsible %}
-
+```
 
 As a result, the customer links look like following:
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will remove errant `<div>` tags from the rendered HTML as reported in #2282. Fixes #2282. 
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
