### PR TITLE
MAGEDOC-3040: RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ email: mailto:DL-Magento-Doc-Feedback@magento.com
 description: > # this means to ignore newlines until "baseurl:"
   Magento 2 Developer Documentation.
 baseurl: ""
-# url: "https://github.com/magento/devdocs" # the base hostname & protocol for your site
+url: "https://devdocs.magento.com" # the base hostname & protocol for your site
 # twitter_username: magento
 # github_username:  magento
 theme: devdocs

--- a/_includes/layout/header-styles.html
+++ b/_includes/layout/header-styles.html
@@ -1,1 +1,2 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/common/css/devdocs.css" />
+<link rel="alternate" type="application/rss+xml" title="Magento DevDocs RSS" href="/feed.xml" />

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,25 @@
+---
+layout: null
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% for page in site.html_pages %}
+      {% unless page.tag == 'omit' %}
+        <item>
+          <title>{{ page.title | xml_escape }}</title>
+          <description>{{ page.content | xml_escape }}</description>
+          <link>{{ page.url | prepend: site.url }}</link>
+        </item>
+      {% endunless %}
+    {% endfor %}
+  </channel>
+</rss>

--- a/feed.xml
+++ b/feed.xml
@@ -16,7 +16,7 @@ layout: null
       {% unless page.tag == 'omit' %}
         <item>
           <title>{{ page.title | xml_escape }}</title>
-          <description>{{ page.content | xml_escape }}</description>
+          <description>{{ page.content | xml_escape | strip_html | truncatewords: 75 }}</description>
           <link>{{ page.url | prepend: site.url }}</link>
         </item>
       {% endunless %}


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [X] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will add an RSS feed to the devdocs site so that readers can subscribe to updates using the feed reader of their choice.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

I don't think we need to worry about sorting the `<item>` nodes. Feed readers typically let users customize the sort order of articles anyway. When I previously implemented a feed on a Jekyll site, my reader would only show new topics that were published. I suggest we merge this, subscribe to the feed and test it.

To test, build the site locally, then navigate to http://localhost:4000/feed.xml in a browser. It'll take a while to load and format the file, so be patient. I've tried opening a tunnel from my machine to the internet using ngrok so I can test this using Feedly, but it's not working. Feedly doesn't recognize it, so I'm open to testing suggestions.

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
