### PR TITLE
fix outdated link

### DIFF
--- a/guides/v2.3/install-gde/prereq/install-rabbitmq.md
+++ b/guides/v2.3/install-gde/prereq/install-rabbitmq.md
@@ -135,8 +135,7 @@ After you have connected Magento and RabbitMQ, you must start the message queue 
 
 *	[Installing optional software]({{page.baseurl}}/install-gde/prereq/optional.html)
 *	[Apache]({{page.baseurl}}/install-gde/prereq/apache.html)
-*	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{page.baseurl}}/install-gde/prereq/php-ubuntu.html)
-*	[PHP 5.5, 5.6, or 7.0&mdash;CentOS]({{page.baseurl}}/install-gde/prereq/php-centos.html)
+*	[PHP 7.1 or 7.2]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html)
 *	[Configuring security options]({{page.baseurl}}/install-gde/prereq/security.html)
 *	[How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
 *	[Message queue overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)


### PR DESCRIPTION
The pages 

*	({{page.baseurl}}/install-gde/prereq/php-ubuntu.html)
*	({{page.baseurl}}/install-gde/prereq/php-centos.html)

are no longer existing for magento 2.3

Instead there is a new page called install-gde/prereq/php-centos-ubuntu.html, so the link should be changed.

Also the php versions changed

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement
