### PR TITLE
MAGECLOUD-2581 use env variable to add creds

### DIFF
--- a/_data/toc/cloud-guide.yml
+++ b/_data/toc/cloud-guide.yml
@@ -371,7 +371,7 @@ pages:
           url: /cloud/trouble/message-queues.html
           versions: ["2.1","2.2","2.3"]
 
-    - label: Upgrades and Patches
+    - label: Upgrades and patches
       url: /cloud/project/project-upgrade-parent.html
       children:
         - label: ece-tools release notes

--- a/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
+++ b/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
@@ -13,11 +13,11 @@ Before preparing your project and importing code, push all pending changes from 
 The import preparation steps include the following:
 
 -  [Prepare and add required files](#required-files)
--  [Add Authentication Keys to `auth.json`.](#auth-json)
+-  [Add Authentication Keys to `auth.json`](#auth-json)
 -  [Modify your existing `composer.json`](#composer-json)
--  [Transfer media files to Cloud.](#media)
+-  [Transfer media files to Cloud](#media)
 -  [Add your {{site.data.var.ee}} authentication credentials](#encryption-key)
--  [Migrate your {{site.data.var.ee}} data.](#migrate-db)
+-  [Migrate your {{site.data.var.ee}} data](#migrate-db)
 
 ## Prepare and add required files {#required-files}
 

--- a/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
+++ b/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
@@ -13,10 +13,10 @@ Before preparing your project and importing code, push all pending changes from 
 The import preparation steps include the following:
 
 -  [Prepare and add required files](#required-files)
--  [Add Authentication Keys to `auth.json`](#auth-json)
+-  [Add Magento authentication keys](#auth-json)
 -  [Modify your existing `composer.json`](#composer-json)
 -  [Transfer media files to Cloud](#media)
--  [Add your {{site.data.var.ee}} authentication credentials](#encryption-key)
+-  [Add your {{site.data.var.ee}} encryption key](#encryption-key)
 -  [Migrate your {{site.data.var.ee}} data](#migrate-db)
 
 ## Prepare and add required files {#required-files}
@@ -70,12 +70,12 @@ Add these files to your {{site.data.var.ee}} code:
 
 When you push your code, all services are configured into the associated environment per active branch of code. These files affect all Starter environments and all Pro Integration environments. To update these settings in Pro Staging and Production, you need to enter a ticket.
 
-## Add Magento authentication keys
+## Add Magento authentication keys {#auth-json}
 
 You must have an authentication key to access the {{site.data.var.ee}} repository and to enable install and update commands for your {{site.data.var.ece}} project. There are two methods for specifying Composer authorization credentials.
 
 -  **authentication file**—You must have an `auth.json` file that contains your {{site.data.var.ee}} [authorization credentials]({{ site.baseurl }}/guides/v2.1/install-gde/prereq/connect-auth.html) in your {{site.data.var.ece}} root directory.
--  **environment variable**—Alternatively, you can set up authentication keys in your {{site.data.var.ece}} project using an environment variable.
+-  **environment variable**—Alternatively, you can use an environment variable to set up authentication keys in your {{site.data.var.ece}} project to prevent accidental exposure.
 
 #### To create a new `auth.json` file:
 
@@ -127,7 +127,7 @@ This method is best to prevent accidental exposure of credentials, such as pushi
 
 1.  Click **Add Variable**.
 
-1.  You can remove the `auth.json` file from each environment.
+1.  Remove the `auth.json` file from each environment.
 
 
 ## Edit `composer.json` {#composer-json}
@@ -190,7 +190,7 @@ Use the command [`magento setup:backup --media`]({{ page.baseurl }}/install-gde/
 
 ## Copy the encryption key {#encryption-key}
 
-To be able to decrypt encrypted data from your imported database, copy your encryption from your existing `env.php` file. Every environment inIntegration, Staging, and Production has an `env.php` of sensitive data and environment variables. The file contains a nested PHP array storing configuration data.
+To decrypt the encrypted data from your imported database, copy your encryption from your existing `env.php` file. Every environment in Integration, Staging, and Production has an `env.php` of sensitive data and environment variables. The file contains a nested PHP array storing configuration data.
 
 1.  Open `<Magento install dir>/app/etc/env.php` in a text editor.
 2.  Search for the value of `key` in the `crypt` array.

--- a/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
+++ b/guides/v2.1/cloud/access-acct/first-time-setup_import-prepare.md
@@ -8,43 +8,46 @@ functional_areas:
 
 You need to prepare your existing {{site.data.var.ee}} implementation to import it into a new {{site.data.var.ece}} project. This includes updating and adding files, transferring media files, and migrating data.
 
-Before preparing your project and importing code, push all pending changes to Git. Your remote {{site.data.var.ece}} branch should be fully updated. When you push, build and deploy scripts run to update code, static content, and environment services.
+Before preparing your project and importing code, push all pending changes from your local workstation to your remote {{site.data.var.ece}} repository. When you push, the build and deploy scripts run to update code, static content, and environment services.
 
-These import preparation steps include the following:
+The import preparation steps include the following:
 
-* [Prepare and add required files](#required-files):
-* [Add Cloud-specific files and directories ]to {{site.data.var.ee}}. Without these files and directories, your {{site.data.var.ee}} code can't be imported to Cloud.
-* [Add Authentication Keys to `auth.json`.](#auth-json)
-* [Modify your existing `composer.json`](#composer-json) to specify Cloud-specific dependencies. Make sure to include all modules. Cloud uses this file for `composer install` commands. Add `composer.lock` to Git. Cloud uses this file for `composer update` commands and during the build and deploy process.
-* [Transfer media files to Cloud.](#media)
-* [Add your {{site.data.var.ee}} authentication credentials](#encryption-key) to `auth.json` if you haven't done so already.
-* [Migrate your {{site.data.var.ee}} data.](#migrate-db)
+-  [Prepare and add required files](#required-files)
+-  [Add Authentication Keys to `auth.json`.](#auth-json)
+-  [Modify your existing `composer.json`](#composer-json)
+-  [Transfer media files to Cloud.](#media)
+-  [Add your {{site.data.var.ee}} authentication credentials](#encryption-key)
+-  [Migrate your {{site.data.var.ee}} data.](#migrate-db)
 
 ## Prepare and add required files {#required-files}
 
-To import {{site.data.var.ee}} code to a {{site.data.var.ece}} project, you need to add a directory and the following files to your existing code.
+To import {{site.data.var.ee}} code to a {{site.data.var.ece}} project, you must add the following files to your existing code:
 
-*  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html) manages applications, service relationships, mounts for writable directories, and cron jobs
-*  [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) for service configurations including MySQL, PHP, Redis, Solr (2.0.X only), ElasticSearch (2.1.X and later)
-*  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html) for handling routes including redirections, caching, and server-side includes
-*  [`magento-vars.php`]({{ page.baseurl }}/cloud/project/project-multi-sites.html) for multiple websites and stores
+-  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)—manages applications, service relationships, mounts for writable directories, and cron jobs
+-  [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)—for service configurations including MySQL, PHP, Redis, Solr (2.0.X only), ElasticSearch (2.1.X and later)
+-  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)—for handling routes including redirections, caching, and server-side includes
+-  [`magento-vars.php`]({{ page.baseurl }}/cloud/project/project-multi-sites.html)—for multiple websites and stores
 
-You need to add these files to your {{site.data.var.ee}} code:
+Add these files to your {{site.data.var.ee}} code:
 
-1.  Go to the [{{site.data.var.ece}} GitHub](https://github.com/magento/magento-cloud){:target="\_blank"}.
-2.  Select the branch corresponding to the {{site.data.var.ee}} version you currently have.
+1.  In the [{{site.data.var.ece}} GitHub repository](https://github.com/magento/magento-cloud){:target="\_blank"}, select the branch corresponding to the {{site.data.var.ee}} version you currently have.
 
     The following figure shows an example of selecting the `2.1.4` branch.
 
     ![Switch to your current Magento Commerce branch]({{ site.baseurl }}/common/images/cloud_cloud-git-214.png){:width="600px"}
 
-    In the procedure that follows, you'll copy the contents of some of these files to your {{site.data.var.ee}} system.
-3.  Log in to your {{site.data.var.ee}} system as, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
-4.  Enter the following commands in the order shown:
+1.  Log in to your {{site.data.var.ee}} system as, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
+1.  Change to the Magento installation directory and create a `.magento` directory.
 
-        cd <Magento installation dir>
-        mkdir .magento
-5.  One at a time, create the following files in your {{site.data.var.ee}} system using the contents of the files in the {{site.data.var.ece}} GitHub:
+    ```bash
+    cd <Magento installation dir>
+    ```
+
+    ```bash
+    mkdir .magento
+    ```
+
+5.  One at a time, create the following files in your {{site.data.var.ee}} system using the contents of the files in the {{site.data.var.ece}} repository:
 
     *   `<Magento Commerce install dir>/.magento.app.yaml`
     *   `<Magento Commerce install dir>/magento-vars.php`
@@ -65,36 +68,67 @@ You need to add these files to your {{site.data.var.ee}} code:
         * Make sure to create `magento-vars.php` in the Magento root directory.
         * Make sure to create `routes.yaml` and `services.yaml` in the `.magento` subdirectory.
 
-Modify these files as necessary as discussed in the following topics:
-
-*  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)
-*  [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)
-*  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
-
 When you push your code, all services are configured into the associated environment per active branch of code. These files affect all Starter environments and all Pro Integration environments. To update these settings in Pro Staging and Production, you need to enter a ticket.
 
-## Add or update `auth.json` with Magento Authentication keys {#auth-json}
+## Add Magento authentication keys
 
-To enable install and update commands for {{site.data.var.ece}}, you must have an `auth.json` file in your project's root directory. `auth.json` contains your {{site.data.var.ee}} [authorization credentials]({{ site.baseurl }}/guides/v2.1/install-gde/prereq/connect-auth.html) for {{site.data.var.ece}}.
+You must have an authentication key to access the {{site.data.var.ee}} repository and to enable install and update commands for your {{site.data.var.ece}} project. There are two methods for specifying Composer authorization credentials.
 
-In some cases, you might already have `auth.json`. Verify if you have the file and add your authentication credentials before you create a new one. It's located in your Magento root directory. You can also [get a sample `auth.json`](https://github.com/magento/magento2/blob/2.2-develop/auth.json.sample){:target="\_blank"}.
+-  **authentication file**—You must have an `auth.json` file that contains your {{site.data.var.ee}} [authorization credentials]({{ site.baseurl }}/guides/v2.1/install-gde/prereq/connect-auth.html) in your {{site.data.var.ece}} root directory.
+-  **environment variable**—Alternatively, you can set up authentication keys in your {{site.data.var.ece}} project using an environment variable.
 
-To create a new `auth.json` in the {% glossarytooltip c57aef7c-97b4-4b2b-a999-8001accef1fe %}event{% endglossarytooltip %} you don't have one:
+#### To create a new `auth.json` file:
 
-1.  Use a text editor to create a file named `auth.json` in your Magento root directory.
-3.  Replace `<public-key>` and `<private-key>` with your {{site.data.var.ee}} authentication credentials.
+First, verify if you have an `auth.json` file, located in your Magento root directory. You can also [get a sample `auth.json`](https://github.com/magento/magento2/blob/2.2-develop/auth.json.sample){:target="\_blank"}.
 
-    See the following example:
+1.  Using a text editor, create an `auth.json` file and save it in your Magento root directory.
 
-        {
-           "http-basic": {
-              "repo.magento.com": {
-              "username": "<public-key>",
-              "password": "<private-key>"
-            }
-          }
+1.  Replace `<public-key>` and `<private-key>` with your {{site.data.var.ee}} authentication credentials.
+
+    ```json
+    {
+       "http-basic": {
+          "repo.magento.com": {
+          "username": "<public-key>",
+          "password": "<private-key>"
         }
-3.  Save your changes to `auth.json` and exit the text editor.
+      }
+    }
+    ```
+
+1.  Save your changes to `auth.json` file and exit the text editor.
+
+#### To add authentication keys using an environment variable:
+
+This method is best to prevent accidental exposure of credentials, such as pushing an `auth.json` file to a public repository.
+
+1.  In the _Project Web UI_, click the configuration icon in the upper left corner.
+
+1.  In the _Configure Project_ view, click the **Variables** tab.
+
+1.  Click **Add Variable**.
+
+1.  In the _Name_ field, enter `env:COMPOSER_AUTH`.
+
+1.  In the _Value_ field, add the following and replace `<public-key>` and `<private-key>` with your {{site.data.var.ee}} authentication credentials:
+
+    ```json
+    {
+       "http-basic": {
+          "repo.magento.com": {
+          "username": "<public-key>",
+          "password": "<private-key>"
+        }
+      }
+    }
+    ```
+
+1.  Select **Visible during build** and deselect **Visible at run**.
+
+1.  Click **Add Variable**.
+
+1.  You can remove the `auth.json` file from each environment.
+
 
 ## Edit `composer.json` {#composer-json}
 

--- a/guides/v2.1/cloud/before/before-setup-env-install.md
+++ b/guides/v2.1/cloud/before/before-setup-env-install.md
@@ -1,9 +1,6 @@
 ---
 group: cloud
-subgroup: 080_setup
 title: Install Magento
-menu_title: Install Magento
-menu_order: 50
 redirect_from:
   - /guides/v2.0/cloud/before/before-setup-env-perms.html
   - /guides/v2.1/cloud/before/before-setup-env-perms.html
@@ -22,67 +19,82 @@ With your workspace prepared, install Magento on your local to verify custom cod
 
 ## Prepare to install Magento {#prepare}
 
-To be able to customize the Magento software on your local machine, you should install it using the following information:
+To customize the Magento software on your local workstation, prepare the following:
 
 *	Hostname or IP address of your machine
-*	Admin username, password, and URL you created earlier
-*	Magento authentication keys for installing Magento locally
+*	Admin username, password, and URL created earlier
+*	Magento authentication keys for installing Magento
 
-### Get Magento Admin environment variables {#variables}
+#### To see the Magento Admin environment variables:
 
-You will need the Admin environment variable values for the installation command line.
+You need the ADMIN environment variables for the installation command line.
 
-1. Log in to your local development system, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
-2. Change to a directory to which the Magento file system owner has write access.
-3. Enter the following command in a terminal to log in to your project:
+List the environment variables.
 
-		magento-cloud login
-4. Before you begin, list the environment variables.
+```bash
+magento-cloud variable:get -e <environment-ID>
+```
 
-		magento-cloud variable:get -e <environment ID>
+```terminal
++----------------+---------------+-----------+------+
+| ID             | Value         | Inherited | JSON |
++----------------+---------------+-----------+------+
+| ADMIN_PASSWORD | admin_A456    | Yes       | No   |
+| ADMIN_URL      | magento_A8v10 | Yes       | No   |
+| ADMIN_USERNAME | admin_A456    | Yes       | No   |
++----------------+---------------+-----------+------+
+```
 
-The following results provides an example of variables:
+#### To et Magento authentication keys
 
-	+----------------+---------------+-----------+------+
-	| ID             | Value         | Inherited | JSON |
-	+----------------+---------------+-----------+------+
-	| ADMIN_PASSWORD | admin_A456    | Yes       | No   |
-	| ADMIN_URL      | magento_A8v10 | Yes       | No   |
-	| ADMIN_USERNAME | admin_A456    | Yes       | No   |
-	+----------------+---------------+-----------+------+
+You need Magento authentication keys to install Magento in your local development environment. These are different that the authentication keys included in the code repository `auth.json` file.
 
-### Get Magento authentication keys {#keys}
+#### To create authentication keys through the Magento Marketplace:
 
-You need Magento authentication keys to install Magento locally for your local environment. These are separate to the authentication keys included in the cloud code repository in `auth.json`.
+1.  Log in to the [Magento Marketplace](https://marketplace.magento.com). If you do not have an account, click **Register**.
 
-To create authentication keys through the Magento Marketplace:
+1.  Click your account name in the top-right and select **My Profile**.
 
-1. Log in to the [Magento Marketplace](https://marketplace.magento.com). If you don't have an account, click **Register**.
-2. Click your account name in the top-right of the page and select **My Profile**.
-3. Click **Access Keys** in the Marketplace tab.
+1.  Click **Access Keys** under _My Products_ in the _Marketplace_ tab.
 
 	![Click Access Keys]({{ site.baseurl }}/common/images/cloud_access-key.png)
-4. Click **Create A New Access Key**. Enter a specific name for the keys, for example CloudProductOwner or the name of the developer receiving the keys.
-5. The keys generate a Public and Private key you can click to copy. Save this information or keep the page open when installing {{site.data.var.ee}}.
+
+1.  Click **Create A New Access Key**.
+
+1.  Enter a specific name for the keys, for example _CloudProductOwner_ or the name of the developer receiving the keys.
+
+1.  The keys generate a **Public** and **Private** key you can click to copy. Save this information or keep the page open when installing {{site.data.var.ee}}.
 
 ## Set the docroot {#docroot}
 
-Set the docroot to the `/magento` directory until you complete all setup. If you change the docroot to `/magento/pub` prior to completion, you will encounter issues running the Web Setup Wizard.
+Set the `docroot` to the `/magento` directory until you complete all setup. If you change the `docroot` to `/magento/pub` prior to completion, you will encounter issues running the Web Setup Wizard.
 
-For the Production environment, you should set the docroot to `/magento/pub`, which helps restrict access to vulnerable areas of the system. The webserver docroot should be set to `/magento/pub` only after Magento is installed (including any upgrades and patches), configured, and static files have been generated and populated in `/magento/pub`. Alternatively, you could also create a subdomain (for example, `install.domain.com`) and configure your webserver's docroot to the Magento installed root folder.
+For the Production environment, set the `docroot` to `/magento/pub`, which helps restrict access to vulnerable areas of the system. The webserver `docroot` should be set to `/magento/pub` only after Magento is installed (including any upgrades and patches), configured, and static files generated and populated in `/magento/pub`. Alternatively, you could create a subdomain (for example, `install.domain.com`) and configure your webserver `docroot` to the Magento installed root folder.
 
 ## Set file system permissions and ownership {#file-system-permissions}
 
 After you have installed Magento, you need to set the file system permissions and ownership.
 
 1.  Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
-2.  Enter the following commands in the order shown:
 
-		cd <your Magento install dir>
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
-  	    chown -R :<web server group> .
-  	    chmod u+x bin/magento
+1.  Enter the following commands in the order shown:
+
+    ```bash
+    cd <your Magento install dir>
+    ```
+
+    ```terminal
+    find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
+    find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    ```
+
+    ```bash
+    chown -R :<web server group> .
+    ```
+
+    ```bash
+    chmod u+x bin/magento
+    ```
 
 {% include install/file-system-perms-twouser_cmds-only.md %}
 
@@ -90,22 +102,29 @@ After you have installed Magento, you need to set the file system permissions an
 
 Prior to installing, you should [Update installation dependencies]({{ page.baseurl }}/install-gde/install/prepare-install.html#install-composer-install) using Composer commands.
 
-You should be ready to install Magento using one of the following options:
+Be ready to install Magento using one of the following options:
 
 * [Install the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
 * [Install the Magento software using the Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
-The following example installs using the command line method:
+#### To install Magento using the command line:
 
-1. Switch to the user:
+1. Switch to the user.
 
-    <pre>sudo su - magento</pre>
-2. Change directories for the installation:
+    ```bash
+	sudo su - magento
+	```
 
-    <pre>cd /app/bin</pre>
-3. Enter a CLI command with options for entering the name, email, admin credentials, URL, and additional information. For a list of all options, see [Installer help commands]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html#instgde-cli-help-cmds).
+2. Change directories for the installation.
 
-    <pre>php magento setup:install \
+    ```bash
+	cd /app/bin
+	```
+
+1. Enter a CLI command with options for entering the name, email, ADMIN credentials, URL, and additional information. For a list of all options, see [Installer help commands]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html#instgde-cli-help-cmds).
+
+    ```bash
+    php magento setup:install \
       --admin-firstname=John \
       --admin-lastname=Smith \
       --admin-email=jsmith@mail.com \
@@ -119,27 +138,42 @@ The following example installs using the command line method:
       --currency=USD \
       --timezone=America/Chicago \
       --language=en_US \
-      --use-rewrites=1</pre>
+      --use-rewrites=1
+    ```
 
 ## Post-install configurations
 
 After installing Magento, run the commands for [compile]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) and [deploy]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html) for the code:
 
-1. If you are not in the correct Magento user, switch:
+1.  Switch to the correct user.
 
-        sudo su - magento
-2. Change directory to `app/bin`.
-3. Run the compile command:
+    ```bash
+    sudo su - magento
+    ```
 
-		php magento setup:di:compile
-4. When complete, Run the deploy command:
+1.  Change to the `app/bin` directory.
 
-		php magento setup:static:deploy
+1.  Compile Magento.
 
-Optionally, if you used Vagrant with the hostmanager plugin, update the hosts file:
+    ```bash
+    php magento setup:di:compile
+    ```
 
-1. Access the localdev root for the Vagrant box.
-2. Enter the command `vagrant hostmanager` to update the hosts file.
+1.  Deploy Magento
+
+    ```bash
+    php magento setup:static:deploy
+    ```
+
+Optionally, if you used Vagrant with the _hostmanager_ plugin, update the hosts file.
+
+1.  Access the `localdev` root for the Vagrant box.
+
+1.  Update the hosts file.
+
+    ```bash
+    vagrant hostmanager
+    ```
 
 ## Additional software and services
 
@@ -152,7 +186,12 @@ For development and testing in an environment as close to Integration as possibl
 
 ## Verify your local workspace
 
-To verify the local, access the store using the URL you passed in the install command. For this example, the local Magento store should load using http://magento.local/. The Admin panel should open using http://magento.local/admin. If you change the URI for the Admin panel, use this command to locate it:
+To verify the local, access the store using the URL you passed in the install command. For this example, you can access the local Magento store using the following URL formats:
+
+-  `http://magento.local/`
+-  `http://magento.local/admin`
+
+To change the URI for the Admin panel, use this command to locate it:
 
 	php bin/magento info:adminuri
 

--- a/guides/v2.1/cloud/before/before-setup-env-install.md
+++ b/guides/v2.1/cloud/before/before-setup-env-install.md
@@ -45,7 +45,7 @@ magento-cloud variable:get -e <environment-ID>
 +----------------+---------------+-----------+------+
 ```
 
-#### To et Magento authentication keys
+### Get Magento authentication keys
 
 You need Magento authentication keys to install Magento in your local development environment. These are different that the authentication keys included in the code repository `auth.json` file.
 
@@ -65,7 +65,7 @@ You need Magento authentication keys to install Magento in your local developmen
 
 1.  The keys generate a **Public** and **Private** key you can click to copy. Save this information or keep the page open when installing {{site.data.var.ee}}.
 
-## Set the docroot {#docroot}
+## Set the docroot
 
 Set the `docroot` to the `/magento` directory until you complete all setup. If you change the `docroot` to `/magento/pub` prior to completion, you will encounter issues running the Web Setup Wizard.
 
@@ -98,7 +98,7 @@ After you have installed Magento, you need to set the file system permissions an
 
 {% include install/file-system-perms-twouser_cmds-only.md %}
 
-## Install Magento {#install}
+## Install Magento
 
 Prior to installing, you should [Update installation dependencies]({{ page.baseurl }}/install-gde/install/prepare-install.html#install-composer-install) using Composer commands.
 

--- a/guides/v2.1/cloud/before/before-setup-env-install.md
+++ b/guides/v2.1/cloud/before/before-setup-env-install.md
@@ -47,7 +47,7 @@ magento-cloud variable:get -e <environment-ID>
 
 ### Get Magento authentication keys
 
-You need Magento authentication keys to install Magento in your local development environment. These are different that the authentication keys included in the code repository `auth.json` file.
+You need Magento authentication keys to install Magento in your local development environment. These are different than the authentication keys included in the code repository `auth.json` file. See [Add Magento authentication keys]({{page.baseurl}}/cloud/access-acct/first-time-setup_import-prepare.html).
 
 #### To create authentication keys through the Magento Marketplace:
 


### PR DESCRIPTION
Add instructions to use the `env:COMPOSER_AUTH` variable as a best-secure-practice for adding credentials to the Cloud project.

I also cleaned up the formatting of a related topic. I did NOT clean and verify the instructions of that related topic.

whatsnew
Documented a more secure method of [adding authentication credentials]({{page.baseurl}}/cloud/access-acct/first-time-setup_import-prepare.html#add-magento-authentication-keys) to a Cloud project.