### PR TITLE
removed archives-php-issue.md for magento 2.3

### DIFF
--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -21,8 +21,6 @@ The audience for this topic is anyone who downloaded a compressed Magento softwa
 
 ## Get the Magento software
 
-{% include install/archives-php-issue.md %}
-
 {% include install/get-software_zip.md %}
 
 ## Transfer the Magento archive to your server {#zip-transfer}


### PR DESCRIPTION
The warning box in {% include install/archives-php-issue.md %} says

> Magento 2.2 archives are compatible with PHP 7.0 only. If you’re using PHP 7.1, download Magento 2.2 with Composer instead to avoid compatibility issues during installation.

which only applies to magento 2.2.

As magento 2.3 dropped php 7.0 support it might even be confusing, so I suggest to remove this warning for magento 2.3

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement




