### PR TITLE
Magento cloud magecloud 2838

### DIFF
--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -13,19 +13,22 @@ functional_areas:
 
 The `{{site.data.var.ct}}` package v2002.0.13 or later deploys to a read-only file system in the Docker container, which mirrors the read-only file system deployed in the Production environment. You can use the `docker:build` command in the `{{site.data.var.ct}}` package to generate the Docker compose configuration and deploy {{site.data.var.ece}} in a Docker container. To specify a particular version, use the following options:
 
-| Service     | Key      | Default value | Possible values |
-| ----------- | -------- | ------------- | --------------- |
-| PHP         | --php    | 7.1           | 7.0, 7.1, 7.2   |
-| Nginx       | --nginx  | latest        | 1.9, latest     |
-| MariaDB     | --db     | 10            | 10              |
+| Service     | Key        | Default value | Possible values |
+| ----------- | ---------- | ------------- | --------------- |
+| PHP         | `--php`    | 7.1           | 7.0, 7.1, 7.2   |
+| Nginx       | `--nginx`  | latest        | 1.9, latest     |
+| MariaDB     | `--db`     | 10            | 10              |
+{:style="table-layout:auto;"}
 
-This version also provides a ` docker:config:convert` command to convert PHP configuration files to Docker ENV files.
+This version also provides a `docker:config:convert` command to convert PHP configuration files to Docker ENV files.
 
 #### Prerequisites
 
-1.  You have PHP (version 7.0+) and [Composer](https://getcomposer.org) installed locally.
+You must have the following software installed on your local workstation:
 
-1.  You have [Docker](https://www.docker.com/get-started) installed on your local machine.
+-  PHP (version 7.0+)
+-  [Composer](https://getcomposer.org)
+-  [Docker](https://www.docker.com/get-started)
 
 #### To launch Docker:
 
@@ -44,8 +47,9 @@ This version also provides a ` docker:config:convert` command to convert PHP con
     ```bash
     ./vendor/bin/ece-tools docker:build
     ```
-    
-    *Note*: On this step you may need to provide `--php` option to use appropriate PHP version according on your Magento's version.
+
+    {: .bs-callout .bs-callout-info}
+    You can use the `--php` option to specify the version of PHP compatible with your {{site.data.var.ee}} version.
 
 1.  Copy the raw configuration files.
 
@@ -78,13 +82,13 @@ This version also provides a ` docker:config:convert` command to convert PHP con
 
 1. Install Magento in your Docker environment.
 
-    * Build Magento in the Docker container:
+    - Build Magento in the Docker container:
 
         ```bash
         docker-compose run build cloud-build
         ```
 
-    * Deploy Magento in the Docker container:
+    - Deploy Magento in the Docker container:
 
         ```bash
         docker-compose run deploy cloud-deploy

--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -26,7 +26,7 @@ This version also provides a `docker:config:convert` command to convert PHP conf
 
 You must have the following software installed on your local workstation:
 
--  PHP (version 7.0+)
+-  PHP version 7.0 or later
 -  [Composer](https://getcomposer.org)
 -  [Docker](https://www.docker.com/get-started)
 


### PR DESCRIPTION
Edited the PR submitted by Cloud team.

whatsnew
Updated the [Launch Docker configuration](https://devdocs.magento.com/guides/v2.2/cloud/docker/docker-config.html) to include the `docker:build --php` option to specify the version of PHP compatible with your Magento Commerce version.