### PR TITLE
GH2104 - cli enable disable commands for profiler

### DIFF
--- a/guides/v2.1/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-profiler.md
@@ -5,9 +5,8 @@ title: Enable profiling (MAGE_PROFILER)
 menu_title: Enable profiling (MAGE_PROFILER)
 menu_order: 7
 menu_node:
-version: 2.1
+version: 2.2
 github_link: config-guide/bootstrap/mage-profiler.md
-redirect_from: /guides/v1.0/config-guide/bootstrap/mage-profiler.html
 functional_areas:
   - Configuration
   - System
@@ -26,7 +25,12 @@ Magento profiling enables you to:
 
 Magento provides the base functionality in [Magento\\Framework\\Profiler]({{ site.mage2000url }}lib/internal/Magento/Framework/Profiler.php){:target="&#95;blank"}.
 
-## Set MAGE_PROFILER
+You can enable and configure the profiler using a [MAGE_PROFILER](#variable) variable or the [command line](#cli).
+
+## Set MAGE_PROFILER {#variable}
+
+You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html).
+
 `MAGE_PROFILER` supports the following values:
 
 -   `1` to enable a specific profiler's output.
@@ -42,4 +46,28 @@ Magento provides the base functionality in [Magento\\Framework\\Profiler]({{ sit
 
 	![]({{ site.baseurl }}/common/images/config_depend-graphs.png)
 
-You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html).
+## CLI commands {#cli}
+
+You can enable or disable the profiler using CLI commands:
+
+-   `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
+-   `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
+
+To enable or diable the profiler:
+
+1. Use a terminal application to access your Magento instance.
+1. Log in to the Magento server as, or switch to, a user who has permissions to write to the Magento file system.
+1. Navigate to the root directory of your Magento 2 installation.
+1. Enter `php bin/magento` with one of the commands to configure the profiler:
+
+  To enable the profiler and create a flagfile:
+
+  ```bash
+  php bin/magento dev:profiler:enable
+  ```
+
+  To disable the profiler and remove the flagfile:
+
+  ```bash
+  php bin/magento dev:profiler:disable
+  ```

--- a/guides/v2.1/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-profiler.md
@@ -18,9 +18,9 @@ Magento profiling enables you to:
 
 -   Enable a built-in profiler.
 
-	You can use a built-in profiler with Magento to perform tasks such as analyzing performance. (The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML.)
+	You can use a built-in profiler with Magento to perform tasks such as analyzing performance. The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML.
 
--   Displays dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
+-   Display dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
 
 	You should be particularly interested in the list of *unused dependencies*, which are objects that were created because they were requested in some constructor, but were never used (that is, none of their methods were called). As a result, processor time and memory spent to create these dependencies are wasted.
 

--- a/guides/v2.1/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.1/config-guide/bootstrap/mage-profiler.md
@@ -5,8 +5,9 @@ title: Enable profiling (MAGE_PROFILER)
 menu_title: Enable profiling (MAGE_PROFILER)
 menu_order: 7
 menu_node:
-version: 2.2
+version: 2.1
 github_link: config-guide/bootstrap/mage-profiler.md
+redirect_from: /guides/v1.0/config-guide/bootstrap/mage-profiler.html
 functional_areas:
   - Configuration
   - System
@@ -25,11 +26,7 @@ Magento profiling enables you to:
 
 Magento provides the base functionality in [Magento\\Framework\\Profiler]({{ site.mage2000url }}lib/internal/Magento/Framework/Profiler.php){:target="&#95;blank"}.
 
-You can enable and configure the profiler using a [MAGE_PROFILER](#variable) variable or the [command line](#cli).
-
 ## Set MAGE_PROFILER {#variable}
-
-You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html).
 
 `MAGE_PROFILER` supports the following values:
 
@@ -46,28 +43,4 @@ You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set th
 
 	![]({{ site.baseurl }}/common/images/config_depend-graphs.png)
 
-## CLI commands {#cli}
-
-You can enable or disable the profiler using CLI commands:
-
--   `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
--   `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
-
-To enable or diable the profiler:
-
-1. Use a terminal application to access your Magento instance.
-1. Log in to the Magento server as, or switch to, a user who has permissions to write to the Magento file system.
-1. Navigate to the root directory of your Magento 2 installation.
-1. Enter `php bin/magento` with one of the commands to configure the profiler:
-
-  To enable the profiler and create a flagfile:
-
-  ```bash
-  php bin/magento dev:profiler:enable
-  ```
-
-  To disable the profiler and remove the flagfile:
-
-  ```bash
-  php bin/magento dev:profiler:disable
-  ```
+You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html).

--- a/guides/v2.2/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-profiler.md
@@ -1,1 +1,73 @@
-../../../v2.1/config-guide/bootstrap/mage-profiler.md
+---
+group: config-guide
+subgroup: 03_Bootstrap
+title: Enable profiling (MAGE_PROFILER)
+menu_title: Enable profiling (MAGE_PROFILER)
+menu_order: 7
+menu_node:
+version: 2.2
+github_link: config-guide/bootstrap/mage-profiler.md
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+Magento profiling enables you to:
+
+-   Enable a built-in profiler.
+
+	You can use a built-in profiler with Magento to perform tasks such as analyzing performance. (The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML.)
+
+-   Displays dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
+
+	You should be particularly interested in the list of *unused dependencies*, which are objects that were created because they were requested in some constructor, but were never used (that is, none of their methods were called). As a result, processor time and memory spent to create these dependencies are wasted.
+
+Magento provides the base functionality in [Magento\\Framework\\Profiler]({{ site.mage2000url }}lib/internal/Magento/Framework/Profiler.php){:target="&#95;blank"}.
+
+You can enable and configure the profiler using a [MAGE_PROFILER](#variable) variable or the [command line](#cli).
+
+## Set MAGE_PROFILER {#variable}
+
+You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html).
+
+`MAGE_PROFILER` supports the following values:
+
+-   `1` to enable a specific profiler's output.
+
+	You can also use one of the following values to enable a specific profiler:
+
+    - `csvfile` which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Csvfile]({{ site.mage2000url }}lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Csvfile.php){:target="&#95;blank"}
+    - Any other value (except `2`), including an empty value, which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Html]({{ site.mage2000url }}lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Html.php){:target="&#95;blank"}
+
+-   `2` to enable dependency graphs.
+
+	Dependency graphs typically display at the bottom of a page. The following figure shows portion of the output:
+
+	![]({{ site.baseurl }}/common/images/config_depend-graphs.png)
+
+## CLI commands {#cli}
+
+You can enable or disable the profiler using CLI commands:
+
+-   `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
+-   `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
+
+To enable or diable the profiler:
+
+1. Use a terminal application to access your Magento instance.
+1. Log in to the Magento server as, or switch to, a user who has permissions to write to the Magento file system.
+1. Navigate to the root directory of your Magento 2 installation.
+1. Enter `php bin/magento` with one of the commands to configure the profiler:
+
+  To enable the profiler and create a flagfile:
+
+  ```bash
+  php bin/magento dev:profiler:enable
+  ```
+
+  To disable the profiler and remove the flagfile:
+
+  ```bash
+  php bin/magento dev:profiler:disable
+  ```

--- a/guides/v2.2/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-profiler.md
@@ -1,10 +1,6 @@
 ---
 group: config-guide
-subgroup: 03_Bootstrap
 title: Enable profiling (MAGE_PROFILER)
-menu_title: Enable profiling (MAGE_PROFILER)
-menu_order: 7
-menu_node:
 version: 2.2
 github_link: config-guide/bootstrap/mage-profiler.md
 functional_areas:

--- a/guides/v2.2/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-profiler.md
@@ -17,9 +17,9 @@ Magento profiling enables you to:
 
 -   Enable a built-in profiler.
 
-	You can use a built-in profiler with Magento to perform tasks such as analyzing performance. (The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML.)
+	You can use a built-in profiler with Magento to perform tasks such as analyzing performance. The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML. When you enable the profiler, a `var/profiler.flag` file generates indicating the profiler is enabled and configurations. When disabled, this file is deleted.
 
--   Displays dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
+-   Display dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
 
 	You should be particularly interested in the list of *unused dependencies*, which are objects that were created because they were requested in some constructor, but were never used (that is, none of their methods were called). As a result, processor time and memory spent to create these dependencies are wasted.
 
@@ -53,17 +53,24 @@ You can enable or disable the profiler using CLI commands:
 -   `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
 -   `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
 
-To enable or diable the profiler:
+To enable dependency graphs, use the variable option.
 
-1. Use a terminal application to access your Magento instance.
-1. Log in to the Magento server as, or switch to, a user who has permissions to write to the Magento file system.
-1. Navigate to the root directory of your Magento 2 installation.
-1. Enter `php bin/magento` with one of the commands to configure the profiler:
+To enable or disable the profiler:
 
-  To enable the profiler and create a flagfile:
+1. Log in to your Magento server.
+1. Change to your Magento installation directory.
+1. As the Magento file system owner, enter the following command to configure the profiler:
+
+  To enable the profiler using type `html` and create a flagfile:
 
   ```bash
-  php bin/magento dev:profiler:enable
+  php bin/magento dev:profiler:enable html
+  ```
+
+  To enable the profiler using type `csvfile` and create a flagfile:
+
+  ```bash
+  php bin/magento dev:profiler:enable csvfile
   ```
 
   To disable the profiler and remove the flagfile:


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Add information on CLI commands to enable and disable profiler. 
Community GH Issue: https://github.com/magento/magento2/issues/9277


## Additional information

* Adds content to https://devdocs.magento.com/guides/v2.2/config-guide/bootstrap/mage-profiler.html
* Includes CLI commands
* Added file to 2.2
* Replace symlink for 2.3 

whatsnew
Added CLI enable/disable commands for profiler in [Enable profiling (MAGE_PROFILER)](https://devdocs.magento.com/guides/v2.2/config-guide/bootstrap/mage-profiler.html) for 2.2 and 2.3