### PR TITLE
MAGEDOC-3163: Remove references to Amazon Sales Channel

### DIFF
--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
@@ -36,9 +36,6 @@ This release introduces significant tools to improve the developer experience: P
 
 * **MultiSource Inventory (MSI)** lets merchants manage physical inventory across locations in Magento. Merchants can represent multiple locations (sources) for physical inventory in Magento. Sources can be grouped into stocks to create inventory pools that can be defined for one or more websites. Merchants can manipulate inventory based on sources. Magento also provides an API for source operations that helps merchants customize inventory actions or third-party order management systems to perform the same actions in an automated way. 
 
-
-* **Amazon Sales Channel** allows you to create and manage Amazon listings and fulfill your orders for both Amazon customers as well customers of your store.  
-
 ### Core product improvements
 
 * **Updates to Magento's tech stack (including upgraded PHP support)** include upgrades to Redis, MySQL, Elasticsearch, compatibility with PHP 7.2. 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
@@ -34,9 +34,6 @@ This release introduces significant tools to improve the developer experience: P
 
 * **MultiSource Inventory (MSI)** lets merchants manage physical inventory across locations in Magento. Merchants can represent multiple locations (sources) for physical inventory in Magento. Sources can be grouped into stocks to create inventory pools that can be defined for one or more websites. Merchants can manipulate inventory based on sources. Magento also provides an API for source operations that helps merchants customize inventory actions or third-party order management systems to perform the same actions in an automated way. 
 
-
-* **Amazon Sales Channel** allows you to create and manage Amazon listings and fulfill your orders for both Amazon customers as well customers of your store.  
-
 ### Core product improvements
 
 * **Updates to Magento's tech stack (including upgraded PHP support)** include upgrades to Redis, MySQL, Elasticsearch, compatibility with PHP 7.2.  

--- a/magento-release-information.md
+++ b/magento-release-information.md
@@ -1,11 +1,7 @@
 ---
 layout: full-width
 group: system-requirements
-subgroup: Magento release information
 title: Magento release information
-menu_title: Magento release information
-menu_order: 1
-menu_node: parent
 ---
 
 To find Release Notes, technical bulletins, and backward-incompatible information for the Magento 2.0.x, 2.1.x, and 2.2.x releases, see the following:
@@ -13,3 +9,4 @@ To find Release Notes, technical bulletins, and backward-incompatible informatio
 *	[Magento 2.0.x release information]({{ site.gdeurl }}release-notes/bk-release-notes.html)
 *	[Magento 2.1.x release information]({{ site.gdeurl21 }}release-notes/bk-release-notes.html)
 *   [Magento 2.2.x release information]({{ site.gdeurl22 }}release-notes/bk-release-notes.html)
+*   [Magento 2.3.x release information]({{ site.gdeurl23 }}release-notes/bk-release-notes.html)


### PR DESCRIPTION


## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will remove references to amazon Sales Channel from the 2.3.0 release notes (Commerce and Open Source).

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URL's 

- https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.html
- https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
