### PR TITLE
Remove wrong and irrelevant information

### DIFF
--- a/guides/v2.1/config-guide/redis/config-redis.md
+++ b/guides/v2.1/config-guide/redis/config-redis.md
@@ -1,10 +1,6 @@
 ---
 group: config-guide
-subgroup: 09_Redis
 title: Configure Redis
-menu_title: Configure Redis
-menu_order: 1
-menu_node: parent
 version: 2.1
 functional_areas:
   - Configuration
@@ -12,60 +8,34 @@ functional_areas:
   - Setup
 ---
 
-## Overview of the Redis solution {#config-redis-over}
+Redis features include:
 
-<a href="http://redis.io/" target="_blank">Redis</a> is an optional backend cache solution to replace <a href="http://framework.zend.com/apidoc/1.0/Zend_Cache/Backend/Zend_Cache_Backend_File.html" target="_blank">Zend_Cache_Backend_File</a>, which is used in Magento 2 by default.
+* Redis can also be used for {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} session storage.
 
-### Issues with `Zend_Cache_Backend_File`
+* The backend supports tag-based cache cleanup without `foreach` loops.
 
-* The `core_cache_tag` table constantly grows. If a Magento instance has multiple web sites and web stores with large catalogs, the table can grow to 15 million records in less than a day. Insertion into `core_cache_tag` leads to issues with MySQL server, including performance degradation. 
+* Redis supports on-disk save and master/slave replication.
 
-  (A *tag* is an identifier that classifies different types of Magento {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} objects.)
-
-* The TwoLevels {% glossarytooltip 74d6d228-34bd-4475-a6f8-0c0f4d6d0d61 %}backend{% endglossarytooltip %} is more difficult to maintain because two services are required to make it work which makes it difficult to analyze cache content when necessary.  
-Further, memcached itself has limitations such as a maximum object size and fixed bucket sizes which also contribute to difficult maintenance.
-
-* The <a href="http://framework.zend.com/manual/1.12/en/zend.cache.backends.html#zend.cache.backends.twolevels" target="_blank">Zend TwoLevels backend</a> does not scale well because using the database as part of the {% glossarytooltip 8f2067d1-4a39-4ed2-916d-7c9c58ccf30c %}cache backend{% endglossarytooltip %} adds additional load to the master database server. Additionally, there is no reliable method for `memcached` replication.
-
-### Why Redis is better
-
-Advantages of Redis include:
-
-* Redis can also be used for {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} session storage, making it possible to completely replace `memcached` with Redis.
-
-* The Redis backend works by indexing tags in files so that tag operations do not require a full scan of every cache file. 
-
-* The {% glossarytooltip 3f0f2ef1-ad38-41c6-bd1e-390daaa71d76 %}metadata{% endglossarytooltip %} and the cache record are stored in the same file rather than separate files resulting in fewer inodes and fewer file stat, read, write, lock, and unlink operations. Also, the original hashed directory structure had very poor distribution due to the `adler32` hashing algorithm and prefixes. The multi-level nested directories have been dropped in favor of single-level nesting made from multiple characters.
-
-* The backend supports tag-based cache cleanup without `foreach` loops. 
-
-* Redis supports on-disk save and master/slave replication. 
-
-  This is a highly requested feature that is not supported by `memcached`. Replication avoids a single point of failure and provides high  availability.
-
-<div class="bs-callout bs-callout-info" id="info">
-   <span class="glyphicon-class">
-   <p>Starting in Magento 2.0.6, you can use either Redis or <a href="{{ page.baseurl }}/config-guide/memcache/memcache.html">memcached</a> for session storage. Earlier issues with the Redis session handler and session locking have been resolved.</p></span>
-</div>
+{:.bs-callout .bs-callout-info}
+Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
 
 ## Install Redis {#config-redis-install}
 
 Installing and configuring the Redis software is beyond the scope of this guide. Consult resources such as:
 
-*	<a href="http://redis.io/download" target="_blank">Download Redis page</a>
-*	<a href="http://redis.io/topics/quickstart" target="_blank">Redis quick start</a>
-*	<a href="https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis" target="_blank">digitalocean</a>
-*	<a href="http://redis.io/documentation" target="_blank">Redis documentation page</a>
+*	[Download Redis page](http://redis.io/download)
+*	[Redis quick start](http://redis.io/topics/quickstart)
+*	[digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
+*	[Redis documentation page](http://redis.io/documentation)
 
-## For more information {#config-redis-info}
+## For more information
 
 You can find more information about configuring Redis from the following:
 
-*	<a href="http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/" target="_blank">David Alger</a>
-*	<a href="http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/" target="_blank">TechyTalk</a>
-<!-- *	<a href="http://info2.magento.com/rs/magentoenterprise/images/MagentoECG-UsingRedisasaCacheBackendinMagento.pdf" target="_blank">Magento Expert Consulting Group (ECG) article <em>written for Magento 1.x</em> -->
+*	[David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
+*	[TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
 
 #### Next
 
-*	<a href="{{ page.baseurl }}/config-guide/redis/redis-pg-cache.html">Use Redis for the Magento page and default cache</a>
-*	<a href="{{ page.baseurl }}/config-guide/redis/redis-session.html">Use Redis for session storage</a>
+*	[Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+*	[Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)

--- a/guides/v2.2/config-guide/redis/config-redis.md
+++ b/guides/v2.2/config-guide/redis/config-redis.md
@@ -1,10 +1,6 @@
 ---
 group: config-guide
-subgroup: 09_Redis
 title: Configure Redis
-menu_title: Configure Redis
-menu_order: 1
-menu_node: parent
 version: 2.2
 functional_areas:
   - Configuration
@@ -12,9 +8,7 @@ functional_areas:
   - Setup
 ---
 
-## Overview of the Redis solution {#config-redis-over}
-
-Redis features:
+Redis features include:
 
 * Redis can also be used for {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} session storage.
 
@@ -22,29 +16,26 @@ Redis features:
 
 * Redis supports on-disk save and master/slave replication.
 
-<div class="bs-callout bs-callout-info" id="info">
-   <span class="glyphicon-class">
-   <p>Starting in Magento 2.0.6, you can use either Redis or <a href="{{ page.baseurl }}/config-guide/memcache/memcache.html">memcached</a> for session storage. Earlier issues with the Redis session handler and session locking have been resolved.</p></span>
-</div>
+{:.bs-callout .bs-callout-info}
+Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
 
 ## Install Redis {#config-redis-install}
 
 Installing and configuring the Redis software is beyond the scope of this guide. Consult resources such as:
 
-*	<a href="http://redis.io/download" target="_blank">Download Redis page</a>
-*	<a href="http://redis.io/topics/quickstart" target="_blank">Redis quick start</a>
-*	<a href="https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis" target="_blank">digitalocean</a>
-*	<a href="http://redis.io/documentation" target="_blank">Redis documentation page</a>
+*	[Download Redis page](http://redis.io/download)
+*	[Redis quick start](http://redis.io/topics/quickstart)
+*	[digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
+*	[Redis documentation page](http://redis.io/documentation)
 
-## For more information {#config-redis-info}
+## For more information
 
 You can find more information about configuring Redis from the following:
 
-*	<a href="http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/" target="_blank">David Alger</a>
-*	<a href="http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/" target="_blank">TechyTalk</a>
-<!-- *	<a href="http://info2.magento.com/rs/magentoenterprise/images/MagentoECG-UsingRedisasaCacheBackendinMagento.pdf" target="_blank">Magento Expert Consulting Group (ECG) article <em>written for Magento 1.x</em> -->
+*	[David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
+*	[TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
 
 #### Next
 
-*	<a href="{{ page.baseurl }}/config-guide/redis/redis-pg-cache.html">Use Redis for the Magento page and default cache</a>
-*	<a href="{{ page.baseurl }}/config-guide/redis/redis-session.html">Use Redis for session storage</a>
+*	[Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+*	[Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)

--- a/guides/v2.2/config-guide/redis/config-redis.md
+++ b/guides/v2.2/config-guide/redis/config-redis.md
@@ -14,34 +14,13 @@ functional_areas:
 
 ## Overview of the Redis solution {#config-redis-over}
 
-<a href="http://redis.io/" target="_blank">Redis</a> is an optional backend cache solution to replace <a href="http://framework.zend.com/apidoc/1.0/Zend_Cache/Backend/Zend_Cache_Backend_File.html" target="_blank">Zend_Cache_Backend_File</a>, which is used in Magento 2 by default.
+Redis features:
 
-### Issues with `Zend_Cache_Backend_File`
-
-* The `core_cache_tag` table constantly grows. If a Magento instance has multiple web sites and web stores with large catalogs, the table can grow to 15 million records in less than a day. Insertion into `core_cache_tag` leads to issues with MySQL server, including performance degradation.
-
-  (A *tag* is an identifier that classifies different types of Magento {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} objects.)
-
-* The TwoLevels {% glossarytooltip 74d6d228-34bd-4475-a6f8-0c0f4d6d0d61 %}backend{% endglossarytooltip %} is more difficult to maintain because two services are required to make it work which makes it difficult to analyze cache content when necessary.
-Further, memcached itself has limitations such as a maximum object size and fixed bucket sizes which also contribute to difficult maintenance.
-
-* The <a href="http://framework.zend.com/manual/1.12/en/zend.cache.backends.html#zend.cache.backends.twolevels" target="_blank">Zend TwoLevels backend</a> does not scale well because using the database as part of the {% glossarytooltip 8f2067d1-4a39-4ed2-916d-7c9c58ccf30c %}cache backend{% endglossarytooltip %} adds additional load to the master database server. Additionally, there is no reliable method for `memcached` replication.
-
-### Why Redis is better
-
-Advantages of Redis include:
-
-* Redis can also be used for {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} session storage, making it possible to completely replace `memcached` with Redis.
-
-* The Redis backend works by indexing tags in files so that tag operations do not require a full scan of every cache file.
-
-* The {% glossarytooltip 3f0f2ef1-ad38-41c6-bd1e-390daaa71d76 %}metadata{% endglossarytooltip %} and the cache record are stored in the same file rather than separate files resulting in fewer inodes and fewer file stat, read, write, lock, and unlink operations. Also, the original hashed directory structure had very poor distribution due to the `adler32` hashing algorithm and prefixes. The multi-level nested directories have been dropped in favor of single-level nesting made from multiple characters.
+* Redis can also be used for {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} session storage.
 
 * The backend supports tag-based cache cleanup without `foreach` loops.
 
 * Redis supports on-disk save and master/slave replication.
-
-  This is a highly requested feature that is not supported by `memcached`. Replication avoids a single point of failure and provides high  availability.
 
 <div class="bs-callout bs-callout-info" id="info">
    <span class="glyphicon-class">


### PR DESCRIPTION
Magento 2 has never shipped using `Zend_Cache_Backend_File`.  
It uses Colin Molenhour's `Cm_Cache_Backend_File`. The whole first paragraph `Issues with Zend_Cache_Backend_File` is relevant to Magento 1 only, so it should be removed

This belief that the file system is slow a myth, and this page furthers it.  
It is based on the fact that the `Zend_Cache_Backend_File` implementation used in Magento 1 was crap.  
The file system is, in fact, a highly efficient key value store. It is cached in memory, too, so access is very fast and efficient.  
On single machine instances `Cm_Cache_Backend_File` scales better than the redis cache backend `Cm_Cache_Backend_Redis` (also by Colin).
The overhead is much lower than using tcp over sockets to connect to a single threaded redis instance.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->

## Additional information

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
