### PR TITLE
Building DevDocs in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ If you have questions, open an issue and ask us. We're looking forward to hearin
 
 ## Build DevDocs in Windows
 
+Some of the technologies we use to develop DevDocs is not compatible with Windows, such as [Jekyll](https://jekyllrb.com/docs/windows/). For this reason, we do not support DevDocs management in Windows; however, we have documented the following procedures to build the DevDocs in a Windows environment. Any further use of this setup or troubleshooting is up to you. 
+
 Download software:
 
 -  [Git for Windows](https://gitforwindows.org)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can build this site locally in the following ways:
 - [Installing the project dependencies locally](#build-using-jekyll) (Mac, Linux)
 - [Using a Docker container](#build-using-docker) (Mac, Linux)
 - [Using a Vagrant virtual machine](#build-using-vagrant) (Mac, Linux, Windows)
+- [Build DevDocs in Windows](#build-devdocs-in-windows) (Windows 7 & 10)
 
 ## Build using Jekyll
 
@@ -191,3 +192,126 @@ If you have questions, open an issue and ask us. We're looking forward to hearin
 *	<a href="mailto:DL-Magento-Doc-Feedback@magento.com">E-mail us</a>
 
 *	<a href="http://devdocs.magento.com">Visit our documentation site</a>, built using [GitHub pages](https://pages.github.com/).
+
+## Build DevDocs in Windows
+
+Download software:
+
+-  [Git for Windows](https://gitforwindows.org)
+-  [Chocolatey](https://chocolatey.org/install)
+
+### Install Chocolatey
+Only Administrators can use Chocolatey features. You can use the Administrator account, or you can use the "Run as Administror" function on the shortcut menu.
+
+1.  Open the **Command Prompt** using **Run as Administrator** in the shortcut menu.
+
+1.  [Install Chocolatey](https://chocolatey.org/install).
+
+    ```cmd
+    @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+    ```
+
+1.  Verify Chocolatey was added to the environment variables:
+
+    -  In the Windows UI, open search and type `path`.
+    -  In the Windows CMD console, type `echo %path%`.
+    
+    You should see `C:\ProgramData\chocolatey\bin` in the path.
+
+1.  Close and reopen the command prompt before using `choco` commands.
+
+After running the script at the command line, you can install any required extensions. Chocolately has many extensions available, similar to Homebrew for MacOS. As a best practice, only use extensions labeled as a "trusted package". You can install editors, such as Nano and Notepad++, using Chocolatey, as well.
+
+#### Install Ruby extension
+
+If you have Ruby installed on the workstation, then you can skip this installation.
+
+1.  Open the **Command Prompt** using **Run as Administrator** in the shortcut menu.
+
+1.  Install the ruby extension:
+
+    ```cmd
+    choco install ruby
+    ```
+
+1.  Verify the environment variables were added properly:
+
+    -  In the Windows UI, open search and type `path`.
+    -  In the Windows CMD console, type `echo %path%`.
+
+>  **NOTE**  
+>  If you encounter problems with ruby, or the `gem` command is not recognized, you can install the `rubyinstaller-devkit.exe` development kit located in the `c:\ProgramData\chocolatey\bin` folder.
+
+### Install Git for Windows
+
+Use Git for Windows to prevent interference with existing Windows environment and to have Git launch commands available on the shortcut menu.
+
+Open the Git Setup file downloaded from the Git for Windows site and use the following settings during installation wizard:
+
+-  select **Use Git from Git Bash only**
+-  select **Checkout as-is, commit Unix-style line endings**
+-  select your preferred editor (can use Nano, Notepad++, or VIM)
+-  select **Enable symbolic links**
+
+Although you can install Git using Chocolatey, I chose to install _Git for Windows_ independently for more control of the installation settings.
+
+#### Set up SSH key
+
+1.  Open Git Bash. The Git Bash command is on the shortcut menu.
+
+1.  Create a working directory for Git repositories and change to the new directory.
+
+    ```bash
+    mkdir <directory-name>
+    ```
+
+1.  Follow the [Generating a new SSH](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) instructions.
+
+
+### Connect to the DevDocs repository
+
+You may have to close and reopen the Git Bash application after the Choco installations.
+
+1.  Open Git Bash. The Git Bash command is on the shortcut menu.
+
+1.  Change to the directory you created for Git repositories and clone the DevDocs repository.
+
+    ```bash
+    git clone <devdocs>
+    ```
+
+1.  Change to the `devdocs` directory.
+
+1.  Install [Bundler](https://bundler.io).
+
+    ```bash
+    gem install bundle
+    ```
+
+1.  Install gem executables required for building the site.
+
+    ```bash
+    bundle install
+    ```
+
+1.  Build site.
+
+    ```bash
+    bundle exec jekyll serve
+    ```
+
+    ```terminal
+    Configuration file: C:/Users/Administrator/mage/devdocs/_config.yml
+                Source: C:/Users/Administrator/mage/devdocs
+           Destination: C:/Users/Administrator/mage/devdocs/_site
+     Incremental build: disabled. Enable with --incremental
+          Generating...
+                        done in 643.551 seconds.
+     Auto-regeneration: enabled for 'C:/Users/Administrator/mage/devdocs'
+        Server address: http://127.0.0.1:4000/
+      Server running... press ctrl-c to stop.
+    ```
+
+>  **NOTE**  
+>  The .bash_profile CAN be created and managed using Git Bash for aliases and other customizations. It sits in the 
+`users/Administrator` folder.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Although you can install Git using Chocolatey, I chose to install _Git for Windo
 1.  Follow the [Generating a new SSH](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) instructions.
 
 
-### Connect to the DevDocs repository
+### Clone and build the DevDocs repository
 
 You may have to close and reopen the Git Bash application after the Choco installations.
 
@@ -277,7 +277,7 @@ You may have to close and reopen the Git Bash application after the Choco instal
 1.  Change to the directory you created for Git repositories and clone the DevDocs repository.
 
     ```bash
-    git clone <devdocs>
+    git clone git@github.com:magento/devdocs.git
     ```
 
 1.  Change to the `devdocs` directory.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Download software:
 -  [Chocolatey](https://chocolatey.org/install)
 
 ### Install Chocolatey
+
 Only Administrators can use Chocolatey features. You can use the Administrator account, or you can use the "Run as Administror" function on the shortcut menu.
 
 1.  Open the **Command Prompt** using **Run as Administrator** in the shortcut menu.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Download software:
 
 ### Install Chocolatey
 
-Only Administrators can use Chocolatey features. You can use the Administrator account, or you can use the "Run as Administror" function on the shortcut menu.
+Only Administrators can use Chocolatey features. You can use the Administrator account, or you can use the "Run as Administrator" function on the shortcut menu.
 
 1.  Open the **Command Prompt** using **Run as Administrator** in the shortcut menu.
 
@@ -243,11 +243,11 @@ If you have Ruby installed on the workstation, then you can skip this installati
     -  In the Windows CMD console, type `echo %path%`.
 
 >  **NOTE**  
->  If you encounter problems with ruby, or the `gem` command is not recognized, you can install the `rubyinstaller-devkit.exe` development kit located in the `c:\ProgramData\chocolatey\bin` folder.
+>  If you encounter problems with Ruby, or the `gem` command is not recognized, you can install the `rubyinstaller-devkit.exe` development kit located in the `c:\ProgramData\chocolatey\bin` folder.
 
 ### Install Git for Windows
 
-Use Git for Windows to prevent interference with existing Windows environment and to have Git launch commands available on the shortcut menu.
+Use Git for Windows to prevent interference with the existing Windows environment and to have _Git Bash_ and _Git GUI_ launch commands available on the shortcut menu.
 
 Open the Git Setup file downloaded from the Git for Windows site and use the following settings during installation wizard:
 
@@ -256,13 +256,13 @@ Open the Git Setup file downloaded from the Git for Windows site and use the fol
 -  select your preferred editor (can use Nano, Notepad++, or VIM)
 -  select **Enable symbolic links**
 
-Although you can install Git using Chocolatey, I chose to install _Git for Windows_ independently for more control of the installation settings.
+Although you can install Git using Chocolatey, we chose to install _Git for Windows_ independently for more control of the installation settings.
 
 #### Set up SSH key
 
-1.  Open Git Bash. The Git Bash command is on the shortcut menu.
+1.  Open Git Bash. The **Git Bash** executable is on the shortcut menu.
 
-1.  Create a working directory for Git repositories and change to the new directory.
+1.  Create a working directory for your Git repositories and change to the new directory.
 
     ```bash
     mkdir <directory-name>
@@ -275,7 +275,7 @@ Although you can install Git using Chocolatey, I chose to install _Git for Windo
 
 You may have to close and reopen the Git Bash application after the Choco installations.
 
-1.  Open Git Bash. The Git Bash command is on the shortcut menu.
+1.  Open Git Bash. The **Git Bash** executable is on the shortcut menu.
 
 1.  Change to the directory you created for Git repositories and clone the DevDocs repository.
 
@@ -316,5 +316,4 @@ You may have to close and reopen the Git Bash application after the Choco instal
     ```
 
 >  **NOTE**  
->  The .bash_profile CAN be created and managed using Git Bash for aliases and other customizations. It sits in the 
-`users/Administrator` folder.
+>  The `.bash_profile` file CAN be created and managed using Git Bash, which is useful for aliases and other customizations, This file is in the `users/Administrator` folder.


### PR DESCRIPTION
An old GH issue #1479 requested Build instructions for Windows.
These instructions were tested on multiple machines in Windows 7 and Windows 10. Also, I solicited one of the Cloud developers to perform a technical review, which passed.

I tried a different scenario with just Chocolatey, but we didn't have the control of all installation options. I settled on this method.