### PR TITLE
Update translate_practice.md

### DIFF
--- a/guides/v2.1/frontend-dev-guide/translations/translate_practice.md
+++ b/guides/v2.1/frontend-dev-guide/translations/translate_practice.md
@@ -58,9 +58,9 @@ For example:
 
 
 
-[Product page where the Add to Compare string is displayed]: {{site.baseurl}}/common/images/fdg_trans_bag.png {width="700px"}
+[Product page where the Add to Compare string is displayed]: {{site.baseurl}}/common/images/fdg_trans_bag.png
 [i18n (internationalization) tool]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
-[Product page where the customized Compare string is displayed]: {{site.baseurl}}/common/images/fdg_translations_bag2.png {width="700px"}
+[Product page where the customized Compare string is displayed]: {{site.baseurl}}/common/images/fdg_translations_bag2.png
 [Translation dictionaries and language packages]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
 [Using translation dictionary to customize strings]: {{page.baseurl}}/frontend-dev-guide/translations/theme_dictionary.html
 [Translations overview]: {{page.baseurl}}/frontend-dev-guide/translations/xlate.html


### PR DESCRIPTION


## This PR is a: Fixed broken image and remove the inline width 
![create a translation dictionary for a theme magento 2 developer documentation](https://user-images.githubusercontent.com/33098216/46907759-02ae6500-cf35-11e8-9566-7a0e86962319.png)


- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary


When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->
On below URLs, images are not displaying its breaking

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/frontend-dev-guide/translations/translate_practice.html
- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/translations/translate_practice.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/translations/translate_practice.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
