### PR TITLE
Fixed NEW_TOPIC issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_TOPIC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_TOPIC.md
@@ -15,10 +15,10 @@ about: Create a request to add missing information to devdocs
 
 <!-- Use the following checklist template as a starting point -->
 
-[ ] The topic provides an explanation of how ____ works.
-[ ] The topic provides steps for ____.
-[ ] The topic contains code samples that shows ____.
-[ ] Other (please specify)
+- [ ] The topic provides an explanation of how ____ works.
+- [ ] The topic provides steps for ____.
+- [ ] The topic contains code samples that shows ____.
+- [ ] Other (please specify)
 
 ## Additional information/resources
 


### PR DESCRIPTION
## This PR is a:

- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

fix the markdown of `NEW_TOPIC` issue template.

## Additional information

List all affected URLs 

- https://github.com/magento/devdocs/blob/master/.github/ISSUE_TEMPLATE/NEW_TOPIC.md

### Was:

![image](https://user-images.githubusercontent.com/25141164/47267594-cbe8d800-d54e-11e8-9f39-052cb05c06da.png)

### Now:


![image](https://user-images.githubusercontent.com/25141164/47267603-f20e7800-d54e-11e8-979a-cedeaa24a3dc.png)
