### PR TITLE
Bring back system-specific settings example list.

### DIFF
--- a/guides/v2.1/config-guide/config/config-php.md
+++ b/guides/v2.1/config-guide/config/config-php.md
@@ -32,11 +32,11 @@ Magento's deployment configuration consists of the shared and system-specific co
 	*	i18n TBD	
 	*	Cache storage settings	
 	*	Session storage settings	
-	*	[x-frame-options]({{ page.baseurl }}config-guide/secy/secy-xframe.html) setting	
+	*	[x-frame-options]({{ page.baseurl }}/config-guide/secy/secy-xframe.html) setting	
 	*	Enabled cache types	
 	*	Your encryption key	
 	*	Web routing parameters (base URLs, Magento Admin URI)	
-	*	[Magento mode]({{ page.baseurl }}config-guide/bootstrap/magento-modes.html)	
+	*	[Magento mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html)	
 	*	Magento installation date	
 	*	System-specific and sensitive configuration settings TBD
 
@@ -54,7 +54,7 @@ Unlike other [module configuration files]({{ page.baseurl }}/config-guide/config
 
 On the top level of this array are *configuration segments*. A segment has arbitrary content (a scalar value or a nested array) distinguished by an arbitrary key&mdash;where both the key and its value are defined by the Magento framework.
 
-<a href="{{ site.mage2000url }}lib/internal/Magento/Framework/App/DeploymentConfig.php" target="_blank">Magento\Framework\App\DeploymentConfig</a> merely provides access to these sections but does not allow you to extend them.
+<a href="{{ site.mage2000url }}/lib/internal/Magento/Framework/App/DeploymentConfig.php" target="_blank">Magento\Framework\App\DeploymentConfig</a> merely provides access to these sections but does not allow you to extend them.
 
 On the next hierarchy level, items in each segment are ordered according to the {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} sequence definition, which is obtained by merging all modules' configuration files, with the {% glossarytooltip 53da11f1-d0b8-4a7e-b078-1e099462b409 %}exception{% endglossarytooltip %} of disabled modules.
 

--- a/guides/v2.1/config-guide/config/config-php.md
+++ b/guides/v2.1/config-guide/config/config-php.md
@@ -28,6 +28,18 @@ Magento's deployment configuration consists of the shared and system-specific co
 	`config.php` contains the list of installed modules, themes, and language packages; and shared configuration settings
 *	`<Magento base dir>/app/etc/env.php`, which contains system-specific settings, such as:
 
+	*	Database credentials and connection settings	
+	*	i18n TBD	
+	*	Cache storage settings	
+	*	Session storage settings	
+	*	[x-frame-options]({{ page.baseurl }}config-guide/secy/secy-xframe.html) setting	
+	*	Enabled cache types	
+	*	Your encryption key	
+	*	Web routing parameters (base URLs, Magento Admin URI)	
+	*	[Magento mode]({{ page.baseurl }}config-guide/bootstrap/magento-modes.html)	
+	*	Magento installation date	
+	*	System-specific and sensitive configuration settings TBD
+
 Together, `config.php` and `env.php` are referred to as Magento's _deployment configuration_ because they are created during installation and are required to start Magento.
 
 <div class="bs-callout bs-callout-info" id="info" markdown="1">


### PR DESCRIPTION
Bring back  system-specific settings example list forgotten in https://github.com/magento/devdocs/commit/5bb696e3fbc1d7e37969b6707e4da378814bf3d7?diff=split#diff-49c614339e5cf6d567471feebd9a610eL10

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will have example list with system-specific settings.