### PR TITLE
fix redirecting link on the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ guide_version: '2.2'
       <img src="{{ site.baseurl }}/i/icons/install.svg" alt="" />
       <h2 class="title">Setup</h2>
       <ul>
-        <li><a href="{{ site.baseurl }}/magento-system-requirements.html">System Requirements</a></li>
+        <li><a href="{{ site.baseurl }}/system-requirements.html">System Requirements</a></li>
         <li><a href="{{ page.baseurl }}/install-gde/bk-install-guide.html">Installation Guide</a></li>
         <li><a href="{{ page.baseurl }}/config-guide/bk-config-guide.html">Configuration Guide</a></li>
         <li><a href="{{ page.baseurl }}/cloud/bk-cloud.html">{{site.data.var.ece}}</a></li>

--- a/system-requirements.md
+++ b/system-requirements.md
@@ -5,7 +5,7 @@ group: system-requirements
 
 To find individual system requirements for the Magento 2.0.x, 2.1.x, 2.2.x, and 2.3.x releases, see the following pages:
 
-*	[Magento 2.0.x system requirements](http://devdocs.magento.com/guides/v2.0/install-gde/system-requirements2.html)
+* [Magento 2.3.x system requirements](http://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html)
+* [Magento 2.2.x system requirements](http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements2.html)
 *	[Magento 2.1.x system requirements](http://devdocs.magento.com/guides/v2.1/install-gde/system-requirements2.html)
-*   [Magento 2.2.x system requirements](http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements2.html)
-*   [Magento 2.3.x system requirements](http://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html)
+*	[Magento 2.0.x system requirements](http://devdocs.magento.com/guides/v2.0/install-gde/system-requirements2.html)


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, the "System Requirements" link on the 2.2 version of the devdocs index page will no longer redirect to the 2.3 version of the topic. 