### PR TITLE
Corrected name of staging and prod deploy log

### DIFF
--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -22,7 +22,7 @@ The following information provides information on verifying logs, testing Fastly
 
 If you encounter errors on deployment or other issues when testing, check the log files. Log files are located under the `var/log` directory.
 
-The deployment log is located in `/var/log/platform/<prodject ID>/post_deploy.log`. The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging user is `yw1unoukjcawe_stg` and the Production user is `yw1unoukjcawe`.
+The deployment log is located in `/var/log/platform/<prodject ID>/deploy.log`. The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging user is `yw1unoukjcawe_stg` and the Production user is `yw1unoukjcawe`.
 
 When accessing logs in Production, you may need to SSH into each of the three nodes to locate the logs.
 

--- a/guides/v2.1/cloud/project/project-start.md
+++ b/guides/v2.1/cloud/project/project-start.md
@@ -83,9 +83,9 @@ Logs from the deploy hook are located on the server in the following locations:
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 
-For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/post_deploy.log`.
+For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/deploy.log`.
 
-For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/post_deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/post_deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/post_deploy.log`.
+For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/post_deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/deploy.log`.
 
 Logs for all deployments that have occurred on this environment are appended to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment.
 

--- a/guides/v2.1/cloud/trouble/environments-logs.md
+++ b/guides/v2.1/cloud/trouble/environments-logs.md
@@ -41,7 +41,7 @@ Logs from the deploy hook are located on the server in the following locations:
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 
-For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/post_deploy.log`.
+For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/deploy.log`.
 
 Logs for all deployments that have occurred on this environment are appended to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment.
 

--- a/guides/v2.1/cloud/trouble/environments-logs.md
+++ b/guides/v2.1/cloud/trouble/environments-logs.md
@@ -36,8 +36,8 @@ For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the 
 Logs from the deploy hook are located on the server in the following locations:
 
 *	Integration: `/var/log/deploy.log`
-*	Staging: `/var/log/platform/<project ID>_stg/post_deploy.log`
-*	Production: `/var/log/platform/<project ID>/post_deploy.log`
+*	Staging: `/var/log/platform/<project ID>_stg/deploy.log`
+*	Production: `/var/log/platform/<project ID>/deploy.log`
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 

--- a/guides/v2.2/cloud/project/project-start.md
+++ b/guides/v2.2/cloud/project/project-start.md
@@ -82,14 +82,14 @@ You can review these logs via SSH into the environment. Change to the directorie
 Logs from the deploy hook are located on the server in the following locations:
 
 *	Integration: `/var/log/deploy.log`
-*	Staging: `/var/log/platform/<project ID>/post_deploy.log`
-*	Production: `/var/log/platform/{1|2|3}.<project ID>/post_deploy.log`
+*	Staging: `/var/log/platform/<project ID>/deploy.log`
+*	Production: `/var/log/platform/{1|2|3}.<project ID>/deploy.log`
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 
 For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/post_deploy.log`.
 
-For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/post_deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/post_deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/post_deploy.log`.
+For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/post_deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/post_deploy.log`.
 
 Logs for all deployments that have occurred on this environment are appended to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment.
 

--- a/guides/v2.2/cloud/trouble/environments-logs.md
+++ b/guides/v2.2/cloud/trouble/environments-logs.md
@@ -39,12 +39,12 @@ For 2.1.9 and later and 2.2.X, we include a `var/log/cloud.log` file inside the 
 Logs from the deploy hook are located on the server in the following locations:
 
 *	Integration: `/var/log/deploy.log`
-*	Staging: `/var/log/platform/<project ID>_stg/post_deploy.log`
-*	Production: `/var/log/platform/<project ID>/post_deploy.log`
+*	Staging: `/var/log/platform/<project ID>_stg/deploy.log`
+*	Production: `/var/log/platform/<project ID>/deploy.log`
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 
-For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/post_deploy.log`.
+For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/deploy.log`.
 
 Logs for all deployments that have occurred on this environment are appended to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment.
 


### PR DESCRIPTION
Fixes issue #2708 

For Magento Commerce Cloud, the `post_deploy` log was renamed to `deploy.log`.

## Summary

Corrected the name of the deployment log for Magento Commerce Cloud staging and production environments.
