### PR TITLE
Fixed table output

### DIFF
--- a/_includes/install/web/install-web_3-web-conf.md
+++ b/_includes/install/web/install-web_3-web-conf.md
@@ -6,7 +6,7 @@
     |--- |--- |
     |Your Store Address|Enter the URL, including scheme and trailing slash, by which users access your storefront. For example, if your storefront hostname is http://www.example.com, enter http://www.example.com/|
     |Magento Admin Address|Enter the relative URL by which to access the Magento Admin.|
-		{:style="table-layout:auto;"}
+    {:style="table-layout:auto;"}
 
 2.	Optionally click **Advanced Options** and enter the following information:
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix the incorrect table output of the affected URL pages.

Fix issue #2873 

## Additional information

List all affected URL's 

https://devdocs.magento.com/guides/v2.0/install-gde/install/web/install-web_3-web-conf.html
https://devdocs.magento.com/guides/v2.1/install-gde/install/web/install-web_3-web-conf.html
https://devdocs.magento.com/guides/v2.2/install-gde/install/web/install-web_3-web-conf.html
https://devdocs.magento.com/guides/v2.3/install-gde/install/web/install-web_3-web-conf.html

There was a tab used for the style attribute which broke the table translation in Jekyll. This has been changed to 4 spaces and renders correctly on my local setup.
