### PR TITLE
improves table for plugin method call order

### DIFF
--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -262,12 +262,15 @@ The prioritization rules for ordering plugins:
 
 Given the following plugins observing the same method with the following properties:
 
-|               | PluginA          | PluginB          | PluginC          |
-| :-----------: | :--------------: | :--------------: | :--------------: |
-| **sortOrder** | 10               | 20               | 30               |
-| **before**    | beforeDispatch() | beforeDispatch() | beforeDispatch() |
-| **around**    |                  | aroundDispatch() | aroundDispatch() |
-| **after**     | afterDispatch()  | afterDispatch()  | afterDispatch()  |
+|                          | PluginA          | PluginB                        | PluginC                        | Action           |
+| :----------------------: | :--------------: | :----------------------------: | :----------------------------: | :--------------: |
+| **sortOrder**            | 10               | 20                             | 30                             |                  |
+| **before**               | beforeDispatch() | beforeDispatch()               | beforeDispatch()               |                  |
+| **around (first half)**  |                  | aroundDispatch() [first half]  | aroundDispatch() [first half]  |                  |
+| **original**             |                  |                                |                                | dispatch()       |
+| **around (second half)** |                  | aroundDispatch() [second half] | aroundDispatch() [second half] |                  |
+| **after**                | afterDispatch()  | afterDispatch()                | afterDispatch()                |                  |
+| :----------------------: | :--------------: | :----------------------------: | :----------------------------: | :--------------: |
 
 The execution flow will be as follows:
 


### PR DESCRIPTION
by splitting up around calls

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will add an additional line ("original") and row ("Action") to the plugin-visualisation table to improve the understandability of the execution order