### PR TITLE
Fixed Cloud terminal code blocks

### DIFF
--- a/guides/v2.1/cloud/before/before-setup-env-install.md
+++ b/guides/v2.1/cloud/before/before-setup-env-install.md
@@ -44,6 +44,7 @@ magento-cloud variable:get -e <environment-ID>
 | ADMIN_USERNAME | admin_A456    | Yes       | No   |
 +----------------+---------------+-----------+------+
 ```
+{: .no-copy}
 
 ### Get Magento authentication keys
 

--- a/guides/v2.1/cloud/env/environments-start.md
+++ b/guides/v2.1/cloud/env/environments-start.md
@@ -98,6 +98,7 @@ When you delete an environment, the environment is set to _inactive_. The code i
     The environment <environment-ID> is currently active: deleting it will delete all associated data.
     Are you sure you want to delete the environment <environment-ID>? [Y/n]
     ```
+    {: .no-copy}
 
     Deleting the environment places it in an _inactive_ state.
 
@@ -119,6 +120,7 @@ When you delete an environment, the environment is set to _inactive_. The code i
     Deleted remote Git branch <environment-ID>
     Run git fetch --prune to remove deleted branches from your local cache.
     ```
+    {: .no-copy}
 
 #### To delete more than one environment:
 

--- a/guides/v2.1/cloud/env/smart-wizards.md
+++ b/guides/v2.1/cloud/env/smart-wizards.md
@@ -36,12 +36,14 @@ A successful configuration returns:
 ```terminal
 SCD on-demand is enabled
 ```
+{: .no-copy}
 
 A failed configuration returns:
 
 ```terminal
 SCD on-demand is disabled
 ```
+{: .no-copy}
 
 ## Verifying an ideal configuration
 
@@ -54,6 +56,7 @@ The _ideal_ configuration for your Cloud project helps to minimize deployment do
 
 Ideal state is not configured
 ```
+{: .no-copy}
 
 Make the following corrections to your configuration:
 
@@ -81,3 +84,4 @@ Make the following corrections to your configuration:
     ```terminal
     Ideal state is configured
     ```
+    {: .no-copy}

--- a/guides/v2.1/cloud/integrations/bitbucket-integration.md
+++ b/guides/v2.1/cloud/integrations/bitbucket-integration.md
@@ -65,7 +65,8 @@ You need to clone your {{site.data.var.ece}} project from an existing environmen
     ```terminal
     origin git@bitbucket.org:<user-name>/<repo-name>.git (fetch)
     origin git@bitbucket.org:<user-name>/<repo-name>.git (push)
-    ```{: .no-copy}
+    ```
+    {: .no-copy}
 
 1.  Push the project files to your new Bitbucket repository. Remember to keep all branch names the same.
 
@@ -152,6 +153,8 @@ The Bitbucket integration requires an [OAuth consumer](https://confluence.atlass
     |          |           | https://magento-url.cloud/api/projects/<project-id>/integrations/<int-id>/hook |
     +----------+-----------+--------------------------------------------------------------------------------+
     ```
+    {: .no-copy}
+    
     Make a note of the **Hook URL** to configure a webhook in BitBucket.
 
 ### Add a webhook in BitBucket
@@ -212,6 +215,7 @@ The Bitbucket integration cannot activate new environments in your {{site.data.v
     Parent environment [master]: integration
     --- (Validation and activation messages)
     ```
+    {: .no-copy}
 
 1.  Verify the environment is active.
 

--- a/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
@@ -111,7 +111,7 @@ To verify this information used for configurations and settings:
 
         php -r 'print_r(json_decode(base64_decode($_ENV["MAGENTO_CLOUD_RELATIONSHIPS"])));'
 
-The response includes all relationships for services and configuration data for that environment. In the response, you will locate data similar to the following for Elasticsearch:
+The response includes all relationships for services and configuration data for that environment. In the response, you can locate data similar to the following for Elasticsearch:
 
 ```
 "elasticsearch" : [
@@ -122,7 +122,8 @@ The response includes all relationships for services and configuration data for 
          "port" : "9200"
       }
    ],
-```{: .no-copy}
+```
+{: .no-copy}
 
 ## Configure Elasticsearch for your site {#configure}
 

--- a/guides/v2.1/cloud/reference/cli-ref-topic.md
+++ b/guides/v2.1/cloud/reference/cli-ref-topic.md
@@ -179,3 +179,4 @@ magento-cloud update
 Checking for Magento Cloud CLI updates (current version: X.XX.X)
 No updates found
 ```
+{: .no-copy}

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -103,7 +103,7 @@ To verify this information used for configurations and settings:
 
         php -r 'print_r(json_decode(base64_decode($_ENV["MAGENTO_CLOUD_RELATIONSHIPS"])));'
 
-The response includes all relationships for services and configuration data for that environment. In the response, you will locate data similar to the following for Elasticsearch:
+The response includes all relationships for services and configuration data for that environment. In the response, you can locate data similar to the following for Elasticsearch:
 
 ```
 "elasticsearch" : [
@@ -114,7 +114,8 @@ The response includes all relationships for services and configuration data for 
          "port" : "9200"
       }
    ],
-```{: .no-copy}
+```
+{: .no-copy}
 
 ## Configure Elasticsearch for your site {#configure}
 

--- a/guides/v2.2/cloud/project/project-upgrade.md
+++ b/guides/v2.2/cloud/project/project-upgrade.md
@@ -180,6 +180,7 @@ There has been an error processing your request
 Exception printing is disabled by default for security reasons.
   Error log record number: <error number>
 ```
+{: .no-copy}
 
 #### To resolve the error:
 


### PR DESCRIPTION
This is a minor fix to some Cloud guide code blocks.
These snippets of code represent system responses and do not need a copy command. The `no-copy` attribute for some code blocks did not have a line return, as expected. Some code blocks with the "terminal" indicator were corrected, some received a new `no-copy` attribute, and some were not touched.