### PR TITLE
Remove external link attribute from Cloud guide

### DIFF
--- a/guides/v2.1/cloud/architecture/pro-architecture-legacy.md
+++ b/guides/v2.1/cloud/architecture/pro-architecture-legacy.md
@@ -158,7 +158,7 @@ The following figure shows the technology used in the Production environment:
 
 {{site.data.var.ee}} seamlessly scales from the smallest 6 CPU cluster with 11.25GB of RAM to the largest 96 CPU cluster with 180GB of RAM. Our triple-redundant architecture means we can offer upscaling without downtime. When upscaling, we rotate each of the three instances to upgrade without downtime of your site.
 
-In addition, extra web servers can be added to an existing cluster should the constriction be at the {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} level rather than the database level. This provides [*horizontal scaling*](https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling){:target="_blank"} to complement the vertical scaling provided by extra CPUs on the database level.
+In addition, extra web servers can be added to an existing cluster should the constriction be at the {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} level rather than the database level. This provides [*horizontal scaling*](https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling) to complement the vertical scaling provided by extra CPUs on the database level.
 
 ## Services {#cloud-arch-services}
 {{site.data.var.ece}} currently supports the following services:

--- a/guides/v2.1/cloud/basic-information/starter-develop-deploy-workflow.md
+++ b/guides/v2.1/cloud/basic-information/starter-develop-deploy-workflow.md
@@ -92,9 +92,9 @@ Configure your store settings from the Magento Admin panel for the Integration e
 For the best information on configurations, review the documentation for {{site.data.var.ee}} and the installed extensions. Here are some links and ideas to help you get kickstarted:
 
 * [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
-* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html){:target="_blank"} for store admin access, name, languages, currencies, branding, sites, store views and more
-* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html){:target="_blank"} for your look and feel of the site and stores including CSS and layouts
-* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html){:target="_blank"} for roles, tools, notifications, and your encryption key for your database
+* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html) for store admin access, name, languages, currencies, branding, sites, store views and more
+* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html) for your look and feel of the site and stores including CSS and layouts
+* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html) for roles, tools, notifications, and your encryption key for your database
 * Extension settings using their documentation
 
 Beyond just store settings, you can further configure multiple sites and stores, configured services, and more. For details, see [Configure Magento Commerce]({{ page.baseurl }}/cloud/configure/configuration-overview.html).

--- a/guides/v2.1/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.1/cloud/before/before-setup-env-2_clone.md
@@ -22,7 +22,7 @@ functional_areas:
 
 The Magento Commerce project is a Git repository of Magento code with a master origin. Develop your custom code and add extensions in one of eight active Git branches in your local. Each active environment includes a database and services to fully access the Magento site and store in the Integration environment.
 
-To begin, you need to clone the `master` environment to your local and add the Magento Admin URL, username, and password (to include with all branches). If you are new to Git workflow, processes, and commands, see Git [documentation](https://git-scm.com/documentation){:target="_blank"}.
+To begin, you need to clone the `master` environment to your local and add the Magento Admin URL, username, and password (to include with all branches). If you are new to Git workflow, processes, and commands, see Git [documentation](https://git-scm.com/documentation).
 
 The commands in these instructions use Magento CLI commands and Git commands to access the `master` environment. For a full list of Magento Cloud CLI commands, enter `magento-cloud list` or see the [Magento CLI reference]({{ page.baseurl }}/cloud/reference/cli-ref-topic.html).
 
@@ -92,7 +92,7 @@ To set Admin variables, you will use this command format:
 
 	magento-cloud variable:set <name> <value> -e <environment ID>
 
-You can also [log into your project](https://accounts.magento.cloud){:target="_blank"} in the Project Web Interface to review project variables entered there. Click the Configure environment gear icon ![Configure your environment]({{ site.baseurl }}/common/images/cloud_edit-project.png) next to the Project name. Click the **Variables** tab and review any configured variables there.
+You can also [log into your project](https://accounts.magento.cloud) in the Project Web Interface to review project variables entered there. Click the Configure environment gear icon ![Configure your environment]({{ site.baseurl }}/common/images/cloud_edit-project.png) next to the Project name. Click the **Variables** tab and review any configured variables there.
 
 {: .bs-callout .bs-callout-warning}
 Every time you add or modify a variable using the web interface or the CLI, the branch will redeploy automatically.
@@ -142,7 +142,7 @@ To set variables using the CLI (with example values used):
 
 To set variables using the Project Web Interface:
 
-1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 2. Click the Configure environment gear icon ![Configure your environment]({{ site.baseurl }}/common/images/cloud_edit-project.png) next to the Project name. If you are asked to create the project, click **Continue Later**.
 
 	![Project without code]({{ site.baseurl }}/common/images/cloud_project_empty.png)

--- a/guides/v2.1/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.1/cloud/before/before-workspace-cloud-account.md
@@ -10,7 +10,7 @@ menu_node:
 #### Previous step:
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
-To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Mangento Enterprise Cloud Edition account](https://accounts.magento.cloud){:target="_blank"}. The account provides access to your project for Magento development and deployment across all supported environments.
+To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Mangento Enterprise Cloud Edition account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.
 
 You should receive an e-mail invitation to verify and access the account. If you don't see the invitation, check your junk e-mail folder. Click the **Verify my account** option in the email to verify and access your account.
 

--- a/guides/v2.1/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.1/cloud/before/before-workspace-magento-prereqs.md
@@ -36,16 +36,16 @@ To best develop and manage your host, we recommend using a virtual machine. The 
 
 For your VM, we recommend installing one of the following:
 
-* [Vagrant](https://www.vagrantup.com/docs/){:target="_blank"} for a virtual machine
-* [Docker](https://docs.docker.com/){:target="_blank"} for a container
+* [Vagrant](https://www.vagrantup.com/docs/) for a virtual machine
+* [Docker](https://docs.docker.com/) for a container
 
-When using Vagrant, we also recommend the package [hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager){:target="_blank"} and using [VirtualBox](https://www.virtualbox.org/wiki/Documentation){:target="_blank"} to manage the environment. VirtualBox extends support and features across all OS and platforms to create and manage multiple VMs and operating systems on your local.
+When using Vagrant, we also recommend the package [hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) and using [VirtualBox](https://www.virtualbox.org/wiki/Documentation) to manage the environment. VirtualBox extends support and features across all OS and platforms to create and manage multiple VMs and operating systems on your local.
 
 ## Development tools {#devtools}
 
-* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git){:target="_blank"} - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host.
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host.
 	For more information, see [How Cloud uses Git]({{ page.baseurl }}/cloud/reference/git-integration.html).
-* [Composer](https://getcomposer.org/download/){:target="_blank"} - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM.
+* [Composer](https://getcomposer.org/download/) - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM.
 	For more information, see [How Cloud uses Composer]({{ page.baseurl }}/cloud/reference/cloud-composer.html).
 
 ## Web server (local) {#webserver}
@@ -54,22 +54,22 @@ We strongly recommend installing [Nginx]({{ page.baseurl }}/install-gde/prereq/n
 
 ## PHP (local) {#php}
 
-Install {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} on your local. We recommend PHP 7.0. For information on installing PHP, see these instructions for [CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html) and [Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html). For instructions for another OS, see the [PHP documentation](http://php.net/manual/en/install.php){:target="_blank"}.
+Install {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} on your local. We recommend PHP 7.0. For information on installing PHP, see these instructions for [CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html) and [Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html). For instructions for another OS, see the [PHP documentation](http://php.net/manual/en/install.php).
 
 The following packages may also be helpful for your PHP installation:
 
-* [bcmath](http://php.net/manual/en/book.bc.php){:target="_blank"}
-* [curl](http://php.net/manual/en/book.curl.php){:target="_blank"}
+* [bcmath](http://php.net/manual/en/book.bc.php)
+* [curl](http://php.net/manual/en/book.curl.php)
 * ext-dom
-* [fpm](https://php-fpm.org/){:target="_blank"}
-* [gd](http://php.net/manual/en/book.image.php){:target="_blank"}
-* [intl](http://php.net/manual/en/book.intl.php){:target="_blank"}
-* [json](http://php.net/manual/en/ref.json.php){:target="_blank"}
-* [mbstring](http://php.net/manual/en/book.mbstring.php){:target="_blank"}
-* [mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="_blank"}
-* [mysql](http://php.net/manual/en/set.mysqlinfo.php){:target="_blank"}
-* [xml](http://php.net/manual/en/book.xml.php){:target="_blank"}
-* [zip](http://php.net/manual/en/book.zip.php){:target="_blank"}
+* [fpm](https://php-fpm.org/)
+* [gd](http://php.net/manual/en/book.image.php)
+* [intl](http://php.net/manual/en/book.intl.php)
+* [json](http://php.net/manual/en/ref.json.php)
+* [mbstring](http://php.net/manual/en/book.mbstring.php)
+* [mcrypt](http://php.net/manual/en/book.mcrypt.php)
+* [mysql](http://php.net/manual/en/set.mysqlinfo.php)
+* [xml](http://php.net/manual/en/book.xml.php)
+* [zip](http://php.net/manual/en/book.zip.php)
 
 ### Set up PHP memory limit {#cloud-first-php}
 
@@ -96,7 +96,7 @@ Before working with your {{site.data.var.ece}} project, make sure you set the PH
 
 ## Database (local) {#database}
 
-You have multiple options for databases to use for your local. One database option you may want to consider is MariaDB. The {{site.data.var.ee}} environments use [MariaDB](https://mariadb.org/){:target="_blank"}, with a [Galera Cluster](http://galeracluster.com/){:target="_blank"} with triple redundancy in the Production environment.
+You have multiple options for databases to use for your local. One database option you may want to consider is MariaDB. The {{site.data.var.ee}} environments use [MariaDB](https://mariadb.org/), with a [Galera Cluster](http://galeracluster.com/) with triple redundancy in the Production environment.
 
 Regardless of database, for **Pro plans** you need to modify the `auto_increment_increment` value.
 
@@ -131,7 +131,7 @@ You need to set an auto-increment value for the MariaDB installation.
 
 ### Pro: Set up the auto-increment for MySQL {#cloud-mysql}
 
-The MySQL configuration parameter [`auto_increment_increment`](http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html){:target="_blank"} is set to `1` by default in a local MySQL installation. You need to change this value to `3`.  The {{site.data.var.ee}} database cluster includes 3 database implementations. The increment ensures data is unique across all databases for consistent data in the High Availability structure.
+The MySQL configuration parameter [`auto_increment_increment`](http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html) is set to `1` by default in a local MySQL installation. You need to change this value to `3`.  The {{site.data.var.ee}} database cluster includes 3 database implementations. The increment ensures data is unique across all databases for consistent data in the High Availability structure.
 
 To avoid issues, we recommend you set `auto_increment_increment=3`.
 
@@ -160,7 +160,7 @@ If necessary, set `auto_increment_increment` to 3:
 
 The Magento Cloud command-line interface (CLI) tool helps you manage your projects and code branches on {{site.data.var.ece}}. For a list of available commands, see [Common Magento CLI commands]({{ page.baseurl }}/cloud/reference/cli-ref-topic.html).
 
-These instructions discuss installation using commands for a Unix environment. For Windows, we recommend using [Cygwin](https://www.cygwin.com/){:target="_blank"} or Git Bash.
+These instructions discuss installation using commands for a Unix environment. For Windows, we recommend using [Cygwin](https://www.cygwin.com/) or Git Bash.
 
 To install the Magento Cloud CLI:
 
@@ -178,7 +178,7 @@ To install the Magento Cloud CLI:
 
 		source $HOME/.bashrc
 
-	For more information about the user shell profile, see [.bash_profile vs .bashrc](https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc){:target="_blank"}
+	For more information about the user shell profile, see [.bash_profile vs .bashrc](https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc)
 
 	You can also add the `$HOME/.magento-cloud/bin` to the Magento user's `PATH`:
 

--- a/guides/v2.1/cloud/before/before-workspace-ssh.md
+++ b/guides/v2.1/cloud/before/before-workspace-ssh.md
@@ -17,7 +17,7 @@ functional_areas:
 #### Previous step:
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
 
-The [SSH protocol ](https://en.wikipedia.org/wiki/Secure_Shell){:target="_blank"} is designed to maintain a secure connection between two systems&mdash;in this case, your local working environment and your {{site.data.var.ece}} Git project.
+The [SSH protocol ](https://en.wikipedia.org/wiki/Secure_Shell) is designed to maintain a secure connection between two systems&mdash;in this case, your local working environment and your {{site.data.var.ece}} Git project.
 
 When initially setting up your local environment, you need to add the SSH keys to the following specific environments:
 

--- a/guides/v2.1/cloud/before/before-workspace.md
+++ b/guides/v2.1/cloud/before/before-workspace.md
@@ -23,7 +23,7 @@ This section walks through the steps for first time merchants with Magento, Mage
 
 ## Set up an account {#newaccount}
 
-To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Commerce (Cloud) account](https://accounts.magento.cloud){:target="_blank"}. The account provides access to your project for Magento development and deployment across all supported environments.
+To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Commerce (Cloud) account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.
 
 You should receive an e-mail invitation to verify and access the project. If you don't see the invitation, check your junk e-mail folder. Click the **Verify my account** option in the email to verify and access your project account.
 
@@ -39,11 +39,11 @@ You need to set up the {% glossarytooltip 5e7de323-626b-4d1b-a7e5-c8d13a92c5d3 %
 
 ## Recommended tools
 
-This guide assumes you're working on a UNIX system or in a UNIX shell environment. For MAC OS and Linux-based systems, feel free to use any CLI tools of choice for issuing commands. For Windows users, we recommend a UNIX environment like [Cygwin](https://www.cygwin.com/){:target="_blank"}, [Putty](http://www.putty.org/){:target="_blank"}, or Git Bash.
+This guide assumes you're working on a UNIX system or in a UNIX shell environment. For MAC OS and Linux-based systems, feel free to use any CLI tools of choice for issuing commands. For Windows users, we recommend a UNIX environment like [Cygwin](https://www.cygwin.com/), [Putty](http://www.putty.org/), or Git Bash.
 
-For development on your local, use any development environment or tools you prefer. For recommendations, many Magento developers use tools including [WebStorm](https://www.jetbrains.com/webstorm/){:target="_blank"}, [PHPStorm](https://www.jetbrains.com/phpstorm/){:target="_blank"}, and [Atom](https://atom.io/){:target="_blank"}.
+For development on your local, use any development environment or tools you prefer. For recommendations, many Magento developers use tools including [WebStorm](https://www.jetbrains.com/webstorm/), [PHPStorm](https://www.jetbrains.com/phpstorm/), and [Atom](https://atom.io/).
 
-Developing code for {{site.data.var.ee}} requires working in Git branches. Not everyone remembers [Git](https://git-scm.com/docs){:target="_blank"} commands with ease. If you want a Git client, use any client of your choice. Some developers use clients including [GitKraken](https://www.gitkraken.com/){:target="_blank"} and [SmartGit](https://www.syntevo.com/smartgit/){:target="_blank"}.
+Developing code for {{site.data.var.ee}} requires working in Git branches. Not everyone remembers [Git](https://git-scm.com/docs) commands with ease. If you want a Git client, use any client of your choice. Some developers use clients including [GitKraken](https://www.gitkraken.com/) and [SmartGit](https://www.syntevo.com/smartgit/).
 
 ## Prerequisites
 

--- a/guides/v2.1/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.1/cloud/cdn/cloud-fastly.md
@@ -11,8 +11,8 @@ functional_areas:
 ---
 
 Fastly is a CDN based on Varnish caching, basically a cloud varnish service. When
-working with Fastly, you are also working directly with a heavily customized version of Varnish (2.1). [Fastly](https://docs.fastly.com/){:target="_blank"}
-with [Varnish](https://varnish-cache.org/docs/){:target="_blank"} caches your
+working with Fastly, you are also working directly with a heavily customized version of Varnish (2.1). [Fastly](https://docs.fastly.com/)
+with [Varnish](https://varnish-cache.org/docs/) caches your
 site pages, assets, CSS, and more in backend data centers you set up. As
 customers access your site and stores, the requests hit Fastly to load cached
 pages faster.
@@ -145,14 +145,14 @@ instructions on creating [custom Fastly VCL snippets]({{ page.baseurl }}/cloud/c
 
 Fastly supports forcing unencrypted requests to TLS through the Force TLS
 feature. Set up a secure base URL in Magento and turn on the Force TLS option
-in the Fastly extension. For details and instructions, see the Fastly [Force TLS guide](https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/FORCE-TLS.md){:target="_blank"}.
+in the Fastly extension. For details and instructions, see the Fastly [Force TLS guide](https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/FORCE-TLS.md).
 
 ## GeoIP service support {#geoip}
 
 Fastly provides a GeoIP service and supports some GeoIP functionality. GeoIP
 handling manages visitor redirection (automatically) and store matching
 (select from list) based on their obtained country code. For more information,
-see the Fastly [GeoIP documentation](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/CONFIGURATION.md#geoip-handling){:target="_blank"}.
+see the Fastly [GeoIP documentation](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/CONFIGURATION.md#geoip-handling).
 
 ## Image Optimization support
 

--- a/guides/v2.1/cloud/cdn/cloud-vcl-custom-snippets.md
+++ b/guides/v2.1/cloud/cdn/cloud-vcl-custom-snippets.md
@@ -106,7 +106,7 @@ The following are **best practices and recommendations**:
 
 -   The default VCL snippets you uploaded include a prepended name of `magentomodule_` with a priority of `50`. For your custom VCL snippets, **do not use the `magentomodule_` name**. Also, consider the priority of your custom snippets and whether they should override the default snippets.
 -   Do not forget to _always_ locate and clone the active version, and edit the bash script with the new version! _Version_ is not part of your VCL snippet files.
--   If you want to override values and settings from the [default Fastly VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets){:target="\_blank"}, we recommend creating a new snippet with updated values and code with a higher priority value of `100`. You should not try to override default VCLs.
+-   If you want to override values and settings from the [default Fastly VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets), we recommend creating a new snippet with updated values and code with a higher priority value of `100`. You should not try to override default VCLs.
 
 ## Export Fastly Service ID and API Token
 
@@ -127,7 +127,7 @@ To view a list of all VCL snippets by version:
 
 Look for the `active` key from the returned list. You need the version to perform a clone in the next section.
 
-For more information on this Fastly API, see this [get version command](https://docs.fastly.com/api/config#version_dfde9093f4eb0aa2497bbfd1d9415987){:target="_blank"}.
+For more information on this Fastly API, see this [get version command](https://docs.fastly.com/api/config#version_dfde9093f4eb0aa2497bbfd1d9415987).
 
 ## Clone the active VCL version and all snippets {#clone}
 
@@ -139,7 +139,7 @@ You can save the new version into a bash environment variable for use in cURL co
 
     export FASTLY_VERSION=<Version>
 
-For more information on this Fastly API, see this [clone command](https://docs.fastly.com/api/config#version_7f4937d0663a27fbb765820d4c76c709){:target="_blank"}.
+For more information on this Fastly API, see this [clone command](https://docs.fastly.com/api/config#version_7f4937d0663a27fbb765820d4c76c709).
 
 ### Create custom VCL snippets {#create-snippet}
 
@@ -159,7 +159,7 @@ The values include:
 
 -   `name`—Name for the VCL snippet.
 -   `dynamic`—Indicates if this is a <a href="https://docs.fastly.com/guides/vcl-snippets/using-dynamic-vcl-snippets">dynamic snippet</a> or <a href="https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets">regular snippet</a>.
--   `type`—Specifies a location for the generated snippet, such as `init` (above subroutines) and `recv` (within subroutines). See [Fastly VCL snippet object values](https://docs.fastly.com/api/config#snippet){:target="\_blank"} for information on these values.
+-   `type`—Specifies a location for the generated snippet, such as `init` (above subroutines) and `recv` (within subroutines). See [Fastly VCL snippet object values](https://docs.fastly.com/api/config#snippet) for information on these values.
 -   `priority`—Determines the order VCL snippets call. Lower values run first, from `1` to `100`. All uploaded snippets from a Magento module have a value of `50`. If you want an action to occur last or to override Magento default VCL snippets, use a higher number, such as `100`. To have code occur immediately, use a lower value, such as `5`.
 -   `content`—The snippet of VCL code to run in one line, without line breaks.
 
@@ -210,7 +210,7 @@ To update a snippet, modify the JSON file you prepared on the [Create VCL snippe
 
     curl -H "Fastly-Key: ${FASTLY_API_TOKEN}" https://api.fastly.com/service/${FASTLY_SERVICE_ID}/version/${FASTLY_VERSION}/snippet/<snippet_name> -H 'Content-Type: application/json' -X PUT --data @<filename.json>
 
-If you want to override values and settings from the [default Fastly VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets){:target="_blank"}, we recommend creating a new snippet with updated values and code that use a priority of `100`.
+If you want to override values and settings from the [default Fastly VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets), we recommend creating a new snippet with updated values and code that use a priority of `100`.
 
 To delete an individual VCL snippet using the API, get a list of snippets and enter a `curl` command with the specific snippet name to delete:
 
@@ -220,13 +220,13 @@ To delete an individual VCL snippet using the API, get a list of snippets and en
 
 You can learn more about creating VCL snippets with the following Fastly resources:
 
--   [All Fastly VCL content](https://docs.fastly.com/guides/vcl/){:target="_blank"}
--   [Fastly VCL guide](https://docs.fastly.com/guides/vcl/guide-to-vcl){:target="_blank"}
--   [Mixing and matching Fastly VCL with custom VCL](https://docs.fastly.com/guides/vcl/mixing-and-matching-fastly-vcl-with-custom-vcl){:target="_blank"}
--   [Fastly VCL snippet object values](https://docs.fastly.com/api/config#snippet){:target="_blank"}
+-   [All Fastly VCL content](https://docs.fastly.com/guides/vcl/)
+-   [Fastly VCL guide](https://docs.fastly.com/guides/vcl/guide-to-vcl)
+-   [Mixing and matching Fastly VCL with custom VCL](https://docs.fastly.com/guides/vcl/mixing-and-matching-fastly-vcl-with-custom-vcl)
+-   [Fastly VCL snippet object values](https://docs.fastly.com/api/config#snippet)
 
 Fastly supports two types of snippets:
 
--   [Regular snippets](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets){:target="_blank"} are versioned VCL snippets. The code and settings are locked per version to create, modify, and deploy with the Fastly service.
--   [Dynamic snippets](https://docs.fastly.com/guides/vcl-snippets/using-dynamic-vcl-snippets){:target="_blank"} are snippets you can only create via API calls. These snippets do not have a version and deploy separately from your Fastly service.
+-   [Regular snippets](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) are versioned VCL snippets. The code and settings are locked per version to create, modify, and deploy with the Fastly service.
+-   [Dynamic snippets](https://docs.fastly.com/guides/vcl-snippets/using-dynamic-vcl-snippets) are snippets you can only create via API calls. These snippets do not have a version and deploy separately from your Fastly service.
 

--- a/guides/v2.1/cloud/cdn/configure-fastly.md
+++ b/guides/v2.1/cloud/cdn/configure-fastly.md
@@ -157,13 +157,13 @@ Complete the following configuration steps in Staging and Production environment
 4.	For **Caching Application**, uncheck the **Use system value** checkbox and select **Fastly CDN** from the drop-down list.
 
 	![Choose Fastly]({{ site.baseurl }}/common/images/cloud-fastly_enable-admin.png){:width="550px"}
-5.	Expand **Fastly Configuration**. You can then [choose caching options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#configure-the-module){:target="_blank"}.
+5.	Expand **Fastly Configuration**. You can then [choose caching options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#configure-the-module).
 6.	When you're done, click **Save Config** at the top of the page.
 7.	Clear the cache according to the notification. After you have cleared the
 cache, navigate back to **Stores** > **Configuration** > **Advanced** > **System** >
 **Fastly Configuration** and continue your configurations.
 
-Configure the following features and enable additional [configuration options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#further-configuration-options){:target="_blank"}:
+Configure the following features and enable additional [configuration options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#further-configuration-options):
 
 * [Upload Fastly VCL snippets](#upload-vcl-snippets)
 * [Configure backends and Origin shielding](#backend)
@@ -180,7 +180,7 @@ the **Upload VCL to Fastly** button to upload your default [VCL snippets](#custo
 You don't have to create or code VCL snippets. We provide a default set of snippets for
 Fastly. You only need to click **Upload VCL to Fastly** to finish this step.
 
-The installed Fastly module includes the following default [VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets){:target="_blank"}
+The installed Fastly module includes the following default [VCL snippets](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets)
 that drive the integration with Fastly. These VCL snippets are not available
 until you upload them. When you click Upload, you push a set of these default
 VCL snippets to Fastly for your specific Service ID and extension.
@@ -210,7 +210,7 @@ After the upload completes, you can create and upload custom VCL snippets with
 advanced settings and options. You use APIs to add these VCL snippets, further
 adding them in your site code depending on the actions.
 
-For more information, see [Fastly VCL documentation](https://docs.fastly.com/guides/vcl/guide-to-vcl){:target="_blank"} and [Fastly VCL snippets](https://docs.fastly.com/guides/vcl-snippets/about-vcl-snippets){:target="_blank"}.
+For more information, see [Fastly VCL documentation](https://docs.fastly.com/guides/vcl/guide-to-vcl) and [Fastly VCL snippets](https://docs.fastly.com/guides/vcl-snippets/about-vcl-snippets).
 
 ## Configure backends and Origin shielding {#backend}
 
@@ -265,7 +265,7 @@ handle your blog.
 6. Click **Upload** to save. The settings are communicated to Fastly.
 7. In the Magento Admin, click **Save Config**.
 
-For more information from Fastly, see the Magento 2 [Backend settings guide](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/Guides/BACKEND-SETTINGS.md){:target="_blank"}.
+For more information from Fastly, see the Magento 2 [Backend settings guide](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/Guides/BACKEND-SETTINGS.md).
 
 ## Configure purge options {#purge}
 
@@ -306,7 +306,7 @@ purge caches through the Cache Management page.
 4. After the page reloads, click **Upload VCL to Fastly** in the
    *Fastly Configuration* section.
 
-For more information, see [the Fastly configuration options](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/CONFIGURATION.md#further-configuration-options){:target="_blank"}.
+For more information, see [the Fastly configuration options](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/CONFIGURATION.md#further-configuration-options).
 
 ## Create a custom error/maintenance page {#fastly-errpg}
 
@@ -327,7 +327,7 @@ To create a custom error/maintenance page:
 
 	{:#info .bs-callout .bs-callout-info}
 	Avoid using images on your site in the event Fastly is not available. To use
-  images, refer to [Data URIs on the css-tricks site](https://css-tricks.com/data-uris/){:target="_blank"}.
+  images, refer to [Data URIs on the css-tricks site](https://css-tricks.com/data-uris/).
 
 4.	When you're done, click **Upload** to send your updates to Fastly.
 5.	Click **Save Config** at the top of the page.
@@ -366,13 +366,13 @@ Fastly options.
 3. For GeoIP Action, select if the visitor is automatically redirected with
    **Redirect** or provided a list of stores to select from with **Dialog**.
 4. For **Country Mapping**, click **Add** to enter a two-letter country code to
-   map with a specific Magento store from a list. For a list of country codes, see [this site](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2){:target="_blank"}.
+   map with a specific Magento store from a list. For a list of country codes, see [this site](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
 	![Add GeoIP country maps]({{ site.baseurl }}/common/images/cloud_fastly-geo-code.png)
 5. Click **Save Config** at the top of the page.
 6. After page reload, click *Upload VCL to Fastly* in the *Fastly Configuration* section.
 
-Fastly also provides a series of [geolocation-related VCL features](https://docs.fastly.com/guides/vcl/geolocation-related-vcl-features){:target="_blank"}
+Fastly also provides a series of [geolocation-related VCL features](https://docs.fastly.com/guides/vcl/geolocation-related-vcl-features)
 for customized geolocation coding.
 
 ## Configure DNS for Fastly {#fastly-dns}
@@ -385,17 +385,17 @@ add a CNAME record for your website that points to the Fastly service:
 you must add a CNAME record for each one.
 
 {:#info .bs-callout .bs-callout-info}
-This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp){:target="_blank"} (also referred to as a _naked_ domain). You must use a DNS
+This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp) (also referred to as a _naked_ domain). You must use a DNS
 provider that supports forwarding DNS queries to use an apex domain.
 
 The following list contains examples of DNS providers for informational purposes.
 Use your preferred DNS provider.
 
-*	CNAME with ALIAS record from [Dyn](http://dyn.com){:target="_blank"}
-*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com){:target="_blank"}
-*	ANAME at [easyDNS](https://www.easydns.com){:target="_blank"}
-*	ACNAME at [CloudFlare](https://www.cloudflare.com){:target="_blank"}
-*	ALIAS at [PointDNS](https://pointhq.com){:target="_blank"}
+*	CNAME with ALIAS record from [Dyn](http://dyn.com)
+*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
+*	ANAME at [easyDNS](https://www.easydns.com)
+*	ACNAME at [CloudFlare](https://www.cloudflare.com)
+*	ALIAS at [PointDNS](https://pointhq.com)
 
 Many other DNS providers also offer workarounds to accomplish this goal. The most
 common is to add a CNAME record for the `www` host on the domain and then use the
@@ -423,13 +423,13 @@ DNS information and going live, let us know you are using TLS, provide your
 domain names, and request the TXT record. You can then send this record to your
 DNS provider. The domain validation process is executed by Fastly.
 
-For details on this TXT record, see the Fastly [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification){:target="_blank"}.
+For details on this TXT record, see the Fastly [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification).
 
 ## Upgrade Fastly {#upgrade}
 
 Fastly updates the Magento module to resolve issues, increase performance, and
-provide new features. You can check the [Magento Marketplace](https://marketplace.magento.com/fastly-magento2.html){:target="_blank"}
-and [GitHub](https://github.com/fastly/fastly-magento2/releases){:target="_blank"}
+provide new features. You can check the [Magento Marketplace](https://marketplace.magento.com/fastly-magento2.html)
+and [GitHub](https://github.com/fastly/fastly-magento2/releases)
 for updates on the latest releases.
 
 When you upgrade Fastly, you get the upgraded subset of default VCL snippets.

--- a/guides/v2.1/cloud/cdn/fastly-image-optimization.md
+++ b/guides/v2.1/cloud/cdn/fastly-image-optimization.md
@@ -23,7 +23,7 @@ images through image optimizers, using default configurations.
 #### To enable Fastly IO:
 
 1.  Log in to your local
-    [Magento Admin]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin){:target="_blank"}
+    [Magento Admin]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin)
     panel as an administrator.
 
 1.  Click **Stores** > **Settings** > **Configuration** > **Advanced** > **System**.
@@ -199,8 +199,8 @@ following example:
   alt="Fusion Backpack"/>
 ```
 
-See `srcset` [browser support](https://caniuse.com/#feat=srcset){:target="_blank"}
-and [specification](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset){:target="_blank"}.
+See `srcset` [browser support](https://caniuse.com/#feat=srcset)
+and [specification](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset).
 
 ## Validate Fastly IO
 

--- a/guides/v2.1/cloud/cdn/fastly-vcl-badreferer.md
+++ b/guides/v2.1/cloud/cdn/fastly-vcl-badreferer.md
@@ -36,7 +36,7 @@ Edge Dictionaries create key-value pairs for running against your VCL snippet. F
 6. Select the checkbox for **Activate after the change** if you want to the dictionary after creating or editing the container.
 7. Add key-value pairs in the new dictionary. For this example, enter the URLs for your blog that should be redirected to your Wordpress backend. Enter a value of 1.
 
-For more information on using Edge Dictionaries with your VCL snippets, see Fastly's [Creating and using Edge Dictionaries](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries){:target="_blank"} and their example [custom VCL snippets](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries#custom-vcl-examples){:target="_blank"}.
+For more information on using Edge Dictionaries with your VCL snippets, see Fastly's [Creating and using Edge Dictionaries](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries) and their example [custom VCL snippets](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries#custom-vcl-examples).
 
 ## Create badreferer.json {#vcl}
 

--- a/guides/v2.1/cloud/cdn/fastly-vcl-wordpress.md
+++ b/guides/v2.1/cloud/cdn/fastly-vcl-wordpress.md
@@ -36,7 +36,7 @@ Edge Dictionaries create key-value pairs for running against your VCL snippet. F
 6. Select the checkbox for **Activate after the change** if you want to the dictionary after creating or editing the container.
 7. Add key-value pairs in the new dictionary. For this example, enter the URLs for your blog that should be redirected to your Wordpress backend. Enter a value of 1.
 
-For more information on using Edge Dictionaries with your VCL snippets, see Fastly's [Creating and using Edge Dictionaries](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries){:target="_blank"} and their example [custom VCL snippets](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries#custom-vcl-examples){:target="_blank"}.
+For more information on using Edge Dictionaries with your VCL snippets, see Fastly's [Creating and using Edge Dictionaries](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries) and their example [custom VCL snippets](https://docs.fastly.com/guides/edge-dictionaries/creating-and-using-dictionaries#custom-vcl-examples).
 
 ## Create wordpress.json {#vcl}
 

--- a/guides/v2.1/cloud/cdn/trouble-fastly.md
+++ b/guides/v2.1/cloud/cdn/trouble-fastly.md
@@ -122,7 +122,7 @@ If you do not have DNS set up for a public hostname, enter a command similar to 
 
 ### Check response headers {#response-headers}
 
-For detailed information on hits and misses, see Fastly's [Understanding cache HIT and MISS headers with shielded services](https://docs.fastly.com/guides/performance-tuning/understanding-cache-hit-and-miss-headers-with-shielded-services){:target="_blank"}.
+For detailed information on hits and misses, see Fastly's [Understanding cache HIT and MISS headers with shielded services](https://docs.fastly.com/guides/performance-tuning/understanding-cache-hit-and-miss-headers-with-shielded-services).
 
 Check the returned response headers and values:
 
@@ -131,8 +131,8 @@ Check the returned response headers and values:
 *	Fastly-Module-Enabled should be either Yes or the Fastly extension version number
 *	X-Cache should be either `HIT` or `HIT, HIT`
 *	x-cache-hits should be 1,1
-*	[Cache-Control: max-age](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9){:target="_blank"} should be greater than 0
-* [Pragma](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32){:target="_blank"} should be `cache`
+*	[Cache-Control: max-age](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
+* [Pragma](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
 
 The following example shows the correct values for `Pragma`, `X-Magento-Tags`, and `Fastly-Module-Enabled`.
 
@@ -253,7 +253,7 @@ If the credentials are correct, you may have issues with your VCLs. To list and 
 
 	curl -X GET -s https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/<Editable Version #>/snippet/ -H "Fastly-Key: <FASTLY_API_TOKEN>"
 
-Review the list of VCLs. If you have issues with the default VCLs from Fastly, you can upload again or verify the content per the [Fastly default VCLs](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets){:target="_blank"}. For editing your custom VCLs, see [Custom Fastly VCL snippets]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html).
+Review the list of VCLs. If you have issues with the default VCLs from Fastly, you can upload again or verify the content per the [Fastly default VCLs](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets). For editing your custom VCLs, see [Custom Fastly VCL snippets]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html).
 
 ## Activating a deactivated version {#activate}
 

--- a/guides/v2.1/cloud/configure/configuration-overview.md
+++ b/guides/v2.1/cloud/configure/configuration-overview.md
@@ -24,7 +24,7 @@ The following options, tools, and features can be set up and configured in your 
 * [Multiple websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html) details how to create and configure multi-sites for your store, for example multiple locales including English, French, and Spanish
 * [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
 * [Install a theme]({{ page.baseurl }}/cloud/howtos/custom-theme.html) for your site and store
-* Install the [Magento Google reCAPTCHA and Two-Factor Authentication extensions](https://docs.magento.com/m2/2.1/ee/user_guide/magento/magento-extensions.html){:target="_blank"} to provide additional security for account access to the Admin panel and storefront. 
+* Install the [Magento Google reCAPTCHA and Two-Factor Authentication extensions](https://docs.magento.com/m2/2.1/ee/user_guide/magento/magento-extensions.html) to provide additional security for account access to the Admin panel and storefront. 
 
 
 ## Configure your deployment: build hooks, services, and routes {#deploy}

--- a/guides/v2.1/cloud/configure/configure-best-practices.md
+++ b/guides/v2.1/cloud/configure/configure-best-practices.md
@@ -10,17 +10,17 @@ functional_areas:
   - Configuration
 ---
 
-For detailed information for configuring your store, sites, and websites, you may want to review the  [Magento 2.2.x User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html){:target="_blank"}. This page provides best practices, helpful information, and guidelines for configuring your stores, sites, and more with additional content to post over time and across versions.
+For detailed information for configuring your store, sites, and websites, you may want to review the  [Magento 2.2.x User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html). This page provides best practices, helpful information, and guidelines for configuring your stores, sites, and more with additional content to post over time and across versions.
 
 ## Understanding marketing campaigns and promotions {#campaigns}
 
 This information is helpful for {{site.data.var.ece}} 2.1.X and 2.2.X.
 
-To create campaigns and promotions, you will create the options and settings in [Content Staging](http://docs.magento.com/m2/ee/user_guide/cms/content-staging.html){:target="_blank"}. This feature allows you to create and preview your campaigns prior to making them public for customer sales. The following information provides helpful information. For exact instructions, see the linked Magento 2 User Guide content.
+To create campaigns and promotions, you will create the options and settings in [Content Staging](http://docs.magento.com/m2/ee/user_guide/cms/content-staging.html). This feature allows you to create and preview your campaigns prior to making them public for customer sales. The following information provides helpful information. For exact instructions, see the linked Magento 2 User Guide content.
 
 _Campaigns_ are marketing events for seasonal sales, new product lines, and more. Each campaign can include custom themes, blocks for content, widgets to control and display content, and associated promotions with price rules. Due to the extensive nature of a campaign, you create them with a start and end date through Content Staging.
 
-_Promotions_ provide discounts, one time offers, coupons, first time buyer incentives, and more. You create these promotions as _Price Rules_ that set the terms, discounts, and options to encourage customers to buy. You can create price rules on the [shopping cart](http://docs.magento.com/m2/ee/user_guide/marketing/price-rules-cart.html){:target="_blank"} or [catalog](http://docs.magento.com/m2/ee/user_guide/marketing/price-rules-catalog.html){:target="_blank"}, with additional options for banners, reward points, and more. We also support scheduling campaigns for your promotions, applying price rules for major events like a new product line or seasonal sales.
+_Promotions_ provide discounts, one time offers, coupons, first time buyer incentives, and more. You create these promotions as _Price Rules_ that set the terms, discounts, and options to encourage customers to buy. You can create price rules on the [shopping cart](http://docs.magento.com/m2/ee/user_guide/marketing/price-rules-cart.html) or [catalog](http://docs.magento.com/m2/ee/user_guide/marketing/price-rules-catalog.html), with additional options for banners, reward points, and more. We also support scheduling campaigns for your promotions, applying price rules for major events like a new product line or seasonal sales.
 
 The following are tips to help create, update, and manage promotions and campaigns:
 
@@ -33,7 +33,7 @@ The following are tips to help create, update, and manage promotions and campaig
 
 This information is helpful for {{site.data.var.ece}} 2.1.X and 2.2.X.
 
-Typically, you can set [Advanced Pricing](http://docs.magento.com/m2/ee/user_guide/catalog/settings-advanced-advanced-pricing.html){:target="_blank"} for products through the Products > Catalogs area of the Magento Admin. With Staged Content, you need to complete a few extra steps to add the pricing to a promotion and campaign.
+Typically, you can set [Advanced Pricing](http://docs.magento.com/m2/ee/user_guide/catalog/settings-advanced-advanced-pricing.html) for products through the Products > Catalogs area of the Magento Admin. With Staged Content, you need to complete a few extra steps to add the pricing to a promotion and campaign.
 
 To edit Advanced Pricing and update Content Staging:
 
@@ -46,17 +46,17 @@ To edit Advanced Pricing and update Content Staging:
 6. Save the promotion. An inactive initial campaign is created.
 7. You can Preview to review the special price, promotion name, regular price, and the scheduled date range for the campaign.
 
-For additional steps, you can continue with instructions with [Schedule Changes for Catalog Price Rules](http://docs.magento.com/m2/ee/user_guide/marketing/price-rule-catalog-scheduled-changes.html){:target="_blank"}. Click **Next** to walk through the steps.
+For additional steps, you can continue with instructions with [Schedule Changes for Catalog Price Rules](http://docs.magento.com/m2/ee/user_guide/marketing/price-rule-catalog-scheduled-changes.html). Click **Next** to walk through the steps.
 
 ## Example Price Rules {#price-rules}
 
 Price rules can include logic and conditions as limitless as your marketing imagination. Some popular examples include Buy One Get One Free, Buy One Get One 50% Off, a $25 dollars off on orders over $100 dollars, and so on.
 
-To create a Price Rule, see our [Magento 2 User Guide](http://docs.magento.com/m2/ee/user_guide/Search.html#search-price%20rules){:target="_blank"}.
+To create a Price Rule, see our [Magento 2 User Guide](http://docs.magento.com/m2/ee/user_guide/Search.html#search-price%20rules).
 
 The following provides an example of creating a Price Rule for a First Order Only discount. For this discount, you would want to:
 
-* Create a price rule with a [customer segment](http://docs.magento.com/m2/ee/user_guide/marketing/customer-segment-price-rule.html){:target="_blank"} with a condition: Total Number of Orders less than 1
+* Create a price rule with a [customer segment](http://docs.magento.com/m2/ee/user_guide/marketing/customer-segment-price-rule.html) with a condition: Total Number of Orders less than 1
 * Add this customer segment as a condition to the cart rule
 * Optional - Add conditions and rules to apply the discounts to specific SKUs or categories of products for focused purchases
 

--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -17,7 +17,7 @@ This version also provides a ` docker:config:convert` command to convert PHP con
 
 #### To launch Docker:
 
-1.  Download a template from the [Magento Cloud repository](https://github.com/magento/magento-cloud){:target="_blank"}.
+1.  Download a template from the [Magento Cloud repository](https://github.com/magento/magento-cloud).
 
 1.  Add your credentials to the `auth.json` file.
 
@@ -84,9 +84,9 @@ This version also provides a ` docker:config:convert` command to convert PHP con
 
 1.  Access your local Magento Cloud template by opening one of the following secure URLs in a browser:
 
-    -  [`http://localhost:8080`](http://localhost:8080){:target="_blank"}
+    -  [`http://localhost:8080`](http://localhost:8080)
 
-    -  [`https://localhost`](https://localhost){:target="_blank"}
+    -  [`https://localhost`](https://localhost)
 
 #### To stop and remove the Docker configuration:
 

--- a/guides/v2.1/cloud/env/setup-notifications.md
+++ b/guides/v2.1/cloud/env/setup-notifications.md
@@ -70,7 +70,7 @@ log:
       min_level: "info"
 ```
 
--   `token`—Your Slack [user token](https://api.slack.com/docs/token-types#user){:target="_blank"}. Your user token authorizes {{site.data.var.ece}} to send messages.
+-   `token`—Your Slack [user token](https://api.slack.com/docs/token-types#user). Your user token authorizes {{site.data.var.ece}} to send messages.
 -   `channel`—Name of the Slack channel {{site.data.var.ece}} sends notifications.
 -   `username`—Username {{site.data.var.ece}} uses to send notification messages in Slack.
 -   `min_level`—Minimum log level for notification messages. We recommend using `info`.

--- a/guides/v2.1/cloud/env/variables-build.md
+++ b/guides/v2.1/cloud/env/variables-build.md
@@ -26,7 +26,7 @@ For more information about customizing the build and deploy process:
 -  **Default**—`6`
 -  **Version**—Magento 2.1.4 and later
 
-Specifies which [gzip](https://www.gnu.org/software/gzip){:target="_blank"} compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
+Specifies which [gzip](https://www.gnu.org/software/gzip) compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
 
 ```yaml
 stage:
@@ -128,7 +128,7 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html){:target="_blank"} debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+ Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -196,7 +196,7 @@ The read-only connection is not available for use in the Integration environment
 -  **Default**—`6`
 -  **Version**—Magento 2.1.4 and later
 
-Specifies which [gzip](https://www.gnu.org/software/gzip){:target="_blank"} compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
+Specifies which [gzip](https://www.gnu.org/software/gzip) compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
 
 ```yaml
 stage:
@@ -379,7 +379,7 @@ You should set this variable to `false` _only_ in Staging or Production environm
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html){:target="_blank"} debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+ Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/howtos/debug.md
+++ b/guides/v2.1/cloud/howtos/debug.md
@@ -144,11 +144,11 @@ To troubleshoot the connection:
 
 #### Port forwarding on Windows {#portwindows}
 
-To set up port forwarding (SSH tunneling) on Windows, you will configure your Windows terminal application. For this example, we walk through creating an SSH tunnel using [Putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html){:target="_blank"}. You can use other applications such as Cygwin. For more information on other applications, please see the vendor documentation provided with those applications.
+To set up port forwarding (SSH tunneling) on Windows, you will configure your Windows terminal application. For this example, we walk through creating an SSH tunnel using [Putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html). You can use other applications such as Cygwin. For more information on other applications, please see the vendor documentation provided with those applications.
 
 To set up an SSH tunnel on Windows using Putty:
 
-1.	If you haven't already done so, download [Putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html){:target="_blank"}.
+1.	If you haven't already done so, download [Putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html).
 2.	Start Putty.
 3.	In the Category pane, click **Session**.
 4.	Enter the following information:
@@ -264,7 +264,7 @@ This section discusses how to use Xdebug in Chrome using the Xdebug Helper exten
 To use Xdebug Helper with Chrome:
 
 1.	Create an [SSH tunnel](#ssh) to the Cloud server.
-2.	Install the [Xdebug Helper extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en){:target="_blank"} from the Chrome store.
+2.	Install the [Xdebug Helper extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en) from the Chrome store.
 3.	Enable the extension in Chrome as shown in the following figure.
 
 	![Enable the Xdebug extension in Chrome]({{ site.baseurl }}/common/images/install_docker_php-storm_xdebug-chrome.png)

--- a/guides/v2.1/cloud/howtos/how-to.md
+++ b/guides/v2.1/cloud/howtos/how-to.md
@@ -13,7 +13,7 @@ functional_areas:
 
 These topics are intended to get you up to speed quickly using {{site.data.var.ece}}. These are step-by-step instructions that provide instructions about specific tasks or that explain how to achieve a goal.
 
-Have suggestions? Open [an issue](https://github.com/magento/devdocs/issues){:target="_blank"} or click the **Edit this page on GitHub** link and give us feedback directly.
+Have suggestions? Open [an issue](https://github.com/magento/devdocs/issues) or click the **Edit this page on GitHub** link and give us feedback directly.
 
 Current topics:
 

--- a/guides/v2.1/cloud/howtos/install-components.md
+++ b/guides/v2.1/cloud/howtos/install-components.md
@@ -31,7 +31,7 @@ We recommend using a branch for adding or updating, configuring, and testing you
 ## Install an extension {#install}
 [Extension installation](#install) uses the following steps:
 
-1.  Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com){:target="_blank"} or another site.
+1.  Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com) or another site.
 1.  [Create a branch](#getstarted) to work with the files.
 1.  [Get the extension's Composer name](#compose) and version from your purchase history.
 1.  In your local {{site.data.var.ece}} project, [update the Magento `composer.json`](#update) file with the name and version of the extension and add the code to Git. The code builds, deploys, and is available through the environment.

--- a/guides/v2.1/cloud/integrations/bitbucket-integration.md
+++ b/guides/v2.1/cloud/integrations/bitbucket-integration.md
@@ -80,11 +80,11 @@ You need to clone your {{site.data.var.ece}} project from an existing environmen
 
 ## Create an OAuth consumer
 
-The Bitbucket integration requires an [OAuth consumer](https://confluence.atlassian.com/x/pwIwDg){:target="_blank"}. You need the OAuth `key` and `secret` from this consumer to complete the next section.
+The Bitbucket integration requires an [OAuth consumer](https://confluence.atlassian.com/x/pwIwDg). You need the OAuth `key` and `secret` from this consumer to complete the next section.
 
 #### To create an OAuth consumer in Bitbucket:
 
-1.  Log in to your [Bitbucket](https://bitbucket.org/account/signin/){:target="_blank"} account.
+1.  Log in to your [Bitbucket](https://bitbucket.org/account/signin/) account.
 
 1.  Click **Settings** > **Access Management** > **OAuth**.
 
@@ -159,7 +159,7 @@ The Bitbucket integration requires an [OAuth consumer](https://confluence.atlass
 
 In order to communicate events—such as a push—with your Cloud git server, you need to create a webhook for your BitBucket repository.
 
-1.  Log in to your [Bitbucket](https://bitbucket.org/account/signin/){:target="_blank"} account.
+1.  Log in to your [Bitbucket](https://bitbucket.org/account/signin/) account.
 
 1.  Click **Repositories** and select your project.
 

--- a/guides/v2.1/cloud/integrations/github-integration.md
+++ b/guides/v2.1/cloud/integrations/github-integration.md
@@ -20,7 +20,7 @@ You must obtain a GitHub token and a webhook to continue the process.
 
 ## Generate a GitHub token
 
-You must be a member of a group with write-access to the GitHub repository, so that you can _push_ to the repository. See [GitHub: Create](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/){:target="_blank"}.
+You must be a member of a group with write-access to the GitHub repository, so that you can _push_ to the repository. See [GitHub: Create](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
 
 ## Enable the GitHub integration
 

--- a/guides/v2.1/cloud/live/go-live-checklist.md
+++ b/guides/v2.1/cloud/live/go-live-checklist.md
@@ -24,7 +24,7 @@ Contact Support to schedule a Go Live Preparation call. We walk through the Go L
 
 You may [need information]({{ page.baseurl }}/cloud/live/live.html#goliveinfo) for this ticket.
 
-1.	Log in to your [Magento Cloud account](https://accounts.magento.cloud){:target="_blank"}.
+1.	Log in to your [Magento Cloud account](https://accounts.magento.cloud).
 2.	Click **Support** > **Submit ticket** from the top menu.
 3.	Follow the prompts to open an issue with Support.	Support assists you with your live deployment and gives you an IP address for your live site so you can set up DNS.
 5. Provide a list of all storefront domain names for the shared SSL certificate.
@@ -43,15 +43,15 @@ You need to complete configurations for your DNS including:
 After checking with your registrar about where to change your DNS settings, add a CNAME record for your website that points to the Fastly service: `prod.magentocloud.map.fastly.net`. If you use multiple hostnames for your site, you must add a CNAME record for each one.
 
 {:.bs-callout .bs-callout-info}
-This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp){:target="_blank"} (also referred to as a _naked_ domain). You must use a DNS provider that supports forwarding DNS queries to use an apex domain.
+This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp) (also referred to as a _naked_ domain). You must use a DNS provider that supports forwarding DNS queries to use an apex domain.
 
 The following list contains examples of DNS providers for informational purposes. Use your preferred DNS provider.
 
-*	CNAME with ALIAS record from [Dyn](http://dyn.com){:target="_blank"}
-*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com){:target="_blank"}
-*	ANAME at [easyDNS](https://www.easydns.com){:target="_blank"}
-*	ACNAME at [CloudFlare](https://www.cloudflare.com){:target="_blank"}
-*	ALIAS at [PointDNS](https://pointhq.com){:target="_blank"}
+*	CNAME with ALIAS record from [Dyn](http://dyn.com)
+*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
+*	ANAME at [easyDNS](https://www.easydns.com)
+*	ACNAME at [CloudFlare](https://www.cloudflare.com)
+*	ALIAS at [PointDNS](https://pointhq.com)
 
 Many other DNS providers also offer workarounds to accomplish this goal. The most common is to add a CNAME record for the `www` host on the domain and then use the DNS provider's redirect service to redirect the apex over to the `www` version of the domain. Consult your DNS provider for more information.
 
@@ -65,7 +65,7 @@ Another option for apex domain is to add A records, which maps a domain name to 
 
 If you use TLS with Fastly enabled in your environment, you must provide your DNS provider with a TXT record from Fastly. We provide a Domain Validated SSL certificate with Subject Alternative Name enabled, issued by GLobalSign. When entering your [Support ticket](#dns) for DNS information and going live, let us know you are using TLS, provide your domain names and request the TXT record. You can then send this record to your DNS provider. The domain validation process is executed by Fastly.
 
-For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification){:target="_blank"}.
+For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification).
 
 ## Verify Production configurations
 
@@ -77,9 +77,9 @@ The following are recommended changes and checks:
 *	Base URL and Base Admin URL are set correctly
 *	Change the default Magento Admin password
 
-	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html){:target="_blank"} for further information on Admin configurations.
+	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html) for further information on Admin configurations.
 *	Optimize all images for the web
-*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html){:target="_blank"} for JS, CSS, and HTTP
+*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html) for JS, CSS, and HTTP
 
 ## Verify Fastly caching {#verifyfastly}
 
@@ -91,15 +91,15 @@ Test and verify Fastly caching is correctly working in Production. For detailed 
 
 ## Performance testing {#performance}
 
-We recommend that you review the [Magento Performance Toolkit]({{ site.mage2100url }}setup/performance-toolkit){:target="_blank"} options as part of your pre-launch readiness process.
+We recommend that you review the [Magento Performance Toolkit]({{ site.mage2100url }}setup/performance-toolkit) options as part of your pre-launch readiness process.
 
 You can also test using the following 3rd party options:
 
-* [Siege](https://www.joedog.org/siege-home/){:target="_blank"}: Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/){:target="_blank"}: Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
-* [New Relic](https://support.newrelic.com/){:target="_blank"} (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
+* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+* [New Relic](https://support.newrelic.com/) (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/){:target="_blank"} and [Pingdom](https://www.pingdom.com/){:target="_blank"}: Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 #### Next step:
 [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)

--- a/guides/v2.1/cloud/live/live.md
+++ b/guides/v2.1/cloud/live/live.md
@@ -37,18 +37,18 @@ We strongly recommend testing in these environments due to the complexity of you
 
 ## Set up Magento Security Scan Tool {#security-scan}
 
-The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out of date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login){:target="_blank"}.
+The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out of date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 
 * Monitor your sites security status and applied security updates
 * Receive security updates and site specific notifications
 
-For detailed instructions to set up and perform scans, see the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html){:target="_blank"}. Typically, you want to start using this tool as you enter UAT testing.
+For detailed instructions to set up and perform scans, see the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html). Typically, you want to start using this tool as you enter UAT testing.
 
 Each site to be scanned must be registered through Magento Security Scan tab. This registration process includes acceptance of Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is completed. Scans can be scheduled for either a specific, recurring date and time or on-demand as required.
 
 To scan your site:
 
-1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login){:target="_blank"}.
+1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 2. Click the Security Scan tab and select **Go to Security Scan**.
 3. In the **Actions** column for the site, select Run Scan. A notification status displays the scheduled scan.
 

--- a/guides/v2.1/cloud/live/paypal-onboarding.md
+++ b/guides/v2.1/cloud/live/paypal-onboarding.md
@@ -27,7 +27,7 @@ PayPal on-boarding supports connecting with the following accounts:
 * PayPal Business account
 * PayPal personal account, converting to a Business account. If you have an existing personal PayPal account, you can login with those credentials and upgrade this account to a business account as you complete the sync.
 
-If you do not have an existing PayPal account, you have an option to create a new one. Enter an e-mail address for a new account. If a matching PayPal account is not found, you will be prompted to create a new PayPal Business account. Or you can create an account directly through [PayPal](https://www.paypal.com/us/webapps/mpp/account-selection){:target="_blank"}.
+If you do not have an existing PayPal account, you have an option to create a new one. Enter an e-mail address for a new account. If a matching PayPal account is not found, you will be prompted to create a new PayPal Business account. Or you can create an account directly through [PayPal](https://www.paypal.com/us/webapps/mpp/account-selection).
 
 Please note the [PayPal account limitations](#limitations) for further information.
 
@@ -40,7 +40,7 @@ PayPal supports connecting PayPal Express Checkout for countries across the glob
 * India, and Japan (future PayPal updates may support these accounts)
 * Israel
 
-For Brazil, you must have an existing PayPal business account to connect. You cannot convert an existing personal PayPal account for Brazil during this process. If you need an account, please create a new business PayPal account through [their website](https://www.paypal.com/us/webapps/mpp/account-selection){:target="_blank"}.
+For Brazil, you must have an existing PayPal business account to connect. You cannot convert an existing personal PayPal account for Brazil during this process. If you need an account, please create a new business PayPal account through [their website](https://www.paypal.com/us/webapps/mpp/account-selection).
 
 ## Configure PayPal Express Checkout
 
@@ -61,7 +61,7 @@ To configure PayPal Express Checkout:
     * API Username, Password, and Signature captured from your PayPal account.
     * __Sandbox Mode__ select Yes or No to indicate if the credentials you entered are for sandbox. If you entered production credentials, select No.
     * __API Uses Proxy__ select Yes or No to set if the system uses a proxy server to establish a connection between Magento and the PayPal payment system. If Yes, enter the proxy host and port.
-6. For detailed information and steps for configuring your account, see [PayPal Express Checkout](http://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html){:target="_blank"} starting with Step 2 Complete the Required Settings.
+6. For detailed information and steps for configuring your account, see [PayPal Express Checkout](http://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html) starting with Step 2 Complete the Required Settings.
 
 
 With the account configured and authenticated, you can enable and disable PayPal payment options under Required PayPal Settings:

--- a/guides/v2.1/cloud/live/sens-data-initial.md
+++ b/guides/v2.1/cloud/live/sens-data-initial.md
@@ -65,7 +65,7 @@ To change locale and static file optimization settings:
 
 	![Set static file optimization settings]({{ site.baseurl }}/common/images/cloud_vars_set-minify.png){:width="550px"}
 8.	Click **Save Config**.
-9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 10.	Log out of the Magento Admin.
 
 ## Export values and transfer config.local.php to your local workstation {#export}
@@ -186,7 +186,7 @@ To change values in the Integration environment Magento Admin:
 
 	![Set static file optimization settings]({{ site.baseurl }}/common/images/cloud_vars_reset-minify.png){:width="550px"}
 8.	Click **Save Config**.
-9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 10.	Log out of the Magento Admin.
 
 ### Generate a new version of config.local.php {#regenerate}

--- a/guides/v2.1/cloud/live/stage-prod-migrate-prereq.md
+++ b/guides/v2.1/cloud/live/stage-prod-migrate-prereq.md
@@ -33,7 +33,7 @@ To prepare your environments for full deployment, you need:
 
 You can locate your URLs through the Project Web Interface. For each selected environment or branch, you will find an Access Site link. Your environments begin with Master, which is Production, and any additional branches you create, including Staging (recommended) and development branches for custom code.
 
-1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 2. Select an environment.
 3. Click **Access site** to display the URL and SSH information.
 

--- a/guides/v2.1/cloud/live/stage-prod-migrate.md
+++ b/guides/v2.1/cloud/live/stage-prod-migrate.md
@@ -108,7 +108,7 @@ For these environments, you are pushing code from repository to repository: Inte
 
 You will migrate {% glossarytooltip 363662cb-73f1-4347-a15e-2d2adabeb0c2 %}static files{% endglossarytooltip %} from your `pub/media` directory to Staging or Production.
 
-We recommend using the Linux remote synchronization and file transfer command [`rsync`](https://en.wikipedia.org/wiki/Rsync){:target="_blank"}. rsync uses an algorithm that minimizes the amount of data by moving only the portions of files that have changed; in addition, it supports compression.
+We recommend using the Linux remote synchronization and file transfer command [`rsync`](https://en.wikipedia.org/wiki/Rsync). rsync uses an algorithm that minimizes the amount of data by moving only the portions of files that have changed; in addition, it supports compression.
 
 We suggest using the following syntax:
 
@@ -121,7 +121,7 @@ Options:
 	v verbose
 	P partial progress
 
-For additional options, see the [rsync man page](http://linux.die.net/man/1/rsync){:target="_blank"}.
+For additional options, see the [rsync man page](http://linux.die.net/man/1/rsync).
 
 
 To migrate static files from your local machine:
@@ -146,7 +146,7 @@ To migrate static files from remote-to-remote environments directly (fast approa
 
 ## Migrate the database {#cloud-live-migrate-db}
 
-**Prerequisite:** A database dump (see Step 3) should include database triggers. For dumping them, make sure you have the [TRIGGER privilege](https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_trigger){:target="_blank"}.
+**Prerequisite:** A database dump (see Step 3) should include database triggers. For dumping them, make sure you have the [TRIGGER privilege](https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_trigger).
 
 **Important:** The Integration environment database is strictly for development testing and may include data you may not want to migrate into Staging and Production.
 

--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -40,7 +40,7 @@ Check the Magento configuration settings through the Admin panel including the B
 
 Verify Fastly is caching properly on Staging and Production. [Configuring Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html) requires careful attention to details, using the correct Fastly Service ID and Fastly API key, and a proper VCL snippet uploaded.
 
-First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains){:target="_blank"}.
+First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains).
 
 The following examples use Pro URLs. You can use any URL with the `dig` command.
 
@@ -70,8 +70,8 @@ Check the returned response headers and values:
 *	`Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
 *	`X-Cache` should be either `HIT` or `HIT, HIT`
 *	`x-cache-hits` should be 1,1
-*	[`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9){:target="_blank"} should be greater than 0
-*	[`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32){:target="_blank"} should be `cache`
+*	[`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
+*	[`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
 
 To verify Fastly is enabled in Staging and Production, check the configuration in the Magento Admin for each environment:
 
@@ -205,15 +205,15 @@ Before launching, we highly recommend performing extensive traffic and performan
 
 Before you begin testing, please enter a ticket with support advising the environments you are testing, what tools you are using, and the time frame. Update the ticket with results and information to track performance. When you complete testing, add your updated results and note in the ticket testing is complete with a date and time stamp.
 
-We recommend that you review the [Magento Performance Toolkit](https://github.com/magento/magento2/tree/2.0/setup/performance-toolkit){:target="_blank"} options as part of your pre-launch readiness process.
+We recommend that you review the [Magento Performance Toolkit](https://github.com/magento/magento2/tree/2.0/setup/performance-toolkit) options as part of your pre-launch readiness process.
 
 For best results, we recommend the following tools:
 
-* [Siege](https://www.joedog.org/siege-home/){:target="_blank"}: Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/){:target="_blank"}: Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 * New Relic (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/){:target="_blank"} and [Pingdom](https://www.pingdom.com/){:target="_blank"}: Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 ## Set up Magento Security Scan Tool {#security-scan}
 

--- a/guides/v2.1/cloud/onboarding/onboarding-portal.md
+++ b/guides/v2.1/cloud/onboarding/onboarding-portal.md
@@ -28,7 +28,7 @@ Browse through the portal to find helpful information and options to get started
 
 Currently, access to the Onboarding Portal is available through your Magento account.
 
-1. [Log in to your Magento account](https://account.magento.com){:target="_blank"}.
+1. [Log in to your Magento account](https://account.magento.com).
 2. On the Magento tab, click the Projects (Cloud) option. A list of projects associated to your account display.
 3. Select your project to open the Onboarding Portal.
 
@@ -50,7 +50,7 @@ The focus of this portal is for business users who may need a bit more planning 
 
 The _Technical Admin_ is a user account in the Project Web Interface with super user permissions. This admin is your point of contact for all technical information and project management. Managing a project includes Git code branches, adding user accounts, setting environment variables and settings, adding routes, and deploying software to environments.
 
-The Technical Admin can be a Magento Solution Partner, a development consultant, or even yourself. In search of a development partner? Check our [Magento Solution Partner](https://magento.com/find-a-partner){:target="_blank"} network.
+The Technical Admin can be a Magento Solution Partner, a development consultant, or even yourself. In search of a development partner? Check our [Magento Solution Partner](https://magento.com/find-a-partner) network.
 
 This user can help you create developer accounts with access to the Magento environments and code, configure technical aspects of the environments, and help with tickets with Support.
 

--- a/guides/v2.1/cloud/onboarding/onboarding-tasks.md
+++ b/guides/v2.1/cloud/onboarding/onboarding-tasks.md
@@ -44,7 +44,7 @@ site.
 
 ## Sign up for a Magento Commerce (Cloud) account {#cloud-first-acct}
 
-Don't have a {{site.data.var.ece}} account yet? Contact [Magento Sales](https://magento.com/explore/contact-sales){:target="_blank"}.
+Don't have a {{site.data.var.ece}} account yet? Contact [Magento Sales](https://magento.com/explore/contact-sales).
 We will create your account and send you a welcome email that provides instructions to access the project.
 
 The person who signs up for a {{site.data.var.ece}} account is referred to as
@@ -56,7 +56,7 @@ Magento sends a welcome email to the Project Owner using the address that was
 provided during the sign up process. The email contains a link to access your
 {{site.data.var.ece}} project and complete initial project set up.
 
-You can also access your project by [logging in to your account](https://accounts.magento.cloud){:target="_blank"}.
+You can also access your project by [logging in to your account](https://accounts.magento.cloud).
 
 ## Project access and users {#users}
 
@@ -68,7 +68,7 @@ Typically, the only user the Project Owner must create is the _Technical Admin_.
 The Technical Admin needs a user account with admin access to create user
 accounts for developers, set environment permissions, and
 manage all branches and environments. The Technical Admin can be a developer,
-a consultant, a [Magento Solution Partner](https://magento.com/find-a-partner){:target="_blank"},
+a consultant, a [Magento Solution Partner](https://magento.com/find-a-partner),
 or yourself.
 
 You can create a Technical Admin through the Project portal, from the Project
@@ -96,7 +96,7 @@ For details, see [Project Web Interface]({{ page.baseurl }}/cloud/project/projec
 
 Get updates about {{site.data.var.ece}}
 platform environments and related services from the
-[Status page](https://status.magento.cloud){:target="_blank"}.
+[Status page](https://status.magento.cloud).
 
 The page lists current status for all {{site.data.var.ece}} components and
 services followed by notifications about incident reports, service upgrades,
@@ -108,7 +108,7 @@ Anyone working on your project can subscribe to the {{site.data.var.ece}}
 status site to receive event notifications and updates through email. You can
 customize your subscription to select only the platform and services that you
 want to track. Sign up from the
-[Subscription page](https://status.magento.cloud/subscribe){:target="_blank"}.
+[Subscription page](https://status.magento.cloud/subscribe).
 
 ## Access your Magento Admin panel {#admin}
 

--- a/guides/v2.1/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.1/cloud/project/project-conf-files_magento-app.md
@@ -12,7 +12,7 @@ functional_areas:
 
 The `.magento.app.yaml` file controls the way your application builds and deploys. Although {{site.data.var.ece}} supports multiple applications per project, typically, a project has a single application with the `.magento.app.yaml` file at the root of the repository.
 
-The `.magento.app.yaml` has many default values, see [a sample `.magento.app.yaml` file](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml){:target="_blank"}. Make sure to review the `.magento.app.yaml` for your installed version. This file can differ across {{site.data.var.ece}} versions.
+The `.magento.app.yaml` has many default values, see [a sample `.magento.app.yaml` file](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml). Make sure to review the `.magento.app.yaml` for your installed version. This file can differ across {{site.data.var.ece}} versions.
 
 {% include cloud/note-pro-using-yaml.md %}
 
@@ -318,56 +318,56 @@ To view the current list of PHP extensions, SSH into your environment and enter 
 
 Magento requires the following PHP extensions that are enabled by default:
 
--  [curl](http://php.net/manual/en/book.curl.php){:target="_blank"}
--  [gd](http://php.net/manual/en/book.image.php){:target="_blank"}
--  [intl](http://php.net/manual/en/book.intl.php){:target="_blank"}
+-  [curl](http://php.net/manual/en/book.curl.php)
+-  [gd](http://php.net/manual/en/book.image.php)
+-  [intl](http://php.net/manual/en/book.intl.php)
 -  PHP 7 only:
 
-	-  [json](http://php.net/manual/en/book.json.php){:target="_blank"}
-	-  [iconv](http://php.net/manual/en/book.iconv.php){:target="_blank"}
--  [mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="_blank"}
--  [PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php){:target="_blank"}
--  [bc-math](http://php.net/manual/en/book.bc.php){:target="_blank"}
--  [mbstring](http://php.net/manual/en/book.mbstring.php){:target="_blank"}
--  [mhash](http://php.net/manual/en/book.mhash.php){:target="_blank"}
--  [openssl](http://php.net/manual/en/book.openssl.php){:target="_blank"}
--  [SimpleXML](http://php.net/manual/en/book.simplexml.php){:target="_blank"}
--  [soap](http://php.net/manual/en/book.soap.php){:target="_blank"}
--  [xml](http://php.net/manual/en/book.xml.php){:target="_blank"}
--  [zip](http://php.net/manual/en/book.zip.php){:target="_blank"}
+	-  [json](http://php.net/manual/en/book.json.php)
+	-  [iconv](http://php.net/manual/en/book.iconv.php)
+-  [mcrypt](http://php.net/manual/en/book.mcrypt.php)
+-  [PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php)
+-  [bc-math](http://php.net/manual/en/book.bc.php)
+-  [mbstring](http://php.net/manual/en/book.mbstring.php)
+-  [mhash](http://php.net/manual/en/book.mhash.php)
+-  [openssl](http://php.net/manual/en/book.openssl.php)
+-  [SimpleXML](http://php.net/manual/en/book.simplexml.php)
+-  [soap](http://php.net/manual/en/book.soap.php)
+-  [xml](http://php.net/manual/en/book.xml.php)
+-  [zip](http://php.net/manual/en/book.zip.php)
 
 You must install the following extensions:
 
--  [ImageMagick](http://php.net/manual/en/book.imagick.php){:target="_blank"} 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
--  [xsl](http://php.net/manual/en/book.xsl.php){:target="_blank"}
--  [redis](https://pecl.php.net/package/redis){:target="_blank"}
+-  [ImageMagick](http://php.net/manual/en/book.imagick.php) 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
+-  [xsl](http://php.net/manual/en/book.xsl.php)
+-  [redis](https://pecl.php.net/package/redis)
 
 In addition, we strongly recommend you enable `opcache`.
 
 Optional PHP extensions available to install:
 
--  [apcu](http://php.net/manual/en/book.apcu.php){:target="_blank"}
--  [blackfire](https://blackfire.io/docs/up-and-running/installation){:target="_blank"}
--  [enchant](http://php.net/manual/en/book.enchant.php){:target="_blank"}
--  [gearman](http://php.net/manual/en/book.gearman.php){:target="_blank"}
--  [geoip](http://php.net/manual/en/book.geoip.php){:target="_blank"}
--  [imap](http://php.net/manual/en/book.imap.php){:target="_blank"}
--  [ioncube](https://www.ioncube.com/loaders.php){:target="_blank"}
--  [pecl-http](https://pecl.php.net/package/pecl_http){:target="_blank"}
--  [pinba](http://pinba.org){:target="_blank"}
--  [propro](https://pecl.php.net/package/propro){:target="_blank"}
--  [pspell](http://php.net/manual/en/book.pspell.php){:target="_blank"}
--  [raphf](https://pecl.php.net/package/raphf){:target="_blank"}
--  [readline](http://php.net/manual/en/book.readline.php){:target="_blank"}
--  [recode](http://php.net/manual/en/book.recode.php){:target="_blank"}
--  [snmp](http://php.net/manual/en/book.snmp.php){:target="_blank"}
--  [sqlite3](http://php.net/manual/en/book.sqlite3.php){:target="_blank"}
--  [ssh2](http://php.net/manual/en/book.ssh2.php){:target="_blank"}
--  [tidy](http://php.net/manual/en/book.tidy.php){:target="_blank"}
--  [xcache](https://xcache.lighttpd.net){:target="_blank"}
--  [xdebug](https://xdebug.org){:target="_blank"}
--  [xhprof](http://php.net/manual/en/book.xhprof.php){:target="_blank"}
--  [xmlrpc](http://php.net/manual/en/book.xmlrpc.php){:target="_blank"}
+-  [apcu](http://php.net/manual/en/book.apcu.php)
+-  [blackfire](https://blackfire.io/docs/up-and-running/installation)
+-  [enchant](http://php.net/manual/en/book.enchant.php)
+-  [gearman](http://php.net/manual/en/book.gearman.php)
+-  [geoip](http://php.net/manual/en/book.geoip.php)
+-  [imap](http://php.net/manual/en/book.imap.php)
+-  [ioncube](https://www.ioncube.com/loaders.php)
+-  [pecl-http](https://pecl.php.net/package/pecl_http)
+-  [pinba](http://pinba.org)
+-  [propro](https://pecl.php.net/package/propro)
+-  [pspell](http://php.net/manual/en/book.pspell.php)
+-  [raphf](https://pecl.php.net/package/raphf)
+-  [readline](http://php.net/manual/en/book.readline.php)
+-  [recode](http://php.net/manual/en/book.recode.php)
+-  [snmp](http://php.net/manual/en/book.snmp.php)
+-  [sqlite3](http://php.net/manual/en/book.sqlite3.php)
+-  [ssh2](http://php.net/manual/en/book.ssh2.php)
+-  [tidy](http://php.net/manual/en/book.tidy.php)
+-  [xcache](https://xcache.lighttpd.net)
+-  [xdebug](https://xdebug.org)
+-  [xhprof](http://php.net/manual/en/book.xhprof.php)
+-  [xmlrpc](http://php.net/manual/en/book.xmlrpc.php)
 
 {:.bs-callout .bs-callout-warning}
 PHP compiled with debug is not supported and the Probe may conflict with XDebug or XHProf. Disable those extensions when enabling the Probe. The Probe conflicts with some PHP extensions like Pinba or IonCube.

--- a/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
@@ -13,7 +13,7 @@ functional_areas:
   - Search
 ---
 
-[Elasticsearch](https://www.elastic.co){:target="_blank"} is an open source product that enables you to take data from any source, any format, and search and visualize it in real time.
+[Elasticsearch](https://www.elastic.co) is an open source product that enables you to take data from any source, any format, and search and visualize it in real time.
 
 *   Elasticsearch performs quick and advanced searches on products in the product catalog
 *   Elasticsearch Analyzers support multiple languages
@@ -61,7 +61,7 @@ elasticsearch:
       - lang-python
 ```
 
-For example, if you are using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite){:target="_blank"}, you should add the following plugins:
+For example, if you are using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite), you should add the following plugins:
 
 ```yaml
 elasticsearch:
@@ -91,9 +91,9 @@ The following are supported Elasticsearch plugins for version 2.4:
 * `mapper-murmur3`: Murmur3 mapper plugin for computing hashes at index-time
 * `mapper-size`: Size mapper plugin, enables the `_size` meta field
 
-If using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite){:target="_blank"}, the required plugins are `analysis-icu` and `analysis-phonetic`. Make sure to add these to the plugins section of `services.yaml.` See [Add Elasticsearch plugins](#addplugins).
+If using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite), the required plugins are `analysis-icu` and `analysis-phonetic`. Make sure to add these to the plugins section of `services.yaml.` See [Add Elasticsearch plugins](#addplugins).
 
-For full documentation on these plugins, see [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/index.html){:target="_blank"}.
+For full documentation on these plugins, see [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/index.html).
 
 ## Verify environment-related relationships {#cloud-es-config-mg}
 

--- a/guides/v2.1/cloud/project/project-conf-files_services-mysql.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-mysql.md
@@ -12,7 +12,7 @@ functional_areas:
   - Setup
 ---
 
-The `mysql` service provides data storage. It's based on [MariaDB](https://mariadb.com/products/subscription-plans){:target="_blank"}, supporting the [XtraDB](https://www.percona.com/software/mysql-database/percona-server/xtradb){:target="_blank"} storage
+The `mysql` service provides data storage. It's based on [MariaDB](https://mariadb.com/products/subscription-plans), supporting the [XtraDB](https://www.percona.com/software/mysql-database/percona-server/xtradb) storage
 engine (equivalent to MySQL with InnoDB).
 
 We support MariaDB version 10.0, which includes reimplemented features from MySQL 5.6 and 5.7.
@@ -90,7 +90,7 @@ relationships:
 Merge and deploy the code to set the configurations for Redis. For information on how these changes affect your environments, see [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html).
 
 {: .bs-callout .bs-callout-info}
-* If you configure one MySQL user, you cannot use the [`DEFINER`](http://dev.mysql.com/doc/refman/5.6/en/show-grants.html){:target="_blank"} access control mechanism for stored procedures and views.
+* If you configure one MySQL user, you cannot use the [`DEFINER`](http://dev.mysql.com/doc/refman/5.6/en/show-grants.html) access control mechanism for stored procedures and views.
 * MySQL errors such as `PDO Exception 'MySQL server has gone away` are usually the result of exhausting your existing disk space. Be sure you have sufficient space allocated to the service in [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html#disk).
 
 ## Verify environment-related relationships {#cloud-es-config-mg}

--- a/guides/v2.1/cloud/project/project-conf-files_services-rabbit.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-rabbit.md
@@ -14,7 +14,7 @@ functional_areas:
 
 The [Message Queue Framework (MQF)]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html) is a system within {{site.data.var.ee}} that allows a {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %} to publish messages to queues. It also defines the consumers that will receive the messages asynchronously.
 
-The MQF uses [RabbitMQ](http://www.rabbitmq.com){:target="_blank"} as the messaging broker, which provides a scalable platform for sending and receiving messages. It also includes a mechanism for storing undelivered messages. RabbitMQ is based on the Advanced Message Queuing Protocol (AMQP) 0.9.1 specification.
+The MQF uses [RabbitMQ](http://www.rabbitmq.com) as the messaging broker, which provides a scalable platform for sending and receiving messages. It also includes a mechanism for storing undelivered messages. RabbitMQ is based on the Advanced Message Queuing Protocol (AMQP) 0.9.1 specification.
 
 We support RabbitMQ version 3.5.
 
@@ -95,7 +95,7 @@ You can do this using [SSH tunneling]({{ page.baseurl }}/cloud/env/environments-
 
 ### Connect from the application {#cloud-rabbitmq-conn-cont}
 
-To connect to RabbitMQ running in an application, you should install a client like [amqp-utils](https://github.com/dougbarth/amqp-utils){:target="_blank"} as a project dependency in your `.magento.app.yaml` file.
+To connect to RabbitMQ running in an application, you should install a client like [amqp-utils](https://github.com/dougbarth/amqp-utils) as a project dependency in your `.magento.app.yaml` file.
 
 For example,
 
@@ -109,4 +109,4 @@ Then, when you SSH into your {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd4
 
 ### Connect from your PHP application {#cloud-rabbitmq-conn-php}
 
-To connect to RabbitMQ using your PHP application, add a PHP {% glossarytooltip 08968dbb-2eeb-45c7-ae95-ffca228a7575 %}library{% endglossarytooltip %} (like [PHP AMQPlib](https://github.com/videlalvaro/php-amqplib){:target="_blank"}) to your source tree.
+To connect to RabbitMQ using your PHP application, add a PHP {% glossarytooltip 08968dbb-2eeb-45c7-ae95-ffca228a7575 %}library{% endglossarytooltip %} (like [PHP AMQPlib](https://github.com/videlalvaro/php-amqplib)) to your source tree.

--- a/guides/v2.1/cloud/project/project-conf-files_services-redis.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-redis.md
@@ -12,7 +12,7 @@ functional_areas:
   - Setup
 ---
 
-[Redis](http://redis.io){:target="_blank"} is an optional, backend cache solution that replaces the Zend Framework [Zend_Cache_Backend_File](http://framework.zend.com/apidoc/1.0/Zend_Cache/Backend/Zend_Cache_Backend_File.html){:target="_blank"}, which is used in Magento 2 by default.
+[Redis](http://redis.io) is an optional, backend cache solution that replaces the Zend Framework [Zend_Cache_Backend_File](http://framework.zend.com/apidoc/1.0/Zend_Cache/Backend/Zend_Cache_Backend_File.html), which is used in Magento 2 by default.
 
 We support Redis versions 2.8 and 3.0. Redis 3.0 supports up to 64 different databases per instance of the service, while 2.8 allows for only a single database. See [Configure Redis]({{ page.baseurl }}/config-guide/redis/config-redis.html).
 

--- a/guides/v2.1/cloud/project/project-conf-files_services.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services.md
@@ -6,7 +6,7 @@ functional_areas:
   - Setup
 ---
 
-Use the `services.yaml` file to configure all of your services supported and used by {{site.data.var.ece}}. These services include MySQL, Redis, ElasticSearch (for 2.1.X and later), and so on. You do not need to subscribe to external service providers.This file is located in the `.magento` directory in your project. See the latest sample of the [`services.yaml`](https://github.com/magento/magento-cloud/blob/master/.magento/services.yaml){:target="_blank"} file.
+Use the `services.yaml` file to configure all of your services supported and used by {{site.data.var.ece}}. These services include MySQL, Redis, ElasticSearch (for 2.1.X and later), and so on. You do not need to subscribe to external service providers.This file is located in the `.magento` directory in your project. See the latest sample of the [`services.yaml`](https://github.com/magento/magento-cloud/blob/master/.magento/services.yaml) file.
 
 When you push your Git branch, our deploy script uses the values defined by configuration files in the `.magento` directory. After deployment, the script deletes the directory and its contents. Your local development environment is not affected.
 

--- a/guides/v2.1/cloud/project/project-integrate-blackfire.md
+++ b/guides/v2.1/cloud/project/project-integrate-blackfire.md
@@ -8,13 +8,13 @@ functional_areas:
   - Services
 ---
 
-[Blackfire.io for Magento Cloud](https://blackfire.io/magento){:target="_blank"} is a PHP profiler and automated performance testing tool that can be used in the development Integration, Staging, and Production environments. It enables you to locate and investigate performance issues in your environment at the code level and creates a performance profile by tracking every PHP call, method, and SQL query performed by your code. Blackfire digs deeper to provide granular performance analytics.
+[Blackfire.io for Magento Cloud](https://blackfire.io/magento) is a PHP profiler and automated performance testing tool that can be used in the development Integration, Staging, and Production environments. It enables you to locate and investigate performance issues in your environment at the code level and creates a performance profile by tracking every PHP call, method, and SQL query performed by your code. Blackfire digs deeper to provide granular performance analytics.
 
-In addition, it profiles your code automatically and notifies you whenever your code does not comply with best practices for Magento 2 code performance management. For a high level overview and demo of Blackfire, review the videos in the [Introduction to Blackfire.io for Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/introduction-to-blackfireio-on-magento-cloud){:target="_blank"}.
+In addition, it profiles your code automatically and notifies you whenever your code does not comply with best practices for Magento 2 code performance management. For a high level overview and demo of Blackfire, review the videos in the [Introduction to Blackfire.io for Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/introduction-to-blackfireio-on-magento-cloud).
 
-For full details on integrations, also review [Configuring Blackfire on Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/configuring-blackfire-on-magento-cloud){:target="_blank"}.
+For full details on integrations, also review [Configuring Blackfire on Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/configuring-blackfire-on-magento-cloud).
 
-Blackfire includes the following [environments](https://blackfire.io/docs/reference-guide/environments){:target="_blank"} through their site:
+Blackfire includes the following [environments](https://blackfire.io/docs/reference-guide/environments) through their site:
 
 -  `Magento Cloud (<your instance reference>)`—Integration and Development
 -  `Magento Cloud (<your instance reference>)`—Staging
@@ -22,21 +22,21 @@ Blackfire includes the following [environments](https://blackfire.io/docs/refere
 
 **For Pro**:
 -  You must enter a Support ticket with your Blackfire credentials to configure your Staging and Production environments with Blackfire.
--  You must bypass the Fastly service in your Production environment when profiling with Blackfire. See [Bypassing Reverse Proxy, Cache, and Content Delivery Networks (CDN)](https://blackfire.io/docs/reference-guide/configuration#bypassing-reverse-proxy-cache-and-content-delivery-networks-cdn){:target="_blank"}.
+-  You must bypass the Fastly service in your Production environment when profiling with Blackfire. See [Bypassing Reverse Proxy, Cache, and Content Delivery Networks (CDN)](https://blackfire.io/docs/reference-guide/configuration#bypassing-reverse-proxy-cache-and-content-delivery-networks-cdn).
 
 ## Get your Blackfire credentials
 
 The Project Owner is the account owner, and their e-mail address is part of the credentials required for accessing Blackfire for your project. You can only use the Project Owner credentials to integrate Blackfire with {{site.data.var.ece}} and to log in to the Blackfire website. An invitation email is sent to the Project Owner's e-mail address to complete activation.
 
-For information on setting up an account on Blackfire, see [Accessing your Blackfire account as a Magento Cloud user](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-1-accessing-your-blackfire-account-as-a-magento-cloud-user){:target="_blank"}. You can access your Blackfire license key through [project details]({{ page.baseurl }}/cloud/project/projects.html#integrations).
+For information on setting up an account on Blackfire, see [Accessing your Blackfire account as a Magento Cloud user](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-1-accessing-your-blackfire-account-as-a-magento-cloud-user). You can access your Blackfire license key through [project details]({{ page.baseurl }}/cloud/project/projects.html#integrations).
 
 ## Add collaborator accounts {#collaborators}
 
-After you access your Blackfire account, you can [add additional collaborator accounts](http://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-2-adding-collaborators-to-the-blackfire-environments){:target="_blank"}.
+After you access your Blackfire account, you can [add additional collaborator accounts](http://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-2-adding-collaborators-to-the-blackfire-environments).
 
 We recommend adding at least one account through Blackfire to manage all access, integrations, and usage of the tool. We also recommend promoting one of the added members to Admin, to manage all Blackfire access and integrations.
 
-1.  Using your Project Owner Blackfire credentials, log in to [Blackfire](https://blackfire.io/login){:target="_blank"}.
+1.  Using your Project Owner Blackfire credentials, log in to [Blackfire](https://blackfire.io/login).
 1.  Navigate to the _Environments_ tab and select an environment.
 1.  Click the **Settings** tab.
 1.  Enter an e-mail address and click **Add Member**.
@@ -50,21 +50,21 @@ You need to install and configure Blackfire on your local workspace with your wo
 
 We recommend using the Blackfire installation guide to walk you through the process:
 
-1.  Log in to [Blackfire](https://blackfire.io/login){:target="_blank"}.
+1.  Log in to [Blackfire](https://blackfire.io/login).
 1.  Navigate to the _Environments_ tab and select the **Integration** environment.
 1.  Click the **Settings** tab.
 1.  Scroll to the bottom and locate the _Server ID_ and _Server Token_ for the environment. You need these values for the instructions.
-1.  Open the [Blackfire installation guide](https://blackfire.io/docs/up-and-running/installation){:target="_blank"}, select the Operating System, and follow the instructions.
+1.  Open the [Blackfire installation guide](https://blackfire.io/docs/up-and-running/installation), select the Operating System, and follow the instructions.
 
 ## Integrate Blackfire {#dev}
 
-We recommend enabling Blackfire in all of your active environments, including the Integration environment. See [Configure the server credentials & the integration with Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-3-configure-the-server-credentials-the-integration-with-magento-cloud){:target="_blank"}. You can integrate with the Pro Integration environment and Starter development branches.
+We recommend enabling Blackfire in all of your active environments, including the Integration environment. See [Configure the server credentials & the integration with Magento Cloud](https://support.blackfire.io/blackfire-on-magento-cloud/getting-started/step-3-configure-the-server-credentials-the-integration-with-magento-cloud). You can integrate with the Pro Integration environment and Starter development branches.
 
 {% include note.html type="info" content="For Starter plans, pushing your code and `.magento.app.yaml` file to the Staging and Master branches updates those environments directly. You can directly add Blackfire to those environments the way you do with development." %}
 
 These instructions assume you have set up your [local workspace]({{ page.baseurl }}/cloud/before/before-workspace.html).
 
-1.  Log in to [Blackfire](https://blackfire.io/login){:target="_blank"}.
+1.  Log in to [Blackfire](https://blackfire.io/login).
 1.  Navigate to the _Environments_ tab and select the **Integration** environment.
 1.  Click the **Builds** tab.
 1.  Click the info icon next to Magento Cloud.
@@ -195,7 +195,7 @@ You can verify that Blackfire works using a browser extension or the CLI. For ex
 
 #### To profile using the browser:
 
-1.  Install the Blackfire browser extension in [Chrome](https://blackfire.io/docs/integrations/chrome#installing-the-companion){:target="_blank"} or [Firefox](https://blackfire.io/docs/integrations/firefox#installing-the-companion){:target="_blank"}. A Blackfire icon displays in your browser next to the address location. If you do not see it, you may need to display the bar.
+1.  Install the Blackfire browser extension in [Chrome](https://blackfire.io/docs/integrations/chrome#installing-the-companion) or [Firefox](https://blackfire.io/docs/integrations/firefox#installing-the-companion). A Blackfire icon displays in your browser next to the address location. If you do not see it, you may need to display the bar.
 1.  Visit the store or site URL for your specific environment, such as the URL for your Integration environment. If you need this URL, you can find it through the Project Web Interface. Select the environment branch and copy the link from the _Access_ section.
 1.  Click the Blackfire icon.
 
@@ -207,7 +207,7 @@ You can verify that Blackfire works using a browser extension or the CLI. For ex
 
 #### To profile using the CLI:
 
-1.  Install the Blackfire [CLI Tool](https://blackfire.io/docs/up-and-running/installation){:target="_blank"}. Click on your preferred Platform tab and scroll down to **Installing the Blackfire CLI tool**.
+1.  Install the Blackfire [CLI Tool](https://blackfire.io/docs/up-and-running/installation). Click on your preferred Platform tab and scroll down to **Installing the Blackfire CLI tool**.
 
 1.  Depending on the type of code, profile using the `blackfire curl` or `blackfire run` command.
 
@@ -218,7 +218,7 @@ You can verify that Blackfire works using a browser extension or the CLI. For ex
 
 After completing the [Blackfire Integration](#dev), you can define events for the Staging and Production environments that enable Blackfire to execute polling requests automatically. An event example is whenever a commit deploys in the Integration environment, or when activating the integration between Blackfire and New Relic.
 
-By simply defining a set of key requests for Blackfire to profile— `/home`, `/checkout`, `/checkout/payment`—Blackfire can notify you if your code complies with established [code performance recommendations](https://blackfire.io/docs/reference-guide/recommendations){:target="_blank"}. The following is a sample build report with recommendations:
+By simply defining a set of key requests for Blackfire to profile— `/home`, `/checkout`, `/checkout/payment`—Blackfire can notify you if your code complies with established [code performance recommendations](https://blackfire.io/docs/reference-guide/recommendations). The following is a sample build report with recommendations:
 
 ![Blackfire build report]({{ site.baseurl }}/common/images/cloud_blackfire-recommendations.png)
 
@@ -242,19 +242,19 @@ scenarios:
     - /index.php/checkout/payment
 ```
 
-See the Blackfire documentation on [Writing tests](https://blackfire.io/docs/cookbooks/tests){:target="_blank"} and [Writing scenarios](https://blackfire.io/docs/cookbooks/scenarios){:target="_blank"}.
+See the Blackfire documentation on [Writing tests](https://blackfire.io/docs/cookbooks/tests) and [Writing scenarios](https://blackfire.io/docs/cookbooks/scenarios).
 
 ### Running your tests automatically
 
 Once you create and deploy your `.blackfire.yml` file, you can enable Blackfire to run your tests automatically in various ways:
 
 -  **Automated builds on Integration**—Whenever you push code on an Integration branch, Blackfire automatically runs your tests. You can receive a notification of the results in various ways, such as a commit status level when using GitHub or Bitbucket. See Blackfire notifications.
--   **Automated builds using a webhook**—Blackfire offers a very flexible way to start builds using a webhook, which can target any endpoint. See [Start building a webhook](https://blackfire.io/docs/reference-guide/builds-and-integrations#start-build-using-a-webhook){:target="_blank"}.
--   **Automated builds with the Blackfire/New Relic integration**—Blackfire and New Relic are very complementary. New Relic monitors the overall traffic performance, and Blackfire profiles much deeper into the PHP code. See [What is the difference between Blackfire and New Relic](https://support.blackfire.io/questions-about-blackfire/what-is-blackfire/what-is-the-difference-between-blackfire-and-new-relic-and-other-apms){:target="_blank"}. You can configure New Relic to fire Blackfire builds whenever relevant. See [New Relic](https://blackfire.io/docs/integrations/new-relic){:target="_blank"}.
+-   **Automated builds using a webhook**—Blackfire offers a very flexible way to start builds using a webhook, which can target any endpoint. See [Start building a webhook](https://blackfire.io/docs/reference-guide/builds-and-integrations#start-build-using-a-webhook).
+-   **Automated builds with the Blackfire/New Relic integration**—Blackfire and New Relic are very complementary. New Relic monitors the overall traffic performance, and Blackfire profiles much deeper into the PHP code. See [What is the difference between Blackfire and New Relic](https://support.blackfire.io/questions-about-blackfire/what-is-blackfire/what-is-the-difference-between-blackfire-and-new-relic-and-other-apms). You can configure New Relic to fire Blackfire builds whenever relevant. See [New Relic](https://blackfire.io/docs/integrations/new-relic).
 
 ### Blackfire notifications
 
-When you configure at least one way of triggering builds with Blackfire, you can be notified whenever a build report is available. Blackfire supports an integration with Slack, GitHub, BitBucket, email, and more. See [Scenario notification channels](https://blackfire.io/docs/reference-guide/notification-channels){:target="_blank"}.
+When you configure at least one way of triggering builds with Blackfire, you can be notified whenever a build report is available. Blackfire supports an integration with Slack, GitHub, BitBucket, email, and more. See [Scenario notification channels](https://blackfire.io/docs/reference-guide/notification-channels).
 
 ## Blackfire troubleshooting
 
@@ -320,9 +320,9 @@ magento-cloud variable:delete php:blackfire.log_level
 
 Blackfire provides great information to better profile and investigate the results on their documentation site:
 
--   [Profiling HTTP requests](https://blackfire.io/docs/cookbooks/profiling-http){:target="_blank"}
--   [Profiling CLI commands](https://blackfire.io/docs/cookbooks/profiling-cli){:target="_blank"}
--   [Profile all requests while you browse](https://blog.blackfire.io/profile-all-requests.html){:target="_blank"}
--   [Writing Tests](https://blackfire.io/docs/cookbooks/tests){:target="_blank"}
--   [Writing scenarios](https://blackfire.io/docs/cookbooks/scenarios){:target="_blank"}
--   [Reference Guide](https://blackfire.io/docs/reference-guide/index){:target="_blank"}
+-   [Profiling HTTP requests](https://blackfire.io/docs/cookbooks/profiling-http)
+-   [Profiling CLI commands](https://blackfire.io/docs/cookbooks/profiling-cli)
+-   [Profile all requests while you browse](https://blog.blackfire.io/profile-all-requests.html)
+-   [Writing Tests](https://blackfire.io/docs/cookbooks/tests)
+-   [Writing scenarios](https://blackfire.io/docs/cookbooks/scenarios)
+-   [Reference Guide](https://blackfire.io/docs/reference-guide/index)

--- a/guides/v2.1/cloud/project/project-patch.md
+++ b/guides/v2.1/cloud/project/project-patch.md
@@ -43,6 +43,6 @@ You can only apply patches during the build phase of redeployment.
     php ./bin/magento cache:clean
     ```
 
-    You can also clean the cache using the [Magento Admin Cache Management](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+    You can also clean the cache using the [Magento Admin Cache Management](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 
 1.  Test the patch, make any necessary changes.

--- a/guides/v2.1/cloud/project/project-routes-more-cache.md
+++ b/guides/v2.1/cloud/project/project-routes-more-cache.md
@@ -67,7 +67,7 @@ The cache duration is determined by the `Cache-Control` response header value. I
 
 ## Cache key {#cloud-cache-key}
 
-To decide how to {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} a response, {{site.data.var.ee}} builds a cache key depending on several factors and store the response associated with this key. When a request comes with the same cache key, the response is reused. Its purpose is similar to the HTTP [`Vary` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44){:target="_blank"}.
+To decide how to {% glossarytooltip 0bc9c8bc-de1a-4a06-9c99-a89a29c30645 %}cache{% endglossarytooltip %} a response, {{site.data.var.ee}} builds a cache key depending on several factors and store the response associated with this key. When a request comes with the same cache key, the response is reused. Its purpose is similar to the HTTP [`Vary` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44).
 
 The parameters `headers` and
 `cookies` keys enable you to change this cache key.

--- a/guides/v2.1/cloud/project/project-routes-more-redir.md
+++ b/guides/v2.1/cloud/project/project-routes-more-redir.md
@@ -136,7 +136,7 @@ If `append_suffix` is set to its default value of `true`, `/from/path/suffix` re
 {% endcollapsible %}
 
 ### `code` {#cloud-route-partial-code}
-Specifies the HTTP status code. Valid status codes are [`301` (Moved Permanently)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2){:target="_blank"}, [`302`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3){:target="_blank"}, [`307`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8){:target="_blank"}, and [`308`](https://tools.ietf.org/html/rfc7238){:target="_blank"}. Defaults to `302`.
+Specifies the HTTP status code. Valid status codes are [`301` (Moved Permanently)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2), [`302`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3), [`307`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8), and [`308`](https://tools.ietf.org/html/rfc7238). Defaults to `302`.
 
 ### `expires` {#cloud-route-partial-expires}
 Optional, the duration the redirect will be cached. Defaults to the `expires` value defined directly under the `redirects` key, but at this level we can fine-tune the expiration of individual partial redirects:

--- a/guides/v2.1/cloud/project/project-routes-more-ssi.md
+++ b/guides/v2.1/cloud/project/project-routes-more-ssi.md
@@ -14,7 +14,7 @@ functional_areas:
 
 [Server side includes](http://httpd.apache.org/docs/current/howto/ssi.html){:target="_site"} (SSI) are directives in {% glossarytooltip a2aff425-07dd-4bd6-9671-29b7edefa871 %}HTML{% endglossarytooltip %} pages that get evaluated on the server while the pages are being rendered. Use of {% glossarytooltip ebe2cd14-d6d4-4d75-b3d7-a4f2384e5af9 %}server side{% endglossarytooltip %} includes enables you to add dynamically generated content to an existing HTML page without having to serve the entire page.
 
-More information about [nginx SSI](http://nginx.org/en/docs/http/ngx_http_ssi_module.html){:target="_blank"}.
+More information about [nginx SSI](http://nginx.org/en/docs/http/ngx_http_ssi_module.html).
 
 You can activate or deactivate SSI on a per-route basis in your
 `.magento/routes.yaml`; for example:

--- a/guides/v2.1/cloud/project/project-start.md
+++ b/guides/v2.1/cloud/project/project-start.md
@@ -25,7 +25,7 @@ When you push your local environment to the remote server, our deploy script use
 
 ## Ignoring files
 
-We include a base `.gitignore` file with the {{site.data.var.ece}} project repository. See [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore){:target="_blank"}. You can add an ignored file when staging a commit by using the `-f` option:
+We include a base `.gitignore` file with the {{site.data.var.ece}} project repository. See [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore). You can add an ignored file when staging a commit by using the `-f` option:
 
 ```bash
 git add <path/filename> -f

--- a/guides/v2.1/cloud/project/project-webint-basic.md
+++ b/guides/v2.1/cloud/project/project-webint-basic.md
@@ -10,7 +10,7 @@ functional_areas:
   - Configuration
 ---
 
-The {{site.data.var.ece}} [Project Web Interface](https://accounts.magento.cloud){:target="_blank"} enables you to do the following for all Starter and Pro environments:
+The {{site.data.var.ece}} [Project Web Interface](https://accounts.magento.cloud) enables you to do the following for all Starter and Pro environments:
 
 * [Access projects](#project-access)
 * Create and manage projects

--- a/guides/v2.1/cloud/project/project-webint-branch.md
+++ b/guides/v2.1/cloud/project/project-webint-branch.md
@@ -145,7 +145,7 @@ To add a deployment key to your private GitHub repository, you must be the admin
 
 If your project needs to access multiple repositories, you can choose to
 attach an SSH key to an automated user account. Because this account won't
-be used by a human, it's referred to as a [*machine user*](https://developer.github.com/guides/managing-deploy-keys/){:target="_blank"}. You can then add the
+be used by a human, it's referred to as a [*machine user*](https://developer.github.com/guides/managing-deploy-keys/). You can then add the
 machine account as collaborator or add the machine user to a team with
 access to the repositories it needs to manipulate.
 

--- a/guides/v2.1/cloud/project/projects.md
+++ b/guides/v2.1/cloud/project/projects.md
@@ -45,7 +45,7 @@ To upgrade and patch Magento, see:
 
 ## Access the Project Web Interface {#login}
 
-With your {{site.data.var.ece}} account created, you can log into the Project Web Interface at [https://accounts.magento.cloud](https://accounts.magento.cloud){:target="_blank"}.
+With your {{site.data.var.ece}} account created, you can log into the Project Web Interface at [https://accounts.magento.cloud](https://accounts.magento.cloud).
 
 ![Log in to a project]({{ site.baseurl }}/common/images/cloud_project-login.png){:width="450px"}
 

--- a/guides/v2.1/cloud/project/sendgrid.md
+++ b/guides/v2.1/cloud/project/sendgrid.md
@@ -7,7 +7,7 @@ functional_areas:
   - Services
 ---
 
-The SendGrid-based SMTP proxy service provides email authentication, reputation monitoring, and dedicated IP addresses. A basic set up includes 12,000 emails per month and excludes use in marketing campaigns. See [SendGrid and Magento—Email Delivery. Simplified](https://sendgrid.com/partners/magento/){:target="_blank"}.
+The SendGrid-based SMTP proxy service provides email authentication, reputation monitoring, and dedicated IP addresses. A basic set up includes 12,000 emails per month and excludes use in marketing campaigns. See [SendGrid and Magento—Email Delivery. Simplified](https://sendgrid.com/partners/magento/).
 
 Magento automates the SendGrid integration for Starter and Pro Integration environments. The Pro Production and Staging environments require manual provisioning and configuration during the IaaS hardware provisioning process.
 
@@ -23,4 +23,4 @@ s2.example.com IN CNAME <s2.example.sendgrid.net>
 
 The CNAME records resolve to the Domain Keys Identified Mail (DKIM) and Sender Policy Framework (SPF) records managed by SendGrid, so that spam filters are less likely to inhibit your messages.
 
-Magento does not support whitelisting, but you can review the [Sender Policy Framework (SPF)](https://sendgrid.com/docs/Glossary/spf.html){:target="_blank"} guidelines to improve delivery. 
+Magento does not support whitelisting, but you can review the [Sender Policy Framework (SPF)](https://sendgrid.com/docs/Glossary/spf.html) guidelines to improve delivery. 

--- a/guides/v2.1/cloud/project/user-admin.md
+++ b/guides/v2.1/cloud/project/user-admin.md
@@ -96,7 +96,7 @@ Use `magento-cloud list` to get the full list of commands.
 
 To create user accounts using the Web Interface:
 
-1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 2.  Click the **Projects** tab as the following figure shows.
 
 	![Click the projects tab to access your Cloud project]({{ site.baseurl }}/common/images/cloud_account_project.png){:width="550px"}

--- a/guides/v2.1/cloud/reference/cloud-composer.md
+++ b/guides/v2.1/cloud/reference/cloud-composer.md
@@ -8,7 +8,7 @@ functional_areas:
   - Cloud
   - Upgrade
 ---
-We use [Composer](https://getcomposer.org/doc){:target="_blank"} to manage {{site.data.var.ece}} dependencies and upgrades and provide context about the included packages, what the packages do, and how they fit together. We highly recommend experience with Composer.
+We use [Composer](https://getcomposer.org/doc) to manage {{site.data.var.ece}} dependencies and upgrades and provide context about the included packages, what the packages do, and how they fit together. We highly recommend experience with Composer.
 
 Composer manages required libraries and dependencies for your project and installs them in the `vendor` directory.
 
@@ -37,7 +37,7 @@ The workflow is as follows:
 During the [build phase]({{ page.baseurl }}/cloud/reference/discover-deploy.html), the Cloud environment runs `composer install` on a fresh clone of your Git branch to retrieve the latest dependencies.
 
 ## magento/magento-cloud-metapackage {#cloud-composer-cloudmeta}
-`magento/magento-cloud-metapackage` should be the only package in the `require` section of your `composer.json`. This is a [_metapackage_](https://getcomposer.org/doc/04-schema.md#type){:target="_blank"} and does not contain any code.
+`magento/magento-cloud-metapackage` should be the only package in the `require` section of your `composer.json`. This is a [_metapackage_](https://getcomposer.org/doc/04-schema.md#type) and does not contain any code.
 
 The metapackage depends on the appropriate versions of [`magento/magento-cloud-configuration`](#cloud-composer-cloudconfig) and [`magento/product-enterprise-edition`](#cloud-composer-prodee). At any given version, this package requires the same version of `magento/product-enterprise-edition`. Therefore, to use {{site.data.var.ee}} version 2.1.4, for example, `composer.json` must specify a requirement for `magento/magento-cloud-metapackage` version 2.1.4.
 

--- a/guides/v2.1/cloud/reference/discover-deploy.md
+++ b/guides/v2.1/cloud/reference/discover-deploy.md
@@ -76,7 +76,7 @@ For detailed instructions, see [Build and deploy full steps](#steps).
 
 ### Phase 1: Code and configuration validation {#cloud-deploy-over-phases-conf}
 
-When you initially set up a project from a template, we retrieve the code from the [the {{site.data.var.ee}} template](https://github.com/magento/magento-cloud){:target="_blank"}. This code repo is cloned to your project as the `master` branch.
+When you initially set up a project from a template, we retrieve the code from the [the {{site.data.var.ee}} template](https://github.com/magento/magento-cloud). This code repo is cloned to your project as the `master` branch.
 
 -  **For Starter**—`master` branch is your Production environment.
 -  **For Pro**—`master` begins as origin branch for the Integration environment.

--- a/guides/v2.1/cloud/reference/git-integration.md
+++ b/guides/v2.1/cloud/reference/git-integration.md
@@ -15,18 +15,18 @@ Git is the center of all code management, build, and deployment for your {{site.
 
 If you need help understand Git, you can review the following resources:
 
-*	[Git documentation](https://git-scm.com/documentation){:target="_blank"} and [videos](https://git-scm.com/videos){:target="_blank"} from the makers of Git
-*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf){:target="_blank"} and [quick guide](http://rogerdudler.github.io/git-guide/){:target="_blank"} from Roger Dudler
-*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg){:target="_blank"} with DevForge to understand how people use the repo and commands with a fun story
+*	[Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
+*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
+*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
 
 ## Git CLI and clients {#clients}
-You can interact with Git using [CLI commands](https://git-scm.com/documentation){:target="_blank"} or using a Git client. Git provides a [Git client](https://git-scm.com/downloads){:target="_blank"} option, or you can use other clients such as installed on your computer to be able to interact with {{site.data.var.ece}}.
+You can interact with Git using [CLI commands](https://git-scm.com/documentation) or using a Git client. Git provides a [Git client](https://git-scm.com/downloads) option, or you can use other clients such as installed on your computer to be able to interact with {{site.data.var.ece}}.
 
-Not everyone remembers [Git](https://git-scm.com/docs){:target="_blank"} commands with ease. If you want a Git client, use any client of your choice. Some developers use clients including [GitKraken](https://www.gitkraken.com/){:target="_blank"} and [SmartGit](https://www.syntevo.com/smartgit/){:target="_blank"}.
+Not everyone remembers [Git](https://git-scm.com/docs) commands with ease. If you want a Git client, use any client of your choice. Some developers use clients including [GitKraken](https://www.gitkraken.com/) and [SmartGit](https://www.syntevo.com/smartgit/).
 
 ## Git branch naming {#requirements}
 
-In addition to Git's requirements for [valid branch names](https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html){:target="_blank"}, {{site.data.var.ece}} adds two additional requirements:
+In addition to Git's requirements for [valid branch names](https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html), {{site.data.var.ece}} adds two additional requirements:
 
 * The `/` character isn't allowed in a branch name.
 * Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`. A branch name of `Sprint2` and `sprint2` are just fine.
@@ -41,11 +41,11 @@ For specifics on creating Git branches, see the following topics:
 ## .gitignore file {#gitignore}
 Depending on your {{site.data.var.ece}} version, you may need different information added to or commented out in your `.gitignore` file. Git uses this file to determine which files and directories to ignore, before you make a commit to your branches. A .gitignore file should be committed into your root Magento in the repository, in order to share the ignore rules with any other users that clone the repository.
 
-We include a base `.gitignore` file with the project repository. For a review of the {{site.data.var.ece}} file, see [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore){:target="_blank"}. You can review the recommended files for your file in the [`.gitignore` reference]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-gitignore.html).
+We include a base `.gitignore` file with the project repository. For a review of the {{site.data.var.ece}} file, see [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore). You can review the recommended files for your file in the [`.gitignore` reference]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-gitignore.html).
 
 ## Git and SSH {#ssh}
 
-You must use Secure Shell (SSH) and not HTTPS to connect to the Git repository. For more information, see [GitHub documentation](https://help.github.com/articles/generating-an-ssh-key){:target="_blank"}.
+You must use Secure Shell (SSH) and not HTTPS to connect to the Git repository. For more information, see [GitHub documentation](https://help.github.com/articles/generating-an-ssh-key).
 
 When setting up your SSH, review our information at [SSH and sFTP]({{ page.baseurl }}/cloud/env/environments-ssh.html).
 

--- a/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.2.md
+++ b/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.2.md
@@ -25,7 +25,7 @@ We made the following change in this release:
 We made the following fixes in this release:
 
 * Improved the performance of static file deployment.
-*	You can now upgrade to version 2.1.2 if you enabled [static file signatures](http://docs.magento.com/m2/ee/user_guide/system/static-file-signature.html){:target="_blank"}.
+*	You can now upgrade to version 2.1.2 if you enabled [static file signatures](http://docs.magento.com/m2/ee/user_guide/system/static-file-signature.html).
 *   You no longer need a `pub/front-static.php` in your template.
 *   We now back up `env.php` before disabling the Redis cache during deployment.
 *   Patches are now applied in alphabetical order.

--- a/guides/v2.1/cloud/requirements/cloud-requirements.md
+++ b/guides/v2.1/cloud/requirements/cloud-requirements.md
@@ -53,9 +53,9 @@ Git is the heart of all your code in repositories. It acts as a version control 
 
 We hope you have a good working knowledge of Git. Need some help? Don't worry, we have you covered with some of our favorite links and information. We'll also include a Git guide to branching and developing soon.
 
-*	[Git documentation](https://git-scm.com/documentation){:target="_blank"} and [videos](https://git-scm.com/videos){:target="_blank"} from the makers of Git
-*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf){:target="_blank"} and [quick guide](http://rogerdudler.github.io/git-guide/){:target="_blank"} from Roger Dudler
-*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg){:target="_blank"} with DevForge to understand how people use the repo and commands with a fun story
+*	[Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
+*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
+*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
 
 To get started with Git, install Git on your local workstation.
 

--- a/guides/v2.1/cloud/setup/first-time-setup-import-first-steps.md
+++ b/guides/v2.1/cloud/setup/first-time-setup-import-first-steps.md
@@ -95,7 +95,7 @@ The complete workflow for importing existing code includes the following steps:
 
 ## Create a new {{site.data.var.ece}} project {#cloud-import-proj}
 
-1.  Access your account. Open the email you received from Magento Cloud (accounts@magento.cloud) and click the _Access your project now_ link. Or you can log in to [your Magento Commerce account](https://accounts.magento.cloud){:target="_blank"}.
+1.  Access your account. Open the email you received from Magento Cloud (accounts@magento.cloud) and click the _Access your project now_ link. Or you can log in to [your Magento Commerce account](https://accounts.magento.cloud).
 
 1.  Click the _This project has no code yet_ link next to the project name.
 

--- a/guides/v2.1/cloud/setup/first-time-setup-import-prepare.md
+++ b/guides/v2.1/cloud/setup/first-time-setup-import-prepare.md
@@ -34,7 +34,7 @@ To import {{site.data.var.ee}} code to a {{site.data.var.ece}} project, you must
 
 Add these files to your {{site.data.var.ee}} code:
 
-1.  In the [{{site.data.var.ece}} GitHub repository](https://github.com/magento/magento-cloud){:target="_blank"}, select the branch corresponding to the {{site.data.var.ee}} version you currently have.
+1.  In the [{{site.data.var.ece}} GitHub repository](https://github.com/magento/magento-cloud), select the branch corresponding to the {{site.data.var.ee}} version you currently have.
 
     The following figure shows an example of selecting the `2.1.4` branch.
 
@@ -60,7 +60,7 @@ Add these files to your {{site.data.var.ee}} code:
 
     For example, to create `<Magento Commerce install dir>/.magento.app.yaml` from the 2.1.4 branch:
 
-    1.  In the  {{site.data.var.ece}} GitHub, click [**.magento.app.yaml**](https://github.com/magento/magento-cloud/blob/2.1.4/.magento.app.yaml){:target="_blank"}.
+    1.  In the  {{site.data.var.ece}} GitHub, click [**.magento.app.yaml**](https://github.com/magento/magento-cloud/blob/2.1.4/.magento.app.yaml).
     2.  In the upper right, click **Raw**, as the following figure shows.
 
         ![View the raw version of the file]({{ site.baseurl }}/common/images/cloud_cloud-git_raw.png){:width="600px"}
@@ -83,7 +83,7 @@ You must have an authentication key to access the {{site.data.var.ee}} repositor
 
 #### To create a new `auth.json` file:
 
-First, verify if you have an `auth.json` file, located in your Magento root directory. You can also [get a sample `auth.json`](https://github.com/magento/magento2/blob/2.2-develop/auth.json.sample){:target="_blank"}.
+First, verify if you have an `auth.json` file, located in your Magento root directory. You can also [get a sample `auth.json`](https://github.com/magento/magento2/blob/2.2-develop/auth.json.sample).
 
 1.  Using a text editor, create an `auth.json` file and save it in your Magento root directory.
 
@@ -136,7 +136,7 @@ This method is best to prevent accidental exposure of credentials, such as pushi
 
 ## Edit `composer.json` {#composer-json}
 
-Before you push code to the {{site.data.var.ece}} Git repository, modify your `composer.json` for Cloud. You can also [view a sample `composer.json`](https://raw.githubusercontent.com/magento/magento-cloud/master/composer.json){:target="_blank"}.
+Before you push code to the {{site.data.var.ece}} Git repository, modify your `composer.json` for Cloud. You can also [view a sample `composer.json`](https://raw.githubusercontent.com/magento/magento-cloud/master/composer.json).
 
 To edit `composer.json`:
 

--- a/guides/v2.1/cloud/trouble/pro-env-management.md
+++ b/guides/v2.1/cloud/trouble/pro-env-management.md
@@ -67,7 +67,7 @@ If you have additional code, such as new extensions in your Production environme
 
 We recommend verifying your user account access and permissions set in the Integration environment. When adding Staging and Production to the Project Web Interface, the process includes all user accounts and settings. You can modify the settings and values for these environments after they are added.
 
-1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 1.  From your project, click **Master** to view the environment information and settings.
 1.  Click ![configure your project]({{ site.baseurl }}/common/images/cloud_edit-project.png) **Configure environment**.
 1.  Click the **Users** tab to review the user accounts and permission configurations.
@@ -77,7 +77,7 @@ We recommend verifying your user account access and permissions set in the Integ
 
 When we convert your project to the new Project Web Interface, we add variables from Integration environment to the Staging and Production environments. You can review, modify, and add variables through the current Project Web Interface prior to conversion.
 
-1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 1. From your project, click the Integration `master` branch to view the environment information and settings.
 1. Click **Configure environment**.
 1. On the _Variables_ tab, review the environment variables.  
@@ -104,7 +104,7 @@ After conversion, you can manually migrate specific environment variables for St
     magento-cloud variable:list
     ```
 
-1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud){:target="_blank"}.
+1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 1.  Click the **Projects** tab and the name of your project.
 1.  Click the Staging or Production environment.
 1.  On the _Variables_ tab, review the environment variables.

--- a/guides/v2.1/cloud/trouble/robots-sitemap.md
+++ b/guides/v2.1/cloud/trouble/robots-sitemap.md
@@ -15,7 +15,7 @@ With {{site.data.var.ece}}, you can only write to specific directories, such as 
 
 For version 2.1.11 and later, you do not have to generate a `robots.txt` because it generates on demand and stores the contents in the database. It does not create a file, but you can view the content in your browser with the url: `<domain.your.project>/robots.txt`
 
-This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.app.yaml` file. See an example of these rules in the [magento-cloud repository](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml#L43-L49){:target="_blank"}.
+This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.app.yaml` file. See an example of these rules in the [magento-cloud repository](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml#L43-L49).
 
 #### To generate a `sitemap.xml` file in version 2.1.11 and later:
 

--- a/guides/v2.1/cloud/trouble/trouble.md
+++ b/guides/v2.1/cloud/trouble/trouble.md
@@ -11,13 +11,13 @@ The troubleshooting topics help to resolve specific issues with your {{site.data
 -  Verify your [credentials]({{ page.baseurl }}/cloud/trouble/trouble_ce-creds.html)
 -  Review the [log files]({{ page.baseurl }}/cloud/live/stage-prod-test.html)
 -  Search for relevant content in the {{site.data.var.ece}} documentation
--  Search the [Magento Help Center](https://support.magento.com/hc/en-us){:target="_blank"} troubleshooting articles, FAQ, and Tech resources
+-  Search the [Magento Help Center](https://support.magento.com/hc/en-us) troubleshooting articles, FAQ, and Tech resources
 
 If you still require technical support, you can create a Support ticket through the Project Web Interface:
 
-1. Log in to the [Magento Help Center](https://support.magento.com/hc/en-us){:target="_blank"}.
+1. Log in to the [Magento Help Center](https://support.magento.com/hc/en-us).
 1. In the upper right-hand corner of the Magento Help Center, click **Submit a Ticket**.
 1. Fill out the support ticket form and attach any helpful documentation, such as screenshots or notes.
 1. Click **Submit**.
 
-See the [Submit a support ticket](https://support.magento.com/hc/en-us/articles/360000913794#submit-ticket){:target="_blank"} article for detailed instructions.
+See the [Submit a support ticket](https://support.magento.com/hc/en-us/articles/360000913794#submit-ticket) article for detailed instructions.

--- a/guides/v2.1/cloud/trouble/trouble_ce-creds.md
+++ b/guides/v2.1/cloud/trouble/trouble_ce-creds.md
@@ -31,7 +31,7 @@ To see the error log:
 
 To resolve this issue, you must clone the project locally and update `auth.json` with the correct {{site.data.var.ee}} [authorization keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) and run `composer update` to update project dependencies. After that, you can deploy your project successfully and get started with your development.
 
-Make sure you're using your own keys, and *not* [shared account keys](http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html){:target="_blank"}.
+Make sure you're using your own keys, and *not* [shared account keys](http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html).
 
 #### Get started
 

--- a/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
+++ b/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
@@ -90,9 +90,9 @@ Configure your store settings from the Magento Admin panel for the Integration e
 For the best information on configurations, review the documentation for {{site.data.var.ee}} and the installed extensions. Here are some links and ideas to help you get kickstarted:
 
 * [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
-* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html){:target="_blank"} for store admin access, name, languages, currencies, branding, sites, store views and more
-* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html){:target="_blank"} for your look and feel of the site and stores including CSS and layouts
-* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html){:target="_blank"} for roles, tools, notifications, and your encryption key for your database
+* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html) for store admin access, name, languages, currencies, branding, sites, store views and more
+* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html) for your look and feel of the site and stores including CSS and layouts
+* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html) for roles, tools, notifications, and your encryption key for your database
 * Extension settings using their documentation
 
 Beyond just store settings, you can further configure multiple sites and stores, configured services, and more. See [Configure Magento Commerce]({{ page.baseurl }}/cloud/configure/configuration-overview.html).

--- a/guides/v2.2/cloud/configure/configuration-overview.md
+++ b/guides/v2.2/cloud/configure/configuration-overview.md
@@ -25,7 +25,7 @@ The following options, tools, and features can be set up and configured in your 
 * [Multiple websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html) details how to create and configure multi-sites for your store, for example multiple locales including English, French, and Spanish
 * [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
 * [Install a theme]({{ page.baseurl }}/cloud/howtos/custom-theme.html) for your site and store
-* Install the [Magento Google reCAPTCHA and Two-Factor Authentication extensions](https://docs.magento.com/m2/ee/user_guide/magento/magento-extensions.html){:target="_blank"} to provide additional security for account access to the Magento Admin panel and storefront.
+* Install the [Magento Google reCAPTCHA and Two-Factor Authentication extensions](https://docs.magento.com/m2/ee/user_guide/magento/magento-extensions.html) to provide additional security for account access to the Magento Admin panel and storefront.
 
 ## Configure your deploy: build hooks, services, and routes {#deploy}
 

--- a/guides/v2.2/cloud/configure/setup-b2b.md
+++ b/guides/v2.2/cloud/configure/setup-b2b.md
@@ -8,7 +8,7 @@ With the {{site.data.var.ece}} Pro subscription for v2.2 and later, you can inst
 For additional information on using and extending B2B, see the following guides:
 
 * [Magento B2B Developer Guide]({{ site.baseurl }}/guides/v2.2/b2b/bk-b2b.html)
-* [Magento B2B User Guide](http://docs.magento.com/m2/b2b/user_guide/getting-started.html){:target="_blank"}
+* [Magento B2B User Guide](http://docs.magento.com/m2/b2b/user_guide/getting-started.html)
 
 We provide these features as a module you can install and setup in {{site.data.var.ece}}. Installation of B2B in a Pro project require additional steps to add the module and update your Git branch.
 
@@ -71,4 +71,4 @@ If you have a config.php file as part of your deployment, you should also add th
 
 ## Configure and use B2B {#use}
 
-For additional information on using and configuring B2B, review the [Magento B2B User Guide](http://docs.magento.com/m2/b2b/user_guide/getting-started.html){:target="_blank"}. To extend functionality, see the [Magento B2B Developer Guide]({{ site.baseurl }}/guides/v2.2/b2b/bk-b2b.html).
+For additional information on using and configuring B2B, review the [Magento B2B User Guide](http://docs.magento.com/m2/b2b/user_guide/getting-started.html). To extend functionality, see the [Magento B2B Developer Guide]({{ site.baseurl }}/guides/v2.2/b2b/bk-b2b.html).

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -31,7 +31,7 @@ The following variables were removed in v2.2:
 -  **Default**—`6`
 -  **Version**—Magento 2.1.4 and later
 
-Specifies which [gzip](https://www.gnu.org/software/gzip){:target="_blank"} compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
+Specifies which [gzip](https://www.gnu.org/software/gzip) compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
 
 ```yaml
 stage:
@@ -139,7 +139,7 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html){:target="_blank"} debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+ Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
  
 ```yaml
 stage:

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -209,7 +209,7 @@ The read-only connection is not available for use in the Integration environment
 -  **Default**—`6`
 -  **Version**—Magento 2.1.4 and later
 
-Specifies which [gzip](https://www.gnu.org/software/gzip){:target="_blank"} compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
+Specifies which [gzip](https://www.gnu.org/software/gzip) compression level (`0` to `9`) to use when compressing static content; `0` disables compression.
 
 ```yaml
 stage:
@@ -411,7 +411,7 @@ You should set this variable to `false` _only_ in Staging or Production environm
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html){:target="_blank"} debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+ Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/howtos/install-components.md
+++ b/guides/v2.2/cloud/howtos/install-components.md
@@ -31,7 +31,7 @@ We recommend using a branch for adding or updating, configuring, and testing you
 ## Install an extension {#install}
 [Extension installation](#install) uses the following steps:
 
-1.  Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com){:target="_blank"} or another site.
+1.  Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com) or another site.
 1.  [Create a branch](#getstarted) to work with the files.
 1.  [Get the extension's Composer name](#compose) and version from your purchase history.
 1.  In your local {{site.data.var.ece}} project, [update the Magento `composer.json`](#update) file with the name and version of the extension and add the code to Git. The code builds, deploys, and is available through the environment.

--- a/guides/v2.2/cloud/live/go-live-checklist.md
+++ b/guides/v2.2/cloud/live/go-live-checklist.md
@@ -27,15 +27,15 @@ You need to complete configurations for your DNS including:
 After checking with your registrar about where to change your DNS settings, add a CNAME record for your website that points to the Fastly service: `prod.magentocloud.map.fastly.net`. If you use multiple hostnames for your site, you must add a CNAME record for each one.
 
 {:.bs-callout .bs-callout-info}
-This does not work for an [apex] domain(https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp){:target="_blank"} (also referred to as a _naked_ domain). You must use a DNS provider that supports forwarding DNS queries to use an apex domain.
+This does not work for an [apex] domain(https://blog.cloudflare.com/zone-apex-naked-domain-root-domain-cname-supp) (also referred to as a _naked_ domain). You must use a DNS provider that supports forwarding DNS queries to use an apex domain.
 
 The following list contains examples of DNS providers for informational purposes. Use your preferred DNS provider.
 
-*	CNAME with ALIAS record from [Dyn](http://dyn.com){:target="_blank"}
-*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com){:target="_blank"}
-*	ANAME at [easyDNS](https://www.easydns.com){:target="_blank"}
-*	ACNAME at [CloudFlare](https://www.cloudflare.com){:target="_blank"}
-*	ALIAS at [PointDNS](https://pointhq.com){:target="_blank"}
+*	CNAME with ALIAS record from [Dyn](http://dyn.com)
+*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
+*	ANAME at [easyDNS](https://www.easydns.com)
+*	ACNAME at [CloudFlare](https://www.cloudflare.com)
+*	ALIAS at [PointDNS](https://pointhq.com)
 
 Many other DNS providers also offer workarounds to accomplish this goal. The most common is to add a CNAME record for the `www` host on the domain and then use the DNS provider's redirect service to redirect the apex over to the `www` version of the domain. Consult your DNS provider for more information.
 
@@ -49,7 +49,7 @@ Another option for apex domain is to add A records, which maps a domain name to 
 
 If you use TLS with Fastly enabled in your environment, you must provide your DNS provider with a TXT record from Fastly. We provide a Domain Validated SSL certificate with Subject Alternative Name enabled, issued by GLobalSign. When entering your [Support ticket](#dns) for DNS information and going live, let us know you are using TLS, provide your domain names and request the TXT record. You can then send this record to your DNS provider. The domain validation process is executed by Fastly.
 
-For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification){:target="_blank"}.
+For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification).
 
 ## Verify Production configurations
 
@@ -61,9 +61,9 @@ The following are recommended changes and checks:
 *	Base URL and Base Admin URL are set correctly
 *	Change the default Magento Admin password
 
-	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html){:target="_blank"} for further information on Admin configurations.
+	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html) for further information on Admin configurations.
 *	Optimize all images for the web
-*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html){:target="_blank"} for JS, CSS, and HTTP
+*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html) for JS, CSS, and HTTP
 
 ## Verify Fastly caching {#verifyfastly}
 
@@ -75,15 +75,15 @@ Test and verify Fastly caching is correctly working in Production. For detailed 
 
 ## Performance testing {#performance}
 
-We recommend that you review the [Magento Performance Toolkit]({{ site.mage2200url }}setup/performance-toolkit){:target="_blank"} options as part of your pre-launch readiness process.
+We recommend that you review the [Magento Performance Toolkit]({{ site.mage2200url }}setup/performance-toolkit) options as part of your pre-launch readiness process.
 
 You can also test using the following 3rd party options:
 
-* [Siege](https://www.joedog.org/siege-home/){:target="_blank"}: Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/){:target="_blank"}: Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
-* [New Relic](https://support.newrelic.com/){:target="_blank"} (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
+* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+* [New Relic](https://support.newrelic.com/) (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks in depth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/){:target="_blank"} and [Pingdom](https://www.pingdom.com/){:target="_blank"}: Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 #### Next step:
 [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)

--- a/guides/v2.2/cloud/live/paypal-onboarding.md
+++ b/guides/v2.2/cloud/live/paypal-onboarding.md
@@ -27,7 +27,7 @@ PayPal on-boarding supports connecting with the following accounts:
 * PayPal Business account
 * PayPal personal account, converting to a Business account. If you have an existing personal PayPal account, you can login with those credentials and upgrade this account to a business account as you complete the sync.
 
-If you do not have an existing PayPal account, you have an option to create a new one. Enter an e-mail address for a new account. If a matching PayPal account is not found, you will be prompted to create a new PayPal Business account. Or you can create an account directly through [PayPal](https://www.paypal.com/us/webapps/mpp/account-selection){:target="_blank"}.
+If you do not have an existing PayPal account, you have an option to create a new one. Enter an e-mail address for a new account. If a matching PayPal account is not found, you will be prompted to create a new PayPal Business account. Or you can create an account directly through [PayPal](https://www.paypal.com/us/webapps/mpp/account-selection).
 
 Please note the [PayPal account limitations](#limitations) for further information.
 
@@ -40,7 +40,7 @@ PayPal supports connecting PayPal Express Checkout for countries across the glob
 * India, and Japan (future PayPal updates may support these accounts)
 * Israel
 
-For Brazil, you must have an existing PayPal business account to connect. You cannot convert an existing personal PayPal account for Brazil during this process. If you need an account, please create a new business PayPal account through [their website](https://www.paypal.com/us/webapps/mpp/account-selection){:target="_blank"}.
+For Brazil, you must have an existing PayPal business account to connect. You cannot convert an existing personal PayPal account for Brazil during this process. If you need an account, please create a new business PayPal account through [their website](https://www.paypal.com/us/webapps/mpp/account-selection).
 
 ## Configure PayPal Express Checkout
 
@@ -61,7 +61,7 @@ To configure PayPal Express Checkout:
     * API Username, Password, and Signature captured from your PayPal account.
     * __Sandbox Mode__ select Yes or No to indicate if the credentials you entered are for sandbox. If you entered production credentials, select No.
     * __API Uses Proxy__ select Yes or No to set if the system uses a proxy server to establish a connection between Magento and the PayPal payment system. If Yes, enter the proxy host and port.
-6. For detailed information and steps for configuring your account, see [PayPal Express Checkout](http://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html){:target="_blank"} starting with Step 2 Complete the Required Settings.
+6. For detailed information and steps for configuring your account, see [PayPal Express Checkout](http://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html) starting with Step 2 Complete the Required Settings.
 
 
 With the account configured and authenticated, you can enable and disable PayPal payment options under Required PayPal Settings:

--- a/guides/v2.2/cloud/live/sens-data-initial.md
+++ b/guides/v2.2/cloud/live/sens-data-initial.md
@@ -66,7 +66,7 @@ To change locale and static file optimization settings:
 
 	![Set static file optimization settings]({{ site.baseurl }}/common/images/cloud_vars_set-minify.png){:width="550px"}
 8.	Click **Save Config**.
-9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+9.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 10.	Log out of the Magento Admin.
 
 ## Export values and transfer config.php to your local system {#export}
@@ -183,7 +183,7 @@ To add additional configuration values in the Integration environment Magento Ad
 4.	In the right pane, expand **JavaScript Settings**.
 5.	From the **Merge JavaScript Files** list, click **Yes**.
 6.	Click **Save Config**.
-7.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+7.	If prompted, [flush the Magento cache](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 8.	Log out of the Magento Admin.
 
 ### Run the config.php command {#regenerate}

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -12,7 +12,7 @@ functional_areas:
 
 The `.magento.app.yaml` file controls the way your application builds and deploys. Although {{site.data.var.ece}} supports multiple applications per project, typically, a project has a single application with the `.magento.app.yaml` file at the root of the repository.
 
-The `.magento.app.yaml` has many default values, see [a sample `.magento.app.yaml` file](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml){:target="_blank"}. Make sure to review the `.magento.app.yaml` for your installed version. This file can differ across {{site.data.var.ece}} versions.
+The `.magento.app.yaml` has many default values, see [a sample `.magento.app.yaml` file](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml). Make sure to review the `.magento.app.yaml` for your installed version. This file can differ across {{site.data.var.ece}} versions.
 
 {% include cloud/note-pro-using-yaml.md %}
 
@@ -318,56 +318,56 @@ To view the current list of PHP extensions, SSH into your environment and enter 
 
 Magento requires the following PHP extensions that are enabled by default:
 
--  [curl](http://php.net/manual/en/book.curl.php){:target="_blank"}
--  [gd](http://php.net/manual/en/book.image.php){:target="_blank"}
--  [intl](http://php.net/manual/en/book.intl.php){:target="_blank"}
+-  [curl](http://php.net/manual/en/book.curl.php)
+-  [gd](http://php.net/manual/en/book.image.php)
+-  [intl](http://php.net/manual/en/book.intl.php)
 -  PHP 7 only:
 
-	-  [json](http://php.net/manual/en/book.json.php){:target="_blank"}
-	-  [iconv](http://php.net/manual/en/book.iconv.php){:target="_blank"}
--  [mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="_blank"}
--  [PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php){:target="_blank"}
--  [bc-math](http://php.net/manual/en/book.bc.php){:target="_blank"}
--  [mbstring](http://php.net/manual/en/book.mbstring.php){:target="_blank"}
--  [mhash](http://php.net/manual/en/book.mhash.php){:target="_blank"}
--  [openssl](http://php.net/manual/en/book.openssl.php){:target="_blank"}
--  [SimpleXML](http://php.net/manual/en/book.simplexml.php){:target="_blank"}
--  [soap](http://php.net/manual/en/book.soap.php){:target="_blank"}
--  [xml](http://php.net/manual/en/book.xml.php){:target="_blank"}
--  [zip](http://php.net/manual/en/book.zip.php){:target="_blank"}
+	-  [json](http://php.net/manual/en/book.json.php)
+	-  [iconv](http://php.net/manual/en/book.iconv.php)
+-  [mcrypt](http://php.net/manual/en/book.mcrypt.php)
+-  [PDO/MySQL](http://php.net/manual/en/ref.pdo-mysql.php)
+-  [bc-math](http://php.net/manual/en/book.bc.php)
+-  [mbstring](http://php.net/manual/en/book.mbstring.php)
+-  [mhash](http://php.net/manual/en/book.mhash.php)
+-  [openssl](http://php.net/manual/en/book.openssl.php)
+-  [SimpleXML](http://php.net/manual/en/book.simplexml.php)
+-  [soap](http://php.net/manual/en/book.soap.php)
+-  [xml](http://php.net/manual/en/book.xml.php)
+-  [zip](http://php.net/manual/en/book.zip.php)
 
 You must install the following extensions:
 
--  [ImageMagick](http://php.net/manual/en/book.imagick.php){:target="_blank"} 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
--  [xsl](http://php.net/manual/en/book.xsl.php){:target="_blank"}
--  [redis](https://pecl.php.net/package/redis){:target="_blank"}
+-  [ImageMagick](http://php.net/manual/en/book.imagick.php) 6.3.7 (or later), ImageMagick can optionally be used with the `gd` extension
+-  [xsl](http://php.net/manual/en/book.xsl.php)
+-  [redis](https://pecl.php.net/package/redis)
 
 In addition, we strongly recommend you enable `opcache`.
 
 Optional PHP extensions available to install:
 
--  [apcu](http://php.net/manual/en/book.apcu.php){:target="_blank"}
--  [blackfire](https://blackfire.io/docs/up-and-running/installation){:target="_blank"}
--  [enchant](http://php.net/manual/en/book.enchant.php){:target="_blank"}
--  [gearman](http://php.net/manual/en/book.gearman.php){:target="_blank"}
--  [geoip](http://php.net/manual/en/book.geoip.php){:target="_blank"}
--  [imap](http://php.net/manual/en/book.imap.php){:target="_blank"}
--  [ioncube](https://www.ioncube.com/loaders.php){:target="_blank"}
--  [pecl-http](https://pecl.php.net/package/pecl_http){:target="_blank"}
--  [pinba](http://pinba.org){:target="_blank"}
--  [propro](https://pecl.php.net/package/propro){:target="_blank"}
--  [pspell](http://php.net/manual/en/book.pspell.php){:target="_blank"}
--  [raphf](https://pecl.php.net/package/raphf){:target="_blank"}
--  [readline](http://php.net/manual/en/book.readline.php){:target="_blank"}
--  [recode](http://php.net/manual/en/book.recode.php){:target="_blank"}
--  [snmp](http://php.net/manual/en/book.snmp.php){:target="_blank"}
--  [sqlite3](http://php.net/manual/en/book.sqlite3.php){:target="_blank"}
--  [ssh2](http://php.net/manual/en/book.ssh2.php){:target="_blank"}
--  [tidy](http://php.net/manual/en/book.tidy.php){:target="_blank"}
--  [xcache](https://xcache.lighttpd.net){:target="_blank"}
--  [xdebug](https://xdebug.org){:target="_blank"}
--  [xhprof](http://php.net/manual/en/book.xhprof.php){:target="_blank"}
--  [xmlrpc](http://php.net/manual/en/book.xmlrpc.php){:target="_blank"}
+-  [apcu](http://php.net/manual/en/book.apcu.php)
+-  [blackfire](https://blackfire.io/docs/up-and-running/installation)
+-  [enchant](http://php.net/manual/en/book.enchant.php)
+-  [gearman](http://php.net/manual/en/book.gearman.php)
+-  [geoip](http://php.net/manual/en/book.geoip.php)
+-  [imap](http://php.net/manual/en/book.imap.php)
+-  [ioncube](https://www.ioncube.com/loaders.php)
+-  [pecl-http](https://pecl.php.net/package/pecl_http)
+-  [pinba](http://pinba.org)
+-  [propro](https://pecl.php.net/package/propro)
+-  [pspell](http://php.net/manual/en/book.pspell.php)
+-  [raphf](https://pecl.php.net/package/raphf)
+-  [readline](http://php.net/manual/en/book.readline.php)
+-  [recode](http://php.net/manual/en/book.recode.php)
+-  [snmp](http://php.net/manual/en/book.snmp.php)
+-  [sqlite3](http://php.net/manual/en/book.sqlite3.php)
+-  [ssh2](http://php.net/manual/en/book.ssh2.php)
+-  [tidy](http://php.net/manual/en/book.tidy.php)
+-  [xcache](https://xcache.lighttpd.net)
+-  [xdebug](https://xdebug.org)
+-  [xhprof](http://php.net/manual/en/book.xhprof.php)
+-  [xmlrpc](http://php.net/manual/en/book.xmlrpc.php)
 
 
 {:.bs-callout .bs-callout-warning}

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -7,7 +7,7 @@ functional_areas:
   - Search
 ---
 
-[Elasticsearch](https://www.elastic.co){:target="_blank"} is an open source product that enables you to take data from any source, any format, and search and visualize it in real time.
+[Elasticsearch](https://www.elastic.co) is an open source product that enables you to take data from any source, any format, and search and visualize it in real time.
 
 *   Elasticsearch performs quick and advanced searches on products in the product catalog
 *   Elasticsearch Analyzers support multiple languages
@@ -55,7 +55,7 @@ elasticsearch:
       - lang-python
 ```
 
-For example, if you are using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite){:target="_blank"}, you should add the following plugins:
+For example, if you are using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite), you should add the following plugins:
 
 ```yaml
 elasticsearch:
@@ -85,9 +85,9 @@ The following are supported Elasticsearch plugins for version 2.4:
 * `mapper-murmur3`: Murmur3 mapper plugin for computing hashes at index-time
 * `mapper-size`: Size mapper plugin, enables the `_size` meta field
 
-If using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite){:target="_blank"}, the required plugins are `analysis-icu` and `analysis-phonetic`. Make sure to add these to the plugins section of `services.yaml.` See [Add Elasticsearch plugins](#addplugins).
+If using [Smile ElasticSuite](https://github.com/Smile-SA/elasticsuite), the required plugins are `analysis-icu` and `analysis-phonetic`. Make sure to add these to the plugins section of `services.yaml.` See [Add Elasticsearch plugins](#addplugins).
 
-For full documentation on these plugins, see [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/index.html){:target="_blank"}.
+For full documentation on these plugins, see [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/index.html).
 
 ## Verify environment-related relationships {#cloud-es-config-mg}
 

--- a/guides/v2.2/cloud/project/project-conf-files_services.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services.md
@@ -6,7 +6,7 @@ functional_areas:
   - Setup
 ---
 
-Use the `services.yaml` file to configure all of your services supported and used by {{site.data.var.ece}}. These services include MySQL, Redis, ElasticSearch (for 2.1.X and later), and so on. You do not need to subscribe to external service providers. This file is located in the `.magento` directory in your project. See the latest sample of the [`services.yaml`](https://github.com/magento/magento-cloud/blob/master/.magento/services.yaml){:target="_blank"} file.
+Use the `services.yaml` file to configure all of your services supported and used by {{site.data.var.ece}}. These services include MySQL, Redis, ElasticSearch (for 2.1.X and later), and so on. You do not need to subscribe to external service providers. This file is located in the `.magento` directory in your project. See the latest sample of the [`services.yaml`](https://github.com/magento/magento-cloud/blob/master/.magento/services.yaml) file.
 
 When you push your Git branch, our deploy script uses the values defined by configuration files in the `.magento` directory. After deployment, the script deletes the directory and its contents. Your local development environment is not affected.
 

--- a/guides/v2.2/cloud/project/project-patch.md
+++ b/guides/v2.2/cloud/project/project-patch.md
@@ -43,6 +43,6 @@ You can only apply patches during the build phase of redeployment.
     php ./bin/magento cache:clean
     ```
 
-    You can also clean the cache using the [Magento Admin Cache Management](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html){:target="_blank"}.
+    You can also clean the cache using the [Magento Admin Cache Management](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 
 1.  Test the patch, make any necessary changes.

--- a/guides/v2.2/cloud/project/project-start.md
+++ b/guides/v2.2/cloud/project/project-start.md
@@ -26,7 +26,7 @@ When you push your local environment to the remote server, our deploy script use
 
 ## Ignoring files
 
-We include a base `.gitignore` file with the {{site.data.var.ece}} project repository. See [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore){:target="_blank"}. You can add an ignored file when staging a commit by using the `-f` option:
+We include a base `.gitignore` file with the {{site.data.var.ece}} project repository. See [.gitignore file](https://github.com/magento/magento-cloud/blob/master/.gitignore). You can add an ignored file when staging a commit by using the `-f` option:
 
 ```bash
 git add <path/filename> -f

--- a/guides/v2.2/cloud/project/project-upgrade.md
+++ b/guides/v2.2/cloud/project/project-upgrade.md
@@ -25,7 +25,7 @@ Prepare your environment with the following tasks:
 {{site.data.var.ece}} 2.2 supports PHP 7.1 and later. Make sure to upgrade the version of PHP on your local development workspace as well. For more information, see the following:
 
 * [PHP]({{ site.baseurl }}/guides/v2.2/cloud/before/before-workspace-magento-prereqs.html#php) information for your local Magento workstation
-* [Migrating PHP](http://php.net/manual/en/migration71.php){:target="_blank"}
+* [Migrating PHP](http://php.net/manual/en/migration71.php)
 * [Magento 2.2.x technology stack requirements]({{ site.baseurl }}/guides/v2.2/install-gde/system-requirements-tech.html#php)
 
 {: .bs-callout .bs-callout-info}

--- a/guides/v2.2/cloud/reference/cloud-composer.md
+++ b/guides/v2.2/cloud/reference/cloud-composer.md
@@ -8,7 +8,7 @@ functional_areas:
   - Upgrade
 ---
 
-We use [Composer](https://getcomposer.org/doc){:target="_blank"} to manage {{site.data.var.ece}} dependencies and upgrades and provide context about the included packages, what the packages do, and how they fit together. We highly recommend experience with Composer.
+We use [Composer](https://getcomposer.org/doc) to manage {{site.data.var.ece}} dependencies and upgrades and provide context about the included packages, what the packages do, and how they fit together. We highly recommend experience with Composer.
 
 Composer manages required libraries and dependencies for your project and installs them in the `vendor` directory.
 
@@ -38,7 +38,7 @@ During the [build phase]({{ page.baseurl }}/cloud/reference/discover-deploy.html
 
 ## magento/magento-cloud-metapackage {#cloud-composer-cloudmeta}
 
-The `vendor/magento/magento-cloud-metapackage` should be the only package in the `require` section of your `composer.json`. This is a [_metapackage_](https://getcomposer.org/doc/04-schema.md#type){:target="_blank"} and does not contain any code.
+The `vendor/magento/magento-cloud-metapackage` should be the only package in the `require` section of your `composer.json`. This is a [_metapackage_](https://getcomposer.org/doc/04-schema.md#type) and does not contain any code.
 
 The metapackage depends on the appropriate versions of `vendor/magento/ece-patches`, [`vendor/magento/ece-tools`](#ece-tools), and [`vendor/magento/product-enterprise-edition`](#cloud-composer-prodee). At any given version, this package requires the same version of `magento/product-enterprise-edition`. For example, to use {{site.data.var.ee}} version 2.2.0, for example, `composer.json` must specify a requirement for `magento/magento-cloud-metapackage` version 2.2.0.
 

--- a/guides/v2.2/cloud/reference/discover-deploy.md
+++ b/guides/v2.2/cloud/reference/discover-deploy.md
@@ -78,7 +78,7 @@ For detailed instructions, see [Build and deploy full steps](#steps).
 
 ### Phase 1: Code and configuration validation {#cloud-deploy-over-phases-conf}
 
-When you initially set up a project from a template, we retrieve the code from the [the {{site.data.var.ee}} template](https://github.com/magento/magento-cloud){:target="_blank"}. This code repo is cloned to your project as the `master` branch.
+When you initially set up a project from a template, we retrieve the code from the [the {{site.data.var.ee}} template](https://github.com/magento/magento-cloud). This code repo is cloned to your project as the `master` branch.
 
 -  **For Starter**—`master` branch is your Production environment.
 -  **For Pro**—`master` begins as origin branch for the Integration environment.

--- a/guides/v2.2/cloud/release-notes/CloudReleaseNotes2.2.md
+++ b/guides/v2.2/cloud/release-notes/CloudReleaseNotes2.2.md
@@ -52,7 +52,7 @@ Magento 2.2.0 includes multiple security enhancements. Although this release inc
 
 In general, we’ve removed serialize/unserialize from most the code to improve protection against remote code execution attacks. We’ve enhanced protection of code where use of object serialization or unserialization was unavoidable.  Additionally, we’ve increased our use of output escaping to protect against cross-site scripting (XSS) attacks.
 
-[Contact us](https://magento.com/company/contact-us){:target="_blank"} for more information.
+[Contact us](https://magento.com/company/contact-us) for more information.
 
 ## Known issues {#known}
 
@@ -117,7 +117,7 @@ We are grateful to the wider Magento community and would like to acknowledge the
 
 For {{site.data.var.ece}} requirements, see [Technologies and Requirements]({{ site.baseurl }}/guides/v2.2/cloud/requirements/cloud-requirements.html).
 
-The {{site.data.var.ee}} technology stack is built on PHP and MySQL. For details, see [Technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) and [System Requirements]({{ site.baseurl }}/magento-system-requirements.html){:target="_blank"}.
+The {{site.data.var.ee}} technology stack is built on PHP and MySQL. For details, see [Technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) and [System Requirements]({{ site.baseurl }}/magento-system-requirements.html).
 
 ## Installation and upgrade instructions {#install-upgrade}
 

--- a/guides/v2.2/cloud/requirements/cloud-requirements.md
+++ b/guides/v2.2/cloud/requirements/cloud-requirements.md
@@ -53,11 +53,11 @@ Git is the heart of all your code in repositories. It acts as a version control 
 
 We hope you have a good working knowledge of Git. Need some help? Don't worry, we have you covered with some of our favorite links and information. We'll also include a Git guide to branching and developing soon.
 
-*	[Git documentation](https://git-scm.com/documentation){:target="_blank"} and [videos](https://git-scm.com/videos){:target="_blank"} from the makers of Git
-*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf){:target="_blank"} and [quick guide](http://rogerdudler.github.io/git-guide/){:target="_blank"} from Roger Dudler
-*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg){:target="_blank"} with DevForge to understand how people use the repo and commands with a fun story
+*	[Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
+*	[Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
+*	[Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
 
-To get started with Git, you should have [Git installed](https://git-scm.com/downloads){:target="_blank"} on your local.
+To get started with Git, you should have [Git installed](https://git-scm.com/downloads) on your local.
 
 {:.bs-callout .bs-callout-info}
 In addition to Git requirements for valid branch names, {{site.data.var.ee}} adds two additional requirements:

--- a/guides/v2.2/cloud/trouble/robots-sitemap.md
+++ b/guides/v2.2/cloud/trouble/robots-sitemap.md
@@ -15,7 +15,7 @@ With {{site.data.var.ece}}, you can only write to specific directories, such as 
 
 You do not have to generate a `robots.txt` because it generates on demand and stores the contents in the database. It does not create a file, but you can view the content in your browser with the url: `<domain.your.project>/robots.txt`
 
-This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.app.yaml` file. See an example of these rules in the [magento-cloud repository](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml#L43-L49){:target="_blank"}.
+This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.app.yaml` file. See an example of these rules in the [magento-cloud repository](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml#L43-L49).
 
 #### To generate a `sitemap.xml` file in version 2.2 and later:
 

--- a/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
@@ -36,16 +36,16 @@ To best develop and manage your host, we recommend using a virtual machine. The 
 
 For your VM, we recommend installing one of the following:
 
-* [Vagrant](https://www.vagrantup.com/docs/){:target="_blank"} for a virtual machine
-* [Docker](https://docs.docker.com/){:target="_blank"} for a container
+* [Vagrant](https://www.vagrantup.com/docs/) for a virtual machine
+* [Docker](https://docs.docker.com/) for a container
 
-When using Vagrant, we also recommend the package [hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager){:target="_blank"} and using [VirtualBox](https://www.virtualbox.org/wiki/Documentation){:target="_blank"} to manage the environment. VirtualBox extends support and features across all OS and platforms to create and manage multiple VMs and operating systems on your local.
+When using Vagrant, we also recommend the package [hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) and using [VirtualBox](https://www.virtualbox.org/wiki/Documentation) to manage the environment. VirtualBox extends support and features across all OS and platforms to create and manage multiple VMs and operating systems on your local.
 
 ## Development tools {#devtools}
 
-* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git){:target="_blank"} - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host.
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host.
 	For more information, see [How Cloud uses Git]({{ page.baseurl }}/cloud/reference/git-integration.html).
-* [Composer](https://getcomposer.org/download/){:target="_blank"} - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM.
+* [Composer](https://getcomposer.org/download/) - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM.
 	For more information, see [How Cloud uses Composer]({{ page.baseurl }}/cloud/reference/cloud-composer.html).
 
 ## Web server (local) {#webserver}
@@ -54,22 +54,22 @@ We strongly recommend installing [Nginx]({{ page.baseurl }}/install-gde/prereq/n
 
 ## PHP (local) {#php}
 
-Install {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} on your local. We recommend PHP 7.1.3+ or 7.2. For information on installing PHP on CentOS and Ubuntu see [PHP](../../../v2.3/install-gde/prereq/php-centos-ubuntu.html). For instructions for another OS, see the [PHP documentation](http://php.net/manual/en/install.php){:target="_blank"}.
+Install {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} on your local. We recommend PHP 7.1.3+ or 7.2. For information on installing PHP on CentOS and Ubuntu see [PHP](../../../v2.3/install-gde/prereq/php-centos-ubuntu.html). For instructions for another OS, see the [PHP documentation](http://php.net/manual/en/install.php).
 
 The following packages may also be helpful for your PHP installation:
 
-* [bcmath](http://php.net/manual/en/book.bc.php){:target="_blank"}
-* [curl](http://php.net/manual/en/book.curl.php){:target="_blank"}
+* [bcmath](http://php.net/manual/en/book.bc.php)
+* [curl](http://php.net/manual/en/book.curl.php)
 * ext-dom
-* [fpm](https://php-fpm.org/){:target="_blank"}
-* [gd](http://php.net/manual/en/book.image.php){:target="_blank"}
-* [intl](http://php.net/manual/en/book.intl.php){:target="_blank"}
-* [json](http://php.net/manual/en/ref.json.php){:target="_blank"}
-* [mbstring](http://php.net/manual/en/book.mbstring.php){:target="_blank"}
-* [mcrypt](http://php.net/manual/en/book.mcrypt.php){:target="_blank"} (for PHP 7.1 and earlier only)
-* [mysql](http://php.net/manual/en/set.mysqlinfo.php){:target="_blank"}
-* [xml](http://php.net/manual/en/book.xml.php){:target="_blank"}
-* [zip](http://php.net/manual/en/book.zip.php){:target="_blank"}
+* [fpm](https://php-fpm.org/)
+* [gd](http://php.net/manual/en/book.image.php)
+* [intl](http://php.net/manual/en/book.intl.php)
+* [json](http://php.net/manual/en/ref.json.php)
+* [mbstring](http://php.net/manual/en/book.mbstring.php)
+* [mcrypt](http://php.net/manual/en/book.mcrypt.php) (for PHP 7.1 and earlier only)
+* [mysql](http://php.net/manual/en/set.mysqlinfo.php)
+* [xml](http://php.net/manual/en/book.xml.php)
+* [zip](http://php.net/manual/en/book.zip.php)
 
 ### Set up PHP memory limit {#cloud-first-php}
 
@@ -96,7 +96,7 @@ Before working with your {{site.data.var.ece}} project, make sure you set the PH
 
 ## Database (local) {#database}
 
-You have multiple options for databases to use for your local. One database option you may want to consider is MariaDB. The {{site.data.var.ee}} environments use [MariaDB](https://mariadb.org/){:target="_blank"}, with a [Galera Cluster](http://galeracluster.com/){:target="_blank"} with triple redundancy in the Production environment.
+You have multiple options for databases to use for your local. One database option you may want to consider is MariaDB. The {{site.data.var.ee}} environments use [MariaDB](https://mariadb.org/), with a [Galera Cluster](http://galeracluster.com/) with triple redundancy in the Production environment.
 
 Regardless of database, for **Pro plans** you need to modify the `auto_increment_increment` value.
 
@@ -131,7 +131,7 @@ You need to set an auto-increment value for the MariaDB installation.
 
 ### Pro: Set up the auto-increment for MySQL {#cloud-mysql}
 
-The MySQL configuration parameter [`auto_increment_increment`](http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html){:target="_blank"} is set to `1` by default in a local MySQL installation. You need to change this value to `3`.  The {{site.data.var.ee}} database cluster includes 3 database implementations. The increment ensures data is unique across all databases for consistent data in the High Availability structure.
+The MySQL configuration parameter [`auto_increment_increment`](http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html) is set to `1` by default in a local MySQL installation. You need to change this value to `3`.  The {{site.data.var.ee}} database cluster includes 3 database implementations. The increment ensures data is unique across all databases for consistent data in the High Availability structure.
 
 To avoid issues, we recommend you set `auto_increment_increment=3`.
 
@@ -161,7 +161,7 @@ If necessary, set `auto_increment_increment` to 3:
 
 The Magento Cloud command-line interface (CLI) tool helps you manage your projects and code branches on {{site.data.var.ece}}. For a list of available commands, see [Common Magento CLI commands]({{ page.baseurl }}/cloud/reference/cli-ref-topic.html).
 
-These instructions discuss installation using commands for a Unix environment. For Windows, we recommend using [Cygwin](https://www.cygwin.com/){:target="_blank"} or Git Bash.
+These instructions discuss installation using commands for a Unix environment. For Windows, we recommend using [Cygwin](https://www.cygwin.com/) or Git Bash.
 
 To install the Magento Cloud CLI:
 
@@ -179,7 +179,7 @@ To install the Magento Cloud CLI:
 
 		source $HOME/.bashrc
 
-	For more information about the user shell profile, see [.bash_profile vs .bashrc](https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc){:target="_blank"}
+	For more information about the user shell profile, see [.bash_profile vs .bashrc](https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc)
 
 	You can also add the `$HOME/.magento-cloud/bin` to the Magento user's `PATH`:
 

--- a/guides/v2.3/cloud/live/go-live-checklist.md
+++ b/guides/v2.3/cloud/live/go-live-checklist.md
@@ -24,7 +24,7 @@ Contact Support to schedule a Go Live Preparation call. We walk through the Go L
 
 You may [need information]({{ page.baseurl }}/cloud/live/live.html#goliveinfo) for this ticket.
 
-1.	Log in to your [Magento Cloud account](https://accounts.magento.cloud){:target="_blank"}.
+1.	Log in to your [Magento Cloud account](https://accounts.magento.cloud).
 2.	Click **Support** > **Submit ticket** from the top menu.
 3.	Follow the prompts to open an issue with Support.	Support assists you with your live deployment and gives you an IP address for your live site so you can set up DNS.
 5. Provide a list of all storefront domain names for the shared SSL certificate.
@@ -47,11 +47,11 @@ This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-na
 
 The following list contains examples of DNS providers for informational purposes. Use your preferred DNS provider.
 
-*	CNAME with ALIAS record from [Dyn](http://dyn.com){:target="_blank"}
-*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com){:target="_blank"}
-*	ANAME at [easyDNS](https://www.easydns.com){:target="_blank"}
-*	ACNAME at [CloudFlare](https://www.cloudflare.com){:target="_blank"}
-*	ALIAS at [PointDNS](https://pointhq.com){:target="_blank"}
+*	CNAME with ALIAS record from [Dyn](http://dyn.com)
+*	ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
+*	ANAME at [easyDNS](https://www.easydns.com)
+*	ACNAME at [CloudFlare](https://www.cloudflare.com)
+*	ALIAS at [PointDNS](https://pointhq.com)
 
 Many other DNS providers also offer workarounds to accomplish this goal. The most common is to add a CNAME record for the `www` host on the domain and then use the DNS provider's redirect service to redirect the apex over to the `www` version of the domain. Consult your DNS provider for more information.
 
@@ -65,7 +65,7 @@ Another option for apex domain is to add A records, which maps a domain name to 
 
 If you use TLS with Fastly enabled in your environment, you must provide your DNS provider with a TXT record from Fastly. We provide a Domain Validated SSL certificate with Subject Alternative Name enabled, issued by GLobalSign. When entering your [Support ticket](#dns) for DNS information and going live, let us know you are using TLS, provide your domain names and request the TXT record. You can then send this record to your DNS provider. The domain validation process is executed by Fastly.
 
-For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification){:target="_blank"}.
+For details on this TXT record, see Fastly's [DNS TXT record validation](https://docs.fastly.com/guides/securing-communications/domain-validation-for-tls-certificates#dns-text-record-verification).
 
 ## Verify Production configurations
 
@@ -77,9 +77,9 @@ The following are recommended changes and checks:
 *	Base URL and Base Admin URL are set correctly
 *	Change the default Magento Admin password
 
-	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html){:target="_blank"} for further information on Admin configurations.
+	See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html) for further information on Admin configurations.
 *	Optimize all images for the web
-*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html){:target="_blank"} for JS, CSS, and HTTP
+*	[Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html) for JS, CSS, and HTTP
 
 ## Verify Fastly caching {#verifyfastly}
 
@@ -91,15 +91,15 @@ Test and verify Fastly caching is correctly working in Production. For detailed 
 
 ## Performance testing {#performance}
 
-We recommend that you review the [Magento Performance Toolkit]({{ site.mage2300url }}setup/performance-toolkit){:target="_blank"} options as part of your pre-launch readiness process.
+We recommend that you review the [Magento Performance Toolkit]({{ site.mage2300url }}setup/performance-toolkit) options as part of your pre-launch readiness process.
 
 You can also test using the following 3rd party options:
 
-* [Siege](https://www.joedog.org/siege-home/){:target="_blank"}: Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/){:target="_blank"}: Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
-* [New Relic](https://support.newrelic.com/){:target="_blank"} (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
+* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+* [New Relic](https://support.newrelic.com/) (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/){:target="_blank"} and [Pingdom](https://www.pingdom.com/){:target="_blank"}: Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 #### Next step:
 [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)


### PR DESCRIPTION
Removed `{:target="_blank"}` and `{:target="\_blank"}`
from the Cloud guide