### PR TITLE
Updated release notes with additional review feedback

### DIFF
--- a/guides/v2.1/cloud/basic-information/starter-architecture.md
+++ b/guides/v2.1/cloud/basic-information/starter-architecture.md
@@ -1,47 +1,43 @@
 ---
 group: cloud
-subgroup: 010_welcome
 title: Starter architecture
-menu_title: Starter architecture
-menu_order: 20
-menu_node:
 version: 2.1
 github_link: cloud/basic-information/starter-architecture.md
 functional_areas:
   - Cloud
 ---
 
-All of your code is contained in the {{site.data.var.ece}} Starter project. The _project_ is your Magento store code, extensions, and integrations in a Master Git branch. Each project supports up to 4 total environments including three active Integration *environments* and a Production environment using the `master` Git branch.
+All of your code is contained in the {{site.data.var.ece}} Starter project. The _project_ is your Magento store code, extensions, and integrations on a `master` branch. Each project supports up to 4 total environments including up to three active Integration *environments* and a Production environment using the `master` branch.
 
-All environments are in PaaS (Platform-as-a-Service) containers. These containers are deployed inside highly restricted containers on a grid of servers. These environments are read-only, accepting deployed code changes from Git branches pushed from your local workspace.
+All environments are in PaaS (Platform-as-a-Service) containers. These containers are deployed inside highly restricted containers on a grid of servers. These environments are read-only, accepting deployed code changes from branches pushed from your local workspace.
 
 You can use any development and branching methodology you like. We strongly recommend creating a Staging environment and branch as one of the Integration environments.
-
-{:.bs-callout .bs-callout-info}
-The following architecture information uses an architecture including Production, Staging, and Integration environments.
 
 ![High-level view of Starter project]({{ site.baseurl }}/common/images/cloud_arch-starter.png)
 
 ## Production with a master branch {#cloud-arch-prod}
-The Production environment is your live store(s) and site(s). The environment includes your `master` Git branch, a web server, database, and configured services to fully test your site.
 
-The Production environment runs your public-facing Magento single and multisite storefronts. This system is read-only, requiring deployment across the architecture from Integration to Staging and finally Production.
+The Production environment is your live store(s) and site(s). The environment includes your `master` branch, a web server, database, and configured services to fully test your site.
+
+The Production environment runs your public-facing Magento single and multi-site storefronts. This system is read-only, requiring deployment across the architecture from the Integration environment to the Staging environment, and finally to the Production environment.
 
 We walk you through [deploying to Production]({{ page.baseurl }}/cloud/live/stage-prod-live.html) and [Go Live]({{ page.baseurl }}/cloud/live/live.html) requirements and processes.
 
-We highly recommend fully testing in your Staging environment and branch prior to pushing to Production.
+We highly recommend fully testing in your Staging environment and branch before pushing to the `master` branch which deploys to the Production environment.
 
 ## Staging branch and environment {#cloud-arch-stage}
-We recommend creating a branch called `staging` from `master`. Use this Staging environment and Git branch as your pre-production environment to test code, modules and extensions, payment gateways, shipping, product data, and much more. This environment will receive all services to match Production including Fastly, New Relic, Blackfire, and search.
 
-Additional sections in this guide provide instructions and walk-throughs for final code deployments and testing production level interactions in a safe Staging environment. For best performance and feature testing, replicate your Production database into Staging.
+We recommend creating a branch called `staging` from `master`. The Staging environment is created from the `staging` branch to provide a pre-production environment to test code, modules and extensions, payment gateways, shipping, product data, and much more. This environment provides the configuration for all services to match the Production environment including Fastly, New Relic, Blackfire, and search.
+
+Additional sections in this guide provide instructions and walk-throughs for final code deployments and testing production level interactions in a safe Staging environment. For best performance and feature testing, replicate your Production database into the Staging environment.
 
 We walk you through [deploying to Staging]({{ page.baseurl }}/cloud/live/stage-prod-live.html) and [testing your store(s)]({{ page.baseurl }}/cloud/live/stage-prod-test.html) requirements and processes.
 
-{: .bs-callout .bs-callout-warning}
+{:.bs-callout .bs-callout-warning}
 We highly recommend testing every merchant and customer interaction in the Staging environment prior to deploying to the Production environment. See [Deploy your store]({{ page.baseurl }}/cloud/live/stage-prod-live.html) and [Test deployment]({{ page.baseurl }}/cloud/live/stage-prod-test.html).
 
 ## Integration environment {#cloud-arch-int}
+
 Developers use the Integration environment to develop, deploy, and test:
 
 -   Magento application code
@@ -49,35 +45,38 @@ Developers use the Integration environment to develop, deploy, and test:
 -   Extensions
 -   Services
 
-You have up to **two** active environments on a grid for **two** active Git branches. Each Integration environment matches the name of the branch and includes a web server, database, and configured services to fully test your site.
+You can have up to **two** active Integration environments on a grid for **two** active branches. Each Integration environment matches the name of the branch and includes a web server, database, and configured services to fully test your site.
 
-You can have an unlimited number of inactive Git branches to store code. To access, view, and test inactive branches, you must activate them.
+You can have an unlimited number of inactive branches to store code. To access, view, and test inactive branches, you must activate them.
 
-{: .bs-callout .bs-callout-info}
-The Integration environment does not support all services. For example, the Fastly CDN and New Relic is not accessible in an Integration environment.
+{:.bs-callout .bs-callout-info}
+The Integration environment does not support all services. For example, Fastly CDN and New Relic are not accessible in an Integration environment.
 
 The process for developing in Integration requires the following process:
 
-* Branch and develop off of `staging`
+* Branch and develop off of the `staging` branch
 * Develop all work on your local workspace in these branches
 * Push code to Git to build and deploy on an Integration environment for testing
-* As work is completed, merge to `staging`
+* As work is completed, merge to the `staging` branch
 
-Additional sections in this guide provide instructions and walk-throughs for setting up your [local workspace]({{ page.baseurl }}/cloud/before/before-workspace.html), working with Git branches, and [deploying code]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
+Additional sections in this guide provide instructions and walk-throughs for setting up your [local workspace]({{ page.baseurl }}/cloud/before/before-workspace.html), working with branches, and [deploying code]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
 
 ## Production and Staging technology stack {#technology}
+
 The Production and Staging environments include the following technologies. You can modify and configure these technologies through the [.magento.app.yaml file]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html).
 
-* Fastly for http caching and CDN
+\
+* Fastly for HTTP caching and CDN
 * Nginx web server speaking to PHP-FPM, one instance with multiple workers
 * Redis server
 * Elasticsearch for searching for {{site.data.var.ece}} 2.1 and later
 * Solr search is supported for {{site.data.var.ece}} 2.0
 
 ### Services {#cloud-arch-services}
+
 {{site.data.var.ece}} currently supports the following services: PHP, MySQL (MariaDB), Solr (Magento 2.0.x), Elasticsearch (Magento 2.1.x and later), Redis, and RabbitMQ.
 
-Each service runs in its own secure container. containers are managed together in the project. Some services are built-in, such as the following:
+Each service runs in its own secure container. Containers are managed together in the project. Some services are built-in, such as the following:
 
 *	HTTP router (handling incoming requests, but also caching and redirects)
 *	PHP application server
@@ -87,12 +86,13 @@ Each service runs in its own secure container. containers are managed together i
 You can even have multiple applications running in the same project. Building a microservice oriented architecture with Magento Commerce is as easy as managing a monolithic application.
 
 ### Software versions {#cloud-arch-software}
+
 {{site.data.var.ece}} uses:
 
 *	Operating system: Debian GNU/Linux 8 (jessie)
 *	Web server: {% glossarytooltip b14ef3d8-51fd-48fe-94df-ed069afb2cdc %}nginx{% endglossarytooltip %} 1.8
 
-This software is *not* upgradable but versions for the following software is configurable:
+You cannot upgrade the operating system and web server software to a new version, but you can configure versions for the following software:
 
 * [PHP]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
 * [MySQL]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html)
@@ -101,24 +101,26 @@ This software is *not* upgradable but versions for the following software is con
 * [RabbitMQ]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
 * [Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
 
-For Staging and Production, you will use Fastly for CDN and caching. We recommend installing Fastly module 1.2.33 or later. For details, see [Fastly in Cloud]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html).
+In the Staging and Production environments, you use Fastly for CDN and caching. We recommend installing Fastly module 1.2.33 or later. See [Fastly in Cloud]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html).
 
-For detailed information on supported versions and extensions, see the following information. These files allow you to configure software versions you want to use in your implementation.
+You use the following files to configure the software versions that you want to use in your implementation.
 
 *	[`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
 *	[`routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)
 *	[`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)
 
 ### Backup and disaster recovery {#backup}
+
 You can create a snapshot of your database and file system using the Project Web Interface or the CLI. The snapshot includes your deployed code, installed software and services, and data. See [Snapshots and backup management]({{ page.baseurl }}/cloud/project/project-webint-snap.html).
 
 ## Prepare for development {#develop}
+
 To branch and develop your Magento store:
 
 * Set up your local environment
-* Clone the `master` branch from the Project to your local
+* Clone the `master` branch from the Project to your local environment
 * Create a `staging` branch from `master`
 * Create branches for development from `staging`
 * Push code to Git that builds and deploys to an environment for testing
 
-Additional sections in this guide provide instructions and walk-throughs for setting up your [local workspace]({{ page.baseurl }}/cloud/before/before-workspace.html), working with Git branches, [deploying code]({{ page.baseurl }}/cloud/live/stage-prod-live.html), and [going live]({{ page.baseurl }}/cloud/live/live.html).
+Additional sections in this guide provide instructions and walk-throughs for setting up your [local workspace]({{ page.baseurl }}/cloud/before/before-workspace.html), working with branches, [deploying code]({{ page.baseurl }}/cloud/live/stage-prod-live.html), and [going live]({{ page.baseurl }}/cloud/live/live.html).

--- a/guides/v2.1/cloud/basic-information/starter-develop-deploy-workflow.md
+++ b/guides/v2.1/cloud/basic-information/starter-develop-deploy-workflow.md
@@ -1,56 +1,29 @@
 ---
 group: cloud
-subgroup: 010_welcome
 title: Starter develop and deploy workflow
-menu_title: Starter develop and deploy workflow
-menu_order: 25
-menu_node:
 version: 2.1
 github_link: cloud/basic-information/starter-develop-deploy-workflow.md
 functional_areas:
   - Cloud
 ---
 
-Everything in {{site.data.var.ece}} is Git-driven. Your [project]({{ page.baseurl }}/cloud/project/projects.html) is a Master Git branch cloned from a Magento 2 repository. Every active Git branch has an associated full environment. Depending on your {{site.data.var.ece}} plan subscription, your deployment workflow may differ.
+The {{site.data.var.ece}} includes a single Git repository with a master branch for the Production environment that can be branched to create Staging and Integration environments for testing and development work. You can have up to four active environments, including a `master` environment for your production server. See [Starter architecture]({{ page.baseurl }}/cloud/basic-information/starter-architecture.html) for an overview.
 
-The general workflow for all development and deployment includes:
+For your environments, we recommend following a Development > Staging > Production workflow to develop and deploy your site.
 
-* Push code to the remote Git branch
-* Build and deploy processes run
-* The environments updated with code, services, and configurations
+* **Production environment (live site)**—Provides a full Production environment with all services built and deployed from the code on the `master` branch.
+* **Staging environment**—Provides a full Staging environment matching the Production environment with all services built and deployed from a `staging` branch that you create by cloning from `master`.
+* **Integration environments**—Provides up to two active development environments that you create by cloning from the `staging` branch. The Integration environment does not support third-party services like Fastly and New Relic.
 
-The Starter plan gives you four active environments, including a `master` environment for your Production server. You have the option to use the remaining three active branches any way you want.
+For your branches, you can follow any methodology. For example, you can follow an Agile methodology such as scrum to create branches for every sprint.
 
-We **recommend creating a Staging branch** for fully testing your code, extensions, integrations, and data as a near-production environment. This branch includes all services and features of your Production environment. The remaining branches you can create from `staging` and use for all development, easily merging work up through `staging` then `master`.
-
-Every active environment gives you the Magento and branch code installed and deployed, configurable services, and a database. Only the Production and Staging environments have full services including Fastly and New Relic.
-
-The following diagram details the branch and environment relationships:
-
-![High-level view of Starter project]({{ site.baseurl }}/common/images/cloud_arch-starter.png)
-
-You can manage all of your environments including Production and Staging directly through the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html), through the store and Admin panel using provided URLs, and using SSH and the [Magento Cloud command-line]({{ page.baseurl }}/cloud/reference/cli-ref-topic.html).
-
-{:.bs-callout .bs-callout-info}
-The following workflow and examples use a Production, Staging, and Integration architecture.
-
-## Starter environments and branches {#env-branches}
-For your environments, we recommend deploying and testing following a Development > Staging > Production workflow.
-
-* Production environment (live site) is your `master` Git branch with an associated full environment with all services
-* Staging environment is a Git branch we recommend you create called `staging`, to receive full services matching Production
-* Integration environments include two active branches we recommend created from `staging`
-
-For your branches, you can follow any methodology. One example follows an agile methodology such as scrum to create [branches for every sprint]({{ page.baseurl }}/cloud/env/environments.html).
-
-From each sprint, you can have branches for every user story. All the stories become testable. You can continually merge to the sprint branch and validate that on a continuous basis. When the sprint ends, there is no testing bottleneck, and you can just merge to master and put the whole sprint into production.
-
-For detailed information, see [Starter architecture]({{ page.baseurl }}/cloud/basic-information/starter-architecture.html).
+From each sprint, you can create branches for every user story. All the stories become testable. You can continually merge to the sprint branch and validate that branch on a continuous basis. When the sprint ends, you can merge the sprint branch to master to deploy all sprint changes to production without having to deal with a testing bottleneck.
 
 ## Development workflow {#development}
-Development and deployment on Starter plans begin with your initial project. You create your project with the "blank site", which is a {{site.data.var.ece}} template code repo with a fully prepared store. This creates a `master` branch of Git code in your Production environment.
 
-The full process involves:
+Development and deployment on Starter plans begin with your initial project. You create your project with the "blank site", which is a {{site.data.var.ece}} template code repo with a fully prepared store. This creates a `master` branch with a copy of the code from your Production environment.
+
+The development process uses the following workflow:
 
 * [Clone and branch](#clone-branch) from Master for Staging and development branches
 * [Develop code](#dev-code) and install extensions locally in a branch
@@ -60,26 +33,27 @@ The full process involves:
 
 ![Develop and deploy workflow]({{ site.baseurl }}/common/images/cloud_workflow-starter.png)
 
-You also have a few optional steps to help develop and test your code and store data:
+You also have a few optional steps to help develop and test your code and your store data:
 
 * [Install sample data](#sample-data) to your store
 * [Pull production store data](#prod-data) down to environments
 
-This process assumes you would have your [local developer workspace]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html) set up. Feel free to read over this process even if your local isn't ready.
+This process assumes that you have set up your [local developer workspace]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html).
 
 ### Clone and branch {#clone-branch}
-When you created your project, a `master` branch was cloned using the {{site.data.var.ece}} Git repository. To start branching and working with code, you will need to clone the `master` to your local.
+
+When you created your project, you cloned the `master` branch from the {{site.data.var.ece}} Git repository. To start branching and working with code, clone the `master` to your local environment.
 
 The format of the Git clone command is:
 
     git fetch origin
     git pull origin <environment ID>
 
-The first time you start working in branches for your Starter project, you need to create a Staging branch. This sets up a Staging environment with a code branch matching the Production `master` branch and environment.
+The first time you start working in branches for your Starter project, you need to create a `staging` branch. This creates a code branch matching the `master` branch that deploys to a Staging environment to test configuration and code changes before deploying to the Production environment.
 
-Next, create branches from `staging` to develop code, add extensions, and configure 3rd party integrations. Anytime you need to develop custom code, add extensions, integrate with a 3rd party service, work in a develop branch created from `staging`. You will have four active Integration environments available. When you push your an active branch of Git code, one of these Integration environments automatically deploys your code to test.
+Next, create branches from `staging` to develop code, add extensions, and configure 3rd party integrations. Anytime you need to develop custom code, add extensions, integrate with a 3rd party service, work in a development branch created from the `staging` branch. You will have four active Integration environments available. When you push an active branch, one of these Integration environments automatically deploys your code to test.
 
-We walk you through the process when you [set up your local]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html).
+We walk you through the process when you [set up your local]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html) environment.
 
 The format of the Git branch command is:
 
@@ -93,28 +67,31 @@ The format of the Magento Cloud CLI branch command is:
 ![Branch from Master]({{ site.baseurl }}/common/images/cloud_workflow-branching.png)
 
 ### Develop code {#dev-code}
-It's the time you have been waiting for...writing code. Using this base branch of {{site.data.var.ece}} code, you can start installing extensions, developing custom code, adding themes, and much more.
+
+It's the time you have been waiting for—writing code. Using this base branch of {{site.data.var.ece}} code, you can start installing extensions, developing custom code, adding themes, and much more.
 
 We recommend using a branching strategy with your development work. Using one branch to do all of your work all at once might make testing difficult. For example, you could follow continuous integration and sprint methodologies to work:
 
 * Add a few extensions and configure them with your first branch
-* Push this code, test, and merge to Staging then Production
+* Push this code, test, and merge to `staging`, and then to `master`
 * Fully configure your services in `services.yaml` and add a theme
-* Push this code, test, and merge to Staging then Production
+* Push this code, test, and merge to`staging`, and then to `master`
 * Integrate with a 3rd party service
-* Push this code, test, and merge to Staging then Production
+* Push this code, test, and merge to `staging`, and then to `master`
 
-And so on until you have your store fully built, configured, and ready to go live. But keep reading, we have even better options for your store and code configuration!
+Repeat this workflow until your store is ready—fully built, configured, and ready to go live. But keep reading, we have even better options for your store and code configuration!
 
 {:.bs-callout .bs-callout-info}
-Do not complete any configurations on your local yet.
+Do not complete any configurations on your local workstation yet.
 
 ![Develop code and push to deploy]({{ site.baseurl }}/common/images/cloud_workflow-push-code.png)
 
 ### Configure store {#configure-store}
-When you are ready to configure your store, have all code pushed to your Integration environment and access the Magento Admin. You should fully configure all store settings in the Integration environment Admin, not on your local. If you need the URL, see the Project Web Interface. The Store Admin URL is located on the branch page.
 
-For the best information on configurations, we recommend reviewing {{site.data.var.ee}} and your extension documentation. Here are some links and ideas to help you get kickstarted:
+When you are ready to configure your store, push all your code to the Integration environment.
+Configure your store settings from the Magento Admin panel for the Integration environment, not in your local environment. You can find the URL in the Project Web Interface. The Store Admin URL is located on the branch page.
+
+For the best information on configurations, review the documentation for {{site.data.var.ee}} and the installed extensions. Here are some links and ideas to help you get kickstarted:
 
 * [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
 * [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html){:target="\_blank"} for store admin access, name, languages, currencies, branding, sites, store views and more
@@ -127,7 +104,8 @@ Beyond just store settings, you can further configure multiple sites and stores,
 Now you need to get these settings into your code. We have a helpful command to do this, keep reading.
 
 ### Generate configuration management files {#config-management}
-If you are familiar with Magento, you may be concerned about how to get your configuration settings from your database in development to Staging and Production. Previously, you had to copy down on paper or a file all of your configuration settings to enter them manually in another environment. Or you may have dumped your database and push that data to another environment.
+
+If you are familiar with Magento, you may be concerned about how to get your configuration settings from your database in development to the Staging and Production environments. Previously, you had to copy all your configuration settings down on paper or to a file, and then manually apply the settings to other environments. Or you may have dumped your database and pushed that data to another environment.
 
 {{site.data.var.ece}} provides a set of two [Configuration Management]({{ site.baseurl }}/guides/v2.1/cloud/live/sens-data-over.html) commands that export configuration settings from your environment into a file. These commands are only available for **{{site.data.var.ece}} 2.1.4 and later** (not 2.2).
 
@@ -139,60 +117,66 @@ The generated file is located in `app/etc/`:
 * For 2.1.4 and later: `config.local.php`
 * For 2.2 and later: `config.php`
 
-You will generate the file in the Integration environment where you configured Magento. We walk you through the process of generating the file, adding it to your Git branch, and deploying it.
+The generated file is `app/etc/config.php`.
+
+You generate the file in the Integration environment where you configured Magento. We walk you through the process of generating the file, adding it to your branch, and deploying it.
 
 **Important notes** on Configuration Management:
 
-* Any configuration setting included in the file is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using `scd-dump`.
+* Any configuration setting included in the file generated from the `app:config:dump` command is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using `scd-dump`.
 
-  For example, we will have you install a module for Fastly in your development environment. You will only configure this module in Staging and Production. Using `scd-dump` keeps those default fields editable.
-* This file can be long depending on the size of your deployment. The `scd-dump` command generates a far small file than `app:config:dump`.
+  For example, we will have you install a module for Fastly in your development environment. You can only configure this module in the Staging and Production environment. Using the `scd-dump` command keeps those default fields editable when you deploy your development changes to the Staging and Production environment.
+
+* The generated file can be long depending on the size of your deployment. The `scd-dump` command generates a much smaller file than the file generated by the `app:config:dump` command.
 
 ![Generate configuration management file]({{ site.baseurl }}/common/images/cloud_workflow-config-mgmt.png)
 
-An additional feature of this command is part of {{site.data.var.ece}} 2.2. Any values determined to be sensitive data, like sandbox credentials for a PayPal module, will be generated into another configuration file called `env.php` in `app/etc/`. This file remains in the exact environment it is created without traveling with your code. You will not add this file to your code repository. You can also create environment variables with CLI commands in all {{site.data.var.ece}} versions.
+If you are using {{site.data.var.ece}} version 2.2 or later, the configuration management commands provide an additional feature to protect sensitive data, like sandbox credentials for a PayPal module. During the export process, any values that contain sensitive data are exported to separate configuration file—`env.php` in the `app/etc/` directory. This file remains in your local environment and does not get copied when you push your code to another branch. You can also create environment variables with CLI commands in all {{site.data.var.ece}} versions.
 
 ![Environment variables generate]({{ site.baseurl }}/common/images/cloud_workflow-env-variables.png)
 
 For more information, see [Configuration Management]({{ site.baseurl }}/guides/v2.1/cloud/live/sens-data-over.html).
 
 ### Push code and test {#push-code}
+
 At this point, you should have a developed code branch with a configuration file (`config.local.php` or `config.php`) ready to test.
 
-Everytime you push code from your local environment, a series of build and deploy scripts run. These scripts generate new Magento code and deploy it to the remote environment. For example, if you are pushing a development branch from your local to the remote Git branch, a matching environment updates services, code, and static content.
+Every time you push code from your local environment, a series of build and deploy scripts run. These scripts generate new Magento code and deploy it to the remote environment. For example, if you are pushing a development branch from your local environment to the remote Integration branch, a matching environment updates services, code, and static content.
 
 You can directly access this environment with a store URL, Magento Admin URL, and SSH. These environments include a web server, database, and configured services. When ready, you can start deploying and testing in Staging.
 
 For more information, see [Deployment workflow](#deploy).
 
 ### Optional: Install sample data {#sample-data}
+
 If you need some example data when developing your store, you can install our sample data. This data simulates an active Magento store, including customers, products, and other data. This sample data works best with a "blank site" {{site.data.var.ece}} template installation when creating your project.
 
-We recommend installing sample data in your local installation and Integration environments. If you use this data in Staging or Production, make sure to clear out the information and products before going live.
+We recommend installing sample data in your local and Integration environments. If you use this data in the Staging or Production environment, make sure to clear out the information and products before going live.
 
 For instructions, see [Install optional sample data]({{ page.baseurl }}/cloud/howtos/sample-data.html).
 
 ![Install optional sample data]({{ site.baseurl }}/common/images/cloud_workflow-sample-data.png)
 
 ### Optional: Pull production data {#prod-data}
-We recommend adding all of your products, catalogs, site content, and so on (not configurations) directly in Production. By adding this data in Production, you immediately update prices, coupons, inventory stock, strategize your sales and future offerings, and much more for your customers. This data does not include extension configurations. You will set those in your development branch on your local.
 
-As you develop features, add extensions, and design themes, having real data to work with is helpful. At any time, you can create a database dump from Production and push that to your Staging environment, and possibly Integration environments as you like.
+We recommend adding all of your products, catalogs, site content, and so on directly to the Production environment. By adding this data to the Production environment, you can provide updated prices, coupons, inventory stock, sales announcements, information about future offerings, and much more for your customers. This data does not include extension configurations, which you configure in your local development branch.
+
+As you develop features, add extensions, and design themes, having real data to work with is helpful. At any time, you can create a database dump from the Production environment and push that to your Staging and Integration environments as needed.
 
 {% include cloud/data-collection.md %}
 
 ![Pull and sanitize production data]({{ site.baseurl }}/common/images/cloud_workflow-data-code-process.png)
 
 {:.bs-callout .bs-callout-info}
-Prior to pushing the data to another environment, you should consider sanitizing your data. You have a couple of options including [using support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html) or developing a script to scrub out customer data.
+Before pushing the data to another environment, you should consider sanitizing your data. You have a couple of options including [using support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html) or developing a script to scrub out customer data.
 
-{: .bs-callout .bs-callout-warning}
-Important: We don't recommend pushing a database from an Integration or Staging environment. This data will overwrite your Production live data including sales, orders, new and updated customers, and much more.
+We do not recommend pushing a database from an Integration or Staging environment to a Production environment. If you do, the data from the Integration or Staging environment overwrites your live Production data including sales, orders, new and updated customers, and much more.
 
 ## Deployment workflow {#deploy}
+
 As we detailed in the architecture information, {{site.data.var.ece}} is Git driven. Deploying {{site.data.var.ece}} is part of your Git push processes for branches.
 
-When you push branched code from your local to the remote Git branch, a series of build and deploy scripts begin.
+When you push branched code from your local environment to the remote branch, a series of build and deploy scripts begin.
 
 Build scripts:
 
@@ -215,23 +199,27 @@ When fully completed, your store comes back online, live, with all of your updat
 To learn more, see [Deployment process]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
 ### Push to Staging and test {#staging}
-You should always push all of your code in iterations to your Staging environment for full testing. The first time you use this environment, you will need to configure a few services including [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html), [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html), and [New Relic APM]({{ page.baseurl }}/cloud/project/new-relic.html). We also recommend configuring payment gateways, shipping, notifications, and other vital services with sandbox or testing credentials.
 
-Staging is a pre-production environment, providing all services and settings as close to Production as possible. Thoroughly test every service, verify your performance testing tools, perform UAT testing as an administrator and customers, until you feel your store is ready for Production.
+You should always push all of your code in iterations to your Staging environment for full testing. The first time you use this environment, you must configure a few services including [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html), [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html), and [New Relic APM]({{ page.baseurl }}/cloud/project/new-relic.html). We also recommend configuring payment gateways, shipping, notifications, and other vital services with sandbox or testing credentials.
+
+Staging is a pre-production environment, providing all services and settings as close to the Production environment as possible. Thoroughly test every service, verify your performance testing tools, perform UAT testing as an administrator and customers, until you feel your store is ready to be deployed to the Production environment.
 
 To learn more, see [Deploy your store]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
 
 ### Push to Master / Production {#pro}
-When you push to the `master` branch, you are pushing to Production. Treat configuration and testing of Production much as your Staging environment. The important difference in this environment is using live credentials. The moment you go live and launch, customers must be able to complete purchases and administrators should be able to manage your live store.
+
+When you push to the `master` branch, you are pushing to the Production environment. Complete configuration and testing activities in the Production environment like you did in the Staging environment with one important difference. In the Production environment use live credentials for during configuration and testing. The moment you go live and launch, customers must be able to complete purchases and administrators should be able to manage your live store.
 
 To learn more, see [Deploy your store]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
 
 ### Go live {#go-live}
-We provide a clear walk-through for going live and launching. It requires more steps than pressing a button. But when complete, your store can serve up products in your customized theme for sale immediately.
+
+We provide a clear walk-through for going live and launching, which requires more steps than pressing a button. After you complete these steps, your store can serve up products in your customized theme for sale immediately.
 
 To learn more, check out [Go live and launch]({{ page.baseurl }}/cloud/live/live.html).
 
 ## Continuous integration {#continuous-integration}
+
 Following your branching and development methodologies, you can easily develop new features, configure changes, and add extensions to continuously develop and deploy updates.
 
 {{site.data.var.ece}} environments support continuous integration for constant updates. This workflow supports releases multiple times a day or on a set schedule according to your business needs.

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -7,7 +7,7 @@ functional_areas:
   - Cloud
   - Configuration
 ---
-The following _deploy_ variables control actions in the deploy phase and can inherit and override values from the [Global stage]({{ page.baseurl }}/cloud/env/variables-intro.html#global-variables). Insert these variables in the `deploy` stage of the `.magento.env.yaml` file:
+The following _deploy_ variables control actions in the deploy phase and can inherit and override values from the [Global stage]({{ page.baseurl }}/cloud/env/variables-intro.html#global-variables). Also, you can override the [ADMIN variables]({{ page.baseurl }}/cloud/env/environment-vars_magento.html). Insert these variables in the `deploy` stage of the `.magento.env.yaml` file:
 
 ```yaml
 stage:
@@ -69,7 +69,7 @@ Enables or disables cleaning [static content files]({{ page.baseurl }}/config-gu
 ```yaml
 stage:
   deploy:
-    CLEAN_STATIC_FILES: false
+    CLEAN_STATIC_FILES: true
 ```
 
 Failure to clean static view files before deploying can cause problems if you

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -61,7 +61,10 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-Cleans the [generated static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) when you perform an action such as enabling or disabling a component. We recommend the default value _true_ in development. The supported values are `true` and `false`.
+Enables or disables cleaning [static content files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) generated during the build or deploy phase. We recommend the default value _true_ in development. If you make modifications to static content through a separate process, set the value to _false_.
+
+-   **`true`**—Removes all existing static content before deploying the updated static content.  content minification; does *not*
+-   **`false`**—The deployment only overwrites existing static content files if the generated content contains a newer version.
 
 ```yaml
 stage:
@@ -69,7 +72,8 @@ stage:
     CLEAN_STATIC_FILES: false
 ```
 
-Failure to clear static view files might result in issues if there are multiple files with the same name and you do not clear all of them. Because of [static file fallback]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_static_cache) rules, if you do not clear static files and there is more than one file named `logo.gif` that are different, fallback might cause the wrong file to display.
+Failure to clean static view files before deploying can cause problems if you
+deploy updates to existing files without removing the previous versions. Because of [static file fallback]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_static_cache) rules, fallback operations can display the wrong file if the directory contains multiple versions of the same file.
 
 ### `CRYPT_KEY`
 
@@ -109,7 +113,7 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.x
 
-Generates symlinks for the `var/generation` and `var/di` generated folders. 
+Generates symlinks for the `var/generation` and `var/di` generated folders.
 
 ```yaml
 stage:
@@ -212,7 +216,7 @@ Themes include numerous files. Set this variable to `true` if you want to skip c
 ```yaml
 stage:
   deploy:
-    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
+    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"
 ```
 
 ### `SCD_MATRIX`
@@ -246,7 +250,7 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**: 
+-  **Default**:
     -  `1`—Starter environments and Pro Integration environments
     -  `3`—Pro Staging and Production environments
 -  **Version**—Available in all versions
@@ -303,7 +307,7 @@ Configure Redis session storage. You must specify the `save`, `redis`, `host`, `
 stage:
   deploy:
     SESSION_CONFIGURATION:
-      redis: 
+      redis:
         bot_first_lifetime: 100
         bot_lifetime: 10001
         database: 0

--- a/guides/v2.1/cloud/env/variables-intro.md
+++ b/guides/v2.1/cloud/env/variables-intro.md
@@ -65,20 +65,22 @@ return array(
    ...
 );
 ```
-
 {% include note.html type="info" content="JS bundling and JS/CSS merging do not work with SCD on demand." %}
 
 ### `SKIP_HTML_MINIFICATION`
 
--  **Default**—`false`
+-  **Default**
+   - `true` for `ece-tools` 2002.0.13 and later
+   - `false` for earlier versions of `ece-tools`
 -  **Version**—Magento 2.1.4 and later
 
-Skip copying the static view files in the `var/view_preprocessed` directory to reduce downtime when deploying to the Staging and Production environments and generates minified HTML when requested.
+Determines whether to copy static view files to the `<magento_root>/init/` directory at the end of the build stage and whether HTML minification of static content occurs during deployment or on request. Set this value to `true` to reduce downtime when deploying to Staging and Production environments.
 
 -   **`false`**—Copies the `view_preprocessed` directory to the `<magento_root>/init/` directory at the end of the build stage, and restores the directory in the `<magento_root>/var` directory at the beginning of the deployment stage.
 -   **`true`**—Enables on-demand static content minification; does *not* copy the `<magento_root>var/view_preprocessed` to the `<magento_root>/init/` directory at the end of the _build_ stage.
 
 Add the `SKIP_HTML_MINIFICATION` environment variable to the `global` stage in the `.magento.env.yaml` file:
+
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.1/cloud/project/project-conf-files_magento-app.md
@@ -1,7 +1,7 @@
 ---
 group: cloud
 title: Application
-version: 2.1
+version: 2.2
 github_link: cloud/project/project-conf-files_magento-app.md
 redirect_from:
   - /guides/v2.0/cloud/before/before-setup-env-cron.html
@@ -34,7 +34,7 @@ The `type`  and `build` properties provide information about the base container 
 The supported `type` language is {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %}. Specify the PHP version as follows:
 
 ```yaml
-type: php:7.0
+type: php:7.1
 ```
 
 The `build` property determines what happens by default when building the project. The `flavor` specifies a default set of build tasks to run. The supported flavor is `composer`.
@@ -59,7 +59,7 @@ access:
 ```
 
 ### `relationships`
-Defines how services are mapped in your application.
+Defines the service mapping in your application.
 
 The left-hand side is the name of the relationship as it will be exposed to the application in the `MAGENTO_CLOUD_RELATIONSHIPS` environment variable. The right-hand side is in the form `<service name>:<endpoint name>`, where `<service name>` comes from `.magento/services.yaml` and  `<endpoint name>` should be the same as the value of `type`  declared in that same file.
 
@@ -72,26 +72,26 @@ cache: "arediscache:redis"
 search: "searchengine:solr"
 ```
 
-See [Services]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) for a full list of currently supported service types and endpoints.
+See [Services]({{page.baseurl}}/cloud/project/project-conf-files_services.html) for a full list of currently supported service types and endpoints.
 
 ### `web`
-Defines how your application is exposed to the web (in HTTP). Here we tell the web application how to serve content, from the front-controller script to a non-static request to an `index.php` file on the root. We support any directory structure so the static file can be in a sub directory, and the `index.php` file can be further down.
+`web` defines how your application is exposed to the web (in HTTP). Here we tell the web application how to serve content, from the front-controller script to a non-static request to an `index.php` file on the root. We support any directory structure so the static file can be in a sub directory, and the `index.php` file can be further down.
 
-Supports the following:
+`web` supports the following:
 
-* `document_root`: The path relative to the root of the application that is exposed on the web. Typical values include `/public` and `/web`.
-* `passthru`: The URL used in the event a static file or PHP file could not be found. This would typically be your applications front controller, often `/index.php` or `/app.php`.
-* `index_files`: To use a static file (for example, `index.html`) to serve your application. This key expects a collection. For this to work, the static file(s) should be included in your whitelist. For example, to use a file named `index.html` as an index file, your whitelist should include an element that matches the filename, like `- \.html$`.
-* `blacklist`: A list of files that should never be executed. Has no effect on static files.
-* `whitelist`: A list of static files (as regular expressions) that can be served. Dynamic files (for example, PHP files) are treated as static files and have their source code served, but they are not executed.
-* `expires`: The number of seconds whitelisted (that is, static) content should be cached by the browser. This enables the cache-control and expires headers for static content. The `expires` directive and resulting headers are left out entirely if this is not set.
+-  `document_root`: The path relative to the root of the application that is exposed on the web. Typical values include `/public` and `/web`.
+-  `passthru`: The URL used in the event a static file or PHP file could not be found. This would typically be your applications front controller, often `/index.php` or `/app.php`.
+-  `index_files`: To use a static file (for example, `index.html`) to serve your application. This key expects a collection. For this to work, the static file(s) should be included in your whitelist. For example, to use a file named `index.html` as an index file, your whitelist should include an element that matches the filename, like `- \.html$`.
+-  `blacklist`: A list of files that should never be executed. Has no effect on static files.
+-  `whitelist`: A list of static files (as regular expressions) that can be served. Dynamic files (for example, PHP files) are treated as static files and have their source code served, but they are not executed.
+-  `expires`: The number of seconds whitelisted (that is, static) content should be cached by the browser. This enables the cache-control and expires headers for static content. The `expires` directive and resulting headers are left out entirely if this is not set.
 
 Contrary to standard `.htaccess` approaches, which accept a *blacklist* and allow everything to be accessed except a specific list, we accept a *whitelist*, which means that anything not matched will trigger a 404 error and will be passed through to your `passthru` URL.
 
 Our default configuration allows the following:
 
-*   From the root (`/`) path, only web, media, and `robots.txt` files can be accessed
-*   From the `/pub/static` and `/pub/media` paths, any file can be accessed
+-  From the root (`/`) path, only web, media, and `robots.txt` files can be accessed
+-  From the `/pub/static` and `/pub/media` paths, any file can be accessed
 
 The following displays the default set of web accessible locations associated with an entry in [`mounts`](#mounts):
 
@@ -133,7 +133,7 @@ web:
 Defines the persistent disk size of the application in MB.
 
 ```yaml
-disk: 256
+disk: 2048
 ```
 
 {% include note.html type="info" content="The minimal recommended disk size is 256MB. If you see the error `UserError: Error building the project: Disk size may not be smaller than 128MB`, increase the size to 256MB." %}
@@ -159,9 +159,10 @@ The format for adding your mount to this list is as follows:
 -  `shared`—Shares a volume between your applications inside an environment.
 -  `disk`—Defines the size available for the shared volume.
 
-{% include note.html type="info" content="The subpath portion of the mount is the unique identifier of the files area. If changed, files at the old location will be permanently lost. Do not change this value once your site has data unless you really want to lose all existing data."%}
+{:.bs-callout .bs-callout-warning}
+Important: The subpath portion of the mount is the unique identifier of the files area. If changed, files at the old location will be permanently lost. Do not change this value once your site has data unless you really want to lose all existing data.
 
-Also, if you want the mount web accessible, you must add it to the [`web`](#web) block of locations.
+If you also want the mount web accessible, you must add it to the [`web`](#web) block of locations.
 
 ### `dependencies`
 Enables you to specify dependencies that your application might need during the build process.
@@ -169,9 +170,9 @@ Enables you to specify dependencies that your application might need during the 
 {{site.data.var.ee}} supports dependencies on the following
 languages:
 
-*	PHP
-*	Ruby
-*	NodeJS
+-  PHP
+-  Ruby
+-  NodeJS
 
 Those dependencies are independent of the eventual dependencies of your application, and are available in the `PATH`, during the build process and in the runtime environment of your application.
 
@@ -206,6 +207,20 @@ hooks:
         php ./vendor/bin/ece-tools post-deploy
 ```
 
+Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files.
+
+```yaml
+hooks:
+    # We run build hooks before your application has been packaged.
+    build: |
+        php ./vendor/bin/ece-tools build:generate
+        # php /path/to/your/script
+        php ./vendor/bin/ece-tools build:transfer
+```
+
+-  `build:generate`—applies patches, validates configuration, generates DI, and generates static content if SCD is enabled for build phase.
+-  `build:transfer`—transfers generated code and static content to the final destination.
+
 The commands run from the application (`/app`) directory. You can use the `cd` command to change the directory. The hooks fail if the final command in them fails. To cause them to fail on the first failed command, add `set -e` to the beginning of the hook.
 
 #### To compile SASS files using grunt:
@@ -213,9 +228,9 @@ The commands run from the application (`/app`) directory. You can use the `cd` c
 ```yaml
 dependencies:
     ruby:
-        sass: "3.4.7"
+      sass: "3.4.7"
     nodejs:
-        grunt-cli: "~0.1.13"
+      grunt-cli: "~0.1.13"
 
 hooks:
     build: |
@@ -223,42 +238,63 @@ hooks:
         npm install
         grunt
         cd
-        php ./bin/magento magento-cloud:build
+        php ./vendor/bin/ece-tools
 ```
 
 You must compile SASS files using `grunt` before static content deployment, which happens during the build. Place the `grunt` command before the `build` command.
 
 ### `crons`
-Describes processes that are triggered on a schedule. We recommend you run cron as the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html). Do _not_ run cron as `root` or as the web server user.
+Describes processes that are triggered on a schedule. We recommend you run `cron` as the [Magento file system owner]({{page.baseurl}}/cloud/before/before-workspace-file-sys-owner.html). Do _not_ run cron as `root` or as the web server user.
 
-More information about crons:
+`crons` support the following:
 
-`crons` supports the following:
+-  `spec`—The cron specification. For Starter environments and Pro Integration environments, the minimum interval is once per five minutes and once per one minute in Pro Staging and Production environments. You need to complete [additional configurations]({{ page.baseurl }}/cloud/configure/setup-cron-jobs.html#add-cron) for crons in those environments.
+-  `cmd`—The command to execute.
 
-*	`spec`: The cron specification. The minimum interval is once per 5 minutes.
-*	`cmd`: The command to execute.
+A Cron job is well suited for the following tasks:
+
+-  They need to happen on a fixed schedule, not continually.
+-  The task itself is not especially long, as a running cron job will block a new deployment.
+-  Or it is long, but can be easily divided into many small queued tasks.
+-  A delay between when a task is registered and when it actually happens is acceptable.
 
 A sample Magento cron job follows:
 
 ```yaml
 crons:
   cronrun:
-    spec: "*/5 * * * *"
-    cmd: "php bin/magento cron:run"
+      spec: "*/5 * * * *"
+      cmd: "php bin/magento cron:run"
+```
+
+For {{site.data.var.ece}} 2.1.X, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.X, cron jobs launch consumers to process batches of messages, and do not require additional configuration.
+
+For more information, see [Set up cron jobs]({{ page.baseurl }}/cloud/configure/setup-cron-jobs.html).
+
+## Variables
+The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.X.
+
+```yaml
+variables:
+  env:
+    CONFIG__DEFAULT__PAYPAL_ONBOARDING__MIDDLEMAN_DOMAIN: 'payment-broker.magento.com'
+    CONFIG__STORES__DEFAULT__PAYMENT__BRAINTREE__CHANNEL: 'Magento_Enterprise_Cloud_BT'
+    CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
 ```
 
 ## Configure PHP options
 You can choose which version of PHP to run in your `.magento.app.yaml` file:
 
 ```
-name: myphpapp
-type: php:5.6
+name: mymagento
+type: php:7.1
 ```
 
-{{site.data.var.ece}} supports PHP 5.5, 5.6, and 7.0.
+{:.bs-callout .bs-callout-info}
+{{site.data.var.ece}} supports PHP 7.1 and later. For Pro projects **created before October 23, 2017**, you must open a [support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) to use PHP 7.1 on your Pro Staging and Production environments.
 
 ### PHP extensions
-You can define additional PHP extensions you want to enable or disable. Example:
+You can define additional PHP extensions to enable or disable:
 
 > .magento.app.yaml
 
@@ -272,73 +308,71 @@ runtime:
     - sqlite3
 ```
 
-To view the current list of PHP extensions:
+To view the current list of PHP extensions, SSH into your environment and enter the following command:
 
 	php -m
 
 Magento requires the following PHP extensions that are enabled by default:
 
-*	[curl](http://php.net/manual/en/book.curl.php){:target="\_blank"}
-*	[gd](http://php.net/manual/en/book.image.php){:target="\_blank"}
-*	[intl](http://php.net/manual/en/book.intl.php){:target="\_blank"}
-*	PHP 7 only:
+-  [curl](http://php.net/manual/en/book.curl.php){:target="\_blank"}
+-  [gd](http://php.net/manual/en/book.image.php){:target="\_blank"}
+-  [intl](http://php.net/manual/en/book.intl.php){:target="\_blank"}
+-  PHP 7 only:
 
-	*	[json](http://php.net/manual/en/book.json.php){:target="\_blank"}
-	*	[iconv](http://php.net/manual/en/book.iconv.php){:target="\_blank"}
-*	[mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="\_blank"}
-*	[PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php){:target="\_blank"}
-*	[bc-math](http://php.net/manual/en/book.bc.php){:target="\_blank"}
-*	[mbstring](http://php.net/manual/en/book.mbstring.php){:target="\_blank"}
-*	[mhash](http://php.net/manual/en/book.mhash.php){:target="\_blank"}
-*	[openssl](http://php.net/manual/en/book.openssl.php){:target="\_blank"}
-*	[SimpleXML](http://php.net/manual/en/book.simplexml.php){:target="\_blank"}
-*	[soap](http://php.net/manual/en/book.soap.php){:target="\_blank"}
-*	[xml](http://php.net/manual/en/book.xml.php){:target="\_blank"}
-*	[zip](http://php.net/manual/en/book.zip.php){:target="\_blank"}
+	-  [json](http://php.net/manual/en/book.json.php){:target="\_blank"}
+	-  [iconv](http://php.net/manual/en/book.iconv.php){:target="\_blank"}
+-  [mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="\_blank"}
+-  [PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php){:target="\_blank"}
+-  [bc-math](http://php.net/manual/en/book.bc.php){:target="\_blank"}
+-  [mbstring](http://php.net/manual/en/book.mbstring.php){:target="\_blank"}
+-  [mhash](http://php.net/manual/en/book.mhash.php){:target="\_blank"}
+-  [openssl](http://php.net/manual/en/book.openssl.php){:target="\_blank"}
+-  [SimpleXML](http://php.net/manual/en/book.simplexml.php){:target="\_blank"}
+-  [soap](http://php.net/manual/en/book.soap.php){:target="\_blank"}
+-  [xml](http://php.net/manual/en/book.xml.php){:target="\_blank"}
+-  [zip](http://php.net/manual/en/book.zip.php){:target="\_blank"}
 
 You must install the following extensions:
 
-* [ImageMagick](http://php.net/manual/en/book.imagick.php){:target="\_blank"} 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
-*	[xsl](http://php.net/manual/en/book.xsl.php){:target="\_blank"}
-*	[redis](https://pecl.php.net/package/redis){:target="\_blank"}
+-  [ImageMagick](http://php.net/manual/en/book.imagick.php){:target="\_blank"} 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
+-  [xsl](http://php.net/manual/en/book.xsl.php){:target="\_blank"}
+-  [redis](https://pecl.php.net/package/redis){:target="\_blank"}
 
 In addition, we strongly recommend you enable `opcache`.
 
-Other PHP extensions you can optionally install:
+Optional PHP extensions available to install:
 
-*	[apcu](http://php.net/manual/en/book.apcu.php){:target="\_blank"}
-*	[blackfire](https://blackfire.io/docs/up-and-running/installation){:target="\_blank"}
-*	[enchant](http://php.net/manual/en/book.enchant.php){:target="\_blank"}
-*	[gearman](http://php.net/manual/en/book.gearman.php){:target="\_blank"}
-*	[geoip](http://php.net/manual/en/book.geoip.php){:target="\_blank"}
-*	[imap](http://php.net/manual/en/book.imap.php){:target="\_blank"}
-*	[ioncube](https://www.ioncube.com/loaders.php){:target="\_blank"}
-*	[pecl-http](https://pecl.php.net/package/pecl_http){:target="\_blank"}
-*	[pinba](http://pinba.org){:target="\_blank"}
-*	[propro](https://pecl.php.net/package/propro){:target="\_blank"}
-*	[pspell](http://php.net/manual/en/book.pspell.php){:target="\_blank"}
-*	[raphf](https://pecl.php.net/package/raphf){:target="\_blank"}
-*	[readline](http://php.net/manual/en/book.readline.php){:target="\_blank"}
-*	[recode](http://php.net/manual/en/book.recode.php){:target="\_blank"}
-*	[snmp](http://php.net/manual/en/book.snmp.php){:target="\_blank"}
-*	[sqlite3](http://php.net/manual/en/book.sqlite3.php){:target="\_blank"}
-*	[ssh2](http://php.net/manual/en/book.ssh2.php){:target="\_blank"}
-*	[tidy](http://php.net/manual/en/book.tidy.php){:target="\_blank"}
-*	[xcache](https://xcache.lighttpd.net){:target="\_blank"}
-*	[xdebug](https://xdebug.org){:target="\_blank"}
-*	[xhprof](http://php.net/manual/en/book.xhprof.php){:target="\_blank"}
-*	[xmlrpc](http://php.net/manual/en/book.xmlrpc.php){:target="\_blank"}
+-  [apcu](http://php.net/manual/en/book.apcu.php){:target="\_blank"}
+-  [blackfire](https://blackfire.io/docs/up-and-running/installation){:target="\_blank"}
+-  [enchant](http://php.net/manual/en/book.enchant.php){:target="\_blank"}
+-  [gearman](http://php.net/manual/en/book.gearman.php){:target="\_blank"}
+-  [geoip](http://php.net/manual/en/book.geoip.php){:target="\_blank"}
+-  [imap](http://php.net/manual/en/book.imap.php){:target="\_blank"}
+-  [ioncube](https://www.ioncube.com/loaders.php){:target="\_blank"}
+-  [pecl-http](https://pecl.php.net/package/pecl_http){:target="\_blank"}
+-  [pinba](http://pinba.org){:target="\_blank"}
+-  [propro](https://pecl.php.net/package/propro){:target="\_blank"}
+-  [pspell](http://php.net/manual/en/book.pspell.php){:target="\_blank"}
+-  [raphf](https://pecl.php.net/package/raphf){:target="\_blank"}
+-  [readline](http://php.net/manual/en/book.readline.php){:target="\_blank"}
+-  [recode](http://php.net/manual/en/book.recode.php){:target="\_blank"}
+-  [snmp](http://php.net/manual/en/book.snmp.php){:target="\_blank"}
+-  [sqlite3](http://php.net/manual/en/book.sqlite3.php){:target="\_blank"}
+-  [ssh2](http://php.net/manual/en/book.ssh2.php){:target="\_blank"}
+-  [tidy](http://php.net/manual/en/book.tidy.php){:target="\_blank"}
+-  [xcache](https://xcache.lighttpd.net){:target="\_blank"}
+-  [xdebug](https://xdebug.org){:target="\_blank"}
+-  [xhprof](http://php.net/manual/en/book.xhprof.php){:target="\_blank"}
+-  [xmlrpc](http://php.net/manual/en/book.xmlrpc.php){:target="\_blank"}
 
 {% include note.html type="info" content="Important: PHP compiled with debug is not supported and the Probe may conflict with XDebug or XHProf. Disable those extensions when enabling the Probe. The Probe conflicts with some PHP extensions like Pinba or IonCube." %}
 
-### Customize `php.ini` settings 
-
+### Customize `php.ini` settings
 You can also create and push a `php.ini` file that is appended to the configuration maintained by {{site.data.var.ee}}.
 
 In your repository, the `php.ini` file should be added to the root of the application (the repository root).
 
-{:.bs-callout .bs-callout-warning}
-Configuring PHP settings improperly can cause issues. We recommend only advanced administrators set these options.
+{% include note.html type="info" content="Configuring PHP settings improperly can cause issues. We recommend only advanced administrators set these options." %}
 
 For example, if you need to increase the PHP memory limit:
 
@@ -349,3 +383,39 @@ For a list of recommended PHP configuration settings, see [Required PHP settings
 After pushing your file, you can check that the custom PHP configuration has been added to your environment by [creating an SSH tunnel]({{ page.baseurl }}/cloud/env/environments-start.html#env-start-tunn) to your environment and entering:
 
 	cat /etc/php5/fpm/php.ini
+
+## Workers
+
+You can define zero or multiple work instances for each application. A worker
+instance runs as a container, independent from the web instance and without
+a running Nginx instance. Additionally, you do not need to set up a web server on
+the worker instance (using Node.js or Go) because the router cannot direct public
+requests to the worker.
+
+A worker instance has the exact same code and compilation output as a web instance.
+The container image is built once and deployed multiple times if needed using the
+same `build` hook and `dependencies`. You can customize the container and
+allocated resources.
+
+Use worker instances for background tasks including:
+
+-  Tasks like queue workers or updating indexes.
+-  Tasks to run periodic reporting that are too long for a cron job.
+-  Tasks should happen "now", but not block a web request.
+-  Tasks are large enough that they risk blocking a deploy, even if they are subdivided.
+-  The task in question is a continually running process rather than a stream of discrete units of work.
+
+A basic, common worker configuration could look like this:
+
+```
+workers:
+    queue:
+        size: S
+        commands:
+            start: |
+                php worker.php
+```
+
+This example defines a single worker named queue, with a "small" container, and runs the command `php worker.php` on startup. If `worker.php` exits, it is automatically restarted.
+
+For {{site.data.var.ece}} 2.1.X, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.X, cron jobs launch consumers to process batches of messages, and does not require additional configuration.

--- a/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
@@ -28,7 +28,7 @@ We support Elasticsearch versions 1.4, 1.7, and 2.4. The default version is 1.7.
 If you're upgrading to Magento Commerce 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
 
 {:.bs-callout .bs-callout-warning}
-If you prefer using an existing search service, like Elasticsearch, instead of relying on {{site.data.var.ece}} to create it for you, use the [`SEARCH_CONFIGURATION`]({{ site.baseurl }}/guides/v2.1/cloud/env/working-with-variables.html#search) environment variable to connect it to your site.
+If you prefer using an existing search service, like Elasticsearch, instead of relying on {{site.data.var.ece}} to create it for you, use the [`SEARCH_CONFIGURATION`]({{ site.baseurl }}/guides/v2.1/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
 
 ## Add Elasticsearch in services.yaml and .magento.app.yaml {#settings}
 To enable Elasticsearch, add the following code with your installed version and allocated disk space in MB to `.magento/services.yaml`.

--- a/guides/v2.1/cloud/reference/discover-deploy.md
+++ b/guides/v2.1/cloud/reference/discover-deploy.md
@@ -21,11 +21,13 @@ Verify the code for your site and stores is in the {{site.data.var.ece}} branch.
 {% include cloud/wings-management.md %}
 
 ## Track the process {#track}
+
 You can track build and deploy actions in real-time using the terminal or the Project Web Interface. The status displays in-progress, pending, success, or failed. You can view the logs in the interface.
 
 If you are using external GitHub repositories, the log of the operations does not display in the GitHub session. You can still follow activity in their interface and in the {{site.data.var.ece}} Project Web Interface.
 
 ## Project configuration {#cloud-deploy-conf}
+
 A set of YAML configuration files located in the project root directory define your Magento installation and describe its dependencies. If you intend to make changes, modify the YAML files in your local branch. The build and deploy scripts access those files for specific settings.
 
 For all Starter environments and Pro Integration environments, pushing your Git branch updates all settings and configurations dependent on these files. For Pro Staging and Production environments, you will need to enter a [Support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html). We will configure those environments using configurations from the Git files.
@@ -40,6 +42,7 @@ For all Starter environments and Pro Integration environments, pushing your Git 
    The `app/etc/config.php` file includes a _scopes_ setting that defines how static files deploy during the build phase. {{site.data.var.ece}} 2.1 supports the `standard` strategy only. Static file deployment takes a long time to complete, so doing it during the build phase reduces deployment and site downtime.
 
 ## Required files for your Git branch {#requiredfiles}
+
 Your Git branch must have the following files for building and deploying in your local environment and to Integration, Staging, and Production environments:
 
 -  `auth.json`—in the root Magento directory. This file includes the Magento Authentication keys entered when creating the project. The file is generated as part of autoprovisioning a new project using a blank template. If you need to verify the file and settings, see [Troubleshoot deployment]({{ page.baseurl }}/cloud/access-acct/trouble.html).
@@ -49,6 +52,7 @@ Your Git branch must have the following files for building and deploying in your
 -  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)—updated and saved to `magento/`.
 
 ## Best practices for builds and deployment {#best-practices}
+
 We highly recommend the following best practices and considerations for your deployment process:
 
 -  **Always follow the deployment process** to ensure your code is THE SAME in Integration, Staging, and Production. This is vital. Pushing code from Integration environments may become important or needed for upgrades, patches, and configurations. This deployment overwrites Production and any differences in code in that environment.
@@ -58,6 +62,7 @@ We highly recommend the following best practices and considerations for your dep
 -  **Test your build and deploy locally and in Staging before deploying to Production.** Extensions and custom code work great in development. Some users push to production only to have failures and issues. Staging gives you an opportunity to fully test your code and implementation in a production environment without extended downtime if something goes wrong in Production.
 
 ## Five phases of Integration build and deployment {#cloud-deploy-over-phases}
+
 The following phases occur in your local development environment and the Integration environment. For Pro plans, the code is not deployed to the Staging or Production environments in these initial phases. See [Deploy code to Staging and Production]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html).
 
 Integration build and deployment consists of the following phases:
@@ -72,6 +77,7 @@ Integration build and deployment consists of the following phases:
 For detailed instructions, see [Build and deploy full steps](#steps).
 
 ### Phase 1: Code and configuration validation {#cloud-deploy-over-phases-conf}
+
 When you initially set up a project from a template, we retrieve the code from the [the {{site.data.var.ee}} template](https://github.com/magento/magento-cloud){:target="\_blank"}. This code repo is cloned to your project as the `master` branch.
 
 -  **For Starter**—`master` branch is your Production environment.
@@ -86,6 +92,7 @@ If you have a syntax error in a configuration file, our Git server refuses the p
 This phase also runs `composer install` to retrieve dependencies.
 
 ### Phase 2: Build {#cloud-deploy-over-phases-build}
+
 {:.bs-callout .bs-callout-info}
 During the build phase, the site is not in maintenance mode and will not be brought down if errors or issues occur. We build only what has changed since the last build.
 
@@ -93,7 +100,7 @@ This phase builds the codebase and runs hooks in the `build` section of `.magent
 
 -  Applies patches located in `vendor/magento/ece-patches`, as well as optional, project-specific patches in `m2-hotfixes`
 -  Regenerates code and the {% glossarytooltip 2be50595-c5c7-4b9d-911c-3bf2cd3f7beb %}dependency injection{% endglossarytooltip %} configuration (that is, the `var/generation` and `var/di` directories) using `bin/magento setup:di:compile`.
--  Checks if the [`app/etc/config.php`]({{ page.baseurl }}/cloud/live/sens-data-over.html) file exists in the codebase. Magento auto-generates this file it does not detect it during the build phase and includes a list of modules and extensions. If it exists, the build phase continues as normal, compresses static files using `gzip`, and deploys the files, which reduces downtime in the deployment phase. Refer to [Magento build options]({{ site.baseurl }}/guides/v2.1/cloud/env/environment-vars_magento.html#build) to learn about customizing or disabling file compression.
+-  Checks if the [`app/etc/config.php`]({{ page.baseurl }}/cloud/live/sens-data-over.html) file exists in the codebase. Magento auto-generates this file it does not detect it during the build phase and includes a list of modules and extensions. If it exists, the build phase continues as normal, compresses static files using `gzip`, and deploys the files, which reduces downtime in the deployment phase. Refer to [Magento build options]({{ site.baseurl }}/guides/v2.1/cloud/env/variables-build.html) to learn about customizing or disabling file compression.
 
     {:.bs-callout .bs-callout-info}
     The `/app/etc/config.php` file includes a _scopes_ setting that defines how static files deploy during the build phase. {{site.data.var.ece}} 2.1 supports the `standard` strategy only. Static file deployment takes a long time to complete, so initiating it during the build phase helps to reduce deployment and site downtime.
@@ -104,6 +111,7 @@ At this point, the cluster has not been created yet, so you should not try to co
 After the application builds, it is mounted on a **read-only file system**. You can configure specific mount points that are going to be read/write. You cannot FTP to the server and add modules. Instead, you must add code to your local repository and run `git push`, which builds and deploys the environment. For the project structure, see [Local project directory structure]({{ page.baseurl }}/cloud/project/project-start.html).
 
 ### Phase 3: Prepare the slug {#cloud-deploy-over-phases-slug}
+
 The result of the build phase is a read-only file system referred to as a *slug*. In this phase, we create an archive and put the slug in permanent storage. The next time you push code, if a service did not change, it uses the slug from the archive.
 
 -  Makes continuous integration build faster by reusing unchanged code
@@ -119,6 +127,7 @@ The slug includes all files and folders **excluding the following** mounts confi
 -  `"pub/static": "shared:files/static"`
 
 ### Phase 4: Deploy slugs and cluster {#cloud-deploy-over-phases-slugclus}
+
 Now we provision your applications and all of the {% glossarytooltip 74d6d228-34bd-4475-a6f8-0c0f4d6d0d61 %}backend{% endglossarytooltip %} services you need:
 
 -  Mounts each service in a container (web server, Elasticsearch, RabbitMQ)
@@ -129,6 +138,7 @@ Now we provision your applications and all of the {% glossarytooltip 74d6d228-34
 Make your changes in a Git branch after all build and deployment completes and push again. All environment file systems are _read-only_. A read-only system guarantees deterministic deployments and dramatically improves your site security because no process can write to the file system. It also works to ensure your code is identical in the Integration, Staging, and Production environments.
 
 ### Phase 5: Deployment hooks {#cloud-deploy-over-phases-hook}
+
 {:.bs-callout .bs-callout-info}
 This phase puts the application in maintenance mode until deployment is complete.
 
@@ -152,7 +162,9 @@ There are two default deploy hooks. The `pre-deploy.php` hook completes necessar
 {:.bs-callout .bs-callout-info}
 Our deploy script uses the values defined by configuration files in the `.magento` directory, then the script deletes the directory and its contents. Your local development environment is not affected.
 
+
 ### Post-deployment: configure routing {#cloud-deploy-over-phases-route}
+
 While the deployment is running, we freeze the incoming traffic at the entry point for 60 seconds. We are now ready to configure routing so your web traffic arrives at your newly created cluster.
 
 Successful deployment removes the maintenance mode to allow for normal access and creates backup (BAK) files for the `app/etc/env.php` and the `app/etc/config.php` configuration files.
@@ -162,6 +174,7 @@ If you enabled static content generation using the `SCD_ON_DEMAND` variable and 
 To review build and deploy logs, see [Use logs for troubleshooting]({{ page.baseurl }}/cloud/trouble/environments-logs.html).
 
 ### Build and deploy full steps {#steps}
+
 With an understanding of the process, we provide the following instructions for build and deploy for your local, Integration, Staging, and finally Production environments:
 
 -  [Build and deploy to your local]({{ page.baseurl }}/cloud/live/live-sanity-check.html)

--- a/guides/v2.1/cloud/reference/docker-config.md
+++ b/guides/v2.1/cloud/reference/docker-config.md
@@ -13,16 +13,17 @@ functional_areas:
 
 The [Magento Cloud Docker repository](https://github.com/magento/magento-cloud-docker){:target="\_blank"} contains build information for the following [Docker hub](https://hub.docker.com/r/magento/){:target="\_blank"} images:
 
--  PHP: magento/magento-cloud-docker-php
+- PHP: magento/magento-cloud-docker-php
     -  PHP-CLI - version 7 and later
     -  PHP-FPM - version 7 and later
--  NGINX:  magento/magento-cloud-docker-nginx
+- NGINX: magento/magento-cloud-docker-nginx
+- Varnish: magento/magento-cloud-docker-varnish
 
 The `ece-tools` package provides a `docker:build` command to generate the Docker Compose configuration. Also, you can specify a version using one of the following options:
 
--  PHP: `--php`
--  NGINX: `--nginx`
--  MariaDB: `--db`
+- PHP: `--php`
+- NGINX: `--nginx`
+- MariaDB: `--db`
 
 ## Launch Docker configuration
 
@@ -99,7 +100,7 @@ You can use the `ece-tools` package to generate the Docker compose configuration
 
 1.  Download a template from the [Magento Cloud repository](https://github.com/magento/magento-cloud){:target="\_blank"}.
 
-1.  Add your credentials to `auth.json` file.
+1.  Add your credentials to the `auth.json` file.
 
 1.  Update the template dependencies.
 
@@ -107,32 +108,54 @@ You can use the `ece-tools` package to generate the Docker compose configuration
     composer install
     ```
 
-1.  In your local environment, start the Docker configuration generator.
+    {: .bs-callout .bs-callout-info}
+    You can use the `--ignore-platform-reqs` option to bypass restrictions related to the PHP version.
+
+1. In your local environment, start the Docker configuration generator.
 
     ```bash
     vendor/bin/ece-tools docker:build
     ```
 
-1.  Copy the configuration files.
+1. Copy the raw configuration files.
 
     ```bash
-	cp docker/config.env.dist docker/config.env
+    cp docker/config.php.dist docker/config.php
     ```
 
     ```bash
-	cp docker/global.env.dist docker/global.env
+    cp docker/global.php.dist docker/global.php
     ```
 
-1.  Build files to containers and run in the background.
+1. Convert Docker environment configuration files from the raw configs.
+
+    ```bash
+    vendor/bin/ece-tools docker:config:convert
+    ```
+
+    This converts your `.php` files to `.env` configuration files.
+
+    * `docker/config.env`
+    * `docker/global.env`
+
+1. Build files to containers and run Docker in the background.
 
     ```bash
     docker-compose up -d --build
     ```
 
-1.  Install Magento. This step may take some time to complete.
+1. Install Magento in your Docker environment.
+
+    * Build Magento in the Docker container:
 
     ```bash
-    docker-compose run cli magento-installer
+    docker-compose run build cloud-build
+    ```
+
+    * Deploy Magento in the Docker container:
+
+    ```bash
+    docker-compose run deploy cloud-deploy
     ```
 
 1.  Access your local Magento Cloud template by opening one of the following secure URLs in a browser:
@@ -149,8 +172,6 @@ Remove all components of your local Magento Cloud Docker instance including cont
 ```bash
 docker-compose down
 ```
-
-## Automate integration testing
 
 Installing Magento Commerce Cloud in a dedicated Docker environment presents an opportunity for you to customize the following features and capabilities to implement automated integration testing:
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -26,66 +26,69 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New in the `ece-tools` package
 
--  **Enable zero-downtime deployment**—<!--MAGECLOUD-2169-->Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
 
-  -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scdlink):  `SKIP_SCD=false`
+  -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
   -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
 
 -  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
 
-   -  <!--MAGECLOUD-2356-->Added a command—`docker:config:convert` that converts PHP configuration files to Docker ENV files.
+   -  JIRA--MAGECLOUD-2359-->Added a command—`docker:config:convert` that converts PHP configuration files to Docker ENV files.
 
-   -  <!--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases so that {{site.data.var.ece}} deploys to a read-only file system. During the build phase, the file system is writeable.
+   -  JIRA--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases so that {{site.data.var.ece}} deploys to a read-only file system. During the build phase, the file system is writeable.
 
-- <!--MAGECLOUD-2363-->**Allow custom scripts in the build phase**—We split the build phase into two separate processes so that developers can use build hooks to update the generated content before packaging the {{site.data.var.ee}} application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+-  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file](({{ page.baseurl }}cloud//reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
--  **Cron scheduling improvements**—<!--MAGECLOUD-2445-->Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+-  JIRA--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
 -  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
 
-   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables
-and values.
+   -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables
+   and values.
 
-   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-    -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+    -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
 
-    -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 
-   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
 
-   -  <!--MAGECLOUD-2227-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+   -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  <!--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+   -  JIRA--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
 
-   -  <!--MAGECLOUD-2363-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+   -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
 
 #### Resolved Issues
 
 -  **Cron-specific fixes**
 
-   -  <!--MAGECLOUD-2427-->Changed the default settings for cron job history lifetime from 3d to 1h to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+   -  JIRA--MAGECLOUD-2427-->Changed the default settings for cron job history lifetime from 3d to 1h to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-   -  <!--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.2.
+   -  JIRA--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.2.
 
--  <!--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
+-  JIRA--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
 
-- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
-- <!--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
+- JIRA--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
 
-- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+- JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
 
--  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+-  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
 
->>>>>>> Stashed changes
+-  JIRA-- MAGECLOUD-2515-->Fixed a Redis session locking issue that caused an Admin login delay. The fix is available for all versions of Magento v2.1 and v2.2.
+
 
 ## v2002.0.12
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -18,14 +18,81 @@ You can list the available ece-tools commands using:
 php ./vendor/bin/ece-tools list
 ```
 
-The following updates describe the latest improvements to the ece-tools package, which update as needed through patching and product upgrades managed by the `magento-cloud-metapackage`. The ece-tools package adheres to the version sequence:  `200<major>.<minor>.<patch>`.
+The following updates describe the latest improvements to the `ece-tools` package, which uses the following version sequence:  `200<major>.<minor>.<patch>`.  See [Upgrades and patches]({{ site.baseurl }}/guides/v2.1/cloud/project/project-upgrade-parent.html) for information about updating to the latest release of the `ece-tools` package.
+
+
+## v2002.0.13
+
+
+#### New in the `ece-tools` package
+
+-  **Enable zero-downtime deployment**—<!--MAGECLOUD-2169-->Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
+
+  -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scdlink):  `SKIP_SCD=false`
+  -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
+
+-  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
+
+   -  <!--MAGECLOUD-2356-->Added a command—`docker:config:convert` that converts PHP configuration files to Docker ENV files.
+
+   -  <!--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases so that {{site.data.var.ece}} deploys to a read-only file system. During the build phase, the file system is writeable.
+
+- <!--MAGECLOUD-2363-->**Allow custom scripts in the build phase**—We split the build phase into two separate processes so that developers can use build hooks to update the generated content before packaging the {{site.data.var.ee}} application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+-  **Cron scheduling improvements**—<!--MAGECLOUD-2445-->Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+
+-  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
+
+   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables
+and values.
+
+   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+
+   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+
+-  **Environment variable updates**—Changed the following environment variables:
+
+    -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+
+    -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+
+-  **Logging**-Made the following changes to improve log messages and reduce log size:
+
+   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+
+   -  <!--MAGECLOUD-2227-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+
+   -  <!--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+
+   -  <!--MAGECLOUD-2363-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+
+
+#### Resolved Issues
+
+-  **Cron-specific fixes**
+
+   -  <!--MAGECLOUD-2427-->Changed the default settings for cron job history lifetime from 3d to 1h to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+
+   -  <!--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.2.
+
+-  <!--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
+
+- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+
+- <!--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
+
+- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+
+-  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+
+>>>>>>> Stashed changes
 
 ## v2002.0.12
 
 {:.bs-callout bs-callout-info}
 The ece-tools version 2002.0.12 now supports Magento 2.1.14.
 
-#### New Features
+#### New in the `ece-tools` package
 
 -  <!-- MAGECLOUD-2250 -->**Docker Compose for Cloud**—Added a new command—`docker:build`—to generate a [Docker Compose]({{ page.baseurl }}/cloud/reference/docker-config.html) configuration from the Cloud `ece-tools` repository.
 
@@ -51,7 +118,7 @@ Cloud configuration:
     -  <!-- MAGECLOUD-2047 --> Added the [DATABASE_CONFIGURATION]({{ page.baseurl }}/cloud/env/variables-deploy.html#database_configuration) environment variable to customize your database connections for deployment.
     -  <!-- MAGECLOUD-2129 -->The new [MIN_LOGGING_LEVEL]({{ page.baseurl }}/cloud/env/variables-intro.html#min_logging_level) variable overrides the minimum logging level for all output streams without making changes to the code.
 
-#### Fixed Issues
+#### Resolved issues
 
 -  Fixed an issue that caused downtime between the deploy and post-deploy phase. Now, the post_deploy phase begins _immediately_ after the deploy phase ends.
 
@@ -68,14 +135,14 @@ Cloud configuration:
 {:.bs-callout .bs-callout-info}
 The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 
-#### New features
+#### New in the `ece-tools` package
 
 - **Configuring read-only connections to non-master nodes**—This release adds the ability to configure a read-only connection to a non-master node to receive read-only traffic (for <!--MAGECLOUD-143 -->[Redis]({{ page.baseurl }}/cloud/env/variables-deploy.html#redis_use_slave_connection) and for <!--MAGECLOUD-143 --> [MariaDB]({{ page.baseurl }}/cloud/env/variables-deploy.html#mysql_use_slave_connection)).
 -  <!--MAGECLOUD-1910 -->**Configuration Wizard**—Added a new wizard to help verify your configuration for static content deployment. See [Smart wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html).
 -  <!-- MAGECLOUD-1966-->**Symfony Console support**—Added support for Symfony Console 4 with Magento 2.3.
 -  <!-- MAGECLOUD-1607 -->**Cron scheduling optimizations**—Improved the queue management and enhanced logging to help with debugging cron-related issues.
 
-#### Fixed issues
+#### Resolved issues
 
 -  <!-- MAGECLOUD-1221 -->Deployment validation fails if an `ADMIN_EMAIL` or `ADMIN_USERNAME` value is the same as an existing Magento administrator account.
 -  <!-- MAGECLOUD-1282 -->Removed SOLR support for 2.2.x versions. 2.1.x versions retain the ability to enable SOLR.
@@ -96,7 +163,7 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 
 ## v2002.0.10
 
-#### New features
+#### New in the `ece-tools` package
 
 -  <!-- MAGECLOUD-1285 -->**Static Content Deployment (SCD)**—There is a new, alternative deployment process to generate static content when requested (on-demand). This decreases downtime and improves cache handling by generating the most critical assets.
     -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the new `SCD_ON_DEMAND` global environment variable to generate static content when requested.
@@ -112,7 +179,7 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
     -  <!-- MAGECLOUD-1738 -->`SCD_ON_DEMAND`—_Global_ environment variable to generate static content when requested.
     -   `WARM_UP_PAGES`—You can list the pages to use to pre-load the cache. Available in the new [Post-deploy variables]({{ site.baseurl }}/guides/v2.1/cloud/env/variables-post-deploy.html).
 
-#### Fixed issues
+#### Resolved issues
 
 -  <!-- MAGECLOUD-982 -->We fixed an issue that involved a locally applied patch breaking the deployment on an instance. Now, ECE-Tools can detect that a patch has been applied.
 
@@ -127,7 +194,7 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 {:.bs-callout .bs-callout-info}
 You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guides/v2.1/cloud/project/project-upgrade-parent.html) to get this and all future updates.
 
-#### New features
+#### New in the `ece-tools` package
 -   <!-- MAGECLOUD-1086 -->**ece-tools**—The `ece-tools` package now supports Magento 2.1.x. You must [upgrade to ece-tools]({{ site.baseurl }}/guides/v2.1/cloud/project/ece-tools-upgrade-project.html) to use these features.
 
 -   <!-- MAGECLOUD-1552 -->**Redis configuration**—You can now [configure Redis]({{ site.baseurl }}/guides/v2.1/cloud/env/working-with-variables.html#redis) page and default cache and Redis session storage using an environment variable.
@@ -142,7 +209,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 
 -   <!-- MAGECLOUD-1674 -->**Logging**—We simplified logging around built-in patching operations.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1615 -->We removed `developer` mode support and the `APPLICATION_MODE` environment variable because they were causing unexpected behavior.
 
 -   <!-- MAGECLOUD-1630 -->We fixed an issue that was causing static content deployment failures related to Redis. Now, multi-threaded static content deployment runs as designed.
@@ -156,7 +223,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 {:.bs-callout .bs-callout-info}
 We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this release. You no longer need to update the `vendor/magento/ece-patches` package separately.
 
-#### New features
+#### New in the `ece-tools` package
 -   <!-- MAGECLOUD-1253 -MAGECLOUD-1495-->**Improved logging**
     -   We improved log messaging to provide better explanations when the build or deploy process overrides an environment variable.
     -   You can now view installation and upgrade progress in real time. Tail the `install_update.log` file to view progress. For example,
@@ -175,7 +242,7 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 -   <!--MAGECLOUD-1090-->We implemented smart patching. Now the package applies patches based not on {{site.data.var.ece}} version, but on patched package version.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1162 -->We fixed a logging issue that was causing build errors.
 
 -   <!-- MAGECLOUD-1389 -->We fixed an issue that was causing timeout exceptions when running deployments in interactive mode.
@@ -198,12 +265,12 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 ## v2002.0.7
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1454-->We removed `var/view_preprocessed` symlinking to fix an issue that was causing JavaScript minification conflicts.
 
 ## v2002.0.6
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1413 -->We fixed an issue that was causing `gzip` errors when a file or directory name contains spaces.
 
 -   <!-- MAGECLOUD-1424 -->We fixed an issue that was preventing deployment scripts from properly recognizing and enabling module dependencies.
@@ -211,7 +278,7 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 ## v2002.0.5
 
-#### New features
+#### New in the `ece-tools` package
 -   **Configure a cron consumer with an environment variable**—You can now configure cron consumers using the new `CRON_CONSUMERS_RUNNER` environment variable.
 
 -   **Configuration scanning**—We now scan for critical components during the build/deploy process and halt the process if the scan fails, which prevents unnecessary downtime due to the site being in maintenance mode.
@@ -230,7 +297,7 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 -   **Cron interval limitations lifted**—The default cron interval for all environments provisioned in the us-3, eu-3, and ap-3 regions is 1 minute. The default cron interval in all other regions is 5 minutes for Pro Integration environments and 1 minute for Pro Staging and Production environments. To modify your existing cron jobs, edit your settings in `.magento.app.yaml` or create a support ticket for Production/Staging environments. Refer to [Set up cron jobs]({{ site.baseurl }}/guides/v2.1/cloud/configure/setup-cron-jobs.html) for more information.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1327 -->We fixed an issue that was causing long deploy times due to the deploy process invoking the `cache-clean` operation before static content deployment.
 
 -   <!-- MAGECLOUD-1322 -->We fixed an issue causing errors during the static content generation step of deployment on Production environments.
@@ -249,27 +316,27 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 ## v2002.0.4
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1355 -->You can now [manually reset stuck Magento cron jobs]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-cron-jobs.html#reset-cron-jobs) using a CLI command in all environments via SSH access. The deployment process automatically resets cron jobs. Not available in 2.1.
 
 ## v2002.0.3
 
-#### Fixed issues
+#### Resolved issues
 -   <!--MAGECLOUD-1311-->We fixed an issue that was causing pages to time out because Redis was taking too long to read/write. You can now use the `disable_locking` parameter in Redis configurations to prevent this issue.
 
 ## v2002.0.2
 
-#### Fixed issues
+#### Resolved issues
 -   <!--MAGECLOUD-1246-->The RabbitMQ configuration process now obtains all required parameters automatically.
 
 ## v2002.0.1
 
-#### New features
+#### New in the `ece-tools` package
 -   <!--- MAGECLOUD-1057 -->{{site.data.var.ece}} now supports scopes and [static content deployment strategies]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html). We have added the `–s` parameter with a default setting of `quick` for the static content deployment strategy. You can use the environment variable [SCD_STRATEGY]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html) to customize and use these strategies with your build and deploy actions. This variable supports the options `standard`, `quick`, or `compact`. If you select `compact`, we override the `STATIC_CONTENT_THREADS` value with `1`, which can slow deployment, especially in production environments. Not available in 2.1.
 
 -   <!--- MAGECLOUD-1014 & MAGECLOUD-1023 -->We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `var/log/cloud.log` file inside the Magento root application directory.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-919 & MAGECLOUD-1030-->Refactored the `ece-tools` package to make it compatible with {{site.data.var.ece}} 2.2.0 and higher.
 
 -   <!-- MAGECLOUD-1186-->We fixed an issue that was preventing `ece-tools` from halting execution and throwing an exception if no patches can be applied.

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -26,20 +26,19 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
+-  **Docker Compose for Cloud**—Made the following improvements to the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
--  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
+   -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files and transform those files to Docker ENV files.
 
-   -  JIRA--MAGECLOUD-2359-->Now you can manage environment variables more easily by customizing sample PHP configuration files and transforming those files to Docker ENV files using the new `docker:config:convert` command.
+   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
-   -  JIRA--MAGECLOUD--2357-->Now the {{site.data.var.ece}} installation process supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
-   -  JIRA--MAGECLOUD--2442-->Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
+   -  JIRA--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
 
-   -  JIRA--MAGECLOUD--2358-->Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
-
-   -  JIRA--MAGECLOUD--2360-->Added SSL support to access your local site and Admin panel.
+   -  JIRA--MAGECLOUD--2360-->Secure site access—Added SSL support to access your store {{site.data.var.ece}} and Admin panel.
 
 -  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
@@ -197,7 +196,7 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 
 -  <!-- MAGECLOUD-982 -->We fixed an issue that involved a locally applied patch breaking the deployment on an instance. Now, ECE-Tools can detect that a patch has been applied.
 
--  <!-- MAGECLOUD-1735 -->Fixed a conflict between JavaScript bundling and GZIP functionality. Now these features work correctly together.
+-  <!-- MAGECLOUD-1735 -->Fixed a conflict between JavaScript bundling and Gzip functionality. Now these features work correctly together.
 
 -  <!-- MAGECLOUD-1744 -->Fixed an issue that caused ece-tools CLI commands to fail when using earlier PHP 7.0.x versions.
 
@@ -367,3 +366,4 @@ This package is no longer compatible with other versions of {{site.data.var.ece}
 
 ### Initial release
 Initial release of `ece-tools` for {{site.data.var.ece}} 2.2.0.
+ar.ece}} 2.2.0.

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -104,7 +104,7 @@ Now you can easily move your configuration files between environments.
 
 ## v2002.0.12
 
-{:.bs-callout bs-callout-info}
+{:.bs-callout .bs-callout-info}
 The ece-tools version 2002.0.12 now supports Magento 2.1.14.
 
 #### New features

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -30,7 +30,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
-   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files and transform those files to Docker ENV files.
+   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files in the `docker/config.env.dist docker` directory and transform those files to Docker ENV files.
 
    -  <!--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
@@ -93,13 +93,13 @@ Now you can easily move your configuration files between environments.
 
   If you generated `config.php` files using earlier versions of the `ece-tools` package, update to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-- <!--MAGECLOUD-2556-->Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
+- <!--MAGECLOUD-2556-->Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a non-www or *naked* domain) to a www domain.
 
 -  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
 
--  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default. The configuration error was introduced in v1.3.4 Redis session handler codebase-[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract) when the default value for the `disable_locking` parameter was changed.
+-  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking for {{site.data.var.ece}} v2.1.11+ and v2.2.1+, which can cause slow performance and timeouts. Now, session locking is disabled by default. The issue was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler package [colinmollenhour/php-redis-session-abstract package](https://github.com/colinmollenhour/php-redis-session-abstract).
 
-- <!--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 to 2.5.
+- <!--MAGECLOUD-2464-->Fixed an issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2.0 to 2.2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -24,47 +24,51 @@ The following updates describe the latest improvements to the `ece-tools` packag
 ## v2002.0.13
 
 
-#### New in the `ece-tools` package
+#### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
-   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
-   -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
 
 -  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
 
-   -  JIRA--MAGECLOUD-2359-->Added a command—`docker:config:convert` that converts PHP configuration files to Docker ENV files.
+   -  JIRA--MAGECLOUD-2359-->Now you can manage environment variables more easily by customizing sample PHP configuration files and transforming those files to Docker ENV files using the new `docker:config:convert` command.
 
-   -  JIRA--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases so that {{site.data.var.ece}} deploys to a read-only file system. During the build phase, the file system is writeable.
+   -  JIRA--MAGECLOUD--2357-->Now the {{site.data.var.ece}} installation process supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
--  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file](({{ page.baseurl }}cloud//reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+   -  JIRA--MAGECLOUD--2442-->Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+   -  JIRA--MAGECLOUD--2358-->Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
 
--  JIRA--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+   -  JIRA--MAGECLOUD--2360-->Added SSL support to access your local site and Admin panel.
+
+-  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+-  JIRA--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after deployment completes.
 
 -  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
 
    -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables
    and values.
 
-   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-    -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase if the `CLEAN_STATIC_SITE` environment variable is enabled in the `deploy` section of the `.magento.env.yaml` file. Previously, this variable only affected static content files generated during the deploy phase.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 
-   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
 
    -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  JIRA--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+   -  JIRA--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
 
    -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
@@ -73,21 +77,28 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  **Cron-specific fixes**
 
-   -  JIRA--MAGECLOUD-2427-->Changed the default settings for cron job history lifetime from 3d to 1h to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+   -  JIRA--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-   -  JIRA--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.2.
+   -  JIRA--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.1.
 
 -  JIRA--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
 
-- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
 - JIRA--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
 
 - JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+Now you can easily move your configuration files between environments.
+
+If you generated `config.php` files using earlier versions of the `ece-tools` package, upgrade to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
+
+- JIRA--MAGECLOUD-2556>Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 
 -  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
 
--  JIRA-- MAGECLOUD-2515-->Fixed a Redis session locking issue that caused an Admin login delay. The fix is available for all versions of Magento v2.1 and v2.2.
+-  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default. The configuration error was introduced in v1.3.4 Redis session handler codebase-[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract) when the default value for the `disable_locking` parameter was changed.
+
+- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 - 2.5.
 
 
 ## v2002.0.12
@@ -95,7 +106,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 {:.bs-callout bs-callout-info}
 The ece-tools version 2002.0.12 now supports Magento 2.1.14.
 
-#### New in the `ece-tools` package
+#### New features
 
 -  <!-- MAGECLOUD-2250 -->**Docker Compose for Cloud**—Added a new command—`docker:build`—to generate a [Docker Compose]({{ page.baseurl }}/cloud/reference/docker-config.html) configuration from the Cloud `ece-tools` repository.
 
@@ -116,7 +127,7 @@ Cloud configuration:
 - <!-- MAGECLOUD-1908 -->**Environment Configuration sample file**—We added a `.magento.env.yaml` sample file to the ece-tools package that includes a detailed description and possible values for each environment variable.
     -  <!-- MAGECLOUD-1907 -->We also added a deep validation for the `.magento.env.yaml` configuration that prevents failures in the deployment process caused by unexpected values. When a failure occurs, you now receive a detailed error message that begins with: `Environment configuration is not valid. Please correct .magento.env.yaml file with next suggestions:`
 
--  Added the following new [**Environment variables**]({{ page.baseurl }}/cloud/env/variables-intro.html):
+-  Added the following [**Environment variables**]({{ page.baseurl }}/cloud/env/variables-intro.html):
     - <!-- MAGECLOUD-1501 -->Now you can define multiple locales for each theme using the new [SCD_MATRIX]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_matrix) environment variable, which reduces the amount of theme files to deploy.
     -  <!-- MAGECLOUD-2047 --> Added the [DATABASE_CONFIGURATION]({{ page.baseurl }}/cloud/env/variables-deploy.html#database_configuration) environment variable to customize your database connections for deployment.
     -  <!-- MAGECLOUD-2129 -->The new [MIN_LOGGING_LEVEL]({{ page.baseurl }}/cloud/env/variables-intro.html#min_logging_level) variable overrides the minimum logging level for all output streams without making changes to the code.
@@ -138,7 +149,7 @@ Cloud configuration:
 {:.bs-callout .bs-callout-info}
 The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 
-#### New in the `ece-tools` package
+#### New features
 
 - **Configuring read-only connections to non-master nodes**—This release adds the ability to configure a read-only connection to a non-master node to receive read-only traffic (for <!--MAGECLOUD-143 -->[Redis]({{ page.baseurl }}/cloud/env/variables-deploy.html#redis_use_slave_connection) and for <!--MAGECLOUD-143 --> [MariaDB]({{ page.baseurl }}/cloud/env/variables-deploy.html#mysql_use_slave_connection)).
 -  <!--MAGECLOUD-1910 -->**Configuration Wizard**—Added a new wizard to help verify your configuration for static content deployment. See [Smart wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html).
@@ -166,17 +177,17 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 
 ## v2002.0.10
 
-#### New in the `ece-tools` package
+#### New features
 
 -  <!-- MAGECLOUD-1285 -->**Static Content Deployment (SCD)**—There is a new, alternative deployment process to generate static content when requested (on-demand). This decreases downtime and improves cache handling by generating the most critical assets.
-    -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the new `SCD_ON_DEMAND` global environment variable to generate static content when requested.
-    -  <!-- MAGECLOUD-1788 -->**Post-deploy hook**—Added a new `post_deploy` hook for the `.magento.app.yaml` file that clears the cache and pre-loads (warms) the cache _after_ the container begins accepting connections. It is available only for Pro projects that contain [Staging and Production environments in the Project Web UI]({{ page.baseurl }}/cloud/trouble/pro-env-management.html) and for Starter projects. Although not required, this works in tandem with the `SCD_ON_DEMAND` environment variable.
+    -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the `SCD_ON_DEMAND` global environment variable to generate static content when requested.
+    -  <!-- MAGECLOUD-1788 -->**Post-deploy hook**—Added a `post_deploy` hook for the `.magento.app.yaml` file that clears the cache and pre-loads (warms) the cache _after_ the container begins accepting connections. It is available only for Pro projects that contain [Staging and Production environments in the Project Web UI]({{ page.baseurl }}/cloud/trouble/pro-env-management.html) and for Starter projects. Although not required, this works in tandem with the `SCD_ON_DEMAND` environment variable.
 
 -  <!-- MAGECLOUD-1842 -->**Optimization**—Optimized moving or copying files during deployment to improve deployment speed and decrease loads on the file system.
 
 -  <!-- MAGECLOUD-1751 -->**Deployment Logging**—Added the ability to enable Syslog and Graylog Extended Log Format (GELF) handlers for outputting logs during the deployment process. See [Logging handlers]({{ page.baseurl }}/cloud/env/log-handlers.html).
 
--  Added the following new [**Environment variables**]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html):
+-  Added the following [**Environment variables**]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html):
     -  <!-- MAGECLOUD-1556 -->`CRYPT_KEY`—Provide a cryptographic key to another environment when moving a database.
     -  <!-- MAGECLOUD-1621 and MAGECLOUD-1736-->`SKIP_HTML_MINIFICATION`—_Global_ environment variable that skips copying the static view files in the `var/view_preprocessed` directory and generates minified HTML when requested.
     -  <!-- MAGECLOUD-1738 -->`SCD_ON_DEMAND`—_Global_ environment variable to generate static content when requested.
@@ -197,7 +208,7 @@ The ece-tools version 2002.0.11 now supports Magento 2.1.13.
 {:.bs-callout .bs-callout-info}
 You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guides/v2.1/cloud/project/project-upgrade-parent.html) to get this and all future updates.
 
-#### New in the `ece-tools` package
+#### New features
 -   <!-- MAGECLOUD-1086 -->**ece-tools**—The `ece-tools` package now supports Magento 2.1.x. You must [upgrade to ece-tools]({{ site.baseurl }}/guides/v2.1/cloud/project/ece-tools-upgrade-project.html) to use these features.
 
 -   <!-- MAGECLOUD-1552 -->**Redis configuration**—You can now [configure Redis]({{ site.baseurl }}/guides/v2.1/cloud/env/working-with-variables.html#redis) page and default cache and Redis session storage using an environment variable.
@@ -226,7 +237,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 {:.bs-callout .bs-callout-info}
 We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this release. You no longer need to update the `vendor/magento/ece-patches` package separately.
 
-#### New in the `ece-tools` package
+#### New features
 -   <!-- MAGECLOUD-1253 -MAGECLOUD-1495-->**Improved logging**
     -   We improved log messaging to provide better explanations when the build or deploy process overrides an environment variable.
     -   You can now view installation and upgrade progress in real time. Tail the `install_update.log` file to view progress. For example,
@@ -281,7 +292,7 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 ## v2002.0.5
 
-#### New in the `ece-tools` package
+#### New features
 -   **Configure a cron consumer with an environment variable**—You can now configure cron consumers using the new `CRON_CONSUMERS_RUNNER` environment variable.
 
 -   **Configuration scanning**—We now scan for critical components during the build/deploy process and halt the process if the scan fails, which prevents unnecessary downtime due to the site being in maintenance mode.
@@ -334,7 +345,7 @@ We merged `vendor/magento/ece-patches` with `vendor/magento/ece-tools` in this r
 
 ## v2002.0.1
 
-#### New in the `ece-tools` package
+#### New features
 -   <!--- MAGECLOUD-1057 -->{{site.data.var.ece}} now supports scopes and [static content deployment strategies]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html). We have added the `–s` parameter with a default setting of `quick` for the static content deployment strategy. You can use the environment variable [SCD_STRATEGY]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html) to customize and use these strategies with your build and deploy actions. This variable supports the options `standard`, `quick`, or `compact`. If you select `compact`, we override the `STATIC_CONTENT_THREADS` value with `1`, which can slow deployment, especially in production environments. Not available in 2.1.
 
 -   <!--- MAGECLOUD-1014 & MAGECLOUD-1023 -->We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `var/log/cloud.log` file inside the Magento root application directory.

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -89,7 +89,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 - JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
 Now you can easily move your configuration files between environments.
 
-If you generated `config.php` files using earlier versions of the `ece-tools` package, upgrade to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
+  If you generated `config.php` files using earlier versions of the `ece-tools` package, update to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
 - JIRA--MAGECLOUD-2556>Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -28,8 +28,8 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
 
-  -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
-  -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
+   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
+   -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
 
 -  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -98,7 +98,7 @@ If you generated `config.php` files using earlier versions of the `ece-tools` pa
 
 -  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default. The configuration error was introduced in v1.3.4 Redis session handler codebase-[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract) when the default value for the `disable_locking` parameter was changed.
 
-- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 - 2.5.
+- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 to 2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -26,13 +26,13 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
    -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files and transform those files to Docker ENV files.
 
-   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
    -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
@@ -42,7 +42,11 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. If you have existing hooks, you need to update them to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+  If you generated `config.php` files using earlier versions of the `ece-tools` package, update to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
+
+.magento.app.yaml has new build and deploy hooks. As part of your upgrade, you should update the .magento.app.yaml file with new build and deploy hooks and a set of environment variables.
 
 -  JIRA--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after deployment completes.
 
@@ -59,7 +63,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
    -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase if the `CLEAN_STATIC_SITE` environment variable is enabled in the `deploy` section of the `.magento.env.yaml` file. Previously, this variable only affected static content files generated during the deploy phase.
+   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -26,82 +26,80 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  <!--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
-   -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files and transform those files to Docker ENV files.
+   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files and transform those files to Docker ENV files.
 
-   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  <!--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
-   -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
+   -  <!--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
-   -  JIRA--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
+   -  <!--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
 
-   -  JIRA--MAGECLOUD--2360-->Secure site access—Added SSL support to access your store {{site.data.var.ece}} and Admin panel.
+   -  <!--MAGECLOUD--2360-->Secure site access—Added SSL support to access your {{site.data.var.ee}} store and Admin panel.
 
--  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+-  <!--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} extension support**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. If you have existing hooks, you need to update them to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+- <!--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. If you have existing hooks, you need to update them to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
 
   If you generated `config.php` files using earlier versions of the `ece-tools` package, update to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-.magento.app.yaml has new build and deploy hooks. As part of your upgrade, you should update the .magento.app.yaml file with new build and deploy hooks and a set of environment variables.
+-  <!--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after deployment completes.
 
--  JIRA--MAGECLOUD-2445--> **Cron scheduling improvements**—Improved the cron job management process during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after deployment completes.
+-  **Environment configuration checks**—Improved validation of the environment configuration to warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
 
--  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
-
-   -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables
+   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated environment variables
    and values.
 
-   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
+   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
+   -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site.
+   -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site.
 
--  **Logging**-Made the following changes to improve log messages and reduce log size:
+-  **Logging**—Made the following changes to improve log messages and reduce log size:
 
-   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
+   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
 
-   -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+   -  <!--MAGECLOUD-2209-->Added logging for deployment failures that occur when the generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  JIRA--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
+   -  <!--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
 
-   -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+   -  <!--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
 
 #### Resolved Issues
 
 -  **Cron-specific fixes**
 
-   -  JIRA--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+   -  <!--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-   -  JIRA--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.1.
+   -  <!--MAGECLOUD-2508-->Fixed an issue with the [`cron:unlock`]({{ site.baseurl }}/guides/v2.2/cloud/trouble/reset-cron-jobs.html) command so that it works in {{site.data.var.ee}} v2.1. Previously, the command was supported only in v2.1.
 
--  JIRA--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
+-  <!--MAGECLOUD-2491-->Fixed a Sitemap processing issue in the `ece-tools` package that caused third-party extension conflicts after using the `ece-tools` package to apply recent patches that included Sitemap-related changes.
 
-- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
-- JIRA--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
+- <!--MAGECLOUD-2097-->Fixed permission checks that caused `Missing write permissions` errors during the upgrade process.
 
-- JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
 Now you can easily move your configuration files between environments.
 
   If you generated `config.php` files using earlier versions of the `ece-tools` package, update to `ece-tools` v2002.0.13 and regenerate the files using the improved command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-- JIRA--MAGECLOUD-2556>Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
+- <!--MAGECLOUD-2556-->Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 
--  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+-  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
 
--  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default. The configuration error was introduced in v1.3.4 Redis session handler codebase-[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract) when the default value for the `disable_locking` parameter was changed.
+-  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default. The configuration error was introduced in v1.3.4 Redis session handler codebase-[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract) when the default value for the `disable_locking` parameter was changed.
 
-- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 to 2.5.
+- <!--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ece}} versions 2.2 to 2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
+++ b/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
@@ -1,83 +1,57 @@
 ---
 group: cloud
-subgroup: 010_welcome
 title: Starter develop and deploy workflow
-menu_title: Starter develop and deploy workflow
-menu_order: 25
-menu_node:
 version: 2.0
 github_link: cloud/basic-information/starter-develop-deploy-workflow.md
 ---
 
-Everything in {{site.data.var.ece}} is Git-driven. Your [project]({{ page.baseurl }}/cloud/project/projects.html) is a Master Git branch cloned from a Magento 2 repository. Every active Git branch has an associated full environment. Depending on your {{site.data.var.ece}} plan subscription, your deployment workflow may differ.
+The {{site.data.var.ece}} includes a single Git repository with a master branch for the Production environment that can be branched to create Staging and Integration environments for testing and development work. You can have up to four active environments, including a `master` environment for your production server. See [Starter architecture]({{ page.baseurl }}/cloud/basic-information/starter-architecture.html) for an overview.
 
-The general workflow for all development and deployment includes:
+For your environments, we recommend following a Development > Staging > Production workflow to develop and deploy your site.
 
-* Push code to the remote Git branch
-* Build and deploy processes run
-* The environments updated with code, services, and configurations
+* **Production environment (live site)**—Provides a full Production environment with all services built and deployed from the code on the `master` branch.
+* **Staging environment**—Provides a full Staging environment that matches the Production environment with all services built and deployed from a `staging` branch that you create by cloning from `master`.
+* **Integration environments**—Provides up to two active development environments that you create from the `staging` branch. The Integration environment does not support third-party services like Fastly and New Relic.
 
-The Starter plan gives you four active environments, including a `master` environment for your Production server. You have the option to use the remaining three active branches any way you want.
+For your branches, you can follow any development methodology. For example, you can follow an Agile methodology such as scrum to create branches for every sprint.
 
-We **recommend creating a Staging branch** for fully testing your code, extensions, integrations, and data as a near-production environment. This branch includes all services and features of your Production environment. The remaining branches you can create from `staging` and use for all development, easily merging work up through `staging` then `master`.
-
-Every active environment gives you the Magento and branch code installed and deployed, configurable services, and a database. Only the Production and Staging environments have full services including Fastly and New Relic.
-
-The following diagram details the branch and environment relationships:
-
-![High-level view of Starter project]({{ site.baseurl }}/common/images/cloud_arch-starter.png)
-
-You can manage all of your environments including Production and Staging directly through the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html), through the store and Admin panel using provided URLs, and using SSH and the [Magento Cloud command-line]({{ page.baseurl }}/cloud/reference/cli-ref-topic.html).
-
-{:.bs-callout .bs-callout-info}
-The following workflow and examples use a Production, Staging, and Integration architecture.
-
-## Starter environments and branches {#env-branches}
-For your environments, we recommend deploying and testing following a Development > Staging > Production workflow.
-
-* Production environment (live site) is your `master` Git branch with an associated full environment with all services
-* Staging environment is a Git branch we recommend you create called `staging`, to receive full services matching Production
-* Integration environments include two active branches we recommend created from `staging`
-
-For your branches, you can follow any methodology. One example follows an Agile methodology such as scrum to create [branches for every sprint]({{ page.baseurl }}/cloud/env/environments.html).
-
-From each sprint, you can have branches for every user story. All the stories become testable. You can continually merge to the sprint branch and validate that on a continuous basis. When the sprint ends, there is no testing bottleneck, and you can just merge to master and put the whole sprint into production.
-
-For detailed information, see [Starter architecture]({{ page.baseurl }}/cloud/basic-information/starter-architecture.html).
+From each sprint, you can create branches for every user story. All the stories become testable. You can continually merge to the sprint branch and validate that branch on a continuous basis. When the sprint ends, you can merge the sprint branch to master to deploy all sprint changes to production without having to deal with a testing bottleneck.
 
 ## Development workflow {#development}
-Development and deployment on Starter plans begin with your initial project. You create your project with the "blank site", which is a {{site.data.var.ece}} template code repo with a fully prepared store. This creates a `master` branch of Git code in your Production environment.
 
-The full process involves:
+Development and deployment on Starter plans begin with your initial project. You create your project with the "blank site", which is a {{site.data.var.ece}} template code repo with a fully prepared store. This creates a `master` branch with a copy of the code from your Production environment.
 
-* [Clone and branch](#clone-branch) from Master for Staging and development branches
-* [Develop code](#dev-code) and install extensions locally in a branch
+The development workflow uses the following process:
+
+* [Clone and branch](#clone-branch) from the `master` to create `staging` and development branches
+* [Develop code](#dev-code) and install extensions locally in a development branch
 * [Configure](#configure-store) your store and extension settings
 * [Generate configuration](#config-management) management files
-* [Push code](#push-code) and configuration to build and deploy to an environment
+* [Push code](#push-code) and configuration to build and deploy to the Staging and Production environments
 
 ![Develop and deploy workflow]({{ site.baseurl }}/common/images/cloud_workflow-starter.png)
 
-You also have a few optional steps to help develop and test your code and store data:
+You also have a few optional steps to help develop and test your code and your store data:
 
 * [Install sample data](#sample-data) to your store
 * [Pull production store data](#prod-data) down to environments
 
-This process assumes you would have your [local developer workspace]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html) set up. Feel free to read over this process even if your local isn't ready.
+This process assumes that you have set up your [local developer workspace]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html).
 
 ### Clone and branch {#clone-branch}
-When you created your project, a `master` branch was cloned using the {{site.data.var.ece}} Git repository. To start branching and working with code, you will need to clone the `master` to your local.
+
+For a new Starter Plan project, a `master` branch was cloned from the {{site.data.var.ece}} Git repository. To start branching and working with code, you need to clone the `master` branch to your local environment.
 
 The format of the Git clone command is:
 
     git fetch origin
     git pull origin <environment ID>
 
-The first time you start working in branches for your Starter project, you need to create a Staging branch. This sets up a Staging environment with a code branch matching the Production `master` branch and environment.
+The first time you start working in branches for your Starter project, you need to create a `staging` branch. This creates a code branch matching the `master` branch that deploys to a Staging environment to test configuration and code changes before deploying to the Production environment.
 
-Next, create branches from `staging` to develop code, add extensions, and configure 3rd party integrations. Anytime you need to develop custom code, add extensions, integrate with a 3rd party service, work in a develop branch created from `staging`. You will have four active Integration environments available. When you push your an active branch of Git code, one of these Integration environments automatically deploys your code to test.
+Next, create branches from `staging` to develop code, add extensions, and configure 3rd party integrations. Anytime you need to develop custom code, add extensions, integrate with a 3rd party service, work in a development branch created from the `staging` branch. You will have four active Integration environments available. When you push an active branch, one of these Integration environments automatically deploys your code to test.
 
-We walk you through the process when you [set up your local]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html).
+We walk you through the process when you [set up your local]({{ page.baseurl }}/cloud/access-acct/first-time-setup.html) environment.
 
 The format of the Git branch command is:
 
@@ -91,6 +65,7 @@ The format of the Magento Cloud CLI branch command is:
 ![Branch from Master]({{ site.baseurl }}/common/images/cloud_workflow-branching.png)
 
 ### Develop code {#dev-code}
+
 It's the time you have been waiting for...writing code. Using this base branch of {{site.data.var.ece}} code, you can start installing extensions, developing custom code, adding themes, and much more.
 
 We recommend using a branching strategy with your development work. Using one branch to do all of your work all at once might make testing difficult. For example, you could follow continuous integration and sprint methodologies to work:
@@ -105,27 +80,30 @@ We recommend using a branching strategy with your development work. Using one br
 And so on until you have your store fully built, configured, and ready to go live. But keep reading, we have even better options for your store and code configuration!
 
 {:.bs-callout .bs-callout-info}
-Do not complete any configurations on your local yet.
+Do not complete any configurations in your local workstation yet.
 
 ![Develop code and push to deploy]({{ site.baseurl }}/common/images/cloud_workflow-push-code.png)
 
 ### Configure store {#configure-store}
-When you are ready to configure your store, have all code pushed to your Integration environment and access the Magento Admin. You should fully configure all store settings in the Integration environment Admin, not on your local. If you need the URL, see the Project Web Interface. The Store Admin URL is located on the branch page.
 
-For the best information on configurations, we recommend reviewing {{site.data.var.ee}} and your extension documentation. Here are some links and ideas to help you get kickstarted:
+When you are ready to configure your store, push all your code to the Integration environment.
+Configure your store settings from the Magento Admin panel for the Integration environment, not in your local environment. You can find the URL in the Project Web Interface. The Store Admin URL is located on the branch page.
+
+For the best information on configurations, review the documentation for {{site.data.var.ee}} and the installed extensions. Here are some links and ideas to help you get kickstarted:
 
 * [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
-* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html){:target="_blank"} for store admin access, name, languages, currencies, branding, sites, store views and more
-* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html){:target="_blank"} for your look and feel of the site and stores including CSS and layouts
-* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html){:target="_blank"} for roles, tools, notifications, and your encryption key for your database
+* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html){:target="\_blank"} for store admin access, name, languages, currencies, branding, sites, store views and more
+* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html){:target="\_blank"} for your look and feel of the site and stores including CSS and layouts
+* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html){:target="\_blank"} for roles, tools, notifications, and your encryption key for your database
 * Extension settings using their documentation
 
-Beyond just store settings, you can further configure multiple sites and stores, configured services, and more. For details, see [Configure Magento Commerce]({{ page.baseurl }}/cloud/configure/configuration-overview.html).
+Beyond just store settings, you can further configure multiple sites and stores, configured services, and more. See [Configure Magento Commerce]({{ page.baseurl }}/cloud/configure/configuration-overview.html).
 
 Now you need to get these settings into your code. We have a helpful command to do this, keep reading.
 
 ### Generate configuration management files {#config-management}
-If you are familiar with Magento, you may be concerned about how to get your configuration settings from your database in development to Staging and Production. Previously, you had to copy down on paper or a file all of your configuration settings to enter them manually in another environment. Or you may have dumped your database and push that data to another environment.
+
+If you are familiar with Magento, you may be concerned about how to get your configuration settings from your database in development to the Staging and Production environments. Previously, you had to copy all your configuration settings down on paper or to a file, and then manually apply the settings to other environments. Or you may have dumped your database and pushed that data to another environment.
 
 {{site.data.var.ece}} provides a set of two [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) commands that export configuration settings from your environment into a file. These commands are only available for **{{site.data.var.ece}} 2.2 and later**.
 
@@ -134,60 +112,64 @@ If you are familiar with Magento, you may be concerned about how to get your con
 
 The generated file is `app/etc/config.php`.
 
-You will generate the file in the Integration environment where you configured Magento. We walk you through the process of generating the file, adding it to your Git branch, and deploying it.
+You generate the file in the Integration environment where you configured Magento. We walk you through the process of generating the file, adding it to your branch, and deploying it.
 
 **Important notes** on Configuration Management:
 
-* Any configuration setting included in the file is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using `scd-dump`.
+* Any configuration setting included in the file generated from the `app:config:dump` command is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using `scd-dump`.
 
-  For example, we will have you install a module for Fastly in your development environment. You will only configure this module in Staging and Production. Using `scd-dump` keeps those default fields editable.
-* This file can be long depending on the size of your deployment. The `scd-dump` command generates a far small file than `app:config:dump`.
+  For example, we will have you install a module for Fastly in your development environment. You can only configure this module in the Staging and Production environment. Using the `scd-dump` command keeps those default fields editable when you deploy your development changes to the Staging and Production environment.
+
+* The generated file can be long depending on the size of your deployment. The `scd-dump` command generates a much smaller file than the file generated by the `app:config:dump` command.
 
 ![Generate configuration management file]({{ site.baseurl }}/common/images/cloud_workflow-config-mgmt.png)
 
-An additional feature of this command is part of {{site.data.var.ece}} 2.2. Any values determined to be sensitive data, like sandbox credentials for a PayPal module, will be generated into another configuration file called `env.php` in `app/etc/`. This file remains in the exact environment it is created without traveling with your code. You will not add this file to your code repository. You can also create environment variables with CLI commands in all {{site.data.var.ece}} versions.
+If you are using {{site.data.var.ece}} version 2.2 or later, the configuration management commands provide an additional feature to protect sensitive data, like sandbox credentials for a PayPal module. During the export process, any values that contain sensitive data are exported to separate configuration file—`env.php` in the `app/etc/` directory. This file remains in your local environment and does not get copied when you push your code to another branch. You can also create environment variables with CLI commands in all {{site.data.var.ece}} versions.
 
 ![Environment variables generate]({{ site.baseurl }}/common/images/cloud_workflow-env-variables.png)
 
 For more information, see [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
 ### Push code and test {#push-code}
+
 At this point, you should have a developed code branch with a configuration file (`config.local.php` or `config.php`) ready to test.
 
-Everytime you push code from your local environment, a series of build and deploy scripts run. These scripts generate new Magento code and deploy it to the remote environment. For example, if you are pushing a development branch from your local to the remote Git branch, a matching environment updates services, code, and static content.
+Every time you push code from your local environment, a series of build and deploy scripts run. These scripts generate new Magento code and deploy it to the remote environment. For example, if you are pushing a development branch from your local environment to the remote branch, a matching environment updates services, code, and static content.
 
-You can directly access this environment with a store URL, Magento Admin URL, and SSH. These environments include a web server, database, and configured services. When ready, you can start deploying and testing in Staging.
+You can directly access this environment with a store URL, Magento Admin URL, and SSH. These environments include a web server, database, and configured services. When ready, you can start deploying and testing in the Staging environment.
 
 For more information, see [Deployment workflow](#deploy).
 
 ### Optional: Install sample data {#sample-data}
+
 If you need some example data when developing your store, you can install our sample data. This data simulates an active Magento store, including customers, products, and other data. This sample data works best with a "blank site" {{site.data.var.ece}} template installation when creating your project.
 
-We recommend installing sample data in your local installation and Integration environments. If you use this data in Staging or Production, make sure to clear out the information and products before going live.
+We recommend installing sample data in your local and Integration environments. If you use this data in Staging or Production, make sure to clear out the information and products before going live.
 
 For instructions, see [Install optional sample data]({{ page.baseurl }}/cloud/howtos/sample-data.html).
 
 ![Install optional sample data]({{ site.baseurl }}/common/images/cloud_workflow-sample-data.png)
 
 ### Optional: Pull production data {#prod-data}
-We recommend adding all of your products, catalogs, site content, and so on (not configurations) directly in Production. By adding this data in Production, you immediately update prices, coupons, inventory stock, strategize your sales and future offerings, and much more for your customers. This data does not include extension configurations. You will set those in your development branch on your local.
 
-As you develop features, add extensions, and design themes, having real data to work with is helpful. At any time, you can create a database dump from Production and push that to your Staging environment, and possibly Integration environments as you like.
+We recommend adding all of your products, catalogs, site content, and so on directly to the Production environment. By adding this data to the Production environment, you can provide updated prices, coupons, inventory stock, sales announcements, information about future offerings, and much more for your customers. This data does not include extension configurations, which you configure in your local development branch.
+
+As you develop features, add extensions, and design themes, having real data to work with is helpful. At any time, you can create a database dump from the Production environment and push that to your Staging and Integration environments as needed.
 
 {% include cloud/data-collection.md %}
 
 ![Pull and sanitize production data]({{ site.baseurl }}/common/images/cloud_workflow-data-code-process.png)
 
 {:.bs-callout .bs-callout-info}
-Prior to pushing the data to another environment, you should consider sanitizing your data. You have a couple of options including [using support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html) or developing a script to scrub out customer data.
+Before pushing the data to another environment, you should consider sanitizing your data. You have a couple of options including [using support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html) or developing a script to scrub out customer data.
 
 {:.bs-callout .bs-callout-warning}
-Important: We don't recommend pushing a database from an Integration or Staging environment. This data will overwrite your Production live data including sales, orders, new and updated customers, and much more.
+We do not recommend pushing a database from an Integration or Staging environment to a Production environment. If you do, the data from the Integration or Staging environment overwrites your live Production data including sales, orders, new and updated customers, and much more.
 
 ## Deployment workflow {#deploy}
 As we detailed in the architecture information, {{site.data.var.ece}} is Git driven. Deploying {{site.data.var.ece}} is part of your Git push processes for branches.
 
-When you push branched code from your local to the remote Git branch, a series of build and deploy scripts begin.
+When you push branched code from your local environment to the remote branch, a series of build and deploy scripts begin.
 
 Build scripts:
 
@@ -217,12 +199,12 @@ Staging is a pre-production environment, providing all services and settings as 
 To learn more, see [Deploy your store]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
 
 ### Push to Master / Production {#pro}
-When you push to the `master` branch, you are pushing to Production. Treat configuration and testing of Production much as your Staging environment. The important difference in this environment is using live credentials. The moment you go live and launch, customers must be able to complete purchases and administrators should be able to manage your live store.
 
+When you push to the `master` branch, you are pushing to the Production environment. Complete configuration and testing activities in the Production environment like you did in the Staging environment with one important difference. In the Production environment use live credentials for during configuration and testing. The moment you go live and launch, customers must be able to complete purchases and administrators should be able to manage your live store.
 To learn more, see [Deploy your store]({{ page.baseurl }}/cloud/live/stage-prod-live.html).
 
 ### Go live {#go-live}
-We provide a clear walk-through for going live and launching. It requires more steps than pressing a button. But when complete, your store can serve up products in your customized theme for sale immediately.
+We provide a clear walk-through for going live and launching, which requires more steps than pressing a button. After you complete these steps, your store can serve up products in your customized theme for sale immediately.
 
 To learn more, check out [Go live and launch]({{ page.baseurl }}/cloud/live/live.html).
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -61,29 +61,32 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-Cleans the [generated static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) when you perform an action such as enabling or disabling a component. We recommend the default value _true_ in development. The supported values are `true` and `false`.
+Determines whether to clean the existing [static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) before deploying updated static content generated during the build or deploy phase. We recommend the default value _true_ in development. When this variable is set to `false`, previously existing static content files are overwritten only if a newer version is being generated.
+
+If you create static content using another process outside of Magento, you might want to change the value to `false` to keep the content from getting deleted by Magento static content deployments.
 
 ```yaml
 stage:
   deploy:
-    CLEAN_STATIC_FILES: false
+    CLEAN_STATIC_FILES: true
 ```
 
-Failure to clear static view files might result in issues if there are multiple files with the same name and you do not clear all of them. Because of [static file fallback]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_static_cache) rules, if you do not clear static files and there is more than one file named `logo.gif` that are different, fallback might cause the wrong file to display.
+Failure to clean static view files before deploying can cause problems if you
+deploy updates to existing files without removing the previous versions. Because of [static file fallback]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_static_cache) rules, fallback operations can display the wrong file if the directory contains multiple versions of the same file.
 
 ### `CRON_CONSUMERS_RUNNER`
 
 -  **Default**—`cron_run = false`, `max_messages = 1000`
 -  **Version**—Magento 2.2.0 and later
 
-Use this environment variable to make sure message queues are running after a deployment. 
+Use this environment variable to make sure message queues are running after a deployment.
 
 -   `cron_run`—A boolean value that enables or disables the `consumers_runner` cron job (default = `false`).
 -   `max_messages`—A number specifying the maximum number of messages each consumer must process before terminating (default = `1000`). Although we do not recommend it, you can use `0` to prevent the consumer from terminating.
 -   `consumers`—An array of strings specifying which consumer(s) to run. An empty array runs _all_ consumers. Refer to [List consumers]({{ page.baseurl }}/config-guide/mq/manage-mysql.html#list-consumers) for more information.
 
 ```yaml
-stage: 
+stage:
   deploy:
     CRON_CONSUMERS_RUNNER:
       cron_run: true
@@ -223,7 +226,7 @@ Themes can include numerous files. Set this variable to `true` if you want to sk
 ```yaml
 stage:
   deploy:
-    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme" 
+    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"
 ```
 
 ### `SCD_MATRIX`
@@ -276,7 +279,7 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**: 
+-  **Default**:
     -  `1`—Starter environments and Pro Integration environments
     -  `3`—Pro Staging and Production environments
 -  **Version**—Magento 2.1.4 and later
@@ -330,10 +333,10 @@ stage:
 Configure Redis session storage. You must specify the `save`, `redis`, `host`, `port`, and `database` options for the session storage variable. For example:
 
 ```yaml
-stage: 
+stage:
   deploy:
-    SESSION_CONFIGURATION: 
-      redis: 
+    SESSION_CONFIGURATION:
+      redis:
         bot_first_lifetime: 100
         bot_lifetime: 10001
         database: 0

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -207,7 +207,11 @@ hooks:
         php ./vendor/bin/ece-tools post-deploy
 ```
 
+<<<<<<< HEAD
 Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files.
+=======
+Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files. 
+>>>>>>> parent of 897f37ddfa... Revert "Sync Cloud 2002.0.13 with master"
 
 ```yaml
 hooks:

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -207,7 +207,7 @@ hooks:
         php ./vendor/bin/ece-tools post-deploy
 ```
 
-Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files. 
+Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files.
 
 ```yaml
 hooks:
@@ -287,11 +287,11 @@ You can choose which version of PHP to run in your `.magento.app.yaml` file:
 
 ```
 name: mymagento
-type: php:7.0
+type: php:7.1
 ```
 
 {:.bs-callout .bs-callout-info}
-{{site.data.var.ece}} supports PHP 7.0 and 7.1. For Pro projects **created before October 23, 2017**, you must open a [support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) to use PHP 7.1 on your Pro Staging and Production environments.
+{{site.data.var.ece}} supports PHP 7.1 and later. For Pro projects **created before October 23, 2017**, you must open a [support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) to use PHP 7.1 on your Pro Staging and Production environments.
 
 ### PHP extensions
 You can define additional PHP extensions to enable or disable:

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -207,11 +207,7 @@ hooks:
         php ./vendor/bin/ece-tools post-deploy
 ```
 
-<<<<<<< HEAD
 Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files.
-=======
-Also, you can customize the build phase further by using the `generate` and `transfer` commands to perform additional actions when specifically building code or moving files. 
->>>>>>> parent of 897f37ddfa... Revert "Sync Cloud 2002.0.13 with master"
 
 ```yaml
 hooks:

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -22,7 +22,7 @@ We support Elasticsearch versions 1.4, 1.7, 2.4, and 5.2. The default version is
 Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
 
 {:.bs-callout .bs-callout-warning}
-If you prefer using an existing search service, like Elasticsearch, instead of relying on {{site.data.var.ece}} to create it for you, use the [`SEARCH_CONFIGURATION`]({{ site.baseurl }}/guides/v2.1/cloud/env/working-with-variables.html#search) environment variable to connect it to your site.
+If you prefer using an existing search service, like Elasticsearch, instead of relying on {{site.data.var.ece}} to create it for you, use the [`SEARCH_CONFIGURATION`]({{ site.baseurl }}/guides/v2.1/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
 
 ## Add Elasticsearch in services.yaml and .magento.app.yaml {#settings}
 To enable Elasticsearch, add the following code with your installed version and allocated disk space in MB to `.magento/services.yaml`.

--- a/guides/v2.2/cloud/reference/discover-deploy.md
+++ b/guides/v2.2/cloud/reference/discover-deploy.md
@@ -23,11 +23,13 @@ Verify the code for your site and stores is in the {{site.data.var.ece}} branch.
 {% include cloud/wings-management.md %}
 
 ## Track the process {#track}
+
 You can track build and deploy actions in real-time using the terminal or the Project Web Interface. The status displays in-progress, pending, success, or failed. You can view the logs in the interface.
 
 If you are using external GitHub repositories, the log of the operations does not display in the GitHub session. You can still follow activity in their interface and in the {{site.data.var.ece}} Project Web Interface.
 
 ## Project configuration {#cloud-deploy-conf}
+
 A set of YAML configuration files located in the project root directory define your Magento installation and describe its dependencies. If you intend to make changes, modify the YAML files in your local branch. The build and deploy scripts access those files for specific settings.
 
 For all Starter environments and Pro Integration environments, pushing your Git branch updates all settings and configurations dependent on these files.
@@ -42,6 +44,7 @@ For all Starter environments and Pro Integration environments, pushing your Git 
    The `app/etc/config.php` file includes a _scopes_ setting that defines how static files deploy during the build phase. By default, the scope is [quick]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html#static-file-quick). Static file deployment takes a long time to complete, so doing it during the build phase reduces deployment and site downtime.
 
 ## Required files for your Git branch {#requiredfiles}
+
 Your Git branch must have the following files for building and deploying in your local environment and to Integration, Staging, and Production environments:
 
 -  `auth.json`—in the root Magento directory. This file includes the Magento Authentication keys entered when creating the project. The file is generated as part of autoprovisioning a new project using a blank template. If you need to verify the file and settings, see [Troubleshoot deployment]({{ page.baseurl }}/cloud/access-acct/trouble.html).
@@ -51,6 +54,7 @@ Your Git branch must have the following files for building and deploying in your
 -  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)—updates and saves to `magento/`.
 
 ## Best practices for builds and deployment {#best-practices}
+
 We highly recommend the following best practices and considerations for your deployment process:
 
 -  **Always follow the deployment process** to ensure your code is THE SAME in Integration, Staging, and Production. This is vital. Pushing code from Integration environments may become important or needed for upgrades, patches, and configurations. This deployment overwrites Production and any differences in code in that environment.
@@ -60,6 +64,7 @@ We highly recommend the following best practices and considerations for your dep
 -  **Test your build and deploy locally and in Staging before deploying to Production.** Extensions and custom code work great in development. Some users push to production only to have failures and issues. Staging gives you an opportunity to fully test your code and implementation in a production environment without extended downtime if something goes wrong in Production.
 
 ## Five phases of Integration build and deployment {#cloud-deploy-over-phases}
+
 The following phases occur in your local development environment and the Integration environment. For Pro plans, the code is not deployed to the Staging or Production environments in these initial phases. See [Deploy code to Staging and Production]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html).
 
 Integration build and deployment consists of the following phases:
@@ -97,7 +102,7 @@ This phase builds the codebase and runs hooks in the `build` section of `.magent
 
 -  Applies patches located in `vendor/magento/ece-patches`, as well as optional, project-specific patches in `m2-hotfixes`
 -  Regenerates code and the {% glossarytooltip 2be50595-c5c7-4b9d-911c-3bf2cd3f7beb %}dependency injection{% endglossarytooltip %} configuration (that is, the Magento `generated/` directory, which includes `generated/code` and `generated/metapackage`) using `bin/magento setup:di:compile`.
--  Checks if the [`app/etc/config.php`]({{ page.baseurl }}/cloud/live/sens-data-over.html) file exists in the codebase. Magento auto-generates this file it does not detect it during the build phase and includes a list of modules and extensions. If it exists, the build phase continues as normal, compresses static files using `gzip`, and deploys the files, which reduces downtime in the deployment phase. Refer to [Magento build options]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html#build) to learn about customizing or disabling file compression.
+-  Checks if the [`app/etc/config.php`]({{ page.baseurl }}/cloud/live/sens-data-over.html) file exists in the codebase. Magento auto-generates this file it does not detect it during the build phase and includes a list of modules and extensions. If it exists, the build phase continues as normal, compresses static files using `gzip`, and deploys the files, which reduces downtime in the deployment phase. Refer to [Magento build options]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-build.html) to learn about customizing or disabling file compression.
 
   {:.bs-callout .bs-callout-info}
   The `app/etc/config.php` file includes a _scopes_ setting that defines how static files deploy during the build phase. By default, the scope is [`quick`]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html#static-file-quick). Static file deployment takes a long time to complete, so initiating it during the build phase helps to reduce deployment and site downtime.
@@ -133,7 +138,6 @@ Now we provision your applications and all of the {% glossarytooltip 74d6d228-34
 
 {:.bs-callout .bs-callout-info}
 Make your changes in a Git branch after all build and deployment completes and push again. All environment file systems are _read-only_. A read-only system guarantees deterministic deployments and dramatically improves your site security because no process can write to the file system. It also works to ensure your code is identical in the Integration, Staging, and Production environments.
-
 
 ### Phase 5: Deployment hooks {#cloud-deploy-over-phases-hook}
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -25,24 +25,24 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
--  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
+-  **Docker Compose for Cloud**—Made the following improvements to the [Docker setup and configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
-   -  JIRA--MAGECLOUD-2359-->Now you can manage environment variables more easily by customizing sample PHP configuration files and transforming those files to Docker ENV files using the new `docker:config:convert` command.
+   -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you can configure environment variables in PHP configuration files, and then convert them to Docker ENV files.
 
-   -  JIRA--MAGECLOUD--2357-->Added the capability to deploy {{site.data.var.ee}} to a read-only file system. During the build phase, the file system is writeable. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
-   -  JIRA--MAGECLOUD--2442-->Added a Redis image, which is deployed and configured automatically to work with your Docker installation.
+   -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
-   -  JIRA--MAGECLOUD--2358-->Added a Varnish image, which is deployed automatically and can be manually configured following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
+   -  JIRA--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html).
 
-   -  JIRA--MAGECLOUD--2360-->Added SSL support to access your local site and Admin panel.
+   -  JIRA--MAGECLOUD--2360-->Secure site access—Added SSL support to access your store {{site.data.var.ece}} and Admin panel.
 
 
 -  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html#hooks).
 
 -  JIRA--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
@@ -58,7 +58,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
    -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase if the `CLEAN_STATIC_SITE` environment variable is enabled in the `deploy` section of the `.magento.env.yaml` file. Previously, this variable only affected static content files generated during the deploy phase.
+   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Now you can disable the CLEAN_STATIC_SITE environment variable to prevent static content from being overwritten during the {{site.data.var.ece}} deployment. When `CLEAN_STATIC_FILES` is disabled, the deployment process only overwrites updates to existing files. Use this setting if you deploy static content using a separate process.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 
@@ -81,7 +81,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 Now you can easily move your configuration files between environments. After updating to `ece-tools` v2002.0.13, regenerate
 older `config.php` files with the improved `config:dump` command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-- JIRA--MAGECLOUD-2556>Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
+- JIRA--MAGECLOUD-2556>Fixed an issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a www domain to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 
 -  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if you do not include the `engine` parameter in the updated `.magento.env.yaml` configuration file. Now, the merge operation correctly overwrites only the values you specify in the updated `.magento.env.yaml` without requiring you to set the `engine` parameter.
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -25,70 +25,71 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  <!--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker setup and configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
-   -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you can configure environment variables in PHP configuration files, and then convert them to Docker ENV files.
+   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you can configure environment variables in PHP configuration files, and then convert them to Docker ENV files.
 
-   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  <!--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
-   -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
+   -  <!--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
-   -  JIRA--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html).
+   -  <!--MAGECLOUD--2358-->Varnish service support— Added a Varnish image, which is deployed automatically to a Docker container. After deployment, you can manually configure Varnish following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html).
 
-   -  JIRA--MAGECLOUD--2360-->Secure site access—Added SSL support to access your store {{site.data.var.ece}} and Admin panel.
+   -  <!--MAGECLOUD--2360-->Secure site access—Added SSL support to access your {{site.data.var.ee}} store and Admin panel.
 
 
--  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+-  <!--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} extension support**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. You must update existing hooks to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+- <!--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ee}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. You must update existing hooks to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
 
--  JIRA--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+-  <!--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
--  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
+-  **Environment configuration checks**—Improved validation of the environment configuration to warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
 
-   -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables and values.
+   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated environment variables and values.
 
-   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
+   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
+   -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site. 
+   -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site.
 
--  **Logging**-Made the following changes to improve log messages and reduce log size:
+-  **Logging**—
+Made the following changes to improve log messages and reduce log size:
 
-   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
+   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
 
-   -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+   -  <!--MAGECLOUD-2209-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  JIRA--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
+   -  <!--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
 
-   -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+   -  <!--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
 
 #### Resolved Issues
 
--  JIRA--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+-  <!--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html) (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html) (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
-- JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
 Now you can easily move your configuration files between environments. After updating to `ece-tools` v2002.0.13, regenerate
 older `config.php` files with the improved `config:dump` command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-- JIRA--MAGECLOUD-2556>Fixed an issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a www domain to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
+- <!--MAGECLOUD-2556>Fixed an issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a www domain to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 
--  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if you do not include the `engine` parameter in the updated `.magento.env.yaml` configuration file. Now, the merge operation correctly overwrites only the values you specify in the updated `.magento.env.yaml` without requiring you to set the `engine` parameter.
+-  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if you do not include the `engine` parameter in the updated `.magento.env.yaml` configuration file. Now, the merge operation correctly overwrites only the values you specify in the updated `.magento.env.yaml` without requiring you to set the `engine` parameter.
 
 
--  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default in v2.1.4 and later. The error was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler—[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract).
+-  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default in v2.1.4 and later. The error was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler—[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract).
 
-- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 to 2.5.
+- <!--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 to 2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -29,7 +29,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker setup and configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
-   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you can configure environment variables in PHP configuration files, and then convert them to Docker ENV files.
+   -  <!--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you configure environment variables in the sample PHP configuration files in the `docker/config.env.dist docker` directory and transform those files to Docker ENV files.
 
    -  <!--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
@@ -82,14 +82,13 @@ Made the following changes to improve log messages and reduce log size:
 Now you can easily move your configuration files between environments. After updating to `ece-tools` v2002.0.13, regenerate
 older `config.php` files with the improved `config:dump` command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
-- <!--MAGECLOUD-2556>Fixed an issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a www domain to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
+- <!--MAGECLOUD-2556-->Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a non-www or *naked* domain) to a www domain.
 
 -  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if you do not include the `engine` parameter in the updated `.magento.env.yaml` configuration file. Now, the merge operation correctly overwrites only the values you specify in the updated `.magento.env.yaml` without requiring you to set the `engine` parameter.
 
+-  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking for {{site.data.var.ece}} v2.1.11+ and v2.2.1+, which can cause slow performance and timeouts. Now, session locking is disabled by default. The issue was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler package [colinmollenhour/php-redis-session-abstract package](https://github.com/colinmollenhour/php-redis-session-abstract).
 
--  <!-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default in v2.1.4 and later. The error was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler—[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract).
-
-- <!--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 to 2.5.
+- <!--MAGECLOUD-2464-->Fixed an issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2.0 to 2.2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -133,7 +133,7 @@ to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain
 
 ## v2002.0.11
 
-{:.bs-callout bs-callout-info}
+{:.bs-callout .bs-callout-info}
 The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
 #### New features

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -18,11 +18,68 @@ You can list the available ece-tools commands using:
 php ./vendor/bin/ece-tools list
 ```
 
-The following updates describe the latest improvements to the ece-tools package, which update as needed through patching and product upgrades managed by the `magento-cloud-metapackage`. The ece-tools package adheres to the version sequence:  `200<major>.<minor>.<patch>`.
+The following updates describe the latest improvements to the `ece-tools` package, which uses the following version sequence:  `200<major>.<minor>.<patch>`.  See [Upgrades and patches]({{ site.baseurl }}/guides/v2.1/cloud/project/project-upgrade-parent.html) for information about updating to the latest release of the `ece-tools` package.
+
+
+## v2002.0.13
+
+#### New in the `ece-tools` package
+
+-  **Enable zero-downtime deployment**—<!--MAGECLOUD-2169-->Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
+
+   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scdlink):  `SKIP_SCD=false`
+
+   -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
+
+-  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
+
+   -  <!--MAGECLOUD-2356-->Added a command—`docker:config:convert` to convert PHP configuration files to Docker ENV files.
+
+   -  <!--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases to deploy {{site.data.var.ece}} to a read-only file system. During the build phase, the file system is writeable.
+
+- <!--MAGECLOUD-2363-->**Allow custom scripts in the build phase**—Split the build phase into two separate processes so that developers can use build hooks to update the generated content before the application is packaged for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+-  **Cron scheduling improvements**—<!--MAGECLOUD-2445-->Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+
+-  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
+
+   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables and values.
+
+   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+
+   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+
+-  **Environment variable updates**—Changed the following environment variables:
+
+   -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+
+    -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+
+-  **Logging**-Made the following changes to improve log messages and reduce log size:
+
+   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+
+   -  <!--MAGECLOUD-2227-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+
+   -  <!--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+
+   -  <!--MAGECLOUD-2363-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+
+
+#### Resolved Issues
+
+-  <!--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+
+- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+
+- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+
+-  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+
 
 ## v2002.0.12
 
-#### New Features
+#### New in the `ece-tools` package
 
 -  <!-- MAGECLOUD-2250 -->**Docker Compose for Cloud**—Added a new command—`docker:build`—to generate a [Docker Compose]({{ page.baseurl }}/cloud/reference/docker-config.html) configuration from the Cloud `ece-tools` repository.
 
@@ -47,7 +104,7 @@ to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain
     -  <!-- MAGECLOUD-2047 --> Added the [DATABASE_CONFIGURATION]({{ page.baseurl }}/cloud/env/variables-deploy.html#database_configuration) environment variable to customize your database connections for deployment.
     -  <!-- MAGECLOUD-2129 -->The new [MIN_LOGGING_LEVEL]({{ page.baseurl }}/cloud/env/variables-intro.html#min_logging_level) variable overrides the minimum logging level for all output streams without making changes to the code.
 
-#### Fixed Issues
+#### Resolved issues
 
 -  Fixed an issue that caused downtime between the deploy and post-deploy phase. Now, the post_deploy phase begins _immediately_ after the deploy phase ends.
 
@@ -64,14 +121,14 @@ to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain
 {:.bs-callout bs-callout-info}
 The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
-#### New features
+#### New in the `ece-tools` package
 
 - **Configuring read-only connections to non-master nodes**—This release adds the ability to configure a read-only connection to a non-master node to receive read-only traffic (for <!--MAGECLOUD-143 -->[Redis]({{ page.baseurl }}/cloud/env/variables-deploy.html#redis_use_slave_connection) and for <!--MAGECLOUD-143 --> [MariaDB]({{ page.baseurl }}/cloud/env/variables-deploy.html#mysql_use_slave_connection)).
 -  <!--MAGECLOUD-1910 -->**Configuration Wizard**—Added a new wizard to help verify your configuration for static content deployment. See [Smart wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html).
 -  <!-- MAGECLOUD-1966 -->**Symfony Console support**—Added support for Symfony Console 4 with Magento 2.3.
 -  <!-- MAGECLOUD-1607 -->**Cron scheduling optimizations**—Improved the queue management and enhanced logging to help with debugging cron-related issues.
 
-#### Fixed issues
+#### Resolved issues
 
 -  <!-- MAGECLOUD-1221 -->Deployment validation fails if an `ADMIN_EMAIL` or `ADMIN_USERNAME` value is the same as an existing Magento administrator account.
 -  <!-- MAGECLOUD-1282 -->Removed SOLR support for 2.2.x versions. 2.1.x versions retain the ability to enable SOLR.
@@ -92,7 +149,7 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
 ## v2002.0.10
 
-#### New features
+#### New in the `ece-tools` package
 
 -  <!-- MAGECLOUD-1285 -->**Static Content Deployment (SCD)**—There is a new, alternative deployment process to generate static content when requested (on-demand). This decreases downtime and improves cache handling by generating the most critical assets.
     -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the new `SCD_ON_DEMAND` global environment variable to generate static content when requested.
@@ -108,7 +165,7 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
     -  <!-- MAGECLOUD-1738 -->`SCD_ON_DEMAND`—_Global_ environment variable to generate static content when requested.
     -   `WARM_UP_PAGES`—You can list the pages to use to pre-load the cache. Available in the new [Post-deploy variables]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-post-deploy.html).
 
-#### Fixed issues
+#### Resolved issues
 
 -  <!-- MAGECLOUD-982 -->We fixed an issue that involved a locally applied patch breaking the deployment on an instance. Now, ece-tools can detect that a patch has been applied.
 
@@ -125,7 +182,7 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 {:.bs-callout .bs-callout-info}
 You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guides/v2.2/cloud/project/project-upgrade-parent.html) to get this and all future updates.
 
-#### New features
+#### New in the `ece-tools` package
 -   <!-- MAGECLOUD-1086 -->**ece-tools**—The `ece-tools` package now supports Magento 2.1.x.
 
 -   <!-- MAGECLOUD-1552 -->**Redis configuration**—You can now [configure Redis]({{ site.baseurl }}/guides/v2.2/cloud/env/working-with-variables.html#redis) page and default cache and Redis session storage using an environment variable.
@@ -140,7 +197,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 
 -   <!-- MAGECLOUD-1674 -->**Logging**—We simplified logging around built-in patching operations.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1615 -->We removed `developer` mode support and the `APPLICATION_MODE` environment variable because they were causing unexpected behavior.
 
 -   <!-- MAGECLOUD-1630 -->We fixed an issue that was causing static content deployment failures related to Redis. Now, multi-threaded static content deployment runs as designed.
@@ -154,7 +211,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 {:.bs-callout .bs-callout-info}
 We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/composer-packages/ece-patches.html) with `vendor/magento/ece-tools` in this release. You no longer need to update the `vendor/magento/ece-patches` package separately.
 
-#### New features
+#### New in the `ece-tools` package
 -   <!-- MAGECLOUD-1253 -MAGECLOUD-1495-->**Improved logging**
     -   We improved log messaging to provide better explanations when the build or deploy process overrides an environment variable.
     -   You can now view installation and upgrade progress in real time. Tail the `install_update.log` file to view progress. For example,
@@ -174,7 +231,7 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 -   <!--MAGECLOUD-1090-->We implemented smart patching. Now the package applies patches based not on {{site.data.var.ece}} version, but on patched package version.
 
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1162 -->We fixed a logging issue that was causing build errors.
 
 -   <!-- MAGECLOUD-1389 -->We fixed an issue that was causing timeout exceptions when running deployments in interactive mode.
@@ -198,12 +255,12 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 ## v2002.0.7
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1454-->We removed `var/view_preprocessed` symlinking to fix an issue that was causing JavaScript minification conflicts.
 
 ## v2002.0.6
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1413 -->We fixed an issue that was causing `gzip` errors when a file or directory name contains spaces.
 
 -   <!-- MAGECLOUD-1424 -->We fixed an issue that was preventing deployment scripts from properly recognizing and enabling module dependencies.
@@ -211,7 +268,7 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 ## v2002.0.5
 
-#### New features
+#### New in the `ece-tools` package
 -   **Configure a cron consumer with an environment variable**—You can now configure cron consumers using the new `CRON_CONSUMERS_RUNNER` environment variable.
 
 -   **Configuration scanning**—We now scan for critical components during the build/deploy process and halt the process if the scan fails, which prevents unnecessary downtime due to the site being in maintenance mode.
@@ -230,7 +287,7 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 -   **Cron interval limitations lifted**—The default cron interval for all environments provisioned in the us-3, eu-3, and ap-3 regions is 1 minute. The default cron interval in all other regions is 5 minutes for Pro Integration environments and 1 minute for Pro Staging and Production environments. To modify your existing cron jobs, edit your settings in `.magento.app.yaml` or create a support ticket for Production/Staging environments. Refer to [Set up cron jobs]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-cron-jobs.html) for more information.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1327 -->We fixed an issue that was causing long deploy times due to the deploy process invoking the `cache-clean` operation before static content deployment.
 
 -   <!-- MAGECLOUD-1322 -->We fixed an issue causing errors during the static content generation step of deployment on Production environments.
@@ -249,27 +306,27 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 ## v2002.0.4
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-1355 -->You can now [manually reset stuck Magento cron jobs]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-cron-jobs.html#reset-cron-jobs) using a CLI command in all environments via SSH access. The deployment process automatically resets cron jobs. Not available in 2.1.
 
 ## v2002.0.3
 
-#### Fixed issues
+#### Resolved issues
 -   <!--MAGECLOUD-1311-->We fixed an issue that was causing pages to time out because Redis was taking too long to read/write. You can now use the `disable_locking` parameter in Redis configurations to prevent this issue.
 
 ## v2002.0.2
 
-#### Fixed issues
+#### Resolved issues
 -   <!--MAGECLOUD-1246-->The RabbitMQ configuration process now obtains all required parameters automatically.
 
 ## v2002.0.1
 
-#### New features
+#### New in the `ece-tools` package
 -   <!--- MAGECLOUD-1057 -->{{site.data.var.ece}} now supports scopes and [static content deployment strategies]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html). We have added the `–s` parameter with a default setting of `quick` for the static content deployment strategy. You can use the environment variable [SCD_STRATEGY]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html) to customize and use these strategies with your build and deploy actions. This variable supports the options `standard`, `quick`, or `compact`. If you select `compact`, we override the `STATIC_CONTENT_THREADS` value with `1`, which can slow deployment, especially in production environments. Not available in 2.1.
 
 -   <!--- MAGECLOUD-1014 & MAGECLOUD-1023 -->We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `var/log/cloud.log` file inside the Magento root application directory.
 
-#### Fixed issues
+#### Resolved issues
 -   <!-- MAGECLOUD-919 & MAGECLOUD-1030-->Refactored the `ece-tools` package to make it compatible with {{site.data.var.ece}} 2.2.0 and higher.
 
 -   <!-- MAGECLOUD-1186-->We fixed an issue that was preventing `ece-tools` from halting execution and throwing an exception if no patches can be applied.

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -23,23 +23,26 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 ## v2002.0.13
 
-#### New in the `ece-tools` package
+#### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
-
-   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
-
-   -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
 -  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
 
-   -  JIRA--MAGECLOUD-2359-->Added a command—`docker:config:convert` to convert PHP configuration files to Docker ENV files.
+   -  JIRA--MAGECLOUD-2359-->Now you can manage environment variables more easily by customizing sample PHP configuration files and transforming those files to Docker ENV files using the new `docker:config:convert` command.
 
-   -  JIRA--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases to deploy {{site.data.var.ece}} to a read-only file system. During the build phase, the file system is writeable.
+   -  JIRA--MAGECLOUD--2357-->Added the capability to deploy {{site.data.var.ee}} to a read-only file system. During the build phase, the file system is writeable. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
--  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file](({{ page.baseurl }}cloud//reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+   -  JIRA--MAGECLOUD--2442-->Added a Redis image, which is deployed and configured automatically to work with your Docker installation.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+   -  JIRA--MAGECLOUD--2358-->Added a Varnish image, which is deployed automatically and can be manually configured following Magento best practices. See [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
+
+   -  JIRA--MAGECLOUD--2360-->Added SSL support to access your local site and Admin panel.
+
+
+-  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
+
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
 
 -  JIRA--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
@@ -47,23 +50,23 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
    -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables and values.
 
-   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the [elasticsearch composer package](https://packagist.org/packages/elasticsearch/elasticsearch) used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase if the `CLEAN_STATIC_SITE` environment variable is enabled in the `deploy` section of the `.magento.env.yaml` file. Previously, this variable only affected static content files generated during the deploy phase.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 
-   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures even if your environment configuration does not specify debug level logging. See [`MIN_LOGGING_LEVEL`]({{ page.baseurl }}//cloud/env/variables-intro.html#min_logging_level).
 
    -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  JIRA--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+   -  JIRA--MAGECLOUD-2402-->Reduced the deploy log size and fixed formatting issues caused by setup commands that use the interactive progress bar.
 
    -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
@@ -72,38 +75,45 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  JIRA--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html) (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
 - JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+Now you can easily move your configuration files between environments. After updating to `ece-tools` v2002.0.13, regenerate
+older `config.php` files with the improved `config:dump` command. See [Configuration management for store settings]({{ page.baseurl }}/cloud/live/sens-data-over.html).
 
--  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+- JIRA--MAGECLOUD-2556>Fixed an  issue that caused an error during the deploy phase if the route configuration in the `.magento/routes.yaml` file redirects from a ```www``` to an [apex](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp/) domain (also referred to as a *naked* domain).
 
--  JIRA-- MAGECLOUD-2515-->Fixed a Redis session locking issue that caused an Admin login delay. The fix is available for all versions of Magento v2.1 and v2.2.
+-  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if you do not include the `engine` parameter in the updated `.magento.env.yaml` configuration file. Now, the merge operation correctly overwrites only the values you specify in the updated `.magento.env.yaml` without requiring you to set the `engine` parameter.
+
+
+-  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default in v2.1.4 and later. The error was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler—[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract).
+
+- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 - 2.5.
 
 
 ## v2002.0.12
 
-#### New in the `ece-tools` package
+#### New features
 
--  <!-- MAGECLOUD-2250 -->**Docker Compose for Cloud**—Added a new command—`docker:build`—to generate a [Docker Compose]({{ page.baseurl }}/cloud/reference/docker-config.html) configuration from the Cloud `ece-tools` repository.
+-  <!-- MAGECLOUD-2250 -->**Docker Compose for Cloud**—Added a command—`docker:build`—to generate a [Docker Compose]({{ page.baseurl }}/cloud/reference/docker-config.html) configuration from the Cloud `ece-tools` repository.
 
 -  <!-- MAGECLOUD-2019 -->**Change Locales**—Now you can [change store locale]({{page.baseurl}}/cloud/live/sens-data-over.html#change-locales) without the exporting and importing configuration process. While Magento is in Production and the SCD_ON_DEMAND is enabled, the Magento store and admin locale options are available.
 
--  <!-- MAGECLOU-1998 -->**Site map and Robots**—Created a [new workflow]({{ page.baseurl }}/cloud/trouble/robots-sitemap.html)
+-  <!-- MAGECLOU-1998 -->**Site map and Robots**—Created a [workflow]({{ page.baseurl }}/cloud/trouble/robots-sitemap.html)
 to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain configuration without requiring a change to the infrastructure.
 
-- <!-- MAGECLOUD-1910 -->**Wizards**—Added two [new wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html) to help you with Cloud configuration:
+- <!-- MAGECLOUD-1910 -->**Wizards**—Added two [wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html) to help you with Cloud configuration:
     -  `ideal-state`—configure the ideal state for minimal deployment downtime
     -  `master-slave`—configure load balancing for database and Redis
 
-- <!-- MAGECLOUD-1521 -->**Module Refresh**—Added a new Cloud command—`module:refresh`—to enable modules that were disabled or not explicitly enabled, similar to the way that it is done automatically during a build. See [Build and deploy on local in Build phase]({{ page.baseurl }}/cloud/live/live-sanity-check.html#build).
+- <!-- MAGECLOUD-1521 -->**Module Refresh**—Added a Cloud command—`module:refresh`—to enable modules that were disabled or not explicitly enabled, similar to the way that it is done automatically during a build. See [Build and deploy on local in Build phase]({{ page.baseurl }}/cloud/live/live-sanity-check.html#build).
 
 -  <!-- MAGECLOUD-2105 -->Added the ability to choose to merge or overwrite configuration for services using the `_merge` option in [CACHE]({{ page.baseurl }}/cloud/env/variables-deploy.html#cache_configuration), [SESSION]({{ page.baseurl }}/cloud/env/variables-deploy.html#session_configuration), [QUEUE]({{ page.baseurl }}/cloud/env/variables-deploy.html#queue_configuration), and [SEARCH]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) configurations.
 
 - <!-- MAGECLOUD-1908 -->**Environment Configuration sample file**—We added a `.magento.env.yaml` sample file to the ece-tools package that includes a detailed description and possible values for each environment variable.
     -  <!-- MAGECLOUD-1907 -->We also added a deep validation for the `.magento.env.yaml` configuration that prevents failures in the deployment process caused by unexpected values. When a failure occurs, you now receive a detailed error message that begins with: `Environment configuration is not valid. Please correct .magento.env.yaml file with next suggestions:`
 
--  Added the following new [**Environment variables**]({{ page.baseurl }}/cloud/env/variables-intro.html):
+-  Added the following [**Environment variables**]({{ page.baseurl }}/cloud/env/variables-intro.html):
     - <!-- MAGECLOUD-1501 -->Now you can define multiple locales for each theme using the new [SCD_MATRIX]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_matrix) environment variable, which reduces the amount of theme files to deploy.
     -  <!-- MAGECLOUD-2047 --> Added the [DATABASE_CONFIGURATION]({{ page.baseurl }}/cloud/env/variables-deploy.html#database_configuration) environment variable to customize your database connections for deployment.
     -  <!-- MAGECLOUD-2129 -->The new [MIN_LOGGING_LEVEL]({{ page.baseurl }}/cloud/env/variables-intro.html#min_logging_level) variable overrides the minimum logging level for all output streams without making changes to the code.
@@ -125,10 +135,10 @@ to add a `robots.txt` file and generate a `sitemap.xml` file for a single domain
 {:.bs-callout bs-callout-info}
 The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
-#### New in the `ece-tools` package
+#### New features
 
 - **Configuring read-only connections to non-master nodes**—This release adds the ability to configure a read-only connection to a non-master node to receive read-only traffic (for <!--MAGECLOUD-143 -->[Redis]({{ page.baseurl }}/cloud/env/variables-deploy.html#redis_use_slave_connection) and for <!--MAGECLOUD-143 --> [MariaDB]({{ page.baseurl }}/cloud/env/variables-deploy.html#mysql_use_slave_connection)).
--  <!--MAGECLOUD-1910 -->**Configuration Wizard**—Added a new wizard to help verify your configuration for static content deployment. See [Smart wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html).
+-  <!--MAGECLOUD-1910 -->**Configuration Wizard**—Added a wizard to help verify your configuration for static content deployment. See [Smart wizards]({{ page.baseurl }}/cloud/env/smart-wizards.html).
 -  <!-- MAGECLOUD-1966 -->**Symfony Console support**—Added support for Symfony Console 4 with Magento 2.3.
 -  <!-- MAGECLOUD-1607 -->**Cron scheduling optimizations**—Improved the queue management and enhanced logging to help with debugging cron-related issues.
 
@@ -148,22 +158,23 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 -  **SCD-specific improvements**
     -  <!-- MAGECLOUD-1819 -->You can now use the `VERBOSE_COMMANDS` and the `SCD_COMPRESSION_LEVEL` environment variables during both _build_ and _deploy_ phases.
     -  <!-- MAGECLOUD-2043 -->Fixed an issue that caused deployment to fail with a random error when encountering an unexpected value for the `SCD_COMPRESSION_LEVEL` environment variable. Improved the configuration validation to provide meaningful notifications. See [`SCD_COMPRESSION_LEVEL`]({{ page.baseurl }}/cloud/env/variables-build.html#scd_compression_level) for acceptable values.
+
     -  <!-- MAGECLOUD-2044 -->Fixed the behavior of the `SCD_COMPRESSION_LEVEL` environment variable configuration flow so the overrides work as expected.
     -  <!-- MAGECLOUD-2046 -->Fixed an issue that prevented the configuration of the `SCD_THREADS` environment variable in the `.magento.env.yaml` file _deploy_ stage.
 
 ## v2002.0.10
 
-#### New in the `ece-tools` package
+#### New features
 
 -  <!-- MAGECLOUD-1285 -->**Static Content Deployment (SCD)**—There is a new, alternative deployment process to generate static content when requested (on-demand). This decreases downtime and improves cache handling by generating the most critical assets.
-    -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the new `SCD_ON_DEMAND` global environment variable to generate static content when requested.
-    -  <!-- MAGECLOUD-1788 -->**Post-deploy hook**—Added a new `post_deploy` hook for the `.magento.app.yaml` file that clears the cache and pre-loads (warms) the cache _after_ the container begins accepting connections. It is available only for Pro projects that contain [Staging and Production environments in the Project Web UI]({{ page.baseurl }}/cloud/trouble/pro-env-management.html) and for Starter projects. Although not required, this works in tandem with the `SCD_ON_DEMAND` environment variable.
+    -  <!-- MAGECLOUD-1738 -->**New environment variable**—Added the `SCD_ON_DEMAND` global environment variable to generate static content when requested.
+    -  <!-- MAGECLOUD-1788 -->**Post-deploy hook**—Added a `post_deploy` hook for the `.magento.app.yaml` file that clears the cache and pre-loads (warms) the cache _after_ the container begins accepting connections. It is available only for Pro projects that contain [Staging and Production environments in the Project Web UI]({{ page.baseurl }}/cloud/trouble/pro-env-management.html) and for Starter projects. Although not required, this works in tandem with the `SCD_ON_DEMAND` environment variable.
 
 -  <!-- MAGECLOUD-1842 -->**Optimization**—Optimized moving or copying files during deployment to improve deployment speed and decrease loads on the file system.
 
 -  <!-- MAGECLOUD-1751 -->**Deployment Logging**—Added the ability to enable Syslog and Graylog Extended Log Format (GELF) handlers for outputting logs during the deployment process. See [Logging handlers]({{ page.baseurl }}/cloud/env/log-handlers.html).
 
--  Added the following new [**Environment variables**]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html):
+-  Added the following [**Environment variables**]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-intro.html):
     -  <!-- MAGECLOUD-1556 -->`CRYPT_KEY`—Provide a cryptographic key to another environment when moving a database.
     -  <!-- MAGECLOUD-1621 and MAGECLOUD-1736-->`SKIP_HTML_MINIFICATION`—_Global_ environment variable that skips copying the static view files in the `var/view_preprocessed` directory and generates minified HTML when requested.
     -  <!-- MAGECLOUD-1738 -->`SCD_ON_DEMAND`—_Global_ environment variable to generate static content when requested.
@@ -186,7 +197,7 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 {:.bs-callout .bs-callout-info}
 You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guides/v2.2/cloud/project/project-upgrade-parent.html) to get this and all future updates.
 
-#### New in the `ece-tools` package
+#### New features
 -   <!-- MAGECLOUD-1086 -->**ece-tools**—The `ece-tools` package now supports Magento 2.1.x.
 
 -   <!-- MAGECLOUD-1552 -->**Redis configuration**—You can now [configure Redis]({{ site.baseurl }}/guides/v2.2/cloud/env/working-with-variables.html#redis) page and default cache and Redis session storage using an environment variable.
@@ -215,7 +226,7 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 {:.bs-callout .bs-callout-info}
 We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/composer-packages/ece-patches.html) with `vendor/magento/ece-tools` in this release. You no longer need to update the `vendor/magento/ece-patches` package separately.
 
-#### New in the `ece-tools` package
+#### New features
 -   <!-- MAGECLOUD-1253 -MAGECLOUD-1495-->**Improved logging**
     -   We improved log messaging to provide better explanations when the build or deploy process overrides an environment variable.
     -   You can now view installation and upgrade progress in real time. Tail the `install_update.log` file to view progress. For example,
@@ -272,12 +283,12 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 ## v2002.0.5
 
-#### New in the `ece-tools` package
+#### New features
 -   **Configure a cron consumer with an environment variable**—You can now configure cron consumers using the new `CRON_CONSUMERS_RUNNER` environment variable.
 
 -   **Configuration scanning**—We now scan for critical components during the build/deploy process and halt the process if the scan fails, which prevents unnecessary downtime due to the site being in maintenance mode.
 
--   **Build/deploy notifications**—We added a new configuration file that you can use to [set up Slack and/or email notifications]({{ site.baseurl }}/guides/v2.2/cloud/env/setup-notifications.html) for build/deploy actions in all your environments.
+-   **Build/deploy notifications**—We added a configuration file that you can use to [set up Slack and/or email notifications]({{ site.baseurl }}/guides/v2.2/cloud/env/setup-notifications.html) for build/deploy actions in all your environments.
 
 -   **Static content compression**—We now compress static content using [gzip](https://www.gnu.org/software/gzip/){:target="\_blank"} during the build and deploy phases. This compression, coupled with Fastly compression, helps reduce the size of your store and increase deployment speed. If necessary, you can disable compression using a [build option]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html#build) or [deploy variable]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html#deploy). See the following topics for more information:
 
@@ -287,7 +298,7 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 -   **Configuration management**—We now auto-generate an `app/etc/config.php` file in your git repository during the build phase if it doesn't already exist. The auto-generated file includes only a list of modules and extensions. If the file already exists, the build phase continues as normal. If you follow [Configuration Management]({{ site.baseurl }}/guides/v2.2/cloud/live/sens-data-over.html) at a later time, the commands update the file without requiring additional steps. Refer to [Deployment process]({{ site.baseurl }}/guides/v2.2/cloud/reference/discover-deploy.html) for more information.
 
--   **Database dumps**—We added a new `magento/ece-tools` CLI command for creating database dumps in all environments. For Pro plan Production environments, this command only dumps from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. We recommend putting the application in maintenance mode before doing a database dump in Production environments. See [Snapshots and backup management]({{ site.baseurl }}/guides/v2.2/cloud/project/project-webint-snap.html#db-dump) for more information.
+-   **Database dumps**—We added a `magento/ece-tools` CLI command for creating database dumps in all environments. For Pro plan Production environments, this command only dumps from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. We recommend putting the application in maintenance mode before doing a database dump in Production environments. See [Snapshots and backup management]({{ site.baseurl }}/guides/v2.2/cloud/project/project-webint-snap.html#db-dump) for more information.
 
 -   **Cron interval limitations lifted**—The default cron interval for all environments provisioned in the us-3, eu-3, and ap-3 regions is 1 minute. The default cron interval in all other regions is 5 minutes for Pro Integration environments and 1 minute for Pro Staging and Production environments. To modify your existing cron jobs, edit your settings in `.magento.app.yaml` or create a support ticket for Production/Staging environments. Refer to [Set up cron jobs]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-cron-jobs.html) for more information.
 
@@ -325,10 +336,10 @@ We merged [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/co
 
 ## v2002.0.1
 
-#### New in the `ece-tools` package
+#### New features
 -   <!--- MAGECLOUD-1057 -->{{site.data.var.ece}} now supports scopes and [static content deployment strategies]({{ site.baseurl }}/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html). We have added the `–s` parameter with a default setting of `quick` for the static content deployment strategy. You can use the environment variable [SCD_STRATEGY]({{ site.baseurl }}/guides/v2.2/cloud/env/environment-vars_magento.html) to customize and use these strategies with your build and deploy actions. This variable supports the options `standard`, `quick`, or `compact`. If you select `compact`, we override the `STATIC_CONTENT_THREADS` value with `1`, which can slow deployment, especially in production environments. Not available in 2.1.
 
--   <!--- MAGECLOUD-1014 & MAGECLOUD-1023 -->We have created a new log file on environments to capture and compile build and deploy actions. The file is located in the `var/log/cloud.log` file inside the Magento root application directory.
+-   <!--- MAGECLOUD-1014 & MAGECLOUD-1023 -->We have created a log file on environments to capture and compile build and deploy actions. The file is located in the `var/log/cloud.log` file inside the Magento root application directory.
 
 #### Resolved issues
 -   <!-- MAGECLOUD-919 & MAGECLOUD-1030-->Refactored the `ece-tools` package to make it compatible with {{site.data.var.ece}} 2.2.0 and higher.

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -25,13 +25,13 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New features
 
--  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now {{site.data.var.ece}} queues requests with required database changes during deployment and applies the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. See [Static content deployment options to reduce deployment downtime on Cloud](https://support.magento.com/hc/en-us/articles/360004861194-Static-content-deployment-options-to-reduce-deployment-downtime-on-Cloud){:target="\_blank"}.
 
 -  **Docker Compose for Cloud**—Made the following improvements to the [Docker setup and configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process:
 
    -  JIRA--MAGECLOUD-2359-->Added sample PHP configuration files and a command—`docker:config:convert` to simplify environment configuration. Now, you can configure environment variables in PHP configuration files, and then convert them to Docker ENV files.
 
-   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
+   -  JIRA--MAGECLOUD--2357-->The {{site.data.var.ece}} installation process now supports deploying to both read-only and  read-write file systems to more closely emulate the Cloud file system. See [Launch Docker]({{ page.baseurl }}/cloud/reference/docker-config.html#launch-docker-configuration).
 
    -  JIRA--MAGECLOUD--2442-->Redis service support—Added a Redis image, which is deployed to a Docker container and configured automatically to work with your Docker installation.
 
@@ -42,7 +42,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 -  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file]({{ page.baseurl }}/cloud/reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
-- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. See [Application hooks]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html#hooks).
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can use hooks to apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* process deploys the application. You must update existing hooks to use the new functionality. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
 
 -  JIRA--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
@@ -58,7 +58,7 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
    -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value to `true` to enable on-demand HTML content minification, which minimizes downtime when deploying to Staging and Production environments. This configuration is required for zero-downtime deployments.
 
-   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Now you can disable the CLEAN_STATIC_SITE environment variable to prevent static content from being overwritten during the {{site.data.var.ece}} deployment. When `CLEAN_STATIC_FILES` is disabled, the deployment process only overwrites updates to existing files. Use this setting if you deploy static content using a separate process.
+   -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to manage the clean static files processing for static content generated during the build phase based on the CLEAN_STATIC_FILES environment variable setting. Previously, static content files generated during the build phase were not cleaned, which can cause errors and performance issues after deploying content to your site. 
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -88,7 +88,7 @@ older `config.php` files with the improved `config:dump` command. See [Configura
 
 -  JIRA-- MAGECLOUD-2515-->Fixed a Redis configuration issue that incorrectly enabled session locking in {{site.data.var.ece}} v2.1.4 and later, which can cause slow performance and timeouts. Now, session locking is disabled by default in v2.1.4 and later. The error was caused by a change in the default behavior of the `disable_locking` parameter introduced in v1.3.4 of the Redis session handler—[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract).
 
-- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 - 2.5.
+- JIRA--MAGECLOUD-2464-->Fixed a compatibility issue in the `ece-tools` package that caused problems with cron queue management in {{site.data.var.ee}} versions 2.2 to 2.5.
 
 
 ## v2002.0.12

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -25,56 +25,60 @@ The following updates describe the latest improvements to the `ece-tools` packag
 
 #### New in the `ece-tools` package
 
--  **Enable zero-downtime deployment**—<!--MAGECLOUD-2169-->Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
+-  JIRA--MAGECLOUD-2169-->**Enable zero-downtime deployment**—Now you can configure {{site.data.var.ece}} to queue requests with required database changes during deployment and apply the changes as soon as the deployment completes. Requests can be held for up to 5 minutes to ensure that no sessions are lost. This feature is available when you configure the following Static Content Deployment (SCD) settings in the `magento.env.yaml` configuration file.
 
-   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scdlink):  `SKIP_SCD=false`
+   -  [Enable static content deployment on the build phase]({{ page.baseurl }}/cloud/env/variables-build.html#skip_scd):  `SKIP_SCD=false`
 
    -  [Enable on-demand static content generation]({{ page.baseurl }}/cloud/env/variables-intro.html#scd_on_demand): `SCD_ON_DEMAND=true`
 
 -  **Docker Compose for Cloud**—Improved the [Docker configuration]({{ page.baseurl }}/cloud/reference/docker-config.html) process to launch a {{site.data.var.ece}} development environment in your local workspace. (Requires `ece-tools` version 2002.0.13 or later).
 
-   -  <!--MAGECLOUD-2356-->Added a command—`docker:config:convert` to convert PHP configuration files to Docker ENV files.
+   -  JIRA--MAGECLOUD-2359-->Added a command—`docker:config:convert` to convert PHP configuration files to Docker ENV files.
 
-   -  <!--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases to deploy {{site.data.var.ece}} to a read-only file system. During the build phase, the file system is writeable.
+   -  JIRA--MAGECLOUD--2357-->Split the {{site.data.var.ee}} installation process into separate build and deploy phases to deploy {{site.data.var.ece}} to a read-only file system. During the build phase, the file system is writeable.
 
-- <!--MAGECLOUD-2363-->**Allow custom scripts in the build phase**—Split the build phase into two separate processes so that developers can use build hooks to update the generated content before the application is packaged for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+-  JIRA--MAGECLOUD-2205-->**Improved {{site.data.var.ece}} support for third-party extensions**—Downgraded the minimum version requirement for the guzzlehttp/guzzle package in the {{site.data.var.ece}} [composer.json file](({{ page.baseurl }}cloud//reference/cloud-composer.html) to version 6.2 so that the `ece-tools` package is compatible with more extensions.
 
--  **Cron scheduling improvements**—<!--MAGECLOUD-2445-->Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
+- JIRA--MAGECLOUD-2363-->**Apply custom changes to your {{site.data.var.ece}} application during the build phase**—We split the build phase into two separate processes so that you can apply custom changes to the generated static content before packaging the application for deployment. The *build:generate* process generates code, applies patches, and generates static content. The *build:transfer* phase deploys the application. See [Application hooks]({{ page.baseurl }}//cloud/project/project-conf-files_magento-app.html#hooks).
+
+-  JIRA--MAGECLOUD-2445-->**Cron scheduling improvements**—Improved cron job management during the deploy phase to prevent database locks and other critical issues. Now, all cron jobs stop during the deploy phase and restart after the deploy phase completes.
 
 -  **Environment configuration checks**—Improved validation of the environment configuration to proactively warn customers about version incompatibilities and configuration errors before building and deploying {{site.data.var.ece}}.
 
-   -  <!--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables and values.
+   -  JIRA--MAGECLOUD-2183-->Added version-specific validation to identify unsupported or deprecated {{site.data.var.ece}} environment variables and values.
 
-   -  <!--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
+   -  JIRA--MAGECLOUD-2389-->Added an Elasticsearch compatibility check. Now, the deployment fails if the `.magento/services.yaml` file specifies an Elasticsearch version that is incompatible with the elasticsearch composer package used to install {{site.data.var.ee}} v2.1.4 and later. Previously, you could deploy with an unsupported version of the Elasticsearch service, which caused product catalog issues after site deployment. See [Setup Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html).
 
-   -  <!--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
+   -  JIRA--MAGECLOUD-2156-->Improved validation of environment variables to identify configuration settings that can cause conflicts during the {{site.data.var.ece}} build, deploy, and post-deploy phases. For example, a warning message displays during the install and upgrade process if the global setting for static site content deployment conflicts with settings on the build or deploy phase.
 
 -  **Environment variable updates**—Changed the following environment variables:
 
-   -  <!--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
+   -  JIRA--MAGECLOUD-2435-->**[SKIP_HTML_MINIFICATION global variable]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification)**—Changed the default value from `false` to `true` to enable the on-demand static content minification setting in the default environment configuration. This change decreases downtime significantly and is required for zero-downtime deployments. See [Global variables]({{ page.baseurl }}/cloud/env/variables-intro.html##skip_html_minification).
 
-    -  <!--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
+    -  JIRA--MAGECLOUD-1506-->**[CLEAN_STATIC_FILES deploy variable]({{ page.baseurl }}/cloud/env/variables-deploy.html#clean_static_files)**—Added the capability to clean static content files generated during the build phase and updated the default to clean static content by default (``CLEAN_STATIC_FILES=`true``). Previously, you could only clean static content files generated during the deploy phase.
 
 -  **Logging**-Made the following changes to improve log messages and reduce log size:
 
-   -  <!--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
+   -  JIRA--MAGECLOUD-2489-->Deployment failure log entries now include the command output from the operations that cause the failures.
 
-   -  <!--MAGECLOUD-2227-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
+   -  JIRA--MAGECLOUD-2209-->Added logging for deployment failures that occur when generated factories required by some extensions cannot be generated correctly because the file system is in a read-only state.
 
-   -  <!--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
+   -  JIRA--MAGECLOUD-2402-->Improved the deploy log to reduce log size and fix formatting issues caused by setup commands that used the interactive progress bar.
 
-   -  <!--MAGECLOUD-2363-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
+   -  JIRA--MAGECLOUD-2227-->Eliminated unnecessary verbosity and updated the priority levels for some log statements.
 
 
 #### Resolved Issues
 
--  <!--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
+-  JIRA--MAGECLOUD-2427-->Changed the default cron job configuration settings for history lifetime from 3d (4320 min) to 1h (60 min) to prevent performance issues and deployment failures that can occur when the cron queue fills too quickly.
 
-- <!-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) process (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
+- JIRA-- MAGECLOUD-2182-->Fixed an issue with the [static content compression process]({{ site.baseurl }}cloud/env/variables-deploy.html#scd_compression_level) (`gzip`) that caused `not overwritten` and `no such file or directory` errors when referencing the compressed file during the deployment process.
 
-- <!--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
+- JIRA--MAGECLOUD-2444-->Fixed an issue that prevented the `php ./vendor/bin/ece-tools config:dump` command from removing redundant sections from the `config.php` file during the dump process if the store locale is not specified.
 
--  <!--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+-  JIRA--MAGECLOUD-2520-->Fixed an issue with the `_merge` option for the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) variable that caused incorrect merge results if the updated `.magento.env.yaml` configuration file did not include the `engine` parameter value along with other updated values. Now, the merge operation correctly overwrites only the parameter values included in the updated `.magento.env.yaml` without requiring you to specify the `engine` parameter value.
+
+-  JIRA-- MAGECLOUD-2515-->Fixed a Redis session locking issue that caused an Admin login delay. The fix is available for all versions of Magento v2.1 and v2.2.
 
 
 ## v2002.0.12


### PR DESCRIPTION
## This PR is a:

- [x] Content update

## Summary

Updates for 

**Docker changes**
- [MAGECLOUD-2357|https://magento2.atlassian.net/browse/MAGECLOUD-2357]:   Simplified text for the update for deploying to read-only FS
- [MAGECLOUD-2359|https://magento2.atlassian.net/browse/MAGECLOUD-2359]:  Added path to edit PHP files for Docker setup `docker/config.env.dist`
**Env variable**
[MAGECLOUD-1506:  Updated release note to explain CLEAN_STATIC_FILES behavior change

**Resolved issues**

[MAGECLOUD-2464|https://magento2.atlassian.net/browse/MAGECLOUD-2464]: Fixed Magento version reference and revised text based on updated JIRA ticket

[MAGECLOUD-2556|https://magento2.atlassian.net/browse/MAGECLOUD-2556]:  Corrected redirect reference

[MAGECLOUD-2515|https://magento2.atlassian.net/browse/MAGECLOUD-2515]: Revised text based on updated JIRA ticket.  