### PR TITLE
Removed sprintf from translation docs

### DIFF
--- a/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
+++ b/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
@@ -25,7 +25,7 @@ For example:
 If your string contains a variable, to add a placeholder for this variable in the dictionary, use syntax similar to the following:
 
 ```php
-### <?php echo __('Hello %s', $yourVariable) ?>
+### <?php echo __('Hello %1', $yourVariable) ?>
 ```
 
 In this example, the <i>'Hello %s'</i> string is added to the dictionary when the i18n tool is run.

--- a/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
+++ b/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
@@ -25,7 +25,7 @@ For example:
 If your string contains a variable, to add a placeholder for this variable in the dictionary, use syntax similar to the following:
 
 ```php
-### <?php echo sprintf(__('Hello %s'), $yourVariable) ?>
+### <?php echo __('Hello %s', $yourVariable) ?>
 ```
 
 In this example, the <i>'Hello %s'</i> string is added to the dictionary when the i18n tool is run.

--- a/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
+++ b/guides/v2.1/frontend-dev-guide/translations/translate_theory.md
@@ -28,7 +28,7 @@ If your string contains a variable, to add a placeholder for this variable in th
 ### <?php echo __('Hello %1', $yourVariable) ?>
 ```
 
-In this example, the <i>'Hello %s'</i> string is added to the dictionary when the i18n tool is run.
+In this example, the <i>'Hello %1'</i> string is added to the dictionary when the i18n tool is run.
 
 ## Strings added in email templates {#add_strings_email}
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [X] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary
Removed sprintf keyword as per issue #2953 
https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/translations/translate_theory.html
