### PR TITLE
Backward incompatible changes for Magento 2.1.15

### DIFF
--- a/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
@@ -1,0 +1,8 @@
+
+<h2 id="class">Class</h2>
+<table><tbody>
+    <tr>
+        <th>Target</th>
+        <th>What Changed</th>
+    </tr>
+</tbody></table>

--- a/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
@@ -1,8 +1,2 @@
-
-<h2 id="class">Class</h2>
-<table><tbody>
-    <tr>
-        <th>Target</th>
-        <th>What Changed</th>
-    </tr>
-</tbody></table>
+<h3 id="no-changes-2.1.14-2.1.15">No changes</h3>
+<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
@@ -1,17 +1,8 @@
-
-<h2 id="class">Class</h2>
+<h3 id="interfaces-2.1.14-2.1.15">Changes in interface</h3>
 <table><tbody>
     <tr>
-        <th>Target</th>
         <th>What Changed</th>
-    </tr>
-</tbody></table>
-
-<h2 id="interface">Interface</h2>
-<table><tbody>
-    <tr>
-        <th>Target</th>
-        <th>What Changed</th>
+        <th>How Changed</th>
     </tr>
     <tr>
         <td>Magento\Framework\Stdlib\DateTime\TimezoneInterface::date</td>

--- a/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
@@ -1,0 +1,20 @@
+
+<h2 id="class">Class</h2>
+<table><tbody>
+    <tr>
+        <th>Target</th>
+        <th>What Changed</th>
+    </tr>
+</tbody></table>
+
+<h2 id="interface">Interface</h2>
+<table><tbody>
+    <tr>
+        <th>Target</th>
+        <th>What Changed</th>
+    </tr>
+    <tr>
+        <td>Magento\Framework\Stdlib\DateTime\TimezoneInterface::date</td>
+        <td>[public] Added optional parameter(s).</td>
+    </tr>
+</tbody></table>

--- a/guides/v2.1/release-notes/backward-incompatible-changes/commerce.md
+++ b/guides/v2.1/release-notes/backward-incompatible-changes/commerce.md
@@ -23,6 +23,10 @@ The changes are aggregated into two tables:
 When the [@api] and [@deprecated] doc blocks tags are added to the code base, they are recognized as _Class was added_ or _Method has been added_.
 </div>
 
+## 2.1.14 - 2.1.15    {#releases-2_1_14-2_1_15}
+
+{% include backward-incompatible-changes/commerce/2.1.14-2.1.15.html %}
+
 ## 2.1.13 - 2.1.14    {#releases-2_1_13-2_1_14}
 
 {% include backward-incompatible-changes/commerce/2.1.13-2.1.14.html %}

--- a/guides/v2.1/release-notes/backward-incompatible-changes/open-source.md
+++ b/guides/v2.1/release-notes/backward-incompatible-changes/open-source.md
@@ -18,6 +18,10 @@ The changes are aggregated into two tables:
 When the [@api] and [@deprecated] doc blocks tags are added to the code base, they are recognized as _Class was added_ or _Method has been added_. 
 </div>
 
+## 2.1.14 - 2.1.15    {#releases-2_1_14-2_1_15}
+
+{% include backward-incompatible-changes/open-source/2.1.14-2.1.15.html %}
+
 ## 2.1.13 - 2.1.14    {#releases-2_1_13-2_1_14}
 
 {% include backward-incompatible-changes/open-source/2.1.13-2.1.14.html %}


### PR DESCRIPTION
Generated backward incompatible changes for Magento 2.1

whatsnew
Updated the backward incompatible changes for [Open Source](https://devdocs.magento.com/guides/v2.1/release-notes/backward-incompatible-changes/open-source.html#releases-2_1_14-2_1_15) and [Commerce](https://devdocs.magento.com/guides/v2.1/release-notes/backward-incompatible-changes/commerce.html#releases-2_1_14-2_1_15) after the Magento 2.1.15 release.