### PR TITLE
Link to advanced-setup went to a markdown file instead of a html file…

### DIFF
--- a/guides/v2.2/performance-best-practices/hardware.md
+++ b/guides/v2.2/performance-best-practices/hardware.md
@@ -24,7 +24,7 @@ Magento 2 has differing PHP memory requirements, based on how your system is dep
 Scenarios and expected PHP memory requirements:
 * Webnode serving only storefront pages: 256 MB
 * Webnode serving admin pages with a large catalog: 1 GB
-* Magento 2 cron indexing a site with a large catalog: >256 MB (See [advanced-setup]({{ page.baseurl }}/performance-best-practices/advanced-setup.md) to tune for optimal performance.)
+* Magento 2 cron indexing a site with a large catalog: >256 MB (See [advanced-setup]({{ page.baseurl }}/performance-best-practices/advanced-setup.html) to tune for optimal performance.)
 * Magento 2 compile and deploy of static assets: 756 MB
 * Magento 2 using the web setup wizard to install or upgrade a store with several 3rd party extensions: 2 GB
 * Magento 2 performance toolkit profile generation: >1 GB PHP RAM, >16 MB MySQL TMP_TABLE_SIZE & MAX_HEAP_TABLE_SIZE settings


### PR DESCRIPTION
…, fixed in this commit.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix a link which pointed to a markdown file instead of a html file.

You might want to search the entire codebase, there are a couple more occurrences which are probably incorrect. [One example](https://devdocs.magento.com/guides/v2.3/rest/operation-status-search.html) (link to 'Bulk API request' is incorrect as well). Don't have the time to check them all right now.
Regex you can use to search through all source code: `\{\{\s?page.baseurl\s?\}\}.+\.md` (might flag false positives) 

## Additional information

List all affected URL's 

- https://devdocs.magento.com/guides/v2.2/performance-best-practices/hardware.html
