### PR TITLE
[fix] typo in design styleguide

### DIFF
--- a/guides/v2.0/design-styleguide/number-formats/number-formats.md
+++ b/guides/v2.0/design-styleguide/number-formats/number-formats.md
@@ -158,4 +158,4 @@ This is how we write about money:
 
 * Do not indicate standard or daylight time. ... *Correct example:* Central Time is written as "CT", not "CST" or "CDT".
 
-* Do not use military time. ... *Inorrect example:* Using 19:40, instead of 7:40pm.
+* Do not use military time. ... *Incorrect example:* Using 19:40, instead of 7:40pm.

--- a/guides/v2.1/design-styleguide/number-formats/number-formats.md
+++ b/guides/v2.1/design-styleguide/number-formats/number-formats.md
@@ -158,4 +158,4 @@ This is how we write about money:
 
 * Do not indicate standard or daylight time. ... *Correct example:* Central Time is written as "CT", not "CST" or "CDT".
 
-* Do not use military time. ... *Inorrect example:* Using 19:40, instead of 7:40pm.
+* Do not use military time. ... *Incorrect example:* Using 19:40, instead of 7:40pm.


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix the spelling of `Incorrect` in `guides/v2.x/design-styleguide/number-formats/number-formats.md`.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

I know that the v2.0 is EOL, but as it is only a typo and no content change I hope it will be fine, otherwise I can remove the separate commit for v2.0