### PR TITLE
Fix typos in extension dev guide

### DIFF
--- a/guides/v2.0/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/guides/v2.0/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -98,7 +98,7 @@ public function afterSave
 }
 {% endhighlight %}
 
-But if some entity doesn't have implementation to fetch extension attributes, we will always retrieve `null` and each time when we fetch extension atrributes we need to check if they are `null` - need to create them. To avoid such code duplication, we need to create `afterGet` plugin for our entity with extension attributes.
+But if some entity doesn't have implementation to fetch extension attributes, we will always retrieve `null` and each time when we fetch extension attributes we need to check if they are `null` - need to create them. To avoid such code duplication, we need to create `afterGet` plugin for our entity with extension attributes.
 
 Let's assume the product entity doesn't have any implementation of extension attributes, so our plugin might looks like this:
 

--- a/guides/v2.0/extension-dev-guide/indexing-custom.md
+++ b/guides/v2.0/extension-dev-guide/indexing-custom.md
@@ -11,7 +11,7 @@ github_link: extension-dev-guide/indexing-custom.md
 ---
 
 ## Adding a custom indexer {#m2devgde-indexing-custom}
-This topic discusses how to create a custom indexer. We've recently made a performance improvment that enables you to declare one or more *shared* indexers; if one of the shared indexes is already up-to-date, it doesn't need to be reindexed.
+This topic discusses how to create a custom indexer. We've recently made a performance improvement that enables you to declare one or more *shared* indexers; if one of the shared indexes is already up-to-date, it doesn't need to be reindexed.
 
 To implement your own indexer, add the following code in your module:
 

--- a/guides/v2.1/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/guides/v2.1/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -98,7 +98,7 @@ public function afterSave
 }
 {% endhighlight %}
 
-But if some entity doesn't have implementation to fetch extension attributes, we will always retrieve `null` and each time when we fetch extension atrributes we need to check if they are `null` - need to create them. To avoid such code duplication, we need to create `afterGet` plugin for our entity with extension attributes.
+But if some entity doesn't have implementation to fetch extension attributes, we will always retrieve `null` and each time when we fetch extension attributes we need to check if they are `null` - need to create them. To avoid such code duplication, we need to create `afterGet` plugin for our entity with extension attributes.
 
 Let's assume the product entity doesn't have any implementation of extension attributes, so our plugin might looks like this:
 

--- a/guides/v2.1/extension-dev-guide/indexing-custom.md
+++ b/guides/v2.1/extension-dev-guide/indexing-custom.md
@@ -11,7 +11,7 @@ github_link: extension-dev-guide/indexing-custom.md
 ---
 
 ## Adding a custom indexer {#m2devgde-indexing-custom}
-This topic discusses how to create a custom indexer. We've recently made a performance improvment that enables you to declare one or more *shared* indexers; if one of the shared indexes is already up-to-date, it doesn't need to be reindexed.
+This topic discusses how to create a custom indexer. We've recently made a performance improvement that enables you to declare one or more *shared* indexers; if one of the shared indexes is already up-to-date, it doesn't need to be reindexed.
 
 To implement your own indexer, add the following code in your module:
 

--- a/guides/v2.2/extension-dev-guide/framework/serializer.md
+++ b/guides/v2.2/extension-dev-guide/framework/serializer.md
@@ -116,7 +116,7 @@ public function loadDataFromCache()
 ## Backward Compatibility Note
 
 The `SerializerInterface` interface and its implementations only exist since Magento version 2.2.  
-Because of this, it is not posssible to use these classes in code that has to be compatible with Magento 2.1 or 2.0.  
+Because of this, it is not possible to use these classes in code that has to be compatible with Magento 2.1 or 2.0.  
 
 In code that is compatible with earlier versions of Magento 2, constructor dependency injection can not be used to get an instance of `SerializerInterface`.  
 Instead, a runtime check if the `SerializerInterface` definition exists can made, and if it does, it can be instantiated by directly accessing the object manager using a static method. Alternatively a check against the Magento 2 version or the `magento/framework` composer package version would work, too.  

--- a/guides/v2.2/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.2/extension-dev-guide/indexer-batch.md
@@ -80,7 +80,7 @@ cataloginventory_stock (Stock)	| `Magento/CatalogInventory/etc/di.xml`	| `Magent
 catalog_category_product (Category Products)| `Magento/Catalog/etc/di.xml`	| `Magento\Catalog\Model\Indexer\Category\Product\Action\Full` |	batchRowsCount	| 100000
 catalog_product_attribute (Product Attribute)| `Magento/Catalog/etc/di.xml` | `Magento\Catalog\Model\ResourceModel\Product\Indexer\Eav\BatchSizeCalculator` | batchSizes['decimal'], batchSizes['source'] | 1000, 1000
 
-Changing the batch size can help you optimize indexer running time. For example, for a store with the following characteristcs:
+Changing the batch size can help you optimize indexer running time. For example, for a store with the following characteristics:
 
 * 10 websites
 * 10 store groups

--- a/guides/v2.2/extension-dev-guide/message-queues/bulk-operations.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/bulk-operations.md
@@ -16,7 +16,7 @@ functional_areas:
 
 Bulk operations are actions that are performed on a large scale. Example bulk operations tasks include importing or exporting items, changing prices on a mass scale, and assigning products to a warehouse.
 
-For each indvidual task of a bulk operation, the system creates a message that is published in a [message queue]( {{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html). A consumer runs in the background and processes the messages that it receives. Because tasks are processed in the background through the message queue system, when a merchant launches a bulk operation from the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} panel, control is quickly returned to the merchant. In previous releases, the merchant could not use the Admin panel until all tasks were completed.
+For each individual task of a bulk operation, the system creates a message that is published in a [message queue]( {{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html). A consumer runs in the background and processes the messages that it receives. Because tasks are processed in the background through the message queue system, when a merchant launches a bulk operation from the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} panel, control is quickly returned to the merchant. In previous releases, the merchant could not use the Admin panel until all tasks were completed.
 
 The primary Bulk Operation interface is `OperationInterface`. It defines the getter and setter methods the bulk operation uses to create and process messages. The following interfaces are also used:
 

--- a/guides/v2.2/extension-dev-guide/message-queues/config-mq.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/config-mq.md
@@ -229,7 +229,7 @@ The `queue_publisher.xml` file defines which connection and exchange to use to p
 #### `connection` element
 {:.no_toc}
 
-The `connection` element is a subnode of the `publisher` element. There must not be more than one enabled active connection to a pushlisher defined at a time. If you omit the `connection` element, the default connection of `amqp` and exchange `magento` will be used.
+The `connection` element is a subnode of the `publisher` element. There must not be more than one enabled active connection to a publisher defined at a time. If you omit the `connection` element, the default connection of `amqp` and exchange `magento` will be used.
 
 | Attribute            | Description |
 | -------------------- | ----------- |

--- a/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.md
@@ -13,7 +13,7 @@ Optionally, if you plan to enable rollback for your patch during module uninstal
 
 The declarative schema approach removes the version from the `setup_module` table (in a backward compatible way), leaving only the Composer version. Therefore, you can create all new patches and modules without specifying a `setup_module` version.
 
-The sequnce of installing patches is handled through a dependency-based approach. Patches can either be independent or dependent on other patches. Independent patches can be installed in any sequence. A dependent patch requires a minimal number of patches so that it can be installed successfully.
+The sequence of installing patches is handled through a dependency-based approach. Patches can either be independent or dependent on other patches. Independent patches can be installed in any sequence. A dependent patch requires a minimal number of patches so that it can be installed successfully.
 
 To define a dependency in a patch, make a static reference to the patch class. The class can be in any module.
 

--- a/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
@@ -13,7 +13,7 @@ Once you start with data patches, you cannot continue to use upgrade scripts.
 
 ## Convert install/upgrade schema scripts to  db_schema.xml files
 
-The **Schema Listener Tool** converts pre-Magento 2.3 migration scripts into declarative schema. To use this tool, you specify an argment when you run the `setup:install` or `setup:upgrade` CLI command. As Magento is installed or upgraded, the system logs all schema changes per module, then persists the changes in a series of `db_schema.xml` files (one per affected module).
+The **Schema Listener Tool** converts pre-Magento 2.3 migration scripts into declarative schema. To use this tool, you specify an argument when you run the `setup:install` or `setup:upgrade` CLI command. As Magento is installed or upgraded, the system logs all schema changes per module, then persists the changes in a series of `db_schema.xml` files (one per affected module).
 
 <div class="bs-callout bs-callout-info" id="info" markdown="1">
 The Schema Listener tool listens for schema changes and attempts to change Magento code, so it should not be run in production mode. It is disabled by default.
@@ -32,7 +32,7 @@ The Schema Listener Tool cannot convert everything that can appear in a pre-Mage
 
 * The tool supports only DDL operations represented in `\Magento\Framework\DB\Adapter\Pdo\Mysql`. As a result, the tool ignores all custom DDL operations.
 * The tool ignores all raw SQL in your `InstallSchema` or `UpgradeSchema` scripts.
-* Any DDL statements in a `Recurring` file will not be transfered to the new schema, because this file should be designed to run during each installation or upgrade.
+* Any DDL statements in a `Recurring` file will not be transferred to the new schema, because this file should be designed to run during each installation or upgrade.
 * See [Configure declarative schema]({{ page.baseurl }}/extension-dev-guide/declarative-schema/db-schema.html) if you need to make manual modifications to your schema.
 
 ## Convert install/upgrade data scripts to the data patch format

--- a/guides/v2.3/extension-dev-guide/message-queues/bulk-operations.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/bulk-operations.md
@@ -10,7 +10,7 @@ functional_areas:
 
 Bulk operations are actions that are performed on a large scale. Example bulk operations tasks include importing or exporting items, changing prices on a mass scale, and assigning products to a warehouse.
 
-For each indvidual task of a bulk operation, the system creates a message that is published in a [message queue]( {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html). A consumer runs in the background and processes the messages that it receives. Because tasks are processed in the background through the message queue system, when a merchant launches a bulk operation from the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} panel, control is quickly returned to the merchant. In previous releases, the merchant could not use the Admin panel until all tasks were completed.
+For each individual task of a bulk operation, the system creates a message that is published in a [message queue]( {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html). A consumer runs in the background and processes the messages that it receives. Because tasks are processed in the background through the message queue system, when a merchant launches a bulk operation from the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} panel, control is quickly returned to the merchant. In previous releases, the merchant could not use the Admin panel until all tasks were completed.
 
 The primary Bulk Operation interface is `OperationInterface`. It defines the getter and setter methods the bulk operation uses to create and process messages. The following interfaces are also used:
 

--- a/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
@@ -223,7 +223,7 @@ The `queue_publisher.xml` file defines which connection and exchange to use to p
 #### `connection` element
 {:.no_toc}
 
-The `connection` element is a subnode of the `publisher` element. There must not be more than one enabled active connection to a pushlisher defined at a time. If you omit the `connection` element, the default connection of `amqp` and exchange `magento` will be used.
+The `connection` element is a subnode of the `publisher` element. There must not be more than one enabled active connection to a publisher defined at a time. If you omit the `connection` element, the default connection of `amqp` and exchange `magento` will be used.
 
 | Attribute            | Description |
 | -------------------- | ----------- |


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [ ] Content fix or rewrite
- [x] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix several typos in `guides/v2.x/extension-dev-guide/...`
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

I know that v2.0 is EOL, that's why I separated the typo corrections for v2.0 into a separate commit. 
This commit can be reverted just in case.

I also left out the correction of the word `visible` as it is already handled by this PR: #2475