### PR TITLE
Add attribute_options object

### DIFF
--- a/guides/v2.3/graphql/reference/custom-attribute-metadata.md
+++ b/guides/v2.3/graphql/reference/custom-attribute-metadata.md
@@ -3,7 +3,7 @@ group: graphql
 title: CustomAttributeMetadata endpoint
 ---
 
-The `customAttributeMetadata` endpoint returns the attribute type, given an attribute code and entity type. All entity attributes can be added to an equivalent GraphQL type, including custom, extension, and EAV (which have precedence set in that order for collisions). The ability to know the type of attribute a given field is obscured from the GraphQL query consumer.
+The `customAttributeMetadata` endpoint returns the attribute type, given an attribute code and entity type. All entity attributes can be added to an equivalent GraphQL type, including custom, extension, and EAV (which have precedence set in that order for collisions). The GraphQL query consumer does not have the ability to know a field's attribute type.
 
 ## Supported attributes
 

--- a/guides/v2.3/graphql/reference/custom-attribute-metadata.md
+++ b/guides/v2.3/graphql/reference/custom-attribute-metadata.md
@@ -5,6 +5,24 @@ title: CustomAttributeMetadata endpoint
 
 The `customAttributeMetadata` endpoint returns the attribute type, given an attribute code and entity type. All entity attributes can be added to an equivalent GraphQL type, including custom, extension, and EAV (which have precedence set in that order for collisions). The ability to know the type of attribute a given field is obscured from the GraphQL query consumer.
 
+## Supported attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`attribute_code` | String | The unique identifier for an attribute code. This value should be in lowercase letters without spaces.
+`entity_type` | String | The type of entity that defines the attribute
+`attribute_type` | String | The data type of the attribute (Response only)
+`attribute_options` | `AttributeOption` | A list of attribute options
+{:style="table-layout:auto;"}
+
+### AttributeOption object
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`label` | String | The name of an attribute option
+`value` | String | The value assigned to an attribute option
+{:style="table-layout:auto;"}
+
 ## Example usage
 
 The following query returns the attribute type for various custom and EAV attributes.
@@ -43,12 +61,12 @@ The following query returns the attribute type for various custom and EAV attrib
       attribute_code
       entity_type
       attribute_type
+      attribute_options
     }
   }
  }
  {% endhighlight %}
 
-The key you're storing EAV attributes under
 **Response**
 
 {% highlight json %}
@@ -86,11 +104,3 @@ The key you're storing EAV attributes under
   }
 }
 {% endhighlight %}
-
-## Supported attributes
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String | The unique identifier for an attribute code. This value should be in lowercase letters without spaces.
-`attribute_type` | String | The data type of the attribute (Response only)
-`entity_type` | String | The type of entity that defines the attribute

--- a/guides/v2.3/graphql/reference/custom-attribute-metadata.md
+++ b/guides/v2.3/graphql/reference/custom-attribute-metadata.md
@@ -31,40 +31,23 @@ The following query returns the attribute type for various custom and EAV attrib
 
 {% highlight json %}
 {
-  customAttributeMetadata(attributes:
-  [
-    {
-      attribute_code: "available_sort_by",
-      entity_type: "catalog_category"
-    },
-    {
-      attribute_code: "quantity_and_stock_status",
-      entity_type: "catalog_product"
-    },
-    {
-      attribute_code: "default_billing",
-      entity_type: "customer"
-    },
-    {
-     attribute_code: "region"
-     entity_type: "customer_address"
-    },
-    {
-      attribute_code: "media_gallery",
-      entity_type: "catalog_product"
-    }
-  ]
-  )
-  {
-    items
-    {
-      attribute_code
-      entity_type
-      attribute_type
-      attribute_options
-    }
-  }
+ customAttributeMetadata(
+   attributes: {
+     attribute_code: "color"
+     entity_type: "4"
+   }
+ ) {
+   items {
+     attribute_code
+     entity_type
+     attribute_type
+     attribute_options {
+       value
+       label
+     }
+   }
  }
+}
  {% endhighlight %}
 
 **Response**
@@ -75,29 +58,71 @@ The following query returns the attribute type for various custom and EAV attrib
     "customAttributeMetadata": {
       "items": [
         {
-          "attribute_code": "available_sort_by",
-          "entity_type": "catalog_category",
-          "attribute_type": "EavDataAttributeOptionInterface"
-        },
-        {
-          "attribute_code": "quantity_and_stock_status",
-          "entity_type": "catalog_product",
-          "attribute_type": "CatalogInventoryDataStockItemInterface[]"
-        },
-        {
-          "attribute_code": "default_billing",
-          "entity_type": "customer",
-          "attribute_type": "CustomerDataAddressInterface"
-        },
-        {
-          "attribute_code": "region",
-          "entity_type": "customer_address",
-          "attribute_type": "CustomerDataRegionInterface"
-        },
-        {
-          "attribute_code": "media_gallery",
-          "entity_type": "catalog_product",
-          "attribute_type": "ProductMediaGallery"
+          "attribute_code": "color",
+          "entity_type": "4",
+          "attribute_type": "Int",
+          "attribute_options": [
+            {
+              "value": "49",
+              "label": "Black"
+            },
+            {
+              "value": "214",
+              "label": "blue"
+            },
+            {
+              "value": "215",
+              "label": "green"
+            },
+            {
+              "value": "213",
+              "label": "red"
+            },
+            {
+              "value": "50",
+              "label": "Blue"
+            },
+            {
+              "value": "51",
+              "label": "Brown"
+            },
+            {
+              "value": "52",
+              "label": "Gray"
+            },
+            {
+              "value": "53",
+              "label": "Green"
+            },
+            {
+              "value": "54",
+              "label": "Lavender"
+            },
+            {
+              "value": "55",
+              "label": "Multi"
+            },
+            {
+              "value": "56",
+              "label": "Orange"
+            },
+            {
+              "value": "57",
+              "label": "Purple"
+            },
+            {
+              "value": "58",
+              "label": "Red"
+            },
+            {
+              "value": "59",
+              "label": "White"
+            },
+            {
+              "value": "60",
+              "label": "Yellow"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] xug fix or improvement

## Summary

When this pull request is merged, it will document the `attribute_options` object, which was added in [GraphQL PR108](https://github.com/magento/graphql-ce/pull/108).

whatsnew
Updated [CustomAttributeMetadata endpoint](https://devdocs.magento.com/guides/v2.3/graphql/reference/custom-attribute-metadata.html) to include the new `attribute_options` object.
