### PR TITLE
Update "Name your component" topic

### DIFF
--- a/guides/v2.3/extension-dev-guide/build/create_component.md
+++ b/guides/v2.3/extension-dev-guide/build/create_component.md
@@ -27,13 +27,14 @@ The smallest working `module.xml` file would look something like this:
 ``` xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-        <module name="Vendor_ComponentName"/>
+        <module name="Vendor_ComponentName" setup_version="2.0.0"/>
 </config>
 ```
 
-The `name` parameter defines the name of your component. It is required for all components. If you do not use [Declarative Schema]({{ page.baseurl/extension-dev-guide/declarative-schema/index.html }})  to help manage the installation and upgrade processes for your component, then you must also add the  `setup_version` parameter to the `module` line. Set the `setup_version` value to your module's {% glossarytooltip 66b924b4-8097-4aea-93d9-05a81e6cc00c %}database schema{% endglossarytooltip %} version. Omit the `setup_version` parameter if you implement Declarative Schema.
+The `name` parameter defines the name of your component. It is required for all components. If you do not use [Declarative Schema]({{ page.baseurl }}/extension-dev-guide/declarative-schema/index.html)  to help manage the installation and upgrade processes for your component, then you must also add the  `setup_version` parameter to the `module` line. Set the `setup_version` value to your module's {% glossarytooltip 66b924b4-8097-4aea-93d9-05a81e6cc00c %}database schema{% endglossarytooltip %} version. Omit the `setup_version` parameter if you implement Declarative Schema.
 
-Avoid using "Ui" for your custom module name because the `%Vendor%_Ui` notation, required when specifying paths, might cause issues.
+{: .bs-callout .bs-callout-info}
+Avoid using "Ui" for your custom module name, because the `%Vendor%_Ui` notation, required when specifying paths, might cause issues.
 
 ## Add the component's `composer.json` file {#add-composer-json}
 `composer.json` provides a component name and also specifies component dependencies.
@@ -44,6 +45,8 @@ In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/compman-start.h
 * If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
 * We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
 
+Refer to [Module version dependencies]({{ page.baseurl }}/extension-dev-guide/versioning/dependencies.html) to determine versioning requirements.
+
 ### Example `composer.json` file
 
 ```json
@@ -52,17 +55,17 @@ In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/compman-start.h
     "description": "Test component for Magento 2",
     "require": {
         "php": "~7.1.3||~7.2.0",
-        "magento/module-store": "1.0.0-beta",
-        "magento/module-catalog": "1.0.0-beta",
-        "magento/module-catalog-inventory": "1.0.0-beta",
+        "magento/module-store": "102.1",
+        "magento/module-catalog": "102.1",
+        "magento/module-catalog-inventory": "102.1",
         "magento/module-ui": "self.version",
         "magento/magento-composer-installer": "*"
     },
     "suggest": {
-      "magento/module-webapi": "1.0.0-beta"
+      "magento/module-webapi": "102.1"
     },
     "type": "magento2-module",
-    "version": "1.0.0-beta",
+    "version": "102.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/guides/v2.3/extension-dev-guide/build/create_component.md
+++ b/guides/v2.3/extension-dev-guide/build/create_component.md
@@ -1,1 +1,95 @@
-../../../v2.2/extension-dev-guide/build/create_component.md
+---
+group: php-developer-guide
+title: Name your component
+redirect_from:
+  - /guides/v1.0/extension-dev-guide/create_module.html
+  - /guides/v2.0/extension-dev-guide/create_module.html
+  - /guides/v2.0/extension-dev-guide/create_component.html
+---
+
+You give a name to your component in its `composer.json` and `module.xml` files. These files also contain other required configuration parameters, such as the module's schema version.
+
+## Prerequisites {#prereq}
+
+Before you continue, make sure you have completed all of the following tasks:
+*   Create a [file structure]({{page.baseurl}}/extension-dev-guide/build/module-file-structure.html).
+*   Create the [configuration files]({{page.baseurl}}/extension-dev-guide/build/required-configuration-files.html) you'll need.
+*   [Register]({{page.baseurl}}/extension-dev-guide/build/component-registration.html) your component.
+
+## Add the component's `module.xml` file {#module-xml}
+
+Declare the component itself by adding a `module.xml` file in the `/etc` folder of your component.
+
+A component declares itself (that is, defines its name and existence) in the `module.xml` file, located in the Magento install directory at `<ComponentName>/etc/`.
+
+The smallest working `module.xml` file would look something like this:
+
+``` xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+        <module name="Vendor_ComponentName"/>
+</config>
+```
+
+The `name` parameter defines the name of your component. It is required for all components. If you do not use [Declarative Schema]({{ page.baseurl/extension-dev-guide/declarative-schema/index.html }})  to help manage the installation and upgrade processes for your component, then you must also add the  `setup_version` parameter to the `module` line. Set the `setup_version` value to your module's {% glossarytooltip 66b924b4-8097-4aea-93d9-05a81e6cc00c %}database schema{% endglossarytooltip %} version. Omit the `setup_version` parameter if you implement Declarative Schema.
+
+Avoid using "Ui" for your custom module name because the `%Vendor%_Ui` notation, required when specifying paths, might cause issues.
+
+## Add the component's `composer.json` file {#add-composer-json}
+`composer.json` provides a component name and also specifies component dependencies.
+
+In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/compman-start.html) looks for a `composer.json` in a component's root directory and can perform actions on the component and its dependencies:
+
+* If a component has `composer.json` *and* the component was installed using {% glossarytooltip d85e2d0a-221f-4d03-aa43-0cda9f50809e %}Composer{% endglossarytooltip %} (including from packagist, the Magento Marketplace, or other source), the Component Manager can update, uninstall, enable, or disable the component.
+* If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
+* We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
+
+### Example `composer.json` file
+
+```json
+{
+    "name": "your-name/module-Acme",
+    "description": "Test component for Magento 2",
+    "require": {
+        "php": "~7.1.3||~7.2.0",
+        "magento/module-store": "1.0.0-beta",
+        "magento/module-catalog": "1.0.0-beta",
+        "magento/module-catalog-inventory": "1.0.0-beta",
+        "magento/module-ui": "self.version",
+        "magento/magento-composer-installer": "*"
+    },
+    "suggest": {
+      "magento/module-webapi": "1.0.0-beta"
+    },
+    "type": "magento2-module",
+    "version": "1.0.0-beta",
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [ "registration.php" ],
+        "psr-4": {
+            "Magento\\CatalogImportExport\\": ""
+        }
+    }
+}
+```
+
+In this example:
+
+* `name` is the name of your component.
+* `description` is a concise explanation of your component's purpose.
+* `require` lists any components your component depends on.
+* `suggest` lists soft dependencies. The component can operate without them, but if the components are active, this component might impact their functionality. `Suggest` does not affect component load order.
+* `type` determines what the {% glossarytooltip 3425e9ae-5edf-4fc6-b645-06023e9e5e5b %}Magento component{% endglossarytooltip %} type. Choose from *magento2-theme*, *magento2-language*, or *magento2-module*.
+* `version` lists the version of the component.
+* `license` lists applicable licenses that apply to your component.
+* `autoload` instructs Composer to load the specified files.
+
+{: .bs-callout .bs-callout-info}
+Magento does not currently support the [`path`](https://getcomposer.org/doc/05-repositories.md#path) repository.
+
+#### Next
+
+[Component load order]({{ page.baseurl }}/extension-dev-guide/build/module-load-order.html)

--- a/guides/v2.3/extension-dev-guide/build/create_component.md
+++ b/guides/v2.3/extension-dev-guide/build/create_component.md
@@ -27,7 +27,7 @@ The smallest working `module.xml` file would look something like this:
 ``` xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-        <module name="Vendor_ComponentName" setup_version="2.0.0"/>
+        <module name="Vendor_ComponentName"/>
 </config>
 ```
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will address the changes requested in issue #3126. I also updated the `composer.json` file because it was badly out of date. 

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs: https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/create_component.html

Since I broke the symlink from 2.2, it appears the whole topic is new. What I actually changed:

* Removed `setup_version` from the first code sample
* Rewrote the paragraph beneath that code sample
* Under "Add the component’s composer.json file", added a cross reference to Module version dependencies
* Updated the `composer.json` example

@buskamuza approved the paragraph that I rewrote, but I would like her approval on the `composer.json` updates.