### PR TITLE
Added information about maintenance mode

### DIFF
--- a/guides/v2.1/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.1/config-guide/bootstrap/magento-modes.md
@@ -34,9 +34,6 @@ You can run Magento in any of the following *modes*:
 				<li>Enables enhanced debugging</li>
 				<li>Shows custom <code>X-Magento-*</code> HTTP request and response headers</li>
 				<li>Results in the slowest performance (because of the preceding)</li></ul>
-        <div class="bs-callout bs-callout-info">
-        <a href="{{ page.baseurl }}/cloud/bk-cloud.html">{{site.data.var.ece}}</a> supports production mode only.
-        </div>
     </td>
 	</tr>
 	<tr>
@@ -48,8 +45,21 @@ You can run Magento in any of the following *modes*:
 				<li><b>Does not allow you to enable or disable cache types in Magento Admin.</b> <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</li>
 			</ul></td>
 	</tr>
+<tr>
+		<td>maintenance</td>
+		<td><p>Intended to prevent access to the Magento application while it is being updated or reconfigured, this mode:</p>
+			<ul><li>Displays a default <code>Service Temporarily Unavailable</code> page when customers visit store URLs.</li>
+				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the       <code>.maintenance.flag</code> file.</li>
+				<li>You can configure maintenance mode to allow visitor access from a specified list of IP addresses.</li>
+				<li>You can configure a custom maintenance page to display when the Magento application enters maintenance mode.</li>
+			</ul></td>
+		</tr>
 </tbody>
 </table>
+
+{:.bs-callout .bs-callout-info}
+[{{site.data.var.ece}}]({{ page.baseurl }}/cloud/bk-cloud.html) supports only production and maintenance modes.
+
 
 ## Default mode
 
@@ -68,9 +78,6 @@ For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide
 ## Developer mode
 
 You should run the Magento software in developer mode when you're extending or customizing it.
-
-{:.bs-callout .bs-callout-info}
-[{{site.data.var.ece}}]({{ page.baseurl }}/cloud/bk-cloud.html) supports production mode only.
 
 In developer mode:
 
@@ -92,6 +99,15 @@ In production mode:
 
 -   Static view files are not materialized and URLs for them are composed on the fly. Static view files are served from the {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} only.)
 -   Errors are logged to the file system and are never displayed to the user.
+
+## Maintenance mode
+
+Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
+
+You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.
+
+For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
+
 
 #### Next step
 

--- a/guides/v2.1/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.1/config-guide/bootstrap/magento-modes.md
@@ -48,10 +48,9 @@ You can run Magento in any of the following *modes*:
 <tr>
 		<td>maintenance</td>
 		<td><p>Intended to prevent access to the Magento application while it is being updated or reconfigured, this mode:</p>
-			<ul><li>Displays a default <code>Service Temporarily Unavailable</code> page when customers visit store URLs.</li>
-				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the       <code>.maintenance.flag</code> file.</li>
+			<ul><li>Redirects site visitors to a default <code>Service Temporarily Unavailable</code> page.</li>
+				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the <code>.maintenance.flag</code> file.</li>
 				<li>You can configure maintenance mode to allow visitor access from a specified list of IP addresses.</li>
-				<li>You can configure a custom maintenance page to display when the Magento application enters maintenance mode.</li>
 			</ul></td>
 		</tr>
 </tbody>
@@ -102,11 +101,11 @@ In production mode:
 
 ## Maintenance mode
 
-Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
+Run Magento in maintenance mode to take your site offline while you complete maintainenance, upgrade, or configuration tasks.  In maintenance mode, the site redirects visitors to a default `Service Temporarily Unavailable` page.
 
-You can [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html) and configure exempt IP addresses using Magento CLI commands.
+You can create a [custom mainenance page]({{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html#compman-trouble-maint-create.html), manually enable and disable maintenance mode, and configure maintenance mode to allow visitors from authorized IP addresses to view the store normally. See [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html).
 
-For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
+If you are using {{site.data.var.ece}}, Magento applicationruns in maintenance mode during the deploy phase. When the deployment completes successfully, Magento returns to running in production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
 
 #### Next step

--- a/guides/v2.1/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.1/config-guide/bootstrap/magento-modes.md
@@ -104,7 +104,7 @@ In production mode:
 
 Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
 
-You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.
+You can [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html) and configure exempt IP addresses using Magento CLI commands.
 
 For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 

--- a/guides/v2.1/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -10,6 +10,16 @@ functional_areas:
   - Setup
 ---
 
+
+Magento uses [maintenance mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#maintenance-mode) to disable bootstrapping; for example, while you're maintaining, upgrading, or reconfiguring your site.
+
+Magento detects maintenance mode as follows:
+
+*	If `var/.maintenance.flag` does not exist, maintenance mode is off and Magento operates normally.
+*	Otherwise, maintenance mode is on unless `var/.maintenance.ip` exists:
+
+	`var/.maintenance.ip` can contain a list of IP addresses. If an entry point is accessed using HTTP and the client IP address corresponds to one of the entries in that list, then maintenance mode is off.
+
 ## First steps {#instgde-cli-before}
 
 {% include install/first-steps-cli.md %}
@@ -22,14 +32,7 @@ Before you use this command, you must [install the Magento software]({{ page.bas
 
 ## Enable or disable maintenance mode {#instgde-cli-maint}
 
-Magento uses *maintenance mode* to disable bootstrapping; for example, while you're maintaining, upgrading, or reconfiguring your site.
-
-Magento detects maintenance mode as follows:
-
-*	If `var/.maintenance.flag` does not exist, maintenance mode is off and Magento operates normally.
-*	Otherwise, maintenance mode is on unless `var/.maintenance.ip` exists:
-
-	`var/.maintenance.ip` can contain a list of IP addresses. If an entry point is accessed using HTTP and the client IP address corresponds to one of the entries in that list, then maintenance mode is off.
+Use the `magento maintenance` CLI command to enable or disable Magento maintenance mode.
 
 Command usage:
 

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -18,7 +18,7 @@ You can run Magento in any of the following *modes*:
 		<tr>
 		<td>default</td>
 		<td><p>Enables you to deploy the Magento application on a single server without changing any settings. However, default mode is not optimized for production.</p>
-			<p>To deploy the Magento application on more than one server or to optimize it for production, change to one of the other modes.</p>
+			<p>To deploy Magento application on more than one server or to optimize it for production, change to one of the other modes.</p>
 			<ul><li>Static view file caching is enabled</li>
 				<li>Exceptions are not displayed to the user; instead, exceptions are written to log files.</li>
 				<li>Hides custom <code>X-Magento-*</code> HTTP request and response headers</li></ul>
@@ -44,13 +44,12 @@ You can run Magento in any of the following *modes*:
 				<li><b>Does not allow you to enable or disable cache types in Magento Admin.</b> <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</li>
 			</ul></td>
 	</tr>
-	<tr>
+<tr>
 		<td>maintenance</td>
-		<td><p>Intended to prevent access to the Magento application while it is being updated or reconfigured, this mode:</p>
-			<ul><li>Displays a default <code>Service Temporarily Unavailable</code> page when customers visit store URLs.</li>
-				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the       <code>.maintenance.flag</code> file.</li>
+		<td><p>Intended to prevent access to a Magento Commerce site while it is being updated or reconfigured, this mode:</p>
+			<ul><li>Redirects site visitors to a default <code>Service Temporarily Unavailable</code> page.</li>
+				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the <code>.maintenance.flag</code> file.</li>
 				<li>You can configure maintenance mode to allow visitor access from a specified list of IP addresses.</li>
-				<li>You can configure a custom maintenance page to display when the Magento application enters maintenance mode.</li>
 			</ul></td>
 		</tr>
 </tbody>
@@ -75,7 +74,7 @@ For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide
 
 ## Developer mode
 
-You can run the Magento software in developer mode when you're extending or customizing it.
+Run Magento in developer mode when you are extending or customizing it.
 
 In developer mode:
 
@@ -89,7 +88,7 @@ For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide
 
 ## Production mode
 
-You should run the Magento software in production mode when it is deployed to a production server. After optimizing the server environment, such as the database and web server, you should run the [static view files deployment tool]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html) to write static view files to the Magento `pub/static` directory.
+Run Magento in production mode when it is deployed to a production server. After optimizing the server environment, such as the database and web server, you should run the [static view files deployment tool]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html) to write static view files to the Magento `pub/static` directory.
 
 This improves performance by providing all necessary static files at deployment instead of forcing Magento to dynamically locate and copy (materialize) static files on demand during run time.
 
@@ -103,11 +102,11 @@ In production mode:
 	
 ## Maintenance mode
 
-Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
+Run Magento in maintenance mode to take your site offline while you complete maintainenance, upgrade, or configuration tasks.  In maintenance mode, the site redirects visitors to a default `Service Temporarily Unavailable` page.
 
-You can [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html) and configure exempt IP addresses using Magento CLI commands.
+You can create a [custom mainenance page]({{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html#compman-trouble-maint-create.html), manually enable and disable maintenance mode, and configure maintenance mode to allow visitors from authorized IP addresses to view the store normally. See [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html).
 
-For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
+If you are using {{site.data.var.ece}}, the Magento application runs in maintenance mode during the deploy phase. When the deployment completes successfully, Magento returns to running in production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
 #### Next step
 

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -96,6 +96,7 @@ In production mode:
 	You _cannot_ enable or disable cache types using the Magento Admin
 	
 ## Maintenance mode
+
 Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
 
 You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -94,6 +94,13 @@ In production mode:
 -   You can enable and disable cache types only using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en).
 
 	You _cannot_ enable or disable cache types using the Magento Admin
+	
+## Maintenance mode
+Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
+
+You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.
+
+For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
 #### Next step
 

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -33,9 +33,6 @@ You can run Magento in any of the following *modes*:
 				<li>Enables enhanced debugging</li>
 				<li>Shows custom <code>X-Magento-*</code> HTTP request and response headers</li>
 				<li>Results in the slowest performance (because of the preceding)</li></ul>
-        <div class="bs-callout bs-callout-info">
-        <a href="{{ page.baseurl }}/cloud/bk-cloud.html">{{site.data.var.ece}}</a> supports production mode only.
-        </div>
     </td>
 	</tr>
 	<tr>
@@ -47,8 +44,20 @@ You can run Magento in any of the following *modes*:
 				<li><b>Does not allow you to enable or disable cache types in Magento Admin.</b> <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en">More information about enabling and disabling the cache</a>.</li>
 			</ul></td>
 	</tr>
+	<tr>
+		<td>maintenance</td>
+		<td><p>Intended to prevent access to the Magento application while it is being updated or reconfigured, this mode:</p>
+			<ul><li>Displays a default <code>Service Temporarily Unavailable</code> page when customers visit store URLs.</li>
+				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the       <code>.maintenance.flag</code> file.</li>
+				<li>You can configure maintenance mode to allow visitor access from a specified list of IP addresses.</li>
+				<li>You can configure a custom maintenance page to display when the Magento application enters maintenance mode.</li>
+			</ul></td>
+		</tr>
 </tbody>
 </table>
+
+{:.bs-callout .bs-callout-info}
+[{{site.data.var.ece}}]({{ page.baseurl }}/cloud/bk-cloud.html) supports only the production and maintenance modes.
 
 ## Default mode
 
@@ -66,10 +75,7 @@ For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide
 
 ## Developer mode
 
-You should run the Magento software in developer mode when you're extending or customizing it.
-
-{:.bs-callout .bs-callout-info}
-[{{site.data.var.ece}}]({{ page.baseurl }}/cloud/bk-cloud.html) supports production mode only.
+You can run the Magento software in developer mode when you're extending or customizing it.
 
 In developer mode:
 
@@ -101,7 +107,7 @@ Run the Magento software in maintenance mode when you need to take your site off
 
 You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.
 
-For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
+For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
 #### Next step
 

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -60,7 +60,7 @@ You can run Magento in any of the following *modes*:
 
 ## Default mode
 
-As its name implies, default mode is how the Magento software operates if no other mode is specified. Default mode enables you to deploy the Magento application on a single server without changing any settings. However, default mode is not as optimized for production as is production mode.
+As its name implies, default mode is how Magento operates if no other mode is specified. Default mode enables you to deploy the Magento application on a single server without changing any settings. However, default mode is not as optimized for production as is production mode.
 
 To deploy the Magento application on more than one server or to optimize it for production, change to one of the other modes.
 

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -18,7 +18,7 @@ You can run Magento in any of the following *modes*:
 		<tr>
 		<td>default</td>
 		<td><p>Enables you to deploy the Magento application on a single server without changing any settings. However, default mode is not optimized for production.</p>
-			<p>To deploy Magento application on more than one server or to optimize it for production, change to one of the other modes.</p>
+			<p>To deploy the Magento application on more than one server or to optimize it for production, change to one of the other modes.</p>
 			<ul><li>Static view file caching is enabled</li>
 				<li>Exceptions are not displayed to the user; instead, exceptions are written to log files.</li>
 				<li>Hides custom <code>X-Magento-*</code> HTTP request and response headers</li></ul>
@@ -48,7 +48,7 @@ You can run Magento in any of the following *modes*:
 		<td>maintenance</td>
 		<td><p>Intended to prevent access to a Magento Commerce site while it is being updated or reconfigured, this mode:</p>
 			<ul><li>Redirects site visitors to a default <code>Service Temporarily Unavailable</code> page.</li>
-				<li>When the application is in maintenance mode, the <code>var/</code> directory contains the <code>.maintenance.flag</code> file.</li>
+				<li>When the site is in maintenance mode, the <code>var/</code> directory contains the <code>.maintenance.flag</code> file.</li>
 				<li>You can configure maintenance mode to allow visitor access from a specified list of IP addresses.</li>
 			</ul></td>
 		</tr>

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -105,7 +105,7 @@ In production mode:
 
 Run the Magento software in maintenance mode when you need to take your site offline, for example when you are performing installation and upgrade tasks. When your site is in maintenance mode, normal site visitors get a `Service Temporarily Unavailable` message when they navigate to your store. You can configure maintenance mode to allow visitors from authorized IP addresses to view the store normally.
 
-You can [enable and disable maintenance mode] and configure exempt IP addresses using Magento CLI commands.
+You can [enable and disable maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html) and configure exempt IP addresses using Magento CLI commands.
 
 For customers using {{site.data.var.ece}}, maintenance mode is enabled automatically for the duration of the deploy phase. When the deployment completes sucessfully, maintenance mode is turned off, and the Magento application is put back into production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -14,6 +14,15 @@ functional_areas:
   - Setup
 ---
 
+Magento uses [maintenance mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#maintenance-mode) to disable bootstrapping; for example, while you're maintaining, upgrading, or reconfiguring your site.
+
+Magento detects maintenance mode as follows:
+
+*	If `var/.maintenance.flag` does not exist, maintenance mode is off and Magento operates normally.
+*	Otherwise, maintenance mode is on unless `var/.maintenance.ip` exists:
+
+	`var/.maintenance.ip` can contain a list of IP addresses. If an entry point is accessed using HTTP and the client IP address corresponds to one of the entries in that list, then maintenance mode is off.
+	
 ## First steps {#instgde-cli-before}
 {% include install/first-steps-cli.md %}
 In addition to the command arguments discussed here, see [Common arguments]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands.html#instgde-cli-subcommands-common).
@@ -24,14 +33,7 @@ Before you use this command, you must [install the Magento software]({{ page.bas
 
 ## Enable or disable maintenance mode {#instgde-cli-maint}
 
-Magento uses *maintenance mode* to disable bootstrapping; for example, while you're maintaining, upgrading, or reconfiguring your site.
-
-Magento detects maintenance mode as follows:
-
-*	If `var/.maintenance.flag` does not exist, maintenance mode is off and Magento operates normally.
-*	Otherwise, maintenance mode is on unless `var/.maintenance.ip` exists:
-
-	`var/.maintenance.ip` can contain a list of IP addresses. If an entry point is accessed using HTTP and the client IP address corresponds to one of the entries in that list, then maintenance mode is off.
+Use the `magento maintenance` CLI command to enable or disable Magento maintenance mode.
 
 Command usage:
 


### PR DESCRIPTION
- Description of maintenance mode
- Link to enable and disable and configure maintenance mode for Magento Commerce
- Link to information about how Magento Commerce Cloud uses maintenance mode on deploy phase

## This PR is a:

- [x] Content update


whatsnew
Added information about Magento Maintenance mode to the [About Magento modes article](https://devdocs.magento.com/guides/v2.2/config-guide/bootstrap/magento-modes.html) in the Magento configuration guide.
