### PR TITLE
Fix Magento edition name

### DIFF
--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
@@ -40,7 +40,7 @@ This release introduces significant tools to improve the developer experience: P
 
 * **Improvements to import and export**  focus on enhancements to existing processes, including the  addition of new object types. 
 
-* **Elasticsearch support for Magento Open Source**. Elasticsearch support was previously provided in Magento Commerce only. 
+* **Elasticsearch support for {{site.data.var.ce}}**. Elasticsearch support was previously provided in Magento Commerce only. 
 
 * **Improvements to release packaging** plus an increase in test automation, results in a faster, more efficient release process and improved product quality. 
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
@@ -40,7 +40,7 @@ This release introduces significant tools to improve the developer experience: P
 
 * **Improvements to import and export**  focus on enhancements to existing processes, including the  addition of new object types. 
 
-* **Elasticsearch support for Magento Community version**. Elasticsearch support was previously provided in Magento Commerce only. 
+* **Elasticsearch support for Magento Open Source**. Elasticsearch support was previously provided in Magento Commerce only. 
 
 * **Improvements to release packaging** plus an increase in test automation, results in a faster, more efficient release process and improved product quality. 
 


### PR DESCRIPTION
It's not called Magento Community anymore. Magento Open Source is the new name.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

fix the name of the free Magento product in the changelog.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.html
