### PR TITLE
Changed example code

### DIFF
--- a/guides/v2.2/config-guide/redis/redis-pg-cache.md
+++ b/guides/v2.2/config-guide/redis/redis-pg-cache.md
@@ -122,33 +122,27 @@ The following example enables Redis page caching, sets the host to `redis.exampl
 As a result of the two example commands, Magento adds lines similar to the following to `<Magento install dir>app/etc/env.php`:
 
 ```
-'cache' =>
-  array(
-    'frontend' =>
-      array(
-        'default' =>
-          array(
+'cache' => [
+    'frontend' => [
+        'default' => [
             'backend' => 'Cm_Cache_Backend_Redis',
-            'backend_options' =>
-              array(
+            'backend_options' => [
                 'server' => 'redis.example.com',
                 'database' => '0',
                 'port' => '6379'
-              ),
-        ),
-        'page_cache' =>
-          array(
+            ],
+        ],
+        'page_cache' => [
             'backend' => 'Cm_Cache_Backend_Redis',
-            'backend_options' =>
-              array(
+            'backend_options' => [
                 'server' => 'redis.example.com',
                 'port' => '6379',
                 'database' => '1',
                 'compress_data' => '0'
-              )
-        )
-    )
-  ),
+            ]
+        ]
+    ]
+],
 ```
 
 ## Basic verification {#redis-verify}


### PR DESCRIPTION
## This PR is a:

- Content update
- Content fix or rewrite
- Improvement

## Summary

Magento uses [ ] for arrays instead of array() in the env.php file. 
Changed this example code so that it confirms to this standard.

## Additional information

List all affected URL's 

https://devdocs.magento.com/guides/v2.3/config-guide/redis/redis-pg-cache.html
