### PR TITLE
Fixed Typo on get-payment-info.html

### DIFF
--- a/guides/v2.1/payments-integrations/base-integration/get-payment-info.md
+++ b/guides/v2.1/payments-integrations/base-integration/get-payment-info.md
@@ -11,7 +11,7 @@ functional_areas:
 To implement transaction {% glossarytooltip 34ecb0ab-b8a3-42d9-a728-0b893e8c0417 %}authorization{% endglossarytooltip %} our payment should receive some payment details from payment form, like credit card details,
 and send received details to payment processor.
 
-Depends on your payment integration payment details might be different, but, usually, it's credit card details, tokenized cards, payment nonce, etc.
+Depending on your payment integration payment details might be different, but, usually, it's credit card details, tokenized cards, payment nonce, etc.
 
 However, in any case you should write some code to retrieve payment details from payment form.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix a typo on 
guides/v2.2/payments-integrations/base-integration/get-payment-info.html

depends -> depening

## Additional information

List all affected URL's 
https://devdocs.magento.com/guides/v2.1/payments-integrations/base-integration/get-payment-info.html
https://devdocs.magento.com/guides/v2.2/payments-integrations/base-integration/get-payment-info.html
https://devdocs.magento.com/guides/v2.3/payments-integrations/base-integration/get-payment-info.html
