### PR TITLE
Fix wrong spelling/apostrophe of Developers' guide per Hotjar feedback

### DIFF
--- a/guides/v2.1/frontend-dev-guide/bk-frontend-dev-guide.md
+++ b/guides/v2.1/frontend-dev-guide/bk-frontend-dev-guide.md
@@ -37,7 +37,7 @@ You can apply these levels of customization to your site, where the levels requi
     
     This third level of customization is not addressed in this guide.
     
-    See the Developers' Guide for details on how to develop new modules.
+    See the Developer Guide for details on how to develop new modules.
     
     This requires PHP programming knowledge in addition to knowledge of all of the preceding areas.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will fix the spelling of "Developer Guide".

<!-- (REQUIRED) What does this PR change? -->

## Additional information
From Hotjar feedback ID 16832568

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/frontend-dev-guide/bk-frontend-dev-guide.html
- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/bk-frontend-dev-guide.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/bk-frontend-dev-guide.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
