### PR TITLE
[MFTF 2.3.7] MQE-1248: Expose MFTF DEFAULT_TIMEZONE configuration in .env

### DIFF
--- a/mftf/2.3/configuration.md
+++ b/mftf/2.3/configuration.md
@@ -62,6 +62,16 @@ In most cases, these values are not required.
 Sensible defaults are in place.
 But in case you do need to do some configuration, they are shown here for your reference.
 
+### DEFAULT_TIMEZONE
+
+Timezone used for `generateDate` actions that do not have a `timezone` specified. Will use `America/Los_Angeles` if one is not specified.
+
+Example: 
+
+```conf
+DEFAULT_TIMEZONE=UTC
+```
+
 ### SELENIUM
 
 The `SELENIUM_*` values form the URL of a custom Selenium server for running testing.


### PR DESCRIPTION

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

- Added DEFAULT_TIMEZONE configuration parameter.

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->