### PR TITLE
Fixed issue #2575

### DIFF
--- a/guides/v2.1/cloud/onboarding/onboarding-tasks.md
+++ b/guides/v2.1/cloud/onboarding/onboarding-tasks.md
@@ -78,7 +78,7 @@ see [Create and manage users]({{ page.baseurl }}/cloud/project/user-admin.html).
 When you sign up for a Pro or Starter subscription plan, we provision
 your initial project environment with a template {{site.data.var.ece}}
 repository to build and manage your site. For information about what is included
-in Pro and Starter plans, see [Starter Architecture]({{ site.baseurl }}/cloud/basic-information/starter-architecture.html) and [Pro Architecture]({{ site.baseurl }}/cloud/basic-information/pro-architecture.html).
+in Pro and Starter plans, see [Starter Architecture]({{ page.baseurl }}/cloud/basic-information/starter-architecture.html) and [Pro Architecture]({{ page.baseurl }}/cloud/basic-information/pro-architecture.html).
 
 You can use the Project Web Interface to manage your project, add user accounts,
 and begin developing your store(s). The Project Owner, Technical Admin users,


### PR DESCRIPTION
The starter and pro architecture links are broken.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary
magento/devdocs#2575: Feedback on page: /guides/v2.2/cloud/onboarding/onboarding-tasks.html

When this pull request is merged, it will fix the starter and pro architecture's broken links.

<!-- (REQUIRED) What does this PR change? -->

## Additional information
N/A
<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
