### PR TITLE
Add information for 2FA on contributor and partner accounts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you write and contribute a full topic, we will add your name (or your company
 
 ## Get started
 
-* Make sure you have a [GitHub account](https://github.com/signup/free). We recommend adding [Two-Factor Authentication](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#two-factor) to your account. Partners are required to add 2FA protection when contributing to Magento respositories.
+* Make sure you have a [GitHub account](https://github.com/signup/free). We recommend adding [Two-Factor Authentication](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#two-factor)(2FA) to your account. Partners are required to add 2FA protection when contributing to Magento respositories.
 * Make sure you sign the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca).
 * Check the [guidelines](#contribution-guidelines).
 * [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [DevDocs repository](GitHub.com/magento/devdocs). [Sync](https://help.github.com/articles/syncing-a-fork/) as needed.
@@ -25,7 +25,7 @@ If you write and contribute a full topic, we will add your name (or your company
 
 **Note:** If you have not signed the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca), the PR will provide a link to complete. All contributors are required to submit the form and agree to the terms to complete it.
 
-**Tip:** If you are not sure where to start contributing, check out our GitHub issues labeled [help wanted](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [good first issue](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+**Tip![:]()** If you are not sure where to start contributing, check out our GitHub issues labeled [help wanted](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [good first issue](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## Contribution guidelines
 We use [Markdown](http://daringfireball.net/projects/markdown/) to write our documentation, which is a simple markup language that we convert to HTML using [Kramdown](http://kramdown.gettalong.org/syntax.html).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you write and contribute a full topic, we will add your name (or your company
 
 ## Get started
 
-* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Make sure you have a [GitHub account](https://github.com/signup/free). We recommend adding [Two-Factor Authentication](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#two-factor) to your account. Partners are required to add 2FA protection when contributing to Magento respositories.
 * Make sure you sign the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca).
 * Check the [guidelines](#contribution-guidelines).
 * [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [DevDocs repository](GitHub.com/magento/devdocs). [Sync](https://help.github.com/articles/syncing-a-fork/) as needed.
@@ -25,7 +25,7 @@ If you write and contribute a full topic, we will add your name (or your company
 
 **Note:** If you have not signed the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca), the PR will provide a link to complete. All contributors are required to submit the form and agree to the terms to complete it.
 
-**TIP:** If you are not sure where to start contributing, check out our GitHub issues labeled [help wanted](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [good first issue](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+**Tip:** If you are not sure where to start contributing, check out our GitHub issues labeled [help wanted](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [good first issue](https://github.com/magento/devdocs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## Contribution guidelines
 We use [Markdown](http://daringfireball.net/projects/markdown/) to write our documentation, which is a simple markup language that we convert to HTML using [Kramdown](http://kramdown.gettalong.org/syntax.html).

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -42,9 +42,9 @@ Often when the Community Engineering Team works on reviewing the suggested chang
 
 When setting up access and tokens for Magento GitHub repositories, we recommend adding Two-Factor Authentication (2FA) to enhance security. Magento **requires all Partners** who contribute code to enable Two-Factor Authentication (2FA) on their accounts. You can use a mobile device or 2FA application for added protection.
 
-Two-factor authentication adds an additional layer of security beyond just a username/password when you access GitHub. With 2FA enabled, you log into a service with your credentials then complete an additional step providing a 2FA code. This second form of authentication helps us ensure that a malicious user will not be able to gain access to your GitHub account or any private Magento GitHub repositories.
+2FA adds an additional layer of security beyond just a username/password when you access GitHub. With 2FA enabled, you log into a service with your credentials then complete an additional step providing a 2FA code. This second form of authentication helps us ensure that a malicious user will not be able to gain access to your GitHub account or any private Magento GitHub repositories.
 
-For details, see [this GitHub guide](https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) to protect your account with 2FA.
+For details, see [Configuring Two-Factor Authentication via a mobile app guide](https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) to add 2FA protection to your GitHub account.
 
 ## Questions or enhancement requests? {#question}
 

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -44,7 +44,7 @@ When setting up access and tokens for Magento GitHub repositories, we recommend 
 
 Two-factor authentication adds an additional layer of security beyond just a username/password when you access GitHub. With 2FA enabled, you log into a service with your credentials then complete an additional step providing a 2FA code. This second form of authentication helps us ensure that a malicious user will not be able to gain access to your GitHub account or any private Magento GitHub repositories.
 
-For details, see [this GitHub guide](https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) to protecting your account with 2FA.
+For details, see [this GitHub guide](https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) to protect your account with 2FA.
 
 ## Questions or enhancement requests? {#question}
 

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -38,6 +38,14 @@ Often when the Community Engineering Team works on reviewing the suggested chang
 <p>Please refer to <a href="http://www.magento.com/legaldocuments/mca">Magento Contributor Agreement</a> for detailed information about the License Agreement. All contributors are required to submit a click-through form to agree to the terms. </p>
 </div>
 
+## GitHub and Two-Factor Authentication {#two-factor}
+
+When setting up access and tokens for Magento GitHub repositories, we recommend adding Two-Factor Authentication (2FA) to enhance security. Magento **requires all Partners** who contribute code to enable Two-Factor Authentication (2FA) on their accounts. You can use a mobile device or 2FA application for added protection.
+
+Two-factor authentication adds an additional layer of security beyond just a username/password when you access GitHub. With 2FA enabled, you log into a service with your credentials then complete an additional step providing a 2FA code. This second form of authentication helps us ensure that a malicious user will not be able to gain access to your GitHub account or any private Magento GitHub repositories.
+
+For details, see [this GitHub guide](https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/) to protecting your account with 2FA.
+
 ## Questions or enhancement requests? {#question}
 
 We use this repository (the Magento 2 GitHub repository) to capture code and documentation issues. We recommend that you post all questions to a question-and-answer site, such as [Stack Exchange](https://magento.stackexchange.com/){:target="\_blank"} and the [Magento Forums](https://community.magento.com/){:target="\_blank"}, where Magento community members can quickly provide recommendations and advice.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Adds 2FA requirements and content to 
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html
https://github.com/magento/devdocs/blob/develop/.github/CONTRIBUTING.md

For GitHub ticket:  https://github.com/magento/devdocs/issues/2645


whatsnew
Added information for Two-Factor Authentication for contributors in [Code Contributions](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html) and the [Contributing](https://github.com/magento/devdocs/blob/develop/.github/CONTRIBUTING.md)