### PR TITLE
Add contributor rewards to Contributor Guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,18 +10,16 @@ Working through the backlog takes time, though, so we appreciate your patience.
 ## Rewards for contributions
 
 DevDocs works with the Community Engineering teams and projects.
-As you contribute PRs, you gain [Contribution Points](https://github.com/magento/magento2/wiki/Contribution-Rewards).
+As you contribute PRs, you gain [Contribution Points](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#points).
 
 If you write and contribute a full topic, we will add your name (or your company's name) at the top of the DevDocs page and link it to your blog or website! We post your picture and a link to your GitHub account on the [Top recent contributors](https://devdocs.magento.com/guides/v2.2/contributor-guide/quarterly-contributors.html) page.
 
-## Get started
+## Prerequisites
 
 * Make sure you have a [GitHub account](https://github.com/signup/free). We recommend adding [Two-Factor Authentication](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#two-factor)(2FA) to your account. Partners are required to add 2FA protection when contributing to Magento respositories.
 * Make sure you sign the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca).
 * Check the [guidelines](#contribution-guidelines).
-* [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [DevDocs repository](GitHub.com/magento/devdocs). [Sync](https://help.github.com/articles/syncing-a-fork/) as needed.
-* Write content and commit.  Need help, see our [templates](#templates).
-* Create a [pull request](https://help.github.com/articles/creating-a-pull-request/). Fill out as much info as possible and link any GitHub issues.
+* [Fork](https://help.github.com/articles/fork-a-repo/) or [clone](https://help.github.com/articles/cloning-a-repository/) the [DevDocs repository](GitHub.com/magento/devdocs). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
 
 **Note:** If you have not signed the [Magento Contributor Agreement](http://www.magento.com/legaldocuments/mca), the PR will provide a link to complete. All contributors are required to submit the form and agree to the terms to complete it.
 
@@ -29,9 +27,9 @@ If you write and contribute a full topic, we will add your name (or your company
 
 ## Contribution guidelines
 
-We use [Markdown](http://daringfireball.net/projects/markdown/) to write our documentation, which is a simple markup language that we convert to HTML using [Kramdown](http://kramdown.gettalong.org/syntax.html).
+We use [Markdown](http://daringfireball.net/projects/markdown/) to write our documentation, which is a simple markup language that we convert to HTML using [Kramdown](http://kramdown.gettalong.org/syntax.html). Check [Templates](#templates) for examples of styles and markdown.
 
-You can update, or add content to, existing topics in their respective versioned directories (for 2.0, 2.1, 2.2, and onward).
+You can update existing or add new topics in their respective Magento 2 versioned directories (2.1, 2.2, 2.3, and onward). If you need help finding a directory for your content, we can help in your PR.
 
 The following guidelines may answer most of your questions and help you get started:
 
@@ -44,7 +42,11 @@ The following guidelines may answer most of your questions and help you get star
     -   The DevDocs team can find the best home for your new topics and add it to the navigation.
     -   If a topic has a symlink, you can remove it with git commands and add a new file. Copy and paste a previous version of the topic to get started.
 
-1.  Focus on the content and on creating useful information for your fellow Magento developers and community members. Don't forget to review your work for typos, formatting errors, or sentences that need clarifying before opening a pull request.
+## Write and submit PRs
+
+1.  Create a branch and start writing content in existing or new files.
+
+1.  Focus on the content with useful information, code samples, and important notes for your fellow Magento developers and community members. Don't forget to review your work for typos, formatting errors, or sentences that need clarifying before opening a pull request.
 
 1.  Use the following guidelines to help you with the writing process:
 
@@ -54,6 +56,9 @@ The following guidelines may answer most of your questions and help you get star
     -   Remember to use active voice (not passive), write in the present tense, and use a friendly tone in second person. For example, _"The log captures commands, output..."_.
     -   Use notes to alert readers about important details.
     -   Use cross-references to other topics if appropriate. We can help you with the syntax if it is not clear. The template provides an example you can use.
+    -   Need help with markdown? See our [templates](#templates).
+
+1.  Create a [pull request](https://help.github.com/articles/creating-a-pull-request/). Fill out as much info as possible and link any GitHub issues. DevDocs and Maintainers will review the PR. Watch for comments and requests for changes. We will merge the content when ready with appropriate labels.
 
 ## Preview HTML locally
 
@@ -61,7 +66,7 @@ To preview your changes in HTML output, follow the instructions in the [README](
 
 ## Templates
 
-Edit and add content to existing pages. For new topics, we provide templates to help get you started:
+We provide templates to help you started writing new content and understanding markdown formatting:
 
 * **General topic template** - [Markdown](https://github.com/magento/devdocs/blob/master/guides/v2.1/contributor-guide/templates/basic_template.md) | [HTML](https://devdocs.magento.com/guides/v2.2/contributor-guide/templates/basic_template.html): This is a template for writing any topic with example formats and styles.
 * **Tutorial templates**: These templates provide example formats and styles for step-by-step instructions (like how-tos). Each file adds navigation buttons when content is generated. Templates include:
@@ -71,7 +76,7 @@ Edit and add content to existing pages. For new topics, we provide templates to 
 
 ### Edit metadata
 
-The Markdown (.md) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file.
+The Markdown (.md) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file. For more info, see the [Basic Template](https://devdocs.magento.com/guides/v2.2/contributor-guide/templates/basic_template.html).
 
 ```yaml
 ---
@@ -87,8 +92,6 @@ title: Continue with your installation
 | ------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `group`       | Defines which guide the file belongs to and which left-hand menu collection the to use.                              |
 | `title`       | Sets the title of the page in the HTML meta and the main title on the page.                                          |
-| `version`     | Specifies which version(s) of Magento the topic affects. We also use this data to build links to the file on GitHub. |
-| `github_link` | Specifies the name and location of the source file in the GitHub repository.                                         |
 
 ## Report an issue
 
@@ -106,7 +109,7 @@ You have a couple of options to enter an issue:
 
 Have a question? Need help? Magento DevDocs, Maintainers, and other Contributors are available through:
 
-* [Slack](https://magentocommeng.slack.com/messages/CAN932A3H)
+* [Slack](https://magentocommeng.slack.com/messages/CAN932A3H) ([Join us](http://tinyurl.com/engcom-signup))
 * [Twitter @MagentoDevDocs](https://twitter.com/MagentoDevDocs)
 *	[E-mail](mailto:DL-Magento-Doc-Feedback@magento.com)
 

--- a/_includes/contributor/labels.md
+++ b/_includes/contributor/labels.md
@@ -1,0 +1,105 @@
+### Release Lines
+{:.no_toc}
+
+Release line labels indicate the specific Magento release lines affected by the issue or PR. For example, if working on a fix for 2.2.6, you would apply the Release Line: 2.2. This effectively includes all releases in this line.
+
+* `Release Line: 2.1`
+* `Release Line: 2.2`
+* `Release Line: 2.3`
+
+### Progress
+{:.no_toc}
+
+Progress labels indicate the Pull Request status on each review stage:
+
+* `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
+* `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
+* `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
+* `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
+
+### Contribution awards
+{:.no_toc}
+
+The level of investigation, research, and work required for a task may differ. Contribution Rewards labels  indicate what type of contribution awards will be applied when completing an issue and PR. Some awards will provide higher points and rewards than others.
+
+* `Award: complex`
+* `Award: advanced`
+* `Award: special achievement`
+* `Award: category of expertise`
+* `Award: test coverage`
+* `Award: devdocs update`
+* `Award: MFTF test coverage`
+* `Award: bug fix`
+* `Cleanup`
+* `Port` - For up-port and back-port work
+<!-- For more information on awards and points, see our [Contribution Rewards](http://test.com). -->
+
+### Partners
+{:.no_toc}
+
+All partners Pull Requests should be marked with label `partners-contribution`. Additionally, add a partner label for PRs submitted by specific Partners. Use the format: `Partner: <PartnerName>`. The following are Partner examples:
+
+* `partners-contribution`
+* `Partner: Atwix`
+* `Partner: Comwrap`
+* `Partner: Interactiv4`
+* `Partner: Wagento`
+* `etc`
+
+### Components
+{:.no_toc}
+
+Component labels indicate the components affected by the Pull Request. To learn more about available components and assigned architects, see [Magento Components Assignment](https://github.com/magento/magento2/wiki/Magento-Components-Assignment).
+
+* `Component: Catalog`
+* `Component: Report`
+* `Component: Checkout`
+* `etc`
+
+### Events
+{:.no_toc}
+
+Event labels mark recommended issues and submitted PRs for a specific event. Events may include Contribution Days, Hackathons, Imagine, special events like Smashtoberfest, and others. Contributors and Maintainers can easily locate code when attending those events. Some events may also have a [Community Engineering Slack](https://magentocommeng.slack.com) channel using the same label.
+
+* `Event: mm18in`
+* `Event: mm17es`
+* `Event: mlau18`
+* `etc`
+
+### General
+{:.no_toc}
+
+General labels include a variety of tasks and definitions for pull requests and issues.
+
+* `good first issue` - Indicates a good issue for first-time contributors.
+* `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
+* `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
+
+### Issue Resolution Status
+{:.no_toc}
+<!-- old labels -->
+
+* `G1 Passed` - Automatic verification of the issue description successfully passed. Minimum required information is provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
+* `G1 Failed` - Automatic verification of the issue description failed. Minimum required information is not provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
+* `G2 Passed` - The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce.
+* `G3 Passed` - The Community Engineering Team has validated and confirmed the issue.
+* `Reproduced on 2.1.x` - The Community Engineering Team reproduced the issue on latest 2.1.x release.
+* `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
+* `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
+* `Fixed in 2.1.x` - The issue has been fixed in one of the 2.1.x releases or in 2.1-develop branch and will be available with the upcoming patch release.
+* `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
+* `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
+* `acknowledged` - The Community Engineering Team has created internal ticket.
+* `needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the issue.
+* `Cannot Reproduce` - The Community Engineering Team cannot reproduce the issue with the given steps to reproduce.
+* `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
+
+### DevDocs
+{:.no_toc}
+
+All [contributions to DevDocs](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) receive the following labels:
+
+* `New topic`- New file submissions for content that has never existed on devdocs
+* `Major update` - Significant updates to existing content, such as a new section or example
+* `Technical` - Updates to the code or processes that alter the technical content of the document
+* `Editorial` - Fixes for typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies.

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -9,8 +9,8 @@ Every merged PR receives one of the base achievements and potentially one or mor
 
 Examples:
 
-- Contributor submitsPR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
-- Contributor submitsPR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
+- Contributor submits PR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
+- Contributor submits PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
 - Contributor submits PR port of existing merged PR:
   - Original contributor: (Improvement(base) 10 points + Complex(additional) 20 points) + Author of Ported Issue 5 points = 35 points
   - Porting contributor: Port(base) 5 points

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -1,8 +1,22 @@
-When the Community Engineering team assesses each Pull Request during processing, they also calculate the Contribution Points to award. Every merged PR receives one of the base achievements and potentially one or more additional achievements. Points will be awarded after the PR has been merged.
+Magento is thankful for all contributions, and we always recognize our most active members. The aim is to find and recognize our top contributors according to points awarded during a given time period (monthly/quarterly/yearly). Contributors can earn points in numerous ways with a focus in pull requests to the backlog and special projects.
 
-For example, your PR may receive Improvement(base), Complex(additional), and Test coverage(additional) which sums up to 40 points.
+The Community Engineering team assesses each pull request and determines the best awards for the work involved. Contribution Points are calculated according to the assessment results. Each contributor receives points after the pull request is merged.
 
-Achievements applied to pull requests are displayed as labels on GitHub and also published in the section "Magento Contributors" on [magento.com](https://magento.com/magento-contributors)
+### How points are awarded
+{:.no_toc}
+
+Every merged PR receives one of the base achievements and potentially one or more additional achievements. Points will be awarded after the PR has been merged. Contributors and Maintainers receive the same amount of points due to the level of work completed by each person on the PR.
+
+Examples:
+
+- Contributor submitsPR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
+- Contributor submitsPR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
+- Contributor submits PR port of existing merged PR:
+  - Original contributor: (Improvement(base) 10 points + Complex(additional) 20 points) + Author of Ported Issue 5 points = 35 points
+  - Porting contributor: Port(base) 5 points
+- Maintainer reviews and approves PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
+
+Earned achievements displays as labels on GitHub PRs and displayed per Magento Contributor, Partner, and Maintainer on [magento.com](https://magento.com/magento-contributors).
 
 ### Base achievements
 {:.no_toc}
@@ -13,24 +27,27 @@ Achievement | Points | Description
 | ------------ | --- | --- |
 Improvement| 10 | Contribution contains code improvements, refactoring or a bug fix.
 Port | 5 | Contribution ports an existing solution between release lines. The author of original PR receives additional **5 points** when another person contributes the ported Pull Request.
-Code Cleanup | 1 | Contribution contains code cleanup (typos, inline documentation, coding style, removed unused code, etc).
+Code Cleanup | 1 | Contribution contains code cleanup (typos, inline documentation, coding style, remove unused code, and so on).
+  |   |
 
 ### Additional achievements
 {:.no_toc}
+
+Every Pull Request may receive several additional achievements according to assessment result. All additional achievements sum up with base achievements.
 
 Achievement | Points | Description
 | ------------ | --- | --- |
 Advanced | 30 | Contribution provides new features. For example: introducing a new CLI command, integration with the new payment or shipping methods, and so on
 Complex | 20 | Contribution contains complete refactoring of legacy code, improvements to application design, updates to libraries, and so on
-Special achievement | 20 | Contribution earns recognition in a specific category. For example extensive tests coverage, improved framework design, improved APIs or API coverage, improved customizability, etc
-Test coverage | 10 | Contribution contains fix or improvement and some kind of new test or test cases
+Special achievement | 20 | Contribution earns recognition in a specific category. For example: extensive tests coverage, improved framework design, improved APIs or API coverage, improved customizability, and so on
+Test coverage | 10 | Contribution contains fix or improvement and new tests or test cases
 MFTF test coverage| 10 | Contribution contains MFTF tests
 Bug fix | 10 | Contribution fixes one or more known issues from GitHub
 Author of Ported Issue | 5 | Additional points for a contribution that ports (up or back port) a previous PR across release lines by another contributor
 
 ## DevDocs awards and points
 
-You can gain points for merged submissions to the [DevDocs repository](https://github.com/magento/devdocs). These earned points add to your contributor totals, also based on labels assigned to your PRs. Each PR receives one base achievement and potentially one additional achievement.
+You can gain points for merged submissions to the [DevDocs repository](https://github.com/magento/devdocs). These earned points add to your contributor totals, also based on labels assigned to your PRs. Each PR receives one base achievement and potentially additional achievements.
 
 ### Base achievements
 {:.no_toc}

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -1,0 +1,54 @@
+When the Community Engineering team assesses each Pull Request during processing, they also calculate the Contribution Points to award. Every merged PR receives one of the base achievements and potentially one or more additional achievements. Points will be awarded after the PR has been merged.
+
+For example, your PR may receive Improvement(base), Complex(additional), and Test coverage(additional) which sums up to 40 points.
+
+Achievements applied to pull requests are displayed as labels on GitHub and also published in the section "Magento Contributors" on [magento.com](https://magento.com/magento-contributors)
+
+### Base achievements
+{:.no_toc}
+
+Every merged Pull Request receive one of the base achievements.
+
+Achievement | Points | Description
+| ------------ | --- | --- |
+Improvement| 10 | Contribution contains code improvements, refactoring or a bug fix.
+Port | 5 | Contribution ports an existing solution between release lines. The author of original PR receives additional **5 points** when another person contributes the ported Pull Request.
+Code Cleanup | 1 | Contribution contains code cleanup (typos, inline documentation, coding style, removed unused code, etc).
+
+### Additional achievements
+{:.no_toc}
+
+Achievement | Points | Description
+| ------------ | --- | --- |
+Advanced | 30 | Contribution provides new features. For example: introducing a new CLI command, integration with the new payment or shipping methods, and so on
+Complex | 20 | Contribution contains complete refactoring of legacy code, improvements to application design, updates to libraries, and so on
+Special achievement | 20 | Contribution earns recognition in a specific category. For example extensive tests coverage, improved framework design, improved APIs or API coverage, improved customizability, etc
+Test coverage | 10 | Contribution contains fix or improvement and some kind of new test or test cases
+MFTF test coverage| 10 | Contribution contains MFTF tests
+Bug fix | 10 | Contribution fixes one or more known issues from GitHub
+Author of Ported Issue | 5 | Additional points for a contribution that ports (up or back port) a previous PR across release lines by another contributor
+
+## DevDocs awards and points
+
+You can gain points for merged submissions to the [DevDocs repository](https://github.com/magento/devdocs). These earned points add to your contributor totals, also based on labels assigned to your PRs. Each PR receives one base achievement and potentially one additional achievement.
+
+### Base achievements
+{:.no_toc}
+
+Every merged PR to the [DevDocs repository](https://github.com/magento/devdocs) receives one base achievement:
+
+Achievement | Points | Description
+| ------------ | --- | --- |
+Improvement | 10 | Contribution contains document improvement, adding missing features of inconsistency between code base and documentation.
+Editorial | 1 | Contribution contains typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies.
+
+### Additional achievements
+{:.no_toc}
+
+Each PR can earn one of the following additional achievements. If you entered an editorial PR, you may not receive an additional achievement.
+
+Achievement | Points | Description
+| ------------ | --- | --- |
+New topic | 30 | New file submissions for content that has never existed on devdocs
+Major update | 20 | Significant updates to existing content, such as a new section or example
+Technical | 10 | Updates to the code or processes that alter the technical content of the document

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -1,13 +1,15 @@
 Magento is thankful for all contributions, and we always recognize our most active members. The aim is to find and recognize our top contributors according to points awarded during a given time period (monthly/quarterly/yearly). Contributors can earn points in numerous ways with a focus in pull requests to the backlog and special projects.
 
-The Community Engineering team assesses each pull request and determines the best awards for the work involved. Contribution Points are calculated according to the assessment results. Each contributor receives points after the pull request is merged.
+The Community Engineering team assesses each Pull Request and determines the best awards for the work involved. Contribution Points are calculated according to the assessment results. We award points when the PR is merged.
 
 ### How points are awarded
 {:.no_toc}
 
-Every merged PR receives one of the base achievements and potentially one or more additional achievements. Points will be awarded after the PR has been merged. Contributors and Maintainers receive the same amount of points due to the level of work completed by each person on the PR.
+Every merged PR receives one base achievement and potentially one or more additional achievements. These achievements are applied to PRs during review and assessment. Contributors and Maintainers receive points after the PR has been merged.
 
-Examples:
+Due to the level of work required for developing and reviewing a PR, Contributors and Maintainers receive the same amount of points.
+
+See the following examples for calculated reward points:
 
 - Contributor submits PR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
 - Contributor submits PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
@@ -16,24 +18,23 @@ Examples:
   - Porting contributor: Port(base) 5 points
 - Maintainer reviews and approves PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
 
-Earned achievements displays as labels on GitHub PRs and displayed per Magento Contributor, Partner, and Maintainer on [magento.com](https://magento.com/magento-contributors).
+Earned achievements display as labels on GitHub PRs and for each Magento Contributor, Partner, and Maintainer on [magento.com](https://magento.com/magento-contributors).
 
 ### Base achievements
 {:.no_toc}
 
-Every merged Pull Request receive one of the base achievements.
+Every merged PR receives one base achievement.
 
 Achievement | Points | Description
 | ------------ | --- | --- |
-Improvement| 10 | Contribution contains code improvements, refactoring or a bug fix.
-Port | 5 | Contribution ports an existing solution between release lines. The author of original PR receives additional **5 points** when another person contributes the ported Pull Request.
-Code Cleanup | 1 | Contribution contains code cleanup (typos, inline documentation, coding style, remove unused code, and so on).
-  |   |
+Improvement| 10 | Contribution contains code improvements, refactoring, or a bug fix.
+Port | 5 | Contribution ports an existing solution between release lines. The author of the original PR receives an additional **5 points** when another person contributes the ported Pull Request.
+Code Cleanup | 1 | Contribution contains code cleanup such as typos, inline documentation, coding style, remove unused code, and so on.
 
 ### Additional achievements
 {:.no_toc}
 
-Every Pull Request may receive several additional achievements according to assessment result. All additional achievements sum up with base achievements.
+Every PR may receive several additional achievements during assessment.
 
 Achievement | Points | Description
 | ------------ | --- | --- |
@@ -47,17 +48,17 @@ Author of Ported Issue | 5 | Additional points for a contribution that ports (up
 
 ## DevDocs awards and points
 
-You can gain points for merged submissions to the [DevDocs repository](https://github.com/magento/devdocs). These earned points add to your contributor totals, also based on labels assigned to your PRs. Each PR receives one base achievement and potentially additional achievements.
+Contributors and Maintainers can also earn rewards for merged submissions to the [DevDocs repository](https://github.com/magento/devdocs). These earned points add to contributor totals. Like code contributions, the DevDocs team assesses the PRs and apply labels to determine the level of work and achievements. Each PR receives one base achievement and potentially additional achievements.
 
 ### Base achievements
 {:.no_toc}
 
-Every merged PR to the [DevDocs repository](https://github.com/magento/devdocs) receives one base achievement:
+Every merged PR to the [DevDocs repository](https://github.com/magento/devdocs) receives one base achievement. If you enter a PR with editorial fixes and new content, you receive the Improvement and additional achievements.
 
 Achievement | Points | Description
 | ------------ | --- | --- |
-Improvement | 10 | Contribution contains document improvement, adding missing features of inconsistency between code base and documentation.
-Editorial | 1 | Contribution contains typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies.
+Improvement | 10 | Contribution contains document improvements, adding missing features of inconsistency between code base and documentation, and so on.
+Editorial | 1 | Contribution contains fixes only for typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies.
 
 ### Additional achievements
 {:.no_toc}
@@ -68,4 +69,4 @@ Achievement | Points | Description
 | ------------ | --- | --- |
 New topic | 30 | New file submissions for content that has never existed on devdocs
 Major update | 20 | Significant updates to existing content, such as a new section or example
-Technical | 10 | Updates to the code or processes that alter the technical content of the document
+Technical | 10 | Updates to code or processes that alter the technical content of the document

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -18,6 +18,7 @@ The following topics are included in this guide:
 - [Report an issue](#report)
 - [Help triage issues](#triage)
 - [Labels applied by the Community Engineering Team](#labels)
+- [Contribution awards and points](#points)
 
 ## Contribute to Magento 2 code {#contribute}
 
@@ -321,90 +322,12 @@ In addition to contributing code, you can help to triage issues. This can includ
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-### Release Lines
+## Labels applied by the Magento team {#labels}
 
-Release line labels indicate the specific Magento release lines affected by the issue or PR. For example, if working on a fix for 2.2.6, you would apply the Release Line: 2.2. This effectively includes all releases in this line.
+We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-* `Release Line: 2.1`
-* `Release Line: 2.2`
-* `Release Line: 2.3`
+{% include_relative ../includes/contributor/labels.md %}
 
-### Progress
+## Contribution awards and points {#points}
 
-Progress labels indicate the Pull Request status on each review stage:
-
-* `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
-* `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
-* `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
-* `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
-
-### Contribution Rewards
-
-The level of investigation, research, and work required for a task may differ. Contribution Rewards labels  indicate what type of contribution awards will be applied when completing an issue and PR. Some awards will provide higher points and rewards than others.
-
-* `Award: complex`
-* `Award: advanced`
-* `Award: special achievement`
-* `Award: category of expertise`
-* `Award: test coverage`
-* `Award: devdocs update`
-* `Award: MFTF test coverage`
-* `Award: bug fix`
-* `Cleanup`
-* `Port` - For up-port and back-port work
-<!-- For more information on awards and points, see our [Contribution Rewards](http://test.com). -->
-
-### Partners
-
-All partners Pull Requests should be marked with label `partners-contribution`. Additionally, add a partner label for PRs submitted by specific Partners. Use the format: `Partner: <PartnerName>`. The following are Partner examples:
-
-* `partners-contribution`
-* `Partner: Atwix`
-* `Partner: Comwrap`
-* `Partner: Interactiv4`
-* `Partner: Wagento`
-* `etc`
-
-### Components
-
-Component labels indicate the components affected by the Pull Request. To learn more about available components and assigned architects, see [Magento Components Assignment](https://github.com/magento/magento2/wiki/Magento-Components-Assignment).
-
-* `Component: Catalog`
-* `Component: Report`
-* `Component: Checkout`
-* `etc`
-
-### Events
-
-Event labels mark recommended issues and submitted PRs for a specific event. Events may include Contribution Days, Hackathons, Imagine, special events like Smashtoberfest, and others. Contributors and Maintainers can easily locate code when attending those events. Some events may also have a [Community Engineering Slack](https://magentocommeng.slack.com) channel using the same label.
-
-* `Event: mm18in`
-* `Event: mm17es`
-* `Event: mlau18`
-* `etc`
-
-### General Labels
-
-General labels include a variety of tasks and definitions for pull requests and issues.
-
-* `good first issue` - Indicates a good issue for first-time contributors.
-* `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
-* `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
-
-### Issue Resolution Status
-<!-- old labels -->
-
-* `G1 Passed` - Automatic verification of the issue description successfully passed. Minimum required information is provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G1 Failed` - Automatic verification of the issue description failed. Minimum required information is not provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G2 Passed` - The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce.
-* `G3 Passed` - The Community Engineering Team has validated and confirmed the issue.
-* `Reproduced on 2.1.x` - The Community Engineering Team reproduced the issue on latest 2.1.x release.
-* `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
-* `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
-* `Fixed in 2.1.x` - The issue has been fixed in one of the 2.1.x releases or in 2.1-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
-* `acknowledged` - The Community Engineering Team has created internal ticket.
-* `needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the issue.
-* `Cannot Reproduce` - The Community Engineering Team cannot reproduce the issue with the given steps to reproduce.
-* `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
+{% include_relative ../includes/contributor/rewards.md %}

--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -326,8 +326,8 @@ We apply labels to public Pull Requests and Issues to help other participants re
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-{% include_relative ../includes/contributor/labels.md %}
+{% include contributor/labels.md %}
 
 ## Contribution awards and points {#points}
 
-{% include_relative ../includes/contributor/rewards.md %}
+{% include contributor/rewards.md %}

--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -321,8 +321,8 @@ In addition to contributing code, you can help to triage issues. This can includ
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-{% include_relative ../includes/contributor/labels.md %}
+{% include contributor/labels.md %}
 
 ## Contribution awards and points {#points}
 
-{% include_relative ../includes/contributor/rewards.md %}
+{% include contributor/rewards.md %}

--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -17,6 +17,7 @@ The following topics are included in this guide:
 - [Report an issue](#report)
 - [Help triage issues](#triage)
 - [Labels applied by the Community Engineering Team](#labels)
+- [Contribution awards and points](#points)
 
 ## Contribute to Magento 2 code {#contribute}
 
@@ -320,90 +321,8 @@ In addition to contributing code, you can help to triage issues. This can includ
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-### Release Lines
+{% include_relative ../includes/contributor/labels.md %}
 
-Release line labels indicate the specific Magento release lines affected by the issue or PR. For example, if working on a fix for 2.2.6, you would apply the Release Line: 2.2. This effectively includes all releases in this line.
+## Contribution awards and points {#points}
 
-* `Release Line: 2.1`
-* `Release Line: 2.2`
-* `Release Line: 2.3`
-
-### Progress
-
-Progress labels indicate the Pull Request status on each review stage:
-
-* `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
-* `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
-* `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
-* `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
-
-### Contribution Rewards
-
-The level of investigation, research, and work required for a task may differ. Contribution Rewards labels  indicate what type of contribution awards will be applied when completing an issue and PR. Some awards will provide higher points and rewards than others.
-
-* `Award: complex`
-* `Award: advanced`
-* `Award: special achievement`
-* `Award: category of expertise`
-* `Award: test coverage`
-* `Award: devdocs update`
-* `Award: MFTF test coverage`
-* `Award: bug fix`
-* `Cleanup`
-* `Port` - For up-port and back-port work
-<!-- For more information on awards and points, see our [Contribution Rewards](http://test.com). -->
-
-### Partners
-
-All partners Pull Requests should be marked with label `partners-contribution`. Additionally, add a partner label for PRs submitted by specific Partners. Use the format: `Partner: <PartnerName>`. The following are Partner examples:
-
-* `partners-contribution`
-* `Partner: Atwix`
-* `Partner: Comwrap`
-* `Partner: Interactiv4`
-* `Partner: Wagento`
-* `etc`
-
-### Components
-
-Component labels indicate the components affected by the Pull Request. To learn more about available components and assigned architects, see [Magento Components Assignment](https://github.com/magento/magento2/wiki/Magento-Components-Assignment).
-
-* `Component: Catalog`
-* `Component: Report`
-* `Component: Checkout`
-* `etc`
-
-### Events
-
-Event labels mark recommended issues and submitted PRs for a specific event. Events may include Contribution Days, Hackathons, Imagine, special events like Smashtoberfest, and others. Contributors and Maintainers can easily locate code when attending those events. Some events may also have a [Community Engineering Slack](https://magentocommeng.slack.com) channel using the same label.
-
-* `Event: mm18in`
-* `Event: mm17es`
-* `Event: mlau18`
-* `etc`
-
-### General Labels
-
-General labels include a variety of tasks and definitions for pull requests and issues.
-
-* `good first issue` - Indicates a good issue for first-time contributors.
-* `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
-* `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
-
-### Issue Resolution Status
-<!-- old labels -->
-
-* `G1 Passed` - Automatic verification of the issue description successfully passed. Minimum required information is provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G1 Failed` - Automatic verification of the issue description failed. Minimum required information is not provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G2 Passed` - The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce.
-* `G3 Passed` - The Community Engineering Team has validated and confirmed the issue.
-* `Reproduced on 2.1.x` - The Community Engineering Team reproduced the issue on latest 2.1.x release.
-* `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
-* `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
-* `Fixed in 2.1.x` - The issue has been fixed in one of the 2.1.x releases or in 2.1-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
-* `acknowledged` - The Community Engineering Team has created internal ticket.
-* `needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the issue.
-* `Cannot Reproduce` - The Community Engineering Team cannot reproduce the issue with the given steps to reproduce.
-* `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
+{% include_relative ../includes/contributor/rewards.md %}

--- a/guides/v2.3/contributor-guide/contributing.md
+++ b/guides/v2.3/contributor-guide/contributing.md
@@ -16,6 +16,7 @@ The following topics are included in this guide:
 - [Report an issue](#report)
 - [Help triage issues](#triage)
 - [Labels applied by the Community Engineering Team](#labels)
+- [Contribution awards and points](#points)
 
 ## Contribute to Magento 2 code {#contribute}
 
@@ -319,90 +320,12 @@ In addition to contributing code, you can help to triage issues. This can includ
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-### Release Lines
+## Labels applied by the Magento team {#labels}
 
-Release line labels indicate the specific Magento release lines affected by the issue or PR. For example, if working on a fix for 2.2.6, you would apply the Release Line: 2.2. This effectively includes all releases in this line.
+We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-* `Release Line: 2.1`
-* `Release Line: 2.2`
-* `Release Line: 2.3`
+{% include_relative ../includes/contributor/labels.md %}
 
-### Progress
+## Contribution awards and points {#points}
 
-Progress labels indicate the Pull Request status on each review stage:
-
-* `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
-* `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
-* `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
-* `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
-
-### Contribution Rewards
-
-The level of investigation, research, and work required for a task may differ. Contribution Rewards labels  indicate what type of contribution awards will be applied when completing an issue and PR. Some awards will provide higher points and rewards than others.
-
-* `Award: complex`
-* `Award: advanced`
-* `Award: special achievement`
-* `Award: category of expertise`
-* `Award: test coverage`
-* `Award: devdocs update`
-* `Award: MFTF test coverage`
-* `Award: bug fix`
-* `Cleanup`
-* `Port` - For up-port and back-port work
-<!-- For more information on awards and points, see our [Contribution Rewards](http://test.com). -->
-
-### Partners
-
-All partners Pull Requests should be marked with label `partners-contribution`. Additionally, add a partner label for PRs submitted by specific Partners. Use the format: `Partner: <PartnerName>`. The following are Partner examples:
-
-* `partners-contribution`
-* `Partner: Atwix`
-* `Partner: Comwrap`
-* `Partner: Interactiv4`
-* `Partner: Wagento`
-* `etc`
-
-### Components
-
-Component labels indicate the components affected by the Pull Request. To learn more about available components and assigned architects, see [Magento Components Assignment](https://github.com/magento/magento2/wiki/Magento-Components-Assignment).
-
-* `Component: Catalog`
-* `Component: Report`
-* `Component: Checkout`
-* `etc`
-
-### Events
-
-Event labels mark recommended issues and submitted PRs for a specific event. Events may include Contribution Days, Hackathons, Imagine, special events like Smashtoberfest, and others. Contributors and Maintainers can easily locate code when attending those events. Some events may also have a [Community Engineering Slack](https://magentocommeng.slack.com) channel using the same label.
-
-* `Event: mm18in`
-* `Event: mm17es`
-* `Event: mlau18`
-* `etc`
-
-### General Labels
-
-General labels include a variety of tasks and definitions for pull requests and issues.
-
-* `good first issue` - Indicates a good issue for first-time contributors.
-* `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
-* `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
-
-### Issue Resolution Status
-<!-- old labels -->
-
-* `G1 Passed` - Automatic verification of the issue description successfully passed. Minimum required information is provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G1 Failed` - Automatic verification of the issue description failed. Minimum required information is not provided (Preconditions, Steps to Reproduce, Actual Result, Expected Result).
-* `G2 Passed` - The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce.
-* `G3 Passed` - The Community Engineering Team has validated and confirmed the issue.
-* `Reproduced on 2.1.x` - The Community Engineering Team reproduced the issue on latest 2.1.x release.
-* `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
-* `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
-* `Fixed in 2.1.x` - The issue has been fixed in one of the 2.1.x releases or in 2.1-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
-* `acknowledged` - The Community Engineering Team has created internal ticket.
-* `needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the issue.
-* `Cannot Reproduce` - The Community Engineering Team cannot reproduce the issue with the given steps to reproduce.
-* `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
+{% include_relative ../includes/contributor/rewards.md %}

--- a/guides/v2.3/contributor-guide/contributing.md
+++ b/guides/v2.3/contributor-guide/contributing.md
@@ -324,8 +324,8 @@ We apply labels to public Pull Requests and Issues to help other participants re
 
 We apply labels to public Pull Requests and Issues to help other participants retrieve additional information about current progress, component assignments, Magento release lines, and much more. The following information details global labels used in Magento 2 repositories and across Community Engineering contributions.
 
-{% include_relative ../includes/contributor/labels.md %}
+{% include contributor/labels.md %}
 
 ## Contribution awards and points {#points}
 
-{% include_relative ../includes/contributor/rewards.md %}
+{% include contributor/rewards.md %}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Adds content for contributor rewards for pull requests. Already reviewed by Stanislav.
Moved labels and rewards into include files, added to all versions of the Contributor guide. 
Cleanup of CONTRIBUTING.md

whatsnew
Added [Contribution awards and points](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#points) section to the [Contributor Guide](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html)