### PR TITLE
Updated plugin req for Fastly IO

### DIFF
--- a/_data/toc/cloud-guide.yml
+++ b/_data/toc/cloud-guide.yml
@@ -148,7 +148,7 @@ pages:
           versions: ["2.2"]
 
     - label: Configure Fastly
-      url: /cloud/basic-information/cloud-fastly.html
+      url: /cloud/cdn/cloud-fastly.html
       children:
         - label: Set up Fastly
           url: /cloud/access-acct/fastly.html

--- a/guides/v2.1/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.1/cloud/cdn/cloud-fastly.md
@@ -2,6 +2,11 @@
 group: cloud
 title: Fastly
 version: 2.1
+redirect_from:
+  - /guides/v2.0/cloud/basic-information/cloud-fastly.html
+  - /guides/v2.1/cloud/basic-information/cloud-fastly.html
+  - /guides/v2.2/cloud/basic-information/cloud-fastly.html
+  - /guides/v2.3/cloud/basic-information/cloud-fastly.html
 functional_areas:
   - Cloud
   - Setup

--- a/guides/v2.1/cloud/cdn/fastly-image-optimization.md
+++ b/guides/v2.1/cloud/cdn/fastly-image-optimization.md
@@ -18,7 +18,7 @@ images through image optimizers, using default configurations.
 
 **Prerequisites**
 
--  Install or upgrade to Fastly module version 1.2.52 or later
+-  Install or upgrade to Fastly module version 1.2.62 or later
 -  [Configure Fastly Origin shield and backend]({{ page.baseurl }}/cloud/access-acct/fastly.html#backend)
 
 #### To enable Fastly IO:

--- a/guides/v2.2/cloud/basic-information/cloud-fastly.md
+++ b/guides/v2.2/cloud/basic-information/cloud-fastly.md
@@ -1,1 +1,0 @@
-../../../v2.1/cloud/basic-information/cloud-fastly.md

--- a/guides/v2.2/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.2/cloud/cdn/cloud-fastly.md
@@ -1,0 +1,1 @@
+../../../v2.1/cloud/cdn/cloud-fastly.md

--- a/guides/v2.3/cloud/basic-information/cloud-fastly.md
+++ b/guides/v2.3/cloud/basic-information/cloud-fastly.md
@@ -1,1 +1,0 @@
-../../../v2.2/cloud/basic-information/cloud-fastly.md

--- a/guides/v2.3/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.3/cloud/cdn/cloud-fastly.md
@@ -1,0 +1,1 @@
+../../../v2.2/cloud/cdn/cloud-fastly.md


### PR DESCRIPTION
## This PR is a:

- [x] Content update

Fixes issue #2716 and moves the Configure Fastly topic from the `cloud/guides/basic-information/cloud-fastly.md`  to `cloud/guides/cdn`

whatsnew
Updated the Fastly plugin version requirement for Fastly image optimization to version 1.2.62.



