### PR TITLE
Fix Magento logo under Swagger Rest APIs title

### DIFF
--- a/swagger/css/screen.css
+++ b/swagger/css/screen.css
@@ -1227,7 +1227,7 @@
   font-weight: bold;
   text-decoration: none;
   background: transparent url(../images/magento_32.png) no-repeat left center;
-  padding: 20px 0 20px 40px;
+  padding: 12px 0 12px 80px;
   color: white;
 }
 .swagger-section #header form#api_selector {


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

This PR will fix the Magento logo position under swagger doc.

**The issue**: the Rest APIs title is overlapping the Magento logo
![image](https://user-images.githubusercontent.com/2963928/43296828-22d104a4-9124-11e8-8596-b98547fd8fb1.png)

**Solution**: adjust padding to fit background logo with page title.
![image](https://user-images.githubusercontent.com/2963928/43296840-32199e44-9124-11e8-8174-7ed3917b1084.png)

