### PR TITLE
MAGEDOC-3184: Added version-specific link to swagger schema

### DIFF
--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -29,7 +29,7 @@ DELETE /async/V1/products/:sku
 
 {{site.data.var.ce}} and {{site.data.var.ee}} installations support asynchronous web endpoints.
 
-The [Swagger documentation]({{ site.baseurl }}/swagger/index.html) provides a list of all current synchronous Magento API routes.
+The [Swagger documentation]({{ site.baseurl }}/swagger/index_23.html) provides a list of all current synchronous Magento API routes.
 
 The response of an asynchronous request contains the following fields:
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will replace the link to the 2.2 Swagger documentation link with a 2.3 link. 

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URL's 

- https://devdocs.magento.com/guides/v2.3/rest/asynchronous-web-endpoints.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
