### PR TITLE
removes <span> tag and "mandatory element" on html-tag

### DIFF
--- a/guides/v2.1/frontend-dev-guide/layouts/layout-types.md
+++ b/guides/v2.1/frontend-dev-guide/layouts/layout-types.md
@@ -112,7 +112,7 @@ The following table describes the instructions specific for page configuration f
     </tr>
     <tr>
       <td>
-        <code>&lt;span&gt;&lt;page&gt;&lt;/page&gt;&lt;/span&gt;</code>
+        <code>&lt;page&gt;&lt;/page&gt;</code>
       </td>
       <td colspan="1">
         <ul>
@@ -144,9 +144,7 @@ The following table describes the instructions specific for page configuration f
           <li><code>&lt;attribute&gt;</code></li>
         </ul>
       </td>
-      <td colspan="1">
-        <span>Mandatory element.</span>
-      </td>
+      <td colspan="1" />
     </tr>
     <tr>
       <td colspan="1"><code>&lt;head&gt;&lt;/head&gt;</code></td>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix a bug where `<span>` is rendered around `<page>` in the table of allowed tags and removes "mandatory element" comment from `<html>` tag, which is not mandatory.

## Additional information

https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-types.html