### PR TITLE
Revert "Update 2.3.0-alpha-install.md"

### DIFF
--- a/guides/v2.3/release-notes/2.3.0-alpha-install.md
+++ b/guides/v2.3/release-notes/2.3.0-alpha-install.md
@@ -23,14 +23,14 @@ In addition to the [standard Magento prerequisites]({{ site.baseurl }}/guides/v2
    
    Available to everyone with Magento authentication keys. If you do not have authentication keys, complete the instructions in [Get your authentication keys]({{page.baseurl}}/install-gde/prereq/connect-auth.html) before continuing.
    ```bash
-   composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.3.* --stability=alpha <install-directory-name>
+   composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.3.* --stability=alpha <install-directory-name>
    ```
 
    **Commerce**
    
    Only available to Magento partners, merchant developers, and independent extension developers who have signed [Magento's Pre-Release Software Agreement](https://partners.magento.com/portal/pre-release-agreement) and been approved to access the Commerce 2.3.0 Alpha repositories. If you have not signed the pre-release software agreement and been granted access, you must do so before continuing.
    ```bash
-   composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.3.* --stability=alpha <install-directory-name>
+   composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.3.* --stability=alpha <install-directory-name>
    ```
 
    When prompted, enter your authentication keys. Your *public key* is your username; your *private key* is your password.


### PR DESCRIPTION
Reverts magento/devdocs#2855

Reverting because the ` composer --repository-url` flag has been deprecated. 

I'll open another PR to remove other instances of this flag. 