### PR TITLE
[MFTF 2.3.6] Added the MAGENTO_CLI_COMMAND_PATH configuration parameter

### DIFF
--- a/guides/v2.2/magento-functional-testing-framework/2.3/configuration.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.3/configuration.md
@@ -142,3 +142,9 @@ FW_BP is an acronym for FrameWork BasePath.
 
 Use the `MODULE_WHITELIST` environment variable if you are working on a new module.
 When adding a new directory under `Magento/FunctionalTest`, add the directory name under `MODULE_WHITELIST` to enable the MFTF to process it.
+
+### MAGENTO_CLI_COMMAND_PATH
+
+* Use: optional.
+* Description: Path to Magento CLI command entry point. Modify the default value if not using standard Magento installation.
+* Example: `dev/tests/acceptance/utils/command.php`


### PR DESCRIPTION
## This PR is a:

- [x] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

MQE-1168: magentoCLI action not working properly if URL to magento contains directory 

<!-- (REQUIRED) What does this PR change? -->

## Additional information

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->

whatsnew
Added MAGENTO_CLI_COMMAND_PATH to the [configuration](https://devdocs.magento.com/guides/v2.2/magento-functional-testing-framework/2.3/configuration.html).