### PR TITLE
Change minimal php Version to 7.0.13

### DIFF
--- a/_includes/install/php_2.2.md
+++ b/_includes/install/php_2.2.md
@@ -1,6 +1,6 @@
 <div markdown="1">
 
-| 7.0.0, 7.0.1 | 7.0.2 | 7.0.3 | 7.0.4 | 7.0.5 | 7.0.6&ndash;7.0.x | 7.1.x |
-| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png)| ![Supported]({{ site.baseurl }}/common/images/green-check.png) | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png)
+| 7.0.0&ndash;7.0.12 | 7.0.3&ndash;7.0.x | 7.1.x |
+| ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png)
 
 </div>

--- a/_includes/install/php_2.2.md
+++ b/_includes/install/php_2.2.md
@@ -1,6 +1,6 @@
 <div markdown="1">
 
-| 7.0.0&ndash;7.0.12 | 7.0.3&ndash;7.0.x | 7.1.x |
+| 7.0.0&ndash;7.0.12 | 7.0.13&ndash;7.0.x | 7.1.x |
 | ![Not supported]({{ site.baseurl }}/common/images/red-x.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png) | ![Supported (2.1.2 and later)]({{ site.baseurl }}/common/images/green-check.png)
 
 </div>


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
Since 2.2.5 the minimal PHP Version is 7.0.13

See https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.html

>Frameworks
>
>    We’ve bumped the required minimal PHP version to 7.0.13.


