### PR TITLE
Updated CLI upgrade instructions for 2.3

### DIFF
--- a/_includes/layout/navigation.html
+++ b/_includes/layout/navigation.html
@@ -7,17 +7,15 @@
     <div class="nav-popup" role="menu" aria-hidden="true">
       <ul>
           <li><a href="{{ page.baseurl }}/install-gde/bk-install-guide.html">Installation Guide</a></li>
-          {% if page.guide_version == "2.2" %}
+          {% unless page.guide_version == "2.0" or page.guide_version == "2.1"%}
           <li><a href="{{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html">Extension Update and System Upgrade Guide</a></li>
-          {% elsif page.guide_version == "2.1" %}
+          {% else %}
           <li><a href="{{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html">Component Manager and System Upgrade Guide</a></li>
-          {% elsif page.guide_version == "2.0" %}
-          <li><a href="{{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html">Component Manager and System Upgrade Guide</a></li>
-          {% endif %}
+          {% endunless %}
           <li><a href="{{ page.baseurl }}/config-guide/bk-config-guide.html">Configuration Guide</a></li>
-          {% if page.guide_version == "2.2" or page.guide_version == "2.3" %}
+          {% unless page.guide_version == "2.0" or page.guide_version == "2.1"%}
           <li><a href="{{ page.baseurl }}/performance-best-practices/index.html">Performance Best Practices</a></li>
-          {% endif %}
+          {% endunless %}
           <li><a href="{{ page.baseurl }}/migration/bk-migration-guide.html">Migration Guide</a></li>
           <li><a href="{{ page.baseurl }}/cloud/bk-cloud.html">Magento Commerce (Cloud) Guide</a></li>
           <li><a href="{{ site.baseurl }}/magento-release-information.html">Release Information</a></li>

--- a/guides/v2.1/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.1/comp-mgr/bk-compman-upgrade-guide.md
@@ -1,79 +1,71 @@
 ---
 group: compman
-subgroup: 01_Introduction
 title: Upgrade the Magento application and components
-landing-page: System Upgrade Guide
-menu_title: Upgrade the Magento application and components
-menu_node: parent
-menu_order: 1
 version: 2.1
 github_link: comp-mgr/bk-compman-upgrade-guide.md
 functional_areas:
   - Upgrade
 ---
 
+<!-- Topic variables
+{% capture ce %}{{site.data.var.ce}}{% endcapture %}
+{% capture ee %}{{site.data.var.ee}}{% endcapture %}
+-->
+
 This topic discusses the ways you can:
-
-*	Upgrade (that is, *patch*) the Magento software from version 2.0.0 to 2.0.1, for example
-*	Update *components*, which can be any of the following:
-
-	*	Modules (extend Magento capabilities)
-	*	Themes (change the look and feel of your storefront and Admin)
-	*	Language packages (localize the storefront and Admin)
+* Upgrade (that is, *patch*) the Magento software from version {{ page.version }}.0 to {{ page.version }}.1, for example
+* Update *components*, which can be any of the following:
+  *	Modules (extend Magento capabilities)
+  *	Themes (change the look and feel of your storefront and Admin)
+  *	Language packages (localize the storefront and Admin)
 
 ## Upgrade the Magento application
 
 The way you upgrade (that is, patch) the Magento application depends on how you installed it:
 
-*	{{site.data.var.ce}} and {{site.data.var.ee}}: If you used [Composer] to install the Magento application or if you downloaded an [archive], use the [System Upgrade utility] or the [command line].
-*	{{site.data.var.ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{site.data.var.ce}} codebase, [upgrade the software manually].
+* {{ce}} and {{ee}}: If you used [Composer] to install the Magento application or if you downloaded an [archive], use the [System Upgrade utility] or the [command line].
+* {{ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{ce}} codebase, [upgrade the software manually].
 
-*	If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
+* If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
+  * For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
+    
+    Run the System Upgrade utility as discussed in this topic using that subdomain or docroot.
+  
+  *	Upgrade the Magento software using the [command line].
+* To upgrade from {{ce}} to {{ee}}, see [Upgrade from CE to EE].
 
-	*	For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
+{:.bs-callout .bs-callout-info}
+__System upgrade__ refers to updating the Magento 2.x core components and other installed components.
+To migrate from Magento 1.x to Magento 2, see the [Migration Guide].
 
-		Run the System Upgrade utility as discussed in this topic using that subdomain or docroot.
-	*	Upgrade the Magento software using the [command line].
-*	To upgrade from {{site.data.var.ce}} to {{site.data.var.ee}}, see [Upgrade from CE to EE].
-
-{%
-include note.html
-type="info"
-content="__System upgrade__ refers to updating the Magento 2.x core components and other installed components. To migrate from Magento 1.x to Magento 2, see the [Migration Guide]."
-%}
-
-<div class="bs-callout bs-callout-warning" id="warning" markdown="1">
-For upgrade or update, you must use the same authentication keys you used to install the Magento software. For example, you __cannot__ use {{site.data.var.ce}} authentication keys to update or upgrade {{site.data.var.ee}} or vice versa. You also __cannot__ use:
+<div class="bs-callout bs-callout-warning" markdown="1">
+content="For upgrade or update, you must use the same authentication keys you used to install the Magento software.
+For example, you __cannot__ use {{ce}} authentication keys to update or upgrade {{ee}} or vice versa.
+You also __cannot__ use:
 * Another user's authentication keys
-* [Shared account] authentication keys
+* [Shared account] authentication keys"
 </div>
-
-
 
 ## Update components
 
-To update Magento components, use the [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html).
-
+To update Magento components, use the [Component Manager].
 
 ### Next step
 
-Complete the tasks discussed in [Prerequisites]({{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html).
+Complete the tasks discussed in [Prerequisites].
 
-
-
-<!-- ABBREVIATIONS -->
-
+<!-- Tooltips -->
 *[contributing developer]: A developer who contributes code to the Magento 2 CE codebase
 *[contributing developers]: Developers who contribute code to the Magento 2 CE codebase
-
-
-[Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
+ 
+<!-- Link definitions -->
 [archive]: {{ page.baseurl }}/install-gde/prereq/zip_install.html
-[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
 [command line]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
-[upgrade the software manually]: {{ page.baseurl }}/install-gde/install/cli/dev_options.html
-[command line]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
-[Upgrade from CE to EE]: {{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html
+[Component Manager]: {{ page.baseurl }}/comp-mgr/module-man/compman-start.html
+[Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
 [Migration Guide]: {{ page.baseurl }}/migration/bk-migration-guide.html
-[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html
-{:target="_blank"}
+[Prerequisites]: {{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html
+[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html {:target="_blank"}
+[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
+[Upgrade from CE to EE]: {{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html
+[upgrade the software manually]: {{ page.baseurl }}/install-gde/install/cli/dev_options.html

--- a/guides/v2.1/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.1/comp-mgr/bk-compman-upgrade-guide.md
@@ -65,7 +65,8 @@ Complete the tasks discussed in [Prerequisites].
 [Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
 [Migration Guide]: {{ page.baseurl }}/migration/bk-migration-guide.html
 [Prerequisites]: {{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html
-[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html {:target="_blank"}
+[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html
+{:target="_blank"}
 [System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
 [Upgrade from CE to EE]: {{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html
 [upgrade the software manually]: {{ page.baseurl }}/install-gde/install/cli/dev_options.html

--- a/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
@@ -38,13 +38,14 @@ The way you upgrade (that is, patch) the Magento application depends on how you 
 * To upgrade from {{ce}} to {{ee}}, see [Upgrade from Open Source to Commerce].
 
 {:.bs-callout .bs-callout-info}
-__System upgrade__ refers to updating the Magento 2.x core modules and other installed modules. To migrate from Magento 1.x to Magento 2, see the [Migration Guide].
+__System upgrade__ refers to updating the Magento 2.x core modules and other installed modules.
+To migrate from Magento 1.x to Magento 2, see the [Migration Guide].
 
 <div class="bs-callout bs-callout-warning" markdown="1">
-For upgrade or update, you must use the same authentication keys you
-used to install the Magento software. For example, you *cannot* use
-{{ce}} authentication keys to update or upgrade {{ee}} or vice versa.
+For upgrade or update, you must use the same authentication keys you used to install the Magento software.
+For example, you *cannot* use {{ce}} authentication keys to update or upgrade {{ee}} or vice versa.
 You also *cannot* use:
+
 - Another user\'s authentication keys
 - [Shared account] authentication keys
 </div>
@@ -58,12 +59,13 @@ Complete the tasks discussed in [Prerequisites].
 *[contributing developer]: A developer who contributes code to the Magento 2 CE codebase
 *[contributing developers]: Developers who contribute code to the Magento 2 CE codebase
 
-[Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
 [archive]: {{ page.baseurl }}/install-gde/prereq/zip_install.html
+[command line]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
+[Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
+[Migration Guide]: {{ page.baseurl }}/migration/bk-migration-guide.html
+[Prerequisites]: {{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html
+[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html
+{:target="_blank"}
 [System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
-[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html {:target="_blank"}
 [Upgrade from Open Source to Commerce]: {{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html
 [upgrade the software manually]: {{ page.baseurl }}/install-gde/install/cli/dev_options.html
-[command line]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
-[Prerequisites]: {{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html
-[Migration Guide]: {{ page.baseurl }}/migration/bk-migration-guide.html

--- a/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
@@ -1,21 +1,22 @@
 ---
 group: compman
-subgroup: 01_Introduction
 title: Upgrade the Magento application and modules
-landing-page: System Upgrade Guide
-menu_title: Upgrade the Magento application and modules
-menu_node: parent
-menu_order: 1
 version: 2.2
 github_link: comp-mgr/bk-compman-upgrade-guide.md
 functional_areas:
   - Upgrade
 ---
 
+<!-- Topic variables
+{% capture ce %}{{site.data.var.ce}}{% endcapture %}
+{% capture ee %}{{site.data.var.ee}}{% endcapture %}
+-->
+
 ## Upgrade the Magento application and modules
+
 This topic discusses the ways you can:
 
-*	Upgrade (that is, *patch*) the Magento software from version 2.0.0 to 2.0.1, for example
+*	Upgrade (that is, *patch*) the Magento software from version {{ page.version }}.0 to {{ page.version }}.1, for example
 *	Update any of the following:
 
 	*	Modules (also referred to as *extensions*; extend Magento capabilities)
@@ -24,33 +25,45 @@ This topic discusses the ways you can:
 *	Uninstall extensions
 
 ## Upgrade the Magento application
+
 The way you upgrade (that is, patch) the Magento application depends on how you installed it:
 
-*	{{site.data.var.ce}} and {{site.data.var.ee}}: If you used [Composer]({{ page.baseurl }}/install-gde/prereq/integrator_install.html) to install the Magento application or if you downloaded an [archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html), use the [System Upgrade utility]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html) or the [command line]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html).
-*	{{site.data.var.ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{site.data.var.ce}} codebase, <a href="{{ page.baseurl }}/install-gde/install/cli/dev_options.html">upgrade the software manually</a>.
-*	If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
+* {{ce}} and {{ee}}: If you used [Composer] to install the Magento application or if you downloaded an [archive], use the [System Upgrade utility] or the [command line].
+* {{ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{ce}} codebase, [upgrade the software manually].
+* If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
+  *	For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root. 
+	
+	Run the System Upgrade utility as discussed in this topic using that subdomain or docroot.
+  *	Upgrade the Magento software using the [command line].
+* To upgrade from {{ce}} to {{ee}}, see [Upgrade from Open Source to Commerce].
 
-	*	For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root. 
+{:.bs-callout .bs-callout-info}
+__System upgrade__ refers to updating the Magento 2.x core modules and other installed modules. To migrate from Magento 1.x to Magento 2, see the [Migration Guide].
 
-		Run the System Upgrade utility as discussed in this topic using that subdomain or docroot.
-	*	Upgrade the Magento software using the [command line]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html).
-*	To upgrade from {{site.data.var.ce}} to {{site.data.var.ee}}, see <a href="{{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html">Upgrade from Open Source to Commerce</a>.
-
-<div class="bs-callout bs-callout-info" id="info">
-	<p><em>System upgrade</em> refers to updating the Magento 2.x core modules and other installed modules. To migrate from Magento 1.x to Magento 2, see the <a href="{{ page.baseurl }}/migration/bk-migration-guide.html">Migration Guide</a>.</p>
-</div>
-
-<div class="bs-callout bs-callout-warning">
-    <p>For upgrade or update, you must use the same authentication keys you used to install the Magento software. For example, you <em>cannot</em> use {{site.data.var.ce}} authentication keys to update or upgrade {{site.data.var.ee}} or vice versa. You also <em>cannot</em> use:</p>
-    <ul><li>Another user's authentication keys</li>
-    	<li><a href="http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html" target="_blank">Shared account</a> authentication keys</li></ul>   
+<div class="bs-callout bs-callout-warning" markdown="1">
+For upgrade or update, you must use the same authentication keys you
+used to install the Magento software. For example, you *cannot* use
+{{ce}} authentication keys to update or upgrade {{ee}} or vice versa.
+You also *cannot* use:
+- Another user\'s authentication keys
+- [Shared account] authentication keys
 </div>
 
 #### Next step
-Complete the tasks discussed in <a href="{{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html">Prerequisites</a>.
 
+Complete the tasks discussed in [Prerequisites].
 
 <!-- ABBREVIATIONS -->
 
 *[contributing developer]: A developer who contributes code to the Magento 2 CE codebase
 *[contributing developers]: Developers who contribute code to the Magento 2 CE codebase
+
+[Composer]: {{ page.baseurl }}/install-gde/prereq/integrator_install.html
+[archive]: {{ page.baseurl }}/install-gde/prereq/zip_install.html
+[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
+[Shared account]: http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html {:target="_blank"}
+[Upgrade from Open Source to Commerce]: {{ page.baseurl }}/comp-mgr/upgrader/ce-ee-upgrade-start.html
+[upgrade the software manually]: {{ page.baseurl }}/install-gde/install/cli/dev_options.html
+[command line]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
+[Prerequisites]: {{ page.baseurl }}/comp-mgr/prereq/prereq_compman.html
+[Migration Guide]: {{ page.baseurl }}/migration/bk-migration-guide.html

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
@@ -1,15 +1,142 @@
 ---
 group: compman
-subgroup: 02_prereq
 title: Update and upgrade checklist
-menu_title: Update and upgrade checklist
-menu_order: 200
-menu_node:
 version: 2.2
 github_link: comp-mgr/prereq/prereq_compman-checklist.md
 functional_areas:
   - Upgrade
 ---
 
-## Checklist
-{% include comp-man/checklist_2.2.md %}
+Before you continue, to avoid errors during your installation or update, make sure you verify *all* of the following:
+
+*	You set up a [Magento file system owner](#magento-owner-group) and shared that owner's group with the web server user group
+*	Your [cron jobs](#magento-cron) are set up and running
+*	[Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
+*	[File system permissions](#perms) are set properly
+
+Do not continue without performing these checks. Failure to do so could result in errors.
+{:bs-callout bs-callout-warning}
+
+### Set a value for DATA_CONVERTER_BATCH_SIZE {#batch-size}
+
+Magento {{ page.version }} includes security enhancements that requires some data to be converted from serialized data format to JSON encoded format.
+This conversion occurs during the upgrade and it can take a long time, depending on how much data is in your Magento database.
+
+One or more fields in the following tables are affected: `sales_order`, `sales_order_payment`, `quote`, `quote_payment`, `core_config_data`, `magento_reward_history`, `url_rewrite`, `salesrule`, and `catalogrule`.
+(This is not a complete list.)
+
+If you have a large amount of data, you can improve performance by setting the value of an environment variable, `DATA_CONVERTER_BATCH_SIZE`.
+By default, it's set to a value of 50,000.
+
+To set the variable, before the upgrade starts enter the following command as the {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %}Magento file system owner{% endglossarytooltip %} in a bash shell prompt:
+```bash
+export DATA_CONVERTER_BATCH_SIZE <value>
+```
+
+For example,
+```bash
+export DATA_CONVERTER_BATCH_SIZE 100000
+```
+
+After your upgrade completes, you can unset the variable as follows:
+```bash
+unset DATA_CONVERTER_BATCH_SIZE
+```
+
+`DATA_CONVERTER_BATCH_SIZE` requires memory; avoid setting it to a very large value (approximately 1GB) without testing it first.
+{:bs-callout bs-callout-info}
+
+### Magento file system owner and group {#magento-owner-group}
+
+The {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %}Magento file system owner{% endglossarytooltip %} group must have write access to Magento directories and files.
+
+### Cron jobs are running {#magento-cron}
+
+Magento requires three cron jobs, all running as the {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %}Magento file system owner{% endglossarytooltip %}.
+
+To verify your cron jobs are set up properly, enter the following command as the Magento file system owner:
+```bash
+crontab -l
+```
+
+Results similar to the following should display:
+
+```terminal
+* * * * * /usr/bin/php /var/www/magento2/bin/magento cron:run | grep -v "Ran jobs by schedule" >> /var/www/magento2/var/log/magento.cron.log
+* * * * * /usr/bin/php /var/www/magento2/update/cron.php >> /var/www/magento2/var/log/update.cron.log
+* * * * * /usr/bin/php /var/www/magento2/bin/magento setup:cron:run >> /var/www/magento2/var/log/setup.cron.log
+```
+
+Another symptom of cron not running is the following error in the Magento Admin:
+
+![cron isn't running]({{ site.baseurl }}/common/images/compman-cron-not-running.png){:width="500px"}
+
+To see the error, you might need to click **System Messages** at the top of the window as follows:
+
+![System Messages]({{ site.baseurl }}/common/images/compman_sys-messages.png)
+
+For details, see [Set up cron]({{ page.baseurl }}/install-gde/install/post-install-config.html#post-install-cron).
+
+### File system permissions {#perms}
+
+For security reasons, Magento requires certain permissions on the file system. Permissions are different from [*ownership*](#magento-owner-group).
+Ownership determines *who* can perform actions on the file system; permissions determine *what* the user can do.
+
+Directories in the Magento file system must be writable by the [Magento file system owner's]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) group.
+
+To verify your file system permissions are set properly, either log in to the Magento server or use your hosting provider's file manager application.
+
+For example, enter the following commands on a Linux system if the Magento application is installed in `/var/www/html/magento2`:
+```bash
+ls -al /var/www/html/magento2
+```
+
+A sample result follows:
+
+```terminal
+total 1028
+drwxrwx---. 12 magento_user apache   4096 Jun  7 07:55 .
+drwxr-xr-x.  3 root         root     4096 May 11 14:29 ..
+drwxrwx---.  4 magento_user apache   4096 Jun  7 07:53 app
+drwxrwx---.  2 magento_user apache   4096 Jun  7 07:53 bin
+-rw-rw----.  1 magento_user apache 439792 Apr 27 21:23 CHANGELOG.md
+-rw-rw----.  1 magento_user apache   3422 Apr 27 21:23 composer.json
+-rw-rw----.  1 magento_user apache 425214 Apr 27 21:27 composer.lock
+-rw-rw----.  1 magento_user apache   3425 Apr 27 21:23 CONTRIBUTING.md
+-rw-rw----.  1 magento_user apache  10011 Apr 27 21:23 CONTRIBUTOR_LICENSE_AGREEMENT.html
+-rw-rw----.  1 magento_user apache    631 Apr 27 21:23 COPYING.txt
+drwxrwx---.  4 magento_user apache   4096 Jun  7 07:53 dev
+-rw-rw----.  1 magento_user apache   2926 Apr 27 21:23 Gruntfile.js
+-rw-rw----.  1 magento_user apache   7592 Apr 27 21:23 .htaccess
+-rw-rw----.  1 magento_user apache   6419 Apr 27 21:23 .htaccess.sample
+-rw-rw----.  1 magento_user apache   1358 Apr 27 21:23 index.php
+drwxrwx---.  4 magento_user apache   4096 Jun  7 07:53 lib
+-rw-rw----.  1 magento_user apache  10376 Apr 27 21:23 LICENSE_AFL.txt
+-rw-rw----.  1 magento_user apache  30634 Apr 27 21:23 LICENSE_EE.txt
+-rw-rw----.  1 magento_user apache  10364 Apr 27 21:23 LICENSE.txt
+-rw-rw----.  1 magento_user apache   4108 Apr 27 21:23 nginx.conf.sample
+-rw-rw----.  1 magento_user apache   1427 Apr 27 21:23 package.json
+-rw-rw----.  1 magento_user apache   1659 Apr 27 21:23 .php_cs
+-rw-rw----.  1 magento_user apache    804 Apr 27 21:23 php.ini.sample
+drwxrwx---.  2 magento_user apache   4096 Jun  7 07:53 phpserver
+drwxrwx---.  6 magento_user apache   4096 Jun  7 07:53 pub
+-rw-rw----.  1 magento_user apache   2207 Apr 27 21:23 README_EE.md
+drwxrwx---.  7 magento_user apache   4096 Jun  7 07:53 setup
+-rw-rw----.  1 magento_user apache   3731 Apr 27 21:23 .travis.yml
+drwxrwx---.  7 magento_user apache   4096 Jun  7 07:53 update
+drwxrws---. 11 magento_user apache   4096 Jun 13 16:05 var
+drwxrws---. 29 magento_user apache   4096 Jun  7 07:53 vendor
+```
+
+In the preceding example, the Magento file system owner is `magento_user`.
+Directories in the Magento file system have `drwxrwx---` permissions (775) and files have `-rw-rw-rw-` permissions (664).
+
+To get more detailed information, you can optionally enter the following command:
+```bash
+ls -al /var/www/html/magento2/pub
+```
+
+Because Magento deploys static file assets to subdirectories of `pub`, it's a good idea to verify permissions and ownership there as well.
+
+For more information, see [File system permissions and ownership]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
@@ -14,15 +14,16 @@ Before you continue, to avoid errors during your installation or update, make su
 *	[Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
 *	[File system permissions](#perms) are set properly
 
-Do not continue without performing these checks. Failure to do so could result in errors.
 {:bs-callout bs-callout-warning}
+Do not continue without performing these checks. Failure to do so could result in errors.
 
 ### Set a value for DATA_CONVERTER_BATCH_SIZE {#batch-size}
 
 Magento {{ page.version }} includes security enhancements that require some data to be converted from serialized data format to JSON encoded format.
 This conversion occurs during the upgrade and it can take a long time, depending on how much data is in your Magento database.
 
-The following tables are affected the most: 
+The following tables are affected the most:
+
 * `catalogrule`
 * `core_config_data`
 * `magento_reward_history`
@@ -51,8 +52,8 @@ After your upgrade completes, you can unset the variable as follows:
 unset DATA_CONVERTER_BATCH_SIZE
 ```
 
-`DATA_CONVERTER_BATCH_SIZE` requires memory; avoid setting it to a very large value (approximately 1GB) without testing it first.
 {:bs-callout bs-callout-info}
+`DATA_CONVERTER_BATCH_SIZE` requires memory; avoid setting it to a very large value (approximately 1GB) without testing it first.
 
 ### Magento file system owner and group {#magento-owner-group}
 

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
@@ -94,7 +94,7 @@ Directories in the Magento file system must be writable by the [Magento file sys
 
 To verify your file system permissions are set properly, either log in to the Magento server or use your hosting provider's file manager application.
 
-For example, enter the following commands on a Linux system if the Magento application is installed in `/var/www/html/magento2`:
+For example, enter the following command if the Magento application is installed in `/var/www/html/magento2`:
 ```bash
 ls -al /var/www/html/magento2
 ```
@@ -136,8 +136,11 @@ drwxrws---. 11 magento_user apache   4096 Jun 13 16:05 var
 drwxrws---. 29 magento_user apache   4096 Jun  7 07:53 vendor
 ```
 
-In the preceding example, the Magento file system owner is `magento_user`.
-Directories in the Magento file system have `drwxrwx---` permissions (775) and files have `-rw-rw-rw-` permissions (664).
+Here,
+- most of the files are `-rw-rw----`, which is 660
+- `drwxrwx---` = 770
+- `-rw-rw-rw-` = 666
+- the Magento file system owner is `magento_user`.
 
 To get more detailed information, you can optionally enter the following command:
 ```bash

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
@@ -19,16 +19,24 @@ Do not continue without performing these checks. Failure to do so could result i
 
 ### Set a value for DATA_CONVERTER_BATCH_SIZE {#batch-size}
 
-Magento {{ page.version }} includes security enhancements that requires some data to be converted from serialized data format to JSON encoded format.
+Magento {{ page.version }} includes security enhancements that require some data to be converted from serialized data format to JSON encoded format.
 This conversion occurs during the upgrade and it can take a long time, depending on how much data is in your Magento database.
 
-One or more fields in the following tables are affected: `sales_order`, `sales_order_payment`, `quote`, `quote_payment`, `core_config_data`, `magento_reward_history`, `url_rewrite`, `salesrule`, and `catalogrule`.
-(This is not a complete list.)
+The following tables are affected the most: 
+* `catalogrule`
+* `core_config_data`
+* `magento_reward_history`
+* `quote_payment`
+* `quote`
+* `sales_order_payment`
+* `sales_order`
+* `salesrule`
+* `url_rewrite`
 
 If you have a large amount of data, you can improve performance by setting the value of an environment variable, `DATA_CONVERTER_BATCH_SIZE`.
 By default, it's set to a value of 50,000.
 
-To set the variable, before the upgrade starts enter the following command as the {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %}Magento file system owner{% endglossarytooltip %} in a bash shell prompt:
+To set the variable, enter the following command as the {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %}Magento file system owner{% endglossarytooltip %} in a bash shell prompt:
 ```bash
 export DATA_CONVERTER_BATCH_SIZE <value>
 ```

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -7,6 +7,11 @@ functional_areas:
   - Upgrade
 ---
 
+<!-- Topic variables
+{% capture ce %}{{site.data.var.ce}}{% endcapture %}
+{% capture ee %}{{site.data.var.ee}}{% endcapture %}
+-->
+
 Upgrade Magento from the command line if you installed the software using any of the following:
 
 * Downloaded the {% glossarytooltip 7490850a-0654-4ce1-83ff-d88c1d7d07fa %}metapackage{% endglossarytooltip %} using `composer create-project`
@@ -58,9 +63,9 @@ You can optionally create a [custom maintenance mode page].
 
 Backup the existing `composer.json` file in the Magento installation directory.
    
-### (Optional) To upgrade from {{ site.data.var.ce }} to {{ site.data.var.ee }}
+### (Optional) To upgrade from {{ ce }} to {{ ee }}
 
-If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}, deactivate the {{ site.data.var.ce }} update:
+If you are upgrading from {{ ce }} to {{ ee }}, deactivate the {{ ce }} update:
  
 ```bash
 composer remove magento/product-community-edition --no-update
@@ -70,15 +75,15 @@ composer remove magento/product-community-edition --no-update
 
 Require the Magento packages of the corresponding edition (`community` or `enterprise`) and version (`<2.3_version>`).
 
-#### (Optional) If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}
+#### (Optional) If you are upgrading from {{ ce }} to {{ ee }}
 
-If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}, deactivate the {{ site.data.var.ce }} update:
+If you are upgrading from {{ ce }} to {{ ee }}, deactivate the {{ ce }} update:
  
 ```bash
 composer remove magento/product-community-edition --no-update
 ```
 
-#### For {{ site.data.var.ce }}
+#### For {{ ce }}
 
 ```bash
 composer require magento/product-community-edition=2.3.0 --no-update
@@ -95,7 +100,7 @@ composer show magento/product-community-edition 2.3.* --all | grep -m 1 versions
 '
 %}
 
-#### For {{ site.data.var.ee }}
+#### For {{ ee }}
 
 ```bash
 composer require magento/product-enterprise-edition=2.3.0 --no-update
@@ -154,7 +159,7 @@ Backup and remove the `<Magento install dir>/update` directory.
 
 #### Create a Composer project
 
-- For {{ site.data.var.ce }}
+- For {{ ce }}
 
   Example for version 2.3.0:
 
@@ -166,7 +171,7 @@ Backup and remove the `<Magento install dir>/update` directory.
   If you need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
   
 
-- For {{ site.data.var.ee }}
+- For {{ ee }}
 
   Example for version 2.3.0:
 
@@ -339,6 +344,7 @@ Open your storefront to check if the upgrade was successful.
 [Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
 [file system ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-system-perms.html
 [script]: https://raw.githubusercontent.com/magento/magento2/2.3-develop/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
+{:target="_blank"}
 [system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
 [System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
 [Update and upgrade checklist]: ../prereq/prereq_compman-checklist.html

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -15,10 +15,10 @@ Upgrade Magento from the command line if you installed the software using any of
 There are two ways to upgrade your Magento application to 2.3:
 1. Manual: [Upgrade using the command line].
 2. Semi-automated: [Upgrade using the script].
-The upgrading scenario is the same from the system's point of view, excepting that several steps are automated using the PHP script.
+The upgrading scenario is the same from the system's point of view except that several steps are automated using the PHP script.
 
 {:.bs-callout .bs-callout-warning}
-The both ways require to comply with the pre-upgrade checklist.
+Both ways require that you comply with the pre-upgrade checklist.
 
 {:.bs-callout .bs-callout-info}
 If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade. Instead, see [Update the Magento application].
@@ -32,12 +32,8 @@ Comply with the the [Update and upgrade checklist].
 This section applies to you *only* if you set the Magento root directory to `<your Magento install dir>/pub`.
 If you did not do this, skip this section and continue with the next section.
 
-If you use pub as your Magento root directory: 
-
-* For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
-
-  Run the [System Upgrade utility] using that subdomain.
-* Use the [following procedure] to upgrade Magento using the command line.
+For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
+Run the [System Upgrade utility] using that subdomain.
 
 ### PHP and other environment settings
 
@@ -82,7 +78,7 @@ If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}, deac
 composer remove magento/product-community-edition --no-update
 ```
 
-#### For the {{ site.data.var.ce }}
+#### For {{ site.data.var.ce }}
 
 ```bash
 composer require magento/product-community-edition=2.3.0 --no-update
@@ -91,7 +87,7 @@ composer require magento/product-community-edition=2.3.0 --no-update
 {%
 include note.html
 type='tip'
-content=' To see a full list of available 2.3 versions, use:
+content='To see a full list of available 2.3 versions, use:
 
 ```bash
 composer show magento/product-community-edition 2.3.* --all | grep -m 1 versions
@@ -99,7 +95,7 @@ composer show magento/product-community-edition 2.3.* --all | grep -m 1 versions
 '
 %}
 
-#### For the {{ site.data.var.ee }}
+#### For {{ site.data.var.ee }}
 
 ```bash
 composer require magento/product-enterprise-edition=2.3.0 --no-update
@@ -152,25 +148,27 @@ Update the Magento updater if it is installed.
 It is located at `<Magento install dir>/update` when installed.
 To update the tool, follow the guidelines below.
 
-#### Backup and remove the `<Magento install dir>/update` directory
+#### Remove the old updater
+
+Backup and remove the `<Magento install dir>/update` directory.
 
 #### Create a Composer project
 
-- For the {{ site.data.var.ce }}
+- For {{ site.data.var.ce }}
 
-  Example for the 2.3.0 version:
+  Example for version 2.3.0:
 
   ```bash
   composer create-project --repository=https://repo.magento.com magento/project-community-edition=2.3.0 temp_dir --no-install
   ```
   
   {:.bs-callout .bs-callout-info}
-  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  If you need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
   
 
-- For the {{ site.data.var.ee }}
+- For {{ site.data.var.ee }}
 
-  Example for the 2.3.0 version:
+  Example for version 2.3.0:
 
   ```bash
   composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition=2.3.0 temp_dir --no-install
@@ -194,7 +192,7 @@ rm -rf temp_dir
 ### Update metadata in `composer.json`
 
 {:.bs-callout .bs-callout-info}
-It is a cosmetic change, not functional.
+These changes are cosmetic, not functional.
 
 Update the `"name"`, `"version"`, and `"description"` fields in `<Magento install dir>/composer.json`.
 
@@ -204,7 +202,7 @@ Update the `"name"`, `"version"`, and `"description"` fields in `<Magento instal
 composer update
 ```
 
-### Clear `var` subdirectories
+### Clear `var` and `generated` subdirectories
 
 ```bash
 rm -rf <Magento install dir>/var/cache/*
@@ -217,7 +215,7 @@ rm -rf <Magento install dir>/generated/code/*
 ```
 
 {:.bs-callout .bs-callout-info}
-If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
+If you use a cache storage other than the filesystem (for example, Redis or Memcached), you must manually clear the cache there too.
     
 ### Update the database schema and data
 
@@ -225,7 +223,7 @@ If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) 
 php bin/magento setup:upgrade
 ```
 
-### Put your storefront online (that is, cancel maintenance mode)
+### Disable maintenance mode
 
 ```bash
 php bin/magento maintenance:disable
@@ -264,7 +262,7 @@ follow the next steps:
 The script updates Magento with the 2.3 requirements.
 Run this script after upgrading to PHP 7.1/7.2.
 
-When the script is run, the following steps will be executed:
+The upgrade script performs the following tasks:
 - Back up `composer.json`
 - Require the new version of the Magento metapackage
 - Update the `"require-dev"` section in `composer.json`
@@ -295,7 +293,7 @@ php -f pre_composer_update_2.3.php -- --root='<path/to/magento/install/dir>' <op
 composer update
 ```
 
-### Clear `var` subdirectories
+### Clear `var` and `generated` subdirectories
 
 ```bash
 rm -rf <Magento install dir>/var/cache/*
@@ -308,7 +306,7 @@ rm -rf <Magento install dir>/generated/code/*
 ```
 
 {:.bs-callout .bs-callout-info}
-If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
+If you use a cache storage other than the filesystem (for example, Redis or Memcached), you must manually clear the cache there too.
     
 ### Update the database schema and data
 
@@ -316,7 +314,7 @@ If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) 
 php bin/magento setup:upgrade
 ```
 
-### Put your storefront online (that is, cancel maintenance mode)
+### Disable maintenance mode
 
 ```bash
 php bin/magento maintenance:disable
@@ -336,12 +334,11 @@ Open your storefront to check if the upgrade was successful.
 
 <!-- Link definitions -->
 
-[script]: https://raw.githubusercontent.com/magento/magento2/2.3-develop/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
 [authentication keys]: {{ page.baseurl }}/install-gde/prereq/connect-auth.html
 [custom maintenance mode page]: {{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html
 [Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
 [file system ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-system-perms.html
-[following procedure]: #upgrade-cli-upgr
+[script]: https://raw.githubusercontent.com/magento/magento2/2.3-develop/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
 [system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
 [System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
 [Update and upgrade checklist]: ../prereq/prereq_compman-checklist.html

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -1,1 +1,228 @@
-../../../v2.2/comp-mgr/cli/cli-upgrade.md
+---
+group: compman
+title: Command-line upgrade
+version: 2.3
+github_link: comp-mgr/cli/cli-upgrade.md
+functional_areas:
+  - Upgrade
+---
+
+You can upgrade Magento from the command line if you installed the software using any of the following:
+
+* Downloaded the {% glossarytooltip 7490850a-0654-4ce1-83ff-d88c1d7d07fa %}metapackage{% endglossarytooltip %} using `composer create-project`
+* Installed the compressed archive
+
+If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade; instead, see [Update the Magento application].
+{:bs-callout bs-callout-info}
+
+## Pre-upgrade checklist
+
+Comply with the the [Update and upgrade checklist].
+
+### Prerequisite for the `pub` directory root {#upgrade-cli-pub}
+
+This section applies to you *only* if you set the Magento root directory to `<your Magento install dir>/pub`.
+If you did not do this, skip this section and continue with the next section.
+
+If you use pub as your Magento root directory: 
+
+* For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
+
+  Run the [System Upgrade utility] using that subdomain.
+* Use the [following procedure] to upgrade Magento using the command line.
+
+### PHP and other environment settings
+
+Check PHP and other environment settings to be compatible with the [system requirements].
+
+## Switch your store to the maintenance mode {#upgrade-cli-maint}
+
+To prevent access to your store while it's being upgraded, put your store in the maintenance mode.
+
+```bash
+php <your Magento install dir>/bin/magento maintenance:enable
+```
+
+For additional options, see [Enable or disable maintenance mode].
+
+You can optionally create a [custom maintenance mode page].
+{:bs-callout bs-callout-info}
+
+## Upgrade using the command line {#upgrade-cli-upgr}
+   
+### Backup `composer.json`
+
+Backup the existing `composer.json` file in the Magento installation directory.
+   
+### (Optional) To upgrade from {{ site.data.var.ce }} to {{ site.data.var.ee }}
+
+If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}, deactivate the {{ site.data.var.ce }} update:
+ 
+```bash
+composer remove magento/product-community-edition --no-update
+```
+
+### Require the Magento packages using Composer
+
+Require the Magento packages of the corresponding edition (`community` `enterprise`) and version (`<2.3_version>`).
+
+#### (Optional) If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}
+
+If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}, deactivate the {{ site.data.var.ce }} update:
+ 
+```bash
+composer remove magento/product-community-edition --no-update
+```
+
+#### For the {{ site.data.var.ce }}
+
+```bash
+composer require magento/product-community-edition=2.3 --no-update
+```
+
+#### For the {{ site.data.var.ee }}
+
+```bash
+composer require magento/product-enterprise-edition=2.3 --no-update
+```
+
+### Require the additional packages using Composer
+
+```bash
+composer require --dev phpunit/phpunit:~6.2.0 friendsofphp/php-cs-fixer:~2.10.1 lusitanian/oauth:~0.8.10 pdepend/pdepend:2.5.2 sebastian/phpcpd:~3.0.0 squizlabs/php_codesniffer:3.2.2 --no-update
+```
+
+### Remove the unused packages using Composer
+
+```bash
+composer remove --dev sjparkinson/static-review fabpot/php-cs-fixer --no-update
+```
+
+### Update `autoload` in `composer.json`
+
+Open `composer.json` and edit the the `"autoload": "psr-4"` section to include `"Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"`
+
+Example: 
+
+```json
+"autoload": {
+    "psr-4": {
+        "Magento\\Framework\\": "lib/internal/Magento/Framework/",
+        "Magento\\Setup\\": "setup/src/Magento/Setup/",
+        "Magento\\": "app/code/Magento/",
+        "Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"
+    },
+    ...
+}
+```
+
+### (Optional) Update the Magento updater
+
+Update the Magento updater if it is installed.
+It is located at `<Magento install dir>/update` when installed.
+To update the tool, follow the guidelines below.
+
+#### Backup and remove the `<Magento install dir>/update` directory
+
+#### Create a Composer project
+
+##### For the {{ site.data.var.ce }}
+
+```bash
+composer create-project --repository=https://<repository.url> magento/project-community-edition=2.3 temp_dir --no-install
+```
+
+##### For the {{ site.data.var.ee }}
+
+```bash
+composer create-project --repository=https://<repository.url> magento/project-enterprise-edition=2.3 temp_dir --no-install
+```
+
+#### Move the project to `<Magento install dir>/update`
+
+```bash
+mkdir update
+mv temp_dir/update <Magento install dir>/update
+rm -rf temp_dir
+```
+
+### Update metadata in `composer.json`
+
+It is a cosmetic change, not functional.
+{:bs-callout bs-callout-info}
+
+Update the `"name"`, `"version"`, and `"description"` fields in `<Magento install dir>/composer.json`.
+
+### Apply the updates using Composer
+
+```bash
+composer update
+```
+
+### Clear `var` subdirectories
+
+```bash
+rm -rf <Magento install dir>/var/cache/*
+```
+```bash
+rm -rf <Magento install dir>/var/page_cache/*
+```
+```bash
+rm -rf <Magento install dir>/generated/code/*
+```
+
+If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
+{:bs-callout bs-callout-info}
+    
+### Update the database schema and data
+
+```bash
+php bin/magento setup:upgrade
+```
+
+### Put your storefront online (that is, cancel maintenance mode)
+
+```bash
+php bin/magento maintenance:disable
+```
+
+### (Optional) Restart Varnish
+
+Restart Varnish if you use it for page caching.
+
+```bash
+service varnish restart
+```
+
+### Check your storefront online
+
+Open your storefront to check if the upgrade was successful.
+
+#### Troubleshooting
+
+If the application fails with the following error:
+
+```terminal
+We're sorry, an error has occurred while generating this email.
+```
+
+follow the next steps:
+
+1. Reset [file system ownership and permissions] as a user with `root` privileges.
+2. Clear the following directories and check the storefront again:
+* `<your Magento install dir>/var/cache`
+* `<your Magento install dir>/var/page_cache`
+* `<your Magento install dir>/generated/code`
+	  
+
+<!-- Link definitions -->
+
+[Update and upgrade checklist]: ../prereq/prereq_compman-checklist.html
+[system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
+[Update the Magento application]: {{ page.baseurl }}/install-gde/install/cli/dev_update-magento.html
+[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
+[following procedure]: #upgrade-cli-upgr
+[Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
+[custom maintenance mode page]: {{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html
+[authentication keys]: {{ page.baseurl }}/install-gde/prereq/connect-auth.html
+[file system ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-system-perms.html

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -17,11 +17,11 @@ There are two ways to upgrade your Magento application to 2.3:
 2. Semi-automated: [Upgrade using the script].
 The upgrading scenario is the same from the system's point of view, excepting that several steps are automated using the PHP script.
 
-The both ways require to comply with the pre-upgrade checklist.
 {:.bs-callout .bs-callout-warning}
+The both ways require to comply with the pre-upgrade checklist.
 
-If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade. Instead, see [Update the Magento application].
 {:.bs-callout .bs-callout-info}
+If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade. Instead, see [Update the Magento application].
 
 ## Pre-upgrade checklist
 
@@ -53,8 +53,8 @@ php <your Magento install dir>/bin/magento maintenance:enable
 
 For additional options, see [Enable or disable maintenance mode].
 
-You can optionally create a [custom maintenance mode page].
 {:.bs-callout .bs-callout-info}
+You can optionally create a [custom maintenance mode page].
 
 ## Upgrade using the command line {#upgrade-cli-upgr}
    
@@ -163,9 +163,10 @@ To update the tool, follow the guidelines below.
   ```bash
   composer create-project --repository=https://repo.magento.com magento/project-community-edition=2.3.0 temp_dir --no-install
   ```
-
-  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  
   {:.bs-callout .bs-callout-info}
+  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  
 
 - For the {{ site.data.var.ee }}
 
@@ -174,9 +175,9 @@ To update the tool, follow the guidelines below.
   ```bash
   composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition=2.3.0 temp_dir --no-install
   ```
-
-  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  
   {:.bs-callout .bs-callout-info}
+  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
 
 #### Move the project to `<Magento install dir>/update`
 
@@ -192,8 +193,8 @@ rm -rf temp_dir
 
 ### Update metadata in `composer.json`
 
-It is a cosmetic change, not functional.
 {:.bs-callout .bs-callout-info}
+It is a cosmetic change, not functional.
 
 Update the `"name"`, `"version"`, and `"description"` fields in `<Magento install dir>/composer.json`.
 
@@ -215,8 +216,8 @@ rm -rf <Magento install dir>/var/page_cache/*
 rm -rf <Magento install dir>/generated/code/*
 ```
 
-If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
 {:.bs-callout .bs-callout-info}
+If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
     
 ### Update the database schema and data
 
@@ -268,7 +269,7 @@ When the script is run, the following steps will be executed:
 - Require the new version of the Magento metapackage
 - Update the `"require-dev"` section in `composer.json`
 - Add `"Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"` to the `"autoload":"psr-4"` section in `composer.json`
-- Back up and update `Magento/Updater` if it has been installed
+- Back up and update `magento/updater` if it has been installed
 - Update the `"name"`, `"version"`, and `"description"` fields in `composer.json`
 
 ### Download the upgrade script
@@ -306,8 +307,8 @@ rm -rf <Magento install dir>/var/page_cache/*
 rm -rf <Magento install dir>/generated/code/*
 ```
 
-If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
 {:.bs-callout .bs-callout-info}
+If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
     
 ### Update the database schema and data
 

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -7,13 +7,21 @@ functional_areas:
   - Upgrade
 ---
 
-You can upgrade Magento from the command line if you installed the software using any of the following:
+Upgrade Magento from the command line if you installed the software using any of the following:
 
 * Downloaded the {% glossarytooltip 7490850a-0654-4ce1-83ff-d88c1d7d07fa %}metapackage{% endglossarytooltip %} using `composer create-project`
 * Installed the compressed archive
 
-If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade; instead, see [Update the Magento application].
-{:bs-callout bs-callout-info}
+There are two ways to upgrade your Magento application to 2.3:
+1. Manual: [Upgrade using the command line].
+2. Semi-automated: [Upgrade using the script].
+The upgrading scenario is the same from the system's point of view, excepting that several steps are automated using the PHP script.
+
+The both ways require to comply with the pre-upgrade checklist.
+{:.bs-callout .bs-callout-warning}
+
+If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade. Instead, see [Update the Magento application].
+{:.bs-callout .bs-callout-info}
 
 ## Pre-upgrade checklist
 
@@ -35,7 +43,7 @@ If you use pub as your Magento root directory:
 
 Check PHP and other environment settings to be compatible with the [system requirements].
 
-## Switch your store to the maintenance mode {#upgrade-cli-maint}
+### Switch your store to the maintenance mode {#upgrade-cli-maint}
 
 To prevent access to your store while it's being upgraded, put your store in the maintenance mode.
 
@@ -46,7 +54,7 @@ php <your Magento install dir>/bin/magento maintenance:enable
 For additional options, see [Enable or disable maintenance mode].
 
 You can optionally create a [custom maintenance mode page].
-{:bs-callout bs-callout-info}
+{:.bs-callout .bs-callout-info}
 
 ## Upgrade using the command line {#upgrade-cli-upgr}
    
@@ -64,7 +72,7 @@ composer remove magento/product-community-edition --no-update
 
 ### Require the Magento packages using Composer
 
-Require the Magento packages of the corresponding edition (`community` `enterprise`) and version (`<2.3_version>`).
+Require the Magento packages of the corresponding edition (`community` or `enterprise`) and version (`<2.3_version>`).
 
 #### (Optional) If you are upgrading from {{ site.data.var.ce }} to {{ site.data.var.ee }}
 
@@ -91,7 +99,6 @@ composer show magento/product-community-edition 2.3.* --all | grep -m 1 versions
 '
 %}
 
-
 #### For the {{ site.data.var.ee }}
 
 ```bash
@@ -101,14 +108,13 @@ composer require magento/product-enterprise-edition=2.3.0 --no-update
 {%
 include note.html
 type='tip'
-content=' To see a full list of available 2.3 versions, use:
+content='To see a full list of available 2.3 versions, use:
 
 ```bash
 composer show magento/product-enterprise-edition 2.3.* --all | grep -m 1 versions
 ```
 '
 %}
-
 
 ### Require the additional packages using Composer
 
@@ -150,40 +156,44 @@ To update the tool, follow the guidelines below.
 
 #### Create a Composer project
 
-##### For the {{ site.data.var.ce }}
+- For the {{ site.data.var.ce }}
 
-Example for the 2.3.0 version:
+  Example for the 2.3.0 version:
 
-```bash
-composer create-project --repository=https://repo.magento.com magento/project-community-edition=2.3.0 temp_dir --no-install
-```
+  ```bash
+  composer create-project --repository=https://repo.magento.com magento/project-community-edition=2.3.0 temp_dir --no-install
+  ```
 
-If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
-{:bs-callout bs-callout-info}
+  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  {:.bs-callout .bs-callout-info}
 
-##### For the {{ site.data.var.ee }}
+- For the {{ site.data.var.ee }}
 
-Example for the 2.3.0 version:
+  Example for the 2.3.0 version:
 
-```bash
-composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition=2.3.0 temp_dir --no-install
-```
+  ```bash
+  composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition=2.3.0 temp_dir --no-install
+  ```
 
-If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
-{:bs-callout bs-callout-info}
+  If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+  {:.bs-callout .bs-callout-info}
 
 #### Move the project to `<Magento install dir>/update`
 
 ```bash
 mkdir update
+```
+```bash
 mv temp_dir/update <Magento install dir>/update
+```
+```bash
 rm -rf temp_dir
 ```
 
 ### Update metadata in `composer.json`
 
 It is a cosmetic change, not functional.
-{:bs-callout bs-callout-info}
+{:.bs-callout .bs-callout-info}
 
 Update the `"name"`, `"version"`, and `"description"` fields in `<Magento install dir>/composer.json`.
 
@@ -206,7 +216,7 @@ rm -rf <Magento install dir>/generated/code/*
 ```
 
 If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
-{:bs-callout bs-callout-info}
+{:.bs-callout .bs-callout-info}
     
 ### Update the database schema and data
 
@@ -247,16 +257,93 @@ follow the next steps:
    * `<your Magento install dir>/var/cache`
    * `<your Magento install dir>/var/page_cache`
    * `<your Magento install dir>/generated/code`
-	  
+   
+## Upgrade using the script {#upgrade-cli-script}
+
+The script updates Magento with the 2.3 requirements.
+Run this script after upgrading to PHP 7.1/7.2.
+
+When the script is run, the following steps will be executed:
+- Back up `composer.json`
+- Require the new version of the Magento metapackage
+- Update the `"require-dev"` section in `composer.json`
+- Add `"Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"` to the `"autoload":"psr-4"` section in `composer.json`
+- Back up and update `Magento/Updater` if it has been installed
+- Update the `"name"`, `"version"`, and `"description"` fields in `composer.json`
+
+### Download the upgrade script
+
+The file containing the upgrade script is available in the `magento/magento2` repo, which is [`/dev/tools/UpgradeScripts/pre_composer_update_2.3.php`][script].
+Download or copy the file.
+
+### Check out the available options
+
+```bash
+php -f pre_composer_update_2.3.php -- --help
+```
+
+### Run the script
+
+```bash
+php -f pre_composer_update_2.3.php -- --root='<path/to/magento/install/dir>' <options>
+```
+
+### Apply the updates using Composer
+
+```bash
+composer update
+```
+
+### Clear `var` subdirectories
+
+```bash
+rm -rf <Magento install dir>/var/cache/*
+```
+```bash
+rm -rf <Magento install dir>/var/page_cache/*
+```
+```bash
+rm -rf <Magento install dir>/generated/code/*
+```
+
+If you use a cache storage other than filesystem (e.g., Redis, Memcached, etc.) you need to manually clear the cache there too.
+{:.bs-callout .bs-callout-info}
+    
+### Update the database schema and data
+
+```bash
+php bin/magento setup:upgrade
+```
+
+### Put your storefront online (that is, cancel maintenance mode)
+
+```bash
+php bin/magento maintenance:disable
+```
+
+### (Optional) Restart Varnish
+
+Restart Varnish if you use it for page caching.
+
+```bash
+service varnish restart
+```
+
+### Check your storefront online
+
+Open your storefront to check if the upgrade was successful.
 
 <!-- Link definitions -->
 
-[Update and upgrade checklist]: ../prereq/prereq_compman-checklist.html
-[system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
-[Update the Magento application]: {{ page.baseurl }}/install-gde/install/cli/dev_update-magento.html
-[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
-[following procedure]: #upgrade-cli-upgr
-[Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
-[custom maintenance mode page]: {{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html
+[script]: https://raw.githubusercontent.com/magento/magento2/2.3-develop/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
 [authentication keys]: {{ page.baseurl }}/install-gde/prereq/connect-auth.html
+[custom maintenance mode page]: {{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html
+[Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
 [file system ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-system-perms.html
+[following procedure]: #upgrade-cli-upgr
+[system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
+[System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
+[Update and upgrade checklist]: ../prereq/prereq_compman-checklist.html
+[Update the Magento application]: {{ page.baseurl }}/install-gde/install/cli/dev_update-magento.html
+[Upgrade using the command line]: #upgrade-cli-upgr
+[Upgrade using the script]: #upgrade-cli-script

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -77,14 +77,38 @@ composer remove magento/product-community-edition --no-update
 #### For the {{ site.data.var.ce }}
 
 ```bash
-composer require magento/product-community-edition=2.3 --no-update
+composer require magento/product-community-edition=2.3.0 --no-update
 ```
+
+{%
+include note.html
+type='tip'
+content=' To see a full list of available 2.3 versions, use:
+
+```bash
+composer show magento/product-community-edition 2.3.* --all | grep -m 1 versions
+```
+'
+%}
+
 
 #### For the {{ site.data.var.ee }}
 
 ```bash
-composer require magento/product-enterprise-edition=2.3 --no-update
+composer require magento/product-enterprise-edition=2.3.0 --no-update
 ```
+
+{%
+include note.html
+type='tip'
+content=' To see a full list of available 2.3 versions, use:
+
+```bash
+composer show magento/product-enterprise-edition 2.3.* --all | grep -m 1 versions
+```
+'
+%}
+
 
 ### Require the additional packages using Composer
 
@@ -128,15 +152,25 @@ To update the tool, follow the guidelines below.
 
 ##### For the {{ site.data.var.ce }}
 
+Example for the 2.3.0 version:
+
 ```bash
-composer create-project --repository=https://<repository.url> magento/project-community-edition=2.3 temp_dir --no-install
+composer create-project --repository=https://repo.magento.com magento/project-community-edition=2.3.0 temp_dir --no-install
 ```
+
+If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+{:bs-callout bs-callout-info}
 
 ##### For the {{ site.data.var.ee }}
 
+Example for the 2.3.0 version:
+
 ```bash
-composer create-project --repository=https://<repository.url> magento/project-enterprise-edition=2.3 temp_dir --no-install
+composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition=2.3.0 temp_dir --no-install
 ```
+
+If need to use a repository that contains non-public packages such as internal sandboxes, change the URL in `--repository` correspondingly.
+{:bs-callout bs-callout-info}
 
 #### Move the project to `<Magento install dir>/update`
 
@@ -210,9 +244,9 @@ follow the next steps:
 
 1. Reset [file system ownership and permissions] as a user with `root` privileges.
 2. Clear the following directories and check the storefront again:
-* `<your Magento install dir>/var/cache`
-* `<your Magento install dir>/var/page_cache`
-* `<your Magento install dir>/generated/code`
+   * `<your Magento install dir>/var/cache`
+   * `<your Magento install dir>/var/page_cache`
+   * `<your Magento install dir>/generated/code`
 	  
 
 <!-- Link definitions -->


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement
 
## Summary
 
When this pull request is merged, it will add upgrading instructions in the Magento 2.3 docs.
 
whatsnew
Added the [CLI instructions](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html) for upgrading Magento to 2.3.