### PR TITLE
Fix 'page-baseurl-generator'

### DIFF
--- a/_plugins/page-baseurl-generator.rb
+++ b/_plugins/page-baseurl-generator.rb
@@ -9,12 +9,12 @@ module Jekyll
   class PageBaseUrlGenerator < Generator
 
     def generate(site)
-      PATTERN = %r{guides\/v(\d\.\d)}
+      pattern = %r{guides\/v(\d\.\d)}
       config_version = site.config['version']
       pages = site.pages
       baseurl = site.baseurl
       pages.each do |page|
-        matcher = PATTERN.match(page.path)
+        matcher = pattern.match(page.path)
         version = if matcher
                     matcher[1]
                   else


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will replace a constant with variable to eliminate Ruby error in the `page-baseurl-generator`.