### PR TITLE
MAGEDOC-2910: Fix typo

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -101,7 +101,7 @@ The following table explains this command's parameters and values.
           default, with no option specified, is to generate files
           for all <a href=
           "http://www.loc.gov/standards/iso639-2/php/code_list.php"
-          target="\_blank">ISO-636</a> language codes. You can
+          target="\_blank">ISO-639</a> language codes. You can
           specify the name of one language code at a time.
         </p>
         <p>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will correct a typo in the reference to ISO language codes.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
