### PR TITLE
#3080 Missing page for Form Component in Magento 2.2 when switching f…

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-form.md
@@ -1,6 +1,8 @@
 ---
 group: ui-components-guide
 title: Form component
+redirect_from:
+   - /guides/v2.2/ui-components/ui-form.html
 ---
 
 The Form component is a collection of fields that can be grouped in tabs and fieldsets. It enables [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations.


### PR DESCRIPTION
## This PR is a:

- [x] Bug fix or improvement

## Summary

Fix issue reported in [#3080](https://github.com/magento/devdocs/issues/3080#issuecomment-429025217) related to wrong redirection in Component Form page from 2.0 to 2.2

This also fix the issue in 2.3 topic. Try switching from 2.0 to 2.3; will no longer shows a 404 page.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/ui-components/ui-form.html
- https://devdocs.magento.com/guides/v2.3/ui-components/ui-form.html
- https://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-form.html
- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-form.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
