### PR TITLE
Generate all navigations from _data/*yml using the same logic

### DIFF
--- a/_data/footer-links.yml
+++ b/_data/footer-links.yml
@@ -1,0 +1,21 @@
+- label: Become a Contributor
+  url: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
+
+- label: Glossary
+  url: https://magento.github.io/glossary/index.html?audience=developer
+
+- label: Privacy Policy
+  url: https://magento.com/legal/terms/privacy/
+
+- label: Terms of Service
+  url: https://magento.com/legal/terms/
+
+- label: License/Trademark FAQ
+  url: https://magento.com/legal/licensing/
+
+- label: Release Notes
+  url: /release-notes/bk-release-notes.html
+
+- label: Third-Party Licenses
+  url: /magento-third-party.html
+  versionless: true

--- a/_data/toc/configuration-guide.yml
+++ b/_data/toc/configuration-guide.yml
@@ -16,11 +16,11 @@ pages:
 
         - label: Two-Factor Authentication
           url: /security/two-factor-authentication.html
-          versions: ["2.1", "2.2"]
+          include_versions: ["2.1", "2.2"]
 
         - label: Google reCAPTCHA
           url: /security/google-recaptcha.html
-          versions: ["2.1", "2.2"]
+          include_versions: ["2.1", "2.2"]
 
     - label: Magento application initialization and bootstrap
       url: /config-guide/bootstrap/magento-bootstrap.html

--- a/_includes/layout/footer-links.html
+++ b/_includes/layout/footer-links.html
@@ -1,19 +1,7 @@
+{% assign items = site.data.footer-links %}
+
 <ul class="nav footer-links">
-  <li><a href="https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md">Become a Contributor</a>
-  <li><a href="https://magento.github.io/glossary/index.html?audience=developer">Glossary</a></li>
-  <li><a href="http://magento.com/legal/terms/privacy/">Privacy Policy</a></li>
-  <li><a href="http://magento.com/legal/terms/">Terms of Service</a></li>
-  <li><a href="http://magento.com/legal/licensing/">License/Trademark FAQ</a></li>
-  <!-- If the page is in the root, the link points to the default version of release notes.
-       The default version is set in the config.yaml.
-    {%- capture release-notes -%}
-      {%- unless page.baseurl == empty -%}
-        {{page.baseurl}}/release-notes/bk-release-notes.html
-      {%- else -%}
-        /guides/v{{ site.version }}/release-notes/bk-release-notes.html
-      {%- endunless -%}
-    {%- endcapture -%}
-    -->
-  <li><a href="{{release-notes}}">Release Notes</a></li>
-  <li><a href="{{ site.baseurl }}/magento-third-party.html">Third-Party Licenses</a></li>
+{% for item in items %}
+  {% include layout/nav-item.html section=item %}
+{% endfor %}
 </ul>

--- a/_includes/layout/nav-item.html
+++ b/_includes/layout/nav-item.html
@@ -26,17 +26,16 @@
   {% assign compare_url = page.url | prepend: site.baseurl %}
 <li class="{% if compare_url == item_url %}active{% endif %} {{ item.class }}">
   {% if item.url %}
-    <a href="{{ item_url }}">{{ item.label }}</a>
+  <a href="{{ item_url }}">{{ item.label }}</a>
   {% else %}
-    <span>{{ item.label }}</span>
+  <span>{{ item.label }}</span>
   {% endif %}
-
   {% if children %}
-    <ul>
-      {% for child in children %}
-         {% include layout/toc-entry.html section=child %}
-      {% endfor %}
-    </ul>
+  <ul>
+    {% for child in children %}
+      {% include layout/nav-item.html section=child %}
+    {% endfor %}
+  </ul>
   {% endif %}
 </li>
 {% endif %}

--- a/_includes/layout/navigation.html
+++ b/_includes/layout/navigation.html
@@ -21,12 +21,12 @@
               <div class="nav-section-title">{{ subsection.label }}</div>
               <ul>
               {% for item in subchildren %}
-                {% include layout/main-nav-item.html item=item %}
+                {% include layout/nav-item.html section=item %}
               {% endfor%}
               </ul>
             </div>
           {% else if %}
-            {% include layout/main-nav-item.html item=subsection %}
+            {% include layout/nav-item.html section=subsection %}
           {% endif %}
         {% endfor %}
       {% endcapture %}

--- a/_includes/layout/sidebar.html
+++ b/_includes/layout/sidebar.html
@@ -4,12 +4,12 @@
 	<div class="sidebar-wrapper">
 
 		{% assign toc = site.data.toc[page.group] %}
-		
+
 		<h4 class="guide-title">{{ toc.label }}</h4>
 		<div class="collapsible-navigation">
 		    <ul>
 		    {% for entry in toc.pages %}
-		    	{% include layout/toc-entry.html section=entry %}
+		    	{% include layout/nav-item.html section=entry %}
 		    {% endfor %}
 		    </ul>
 		</div>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will generate all navigations from _data/*yml using the same logic.
The logic is stored in _includes/layout/nav-item.html and used in main navigation, sidebar and footer.
`include_versions`, `exclude_versions`, and `versionless` work the same way for all the places.
Added the _data/footer-links.yml file, where footer links are stored.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

Affects all pages.

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
