### PR TITLE
BIC: Add the StoreResolve deprecation section

### DIFF
--- a/guides/v2.3/release-notes/backward-incompatible-changes/index.md
+++ b/guides/v2.3/release-notes/backward-incompatible-changes/index.md
@@ -13,17 +13,13 @@ View a detailed list of PHP code changes that were made in the "2.3-develop" bra
 
 ## API changes
 
-### StoreManager instead of StoreResolve
+### StoreManager instead of StoreResolver
 
-`\Magento\Store\Api\StoreResolverInterface` was deprecated.
+`\Magento\Store\Api\StoreResolverInterface` has been deprecated in favor of the `\Magento\Store\Model\StoreManagerInterface`.
 
-Instead, use `\Magento\Store\Model\StoreManagerInterface`.
+When resolving for a store frontend, use `\Magento\Store\Model\StoreManagerInterface::getStore`.
 
-When resolving a store for frontend, use `\Magento\Store\Model\StoreManagerInterface::getStore`.
-
-Do not use `\Magento\Store\Api\StoreResolverInterface::getCurrentStoreId`.
-
-Example of the diff in `StatusBaseSelectProcessor.php` (`Magento\Catalog\Model\ResourceModel\Product`) after update:
+The following example shows the diff in `Magento\Catalog\Model\ResourceModel\Product\StatusBaseSelectProcessor` class after replacing the deprecated method.
 
 ```diff
 ...

--- a/guides/v2.3/release-notes/backward-incompatible-changes/index.md
+++ b/guides/v2.3/release-notes/backward-incompatible-changes/index.md
@@ -11,6 +11,58 @@ View a detailed list of PHP code changes that were made in the "2.3-develop" bra
 - [{{site.data.var.ce}} changes]({{ page.baseurl }}/release-notes/backward-incompatible-changes/open-source.html)
 - [{{site.data.var.ee}} changes]({{ page.baseurl }}/release-notes/backward-incompatible-changes/commerce.html)
 
+## API changes
+
+### StoreManager instead of StoreResolve
+
+`\Magento\Store\Api\StoreResolverInterface` was deprecated.
+
+Instead, use `\Magento\Store\Model\StoreManagerInterface`.
+
+When resolving a store for frontend, use `\Magento\Store\Model\StoreManagerInterface::getStore`.
+
+Do not use `\Magento\Store\Api\StoreResolverInterface::getCurrentStoreId`.
+
+Example of the diff in `StatusBaseSelectProcessor.php` (`Magento\Catalog\Model\ResourceModel\Product`) after update:
+
+```diff
+...
+     /**
+-     * @var StoreResolverInterface
++     * @var StoreManagerInterface
+     */
+-    private $storeResolver;
++    private $storeManager;
+     /**
+     * @param Config $eavConfig
+     * @param MetadataPool $metadataPool
+-    * @param StoreResolverInterface $storeResolver
++    * @param StoreManagerInterface $storeManager
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __construct(
+        Config $eavConfig,
+        MetadataPool $metadataPool,
+-       StoreResolverInterface $storeResolver
++       StoreManagerInterface $storeManager = null
+    ) {
+        $this->eavConfig = $eavConfig;
+        $this->metadataPool = $metadataPool;
+-        $this->storeResolver = $storeResolver;
++        $this->storeManager = $storeManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(StoreManagerInterface::class);
+
+...
+
+            . ' AND status_attr.attribute_id = ' . (int)$statusAttribute->getAttributeId()
+-           . ' AND status_attr.store_id = ' . $this->storeResolver->getCurrentStoreId(),
++           . ' AND status_attr.store_id = ' . $this->storeManager->getStore()->getId(),
+            []
+        );
+...
+```
+
 ## Application framework libraries
 
 ### Zend Framework


### PR DESCRIPTION
## This PR is a:

- Content update

## Summary

When this pull request is merged, it will add details about the StoreResolve deprecation.

<!-- (REQUIRED) What does this PR change? -->

whatsnew
Added details about the [`\Magento\Store\Api\StoreResolverInterface` deprecation](https://devdocs.magento.com/guides/v2.3/release-notes/backward-incompatible-changes/index.html#storemanager-instead-of-storeresolve).