### PR TITLE
Fixed typo mistakes in ui_comp_guide files

### DIFF
--- a/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-actionscolumn.md
@@ -40,7 +40,7 @@ ActionsColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{[name: string]: Boolean}</td>
     <td><code>{'data-grid-actions-cell': true}</code></td>
   </tr>

--- a/guides/v2.1/ui_comp_guide/components/ui-column.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-column.md
@@ -61,7 +61,7 @@ Column-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{[name: String]: Boolean}</td>
     <td><code>''</code></td>
   </tr>

--- a/guides/v2.1/ui_comp_guide/components/ui-multiselectcolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-multiselectcolumn.md
@@ -55,7 +55,7 @@ MultiselectColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{<br>[name: string]: Boolean<br>}</td>
     <td>{<br><code>'data-grid-checkbox-cell': true</code><br>}</td>
   </tr>

--- a/guides/v2.1/ui_comp_guide/components/ui-onoffcolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-onoffcolumn.md
@@ -34,7 +34,7 @@ OnOffColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{<br><code>[name: string]: boolean</code><br>}</td>
     <td>{<br>'<code>admin__scope-old': true,</code><br><code>'data-grid-onoff-cell': true,</code><br><code>'data-grid-checkbox-cell': false</code><br>}</td>
   </tr>

--- a/guides/v2.1/ui_comp_guide/components/ui-thumbnailcolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-thumbnailcolumn.md
@@ -34,7 +34,7 @@ ThumbnailColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td><code>{[name: string]: boolean}</code></td>
     <td><code>{'data-grid-thumbnail-cell': true}</code></td>
   </tr>

--- a/guides/v2.2/ui_comp_guide/components/ui-actionscolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-actionscolumn.md
@@ -40,7 +40,7 @@ ActionsColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{[name: string]: Boolean}</td>
     <td><code>{'data-grid-actions-cell': true}</code></td>
   </tr>

--- a/guides/v2.2/ui_comp_guide/components/ui-column.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-column.md
@@ -61,7 +61,7 @@ Column-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{[name: String]: Boolean}</td>
     <td><code>''</code></td>
   </tr>

--- a/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
@@ -55,7 +55,7 @@ MultiselectColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{<br>[name: string]: boolean<br>}</td>
     <td>{<br><code>'data-grid-checkbox-cell': true</code><br>}</td>
   </tr>

--- a/guides/v2.2/ui_comp_guide/components/ui-onoffcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-onoffcolumn.md
@@ -34,7 +34,7 @@ OnOffColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td>{<br><code>[name: string]: boolean</code><br>}</td>
     <td>{<br>'<code>admin__scope-old': true,</code><br><code>'data-grid-onoff-cell': true,</code><br><code>'data-grid-checkbox-cell': false</code><br>}</td>
   </tr>

--- a/guides/v2.2/ui_comp_guide/components/ui-thumbnailcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-thumbnailcolumn.md
@@ -34,7 +34,7 @@ ThumbnailColumn-specific configuration:
   </tr>
   <tr>
     <td><code>fieldClass</code></td>
-    <td>Additonal CSS classes added to the column's field elements.</td>
+    <td>Additional CSS classes added to the column's field elements.</td>
     <td><code>{[name: string]: boolean}</code></td>
     <td><code>{'data-grid-thumbnail-cell': true}</code></td>
   </tr>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix typo mistakes in ui_comp_guide files.

<!-- (REQUIRED) What does this PR change? -->

## Additional information
N/A
<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
