### PR TITLE
Added list of email template variables (#3018)

### DIFF
--- a/guides/v2.1/frontend-dev-guide/templates/template-email.md
+++ b/guides/v2.1/frontend-dev-guide/templates/template-email.md
@@ -58,8 +58,47 @@ You can customize header and footer templates using either the [theme](#customiz
 
 To add the store and sales related information to a template, use system variables.
 
-System variables are placeholders which are replaced by particular values when the actual email is generated. For example, the `{% raw %}{{var store_hours}}{% endraw %}` variable is replaced by the value set in the **STORES** > Settings > **Configuration** > GENERAL > **General** > **Store Information** section.
+System variables are placeholders which are replaced by particular values when the actual email is generated. For example, the Store Hours (`{% raw %}{{config path="general/store_information/hours"}}{% endraw %}`) variable is replaced by the value set in the **STORES** > Settings > **Configuration** > GENERAL > **General** > **Store Information** section.
 
+Here is a comprehensive list of some of the most commonly used email template variables that are available:
+
+  * Email Footer Template: `{% raw %}{{template config_path="design/email/footer_template"}}{% endraw %}`
+  * Email Header Template: `{% raw %}{{template config_path="design/email/header_template"}}{% endraw %}`
+  * Email Logo Image Alt: `{% raw %}{{var logo_alt}}{% endraw %}`
+  * Email Logo Image URL: `{% raw %}{{var logo_url}}{% endraw %}`
+  * Email Logo Image Height: `{% raw %}{{var logo_height}}{% endraw %}`
+  * Email Logo Image Width: `{% raw %}{{var logo_width}}{% endraw %}`
+  * Template CSS: `{% raw %}{{var template_styles|raw}}{% endraw %}`
+  * Base Unsecure URL: `{% raw %}{{config path="web/unsecure/base_url"}}{% endraw %}`
+  * Base Secure URL: `{% raw %}{{config path="web/secure/base_url"}}{% endraw %}`
+  * General Contact Name: `{% raw %}{{config path="trans_email/ident_general/name"}}{% endraw %}`
+  * Sales Representative Contact Name: `{% raw %}{{config path="trans_email/ident_sales/name"}}{% endraw %}`
+  * Sales Representative Contact Email: `{% raw %}{{config path="trans_email/ident_sales/email"}}{% endraw %}`
+  * Custom1 Contact Name: `{% raw %}{{config path="trans_email/ident_custom1/name"}}{% endraw %}`
+  * Custom1 Contact Email: `{% raw %}{{config path="trans_email/ident_custom1/email"}}{% endraw %}`
+  * Custom2 Contact Name: `{% raw %}{{config path="trans_email/ident_custom2/name"}}{% endraw %}`
+  * Custom2 Contact Email: `{% raw %}{{config path="trans_email/ident_custom2/email"}}{% endraw %}`
+  * Store Name: `{% raw %}{{config path="general/store_information/name"}}{% endraw %}`
+  * Store Phone Number: `{% raw %}{{config path="general/store_information/phone"}}{% endraw %}`
+  * Store Hours: `{% raw %}{{config path="general/store_information/hours"}}{% endraw %}`
+  * Country: `{% raw %}{{config path="general/store_information/country_id"}}{% endraw %}`
+  * Region/State: `{% raw %}{{config path="general/store_information/region_id"}}{% endraw %}`
+  * Zip/Postal Code: `{% raw %}{{config path="general/store_information/postcode"}}{% endraw %}`
+  * City: `{% raw %}{{config path="general/store_information/city"}}{% endraw %}`
+  * Street Address 1: `{% raw %}{{config path="general/store_information/street_line1"}}{% endraw %}`
+  * Street Address 2: `{% raw %}{{config path="general/store_information/street_line2"}}{% endraw %}`
+  * Store Contact Address: `{% raw %}{{config path="general/store_information/address"}}{% endraw %}`
+  * Customer Account URL: `{% raw %}{{var this.getUrl($store, 'customer/account/')}}{% endraw %}`
+  * Customer Email: `{% raw %}{{var customer.email}}{% endraw %}`
+  * Customer Name: `{% raw %}{{var customer.name}}{% endraw %}`
+  * Billing Address: `{% raw %}{{var formattedBillingAddress|raw}}{% endraw %}`
+  * Email Order Note: `{% raw %}{{var order.getEmailCustomerNote()}}{% endraw %}`
+  * Order ID: `{% raw %}{{var order.increment_id}}{% endraw %}`
+  * Order Items Grid: `{% raw %}{{layout handle="sales_email_order_items" order=$order area="frontend"}}{% endraw %}`
+  * Payment Details: `{% raw %}{{var payment_html|raw}}{% endraw %}`
+  * Shipping Address: `{% raw %}{{var formattedShippingAddress|raw}}{% endraw %}`
+  * Shipping Description: `{% raw %}{{var order.getShippingDescription()}}{% endraw %}`
+  
 {:.bs-callout .bs-callout-info}
 You can also create your own custom variables and set their values in the Admin, under **SYSTEM** > **Custom Variables**.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Insert a list of the most common email template system variables along with their markup tags into the Customize Email Content section of the Customize Email Templates page for reference.
<!-- (REQUIRED) What does this PR change? -->

## Additional information
Added a comprehensive list of the most frequent email template variables that are available to users as well as the configuration paths of their set values for some variables. Closes #3018.

List all affected URL's 

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-email.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
