### PR TITLE
[fix] broken link to cm redis session

### DIFF
--- a/guides/v2.0/release-notes/thirdparty-mccloud.md
+++ b/guides/v2.0/release-notes/thirdparty-mccloud.md
@@ -63,7 +63,7 @@ symfony/yaml || MIT|[Source](https://github.com/symfony/yaml)|[License](https://
 tedivm/jshrink || BSD-3-Clause|[Source](https://github.com/tedious/JShrink)|[License](https://github.com/tedious/JShrink/blob/master/LICENSE)
 tubalmartin/cssmin || BSD-3-Clause|[Source](https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port)|
 Zend Framework||BSD-3-Clause|[Source](http://framework.zend.com/)|[License](https://framework.zend.com/license)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 elasticsearch/elasticsearch || Apache-2.0|[Source](https://github.com/elastic/elasticsearch-php)|[License](https://github.com/elastic/elasticsearch-php/blob/master/LICENSE)
 guzzlehttp/ringphp || MIT|[Source](https://github.com/guzzle/RingPHP)|[License](https://github.com/guzzle/RingPHP/blob/master/LICENSE)
 guzzlehttp/streams || MIT|[Source](https://github.com/guzzle/streams)|[License](https://github.com/guzzle/streams/blob/master/LICENSE)

--- a/guides/v2.0/release-notes/thirdparty_ce.md
+++ b/guides/v2.0/release-notes/thirdparty_ce.md
@@ -54,7 +54,7 @@ symfony/yaml || MIT|[Source](https://github.com/symfony/yaml)|[License](https://
 tedivm/jshrink || BSD-3-Clause|[Source](https://github.com/tedious/JShrink)|[License](https://github.com/tedious/JShrink/blob/master/LICENSE)
 tubalmartin/cssmin || BSD-3-Clause|[Source](https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port)|
 Zend Framework||BSD-3-Clause|[Source](http://framework.zend.com/)|[License](https://framework.zend.com/license)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 extjs |1.0.1|Open GPL 3.0 (when was included)|[Source](https://www.sencha.com/)|[License](https://www.gnu.org/licenses/lgpl.html)
 fotorama|4.6.4 |MIT|[Source](https://github.com/artpolikarpov/fotorama)|[License](https://github.com/artpolikarpov/fotorama/blob/master/MIT-LICENSE)
 jquery|1.11.0 |MIT|[Source](https://jquery.com/)|[License](https://jquery.org/license/)

--- a/guides/v2.0/release-notes/thirdparty_ee.md
+++ b/guides/v2.0/release-notes/thirdparty_ee.md
@@ -54,7 +54,7 @@ symfony/yaml || MIT|[Source](https://github.com/symfony/yaml)|[License](https://
 tedivm/jshrink || BSD-3-Clause|[Source](https://github.com/tedious/JShrink)|[License](https://github.com/tedious/JShrink/blob/master/LICENSE)
 tubalmartin/cssmin || BSD-3-Clause|[Source](https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port)|
 Zend Framework||BSD-3-Clause|[Source](http://framework.zend.com/)|[License](https://framework.zend.com/license)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 elasticsearch/elasticsearch || Apache-2.0|[Source](https://github.com/elastic/elasticsearch-php)|[License](https://github.com/elastic/elasticsearch-php/blob/master/LICENSE)
 guzzlehttp/ringphp || MIT|[Source](https://github.com/guzzle/RingPHP)|[License](https://github.com/guzzle/RingPHP/blob/master/LICENSE)
 guzzlehttp/streams || MIT|[Source](https://github.com/guzzle/streams)|[License](https://github.com/guzzle/streams/blob/master/LICENSE)

--- a/guides/v2.1/release-notes/thirdparty-mccloud.md
+++ b/guides/v2.1/release-notes/thirdparty-mccloud.md
@@ -64,7 +64,7 @@ symfony/yaml || MIT|[Source](https://github.com/symfony/yaml)|[License](https://
 tedivm/jshrink || BSD-3-Clause|[Source](https://github.com/tedious/JShrink)|[License](https://github.com/tedious/JShrink/blob/master/LICENSE)
 tubalmartin/cssmin || BSD-3-Clause|[Source](https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port)|
 Zend Framework||BSD-3-Clause|[Source](http://framework.zend.com/)|[License](https://framework.zend.com/license)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 elasticsearch/elasticsearch || Apache-2.0|[Source](https://github.com/elastic/elasticsearch-php)|[License](https://github.com/elastic/elasticsearch-php/blob/master/LICENSE)
 guzzlehttp/ringphp || MIT|[Source](https://github.com/guzzle/RingPHP)|[License](https://github.com/guzzle/RingPHP/blob/master/LICENSE)
 guzzlehttp/streams || MIT|[Source](https://github.com/guzzle/streams)|[License](https://github.com/guzzle/streams/blob/master/LICENSE)

--- a/guides/v2.1/release-notes/thirdparty_ce.md
+++ b/guides/v2.1/release-notes/thirdparty_ce.md
@@ -66,7 +66,7 @@ sebastian/exporter || BSD-3-Clause|[Source](https://github.com/sebastianbergmann
 sebastian/recursion-context || BSD-3-Clause|[Source](https://github.com/sebastianbergmann/recursion-context)|[License](https://github.com/sebastianbergmann/recursion-context/blob/master/LICENSE)
 sebastian/version || BSD-3-Clause|[Source](https://github.com/sebastianbergmann/version)|[License](https://github.com/sebastianbergmann/version/blob/master/LICENSE)
 seld/jsonlint || MIT|[Source](https://github.com/Seldaek/jsonlint)|[License](https://github.com/Seldaek/jsonlint/blob/master/LICENSE)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 extjs |1.0.1|Open GPL 3.0 (when was included)|[Source](https://www.sencha.com/)|[License](https://www.gnu.org/licenses/lgpl.html)
 fotorama|4.6.4 |MIT|[Source](https://github.com/artpolikarpov/fotorama)|[License](https://github.com/artpolikarpov/fotorama/blob/master/MIT-LICENSE)
 knockoutjs|3.3.0 |MIT|[Source](http://knockoutjs.com/downloads/index.html)|[Source](https://github.com/knockout/knockout/blob/master/LICENSE)

--- a/guides/v2.1/release-notes/thirdparty_ee.md
+++ b/guides/v2.1/release-notes/thirdparty_ee.md
@@ -56,7 +56,7 @@ symfony/yaml || MIT|[Source](https://github.com/symfony/yaml)|[License](https://
 tedivm/jshrink || BSD-3-Clause|[Source](https://github.com/tedious/JShrink)|[License](https://github.com/tedious/JShrink/blob/master/LICENSE)
 tubalmartin/cssmin || BSD-3-Clause|[Source](https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port)|
 Zend Framework||BSD-3-Clause|[Source](http://framework.zend.com/)|[License](https://framework.zend.com/license)
-Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
+Cm ||BSD-3-Clause|[Source](https://github.com/colinmollenhour/Cm_RedisSession)|[License 1](https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) [License 2](http://opensource.org/licenses/BSD-3-Clause)
 elasticsearch/elasticsearch || Apache-2.0|[Source](https://github.com/elastic/elasticsearch-php)|[License](https://github.com/elastic/elasticsearch-php/blob/master/LICENSE)
 guzzlehttp/ringphp || MIT|[Source](https://github.com/guzzle/RingPHP)|[License](https://github.com/guzzle/RingPHP/blob/master/LICENSE)
 guzzlehttp/streams || MIT|[Source](https://github.com/guzzle/streams)|[License](https://github.com/guzzle/streams/blob/master/LICENSE)


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the broken link (https://github.com/colinmollenhour/Cm_RedisSession/blob/master/Cm_RedisSession.xml) to the correct destination (https://github.com/colinmollenhour/Cm_RedisSession/blob/master/app/etc/modules/Cm_RedisSession.xml) in `guides/v2.x/release-notes/thirdparty-mccloud.md`, `guides/v2.x/release-notes/thirdparty_ce.md` and `guides/v2.x/release-notes/thirdparty_ee.md`

<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

Corrections for v2.0 are in a separate commit, which can be reverted as v2.0 is EOL.
 
