### PR TITLE
Fixed incorrect reference to ece-tools db:dump command

### DIFF
--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -53,7 +53,7 @@ Cloud configuration:
 
 -  <!-- MAGECLOUD-2034 -->Fixed an issue when using SCD with multiple locales, which generated the same `js-translation.json` file for each locale.
 
-- <!-- MAGECLOUD-2033  -->Optimized the `support:db:dump` command to avoid locking tables and increase speed.
+- <!-- MAGECLOUD-2033  -->Optimized the `db:dump` command in the `ece-tools` package to avoid locking tables and increase speed.
 
 ## v2002.0.11
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -50,7 +50,7 @@ to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain
 
 -  <!-- MAGECLOUD-2034 -->Fixed an issue when using SCD with multiple locales, which generated the same `js-translation.json` file for each locale.
 
-- <!-- MAGECLOUD-2033  -->Optimized the `support:db:dump` command to avoid locking tables and increase speed.
+- <!-- MAGECLOUD-2033  -->Optimized the `db:dump` command in the `ece-tools` package to avoid locking tables and increase speed.
 
 ## v2002.0.11
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Fixed an incorrect reference to the ece-tools `db:dump` command in the _Magento Cloud Release Notes_.