### PR TITLE
Add a prompt to checkout the correct repo branch

### DIFF
--- a/_includes/install/sampledata/sample-data-clone.md
+++ b/_includes/install/sampledata/sample-data-clone.md
@@ -54,6 +54,17 @@ To clone the Magento sample data GitHub repository using the SSH protocol:
 Permission denied (publickey).
 fatal: The remote end hung up unexpectedly</pre>
     </div>
+7.  Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
+    
+    For example:
+    
+    If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
+    
+    If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
+    
+    To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
+
+        git checkout 2.2.5
 7.  Change to the `<your Magento sample data clone dir>/dev/tools` directory.
 8.  Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
 
@@ -81,6 +92,17 @@ To clone the Magento sample data GitHub repository using the HTTPS protocol:
 
         git clone https://github.com/magento/magento2-sample-data.git
 4.  Wait for the repository to clone on your server.
+7.  Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
+    
+    For example:
+    
+    If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
+    
+    If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
+    
+    To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
+
+        git checkout 2.2.5
 5.  Change to the `<your Magento sample data clone dir>/dev/tools` directory.
 8.  Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
 


### PR DESCRIPTION
When following the existing instructions in these docs, it isn't clear that there are different branches are intended for different installed versions.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Add a step to the instructions, prompting the user to select the correct branch of the sample data repository.

## Additional information

I'm not sure if what I've written here is exactly correct, in terms of which branch/tag you should use. The `develop` and `master` branches are talked about [here](https://github.com/magento/magento2-sample-data/tree/2.2.5#deploy-sample-data-from-github-repository) in the repo's README though, so I think I'm on the right track - but there's no mention of specific versions. I noticed that there is a tag for `2.2.5` and a branch for `2.2.5-develop`. I'm unsure which is more appropriate to use in a given situation. Happy to make additions/amendments if what I've written is incomplete/not got it quite right - I'd like to understand too! :smile: