### PR TITLE
Fix path to theme.less

### DIFF
--- a/guides/v2.1/frontend-dev-guide/css-topics/theme-ui-lib.md
+++ b/guides/v2.1/frontend-dev-guide/css-topics/theme-ui-lib.md
@@ -96,7 +96,7 @@ For example, [`lib/web/css/source/lib/variables/_breadcrumbs.less`] contains var
 To change the default library variables values, specify the new values for the required variables in the `<theme_dir>/web/css/source/_theme.less` file.
 
 <div class="bs-callout bs-callout-info" id="info" markdown="1">
-Please mind, that your `&lt;theme_dir&gt;/web/css/source/_theme.less` file overrides `_theme.less` of the parent theme (if your theme has a parent).
+Please mind, that your `<theme_dir>/web/css/source/_theme.less` file overrides `_theme.less` of the parent theme (if your theme has a parent).
 So if you want to inherit the parent theme's variable values additionally to your changes, add the content of parent’s `_theme.less` to your file as well.
 </div>
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix route to `theme.less` file in Magento UI Library page.

<!-- (REQUIRED) What does this PR change? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
