### PR TITLE
replaced deprecated composer flags

### DIFF
--- a/_includes/install/releasenotes/ce_install_20.md
+++ b/_includes/install/releasenotes/ce_install_20.md
@@ -13,13 +13,13 @@ See one of the following sections:
 
 This software is available from `repo.magento.com`. Before installing the Open Source software using Composer, familiarize yourself with the Composer [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html), then run:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
 
 where `<version>` matches the version you want (for example, `2.0.10`)
 
 For example, to install {{site.data.var.ce}} 2.0.10 in the `magento2` directory:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.0.10 magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.0.10 magento2
 
 ### Get Magento Open Source using a compressed archive {#get-zip}
 {:.no_toc}

--- a/_includes/install/releasenotes/ce_install_21.md
+++ b/_includes/install/releasenotes/ce_install_21.md
@@ -1,8 +1,8 @@
 
- 
+
 ## Install the Magento software
 
-You can get Magento Open Source (formerly Community Edition) 2.1 from Github, Composer, or using a compressed archive. 
+You can get Magento Open Source (formerly Community Edition) 2.1 from Github, Composer, or using a compressed archive.
 
 See one of the following sections for more information:
 
@@ -13,15 +13,15 @@ See one of the following sections for more information:
 ### Get the Magento Open Source software using Composer {#install-rc-composer}
 {:.no_toc}
 
-The Open Source software is available from `repo.magento.com`. Before getting the Open Source software, familiarize yourself with the Composer metapackage  [prerequisites]({{ page.baseurl }}/install-gde/composer.html), then run 
+The Open Source software is available from `repo.magento.com`. Before getting the Open Source software, familiarize yourself with the Composer metapackage  [prerequisites]({{ page.baseurl }}/install-gde/composer.html), then run
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
 
 where `<version>` is `2.1.0`, `2.1.1`, and so on
 
 For example, to install Magento Open Source 2.1.1 in the `magento2` directory:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.1.1 magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.1.1 magento2
 
 ### Get a compressed archive {#install-archive}
 {:.no_toc}

--- a/_includes/install/releasenotes/ee_install_20.md
+++ b/_includes/install/releasenotes/ee_install_20.md
@@ -13,13 +13,13 @@ See one of the following sections:
 
 This software is available from `repo.magento.com`. Before installing the Magento Commerce software using Composer, familiarize yourself with the Composer [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html), then run:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
 
 where `<version>` matches the version you want (for example, `2.0.10`)
 
 For example, to install 2.0.10 in the `magento2` directory:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.0.10 magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.0.10 magento2
 
 ### Get Magento Commerce using a compressed archive {#get-zip}
 {:.no_toc}

--- a/_includes/install/releasenotes/ee_install_21.md
+++ b/_includes/install/releasenotes/ee_install_21.md
@@ -1,5 +1,5 @@
 
- 
+
 ## Install the Magento software
 
 See one of the following sections:
@@ -14,13 +14,13 @@ See one of the following sections:
 Magento Commerce (formerly Enterprise Edition) is available from `repo.magento.com`. Before installing the Magento Commerce software using Composer,  familiarize yourself with these  [prerequisites]({{ page.baseurl }}/install-gde/composer.html), then run:
 
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
 
 where `<version>` is `2.1.0`, `2.1.1`, and so on
 
 For example, to install 2.1.1 in the `magento2` directory:
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.1.1 magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.1.1 magento2
 
 ### Get Magento Commerce using a compressed archive {#get-zip}
 {:.no_toc}

--- a/guides/v2.0/install-gde/install-quick-ref.md
+++ b/guides/v2.0/install-gde/install-quick-ref.md
@@ -54,7 +54,7 @@ If not, see the <a href="{{ page.baseurl }}/install-gde/bk-install-guide.html">I
 When all prerequisites have been met, get the Magento software using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} as follows:
 
 	cd <web server docroot directory>
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
 
 You're required to authenticate; see <a href="{{ page.baseurl }}/install-gde/prereq/connect-auth.html">Get your authentication keys</a> for details. This downloads Magento code only; it doesn't install the software for you.
 

--- a/guides/v2.0/install-gde/prereq/integrator_install_ce.md
+++ b/guides/v2.0/install-gde/prereq/integrator_install_ce.md
@@ -19,7 +19,7 @@ To get the {{site.data.var.ce}} metapackage:
 2.	Change to the web server docroot directory, or to a directory you've configured as a virtual host docroot.
 3.	Enter the following command:
 
-		composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition <installation directory name>
+		composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <installation directory name>
 
 	When prompted, enter your <a href="{{ page.baseurl }}/install-gde/prereq/connect-auth.html">authentication keys</a>. Your *public key* is your username; your *private key* is your password.
 

--- a/guides/v2.0/install-gde/prereq/integrator_install_ee.md
+++ b/guides/v2.0/install-gde/prereq/integrator_install_ee.md
@@ -21,7 +21,7 @@ To get the {{site.data.var.ee}} metapackage:
 2.	Change to the web server docroot directory, or to a directory you've configured as a virtual host docroot.
 3.	Enter the following command:
 
-		composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition <installation directory name>
+		composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <installation directory name>
 
 	When prompted, enter your <a href="{{ page.baseurl }}/install-gde/prereq/connect-auth.html">authentication keys</a>. Your *public key* is your username; your *private key* is your password.
 

--- a/guides/v2.0/release-notes/ReleaseNotes2.1_RC1CE.md
+++ b/guides/v2.0/release-notes/ReleaseNotes2.1_RC1CE.md
@@ -117,7 +117,7 @@ Before proceeding, please familiarize yourself with these prerequisites, then ru
 
 This Release Candidate is available from `repo.magento.com`. Before installing this Release Candidate using Composer,  familiarize yourself with the Composer {% glossarytooltip 7490850a-0654-4ce1-83ff-d88c1d7d07fa %}metapackage{% endglossarytooltip %}  [prerequisites]({{ page.baseurl }}/install-gde/prereq/integrator_install.html){: target="_blank"}, then run
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.1.0-rc1 <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.1.0-rc1 <installation directory name>
 
 ## Upgrade existing installations {#upgrade-rc-nosamp}
 

--- a/guides/v2.0/release-notes/ReleaseNotes2.1_RC1EE.md
+++ b/guides/v2.0/release-notes/ReleaseNotes2.1_RC1EE.md
@@ -1,24 +1,24 @@
 ---
 group: release-notes
 subgroup: 02_rel-notes
-title: Magento Commerce 2.1 Release Candidate 1 (RC1) Release Notes 
-menu_title: Magento Commerce 2.1 Release Candidate 1 (RC1) Release Notes 
+title: Magento Commerce 2.1 Release Candidate 1 (RC1) Release Notes
+menu_title: Magento Commerce 2.1 Release Candidate 1 (RC1) Release Notes
 menu_order: 421
 level3_menu_node: level3child
 level3_subgroup: rc20-relnotes
 ---
 
-We are pleased to present Magento 2.1 Release Candidate 1 (RC1). This release candidate build is not intended for production purposes. Instead, it provides the development community opportunities to: 
+We are pleased to present Magento 2.1 Release Candidate 1 (RC1). This release candidate build is not intended for production purposes. Instead, it provides the development community opportunities to:
 
 * preview the new features and fixes that Magento 2.1 GA will contain
 
 * contribute to the Magento 2.1 code base by identifying unresolved issues
 
-* test your 2.0 extensions against  2.1 
+* test your 2.0 extensions against  2.1
 
-We welcome your participation in this process! Magento Commerce customers can provide feedback in these two ways: 
+We welcome your participation in this process! Magento Commerce customers can provide feedback in these two ways:
 
-* Magento Commerce GitHub repository.  For more information on how to provide feedback and contribute on GitHub, see [Code contributions]({{ page.baseurl }}/contributor-guide/contributing.html){: target="_blank"}. 
+* Magento Commerce GitHub repository.  For more information on how to provide feedback and contribute on GitHub, see [Code contributions]({{ page.baseurl }}/contributor-guide/contributing.html){: target="_blank"}.
 
 * Email to DL-Magento-2.1-Feedback@magento.com.
 
@@ -33,20 +33,20 @@ Backward-incompatible changes are documented in [Magento 2.0 Backward Incompatib
 Magento Commerce (formerly Enterprise Edition) 2.1 includes several new features:
 
 * **Content Staging and Preview** improves productivity by enabling business teams to easily create, preview, and schedule a wide range of content updates without involving IT. Merchants can make updates to products, categories, {% glossarytooltip f3944faf-127e-4097-9918-a2e9c647d44f %}CMS{% endglossarytooltip %} content, promotions, and pricing and can preview these changes based on specific dates and times or store views. User-friendly dashboards provide greater visibility into all planned site changes and updates can be automatically deployed at scheduled times.
- 
+
 * **Elasticsearch is a next-generation search technology** that is replacing Solr in Magento Commerce 2.1. It is simpler to set up, able to handle large catalogs, and can easily scale as search volume grows. It supports 33 languages out-of-the-box, and merchants can configure stop words and synonyms to ensure high quality search results.
 
 * **PayPal in-context {% glossarytooltip 278c3ce0-cd4c-4ffc-a098-695d94d73bde %}checkout{% endglossarytooltip %} helps to increase {% glossarytooltip 38c73ce4-8f01-4f74-ab30-1134cec5664f %}conversion{% endglossarytooltip %} rates** by allowing shoppers to pay with PayPal without leaving the merchant’s site. PayPal saved credit card capabilities allow merchants to securely store credit cards with PayPal so shoppers can make future purchases without re-entering their credit card information.
- 
+
 * **Braintree enhancements enable merchants to qualify for the simplest set of PCI compliance** requirements by using Braintree Hosted Fields to collect all sensitive {% glossarytooltip 117df0a3-29a6-4636-9c29-8f696b3ad737 %}cardholder{% endglossarytooltip %} information in checkout. Merchants retain complete control over their checkout style and {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} because Braintree uses small, transparent iframes to replace individual payment fields. Merchants can now also access Braintree {% glossarytooltip 73a87074-8de7-4e69-a97f-12c65c6f5582 %}settlement{% endglossarytooltip %} reports from within the {% glossarytooltip 18b930cf-09cc-47c9-a5e5-905f86c43f81 %}Magento Admin{% endglossarytooltip %}.
- 
+
 * **Improved management interfaces** make it faster and easier to search for information in the Admin, set up global search synonyms, and create new product, category, and CMS content.
 
 ### Known issue
 
 <b>Issue:</b> Enabling Varnish causes the {% glossarytooltip 50e49338-1e6c-4473-8527-9e401d67ea2b %}category{% endglossarytooltip %} menu to switch from http to https[ (GITHUB-4540)](https://github.com/magento/magento2/issues/4540){: target="_blank"}
 
-<b>Work-around:</b> To use Varnish caching with an HTTP site, add rewrite rules such as the following in Magento's root `.htaccess`: 
+<b>Work-around:</b> To use Varnish caching with an HTTP site, add rewrite rules such as the following in Magento's root `.htaccess`:
 
 <pre>RewriteCond %{HTTPS} on
 RewriteCond %{REQUEST_URI} /yellow-fruit.html
@@ -56,43 +56,43 @@ RewriteRule (.*) http://%{HTTP_HOST}%{REQUEST_URI} [L]</pre>
 RewriteCond %{REQUEST_URI} /red-fruit.html
 RewriteRule (.*) http://%{HTTP_HOST}%{REQUEST_URI} [L]</pre>
 
- 
+
 ### Fixed issues
 
 This release includes fixes for the following GitHub issues:
 
-<!--- 52414 --> * Integration test syntax error has been fixed. [(GITHUB-4343)](https://github.com/magento/magento2/issues/4343){: target="_blank"} 
+<!--- 52414 --> * Integration test syntax error has been fixed. [(GITHUB-4343)](https://github.com/magento/magento2/issues/4343){: target="_blank"}
 
 <!--- 50611--> * Web APIs no longer allow anonymous access by default. [(GITHUB-3786)](https://github.com/magento/magento2/issues/3786){: target="_blank"}
 
-<!--- 51292 --> * The OAuth Token exchange expiration period is now calculated correctly. [(GITHUB-3449)](https://github.com/magento/magento2/issues/3449){: target="_blank"} 
+<!--- 51292 --> * The OAuth Token exchange expiration period is now calculated correctly. [(GITHUB-3449)](https://github.com/magento/magento2/issues/3449){: target="_blank"}
 
 <!--- 46720 --> * Shipping Address is now exposed for the Orders {% glossarytooltip 786086f2-622b-4007-97fe-2c19e5283035 %}API{% endglossarytooltip %}. [(GITHUB-2628)](https://github.com/magento/magento2/issues/2628){: target="_blank"}
 
 
 <!--- 52613 --> * A {% glossarytooltip 6a9783a3-cdec-4fed-843d-8eda12819804 %}Credit Memo{% endglossarytooltip %} REST API issue with updating attributes has been fixed. Previously, certain attributes (such as Order Status) were not updated when the user took action through the API. However, Magento updates these attributes when the same action is completed in the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} interface. [(GITHUB-4329)](https://github.com/magento/magento2/issues/4329){: target="_blank"}  
 
-<!--- 52607 --> *  Varnish caching performance has been enhanced. [(GITHUB-3926)](https://github.com/magento/magento2/issues/3926){: target="_blank"} 
+<!--- 52607 --> *  Varnish caching performance has been enhanced. [(GITHUB-3926)](https://github.com/magento/magento2/issues/3926){: target="_blank"}
 
-<!--- 52316 --> *  Product update operations by either customers or store administrators no longer result in locking queries on {% glossarytooltip 8d40d668-4996-4856-9f81-b1386cf4b14f %}catalog{% endglossarytooltip %} category product index. [(GITHUB-4342)](https://github.com/magento/magento2/issues/4342){: target="_blank"} 
+<!--- 52316 --> *  Product update operations by either customers or store administrators no longer result in locking queries on {% glossarytooltip 8d40d668-4996-4856-9f81-b1386cf4b14f %}catalog{% endglossarytooltip %} category product index. [(GITHUB-4342)](https://github.com/magento/magento2/issues/4342){: target="_blank"}
 
-<!--- 52079 --> * The Order Repository GetList method no longer returns the same shipping address for all orders. [(GITHUB-4019)](https://github.com/magento/magento2/issues/4019){: target="_blank"} 
+<!--- 52079 --> * The Order Repository GetList method no longer returns the same shipping address for all orders. [(GITHUB-4019)](https://github.com/magento/magento2/issues/4019){: target="_blank"}
 
-<!--- 51181 --> * A configurable product's last attribute with price of zero (0) no longer results in an error. The user can configure the product, and the correct price results. [(GITHUB-3912)](https://github.com/magento/magento2/issues/3912){: target="_blank"} 
+<!--- 51181 --> * A configurable product's last attribute with price of zero (0) no longer results in an error. The user can configure the product, and the correct price results. [(GITHUB-3912)](https://github.com/magento/magento2/issues/3912){: target="_blank"}
 
-<!--- 48175 --> * An error message that users typically received during upgrade has been improved. The message now clearly states when a user must login first to `magento.com` before continuing the upgrade process. [(GITHUB-3059)](https://github.com/magento/magento2/issues/3059){: target="_blank"} 
+<!--- 48175 --> * An error message that users typically received during upgrade has been improved. The message now clearly states when a user must login first to `magento.com` before continuing the upgrade process. [(GITHUB-3059)](https://github.com/magento/magento2/issues/3059){: target="_blank"}
 
-<!--- 47440 --> *  Magento now displays the correct product prices on the {% glossarytooltip 2fd4d100-28d2-45ca-bec1-128444ea98e6 %}Configurable product{% endglossarytooltip %} page when catalog prices include tax. [(GITHUB-2471)](https://github.com/magento/magento2/issues/2471){: target="_blank"} 
+<!--- 47440 --> *  Magento now displays the correct product prices on the {% glossarytooltip 2fd4d100-28d2-45ca-bec1-128444ea98e6 %}Configurable product{% endglossarytooltip %} page when catalog prices include tax. [(GITHUB-2471)](https://github.com/magento/magento2/issues/2471){: target="_blank"}
 
 <!--- 47439 --> * The `i18n:collect-phrases -m` command now works correctly. Previously, this command would not find all important Magento phrases. [(GITHUB-2630)](https://github.com/magento/magento2/issues/2630){: target="_blank"}
 
-<!--- 47009 --> *  Plugins/interceptors now work with early stage single instance objects in Developer mode. [(GITHUB-2674)](https://github.com/magento/magento2/issues/2674){: target="_blank"} 
+<!--- 47009 --> *  Plugins/interceptors now work with early stage single instance objects in Developer mode. [(GITHUB-2674)](https://github.com/magento/magento2/issues/2674){: target="_blank"}
 
-<!--- 46808 --> * Admin order creation no longer fails when the "Include Tax In Order Total" option is set to yes. [(GITHUB-2675)](https://github.com/magento/magento2/issues/2675){: target="_blank"} 
+<!--- 46808 --> * Admin order creation no longer fails when the "Include Tax In Order Total" option is set to yes. [(GITHUB-2675)](https://github.com/magento/magento2/issues/2675){: target="_blank"}
 
 <!--- 47639 --> * The `setup:di:compile` script now compiles all files as expected. [(GITHUB-2888)](https://github.com/magento/magento2/issues/2888){: target="_blank"}
 
-<!--- 46044 --> * Synonyms now work as expected with Magento 2.x.  [(GITHUB-2519)](https://github.com/magento/magento2/issues/2519){: target="_blank"} 
+<!--- 46044 --> * Synonyms now work as expected with Magento 2.x.  [(GITHUB-2519)](https://github.com/magento/magento2/issues/2519){: target="_blank"}
 
 <!--- 40320 --> * Attribute 'setup_version' is missing for {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} error when defined as optional. [(GITHUB-1493)](https://github.com/magento/magento2/issues/1493){: target="_blank"}
 
@@ -105,11 +105,11 @@ Our technology stack is built on {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a8
 * PHP 7.0.6 + up until 7.1
 * MySQL 5.6.
 
-We do not support PHP 5.5.x or 7.0.5. 
+We do not support PHP 5.5.x or 7.0.5.
 
 ## Installation and upgrade instructions
 
-You can install Magento Commerce 2.1 Release Candidate 1 (RC1) using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %}. 
+You can install Magento Commerce 2.1 Release Candidate 1 (RC1) using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %}.
 
 This Release Candidate is for test purposes only. Do not install it in a production environment.
 
@@ -123,7 +123,7 @@ See one of the following sections:
 
 This Release Candidate is available from `repo.magento.com`. Before installing this Release Candidate using Composer,  familiarize yourself with these  [prerequisites]({{ page.baseurl }}/install-gde/prereq/integrator_install.html){: target="_blank"}, then run:
 
-		composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.1.0-rc2 <installation directory name>
+		composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.1.0-rc2 <installation directory name>
 
 ## Upgrade existing installations {#upgrade-rc-nosamp}
 
@@ -169,7 +169,7 @@ Developers who contribute to the Open Source codebase can [upgrade manually]({{ 
 
 		composer require magento/product-enterprise-edition 2.1.0-rc1 --no-update
 		composer update
-	
+
 3.	If prompted, enter your [authentication keys]({{ page.baseurl }}/comp-mgr/prereq/prereq_auth-token.html).
 4. Update the database schema and data:
 
@@ -180,14 +180,3 @@ Developers who contribute to the Open Source codebase can [upgrade manually]({{ 
 ## Upgrade to an RC with sample data {#upgrade-rc-samp}
 
 {% include install/sampledata/sample-data-rc1-cli.md %}
-
-
-
-
-
-
-
-
-
-
-

--- a/guides/v2.0/release-notes/ReleaseNotes2.1_RC2CE.md
+++ b/guides/v2.0/release-notes/ReleaseNotes2.1_RC2CE.md
@@ -199,7 +199,7 @@ Before proceeding, please familiarize yourself with these prerequisites, then ru
 
 This Release Candidate is available from `repo.magento.com`. Before installing this Release Candidate using Composer,  familiarize yourself with the Composer {% glossarytooltip 7490850a-0654-4ce1-83ff-d88c1d7d07fa %}metapackage{% endglossarytooltip %}  [prerequisites]({{ page.baseurl }}/install-gde/prereq/integrator_install.html){: target="_blank"}, then run
 
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.1.0-rc1 <installation directory name>
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.1.0-rc1 <installation directory name>
 
 ## Upgrade existing installations {#upgrade-rc-nosamp}
 

--- a/guides/v2.0/release-notes/ReleaseNotes2.1_RC2EE.md
+++ b/guides/v2.0/release-notes/ReleaseNotes2.1_RC2EE.md
@@ -1,24 +1,24 @@
 ---
 group: release-notes
 subgroup: 02_rel-notes
-title: Magento Commerce 2.1 Release Candidate 2 (RC2) Release Notes 
-menu_title: Magento Commerce 2.1 Release Candidate 2 (RC2) Release Notes 
+title: Magento Commerce 2.1 Release Candidate 2 (RC2) Release Notes
+menu_title: Magento Commerce 2.1 Release Candidate 2 (RC2) Release Notes
 menu_order: 411
 level3_menu_node: level3child
 level3_subgroup: rc20-relnotes
 ---
 
-We are pleased to present Magento 2.1 Release Candidate 2 (RC2). This release candidate build is not intended for production purposes. Instead, it provides the development community opportunities to: 
+We are pleased to present Magento 2.1 Release Candidate 2 (RC2). This release candidate build is not intended for production purposes. Instead, it provides the development community opportunities to:
 
 * preview the new features and fixes that Magento 2.1 GA will contain
 
 * contribute to the Magento 2.1 code base by identifying unresolved issues
 
-* test your 2.0 extensions against  2.1 
+* test your 2.0 extensions against  2.1
 
-We welcome your participation in this process! Enterprise Edition customers can provide feedback in these two ways: 
+We welcome your participation in this process! Enterprise Edition customers can provide feedback in these two ways:
 
-* Magento Commerce GitHub repository.  For more information on how to provide feedback and contribute on GitHub, see [Code contributions]({{ page.baseurl }}/contributor-guide/contributing.html){: target="_blank"}. 
+* Magento Commerce GitHub repository.  For more information on how to provide feedback and contribute on GitHub, see [Code contributions]({{ page.baseurl }}/contributor-guide/contributing.html){: target="_blank"}.
 
 * Email to DL-Magento-2.1-Feedback@magento.com.
 
@@ -33,15 +33,15 @@ Backward-incompatible changes are documented in [Magento 2.1 Backward Incompatib
 Magento Commerce 2.1 includes several new and exciting features:
 
 * **Content Staging and Preview** improves productivity by enabling business teams to easily create, preview, and schedule a wide range of content updates without involving IT. Merchants can make updates to products, categories, {% glossarytooltip f3944faf-127e-4097-9918-a2e9c647d44f %}CMS{% endglossarytooltip %} content, promotions, and pricing and can preview these changes based on specific dates and times or store views. User-friendly dashboards provide greater visibility into all planned site changes and updates can be automatically deployed at scheduled times.
- 
-* **Elasticsearch is a next-generation search technology** that is replacing Solr in Magento Enterprise Edition 2.1. It is simpler to set up, able to handle large catalogs, and can easily scale as search volume grows. It supports 33 languages out-of-the-box and merchants can configure stop words and synonyms to ensure high quality search results. 
+
+* **Elasticsearch is a next-generation search technology** that is replacing Solr in Magento Enterprise Edition 2.1. It is simpler to set up, able to handle large catalogs, and can easily scale as search volume grows. It supports 33 languages out-of-the-box and merchants can configure stop words and synonyms to ensure high quality search results.
 
 * **PayPal enhancements** include PayPal in-context {% glossarytooltip 278c3ce0-cd4c-4ffc-a098-695d94d73bde %}checkout{% endglossarytooltip %} and saved credit cards. In-context checkout helps to increase {% glossarytooltip 38c73ce4-8f01-4f74-ab30-1134cec5664f %}conversion{% endglossarytooltip %} rates 69 bps by allowing shoppers to pay with PayPal without leaving the merchant’s site. PayPal saved credit cards boost repeat purchases by allowing merchants to securely store credit card information with PayPal so customers do not need to re-enter it in checkout or when reordering items from the {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}Admin{% endglossarytooltip %} interface.
- 
+
 * **Braintree enhancements enable merchants to qualify for the simplest set of PCI compliance** requirements by using Braintree Hosted Fields to collect all sensitive {% glossarytooltip 117df0a3-29a6-4636-9c29-8f696b3ad737 %}cardholder{% endglossarytooltip %} information in checkout. Merchants retain complete control over their checkout style and {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} because Braintree uses small, transparent iframes to replace individual payment fields. Merchants can now also access Braintree {% glossarytooltip 73a87074-8de7-4e69-a97f-12c65c6f5582 %}settlement{% endglossarytooltip %} reports from within the {% glossarytooltip 18b930cf-09cc-47c9-a5e5-905f86c43f81 %}Magento Admin{% endglossarytooltip %} interface.
- 
+
 * **Improved management interfaces** make it faster and easier to search for information in the Admin, set up global search synonyms, and create new product, category, and CMS content.
- 
+
 
 ### Known issues
 
@@ -51,7 +51,7 @@ Magento 2.1 RC2 includes the following known issues:
 <!--- 53169 --> * Magento does not apply the Cart Price or {% glossarytooltip 8d40d668-4996-4856-9f81-b1386cf4b14f %}Catalog{% endglossarytooltip %} Price {% glossarytooltip 09569c6c-2e5c-4dd8-9c4b-ab299f324d42 %}sales rules{% endglossarytooltip %} accordingly to the store  website's timezone, as expected.
 
 
-<!--- 53536 -->* You cannot update from Magento 2.0.x to Magento 2.1.x with Sample Data. 
+<!--- 53536 -->* You cannot update from Magento 2.0.x to Magento 2.1.x with Sample Data.
 
 ### Fixed issues
 
@@ -59,20 +59,20 @@ Magento 2.1 RC2 includes the following known issues:
 
 #### Solr search
 
-<!--- 50915 --> * Solr search no longer produces a fatal error when you use it to perform an advanced search on products by Size. 
+<!--- 50915 --> * Solr search no longer produces a fatal error when you use it to perform an advanced search on products by Size.
 
-<!--- 50701 --> * Solr search results now displays all products as expected in search results. 
+<!--- 50701 --> * Solr search results now displays all products as expected in search results.
 
 #### Checkout
 
-<!--- 53193 --> * Several address-related issues associated with Checkout have been resolved. 
+<!--- 53193 --> * Several address-related issues associated with Checkout have been resolved.
 
 
 <!--- 53217 --> * Customers with an existing saved address can now add a new address during checkout.  
 
 <!--- 53464 --> * Clicking the Reorder button now loads products as expected when persistent {% glossarytooltip c7ecb18d-cefe-452d-83e2-3c4d5e355db9 %}shopping cart{% endglossarytooltip %} is enabled.
 
-<!--- 53049 --> * The Go to Checkout button now works as expected. Previously, when you clicked the Go to Checkout button, Magento would display a login pop-up window. 
+<!--- 53049 --> * The Go to Checkout button now works as expected. Previously, when you clicked the Go to Checkout button, Magento would display a login pop-up window.
 
 <!--- 53307 --> * Checkout now works as expected when purchasing products during a persisted session.
 
@@ -88,11 +88,11 @@ Magento 2.1 RC2 includes the following known issues:
 
 <!--- 51068 --> * Admin User sessions no longer expire prematurely in installations running Redis for session storage. Previously, you were directed back to the login page after logging in to the Admin panel, waiting a short period time (less than the Admin Session Lifetime value), and trying to navigate to the Dashboard.
 
-<!--- 51066 --> * Magento now returns available services in WSDL schema.  Previously, you could not process SOAP requests as expected. 
+<!--- 51066 --> * Magento now returns available services in WSDL schema.  Previously, you could not process SOAP requests as expected.
 
-<!--- 51440 --> * Fatal errors no longer occur when running CLI commands after compilation in some regression environments. 
+<!--- 51440 --> * Fatal errors no longer occur when running CLI commands after compilation in some regression environments.
 
-<!--- 51407 --> * You can now save a product after applying an update for it. 
+<!--- 51407 --> * You can now save a product after applying an update for it.
 
 
 <!--- 50768 --> * Newly created categories now appear as expected on the Navigation menu.
@@ -101,16 +101,16 @@ Magento 2.1 RC2 includes the following known issues:
 <!--- 53829 --> * Magento no longer references empty targets in other targets.
 
 
-<!--- 50987 --> * You can now run all integration tests in developer mode. 
+<!--- 50987 --> * You can now run all integration tests in developer mode.
 
 
-<!--- 51238 --> * {% glossarytooltip 50e49338-1e6c-4473-8527-9e401d67ea2b %}Category{% endglossarytooltip %} pages now display swatches of configurable products based on color swatch attribute. 
+<!--- 51238 --> * {% glossarytooltip 50e49338-1e6c-4473-8527-9e401d67ea2b %}Category{% endglossarytooltip %} pages now display swatches of configurable products based on color swatch attribute.
 
 
 <!--- 51231 --> * Magento now successfully saves future special dates in the Advanced Price page.
 
 
-<!--- 51751 --> * You can now filter entries in the Product Reviews report by date. 
+<!--- 51751 --> * You can now filter entries in the Product Reviews report by date.
 
 <!--- 51731 --> * Catalog Price Rules are now applied as expected, depending upon the time frame  stated in the Price Rule.  
 
@@ -126,81 +126,81 @@ Magento 2.1 RC2 includes the following known issues:
 <!--- 51596 --> * Phrases with escaped slash characters are now translated. Previously, if a phrase were wrapped with single quotes, Magento would not display it correctly.
 
 
-<!--- 52030 --> * Downloadable products are no longer shown as out of stock on the Category page. 
+<!--- 52030 --> * Downloadable products are no longer shown as out of stock on the Category page.
 
 
-<!--- 52117 --> * Changes to Customer group are now immediately applied to logged-in customers. 
+<!--- 52117 --> * Changes to Customer group are now immediately applied to logged-in customers.
 
 
 <!--- 52078 --> *  You can now successfully save products with custom options.
 
 
-<!--- 51181 --> *  You can now configure a product whose last attribute has a price of zero, and the correct total price results. [ (GITHUB-3912)](https://github.com/magento/magento2/issues/3912){: target="_blank"} 
+<!--- 51181 --> *  You can now configure a product whose last attribute has a price of zero, and the correct total price results. [ (GITHUB-3912)](https://github.com/magento/magento2/issues/3912){: target="_blank"}
 
 
 <!--- 50257 --> *  Optional dropdown product attributes can now be left blank.
 
 
-<!--- 51008 --> *  Magento now successfully migrates data when Google Analytics's "Content Experiments" is enabled. 
+<!--- 51008 --> *  Magento now successfully migrates data when Google Analytics's "Content Experiments" is enabled.
 
-<!--- 53468 --> *  Cart now updates and lists rates for custom shipping methods as expected when you change the shipping address. [ (GITHUB-4679)](https://github.com/magento/magento2/issues/4679){: target="_blank"} 
+<!--- 53468 --> *  Cart now updates and lists rates for custom shipping methods as expected when you change the shipping address. [ (GITHUB-4679)](https://github.com/magento/magento2/issues/4679){: target="_blank"}
 
-<!--- 53131 --> * You can now view configurable products when using sample data. 
+<!--- 53131 --> * You can now view configurable products when using sample data.
 
 <!--- 51611 --> * Layered navigation now includes a list of all product attributes.
 
 
 <!--- 53397 --> * The `collectRates()` method now obtains the full address details for a registered customer.
 
-<!--- 53463 --> * The Customer Address tab is populated as expected after you create a new order. Previously, Magento did not list addresses on this tab when you'd create a new order. 
+<!--- 53463 --> * The Customer Address tab is populated as expected after you create a new order. Previously, Magento did not list addresses on this tab when you'd create a new order.
 
 
-<!--- 52959 --> * Logo folders have been added to the list of allowed resources. [ (GITHUB-4078)](https://github.com/magento/magento2/issues/4078){: target="_blank"} 
+<!--- 52959 --> * Logo folders have been added to the list of allowed resources. [ (GITHUB-4078)](https://github.com/magento/magento2/issues/4078){: target="_blank"}
 
-<!--- 53119 --> * The Force Sign-in button now works as expected. 
+<!--- 53119 --> * The Force Sign-in button now works as expected.
 
-<!--- 53019 --> * Magento no longer makes unexpected calls when you view a product in the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %}. 
+<!--- 53019 --> * Magento no longer makes unexpected calls when you view a product in the {% glossarytooltip 1a70d3ac-6bd9-475a-8937-5f80ca785c14 %}storefront{% endglossarytooltip %}.
 
 
 <!--- 51903 --> * You can now reorder a product with a required custom option (type = file). Previously, if you tried to reorder a product under these conditions, you would encounter an error when opening the shopping cart.
-[ (GITHUB-4058)](https://github.com/magento/magento2/issues/4058){: target="_blank"} 
+[ (GITHUB-4058)](https://github.com/magento/magento2/issues/4058){: target="_blank"}
 
 
-<!--- 53362 --> * Gift Message information is now present as expected in the `extension_attributes` when you request this list by Web API.  Previously, if you placed an order with a Gift Message, and then performed a Web API request to get the list of orders, Gift Message information would be absent in the `extension_attributes`. [ (GITHUB-4309)](https://github.com/magento/magento2/issues/4039){: target="_blank"} 
+<!--- 53362 --> * Gift Message information is now present as expected in the `extension_attributes` when you request this list by Web API.  Previously, if you placed an order with a Gift Message, and then performed a Web API request to get the list of orders, Gift Message information would be absent in the `extension_attributes`. [ (GITHUB-4309)](https://github.com/magento/magento2/issues/4039){: target="_blank"}
 
 
 <!--- 52782 --> * The `getPassword()` and `getPasswordConfirm()` methods now return the `password` and `passwordconfirm` parameters as strings. [ (GITHUB-4355)](https://github.com/magento/magento2/issues/4355){: target="_blank"}
 
 #### Messages and documentation
 
-<!--- 52340 --> * The `getList` method documentation has been enhanced. 
+<!--- 52340 --> * The `getList` method documentation has been enhanced.
 
 <!--- 52000 --> * Error messages associated with `cron` processes are now more helpful. [ (GITHUB-3189)](https://github.com/magento/magento2/issues/3189){: target="_blank"}
 
-<!--- 50898 --> * Magento now displays an appropriate  message when you add less than the required minimum items in your cart. 
+<!--- 50898 --> * Magento now displays an appropriate  message when you add less than the required minimum items in your cart.
 
-<!--- 51378 --> * Message serialization now complies with AMPQ specifications. 
+<!--- 51378 --> * Message serialization now complies with AMPQ specifications.
 
 #### Staging
 
-<!--- 53536 --> * You can now successfully change an entity's Schedule Update End Time from none to a particular time. Previously, attempting to change an End Time from none to a specific time would result in an error. (Sample message: "Update (or link, if we are using downloadable product) does not exists".) 
+<!--- 53536 --> * You can now successfully change an entity's Schedule Update End Time from none to a particular time. Previously, attempting to change an End Time from none to a specific time would result in an error. (Sample message: "Update (or link, if we are using downloadable product) does not exists".)
 
 
-<!--- 53025 --> * You can now edit the Schedule Update of a CMS page as expected. Previously, Magento would duplicate the page when you would click on the CMS Page Schedule Update button after editing it. 
+<!--- 53025 --> * You can now edit the Schedule Update of a CMS page as expected. Previously, Magento would duplicate the page when you would click on the CMS Page Schedule Update button after editing it.
 
 
 <!--- 53220 --> * You can now successfully add an end date to an existing permanent update.
 
-<!--- 51280 --> * Magento no longer duplicates a campaign each time you edit it. Previously, Magento would duplicate a campaign record whenever you selected it from its existing Scheduled Update. 
+<!--- 51280 --> * Magento no longer duplicates a campaign each time you edit it. Previously, Magento would duplicate a campaign record whenever you selected it from its existing Scheduled Update.
 
-<!--- 51443 --> * Product update is now applied as expected in Catalog Staging. 
+<!--- 51443 --> * Product update is now applied as expected in Catalog Staging.
 
-<!--- 51252 --> * You can now successfully save an update that was created for a category with a changed name. 
+<!--- 51252 --> * You can now successfully save an update that was created for a category with a changed name.
 
 
 <!--- 51278 --> * Magento no longer creates a new single update when you edit an existing update.  
 
-<!--- 52963 --> * You can now create and successfully save a future update for a {% glossarytooltip 38fc3629-ee25-4de5-ac7a-72db8e8de6de %}downloadable product{% endglossarytooltip %} associated with links and file content. 
+<!--- 52963 --> * You can now create and successfully save a future update for a {% glossarytooltip 38fc3629-ee25-4de5-ac7a-72db8e8de6de %}downloadable product{% endglossarytooltip %} associated with links and file content.
 
 ### Technology stack
 
@@ -211,11 +211,11 @@ Our technology stack is built on {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a8
 * PHP 7.0.6 + up until 7.1
 * MySQL 5.6.
 
-We do not support PHP 5.5.x or 7.0.5. 
+We do not support PHP 5.5.x or 7.0.5.
 
 ## Installation and upgrade instructions
 
-You can install Magento Commerce 2.1 Release Candidate 2 (RC2) using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %}. 
+You can install Magento Commerce 2.1 Release Candidate 2 (RC2) using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %}.
 
 This Release Candidate is for test purposes only. Do not install it in a production environment.
 
@@ -223,13 +223,13 @@ See one of the following sections:
 
 *	[Install using Composer](#install-rc-composer)
 *	[Upgrade existing installations](#upgrade-rc-nosamp)
-*	[Upgrade to an RC with sample data](#upgrade-rc-samp) 
+*	[Upgrade to an RC with sample data](#upgrade-rc-samp)
 
 ### Install using Composer {#install-rc-composer}
 
 This Release Candidate is available from `repo.magento.com`. Before installing this Release Candidate using Composer,  familiarize yourself with these  [prerequisites]({{ page.baseurl }}/install-gde/prereq/integrator_install.html){: target="_blank"}, then run:
 
-		composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.1.0-rc2 <installation directory name>
+		composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.1.0-rc2 <installation directory name>
 
 ## Upgrade existing installations {#upgrade-rc-nosamp}
 
@@ -275,7 +275,7 @@ Developers who contribute to the Open Source codebase can [upgrade manually]({{ 
 
 		composer require magento/product-enterprise-edition 2.1.0-rc2 --no-update
 		composer update
-	
+
 3.	If prompted, enter your [authentication keys]({{ page.baseurl }}/comp-mgr/prereq/prereq_auth-token.html).
 4. Update the database schema and data:
 

--- a/guides/v2.1/install-gde/install-quick-ref.md
+++ b/guides/v2.1/install-gde/install-quick-ref.md
@@ -54,7 +54,7 @@ If not, see the [Installation overview]({{ page.baseurl }}/install-gde/bk-instal
 When all prerequisites have been met, get the Magento software using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} as follows:
 
 	cd <web server docroot directory>
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
 
 You're required to authenticate; see [Get your authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) for details. This downloads Magento code only; it doesn't install the software for you.
 

--- a/guides/v2.2/install-gde/install-quick-ref.md
+++ b/guides/v2.2/install-gde/install-quick-ref.md
@@ -54,7 +54,7 @@ If not, see the [Installation overview]({{ page.baseurl }}/install-gde/bk-instal
 When all prerequisites have been met, get the Magento software using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} as follows:
 
 	cd <web server docroot directory>
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
 
 You're required to authenticate; see [Get your authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) for details. This downloads Magento code only; it doesn't install the software for you.
 

--- a/guides/v2.3/install-gde/install-quick-ref.md
+++ b/guides/v2.3/install-gde/install-quick-ref.md
@@ -54,7 +54,7 @@ If not, see the [Installation overview]({{page.baseurl }}/install-gde/bk-install
 When all prerequisites have been met, get the Magento software using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} as follows:
 
 	cd <web server docroot directory>
-	composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition magento2
+	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
 
 You're required to authenticate; see [Get your authentication keys]({{page.baseurl }}/install-gde/prereq/connect-auth.html) for details. This downloads Magento code only; it doesn't install the software for you.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will replace all instances of the deprecated `composer create-project --repository-url` flag with the supported `composer create-project --repository` flag. `repository-url` was deprecated in 2016. 

#2855 made me aware of the issue, but the better solution is to replace the deprecated flag. 

whatsnew
Replaced all references to the `composer create-project --repository-url` flag with `composer create-project --repository`.
