### PR TITLE
Fix link to contributing.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ When this pull request is merged, it will...
 Thank you for your contribution!
 
 Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
-https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
+https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 
 Please fill out as much information as you can about your PR to help speed up the review process.
 If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

--- a/_data/toc/contributor-guide.yml
+++ b/_data/toc/contributor-guide.yml
@@ -11,7 +11,7 @@ pages:
     - label: DevDocs Contributions
       children:
         - label: Contribution Guidelines
-          url: https://github.com/magento/devdocs/blob/develop/.github/CONTRIBUTING.md
+          url: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 
         - label: Magento Definition of Done
           url: /contributor-guide/contributing_dod.html

--- a/_includes/home/contributors.html
+++ b/_includes/home/contributors.html
@@ -10,7 +10,7 @@
     <div class="devdocs-contributors" data-contributors-limit="5" data-period-types="monthly"></div>
 
     <div class="home-contributors-buttons">
-      <a href="{{ page.baseurl }}/contributor-guide/contributing_docs.html" class="btn btn-large btn-primary">Become a Contributor</a>
+      <a href="https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md" class="btn btn-large btn-primary">Become a Contributor</a>
     </div>
 
   </div>

--- a/_includes/layout/footer-links.html
+++ b/_includes/layout/footer-links.html
@@ -1,5 +1,5 @@
 <ul class="nav footer-links">
-  <li><a href="{{ page.baseurl }}/contributor-guide/contributing_docs.html">Become a Contributor</a>
+  <li><a href="https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md">Become a Contributor</a>
   <li><a href="https://magento.github.io/glossary/index.html?audience=developer">Glossary</a></li>
   <li><a href="http://magento.com/legal/terms/privacy/">Privacy Policy</a></li>
   <li><a href="http://magento.com/legal/terms/">Terms of Service</a></li>

--- a/community/resources/index.md
+++ b/community/resources/index.md
@@ -62,7 +62,7 @@ They are listed here because the content has been well received within the Magen
 *  *Presentation:* [Premium performance with PHP 7 and Varnish][15]{:target="_blank"} by Miguel Balparda 
 
 [0]: https://github.com/DavidLambauer/awesome-magento2 
-[1]: {{ page.baseurl }}/contributor-guide/contributing_docs.html
+[1]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [2]: http://www.slideshare.net/StaceyWhitney1/mage-titans-usa-2016-joshua-warren-magento-2-integrations
 [3]: http://www.slideshare.net/vrann/mage-titans-usa-2016-magentofacebookrabbitmq
 [4]: http://www.slideshare.net/OlgaKopylova2/m2-deployment

--- a/guides/v2.0/contributor-guide/contributing.md
+++ b/guides/v2.0/contributor-guide/contributing.md
@@ -58,7 +58,7 @@ Submit feature requests or enhancement suggestions to the new <a href="https://c
 4. PRs that include bug fixes must be accompanied by a step-by-step description of how to reproduce the bug.
 3. PRs that include new logic or new features must be submitted along with:
   * Unit/integration test coverage (we will be releasing more information about writing test coverage in the near future).
-  * Proposed <a href="{{ page.baseurl }}/contributor-guide/contributing_docs.html" target="_blank">documentation</a> updates. <a href="{{ site.baseurl }}/" target="_blank">Documentation</a> contributions can be submitted <a href="https://github.com/magento/devdocs" target="_blank">here</a>.
+  * Proposed <a href="https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md" target="_blank">documentation</a> updates. <a href="{{ site.baseurl }}/" target="_blank">Documentation</a> contributions can be submitted <a href="https://github.com/magento/devdocs" target="_blank">here</a>.
 4. For large features or changes, please <a href="https://github.com/magento/magento2/issues" target="_blank">open an issue</a> and discuss it with us first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
 5. To report a bug, please <a href="https://github.com/magento/magento2/issues" target="_blank">open an issue</a>, and follow these <a href="https://github.com/magento/magento2/wiki/Issue-reporting-guidelines">guidelines about bugfix issues</a>.
 
@@ -99,7 +99,7 @@ Check out this video to see the process in action:
 
 First, check the <a href="https://github.com/magento/magento2/pulls?q=is%3Aopen+is%3Apr" target="_blank">existing PRs</a> and make sure you are not duplicating others’ work.
 
-To create a pull request: 
+To create a pull request:
 
 1. Create a feature branch for your changes and push those changes to the copy of your repository on GitHub. This is the best way to organize and even update your PR.
 2. In your repository, click **Pull requests** on the right, and then click **New pull request**. <br><img src="{{ site.baseurl }}/common/images/pr.png" target="_blank">

--- a/guides/v2.0/contributor-guide/quarterly-contributors.md
+++ b/guides/v2.0/contributor-guide/quarterly-contributors.md
@@ -17,5 +17,5 @@ Always feel free to [email us][1] with any questions.
 <div class="devdocs-contributors"></div>
 
 
-[0]: {{ page.baseurl }}/contributor-guide/contributing_docs.html
+[0]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [1]: mailto:DL-Magento-Doc-Feedback@magento.com

--- a/guides/v2.0/magento-devdocs-whatsnew.md
+++ b/guides/v2.0/magento-devdocs-whatsnew.md
@@ -44,7 +44,7 @@ Release Notes for Magento 2.0.18 [Open Source]({{ site.baseurl }}/guides/v2.0/re
 Release Notes for Magento 2.1.12 [Open Source]({{ site.baseurl }}/guides/v2.1/release-notes/ReleaseNotes2.1.12CE.html) and [Commerce]({{ site.baseurl }}/guides/v2.1/release-notes/ReleaseNotes2.1.12EE.html).|2.1.x|New|Feb 27
 Release Notes 2.2.3 [Open Source]({{ site.baseurl }}/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.html) and [Commerce]({{ site.baseurl }}/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.html)|2.2.x|New|Feb 27
 Added supported MySQL technologies to the [MySQL]({{ site.baseurl }}/guides/v2.2/install-gde/prereq/mysql.html) topic.|2.2.x|Updated|Feb 27
-Updated the [DevDocs contributions]({{ site.baseurl }}/guides/v2.2/contributor-guide/contributing_docs.html) topic and published a new list of suggested topics for community contributions.|2.x|Updated|Feb 27
+Updated the [DevDocs contributions](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) topic and published a new list of suggested topics for community contributions.|2.x|Updated|Feb 27
 Formatting to improve consistency in the [Configuration Guide]({{ site.baseurl }}/guides/v2.0/config-guide/bootstrap/magento-modes.html).||Updated|Feb 26
 Added upgrade path for Magento Cloud metapackage. | 2.1.x, 2.2.x | Updated | Feb 23
 Added reference and [examples]({{ site.baseurl }}/guides/v2.2/cloud/env/working-with-variables.html#redis) for two, new [environment variables]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-deploy.html)—`CACHE_CONFIGURATION` and `SESSION_CONFIGURATION`—that help with customizing Redis storage and default caching configuration. | 2.1.x, 2.2.x | Updated | Feb 20

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -71,7 +71,7 @@ Please review the following supported and accepted pull request rules. We define
 1. PRs that include bug fixes must be accompanied by a step-by-step description of how to reproduce the bug.
 1. PRs that include new logic or new features must be submitted along with:
   * Unit/integration test coverage (we will be releasing more information about writing test coverage in the near future).
-  * Proposed [documentation]({{page.baseurl}}/contributor-guide/contributing_docs.html){:target="\_blank"} updates. [Documentation]({{site.baseurl}}/){:target="\_blank"} contributions can be submitted [here](https://github.com/magento/devdocs){:target="\_blank"}.
+  * Proposed [documentation](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md){:target="\_blank"} updates. [Documentation]({{site.baseurl}}/){:target="\_blank"} contributions can be submitted [here](https://github.com/magento/devdocs){:target="\_blank"}.
 1. For large features or changes, please [open an issue](https://github.com/magento/magento2/issues){:target="\_blank"} and discuss it with us first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
 1. To report a bug, please [open an issue](https://github.com/magento/magento2/issues){:target="\_blank"}, and follow these [guidelines about bugfix issues](https://github.com/magento/magento2/wiki/Issue-reporting-guidelines){:target="\_blank"}.
 1. All automated tests must pass successfully (all builds on [Travis CI](https://travis-ci.org/magento/magento2){:target="\_blank"} must be green).

--- a/guides/v2.1/contributor-guide/quarterly-contributors.md
+++ b/guides/v2.1/contributor-guide/quarterly-contributors.md
@@ -16,5 +16,5 @@ Always feel free to [email us][1] with any questions.
 <div class="devdocs-contributors"></div>
 
 
-[0]: {{ page.baseurl }}/contributor-guide/contributing_docs.html
+[0]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [1]: mailto:DL-Magento-Doc-Feedback@magento.com

--- a/guides/v2.1/magento-devdocs-whatsnew.md
+++ b/guides/v2.1/magento-devdocs-whatsnew.md
@@ -162,7 +162,7 @@ Release Notes for Magento 2.0.18 [Open Source]({{ site.baseurl }}/guides/v2.0/re
 Release Notes for Magento 2.1.12 [Open Source]({{ site.baseurl }}/guides/v2.1/release-notes/ReleaseNotes2.1.12CE.html) and [Commerce]({{ site.baseurl }}/guides/v2.1/release-notes/ReleaseNotes2.1.12EE.html).|2.1.x|New|Feb 27
 Release Notes 2.2.3 [Open Source]({{ site.baseurl }}/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.html) and [Commerce]({{ site.baseurl }}/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.html)|2.2.x|New|Feb 27
 Added supported MySQL technologies to the [MySQL]({{ site.baseurl }}/guides/v2.2/install-gde/prereq/mysql.html) topic.|2.2.x|Updated|Feb 27
-Updated the [DevDocs contributions]({{ site.baseurl }}/guides/v2.2/contributor-guide/contributing_docs.html) topic and published a new list of suggested topics for community contributions.|2.x|Updated|Feb 27
+Updated the [DevDocs contributions](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) topic and published a new list of suggested topics for community contributions.|2.x|Updated|Feb 27
 Formatting to improve consistency in the [Configuration Guide]({{ site.baseurl }}/guides/v2.0/config-guide/bootstrap/magento-modes.html).||Updated|Feb 26
 Added upgrade path for Magento Cloud metapackage. | 2.1.x, 2.2.x | Updated | Feb 23
 Added reference and [examples]({{ site.baseurl }}/guides/v2.2/cloud/env/working-with-variables.html#redis) for two, new [environment variables]({{ site.baseurl }}/guides/v2.2/cloud/env/variables-deploy.html)—`CACHE_CONFIGURATION` and `SESSION_CONFIGURATION`—that help with customizing Redis storage and default caching configuration. | 2.1.x, 2.2.x | Updated | Feb 20

--- a/guides/v2.2/magento-functional-testing-framework/contribution-guidelines.md
+++ b/guides/v2.2/magento-functional-testing-framework/contribution-guidelines.md
@@ -165,7 +165,7 @@ Label| Description
 [pull]: #pull-request
 
 [Definition of Done]: {{ page.baseurl }}/contributor-guide/contributing_dod.html
-[documentation update]: {{ page.baseurl }}/contributor-guide/contributing_docs.html
+[documentation update]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [Magento coding standards]: {{ page.baseurl }}/coding-standards/bk-coding-standards.html
 
 [devdocs mftf]: https://github.com/magento/devdocs/tree/develop/guides/v2.3/magento-functional-testing-framework


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Fix all links to contributor-guide/contributing_docs.html with 
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
