### PR TITLE
[fix] typos in install guide

### DIFF
--- a/guides/v2.0/install-gde/prereq/mysql.md
+++ b/guides/v2.0/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magention versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.0/install-gde/prereq/mysql.md
+++ b/guides/v2.0/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.0/install-gde/prereq/mysql.md
+++ b/guides/v2.0/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.0/install-gde/prereq/php-settings.md
+++ b/guides/v2.0/install-gde/prereq/php-settings.md
@@ -49,7 +49,7 @@ This topic discusses how to set required {% glossarytooltip bf703ab1-ca4b-48f9-b
 {% endcollapsible %}
 
 ### Step 1: Find PHP configuration files {#php-required-find}
-This section discusses how you find the configuration files necesary to update required settings.
+This section discusses how you find the configuration files necessary to update required settings.
 
 {% collapsible To find the PHP configuration file, php.ini: %}
 To find the web server configuration, run a <a href="{{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo">`phpinfo.php` file</a> in your web browser and look for the Loaded Configuration File as follows:

--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magention versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -24,7 +24,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
 </div>
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:

--- a/guides/v2.1/install-gde/prereq/php-settings.md
+++ b/guides/v2.1/install-gde/prereq/php-settings.md
@@ -49,7 +49,7 @@ This topic discusses how to set required {% glossarytooltip bf703ab1-ca4b-48f9-b
 {% endcollapsible %}
 
 ### Step 1: Find PHP configuration files {#php-required-find}
-This section discusses how you find the configuration files necesary to update required settings.
+This section discusses how you find the configuration files necessary to update required settings.
 
 {% collapsible To find the PHP configuration file, php.ini: %}
 To find the web server configuration, run a <a href="{{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo">`phpinfo.php` file</a> in your web browser and look for the Loaded Configuration File as follows:

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magention versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.3/install-gde/install/post-install-config.md
+++ b/guides/v2.3/install-gde/install/post-install-config.md
@@ -83,7 +83,7 @@ Elasticsearch available in {{site.data.var.ee}} since 2.1.0 and in {{site.data.v
 
 #### Set up an message queue
 
-Since 2.3.0 {{site.data.var.ce}} includes message queue functionaity. In eralier versions it is availible only for  {{site.data.var.ee}}.
+Since 2.3.0 {{site.data.var.ce}} includes message queue functionality. In earlier versions it is available only for {{site.data.var.ee}}.
 
 *	<a href="{{page.baseurl}}/config-guide/mq/rabbitmq-overview.html">RabbitMQ</a>
 

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -20,7 +20,7 @@ If you're new to all this and need some help getting started, we suggest the fol
 ## General guidelines {#instgde-prereq-mysql-intro}
 <div class="bs-callout bs-callout-info" id="info">
   <p>The Magento application requires MySQL 5.6.x.</p>
-  <p>Magention versions 2.1.2 and later are compatible with MySQL 5.7.x.</p>
+  <p>Magento in version 2.1.2 and later are compatible with MySQL 5.7.x.</p>
   <p>Magento is also compatible with MySQL NDB Cluster 7.4.*, MariaDB 10.0, 10.1, 10.2, Percona 5.7 and other binary compatible MySQL technologies. </p>
 </div>
 

--- a/guides/v2.3/install-gde/prereq/php-settings.md
+++ b/guides/v2.3/install-gde/prereq/php-settings.md
@@ -40,7 +40,7 @@ This topic discusses how to set required {% glossarytooltip bf703ab1-ca4b-48f9-b
 </div>
 
 ## Step 1: Find PHP configuration files {#php-required-find}
-This section discusses how you find the configuration files necesary to update required settings.
+This section discusses how you find the configuration files necessary to update required settings.
 
 ### Find `php.ini` configuration file
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will fix several typos and spelling mistakes.

- Correct the phrase `Magento in version` in `guides/v2.x/install-gde/prereq/mysql.md`
- Correct spelling of `necessary` in `guides/v2.x/install-gde/prereq/php-settings.md`
- Correct spelling fo `functionality`, `earlier` and `available` in `guides/v2.3/install-gde/install/post-install-config.md`

