### PR TITLE
Removed a trailing 'r' after block & container xml tags.

### DIFF
--- a/guides/v2.0/frontend-dev-guide/layouts/xml-instructions.md
+++ b/guides/v2.0/frontend-dev-guide/layouts/xml-instructions.md
@@ -301,7 +301,7 @@ To pass parameters, use the [`<argument></argument>`](#argument) instruction.
 
 ### referenceBlock and referenceContainer {#fedg_layout_xml-instruc_ex_ref}
 
-Updates in `<referenceBlockr>` and `<referenceContainerr>` are applied to the corresponding `<blockr>` or `<container>`.
+Updates in `<referenceBlock>` and `<referenceContainer>` are applied to the corresponding `<block>` or `<container>`.
 
 For example, if you make a reference by `<referenceBlock name="right">`, you're targeting the block `<block name="right">`.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will remove an incorrectly trailing 'r' after some xml elements.

## Additional information

List all affected URL's 

- https://devdocs.magento.com/guides/v2.0/frontend-dev-guide/layouts/xml-instructions.html
