### PR TITLE
Fix misspelling of adminhtml

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -182,7 +182,7 @@ The following table explains this command's parameters and values.
           <code>frontend</code>.
         </p>
         <p>
-          For example, <code>--area adminthml</code>
+          For example, <code>--area adminhtml</code>
         </p>
       </td>
       <td>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- \[x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Fix a code reference in the documentation for deploying static content in the adminhtml area.
_adminthml -> adminhtml_

## Additional information
Searched entire devdocs repository for any additional instances of this misspelling and found none. 