### PR TITLE
MQE-1040: MFTF standalone commands do not pass down constants correctly

### DIFF
--- a/guides/v2.2/magento-functional-testing-framework/2.2/configuration.md
+++ b/guides/v2.2/magento-functional-testing-framework/2.2/configuration.md
@@ -111,10 +111,19 @@ These values can be used in cases where you are working locally on both MFTF's i
 Use them if you have a more advanced local development setup involving symlinking MFTF into the `vendor` directory of `magento2`.
 
 ```config
+MAGENTO_BP
 TESTS_BP
 FW_BP
 TESTS_MODULES_PATH
 ```
+
+#### MAGENTO_BP
+
+BP is an acronym for BasePath.
+
+* Use: Optional.
+* Description: The path to a Magento2 codebase
+* Example: `~/magento2ce/`
 
 #### TESTS_BP
 


### PR DESCRIPTION
- Added MAGENTO_BP to configuration file

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
