### PR TITLE
clarify version availablility

### DIFF
--- a/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
+++ b/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
@@ -5,7 +5,7 @@ ee_only: true
 ---
 
 {: .bs-callout .bs-callout-warning }
-The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} 2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
+The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
 
 ## Installation
 

--- a/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
+++ b/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
@@ -1,14 +1,11 @@
 ---
 group: software-update-guide
-subgroup: 10_Install extensions from the command line
 title: Install the B2B extension
-menu_title: Install the B2B extension
-menu_order: 1
 ee_only: true
 ---
 
 {: .bs-callout .bs-callout-warning }
-The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v2.2.0. You must install it after installing {{site.data.var.ee}}.
+The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} 2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
 
 ## Installation
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, the note at the top of "Install the B2B extension" will no longer indicate that B2B is only available for 2.2.

## Additional information

List all affected URL's 
https://devdocs.magento.com/guides/v2.2/comp-mgr/install-extensions/b2b-installation.html
https://devdocs.magento.com/guides/v2.3/comp-mgr/install-extensions/b2b-installation.html
