### PR TITLE
Add space between  and

### DIFF
--- a/_videos/fundamentals/create-a-new-module.md
+++ b/_videos/fundamentals/create-a-new-module.md
@@ -37,7 +37,7 @@ Let’s create the folder app/code/Learning and inside this folder place another
 
 1. `cd` to the root folder
 2. `mkdir app/code/Learning`
-3. `mkdirapp/code/Learning/FirstUnit`
+3. `mkdir app/code/Learning/FirstUnit`
 
 ## Make sure you have permission to create files and folders in your installation
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add a needed space between `mkdir` and `app/code/Learning/FirstUnit` in the create-a-new-module.html video page.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

This error was gleaned via feedback from Hotjar ID 15582089.

List all affected URL's 

- https://devdocs.magento.com/videos/fundamentals/create-a-new-module/

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
