### PR TITLE
Add Security/XML sections to Technical Guidelines

### DIFF
--- a/guides/v2.0/coding-standards/technical-guidelines.md
+++ b/guides/v2.0/coding-standards/technical-guidelines.md
@@ -697,6 +697,79 @@ class SampleEventObserverThatModifiesInputs
 {:start="14.2"}
 14.2. Events used SHOULD be observed as specifically as possible. A `global` subscription to an event SHOULD NOT be used when the area impacted is just `frontend`.
 
+## 15. Security
+
+15.1. Use prepared statements for SQL queries.
+
+15.2. Broken Authentication protection.
+
+15.2.1. Where possible, implement multi-factor authentication to prevent automated, credential stuffing, brute force, and stolen credential re-use attacks.
+
+15.2.2. Do not ship or deploy with any default credentials, particularly for admin users.
+
+15.2.3. Implement weak-password checks, such as testing new or changed passwords against a list of the [top 10000 worst passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords).
+
+15.2.4. Align password length, complexity, and rotation policies with [NIST 800-63 B's guidelines in section 5.1.1 for Memorized Secrets](https://pages.nist.gov/800-63-3/sp800-63b.html#memsecret) or other modern, evidence-based password policies.
+
+15.2.5. Ensure registration, credential recovery, and API pathways are hardened against account enumeration attacks by using the same messages for all outcomes.
+
+15.2.6. Limit or increasingly delay failed login attempts. Log all failures and alert administrators when credential stuffing, brute force, or other attacks are detected.
+
+15.2.7. Use a server-side, secure, built-in session manager that generates a new random session ID with high entropy after login. Session IDs should not be in the URL, be securely stored and invalidated after logout, idle, and absolute timeouts.
+
+15.3. Cross-Site Scripting (XSS) protection.
+
+15.3.1. Sanitize input; escape output.
+
+15.3.2. Follow [templates XSS security guidelines](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-security.html) for escaping output.
+
+15.3.3. Incoming data should be casted to the expected type. String data should be validated/sanitized.
+
+15.3.4. Incoming string data length should be checked.
+
+15.3.5. Special characters, like null byte characters, should be dropped from Incoming string data.
+
+15.4. A module that introduces Admin Panel functionality should have ACL.
+
+15.5. Misconfiguration protection.
+
+15.5.1. Do not include/require unused libraries/frameworks.
+
+15.5.2. A segmented application architecture that provides effective, secure separation between components or tenants, with segmentation, containerization, or cloud security groups (ACLs).
+
+15.5.3. Sending security directives to clients, e.g. [Security Headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project).
+
+15.6. Sensitive Data Exposure protection.
+
+15.6.1. Exceptions/Notices/Warnings should be caught and logged.
+
+15.6.2. No error output should be displayed to user, some standard message should appear instead.
+
+15.6.3. Logs should not be excessive, e.g. PDO exception contains MySQL credentials that should not be logged.
+
+15.7. Cross-Site Request Forgery (CSRF) protection.
+
+15.7.1. CSRF tokens mechanism should be utilized.
+
+15.7.2. All data manipulation requests should be made with POST requests.
+
+15.8. Frequently update the third-party libraries used in the project/component to eliminate known vulnerabilities.
+
+15.9. Local File Inclusion (LFI) protection.
+
+15.9.1. SHOULD NOT trust user-submitted requests containing path and file name.
+
+15.9.2. SHOULD sanitize user-submitted path and file values to remove dot-dot-slash from the request.
+
+15.10. Remote Code Execution (RCE) protection.
+
+15.10.1. SHOULD NOT use `eval()`, `passthru()`, `system()`, `shell_exec()`, `serialize()`, `unserialize()`, `md5()`, `srand()`, `mt_srand()`.
+
+15.10.2. SHOULD NOT directly pass user-submitted values to `include*()`, `require*()`, `create_function()`, `fopen()`, `preg_replace()`.
+
+15.10.3. SHOULD NOT use variable functions if the variable values are submitted by the user.
+
+
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 
 [RFC2119]: https://tools.ietf.org/html/rfc2119

--- a/guides/v2.1/coding-standards/technical-guidelines.md
+++ b/guides/v2.1/coding-standards/technical-guidelines.md
@@ -697,6 +697,121 @@ class SampleEventObserverThatModifiesInputs
 {:start="14.2"}
 14.2. Events used SHOULD be observed as specifically as possible. A `global` subscription to an event SHOULD NOT be used when the area impacted is just `frontend`.
 
+## 15. XML configuration
+
+15.1 Attributes MUST be used for the configuration values that will not be extended in the future by adding child nodes or new attributes.
+
+15.2 Nodes of the same type that repeat multiple times MUST be wrapped in a grouping node.
+
+15.3 Unnecessarily grouping nodes MUST be avoided.
+
+{% collapsible Examples: %}
+<table>
+    <tr>
+        <th><span style="color: red">Not recommended</span></th>
+        <th><span style="color: green">Recommended</span></th>
+    </tr>
+    <tr>
+        <td>
+{% highlight xml %}
+<!-- This example assumes that the following configuration is in its own file and `item` doesn't repeat multiple times in the file -->
+<config>
+    <items>
+        <item />
+    </items>
+<config>
+{% endhighlight %}
+        </td>
+        <td>
+{% highlight xml %}
+<config>
+    <items>
+        <item />
+    </items>
+<config>
+{% endhighlight %}
+        </td>
+    </tr>
+</table>
+{% endcollapsible %}
+
+---
+
+15.4 The schema MUST NOT allow someone to specify contradicting configuration values (multiple attributes or nodes that are mutually exclusive, for instance).
+
+
+## 16. Security
+
+16.1. Use prepared statements for SQL queries.
+
+16.2. Broken Authentication protection.
+
+16.2.1. Where possible, implement multi-factor authentication to prevent automated, credential stuffing, brute force, and stolen credential re-use attacks.
+
+16.2.2. Do not ship or deploy with any default credentials, particularly for admin users.
+
+16.2.3. Implement weak-password checks, such as testing new or changed passwords against a list of the [top 10000 worst passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords).
+
+16.2.4. Align password length, complexity, and rotation policies with [NIST 800-63 B's guidelines in section 5.1.1 for Memorized Secrets](https://pages.nist.gov/800-63-3/sp800-63b.html#memsecret) or other modern, evidence-based password policies.
+
+16.2.5. Ensure registration, credential recovery, and API pathways are hardened against account enumeration attacks by using the same messages for all outcomes.
+
+16.2.6. Limit or increasingly delay failed login attempts. Log all failures and alert administrators when credential stuffing, brute force, or other attacks are detected.
+
+16.2.7. Use a server-side, secure, built-in session manager that generates a new random session ID with high entropy after login. Session IDs should not be in the URL, be securely stored and invalidated after logout, idle, and absolute timeouts.
+
+16.3. Cross-Site Scripting (XSS) protection.
+
+16.3.1. Sanitize input; escape output.
+
+16.3.2. Follow [templates XSS security guidelines](https://{{ page.baseurl }}/frontend-dev-guide/templates/template-security.html) for escaping output.
+
+16.3.3. Incoming data should be casted to the expected type. String data should be validated/sanitized.
+
+16.3.4. Incoming string data length should be checked.
+
+16.3.5. Special characters, like null byte characters, should be dropped from Incoming string data.
+
+16.4. A module that introduces Admin Panel functionality should have ACL.
+
+16.5. Misconfiguration protection.
+
+16.5.1. Do not include/require unused libraries/frameworks.
+
+16.5.2. A segmented application architecture that provides effective, secure separation between components or tenants, with segmentation, containerization, or cloud security groups (ACLs).
+
+16.5.3. Sending security directives to clients, e.g. [Security Headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project).
+
+16.6. Sensitive Data Exposure protection.
+
+16.6.1. Exceptions/Notices/Warnings should be caught and logged.
+
+16.6.2. No error output should be displayed to user, some standard message should appear instead.
+
+16.6.3. Logs should not be excessive, e.g. PDO exception contains MySQL credentials that should not be logged.
+
+16.7. Cross-Site Request Forgery (CSRF) protection.
+
+16.7.1. CSRF tokens mechanism should be utilized.
+
+16.7.2. All data manipulation requests should be made with POST requests.
+
+16.8. Frequently update the third-party libraries used in the project/component to eliminate known vulnerabilities.
+
+16.9. Local File Inclusion (LFI) protection.
+
+16.9.1. SHOULD NOT trust user-submitted requests containing path and file name.
+
+16.9.2. SHOULD sanitize user-submitted path and file values to remove dot-dot-slash from the request.
+
+16.10. Remote Code Execution (RCE) protection.
+
+16.10.1. SHOULD NOT use `eval()`, `passthru()`, `system()`, `shell_exec()`, `serialize()`, `unserialize()`, `md5()`, `srand()`, `mt_srand()`.
+
+16.10.2. SHOULD NOT directly pass user-submitted values to `include*()`, `require*()`, `create_function()`, `fopen()`, `preg_replace()`.
+
+16.10.3. SHOULD NOT use variable functions if the variable values are submitted by the user.
+
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 
 [RFC2119]: https://tools.ietf.org/html/rfc2119

--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -703,77 +703,119 @@ class SampleEventObserverThatModifiesInputs
 {:start="14.2"}
 14.2. Events used SHOULD be observed as specifically as possible. A `global` subscription to an event SHOULD NOT be used when the area impacted is just `frontend`.
 
-## 15. Security
+## 15. XML configuration
 
-15.1. Use prepared statements for SQL queries.
+15.1 Attributes MUST be used for the configuration values that will not be extended in the future by adding child nodes or new attributes.
 
-15.2. Broken Authentication protection.
+15.2 Nodes of the same type that repeat multiple times MUST be wrapped in a grouping node.
 
-15.2.1. Where possible, implement multi-factor authentication to prevent automated, credential stuffing, brute force, and stolen credential re-use attacks.
+15.3 Unnecessarily grouping nodes MUST be avoided.
 
-15.2.2. Do not ship or deploy with any default credentials, particularly for admin users.
+{% collapsible Examples: %}
+<table>
+    <tr>
+        <th><span style="color: red">Not recommended</span></th>
+        <th><span style="color: green">Recommended</span></th>
+    </tr>
+    <tr>
+        <td>
+{% highlight xml %}
+<!-- This example assumes that the following configuration is in its own file and `item` doesn't repeat multiple times in the file -->
+<config>
+    <items>
+        <item />
+    </items>
+<config>
+{% endhighlight %}
+        </td>
+        <td>
+{% highlight xml %}
+<config>
+    <items>
+        <item />
+    </items>
+<config>
+{% endhighlight %}
+        </td>
+    </tr>
+</table>
+{% endcollapsible %}
 
-15.2.3. Implement weak-password checks, such as testing new or changed passwords against a list of the [top 10000 worst passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords).
+---
 
-15.2.4. Align password length, complexity, and rotation policies with [NIST 800-63 B's guidelines in section 5.1.1 for Memorized Secrets](https://pages.nist.gov/800-63-3/sp800-63b.html#memsecret) or other modern, evidence-based password policies.
+15.4 The schema MUST NOT allow someone to specify contradicting configuration values (multiple attributes or nodes that are mutually exclusive, for instance).
 
-15.2.5. Ensure registration, credential recovery, and API pathways are hardened against account enumeration attacks by using the same messages for all outcomes.
+## 16. Security
 
-15.2.6. Limit or increasingly delay failed login attempts. Log all failures and alert administrators when credential stuffing, brute force, or other attacks are detected.
+16.1. Use prepared statements for SQL queries.
 
-15.2.7. Use a server-side, secure, built-in session manager that generates a new random session ID with high entropy after login. Session IDs should not be in the URL, be securely stored and invalidated after logout, idle, and absolute timeouts.
+16.2. Broken Authentication protection.
 
-15.3. Cross-Site Scripting (XSS) protection.
+16.2.1. Where possible, implement multi-factor authentication to prevent automated, credential stuffing, brute force, and stolen credential re-use attacks.
 
-15.3.1. Sanitize input; escape output.
+16.2.2. Do not ship or deploy with any default credentials, particularly for admin users.
 
-15.3.2. Follow [templates XSS security guidelines](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-security.html) for escaping output.
+16.2.3. Implement weak-password checks, such as testing new or changed passwords against a list of the [top 10000 worst passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords).
 
-15.3.3. Incoming data should be casted to the expected type. String data should be validated/sanitized.
+16.2.4. Align password length, complexity, and rotation policies with [NIST 800-63 B's guidelines in section 5.1.1 for Memorized Secrets](https://pages.nist.gov/800-63-3/sp800-63b.html#memsecret) or other modern, evidence-based password policies.
 
-15.3.4. Incoming string data length should be checked.
+16.2.5. Ensure registration, credential recovery, and API pathways are hardened against account enumeration attacks by using the same messages for all outcomes.
 
-15.3.5. Special characters, like null byte characters, should be dropped from Incoming string data.
+16.2.6. Limit or increasingly delay failed login attempts. Log all failures and alert administrators when credential stuffing, brute force, or other attacks are detected.
 
-15.4. A module that introduces Admin Panel functionality should have ACL.
+16.2.7. Use a server-side, secure, built-in session manager that generates a new random session ID with high entropy after login. Session IDs should not be in the URL, be securely stored and invalidated after logout, idle, and absolute timeouts.
 
-15.5. Misconfiguration protection.
+16.3. Cross-Site Scripting (XSS) protection.
 
-15.5.1. Do not include/require unused libraries/frameworks.
+16.3.1. Sanitize input; escape output.
 
-15.5.2. A segmented application architecture that provides effective, secure separation between components or tenants, with segmentation, containerization, or cloud security groups (ACLs).
+16.3.2. Follow [templates XSS security guidelines]({{ page.baseurl }}/frontend-dev-guide/templates/template-security.html) for escaping output.
 
-15.5.3. Sending security directives to clients, e.g. [Security Headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project).
+16.3.3. Incoming data should be casted to the expected type. String data should be validated/sanitized.
 
-15.6. Sensitive Data Exposure protection.
+16.3.4. Incoming string data length should be checked.
 
-15.6.1. Exceptions/Notices/Warnings should be caught and logged.
+16.3.5. Special characters, like null byte characters, should be dropped from Incoming string data.
 
-15.6.2. No error output should be displayed to user, some standard message should appear instead.
+16.4. A module that introduces Admin Panel functionality should have ACL.
 
-15.6.3. Logs should not be excessive, e.g. PDO exception contains MySQL credentials that should not be logged.
+16.5. Misconfiguration protection.
 
-15.7. Cross-Site Request Forgery (CSRF) protection.
+16.5.1. Do not include/require unused libraries/frameworks.
 
-15.7.1. CSRF tokens mechanism should be utilized.
+16.5.2. A segmented application architecture that provides effective, secure separation between components or tenants, with segmentation, containerization, or cloud security groups (ACLs).
 
-15.7.2. All data manipulation requests should be made with POST requests.
+16.5.3. Sending security directives to clients, e.g. [Security Headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project).
 
-15.8. Frequently update the third-party libraries used in the project/component to eliminate known vulnerabilities.
+16.6. Sensitive Data Exposure protection.
 
-15.9. Local File Inclusion (LFI) protection.
+16.6.1. Exceptions/Notices/Warnings should be caught and logged.
 
-15.9.1. SHOULD NOT trust user-submitted requests containing path and file name.
+16.6.2. No error output should be displayed to user, some standard message should appear instead.
 
-15.9.2. SHOULD sanitize user-submitted path and file values to remove dot-dot-slash from the request.
+16.6.3. Logs should not be excessive, e.g. PDO exception contains MySQL credentials that should not be logged.
 
-15.10. Remote Code Execution (RCE) protection.
+16.7. Cross-Site Request Forgery (CSRF) protection.
 
-15.10.1. SHOULD NOT use eval(), passthru(), system(), shell_exec(), serialize(), unserialize(), md5(), srand(), mt_srand()
+16.7.1. CSRF tokens mechanism should be utilized.
 
-15.10.2. SHOULD NOT directly pass user-submitted values to include*(), require*(), create_function(), fopen(), preg_replace()
+16.7.2. All data manipulation requests should be made with POST requests.
 
-15.10.3. SHOULD NOT use variable functions if the variable values are submitted by the user.
+16.8. Frequently update the third-party libraries used in the project/component to eliminate known vulnerabilities.
+
+16.9. Local File Inclusion (LFI) protection.
+
+16.9.1. SHOULD NOT trust user-submitted requests containing path and file name.
+
+16.9.2. SHOULD sanitize user-submitted path and file values to remove dot-dot-slash from the request.
+
+16.10. Remote Code Execution (RCE) protection.
+
+16.10.1. SHOULD NOT use `eval()`, `passthru()`, `system()`, `shell_exec()`, `serialize()`, `unserialize()`, `md5()`, `srand()`, `mt_srand()`.
+
+16.10.2. SHOULD NOT directly pass user-submitted values to `include*()`, `require*()`, `create_function()`, `fopen()`, `preg_replace()`.
+
+16.10.3. SHOULD NOT use variable functions if the variable values are submitted by the user.
 
 <!-- LINKS: DEFINITIONS AND ADDRESSES -->
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged: t
* The Security section of the Technical Guides will be added to the 2.0 and 2.1 branches. (The section is currently in the 2.2 and 2.3 branches.)
* The XML configuration section will be added to the 2.1, 2.2. and 2.3 branches. This item originates from [PR-2673](https://github.com/magento/devdocs/pull/2673/)
