### PR TITLE
remove Commerce warning for RabbitMQ / 2.3

### DIFF
--- a/_data/toc/installation-guide.yml
+++ b/_data/toc/installation-guide.yml
@@ -111,8 +111,13 @@ pages:
                 - label: Set pre-installation ownership and permissions
                   url: /install-gde/prereq/file-system-perms.html
 
+            - label: RabbitMQ
+              url: /install-gde/prereq/install-rabbitmq.html
+              include_versions: ["2.3"]
+              
             - label: RabbitMQ (Magento Commerce only)
               url: /install-gde/prereq/install-rabbitmq.html
+              include_versions: ["2.2", "2.1", "2.0"]
 
             - label: Set up a remote MySQL database connection
               url: /install-gde/prereq/mysql_remote.html


### PR DESCRIPTION
In Magento 2.3 RabbitMQ will be available in Magento Open Source as well but the link says "Commerce Only".

This warning should be removed for 2.3 therefore,

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
