### PR TITLE
Improve PWA docs site navigability

### DIFF
--- a/_includes/layout/navigation.html
+++ b/_includes/layout/navigation.html
@@ -55,7 +55,7 @@
           <li><a href="{{ page.baseurl }}/pattern-library/bk-pattern.html">Admin Design Pattern Library</a></li>
           <li><a href="{{ page.baseurl }}/design-styleguide/bk-styleguide.html">Admin Style Guide</a></li>
           {% if page.guide_version == "2.3" %}
-          <li><a href="{{ page.baseurl }}/pwa/">PWA Studios</a></li>
+          <li><a href="https://magento-research.github.io/pwa-studio/">Magento PWA Documentation Site</a></li>
           {% endif %}
         </ul>
       </div>

--- a/guides/v2.3/pwa/index.md
+++ b/guides/v2.3/pwa/index.md
@@ -7,28 +7,14 @@ title: Magento Progressive Web Applications (PWA)
 
 A Progressive Web App, or PWA, is a web application that uses modern web technologies and design patterns to provide a reliable, fast, and engaging user experience.
 
-The following features define a basic PWA website:
-
-* **Fast** - PWA sites use a variety of performance optimization strategies to provide a responsive experience or load content fast, even on slow networks.
-* **Secure** - PWA sites use HTTPS connections for enhanced security.
-* **Responsive** - PWA sites implement responsive design strategies to provide a consistent experience on desktops, tablets, and mobile devices. 
-* **Cross-browser compatible** - PWA sites work equally well on all modern browsers, such as Chrome, Edge, Firefox, Safari. 
-* **Offline Mode** - PWA sites cache content to ensure that some content can be served when a user is offline.
-* **Mobile "Install"** - Mobile users can add PWA sites to their home screens and even receive Push notifications from the site.
-* **Shareable content** - Each page in a PWA site has a unique URL that can be shared with other apps or social media.
+PWA websites are fast, secure, responsive, and cross-browser compatible.
+They are able work offline and act like a native app on mobile.
 
 ## What is the Magento PWA Studio project
 
-The Magento PWA Studio project is a set of developer tools that allow for the development, deployment, and maintenance of a PWA storefront on top of Magento 2. 
-It uses modern [tools and libraries] to create a build system and framework that adheres to the Magento principle of extensibility.
+The Magento PWA Studio project is a set of developer tools that allow for the development, deployment, and maintenance of a PWA storefront on top of Magento 2.3 and above.
+It uses modern tools and libraries to create a build system and framework that adheres to the Magento principle of extensibility.
 
-The Magento PWA Studio project provides the following tools:
+For more information, visit the **[Magento PWA Documentation site][]**.
 
-* **[pwa-buildpack]** - Contains the main build and development tools for a Magento PWA.
-* **[peregrine]** - Contains a collection of UI components for a Magento PWA.
-* **[Venia theme]** - A proof of concept Magento 2 theme built using the PWA Studio tools.
-
-[tools and libraries]: https://magento-research.github.io/pwa-studio/technologies/tools-libraries/
-[pwa-buildpack]: https://magento-research.github.io/pwa-studio/pwa-buildpack/
-[peregrine]: https://magento-research.github.io/pwa-studio/peregrine/
-[Venia theme]: https://magento-research.github.io/pwa-studio/venia-pwa-concept/
+[Magento PWA Documentation site]: https://magento-research.github.io/pwa-studio/


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will improve the ability for readers to discover and navigate to the PWA documentation site.

The navigation link has been changed to point to the docs site and the label updated to reflect the destination of that link.

The PWA topic content has been abbreviated to reduce duplication of content already on the PWA doc site and the link to the doc site is now more pronounced.