### PR TITLE
Fixed typo: view_preprocessing/view_preprocessed

### DIFF
--- a/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
@@ -103,7 +103,7 @@ For each CSS file included in the layouts, LESS preprocessor does the following:
 In server-side LESS compilation mode, to have your changes applied, you need to do the following:
 
 1. Clear <code>pub/static/frontend/&lt;Vendor&gt;/&lt;theme&gt;/&lt;locale&gt;</code> by deleting the directory in the file system.
-2. Clear the <code>var/cache</code> and <code>var/view_preprocessing</code> directories by deleting the directory in the file system. (if they already existed there).
+2. Clear the <code>var/cache</code> and <code>var/view_preprocessed</code> directories by deleting the directory in the file system. (if they already existed there).
 2. Trigger {% glossarytooltip 363662cb-73f1-4347-a15e-2d2adabeb0c2 %}static files{% endglossarytooltip %} compilation and publication. This can be done in one of the following ways:
 
 	-  Reloading the page where the modified styles are applied.


### PR DESCRIPTION
Changed view_preprocessing to view_preprocessed as correctly used in other places on the same page. Changes are not visible if view_preprocessed is not cleared and view_preprocessing does not exist.

## This PR is a:
- [x] Bug fix or improvement
 
## Summary
 
When this pull request is merged, it will allow users to follow the instructions to compile their LESS server-side.
