### PR TITLE
[FIX] Fix incorrect indexer interface in example

### DIFF
--- a/guides/v2.1/extension-dev-guide/indexing-custom.md
+++ b/guides/v2.1/extension-dev-guide/indexing-custom.md
@@ -65,7 +65,7 @@ Assuming your module is named `<VendorName>_Merchandizing`, you must write the a
 {% highlight php startinline %}
 <VendorName>\Merchandizing\Model\Indexer;
 
-class Popular implements \Magento\Framework\Indexer\Model\ActionInterface, \Magento\Framework\Mview\ActionInterface
+class Popular implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface
 {
     public function executeFull(); //Should take into account all placed orders in the system
     public function executeList($ids); //Works with a set of placed orders (mass actions and so on)


### PR DESCRIPTION
## This PR is a:
Fix for "Adding a custom indexer documentation" section

## Summary
In the [Adding a custom indexer](https://devdocs.magento.com/guides/v2.2/extension-dev-guide/indexing-custom.html) part of documentation the not existed interface is provided at the "Example of a custom indexer implementation" section. It has `\Magento\Framework\Indexer\Model\ActionInterface` while this interface does not exists. It looks like it should be changed to `\Magento\Framework\Indexer\ActionInterface`

