### PR TITLE
Fix 'Release notes' link in footer

### DIFF
--- a/_includes/layout/footer-links.html
+++ b/_includes/layout/footer-links.html
@@ -4,6 +4,16 @@
   <li><a href="http://magento.com/legal/terms/privacy/">Privacy Policy</a></li>
   <li><a href="http://magento.com/legal/terms/">Terms of Service</a></li>
   <li><a href="http://magento.com/legal/licensing/">License/Trademark FAQ</a></li>
-  <li><a href="{{ page.baseurl }}/release-notes/bk-release-notes.html">Release Notes</a></li>
+  <!-- If the page is in the root, the link points to the default version of release notes.
+       The default version is set in the config.yaml.
+    {%- capture release-notes -%}
+      {%- unless page.baseurl == empty -%}
+        {{page.baseurl}}/release-notes/bk-release-notes.html
+      {%- else -%}
+        /guides/v{{ site.version }}/release-notes/bk-release-notes.html
+      {%- endunless -%}
+    {%- endcapture -%}
+    -->
+  <li><a href="{{release-notes}}">Release Notes</a></li>
   <li><a href="{{ site.baseurl }}/magento-third-party.html">Third-Party Licenses</a></li>
 </ul>


### PR DESCRIPTION
## This PR is a:

- Bug fix

## Summary

When this pull request is merged, it will extend the logic of the updated 'Release notes' link in the footer.