### PR TITLE
update composer.json example

### DIFF
--- a/guides/v2.3/frontend-dev-guide/themes/theme-create.md
+++ b/guides/v2.3/frontend-dev-guide/themes/theme-create.md
@@ -96,7 +96,7 @@ Example of a theme `composer.json` file:
     "name": "magento/theme-frontend-luma",
     "description": "N/A",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~7.1.3|~7.2.0",
         "magento/theme-frontend-blank": "100.0.*",
         "magento/framework": "100.0.*"
     },


### PR DESCRIPTION
The example of the composer.json had php 5.5 to 7.0 es supported php versions.

As non of those versions are supported by magento 2.3 it should be updates to php 7.1 and php 7.2

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement
