### PR TITLE
Fix bug where info box was not rendered

### DIFF
--- a/guides/v2.1/extension-dev-guide/build/module-load-order.md
+++ b/guides/v2.1/extension-dev-guide/build/module-load-order.md
@@ -16,7 +16,7 @@ If you know that your component's logic depends on something in another componen
 
 You can check your module's load order from the `<your Magento install dir>/app/etc/config.php` file after you've successfully set up Magento. This file is created dynamically at run time during set up.
 
-{#info .bs-callout .bs-callout-info}
+{: .bs-callout .bs-callout-info }
 If you change the component load order using `<sequence>`, you must regenerate the component list in `config.php`; otherwise, the load order does not take effect. Currently, the only way to do this is to enable the component using [`magento module:enable `]({{ page.baseurl}}/install-gde/install/cli/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable), where `<module-list>` is the component or components to which you added `<sequence>`.
 
 ### Examples


### PR DESCRIPTION
The info box was not rendered because of wrong syntax

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will properly render the info box on the dev docs.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/extension-dev-guide/build/module-load-order.html
- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-load-order.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/module-load-order.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
