### PR TITLE
Update navigation for configurable product tutorial

### DIFF
--- a/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.md
@@ -5,6 +5,9 @@ title: Create a configurable product with REST APIs tutorial
 menu_title: Initial tasks
 menu_order: 0
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/config-product-intro.md
 functional_areas:

--- a/guides/v2.2/rest/tutorials/configurable-product/create-configurable-product.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-configurable-product.md
@@ -5,6 +5,9 @@ title: Step 2. Create the configurable product
 menu_title: Step 2. Create the configurable product
 menu_order: 20
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/create-configurable-product.md
 functional_areas:

--- a/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
@@ -5,6 +5,9 @@ title: Step 5. Create the personalization option
 menu_title: Step 5. Create the personalization option
 menu_order: 50
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/create-personalization-option.md
 functional_areas:

--- a/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
@@ -5,6 +5,9 @@ title: Step 3. Create the simple products
 menu_title: Step 3. Create the simple products
 menu_order: 30
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/create-simple-products.md
 functional_areas:

--- a/guides/v2.2/rest/tutorials/configurable-product/define-config-product-options.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/define-config-product-options.md
@@ -5,6 +5,9 @@ title: Step 4. Define configurable product options
 menu_title: Step 4. Define configurable product options
 menu_order: 40
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/define-config-product-options.md
 functional_areas:

--- a/guides/v2.2/rest/tutorials/configurable-product/plan-product.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/plan-product.md
@@ -5,6 +5,9 @@ title: Step 1. Plan the product
 menu_title: Step 1. Plan the product
 menu_order: 10
 level3_subgroup: configurable-product-tutorial
+return_to:
+  title: REST API Reference
+  url: rest/bk-rest.html
 version: 2.2
 github_link: rest/tutorials/configurable-product/plan-product.md
 functional_areas:


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary

In [PR-2277](https://github.com/magento/devdocs/pull/2277), @belbiy introduced a fix for broken back links in tutorials. This PR applies this fix to the "Create configurable products" tutorial.
 
When this pull request is merged, all steps in the "Crate configurable products" tutorial will contain a link to the main page of the REST Reference.
 
