### PR TITLE
[fix] missing spaces in mtf section

### DIFF
--- a/guides/v2.1/mtf/mtf_entities/mtf_fixture.md
+++ b/guides/v2.1/mtf/mtf_entities/mtf_fixture.md
@@ -39,7 +39,7 @@ Magento has a tool, `generateFixtureXml.php,`, to automatically generate fixture
 </div>
 
 {: .bs-callout .bs-callout-warning}
-To work with generateFixtureXml tool, [Magento must beinstalled.]({{ page.baseurl }}/install-gde/bk-install-guide.html)
+To work with generateFixtureXml tool, [Magento must be installed.]({{ page.baseurl }}/install-gde/bk-install-guide.html)
 
 In the following table see `generateFixtureXml` arguments.
 
@@ -128,7 +128,7 @@ The following table describes `<field>` attributes.
 | `is_required`       | Specifies whether field is required on the form.   | 1 - required, 0 - optional | 1  |optional     |
 | `group`    | Tab name that contains field (for example, `title` field is placed on **Storefront properties** tab on widget creation page).      |           string           |storefront_properties | optional      |
 | `source`    | Class that prepares field data for use. See [Add the data source to the fixture field](#mtf_fixture_source).      |    string |Magento\Widget\Test\Fixture\Widget\LayoutUpdates   |     optional      |
-| `repository`    | Reference to  the class that stores data sets for the field. [More details about therepository]({{ page.baseurl }}/mtf/mtf_entities/mtf_fixture-repo.html). |  string  |Magento\Widget\Test\Repository\Widget\LayoutUpdates   |     optional      |
+| `repository`    | Reference to  the class that stores data sets for the field. [More details about the repository]({{ page.baseurl }}/mtf/mtf_entities/mtf_fixture-repo.html). |  string  |Magento\Widget\Test\Repository\Widget\LayoutUpdates   |     optional      |
 
 The following image shows how XML is connected with GUI of your new widget.
 
@@ -239,7 +239,7 @@ To apply changes, enter following commands:
 
 Our new field `layout_updates` is complex and contains different elements and logic, depending on the type of layout chosen.
 
-![Layout update subelements]({{ site.baseurl }}/common/images/ftf/mtf_layout_update.jpg)
+![Layout update sub elements]({{ site.baseurl }}/common/images/ftf/mtf_layout_update.jpg)
 
 You can use a data source that provides additional processing of the field (for example, parsing or creation of new field).
 

--- a/guides/v2.1/mtf/mtf_entities/mtf_handler.md
+++ b/guides/v2.1/mtf/mtf_entities/mtf_handler.md
@@ -3,7 +3,7 @@ group: mtf-guide
 title: Handler
 ---
 
-You can use a handler to set up preconditions and prepare an initial testing environment for particular tests. For example, your scenario requires a particular {% glossarytooltip f0dcf847-ce21-4b88-8b45-83e1cbf08100 %}widget{% endglossarytooltip %} that must be implicitly created before the test is started. You need [afixture]({{ page.baseurl }}/mtf/mtf_entities/mtf_fixture.html), a data set, and a handler. The handler transfers data to the application being tested. The data is a list of fields from a fixture and values from data sets.
+You can use a handler to set up preconditions and prepare an initial testing environment for particular tests. For example, your scenario requires a particular {% glossarytooltip f0dcf847-ce21-4b88-8b45-83e1cbf08100 %}widget{% endglossarytooltip %} that must be implicitly created before the test is started. You need a [fixture]({{ page.baseurl }}/mtf/mtf_entities/mtf_fixture.html), a [data set]({{ page.baseurl }}/mtf/mtf_entities/mtf_dataset.html), and a handler. The handler transfers data to the application being tested. The data is a list of fields from a fixture and values from data sets.
 
 This topic focuses on handlers, and we'll discuss types of handlers as well as how to create and use one.
 

--- a/guides/v2.1/mtf/mtf_introduction.md
+++ b/guides/v2.1/mtf/mtf_introduction.md
@@ -72,11 +72,11 @@ For other tests please see the following topics:
 
 - [How to run unit tests during development on the command line orPHPStorm.]({{ page.baseurl }}/test/unit/unit_test_execution.html)
 
-- [How to run unit and integration tests using \`bin/magento\` incontinuousintegration.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html)
+- [How to run unit and integration tests using \`bin/magento\` in continuous integration.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html)
 
 - [More information about JavaScript unittests.]({{ page.baseurl }}/test/js/test_js-unit.html)
 
-- [More information about performancetesting.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-perf-data.html)
+- [More information about performance testing.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-perf-data.html)
 
 ## FTF on GitHub {#mtf_intro_github-link}
 

--- a/guides/v2.1/mtf/mtf_quickstart.md
+++ b/guides/v2.1/mtf/mtf_quickstart.md
@@ -5,14 +5,14 @@ title: Quick start with the Functional Testing Framework
 
 In this chapter you will learn how to:
 
-- [Adjust configuration to set PHPUnit, the FTF, and credentials forMagento modules ifrequired]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
+- [Adjust configuration to set PHPUnit, the FTF, and credentials for Magento modules if required]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 - [Prepare environment for thetest]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
   - Run the Selenium Server
   - Run tests on non default browser
   - Run generator
-- [Run functionaltests]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_runtest.html)
+- [Run functional tests]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_runtest.html)
   - Run all tests
   - Run particular test
-- [Check logs for failedtests]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_logs.html)
+- [Check logs for failed tests]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_logs.html)
   - Check FTF logs
   - Check Magento logs

--- a/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_environment.md
+++ b/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_environment.md
@@ -12,7 +12,7 @@ You can download the Selenium Server from [Selenium project website].
 Install [Java](https://help.ubuntu.com/community/Java) to work with Selenium Server.
 </div>
 
-Specific versions of the Selenium Server are compatible with specific versions of browsers. [Read more about compatibility of browser version and Selenium serverversion.](http://docs.seleniumhq.org/about/platforms.jsp)
+Specific versions of the Selenium Server are compatible with specific versions of browsers. [Read more about compatibility of browser version and Selenium server version.](http://docs.seleniumhq.org/about/platforms.jsp)
 
 <div class="bs-callout bs-callout-info" markdown="1">
 Use Mozilla Firefox ESR 45 with Selenium 2.53.1. Later versions have compatibility issues.

--- a/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_runtest.md
+++ b/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_runtest.md
@@ -9,10 +9,10 @@ FTF uses PHPUnit, which is located in `<magento2_root_dir>/dev/tests/functional/
 
 Be sure that your system is ready for test run.
 
-- [Magento is ready fortests]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_pre)
+- [Magento is ready for tests]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_pre)
 - [The Functional Testing Framework isinstalled]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_check)
 - [The Functional Testing Framework isconfigured]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
-- [Environment is ready to testrun]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
+- [Environment is ready to test run]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
 
 ### Run all tests {#mtf_quickstart_testrun_all}
 

--- a/guides/v2.1/mtf/mtf_update.md
+++ b/guides/v2.1/mtf/mtf_update.md
@@ -5,7 +5,7 @@ title: Update the Functional Testing Framework
 
 Two types of updates are available.
 
--     [Install a new version of the Functional TestingFramework](#mtf_update_install)
+-     [Install a new version of the Functional Testing Framework](#mtf_update_install)
 
 <div class="bs-callout bs-callout-info" id="info">
 <p>Use this type of update if the version of the Functional Testing Framework in <code>&lt;magento2&gt;/dev/tests/functional/composer.json</code> and last version in <code>&lt;magento2&gt;/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md</code> are different. For example, when you updated Magento.</p>
@@ -28,7 +28,7 @@ Step 2.    Remove file `<magento2_root_dir>/dev/tests/functional/composer.lock`.
   <p><b>Why:</b> {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} reads dependencies from <code>composer.lock</code> instead of reading <code>composer.json</code>. File <code>composer.lock</code> currently is not maintained.</p>
 </div>
 
-Step 3.    [Perform and checkinstallation.]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_perform)
+Step 3.    [Perform and check installation.]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_perform)
 
 ### Update components from dependencies in <code>composer.json</code> {#mtf_update_depend}
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will correct missing spaces in links and also adding an additional link to the datasets in `guides/v2.1/mtf/mtf_entities/mtf_handler.md`

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URL's 

- https://devdocs.magento.com/guides/v2.1/mtf/mtf_entities/mtf_fixture.html
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_entities/mtf_handler.html
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_introduction.html
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_quickstart.html 
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_quickstart.html 
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_environment.html
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_quickstart/mtf_quickstart_runtest.html
- https://devdocs.magento.com/guides/v2.1/mtf/mtf_update.html



