### PR TITLE
Remove 404 script from plugins.md

### DIFF
--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -33,8 +33,6 @@ Plugins can not be used on following:
 
 The <code>di.xml</code> file in your {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} declares a plugin for a class object:
 
-<script src="https://gist.github.com/xcomSteveJohnson/c9a36d9ec887c4bbc34d.js"></script>
-
 You must specify these elements:
 
 * `type name`. A class or interface which the plugin observes.


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

<!-- (REQUIRED) What does this PR change? -->
## Summary

I got a `File not found: https://gist.github.com/xcomSteveJohnson/c9a36d9ec887c4bbc34d.js` notification when browsing https://devdocs.magento.com/guides/v2.2/extension-dev-guide/plugins.html

This script no longer exists so should be removed

Also what was the purpose of this script? It seems highly suspicious to me, did we get some XSS code committed in? Have the devdocs been breached?!  ;)

If this is not a malicious act and it was intentional then including gist files from outside sources seem like a bad idea as they're out of control. What's the magento perspective on this?
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information
N/A
<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
