### PR TITLE
Fix github link to point to correct page

### DIFF
--- a/guides/v2.0/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.0/frontend-dev-guide/templates/template-security.md
@@ -5,7 +5,7 @@ title: Templates XSS security
 menu_title: Templates XSS security
 menu_order: 5
 version: 2.0
-github_link: frontend-dev-guide/templates/template-overview.md
+github_link: frontend-dev-guide/templates/template-security.md
 redirect_from: /guides/v1.0/frontend-dev-guide/templates/template-security.html
 functional_areas:
   - Frontend


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will revise the github_link in v2.0 of template-security.md to point to the correct URL (not the parent template-overview.md page).

<!-- (REQUIRED) What does this PR change? -->

## Additional information

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
