### PR TITLE
 ask_magento twitter account no longer available

### DIFF
--- a/_includes/install/get-help.md
+++ b/_includes/install/get-help.md
@@ -4,7 +4,7 @@ In the event you need additional help, consult the following resources.
 
 |Magento edition|How to get help|
 |--- |--- |
-|{{site.data.var.ce}} and {{site.data.var.ee}}|- [Magento support forums](http://community.magento.com/)<br>- [stack Exchange](http://magento.stackexchange.com)<br>- [Twitter](https://twitter.com/ask_magento)|
+|{{site.data.var.ce}} and {{site.data.var.ee}}|- [Magento support forums](http://community.magento.com/)<br>- [stack Exchange](http://magento.stackexchange.com)|
 |{{site.data.var.ce}}|[Submit bug reports](http://www.magentocommerce.com/bug-tracking)|
 |{{site.data.var.ee}} only|[Submit bug reports](http://support.magentocommerce.com)|
 {:style="table-layout:auto;"}

--- a/_includes/install/get-help.md
+++ b/_includes/install/get-help.md
@@ -4,7 +4,7 @@ In the event you need additional help, consult the following resources.
 
 |Magento edition|How to get help|
 |--- |--- |
-|{{site.data.var.ce}} and {{site.data.var.ee}}|- [Magento support forums](http://community.magento.com/)<br>- [stack Exchange](http://magento.stackexchange.com)|
+|{{site.data.var.ce}} and {{site.data.var.ee}}|- [Magento support forums](http://community.magento.com/)<br>- [stack Exchange](http://magento.stackexchange.com)<br>- [Twitter](https://twitter.com/magento)|
 |{{site.data.var.ce}}|[Submit bug reports](http://www.magentocommerce.com/bug-tracking)|
 |{{site.data.var.ee}} only|[Submit bug reports](http://support.magentocommerce.com)|
 {:style="table-layout:auto;"}


### PR DESCRIPTION
The twitter account ask_magento is no longer available (see https://twitter.com/ask_magento)
> This handle is no longer monitored. Find us over at magento!

So, the link should be removed

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

removed old twitter account from help page.

