### PR TITLE
[fix] typo in widget_gallery

### DIFF
--- a/guides/v2.0/javascript-dev-guide/widgets/widget_gallery.md
+++ b/guides/v2.0/javascript-dev-guide/widgets/widget_gallery.md
@@ -527,7 +527,7 @@ Displays the previous preview image.
 
 If the first image ID is passed, the behavior depends on whether [loop](#gallery_loop) is enabled:
 
-* if loop is enbled, the last image is displayed.
+* if loop is enabled, the last image is displayed.
 * if loop is disabled, does not change the displayed image.
 
 #### `seek()` {#gallery_seek}

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
@@ -519,7 +519,7 @@ Displays the previous preview image.
 
 If the first image ID is passed, the behavior depends on whether [loop](#gallery_loop) is enabled:
 
-* if loop is enbled, the last image is displayed.
+* if loop is enabled, the last image is displayed.
 * if loop is disabled, does not change the displayed image.
 
 #### `seek()` {#gallery_seek}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix a typo in widget_gallery.md

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.html
- https://devdocs.magento.com/guides/v2.0/javascript-dev-guide/widgets/widget_gallery.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
