### PR TITLE
Convert HTML to markdown for 2.2 and 2.1 on the database caching page

### DIFF
--- a/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -13,7 +13,8 @@ redirect_from:
   -  /guides/v2.2/config-guide/database/database.html
 ---
 
-This topic discusses how to use the Magento 2 database for caching. After you complete these tasks, cached objects are stored in the `cache` and `cache_tag` Magento 2 database tables. Nothing is stored in `var/cache` or `var/page_cache`.
+## Overview of database caching {#mage-cache-db-over}
+This topic discusses how to use the Magento 2 database for caching. After you complete these tasks, cached objects are stored in the `cache` and `cache_tag` Magento 2 database tables. Nothing is stored `var/cache` or `var/page_cache`.
 
 This topic discusses how to set up database caching and how to verify database caching is working. We discuss the following options:
 
@@ -21,21 +22,21 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
 <div class="bs-callout bs-callout-warning">
-    <p>Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use <a href="{{ page.baseurl }}/config-guide/varnish/config-varnish.html">Varnish</a> in production instead.</p>
-    <p>Varnish is designed to accelerate the HTTP protocol.</p>
+Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use [Varnish] in production instead.
+Varnish is designed to accelerate the HTTP protocol.
 </div>
 
-<h2 id="mage-cache-db-prereq">Prerequisites</h2>
-Before you continue, if you're using your own frontend cache, make sure you <a href="{{ page.baseurl }}/config-guide/config/caching_frontend-cache-types.html">associate cache frontends with cache types</a>. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
+## Prerequisites {#mage-cache-db-prereq}
+Before you continue, if you're using your own frontend cache, make sure you [associate cache frontends with cache types]. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
 
-We provide <a href="#mage-cache-db-config">sample configurations</a> at the end of this topic.
+We provide [sample configurations] at the end of this topic.
 
-<h2 id="mage-cache-db-di">Database caching using the <code>default</code> cache frontend</h2>
+## Database caching using the `default` cache frontend {#mage-cache-db-di}
 To enable database caching using the `default` frontend, you must modify `<your Magento install dir>/app/etc/di.xml`, which is the global deployment injection configuration for the Magento application.
 
 To modify `di.xml`:
 
-1.	Log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `di.xml`:
 
 		cd <your Magento install dir>/app/etc
@@ -72,11 +73,11 @@ To modify `di.xml`:
         	<arguments>
             	<argument name="frontendSettings" xsi:type="array">
             	    <item name="page_cache" xsi:type="array">
-            	      <item name="backend" xsi:type="string">database</item>
-             	       </item>
-             	     <item name="<your cache id>" xsi:type="array">
-             	     <item name="backend" xsi:type="string">database</item>
-             	     </item>
+                        <item name="backend" xsi:type="string">database</item>
+                    </item>
+                    <item name="<your cache id>" xsi:type="array">
+                        <item name="backend" xsi:type="string">database</item>
+                    </item>
            		</argument>
         	</arguments>
     	</type>
@@ -92,19 +93,19 @@ To modify `di.xml`:
 
 5.	Save your changes to `di.xml` and exit the text editor.
 
-7.	Continue with <a href="#mage-cache-db-verify">Verify database caching is working</a>.
+7.	Continue with [Verify database caching is working].
 
-<h2 id="mage-cache-db-env">Database caching using a custom cache frontend</h2>
+## Database caching using a custom cache frontend {#mage-cache-db-env}
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
 <div class="bs-callout bs-callout-info" id="info">
 <span class="glyphicon-class">
-  <p>Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</p></span>
+  Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
 </div>
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
-1.	Log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `env.php`:
 
 		cd <your Magento install dir>/app/etc
@@ -130,24 +131,24 @@ To enable database caching using a custom cache frontend, you must modify `<your
 		    ],
 		],
 
-	An example is shown in <a href="#mage-cache-db-config">Configuration examples</a>.
+	An example is shown in [Configuration examples].
 
 4.	Save your changes to `env.php` and exit the text editor.
 5.	Continue with the next section.
 
-<h2 id="mage-cache-db-verify">Verify database caching is working</h2>
+## Verify database caching is working {#mage-cache-db-verify}
 To verify database caching is working, clear the current cache directories, go to any cacheable page in a web browser, and verify that data is written to the database and not to the file system.
 
 Use the following steps:
 
-1.	If you haven't done so already, log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	If you haven't done so already, log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Clear the current cache directories:
 
-		rm -rf <your Magento install dir>/var/cache/* <your Magento install dir>/var/page_cache/* <your Magento install dir>/var/di/* <your Magento install dir>/var/generation/*
+		rm -rf <your Magento install dir>/var/cache/* <your Magento install dir>/var/page_cache/* <your Magento install dir>/generated/metadata/* <your Magento install dir>/generated/code/*
 
 3.	In a web browser, go to any cacheable page (such as the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %} front door page).
 
-	If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#config-mode">enable developer mode</a>.)
+	If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must [enable developer mode].)
 4.	Enter the following commands:
 
 		ls <your Magento install dir>/var/cache/*
@@ -155,52 +156,53 @@ Use the following steps:
 
     <div class="bs-callout bs-callout-info" id="info">
       <span class="glyphicon-class">
-      <p>Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</p>
-      <p>If you use the <code>default</code> cache frontend, you don't have this issue.</p></span>
+      Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
+      If you use the `default` cache frontend, you don't have this issue.</span>
     </div>
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
-4.	Use a database tool such as <a href="{{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin">phpMyAdmin</a> to verify there is data in the `cache` and `cache_tag` tables.
+4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
 
 	The following figures show examples. The important thing is that there are rows in the tables. *The data in your tables will be different than the following*.
 
 	`cache` table example.
 
-	<img src="{{ site.baseurl }}/common/images/config-db_cache-table.png" alt="Sample contents of the cache table with database caching enabled">
+	![Sample contents of the cache table with database caching enabled]
 
 	`cache_tag` table example.
 
-	<img src="{{ site.baseurl }}/common/images/config-db_cache-tag-table.png" alt="Sample contents of the cache tag table with database caching enabled">
+	![Sample contents of the cache tag table with database caching enabled]
 
 
-<h2 id="mage-cache-db-config">Configuration examples</h2>
+## Configuration examples {#mage-cache-db-config}
 This section contains code sample snippets to refer to when configuring database caching.
 
-<h3 id="mage-cache-db-config-default">Sample <code>di.xml</code> for the default cache frontend</h3>
+### Sample `di.xml` for the default cache frontend {#mage-cache-db-config-default}
+
 `di.xml` snippet:
 
-{% highlight XML %}
- <type name="Magento\Framework\App\Cache\Frontend\Pool">
-        <arguments>
-            <argument name="frontendSettings" xsi:type="array">
-                <item name="page_cache" xsi:type="array">
-                  <item name="backend" xsi:type="string">database</item>
-                    </item>
-                  <item name="default" xsi:type="array">
-                  <item name="backend" xsi:type="string">database</item>
-                  </item>
-            </argument>
-        </arguments>
-    </type>
-    <type name="Magento\Framework\App\Cache\Type\FrontendPool">
-        <arguments>
-            <argument name="typeFrontendMap" xsi:type="array">
+``` xml
+<type name="Magento\Framework\App\Cache\Frontend\Pool">
+    <arguments>
+        <argument name="frontendSettings" xsi:type="array">
+            <item name="page_cache" xsi:type="array">
                 <item name="backend" xsi:type="string">database</item>
-            </argument>
-        </arguments>
- </type>
-{% endhighlight %}
+            </item>
+            <item name="default" xsi:type="array">
+                <item name="backend" xsi:type="string">database</item>
+            </item>
+        </argument>
+    </arguments>
+</type>
+<type name="Magento\Framework\App\Cache\Type\FrontendPool">
+    <arguments>
+        <argument name="typeFrontendMap" xsi:type="array">
+            <item name="backend" xsi:type="string">database</item>
+        </argument>
+    </arguments>
+</type>
+```
 
-<h3 id="mage-cache-db-config-custom">Sample <code>env.php</code> for a custom cache frontend</h3>
+### Sample `env.php` for a custom cache frontend {#mage-cache-db-config-custom}
 `env.php` snippet that enables all cache types with a custom frontend named `magento_cache`:
 
 {% highlight php startinline=true %}
@@ -253,3 +255,17 @@ This section contains code sample snippets to refer to when configuring database
       ],
   ],
 {% endhighlight %}
+
+<!-- Link references -->
+[Varnish]: {{ page.baseurl }}/config-guide/varnish/config-varnish.html
+[associate cache frontends with cache types]: {{ page.baseurl }}/config-guide/config/caching_frontend-cache-types.html
+[sample configurations]: #mage-cache-db-config
+[Magento file system owner]: {{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html
+[Verify database caching is working]: #mage-cache-db-verify
+[Configuration examples]: #mage-cache-db-config
+[enable developer mode]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#change-to-developer-mode
+[phpMyAdmin]: {{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin
+
+<!-- Image references -->
+[Sample contents of the cache table with database caching enabled]: {{ site.baseurl }}/common/images/config-db_cache-table.png
+[Sample contents of the cache tag table with database caching enabled]: {{ site.baseurl }}/common/images/config-db_cache-tag-table.png

--- a/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -20,7 +20,7 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using the `default` cache frontend, in which case you modify `di.xml` only.
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
-{:.bs-callout .bs-callout-info}
+{:.bs-callout .bs-callout-warning}
 Database caching&mdash;like file-based caching&mdash; works well in a development environment but we _strongly recommend_ you use [Varnish] in production instead.
 Varnish is designed to accelerate the HTTP protocol.
 
@@ -98,10 +98,9 @@ To modify `di.xml`:
 ## Database caching using a custom cache frontend {#mage-cache-db-env}
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
-<div class="bs-callout bs-callout-info" id="info">
+{:.bs-callout .bs-callout-info #info}
 <span class="glyphicon-class">
   Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
-</div>
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
@@ -156,7 +155,7 @@ Use the following steps:
 		ls <your Magento install dir>/var/cache/*
 		ls <your Magento install dir>/var/page_cache/*
 
-    {:.bs-callout .bs-callout-info}
+    {:.bs-callout .bs-callout-info #info}
     <span class="glyphicon-class">
     Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
     If you use the `default` cache frontend, you don't have this issue.</span>

--- a/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -13,7 +13,6 @@ redirect_from:
   -  /guides/v2.2/config-guide/database/database.html
 ---
 
-## Overview of database caching {#mage-cache-db-over}
 This topic discusses how to use the Magento 2 database for caching. After you complete these tasks, cached objects are stored in the `cache` and `cache_tag` Magento 2 database tables. Nothing is stored `var/cache` or `var/page_cache`.
 
 This topic discusses how to set up database caching and how to verify database caching is working. We discuss the following options:
@@ -21,10 +20,9 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using the `default` cache frontend, in which case you modify `di.xml` only.
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
-<div class="bs-callout bs-callout-warning">
-Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use [Varnish] in production instead.
+{:.bs-callout .bs-callout-info}
+Database caching&mdash;like file-based caching&mdash; works well in a development environment but we _strongly recommend_ you use [Varnish] in production instead.
 Varnish is designed to accelerate the HTTP protocol.
-</div>
 
 ## Prerequisites {#mage-cache-db-prereq}
 Before you continue, if you're using your own frontend cache, make sure you [associate cache frontends with cache types]. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
@@ -69,6 +67,7 @@ To modify `di.xml`:
 
 4.	Replace the entire block with the following:
 
+    ```xml
 		<type name="Magento\Framework\App\Cache\Frontend\Pool">
         	<arguments>
             	<argument name="frontendSettings" xsi:type="array">
@@ -88,6 +87,7 @@ To modify `di.xml`:
          	   </argument>
         	</arguments>
     	</type>
+      ```
 
     where `<your cache id>` is your unique cache identifier.
 
@@ -144,7 +144,9 @@ Use the following steps:
 1.	If you haven't done so already, log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Clear the current cache directories:
 
+    ```bash
 		rm -rf <your Magento install dir>/var/cache/* <your Magento install dir>/var/page_cache/* <your Magento install dir>/generated/metadata/* <your Magento install dir>/generated/code/*
+    ```
 
 3.	In a web browser, go to any cacheable page (such as the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %} front door page).
 
@@ -154,11 +156,11 @@ Use the following steps:
 		ls <your Magento install dir>/var/cache/*
 		ls <your Magento install dir>/var/page_cache/*
 
-    <div class="bs-callout bs-callout-info" id="info">
-      <span class="glyphicon-class">
-      Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
-      If you use the `default` cache frontend, you don't have this issue.</span>
-    </div>
+    {:.bs-callout .bs-callout-info}
+    <span class="glyphicon-class">
+    Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
+    If you use the `default` cache frontend, you don't have this issue.</span>
+
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
 4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
 

--- a/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -99,8 +99,7 @@ To modify `di.xml`:
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
 {:.bs-callout .bs-callout-info #info}
-<span class="glyphicon-class">
-  Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
+Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
@@ -156,9 +155,8 @@ Use the following steps:
 		ls <your Magento install dir>/var/page_cache/*
 
     {:.bs-callout .bs-callout-info #info}
-    <span class="glyphicon-class">
     Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
-    If you use the `default` cache frontend, you don't have this issue.</span>
+    If you use the `default` cache frontend, you don't have this issue.
 
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
 4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -1,7 +1,7 @@
 ---
 group: extension-dev-guide
 title: Create custom cache engines
-version: 2.3
+version: 2.0
 github_link: extension-dev-guide/cache/partial-caching/database-caching.md
 redirect_from:
   -  /guides/v2.0/config-guide/database/database.html
@@ -22,10 +22,9 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using the `default` cache frontend, in which case you modify `di.xml` only.
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
-<div class="bs-callout bs-callout-warning">
-Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use [Varnish] in production instead.
+{:.bs-callout .bs-callout-info}
+Database caching&mdash;like file-based caching&mdash; works well in a development environment but we _strongly recommend_ you use [Varnish] in production instead.
 Varnish is designed to accelerate the HTTP protocol.
-</div>
 
 ## Prerequisites {#mage-cache-db-prereq}
 Before you continue, if you're using your own frontend cache, make sure you [associate cache frontends with cache types]. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
@@ -70,6 +69,7 @@ To modify `di.xml`:
 
 4.	Replace the entire block with the following:
 
+    ```xml
 		<type name="Magento\Framework\App\Cache\Frontend\Pool">
         	<arguments>
             	<argument name="frontendSettings" xsi:type="array">
@@ -89,6 +89,7 @@ To modify `di.xml`:
          	   </argument>
         	</arguments>
     	</type>
+      ```
 
     where `<your cache id>` is your unique cache identifier.
 
@@ -145,7 +146,9 @@ Use the following steps:
 1.	If you haven't done so already, log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Clear the current cache directories:
 
+    ```bash
 		rm -rf <your Magento install dir>/var/cache/* <your Magento install dir>/var/page_cache/* <your Magento install dir>/generated/metadata/* <your Magento install dir>/generated/code/*
+    ```
 
 3.	In a web browser, go to any cacheable page (such as the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %} front door page).
 
@@ -155,11 +158,11 @@ Use the following steps:
 		ls <your Magento install dir>/var/cache/*
 		ls <your Magento install dir>/var/page_cache/*
 
-    <div class="bs-callout bs-callout-info" id="info">
-      <span class="glyphicon-class">
-      Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
-      If you use the `default` cache frontend, you don't have this issue.</span>
-    </div>
+    {:.bs-callout .bs-callout-info}
+    <span class="glyphicon-class">
+    Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
+    If you use the `default` cache frontend, you don't have this issue.</span>
+
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
 4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
 

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -22,7 +22,7 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using the `default` cache frontend, in which case you modify `di.xml` only.
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
-{:.bs-callout .bs-callout-info}
+{:.bs-callout .bs-callout-warning}
 Database caching&mdash;like file-based caching&mdash; works well in a development environment but we _strongly recommend_ you use [Varnish] in production instead.
 Varnish is designed to accelerate the HTTP protocol.
 
@@ -100,10 +100,9 @@ To modify `di.xml`:
 ## Database caching using a custom cache frontend {#mage-cache-db-env}
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
-<div class="bs-callout bs-callout-info" id="info">
+{:.bs-callout .bs-callout-info #info}
 <span class="glyphicon-class">
   Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
-</div>
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
@@ -158,7 +157,7 @@ Use the following steps:
 		ls <your Magento install dir>/var/cache/*
 		ls <your Magento install dir>/var/page_cache/*
 
-    {:.bs-callout .bs-callout-info}
+    {:.bs-callout .bs-callout-info #info}
     <span class="glyphicon-class">
     Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
     If you use the `default` cache frontend, you don't have this issue.</span>

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -101,8 +101,7 @@ To modify `di.xml`:
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
 {:.bs-callout .bs-callout-info #info}
-<span class="glyphicon-class">
-  Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
+Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
@@ -158,9 +157,8 @@ Use the following steps:
 		ls <your Magento install dir>/var/page_cache/*
 
     {:.bs-callout .bs-callout-info #info}
-    <span class="glyphicon-class">
     Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
-    If you use the `default` cache frontend, you don't have this issue.</span>
+    If you use the `default` cache frontend, you don't have this issue.
 
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
 4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -1,11 +1,7 @@
 ---
 group: extension-dev-guide
-subgroup: 08_Partial caching
 title: Create custom cache engines
-menu_title: Create custom cache engines
-menu_order: 9
-menu_node:
-version: 2.2
+version: 2.3
 github_link: extension-dev-guide/cache/partial-caching/database-caching.md
 redirect_from:
   -  /guides/v2.0/config-guide/database/database.html
@@ -18,7 +14,7 @@ redirect_from:
   -  /guides/v2.3/config-guide/cache/caching-database.html
 ---
 
-<h2 id="mage-cache-db-over">Overview of database caching</h2>
+## Overview of database caching {#mage-cache-db-over}
 This topic discusses how to use the Magento 2 database for caching. After you complete these tasks, cached objects are stored in the `cache` and `cache_tag` Magento 2 database tables. Nothing is stored `var/cache` or `var/page_cache`.
 
 This topic discusses how to set up database caching and how to verify database caching is working. We discuss the following options:
@@ -27,21 +23,21 @@ This topic discusses how to set up database caching and how to verify database c
 *	Using a custom {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} frontend, in which case you modify `env.php` only.
 
 <div class="bs-callout bs-callout-warning">
-    <p>Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use <a href="{{ page.baseurl }}/config-guide/varnish/config-varnish.html">Varnish</a> in production instead.</p>
-    <p>Varnish is designed to accelerate the HTTP protocol.</p>
+Database caching&mdash;like file-based caching&mdash; works well in a development environment but we <em>strongly recommend</em> you use [Varnish] in production instead.
+Varnish is designed to accelerate the HTTP protocol.
 </div>
 
-<h2 id="mage-cache-db-prereq">Prerequisites</h2>
-Before you continue, if you're using your own frontend cache, make sure you <a href="{{ page.baseurl }}/config-guide/config/caching_frontend-cache-types.html">associate cache frontends with cache types</a>. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
+## Prerequisites {#mage-cache-db-prereq}
+Before you continue, if you're using your own frontend cache, make sure you [associate cache frontends with cache types]. If you're using the `default` {% glossarytooltip b00459e5-a793-44dd-98d5-852ab33fc344 %}frontend{% endglossarytooltip %} cache, you don't have to do that.
 
-We provide <a href="#mage-cache-db-config">sample configurations</a> at the end of this topic.
+We provide [sample configurations] at the end of this topic.
 
-<h2 id="mage-cache-db-di">Database caching using the <code>default</code> cache frontend</h2>
+## Database caching using the `default` cache frontend {#mage-cache-db-di}
 To enable database caching using the `default` frontend, you must modify `<your Magento install dir>/app/etc/di.xml`, which is the global deployment injection configuration for the Magento application.
 
 To modify `di.xml`:
 
-1.	Log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `di.xml`:
 
 		cd <your Magento install dir>/app/etc
@@ -98,19 +94,19 @@ To modify `di.xml`:
 
 5.	Save your changes to `di.xml` and exit the text editor.
 
-7.	Continue with <a href="#mage-cache-db-verify">Verify database caching is working</a>.
+7.	Continue with [Verify database caching is working].
 
-<h2 id="mage-cache-db-env">Database caching using a custom cache frontend</h2>
+## Database caching using a custom cache frontend {#mage-cache-db-env}
 This section discusses how to set up database caching with a custom {% glossarytooltip ca5ad9ac-9d39-45b5-80b1-e90d192f20d0 %}cache frontend{% endglossarytooltip %}.
 
 <div class="bs-callout bs-callout-info" id="info">
 <span class="glyphicon-class">
-  <p>Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</p></span>
+  Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</span>
 </div>
 
 To enable database caching using a custom cache frontend, you must modify `<your Magento install dir>/app/etc/env.php` as follows:
 
-1.	Log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `env.php`:
 
 		cd <your Magento install dir>/app/etc
@@ -136,24 +132,24 @@ To enable database caching using a custom cache frontend, you must modify `<your
 		    ],
 		],
 
-	An example is shown in <a href="#mage-cache-db-config">Configuration examples</a>.
+	An example is shown in [Configuration examples].
 
 4.	Save your changes to `env.php` and exit the text editor.
 5.	Continue with the next section.
 
-<h2 id="mage-cache-db-verify">Verify database caching is working</h2>
+## Verify database caching is working {#mage-cache-db-verify}
 To verify database caching is working, clear the current cache directories, go to any cacheable page in a web browser, and verify that data is written to the database and not to the file system.
 
 Use the following steps:
 
-1.	If you haven't done so already, log in to the Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
+1.	If you haven't done so already, log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Clear the current cache directories:
 
 		rm -rf <your Magento install dir>/var/cache/* <your Magento install dir>/var/page_cache/* <your Magento install dir>/generated/metadata/* <your Magento install dir>/generated/code/*
 
 3.	In a web browser, go to any cacheable page (such as the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %} front door page).
 
-	If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#change-to-developer-mode">enable developer mode</a>.)
+	If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must [enable developer mode].)
 4.	Enter the following commands:
 
 		ls <your Magento install dir>/var/cache/*
@@ -161,27 +157,28 @@ Use the following steps:
 
     <div class="bs-callout bs-callout-info" id="info">
       <span class="glyphicon-class">
-      <p>Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.</p>
-      <p>If you use the <code>default</code> cache frontend, you don't have this issue.</p></span>
+      Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
+      If you use the `default` cache frontend, you don't have this issue.</span>
     </div>
 3.	Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
-4.	Use a database tool such as <a href="{{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin">phpMyAdmin</a> to verify there is data in the `cache` and `cache_tag` tables.
+4.	Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
 
 	The following figures show examples. The important thing is that there are rows in the tables. *The data in your tables will be different than the following*.
 
 	`cache` table example.
 
-	<img src="{{ site.baseurl }}/common/images/config-db_cache-table.png" alt="Sample contents of the cache table with database caching enabled">
+	![Sample contents of the cache table with database caching enabled]
 
 	`cache_tag` table example.
 
-	<img src="{{ site.baseurl }}/common/images/config-db_cache-tag-table.png" alt="Sample contents of the cache tag table with database caching enabled">
+	![Sample contents of the cache tag table with database caching enabled]
 
 
-<h2 id="mage-cache-db-config">Configuration examples</h2>
+## Configuration examples {#mage-cache-db-config}
 This section contains code sample snippets to refer to when configuring database caching.
 
-<h3 id="mage-cache-db-config-default">Sample <code>di.xml</code> for the default cache frontend</h3>
+### Sample `di.xml` for the default cache frontend {#mage-cache-db-config-default}
+
 `di.xml` snippet:
 
 ``` xml
@@ -206,7 +203,7 @@ This section contains code sample snippets to refer to when configuring database
 </type>
 ```
 
-<h3 id="mage-cache-db-config-custom">Sample <code>env.php</code> for a custom cache frontend</h3>
+### Sample `env.php` for a custom cache frontend {#mage-cache-db-config-custom}
 `env.php` snippet that enables all cache types with a custom frontend named `magento_cache`:
 
 {% highlight php startinline=true %}
@@ -259,3 +256,17 @@ This section contains code sample snippets to refer to when configuring database
       ],
   ],
 {% endhighlight %}
+
+<!-- Link references -->
+[Varnish]: {{ page.baseurl }}/config-guide/varnish/config-varnish.html
+[associate cache frontends with cache types]: {{ page.baseurl }}/config-guide/config/caching_frontend-cache-types.html
+[sample configurations]: #mage-cache-db-config
+[Magento file system owner]: {{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html
+[Verify database caching is working]: #mage-cache-db-verify
+[Configuration examples]: #mage-cache-db-config
+[enable developer mode]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#change-to-developer-mode
+[phpMyAdmin]: {{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin
+
+<!-- Image references -->
+[Sample contents of the cache table with database caching enabled]: {{ site.baseurl }}/common/images/config-db_cache-table.png
+[Sample contents of the cache tag table with database caching enabled]: {{ site.baseurl }}/common/images/config-db_cache-tag-table.png


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary
Convert HTML to markdown for 2.2 and 2.1 on the database caching page

When this pull request is merged, it will...
Make the source code easier to read

<!-- (REQUIRED) What does this PR change? -->
Replaces some HTML tags with markdown equivalent