### PR TITLE
extend list of compatible database servers

### DIFF
--- a/guides/v2.2/install-gde/system-requirements-tech.md
+++ b/guides/v2.2/install-gde/system-requirements-tech.md
@@ -34,7 +34,7 @@ Upgrading the Magento applications and extensions you obtain from Magento Market
 
 MySQL 5.6, 5.7
 
-Magento is also compatible with MySQL NDB Cluster 7.4.&#42;, MariaDB 10.0, 10.1, 10.2, Percona 5.7, and other binary-compatible MySQL technologies.
+Magento is also compatible with MySQL NDB Cluster 7.4.&#42;, MariaDB 10.0, 10.1, 10.2, 10.3, Percona 5.7, and other binary-compatible MySQL technologies.
 
 {:.bs-callout bs-callout-info}
 Magento only uses MySQL features compatible with MariaDB. MariaDB may not be compatible with all MySQL features, however, so be sure to research compatibility issues before using a feature in your Magento module.


### PR DESCRIPTION
as there are no relevant breaking changes between MariaDB 10.2 and 10.3 (see https://mariadb.com/kb/en/library/changes-improvements-in-mariadb-103/ ) it can be added to the list of compatible database servers as well

## This PR is a:

- Content fix or rewrite

## Summary

When this pull request is merged, it will at MariaDB 10.3 to the list of compatible database servers
