### PR TITLE
MFTF 2.3.5: Editorial updates

### DIFF
--- a/guides/v2.2/magento-functional-testing-framework/2.2/best-practices.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/best-practices.md
@@ -4,6 +4,7 @@ title: Best practices
 mftf-release: 2.2.0
 functional_areas:
  - Testing
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/best-practices.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/commands/codeception.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/commands/codeception.md
@@ -4,6 +4,7 @@ title: Codeception commands
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/codeception.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/commands/robo.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/commands/robo.md
@@ -4,6 +4,7 @@ title: Robo commands
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/robo.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/configuration.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/configuration.md
@@ -4,6 +4,7 @@ title: Configuration
 functional_areas:
  - Testing
 mftf-release: 2.1.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/configuration.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/data.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/data.md
@@ -4,6 +4,7 @@ title: Input testing data
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/data.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/getting-started.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/getting-started.md
@@ -4,6 +4,7 @@ title: Getting started
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/getting-started.html
 ---
 
 _This topic was updated after {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/introduction.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/introduction.md
@@ -4,6 +4,7 @@ title: Introduction to the Magento Functional Testing Framework version 2.2
 functional_areas:
     - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/introduction.html
 ---
 
 _The latest MFTF 2.2 release is [{{page.mftf-release}}]._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/merging.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/merging.md
@@ -4,6 +4,7 @@ title: Merging
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/merging.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/metadata.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/metadata.md
@@ -4,6 +4,7 @@ title: Metadata
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/metadata.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/page.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/page.md
@@ -4,6 +4,7 @@ title: Page structure
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/page.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/section.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/section.md
@@ -4,6 +4,7 @@ title: Section structure
 functional_areas:
  - Testing
 mftf-release: 2.1.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/section.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/section/locator-functions.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/section/locator-functions.md
@@ -4,6 +4,7 @@ title: Use Codeception's Locator functions
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/locator-functions.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/section/parameterized-selectors.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/section/parameterized-selectors.md
@@ -4,6 +4,7 @@ title: Create and use parameterized selectors
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/parameterized-selectors.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/suite.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/suite.md
@@ -4,6 +4,7 @@ title: Suites
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/suite.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/test.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/test.md
@@ -4,6 +4,7 @@ title: Test
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/test.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/test/action-groups.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/test/action-groups.md
@@ -4,6 +4,7 @@ title: Action groups
 functional_areas:
  - Testing
 mftf-release: 2.1.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/action-groups.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/test/actions.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/test/actions.md
@@ -4,6 +4,7 @@ title: Test actions
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/actions.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/test/annotations.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/test/annotations.md
@@ -4,6 +4,7 @@ title: Annotations
 functional_areas:
  - Testing
 mftf-release: 2.2.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/annotations.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/test/assertions.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/test/assertions.md
@@ -4,6 +4,7 @@ title: Assertions
 functional_areas:
  - Testing
 mftf-release: 2.1.0
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/assertions.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/troubleshooting.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/troubleshooting.md
@@ -4,6 +4,7 @@ title: Troubleshooting
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/troubleshooting.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.2/update.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/update.md
@@ -10,6 +10,8 @@ redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/update.html
 _This topic was updated due to the {{page.mftf-release}} MFTF release._
 {: style="text-align: right"}
 
+{% include_relative include/note-2.3-docs.md %}
+
 Magento tests and the framework are stored in different repositories.
 
 Magento tests are stored in the same repository as the Magento code base. When you pull changes in the Magento code, you're potentially pulling corresponding tests as well.

--- a/guides/v2.2/magento-functional-testing-framework/2.2/update.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/update.md
@@ -4,6 +4,7 @@ title: Update the Magento Functional Testing Framework
 functional_areas:
  - Testing
 mftf-release: 2.0.2
+redirect_from: /guides/v2.3/magento-functional-testing-framework/2.2/update.html
 ---
 
 _This topic was updated due to the {{page.mftf-release}} MFTF release._

--- a/guides/v2.2/magento-functional-testing-framework/2.3/getting-started.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.3/getting-started.md
@@ -10,7 +10,7 @@ redirect_from: /guides/v2.2/magento-functional-testing-framework/release-2/getti
 _This topic was updated after {{page.mftf-release}} MFTF release._
 {: style="text-align: right"}
 
-{% if page.guide_version == 2.2 %}
+{% if page.guide_version == "2.2" %}
 {% include_relative include/note-2.2-docs.md %}
 {% endif %}
 

--- a/guides/v2.2/magento-functional-testing-framework/2.3/introduction.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.3/introduction.md
@@ -10,7 +10,7 @@ redirect_from: /guides/v2.2/magento-functional-testing-framework/release-2/intro
 _The latest MFTF release is [{{page.mftf-release}}]._
 {: style="text-align: right"}
 
-{% if page.guide_version == 2.2 %}
+{% if page.guide_version == "2.2" %}
 {% include_relative include/note-2.2-docs.md %}
 {% endif %}
 

--- a/guides/v2.2/magento-functional-testing-framework/2.3/introduction.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.3/introduction.md
@@ -3,7 +3,7 @@ group: mftf-2.3
 title: Introduction to the Magento Functional Testing Framework version 2.3
 functional_areas:
     - Testing
-mftf-release: 2.3.3
+mftf-release: 2.3.5
 redirect_from: /guides/v2.2/magento-functional-testing-framework/release-2/introduction.html
 ---
 

--- a/guides/v2.2/magento-functional-testing-framework/2.3/update.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.3/update.md
@@ -10,13 +10,9 @@ redirect_from: /guides/v2.2/magento-functional-testing-framework/release-2/updat
 _This topic was updated due to the {{page.mftf-release}} MFTF release._
 {: style="text-align: right"}
 
-{% include note.html
-type='info'
-content='Availability in the Magento codebase:
-- The latest release available in the Magento 2.2 codebase (the `2.2-develop` branch) is MFTF 2.2.0.
-- The latest release available in the Magento 2.3 codebase (the `2.3-develop` branch) is MFTF 2.3.0.
-'
-%}
+{% if page.guide_version == "2.2" %}
+{% include_relative include/note-2.2-docs.md %}
+{% endif %}
 
 Magento tests and the framework are stored in different repositories.
 
@@ -27,7 +23,7 @@ The MFTF is installed separately as a dependency using Composer.
 When pulling the latest Magento code, update the corresponding Composer dependencies in the `magento2` root directory.
 This ensures that the MFTF is up to date.
 
-## Update the MFTF to 2.3.0
+## Update the MFTF from 2.2
 
 To update the MFTF (via a command line interface):
 


### PR DESCRIPTION
## This PR is a:

- Content update
- Content fix or rewrite

## Summary

When this pull request is merged, it will update the latest MFTF 2.3 release, add redirects for the better navigation, and fix appearance of the note in the Magento 2.2 MFTF 2.3.