### PR TITLE
Updated disable-module-output.md with DB options (#2959)

### DIFF
--- a/guides/v2.2/config-guide/config/disable-module-output.md
+++ b/guides/v2.2/config-guide/config/disable-module-output.md
@@ -79,3 +79,6 @@ Archive the original `<Magento_install_dir>/app/etc/config.php` file. Then add t
 Here, the `array` beneath `modules_disable_output` contains a list of modules. A value of `1` disables output for that module.
 
 As a sample result of this configuration, customers can no longer sign up to receive newsletters.
+
+{:.bs-callout .bs-callout-info}
+Even if no disabled modules are specified in the above options, the module can be disabled by value in database in table `core_config_data`. Such a module can be found by value with `advanced/modules_disable_output/VendorName_ModuleName` in the `path` column.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Add information about how module output can be disabled through database tables.
<!-- (REQUIRED) What does this PR change? -->

## Additional information
Added brief note about how even if there is no any disabled modules in mentioned in article files it's still possible the module could be disabled by value in a database table and how it can be found by value with advanced/modules_disable_output/VendorName_ModuleName in path column. Closes #2959 

List all affected URL's 

- https://devdocs.magento.com/guides/v2.2/config-guide/config/disable-module-output.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
