### PR TITLE
Added instructions for adding Webhook to Bitbucket

### DIFF
--- a/guides/v2.1/cloud/integrations/bitbucket-integration.md
+++ b/guides/v2.1/cloud/integrations/bitbucket-integration.md
@@ -144,6 +144,18 @@ The Bitbucket integration requires an [OAuth consumer](https://confluence.atlass
     magento-cloud integrations -p '<project-ID>'
     ```
 
+    The integation will list a webhook URL which is needed in the following step.
+
+#### Add Webhook to Repository in Bitbucket:
+
+1.  Log in to your [Bitbucket](https://bitbucket.org/account/signin/){:target="_blank"} account.
+
+1.  Navigate to the Project Settings -> Webhooks
+
+1.  Click **Add webhook** and add the webhook from the previous step, with a Title: Magento Cloud Integration
+
+1.  Click **Save**.
+
 ## Test the integration
 
 After configuring the Bitbucket integration, test it by pushing a simple change to your Bitbucket repository.


### PR DESCRIPTION
This PR adds documentation to the Bitbucket Magento Cloud Integration. There is a missing step where you add the webhook to Bitbucket, which I have added to the documentation. Without this webhook it doesn't do anything, nothing informs Magento Cloud of changes, so builds never fire.

## This PR is a:

- [x ] Content update
- [x ] Content fix or rewrite
- [x ] Bug fix or improvement

## Summary

This pull request adds a missing step to the bitbucket integration setup documentation.

Without this step, the bitbucket integration doesn't do anything because there is no webhook informing the cloud that bitbucket has changed.

## Additional information

List all affected URL's 
- https://devdocs.magento.com/guides/v2.1/cloud/project/bitbucket-integration.html
- This should also be moved into the other branches perhaps, I just did 2.1




