### PR TITLE
Changed default ADMIN_USERNAME back to Admin

### DIFF
--- a/guides/v2.1/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.1/cloud/before/before-setup-env-2_clone.md
@@ -75,8 +75,7 @@ We recommend changing the following variables for the Magento Admin URL and admi
 * `ADMIN_EMAIL`: The email address for the administrative user. This value is required for upgrading and patching Magento Commerce (Cloud) and is used to send password reset emails.
 * `ADMIN_USERNAME`: Username for the administrative user. The administrative user
 can create other users, including other administrative users. The default
-hardcoded username is the Project Owner email address. You can use this
-value, or change it to another secure username.
+hardcoded username is `Admin`. You can use this value, or change it to another secure username.
 * `ADMIN_PASSWORD`: Password for the administrative user. When the project is created, a random password is generated and an email is sent to the Project Owner. During project creation, the Project Owner should have already changed the password. You might
 need to contact the Project Owner for the updated password.
 * `ADMIN_URL`: The relative URL to access the Admin panel. For example: <domain>/admin. For security reasons, we recommend you choose a value other than `admin` or `backend` or another term that is easy to guess.

--- a/guides/v2.1/cloud/onboarding/onboarding-tasks.md
+++ b/guides/v2.1/cloud/onboarding/onboarding-tasks.md
@@ -110,7 +110,7 @@ want to track. Sign up from the
 Users that have administrative access to the Admin panel can add users, configure store services, complete store set up and customization work, and more.
 
 For a new project, the first step after getting the welcome email is to secure Admin access to the project by changing the password on the Project Owner
-account. The default username for this accounts is `Admin`.
+account. The default username for this account is `Admin`.
 
 You can submit a password change request using either of the following methods:
 

--- a/guides/v2.1/cloud/onboarding/onboarding-tasks.md
+++ b/guides/v2.1/cloud/onboarding/onboarding-tasks.md
@@ -110,7 +110,7 @@ want to track. Sign up from the
 Users that have administrative access to the Admin panel can add users, configure store services, complete store set up and customization work, and more.
 
 For a new project, the first step after getting the welcome email is to secure Admin access to the project by changing the password on the Project Owner
-account.
+account. The default username for this accounts is `Admin`.
 
 You can submit a password change request using either of the following methods:
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
Code to change the default username to Project Owner is not merged yet, so changing default back to original "Admin". Also added the default username to the [Access Admin Panel ](https://devdocs.magento.com/guides/v2.2/cloud/onboarding/onboarding-tasks.html#admin) topic per request from Onboarding team. 

Reference:  [MAGECLOUD-1932](https://magento2.atlassian.net/browse/MAGECLOUD-1932)
