### PR TITLE
Update theme-inherit.md

### DIFF
--- a/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
+++ b/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
@@ -153,7 +153,7 @@ To do this, they added an extending layout in `app/design/frontend/OrangeCo/oran
 {%endhighlight xml%}
 
 
-For more information about extending layout refer to the [Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html){target="&#95;blank"} article.
+For more information about extending layout refer to the [Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html) article.
 
 ## Override layouts {#theme-inherit-layout-over}
 


### PR DESCRIPTION
Removed on line 156 the extra {target="_blank"} that does not work. Please consider either fixing this, or have it removed.

Has been checked for v.2.2 and v.2.3 alpha having the same issue. Please apply to all.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Remove the extra {target="_blank"} that does not work on line 156 for v.2.1 documentation.
