### PR TITLE
Updated changing file permission commands to run much faster when usi…

### DIFF
--- a/_includes/install/file-system-perms-oneuser.md
+++ b/_includes/install/file-system-perms-oneuser.md
@@ -12,13 +12,13 @@ To set permissions before you install the Magento software:
 2.	If you have command-line access, enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} +
 		chmod u+x bin/magento
 
 	To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2`:
 
-		cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} \; && find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} \; && chmod u+x bin/magento
+		cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} + && chmod u+x bin/magento
 3.	If you haven't done so already, get the Magento software in one of the following ways:
 
 	*	[Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)

--- a/_includes/install/file-system-perms-oneuser_22.md
+++ b/_includes/install/file-system-perms-oneuser_22.md
@@ -13,13 +13,13 @@ To set permissions before you install the Magento software:
 2.	If you have command-line access, enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} \;
-		find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} \;
+		find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} +
+		find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} +
 		chmod u+x bin/magento
 
 	To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2`:
 
-		cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} \; && find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} \; && chmod u+x bin/magento
+		cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} + && find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} + && chmod u+x bin/magento
 3.	If you haven't done so already, get the Magento software in one of the following ways:
 
 	*	[Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)

--- a/_includes/install/file-system-perms-twouser.md
+++ b/_includes/install/file-system-perms-twouser.md
@@ -98,8 +98,8 @@ To set ownership and permissions before you install the Magento software:
 2.	Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		sudo chown -R :<web server group> .
 		chmod u+x bin/magento
 

--- a/_includes/install/file-system-perms-twouser_22.md
+++ b/_includes/install/file-system-perms-twouser_22.md
@@ -98,8 +98,8 @@ To set ownership and permissions before you install the Magento software:
 2.	Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		sudo chown -R :<web server group> .
 		chmod u+x bin/magento
 

--- a/_includes/install/file-system-perms-twouser_cmds-only.md
+++ b/_includes/install/file-system-perms-twouser_cmds-only.md
@@ -1,7 +1,7 @@
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
 
-	cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \; && chown -R :apache . && chmod u+x bin/magento
+	cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
 
 In the event file system permissions are set improperly and can't be changed by the Magento file system owner, you can enter the command as a user with `root` privileges:
 
-	cd /var/www/html/magento2 && sudo find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && sudo find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \; && sudo chown -R :apache . && sudo chmod u+x bin/magento
+	cd /var/www/html/magento2 && sudo find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento

--- a/_includes/install/file-system-perms-twouser_cmds-only_22.md
+++ b/_includes/install/file-system-perms-twouser_cmds-only_22.md
@@ -1,7 +1,7 @@
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
 
-	cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \; && chown -R :apache . && chmod u+x bin/magento
+	cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
 
 In the event file system permissions are set improperly and can't be changed by the Magento file system owner, you can enter the command as a user with `root` privileges:
 
-	cd /var/www/html/magento2 && sudo find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && sudo find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \; && sudo chown -R :apache . && sudo chmod u+x bin/magento
+	cd /var/www/html/magento2 && sudo find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento

--- a/_includes/install/sampledata/file-sys-perms-digest.md
+++ b/_includes/install/sampledata/file-sys-perms-digest.md
@@ -13,10 +13,10 @@ If you run the Magento application as one user (which is typical of shared hosti
 cd <your Magento install dir>
 ```
 ```bash
-find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
+find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
 ```
 ```bash
-find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} \;
+find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} +
 ```
 ```bash
 chmod u+x bin/magento
@@ -24,7 +24,7 @@ chmod u+x bin/magento
 
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2`:
 ```bash
-cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} \; && chmod u+x bin/magento
+cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} + && chmod u+x bin/magento
 ```
 
 After you set file system permissions, manually clear the `var/cache`, `var/page_cache`, and `var/generation` directories.
@@ -42,10 +42,10 @@ If you run the Magento application with two users, enter the following commands 
 cd <your Magento install dir>
 ```
 ```bash
-find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
+find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
 ```
 ```bash
-find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 ```
 ```bash
 chown -R :<web server group> .
@@ -56,7 +56,7 @@ chmod u+x bin/magento
 
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
 ```bash
-cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \; && chown -R :apache . && chmod u+x bin/magento
+cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
 ```
 
 <!-- Link definitions -->

--- a/_includes/install/sampledata/sample-data-clone.md
+++ b/_includes/install/sampledata/sample-data-clone.md
@@ -140,7 +140,7 @@ To set file system permissions and ownership on the sample data repository:
 
 3.  Set permissions:
 
-        find . -type d -exec chmod g+ws {} \;
+        find . -type d -exec chmod g+ws {} +
 4.  Clear static files:
 
         cd <your {{site.data.var.ce}} install dir>/var

--- a/_includes/install/trouble/rc_perms.md
+++ b/_includes/install/trouble/rc_perms.md
@@ -15,7 +15,7 @@ The way you resolve the issue depends on whether you have a one-user or two-user
 
 If you have command-line access, enter the following command assuming Magento is installed in `/var/www/html/magento2`:
 
-	cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} \; && chmod u+x bin/magento
+	cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} + && chmod u+x bin/magento
 
 If you do not have command-line access, use an FTP client or a file manager application provided by your hosting provider to set permissions.
 

--- a/guides/m1x/install/installer-privileges_after.html
+++ b/guides/m1x/install/installer-privileges_after.html
@@ -100,12 +100,12 @@
             For example, on Ubuntu where Apache usually runs as <code>www-data</code>, enter
             <pre>chown -R www-data .</pre></li>
         <li>Enter the following commands to set permissions:
-            <pre>find . -type f -exec chmod 400 {} \;
-find . -type d -exec chmod 500 {} \;
-find var/ -type f -exec chmod 600 {} \;
-find media/ -type f -exec chmod 600 {} \;
-find var/ -type d -exec chmod 700 {} \;
-find media/ -type d -exec chmod 700 {} \;
+            <pre>find . -type f -exec chmod 400 {} +
+find . -type d -exec chmod 500 {} +
+find var/ -type f -exec chmod 600 {} +
+find media/ -type f -exec chmod 600 {} +
+find var/ -type d -exec chmod 700 {} +
+find media/ -type d -exec chmod 700 {} +
 chmod 700 includes
 chmod 600 includes/config.php</pre></li></ol>
 
@@ -125,8 +125,8 @@ chmod 600 includes/config.php</pre></li></ol>
     <ol><li>Change to the Magento installation directory.<br />
         On CentOS, this is typically <code>/var/www/html/magento</code>. On Ubuntu, it is typically <code>/var/www/magento</code>.</li>
         <li>Enter the following commands:<br />
-            <pre>find . -type d -exec chmod 700 {} \;
-find . -type f -exec chmod 600 {} \;</pre></li>
+            <pre>find . -type d -exec chmod 700 {} +
+find . -type f -exec chmod 600 {} +</pre></li>
         <li>Install your extension using the Magento Connect Manager.</li></ol>
 
     <h3 id="extensions-after">Restoring the Recommended Permissions</h3>
@@ -139,12 +139,12 @@ find . -type f -exec chmod 600 {} \;</pre></li>
             For example, on Ubuntu where Apache usually runs as <code>www-data</code>, enter
             <pre>chown -R www-data .</pre></li>
         <li>Enter the following commands to set permissions:
-            <pre>find . -type f -exec chmod 400 {} \;
-find . -type d -exec chmod 500 {} \;
-find var/ -type f -exec chmod 600 {} \;
-find media/ -type f -exec chmod 600 {} \;
-find var/ -type d -exec chmod 700 {} \;
-find media/ -type d -exec chmod 700 {} \;</pre></li></ol>
+            <pre>find . -type f -exec chmod 400 {} +
+find . -type d -exec chmod 500 {} +
+find var/ -type f -exec chmod 600 {} +
+find media/ -type f -exec chmod 600 {} +
+find var/ -type d -exec chmod 700 {} +
+find media/ -type d -exec chmod 700 {} +</pre></li></ol>
 
     <h2 id="privs-patches">Applying Magento Support Patches</h2>
     <p>Magento Support typically provides a shell script to patch various Magento issues. When you run the shell script, file and directory permissions are typically not changed; however, the files provided with the patch are owned by the user who applied the patch. If you have a dedicated Magento server, this is typically <code>root</code>; therefore, after applying the patch, you must change file ownership.</p>

--- a/guides/m1x/install/installer-privileges_before.html
+++ b/guides/m1x/install/installer-privileges_before.html
@@ -131,8 +131,8 @@
             <pre>chown -R www-data .</pre>
         </li>
         <li>Enter the following commands to set directory permissions to 700 and file permissions to 600:
-            <pre>find . -type d -exec chmod 700 {} \;
-find . -type f -exec chmod 600 {} \;</pre>
+            <pre>find . -type d -exec chmod 700 {} +
+find . -type f -exec chmod 600 {} +</pre>
         </li>
     </ol>
 

--- a/guides/m1x/install/installing_install.html
+++ b/guides/m1x/install/installing_install.html
@@ -315,12 +315,12 @@ cd /var/www/html/magento</pre></li>
 For example, on Ubuntu where Apache usually runs as <code>www-data</code>, enter
 <pre>chown -R www-data .</pre></li>
 <li>Enter the following commands to set directory permissions to 700 and file permissions to 600:
-<pre>find . -type d -exec chmod 700 {} \;
-find . -type f -exec chmod 600 {} \;</pre></li></ol>
+<pre>find . -type d -exec chmod 700 {} +
+find . -type f -exec chmod 600 {} +</pre></li></ol>
 <!-- <li>Set file permissions.
-<code>find . -type f -exec chmod 644 {} \;</code></li>
+<code>find . -type f -exec chmod 644 {} +</code></li>
 <li>Set directory permissions.
-<code>find . -type d -exec chmod 755 {} \;</code></li>
+<code>find . -type d -exec chmod 755 {} +</code></li>
 <li>Make the <code>var</code>, <code>app/etc</code>, and <code>media</code> directories and subdirectories world-writable.
 <code>chmod -R 777 media app/etc var var/.htaccess</code></li>
 <li>Change to the directory above the Magento installation directory.<br />

--- a/guides/m1x/install/installing_upgrade_details.html
+++ b/guides/m1x/install/installing_upgrade_details.html
@@ -22,8 +22,8 @@
 <h1>Upgrading to and Verifying Magento Community Edition and Enterprise Edition&mdash;Part 2</h1>
 <p><a href="{{ site.m1xgithuburl }}guides/m1x/install/installing_upgrade_details.html" target="_blank">Edit this page on GitHub <img src="{{ site.baseurl }}/common/images/github_icon.png" height="15px"></a></p>
 
- 
-<div class="toc"> <h4 class="toc">Table of Contents</h4> 
+
+<div class="toc"> <h4 class="toc">Table of Contents</h4>
 <ul>
 <li><a href="#overview">Overview</a></li>
 <li><a href="#upgrade-ee-versions">Upgrade Roadmaps</a></li>
@@ -317,7 +317,7 @@ The following figure shows an example.<br />
 <li>Click <strong>Go</strong>.</li>
 <li>Repeat these tasks for the path that includes <code>web/secure/base_url</code>.</li>
 <li>Exit phpmyadmin.</li></ol>
-</li></ol> 
+</li></ol>
 
 <h3 id="upgrade-manual-solr">Upgrading Solr (EE 1.14.0.0 only)</h3>
 <p><em>This section applies to upgrading to EE 1.14.0.0 using the Solr search engine only</em>. If you're upgrading to a different version&mdash;or if you're not using Solr&mdash;skip this section and continue with <a href="#upgrade-manual-cleanup">Finishing the File System</a>.</p>
@@ -385,8 +385,8 @@ cd /var/www/html/magento</pre></li>
 For example, on Ubuntu where Apache usually runs as <code>www-data</code>, enter
 <pre>chown -R www-data .</pre></li>
 <li>Enter the following commands to set directory permissions to 700 and file permissions to 600:
-<pre>find . -type d -exec chmod 700 {} \;
-find . -type f -exec chmod 600 {} \;</pre></li></ol>
+<pre>find . -type d -exec chmod 700 {} +
+find . -type f -exec chmod 600 {} +</pre></li></ol>
 
 <!-- Start by changing to your Magento installation directory:
 <code>#Ubuntu example<br />
@@ -395,9 +395,9 @@ cd /var/www/magento<br />
 #CentOS example<br />
 cd /var/www/html/magento</code></li>
 <li>Set file permissions.
-<code>find . -type f -exec chmod 644 {} \;</code></li>
+<code>find . -type f -exec chmod 644 {} +</code></li>
 <li>Set directory permissions.
-<code>find . -type d -exec chmod 755 {} \;</code></li>
+<code>find . -type d -exec chmod 755 {} +</code></li>
 <li>Make the <code>var</code>, <code>app/etc</code>, and <code>media</code> directories and subdirectories world-writable.
 <code>chmod -R 777 media app/etc var var/.htaccess</code></li>
 <li>Change to the directory above the Magento install directory.
@@ -428,7 +428,7 @@ chown -R myuser:www-data magento</code></li></ol> -->
 <p>Complete the following tasks in the order shown:</p>
 <ol><li><a href="#upgrade-manual-scripts">Running the Upgrade Scripts and Fixing Exceptions</a></li>
 <li><a href="#upgrade-manual-post-upgrade-11302">Running the URL Redirect Script <em>(EE 1.12.x and earlier only)</em></a></li>
-<li><a href="#upgrade-manual-post-upgrade-11300">Post-Upgrade Tasks <em>(EE 1.13.0.1 Only)</em></a></li> 
+<li><a href="#upgrade-manual-post-upgrade-11300">Post-Upgrade Tasks <em>(EE 1.13.0.1 Only)</em></a></li>
 <li>To apply the <a href="https://magento.com/security/patches/supee-8788" target="_blank">security patch</a> released in October, 2016, see <a href="{{ site.baseurl }}/guides/m1x/other/ht_install-patches.html#apply-8788" target="_blank">How to Apply the SUPEE-8788 Patch</a>.</li>
 <li><a href="#upgrade-manual-cron">Setting Up the Magento Cron Job</a></li>
 <li><a href="#upgrade-manual-var">Clearing Magento var/ Subdirectories</a></li>
@@ -491,7 +491,7 @@ You can find errors in the web server's error log or in <code>[your Magento inst
 <h3 id="upgrade-manual-index">Verifying the Status of Indexers</h3>
 <p>After the cron job runs, all indexers should be in a Ready status. Before testing your upgrade, verify all indexers are Ready; otherwise, your testing will be inconclusive.</p>
 <p>To verify the status of indexers:</p>
-<ol><li>Log in to the Admin Panel as an administrator.</li> 
+<ol><li>Log in to the Admin Panel as an administrator.</li>
 <li>Click <strong>System</strong> > <strong>Index Management</strong>.<br />
 Verify that all indexers have a status of Ready, as the following figure shows.<br />
 <img src="{{ site.baseurl }}/common/images/m1x/upgrade_index-management_after.png" width="600px" height="154px"/></li>
@@ -555,5 +555,5 @@ The way you do this is up to you; typically, you can configure your DNS server t
 <li>When you log back in to the Admin Panel, everything works as expected.</li></ol>
 
 <p>In the event of any other issue during the upgrade, see <a href="{{ site.m1xgdeurl }}install/installing.html#help" target="_blank">Getting Help With Your Installation or Upgrade</a>.</p>
- 
+
 </p>

--- a/guides/m1x/other/ht_extend_magento_rest_api.html
+++ b/guides/m1x/other/ht_extend_magento_rest_api.html
@@ -38,7 +38,7 @@
 <li><a href="#trouble">Troubleshooting Suggestions</a></li>
 <li><a href="#next">Next Steps</a></li>
 </ul>
-      
+
 <h2 id="overview">Overview</h2>
 <p>Customers of traditional stores and online web stores love coupons. Typically, a merchant sends coupons to customers who input them when checking out. The coupon saves the customer money and hopefully entices the customer to visit the store more frequently. In addition, the merchant can track coupon codes to individual customers to target market those customers.</p>
 
@@ -58,7 +58,7 @@
 This guide gives you all the files to create the module; no programming is necessary. There are four module configuration <code>.xml</code> files and one <code>.php</code> file to create the web service.</li>
 <li>Creating a user for the OAuth access to the new service</li>
 <li>Testing the web service from a separate page</li></ul>
-     
+
 <h2 id="system-reqs">System Requirements</h2>
 <p>To implement and test the Coupon AutoGen API, you must have all of the following:</p>
 <ul><li>Magento Community Edition (CE) 1.7 or later on Ubuntu.</li>
@@ -190,15 +190,15 @@ The General Information page displays as follows.<br />
 <tr>
   <td>To Date</td>
   <td>Select any date in the future.</td>
-</tr>  
+</tr>
  <tr>
   <td>Priority</td>
   <td>Enter <code>0</code>.</td>
-</tr>     
+</tr>
  <tr>
   <td>Public In RSS Feed</td>
   <td>Click <strong>No</strong>.</td>
-</tr>    
+</tr>
 </tbody>
 </table></li>
 <li>In the upper-right corner of the page, click <strong>Save and Continue Edit</strong>.<br />
@@ -317,7 +317,7 @@ Magento disables the selected caches, replacing the green ENABLED status indicat
 <li>Click <strong>Flush Magento Cache</strong> and wait for the cache to be flushed.</li>
 <li>Log out of the Magento Admin Panel.</li></ol>
 
-<h3><a name="extend-rest-api_create-files"></a>Creating Configuration Files</h3> 
+<h3><a name="extend-rest-api_create-files"></a>Creating Configuration Files</h3>
 <p>This section discusses how to create a module (also referred to as an <em>extension</em>). The module consists of configuration files that create a web service that extends the Magento REST API to take input from an external program. This program uses <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5" target="_blank">HTTP POST</a> and OAuth calls to auto-generate coupon codes.</p>
 <p>In this guide, the external program is a PHP script; however, it could be any application that uses OAuth and REST calls. </p>
 <p>For more information about Magento module development, see <a href="http://www.magentocommerce.com/magento-connect/create_your_extension/" target="_blank">developer documentation on Magento Connect</a>.</p>
@@ -389,7 +389,7 @@ For example, if Magento is installed in <code>/var/www/magento</code>, create th
     &lt;/global&gt;
 &lt;/config&gt;
   </pre></code>
-<li>Create a file named <code>api2.xml</code> with the following contents.<br />     
+<li>Create a file named <code>api2.xml</code> with the following contents.<br />
   <code><pre>
 &lt;config&gt;
     &lt;api2&gt;
@@ -534,8 +534,8 @@ If you're not sure which group owns Apache processes, enter the command <code>ps
 <ol><li>As a user with <code>root</code> privileges, enter the following commands in the order shown to change ownership of the files and directories you created as discussed in this guide:<br />
 <pre>cd <em>magento-install-dir</em>/app/code/community
 chown -R <em>your-login-name</em>:www-data CouponDemo
-find . -type f -exec chmod 644 {} \;
-find . -type d -exec chmod 755 {} \;</pre></li>
+find . -type f -exec chmod 644 {} +
+find . -type d -exec chmod 755 {} +</pre></li>
 <li>As a user with <code>root</code> privileges, enter the following commands in the order shown to change the permissions and ownership of <code>CouponDemo_AutoGen.xml</code><br />.
 <pre>cd <em>magento-install-dir</em>/app/etc/modules
 chown <em>your-login-name</em>:www-data CouponDemo_AutoGen.xml
@@ -747,7 +747,7 @@ try {
 <li>Save the file and close the text editor.</li></ol>
 
 <h3 id="test-run">Running the Test Script</h3>
-<p>To run the test script:</p> 
+<p>To run the test script:</p>
 <ol><li>Start a web browser.</li>
 <li>In the browser's address or location field, enter:<br />
 <pre>http://<em>magento-server-host-or-ip</em>[:<em>port</em>]/rest_test.php</pre></li>

--- a/guides/v2.0/cloud/before/before-setup-env-install.md
+++ b/guides/v2.0/cloud/before/before-setup-env-install.md
@@ -79,8 +79,8 @@ After you have installed Magento, you need to set the file system permissions an
 2.  Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
   	    chown -R :<web server group> .
   	    chmod u+x bin/magento
 

--- a/guides/v2.0/config-guide/prod/prod_file-sys-perms.md
+++ b/guides/v2.0/config-guide/prod/prod_file-sys-perms.md
@@ -75,7 +75,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command:
 
-		find app/code pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type f -or -type d \) -exec chmod u-w {} \; && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
+		find app/code pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type f -or -type d \) -exec chmod u-w {} + && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
 
 #### Make code files and directories writable:
 
@@ -138,8 +138,8 @@ To set `setgid` and permissions for developer mode:
 2.	Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 
 ### Two Magento file system owners in production mode {#mage-owner-two-prod}
 
@@ -166,7 +166,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command as a user with `root` privileges:
 
-		find app/code lib pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type d -or -type f \) -exec chmod g-w {} \; && chmod o-rwx app/etc/env.php
+		find app/code lib pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type d -or -type f \) -exec chmod g-w {} + && chmod o-rwx app/etc/env.php
 
 #### Make code files and directories writable:
 
@@ -176,7 +176,7 @@ To make files and directories writable so you can update components and upgrade 
 2.	Change to your Magento installation directory.
 3.	Enter the following command:
 
-		find app/code lib var pub/static pub/media vendor app/etc \( -type d -or -type f \) -exec chmod g+w {} \; && chmod o+rwx app/etc/env.php
+		find app/code lib var pub/static pub/media vendor app/etc \( -type d -or -type f \) -exec chmod g+w {} + && chmod o+rwx app/etc/env.php
 
 {% endcollapsibleh2 %}
 

--- a/guides/v2.0/install-gde/install/legacy-file-system-perms.md
+++ b/guides/v2.0/install-gde/install/legacy-file-system-perms.md
@@ -76,8 +76,8 @@ Use the following steps:
 
 3.	Set permissions:
 
-		find . -type d -exec chmod 770 {} \; && find . -type f -exec chmod 660 {} \; && chmod u+x bin/magento
+		find . -type d -exec chmod 770 {} + && find . -type f -exec chmod 660 {} + && chmod u+x bin/magento
 
 	If you must enter the commands as `sudo`, use:
 
-		sudo find . -type d -exec chmod 770 {} \; && sudo find . -type f -exec chmod 660 {} \; && sudo chmod u+x bin/magento
+		sudo find . -type d -exec chmod 770 {} + && sudo find . -type f -exec chmod 660 {} + && sudo chmod u+x bin/magento

--- a/guides/v2.0/install-gde/prereq/nginx.md
+++ b/guides/v2.0/install-gde/prereq/nginx.md
@@ -96,8 +96,8 @@ For this example, we'll download and extract an archive.
 5. [Set directory ownership and file permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 
 		cd /var/www/html/magento2
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		chown -R :www-data .
 		chmod u+x bin/magento
 
@@ -289,8 +289,8 @@ For this example, we'll download and extract an archive.
 3. [Set directory ownership and file permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 
 		cd /usr/share/nginx/html/magento2
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		chown -R :apache .
 		chmod u+x bin/magento
 

--- a/guides/v2.1/cloud/before/before-setup-env-install.md
+++ b/guides/v2.1/cloud/before/before-setup-env-install.md
@@ -84,8 +84,8 @@ After you have installed Magento, you need to set the file system permissions an
     ```
 
     ```terminal
-    find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     ```
 
     ```bash

--- a/guides/v2.1/comp-mgr/trouble/cman/upgrade_51431.md
+++ b/guides/v2.1/comp-mgr/trouble/cman/upgrade_51431.md
@@ -71,23 +71,23 @@ To set file system permissions before upgrade:
 	*	One Magento user (typical of shared hosting):
 
 			cd <your Magento install dir>
-			find var -type f -exec chmod u+w {} \;
-			find var -type d -exec chmod u+w {} \;
+			find var -type f -exec chmod u+w {} +
+			find var -type d -exec chmod u+w {} +
 
 		If you don't have access to a command line, use a file manager tool provided by your hosting provider to set permissions.
 
 	*	Two Magento users:
 
 			cd <your Magento install dir>
-			find var -type f -exec chmod g+w {} \;
-			find var -type d -exec chmod g+ws {} \;
+			find var -type f -exec chmod g+w {} +
+			find var -type d -exec chmod g+ws {} +
 			chown -R :<web server group> .
 
 		For example, on CentOS where the web server group is typically `apache`:
 
 			cd /var/www/html/magento2
-			find var -type f -exec chmod g+w {} \;
-			find var -type d -exec chmod g+ws {} \;
+			find var -type f -exec chmod g+w {} +
+			find var -type d -exec chmod g+ws {} +
 			chown -R :apache .
 
 For additional details about file ownership and permissions, see [Set pre-installation ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).

--- a/guides/v2.1/config-guide/prod/prod_file-sys-perms.md
+++ b/guides/v2.1/config-guide/prod/prod_file-sys-perms.md
@@ -71,7 +71,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command:
 
-		find app/code pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type f -or -type d \) -exec chmod u-w {} \; && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
+		find app/code pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type f -or -type d \) -exec chmod u-w {} + && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
 
 #### Make code files and directories writable:
 
@@ -133,8 +133,8 @@ To set `setgid` and permissions for developer mode:
 2.	Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 
 ### Two Magento file system owners in production mode {#mage-owner-two-prod}
 
@@ -161,7 +161,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command as a user with `root` privileges:
 
-		find app/code lib pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type d -or -type f \) -exec chmod g-w {} \; && chmod o-rwx app/etc/env.php
+		find app/code lib pub/static app/etc var/generation var/di var/view_preprocessed vendor \( -type d -or -type f \) -exec chmod g-w {} + && chmod o-rwx app/etc/env.php
 
 #### Make code files and directories writable:
 
@@ -171,6 +171,6 @@ To make files and directories writable so you can update components and upgrade 
 2.	Change to your Magento installation directory.
 3.	Enter the following command:
 
-		find app/code lib var pub/static pub/media vendor app/etc \( -type d -or -type f \) -exec chmod g+w {} \; && chmod o+rwx app/etc/env.php
+		find app/code lib var pub/static pub/media vendor app/etc \( -type d -or -type f \) -exec chmod g+w {} + && chmod o+rwx app/etc/env.php
 
 {% endcollapsibleh2 %}

--- a/guides/v2.1/install-gde/composer.md
+++ b/guides/v2.1/install-gde/composer.md
@@ -61,8 +61,8 @@ You must set read-write permissions for the web server group before you install 
 
 ```terminal
 cd /var/www/html/<magento install directory>
-find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 chown -R :www-data . // Ubuntu
 chmod u+x bin/magento
 ```

--- a/guides/v2.1/install-gde/install/legacy-file-system-perms.md
+++ b/guides/v2.1/install-gde/install/legacy-file-system-perms.md
@@ -76,8 +76,8 @@ Use the following steps:
 
 3.	Set permissions:
 
-		find . -type d -exec chmod 770 {} \; && find . -type f -exec chmod 660 {} \; && chmod u+x bin/magento
+		find . -type d -exec chmod 770 {} + && find . -type f -exec chmod 660 {} + && chmod u+x bin/magento
 
 	If you must enter the commands as `sudo`, use:
 
-		sudo find . -type d -exec chmod 770 {} \; && sudo find . -type f -exec chmod 660 {} \; && sudo chmod u+x bin/magento
+		sudo find . -type d -exec chmod 770 {} + && sudo find . -type f -exec chmod 660 {} + && sudo chmod u+x bin/magento

--- a/guides/v2.1/install-gde/prereq/nginx.md
+++ b/guides/v2.1/install-gde/prereq/nginx.md
@@ -113,8 +113,8 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
     ```terminal
     cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     chown -R :www-data . // Ubuntu
     chmod u+x bin/magento
     ```
@@ -304,8 +304,8 @@ For this example, we'll download and extract an archive.
 3. [Set directory ownership and file permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 
 		cd /usr/share/nginx/html/magento2
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		chown -R :apache .
 		chmod u+x bin/magento
 

--- a/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
+++ b/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
@@ -69,7 +69,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command:
 
-		find app/code var vendor pub/static app/etc generated/code generated/metadata var/view_preprocessed \( -type f -or -type d \) -exec chmod u-w {} \; && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
+		find app/code var vendor pub/static app/etc generated/code generated/metadata var/view_preprocessed \( -type f -or -type d \) -exec chmod u-w {} + && chmod o-rwx app/etc/env.php && chmod u+x bin/magento
 
 #### Make code files and directories writable:
 
@@ -132,7 +132,7 @@ To set `setgid` and permissions for developer mode:
 2.	Enter the following commands in the order shown:
 
 		cd <your Magento install dir>
-		find var generated pub/static pub/media app/etc -type f -exec chmod g+w {} \; && find var generated pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var generated pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var generated pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 
 ### Two Magento file system owners in production mode {#mage-owner-two-prod}
 
@@ -159,7 +159,7 @@ To remove writable permissions to files and directories from the web server user
 		php bin/magento deploy:mode:set production
 3.	Enter the following command as a user with `root` privileges:
 
-		find app/code lib pub/static app/etc generated/code generated/metadata var/view_preprocessed \( -type d -or -type f \) -exec chmod g-w {} \; && chmod o-rwx app/etc/env.php
+		find app/code lib pub/static app/etc generated/code generated/metadata var/view_preprocessed \( -type d -or -type f \) -exec chmod g-w {} + && chmod o-rwx app/etc/env.php
 
 #### Make code files and directories writable
 
@@ -169,6 +169,6 @@ To make files and directories writable so you can update components and upgrade 
 2.	Change to your Magento installation directory.
 3.	Enter the following command:
 
-		find app/code lib var generated vendor pub/static pub/media app/etc \( -type d -or -type f \) -exec chmod g+w {} \; && chmod o+rwx app/etc/env.php
+		find app/code lib var generated vendor pub/static pub/media app/etc \( -type d -or -type f \) -exec chmod g+w {} + && chmod o+rwx app/etc/env.php
 
 {% endcollapsibleh2 %}

--- a/guides/v2.2/install-gde/prereq/nginx.md
+++ b/guides/v2.2/install-gde/prereq/nginx.md
@@ -116,8 +116,8 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
     ```terminal
     cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     chown -R :www-data . // Ubuntu
     chmod u+x bin/magento
     ```
@@ -307,8 +307,8 @@ For this example, we'll download and extract an archive.
 3. [Set directory ownership and file permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 
 		cd /usr/share/nginx/html/magento2
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
 		chown -R :apache .
 		chmod u+x bin/magento
 

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -113,8 +113,8 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
     ```terminal
     cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     chown -R :www-data . // Ubuntu
     chmod u+x bin/magento
     ```
@@ -322,8 +322,8 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
     ```terminal
     cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     chown -R :www-data . // Ubuntu
     chmod u+x bin/magento
     ```

--- a/guides/v2.3/release-notes/2.3.0-install.md
+++ b/guides/v2.3/release-notes/2.3.0-install.md
@@ -48,8 +48,8 @@ To minimize storage issues, only the latest Alpha release and the last three Bet
 2. Set file permissions as follows:
     ```terminal
     cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \;
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} \;
+    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     chown -R :www-data . // Ubuntu
     chmod u+x bin/magento
     ```


### PR DESCRIPTION
…ng in combination with the find command. Fixes #3024.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will improve the documentation for changing file permissions on a list of files found by the `find` command. The updated command will run significantly faster.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/m1x/install/installer-privileges_after.html
- https://devdocs.magento.com/guides/m1x/install/installer-privileges_before.html
- https://devdocs.magento.com/guides/m1x/install/installing_install.html
- https://devdocs.magento.com/guides/m1x/install/installing_upgrade_details.html
- https://devdocs.magento.com/guides/m1x/other/ht_extend_magento_rest_api.html
- https://devdocs.magento.com/guides/v2.0/cloud/before/before-setup-env-install.html
- https://devdocs.magento.com/guides/v2.0/config-guide/prod/prod_file-sys-perms.html
- https://devdocs.magento.com/guides/v2.0/install-gde/install/legacy-file-system-perms.html
- https://devdocs.magento.com/guides/v2.0/install-gde/prereq/nginx.html
- https://devdocs.magento.com/guides/v2.1/cloud/before/before-setup-env-install.html
- https://devdocs.magento.com/guides/v2.1/comp-mgr/trouble/cman/upgrade_51431.html
- https://devdocs.magento.com/guides/v2.1/config-guide/prod/prod_file-sys-perms.html
- https://devdocs.magento.com/guides/v2.1/install-gde/composer.html
- https://devdocs.magento.com/guides/v2.1/install-gde/install/legacy-file-system-perms.html
- https://devdocs.magento.com/guides/v2.1/install-gde/prereq/nginx.html
- https://devdocs.magento.com/guides/v2.2/config-guide/prod/prod_file-sys-perms.html
- https://devdocs.magento.com/guides/v2.2/install-gde/prereq/nginx.html
- https://devdocs.magento.com/guides/v2.3/install-gde/prereq/nginx.html
- https://devdocs.magento.com/guides/v2.3/release-notes/2.3.0-install.html
- &plus; all pages where the following includes are used:
    - _includes/install/file-system-perms-oneuser.md
    - _includes/install/file-system-perms-oneuser_22.md
    - _includes/install/file-system-perms-twouser.md
    - _includes/install/file-system-perms-twouser_22.md
    - _includes/install/file-system-perms-twouser_cmds-only.md
    - _includes/install/file-system-perms-twouser_cmds-only_22.md
    - _includes/install/sampledata/file-sys-perms-digest.md
    - _includes/install/sampledata/sample-data-clone.md
    - _includes/install/trouble/rc_perms.md

See issue https://github.com/magento/devdocs/issues/3024