### PR TITLE
MAGECLOUD-2395 Add health notifications to integrations

### DIFF
--- a/_data/toc/cloud-guide.yml
+++ b/_data/toc/cloud-guide.yml
@@ -61,16 +61,6 @@ pages:
           url: /cloud/project/sendgrid.html
           exclude_versions: ["2.0"]
 
-    - label: Integrations
-      url: /cloud/integrations/cloud-integrations.html
-      exclude_versions: ["2.0"]
-      children:
-        - label: Bitbucket integration
-          url: /cloud/integrations/bitbucket-integration.html
-
-        - label: GitHub integration
-          url: /cloud/integrations/github-integration.html
-
     - label: Local development setup
       url: /cloud/setup/first-time-setup.html
       children:
@@ -107,6 +97,19 @@ pages:
 
         - label: Optional - Configure Xdebug
           url: /cloud/howtos/debug.html
+
+    - label: Integrations
+      url: /cloud/integrations/cloud-integrations.html
+      exclude_versions: ["2.0"]
+      children:
+        - label: Bitbucket integration
+          url: /cloud/integrations/bitbucket-integration.html
+
+        - label: GitHub integration
+          url: /cloud/integrations/github-integration.html
+
+        - label: Health notifications
+          url: /cloud/integrations/health-notifications.html
 
     - label: Import existing code into a project
       url: /cloud/setup/first-time-setup-import-first-steps.html

--- a/guides/v2.1/cloud/env/log-handlers.md
+++ b/guides/v2.1/cloud/env/log-handlers.md
@@ -9,7 +9,7 @@ functional_areas:
 
 You can configure logging handlers to send messages to a remote logging server. Logging handler pushes build and deploy logs to other systems, similarly to the way you can push logs to Slack and email. Simply enable a _syslog_ handler, which is ideal for logging messages related to hardware, or a Graylog Extended Log Format (GELF) handler, which is ideal for logging messages from software applications.
 
-The following example configures both of these handlers by adding the configuration to the `.magento.env.yaml` file. For the minimum logging level (`min_level`), see [Set up notifications—Log levels]({{ page.baseurl }}/cloud/env/setup-notifications.html#log-levels).
+The following example configures both of these handlers by adding the configuration to the `.magento.env.yaml` file. For the minimum logging level (`min_level`), see [Log levels](#log-levels).
 
 ```yaml
 log:
@@ -47,3 +47,16 @@ log:
         port: <udp-port>
         chunk_size: 1024
 ```
+
+### Log levels
+
+Log levels determine the level of detail your notification messages contain. You can choose from the following options:
+
+-   **debug**—Detailed debug information.
+-   **info**—Interesting events. For example, a user logs in, SQL logs, etc.
+-   **notice**—Normal but significant events.
+-   **warning**—Exceptional occurrences that are not errors. For example, use of deprecated APIs, poor use of an API, undesirable things that are not necessarily wrong.
+-   **error**—Runtime errors that don't require immediate action but should be logged and monitored.
+-   **critical**—Critical conditions. For example, an unavailable application component, unexpected exceptions.
+-   **alert**—Action must be taken immediately. For example, your website is down, the database is unavailable, etc. This should trigger SMS alerts and wake you up.
+-   **emergency**—The system is unusable.

--- a/guides/v2.1/cloud/env/log-handlers.md
+++ b/guides/v2.1/cloud/env/log-handlers.md
@@ -7,9 +7,9 @@ functional_areas:
   - Configuration
 ---
 
-You can configure logging handlers to send messages to a remote logging server. Logging handler pushes build and deploy logs to other systems, similarly to the way you can push logs to Slack and email. Simply enable a _syslog_ handler, which is ideal for logging messages related to hardware, or a Graylog Extended Log Format (GELF) handler, which is ideal for logging messages from software applications.
+You can configure logging handlers to send messages to a remote logging server. Logging handler pushes build and deploy logs to other systems, similarly to the way you push logs to Slack and email. You can enable a _syslog_ handler, which is ideal for logging messages related to hardware, or a Graylog Extended Log Format (GELF) handler, which is ideal for logging messages from software applications.
 
-The following example configures both of these handlers by adding the configuration to the `.magento.env.yaml` file. For the minimum logging level (`min_level`), see [Log levels](#log-levels).
+The following example configures both of these handlers by adding the configuration to the `.magento.env.yaml` file. For the minimum logging level (`min_level`) values, see [Log levels](#log-levels).
 
 ```yaml
 log:
@@ -50,13 +50,13 @@ log:
 
 ### Log levels
 
-Log levels determine the level of detail your notification messages contain. You can choose from the following options:
+Log levels determine the level of detail in notification messages. The following log level categories include every log level below it. For example, a `debug` level includes logging from every level, whereas an `alert` level only shows alerts and emergencies.
 
--   **debug**—Detailed debug information.
--   **info**—Interesting events. For example, a user logs in, SQL logs, etc.
--   **notice**—Normal but significant events.
--   **warning**—Exceptional occurrences that are not errors. For example, use of deprecated APIs, poor use of an API, undesirable things that are not necessarily wrong.
--   **error**—Runtime errors that don't require immediate action but should be logged and monitored.
--   **critical**—Critical conditions. For example, an unavailable application component, unexpected exceptions.
--   **alert**—Action must be taken immediately. For example, your website is down, the database is unavailable, etc. This should trigger SMS alerts and wake you up.
--   **emergency**—The system is unusable.
+-   **debug**—detailed debug information
+-   **info**—interesting events, such as a user login or SQL log
+-   **notice**—normal, but significant events
+-   **warning**—exceptional occurrences that are not errors, such as the use of a deprecated API or poor use of an API
+-   **error**—run-time errors that do not require immediate action
+-   **critical**—critical conditions, such as an unavailable application component or an unexpected exception
+-   **alert**—immediate action required—such as a website is down or the database is unavailable—that triggers an SMS alert
+-   **emergency**—system is unusable

--- a/guides/v2.1/cloud/env/log-handlers.md
+++ b/guides/v2.1/cloud/env/log-handlers.md
@@ -7,7 +7,7 @@ functional_areas:
   - Configuration
 ---
 
-You can configure logging handlers to send messages to a remote logging server. Logging handler pushes build and deploy logs to other systems, similarly to the way you push logs to Slack and email. You can enable a _syslog_ handler, which is ideal for logging messages related to hardware, or a Graylog Extended Log Format (GELF) handler, which is ideal for logging messages from software applications.
+You can configure logging handlers to send messages to a remote logging server. A logging handler pushes build and deploy logs to other systems, similarly to the way you push logs to Slack and email. You can enable a _syslog_ handler, which is ideal for logging messages related to hardware, or a Graylog Extended Log Format (GELF) handler, which is ideal for logging messages from software applications.
 
 The following example configures both of these handlers by adding the configuration to the `.magento.env.yaml` file. For the minimum logging level (`min_level`) values, see [Log levels](#log-levels).
 

--- a/guides/v2.1/cloud/env/setup-notifications.md
+++ b/guides/v2.1/cloud/env/setup-notifications.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Set up notifications
+title: Notifications
 functional_areas:
   - Cloud
   - Setup
@@ -11,25 +11,25 @@ By default, {{site.data.var.ece}} writes build and deploy actions to the `app/va
 
 For example, you could send a Slack message to alert a group of people when a deployment fails, and prompt an investigation into what went wrong.
 
-## Plan your notifications
+## Plan notifications
 
 Before you configure notifications, consider the following:
 
 -   What kind of notifications do you want to receive (Slack messages, email, both)?
--   How much detail do you want to see in the logs (see [Log levels](#log-levels))?
+-   How much detail do you want to see in the logs?
 -   Where do you want to set up notifications (Integration, Staging, Production)?
 
 For example, during initial development you may prefer email notifications that show detailed logs about your Integration environment to help you debug issues before deploying to the Staging environment. When you are ready to deploy to the Staging or Production environment, you may prefer a Slack message that contains less detailed information.
 
-{% include note.html type="info" content="The configuration file used to set up notifications is at the root of your project directory, so it applies when you push changes to any environment. If you want to customize notifications per environment, you must modify the configuration file before pushing it to that environment." %}
+{:.bs-callout .bs-callout-info}
+The configuration file used to set up notifications is at the root of your project directory, so it applies when you push changes to any environment. If you want to customize notifications per environment, you must modify the configuration file before pushing it to that environment.
 
 ## Configure notifications
 
 To configure notifications:
 
 1.  Open a terminal and [checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) in your local environment.
-1.  Locate the `.magento.env.yaml.sample` file in your project root and rename it `.magento.env.yaml`. The code in this file is commented out by default.
-1.  Remove the code comments and add your messaging system settings, including preferred notification [log level](#log-levels).
+1.  In the `.magento.env.yaml` file in your project root, add your messaging system settings, including preferred notification [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels#log-levels).
 
     For example, to configure both Slack _and_ email configurations, use the following:
 
@@ -95,16 +95,3 @@ log:
 -   `from`—Email address for sending notification messages to recipients.
 -   `subject`—Description of the email.
 -   `min_level`—Minimum log level for notification messages. We recommend using `notice` or `warning`.
-
-### Log levels
-
-Log levels determine the level of detail your notification messages contain. You can choose from the following options:
-
--   **debug**—Detailed debug information.
--   **info**—Interesting events. For example, a user logs in, SQL logs, etc.
--   **notice**—Normal but significant events.
--   **warning**—Exceptional occurrences that are not errors. For example, use of deprecated APIs, poor use of an API, undesirable things that are not necessarily wrong.
--   **error**—Runtime errors that don't require immediate action but should be logged and monitored.
--   **critical**—Critical conditions. For example, an unavailable application component, unexpected exceptions.
--   **alert**—Action must be taken immediately. For example, your website is down, the database is unavailable, etc. This should trigger SMS alerts and wake you up.
--   **emergency**—The system is unusable.

--- a/guides/v2.1/cloud/env/setup-notifications.md
+++ b/guides/v2.1/cloud/env/setup-notifications.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Notifications
+title: Set up notifications
 functional_areas:
   - Cloud
   - Setup
@@ -29,7 +29,7 @@ The configuration file used to set up notifications is at the root of your proje
 To configure notifications:
 
 1.  Open a terminal and [checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) in your local environment.
-1.  In the `.magento.env.yaml` file in your project root, add your messaging system settings, including preferred notification [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels#log-levels).
+1.  In the `.magento.env.yaml` file in your project root, add your messaging system settings, including preferred notification [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels).
 
     For example, to configure both Slack _and_ email configurations, use the following:
 

--- a/guides/v2.1/cloud/env/variables-intro.md
+++ b/guides/v2.1/cloud/env/variables-intro.md
@@ -67,9 +67,6 @@ return array(
 );
 ```
 
-{: .bs-callout .bs-callout-info}
-JS bundling and JS/CSS merging do not work with SCD on demand.
-
 ### `SKIP_HTML_MINIFICATION`
 
 -  **Default**

--- a/guides/v2.1/cloud/env/variables-intro.md
+++ b/guides/v2.1/cloud/env/variables-intro.md
@@ -17,7 +17,7 @@ functional_areas:
 Variables are _hierarchical_, which means that if a variable is not overridden, it is inherited from the parent environment.
 
 You can set [ADMIN variables]({{ page.baseurl }}/cloud/env/environment-vars_magento.html)
-from the Project Web interface or using the Magento CLI. Other environment variables can be managed from the [`.magento.env.yaml`]({{ site.baseurl }}/guides/v2.1/cloud/project/magento-env-yaml.html) file to manage build and deploy actions across all of your environments—including Pro Staging and Production—without requiring a support ticket.
+from the Project Web interface or using the Magento CLI. Other environment variables can be managed from the [`.magento.env.yaml`]({{ page.baseurl }}/cloud/project/magento-env-yaml.html) file to manage build and deploy actions across all of your environments—including Pro Staging and Production—without requiring a support ticket.
 
 ## Global variables
 
@@ -28,18 +28,20 @@ stage:
   global:
     GLOBAL_VARIABLE_NAME: value
 ```
+
 ### `MIN_LOGGING_LEVEL`
 
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Overrides the minimum logging level for all output streams without making changes to the code. This helps to improve troubleshooting problems with deployment. For example, if your deployment fails, you can use this variable to increase the logging granularity globally. See [Set up notifications—Log levels]({{ page.baseurl }}/cloud/env/setup-notifications.html#log-levels). The `min_level` value in Logging handlers overwrites this setting.
+Overrides the minimum logging level for all output streams without making changes to the code. This helps to improve troubleshooting problems with deployment. For example, if your deployment fails, you can use this variable to increase the logging granularity globally. See [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels). The `min_level` value in Logging handlers overwrites this setting.
 
 ```yaml
 stage:
     global:
         MIN_LOGGING_LEVEL: debug
 ```
+
 ### `SCD_ON_DEMAND`
 
 -  **Default**—_Not set_
@@ -64,7 +66,9 @@ return array(
    ...
 );
 ```
-{% include note.html type="info" content="JS bundling and JS/CSS merging do not work with SCD on demand." %}
+
+{: .bs-callout .bs-callout-info}
+JS bundling and JS/CSS merging do not work with SCD on demand.
 
 ### `SKIP_HTML_MINIFICATION`
 
@@ -79,7 +83,6 @@ Enables or disables copying static view files to the `<magento_root>/init/` dire
 -   **`true`**—Enables on-demand HTML minification; does *not* copy the `<magento_root>var/view_preprocessed` to the `<magento_root>/init/` directory at the end of the _build_ stage.
 
 Add the `SKIP_HTML_MINIFICATION` environment variable to the `global` stage in the `.magento.env.yaml` file:
-
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/integrations/cloud-integrations.md
+++ b/guides/v2.1/cloud/integrations/cloud-integrations.md
@@ -6,10 +6,29 @@ functional_areas:
   - Setup
 ---
 
-Integrations are useful for leveraging the functionality of the hosting services and maintaining your current development processes, such as using the code review pull request function in GitHub. Your {{site.data.var.ece}}  project can integrate with the following git-based hosting services:
+Integrations are useful for leveraging the functionality of external services—such as Git hosting or Slack bots—and maintaining your current development processes, such as using the code review pull request function in GitHub. You can add the following integrations to your {{site.data.var.ece}} project:
 
--  [Bitbucket]({{ page.baseurl }}/cloud/integrations/bitbucket-integration.html)
--  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html)
-<!-- -  [GitLab]({{ page.baseurl }}/cloud/integrations/gitlab-integration.html) -->
+-  [Health notifications]({{ page.baseurl }}/cloud/integrations/health-notifications.html)
+-  Git-based hosting services:
+    -  [Bitbucket]({{ page.baseurl }}/cloud/integrations/bitbucket-integration.html)
+    -  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html)
+    <!-- -  [GitLab]({{ page.baseurl }}/cloud/integrations/gitlab-integration.html) -->
 
-{% include cloud/note-private-repo.md %}
+#### To list the configured integrations:
+
+```bash
+magento-cloud integration:list
+```
+
+```terminal
++----------+--------------+---------------------------------------------------------------------------+
+| ID       | Type         | Summary                                                                   |
++----------+--------------+---------------------------------------------------------------------------+
+| <int-id> | bitbucket    | Repository: user/magento-int.git                                          |
+|          |              | Hook URL:                                                                 |
+|          |              | https://magento-url.cloud/api/projects/projectID/integrations/int-ID/hook |
+| <int-id> | health.email | From: you@example.com                                                     |
+|          |              | To: them@example.com                                                      |
++----------+--------------+---------------------------------------------------------------------------+
+```
+{: .no-copy}

--- a/guides/v2.1/cloud/integrations/cloud-integrations.md
+++ b/guides/v2.1/cloud/integrations/cloud-integrations.md
@@ -8,7 +8,10 @@ functional_areas:
 
 Integrations are useful for leveraging the functionality of external services—such as Git hosting or Slack bots—and maintaining your current development processes, such as using the code review pull request function in GitHub. You can add the following integrations to your {{site.data.var.ece}} project:
 
--  [Health notifications]({{ page.baseurl }}/cloud/integrations/health-notifications.html)
+-  [Health notifications]({{ page.baseurl }}/cloud/integrations/health-notifications.html):
+    -  Email
+    -  Slack interactive bot
+    -  PagerDuty integration
 -  Git-based hosting services:
     -  [Bitbucket]({{ page.baseurl }}/cloud/integrations/bitbucket-integration.html)
     -  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html)

--- a/guides/v2.1/cloud/integrations/health-notifications.md
+++ b/guides/v2.1/cloud/integrations/health-notifications.md
@@ -6,24 +6,38 @@ functional_areas:
   - Setup
 ---
 
-{{site.data.var.ece}} monitors disk space usage on all applications and services in your Starter environment or your Pro Integration environment. The health status check occurs every 5 minutes. There are three low-disk warnings for health notifications:
+{{site.data.var.ece}} monitors disk space usage on all applications and services in your Starter environment or your Pro Integration environment. A database disk that runs out of space could cause data corruption. The health status check occurs every 5 minutes and can notify you by email or other external service. There are three low-disk warnings for health notifications:
 
 -  **Warning**—available disk space drops below 20%
 -  **Critical**—available disk space drops below 10%
 -  **All-clear**—available disk space returns above 20%, after a Low disk event
 
-#### To receive health notifications in email:
+## Email notifications
 
-The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipient` address. The following example registers a health email integration with two recipients.
+The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipients` address. The following example registers a health email integration with two recipients.
+
+#### To register health notifications for email:
 
 ```bash
 magento-cloud integration:add --type health.email --from-address you@example.com --recipients them@example.com --recipients others@example.com
 ```
 
-#### To receive health notifications in a Slack channel:
+## Slack channel notifications
 
-Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot-user for your channel, or channels, save the API Token provided by Slack to register your integration, as follows:
+Slack is an external service that uses interactive apps called bots to post messages in a chat room. Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot user for your channel, or channels, save the [bot token](https://api.slack.com/docs/token-types#bot) provided by Slack to register your integration.
+
+#### To register health notifications in a Slack channel:
 
 ```bash
-magento-cloud integration:add --type health.slack --token SLACK_API_TOKEN --channel '#slack-channel-name'
+magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --channel '#slack-channel-name'
+```
+
+## PagerDuty notifications
+
+PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key as known as the _routing key_ to register your integration.
+
+#### To register health notifications for PagerDuty:
+
+```bash
+magento-cloud integration:add --type health.pagerduty --routing-key PAGERDUTY_ROUTING_KEY
 ```

--- a/guides/v2.1/cloud/integrations/health-notifications.md
+++ b/guides/v2.1/cloud/integrations/health-notifications.md
@@ -1,0 +1,29 @@
+---
+group: cloud-guide
+title: Health notifications
+functional_areas:
+  - Cloud
+  - Setup
+---
+
+{{site.data.var.ece}} monitors disk space usage on all applications and services in your Starter environment or your Pro Integration environment. The health status check occurs every 5 minutes. There are three low-disk warnings for health notifications:
+
+-  **Warning**—available disk space drops below 20%
+-  **Critical**—available disk space drops below 10%
+-  **All-clear**—available disk space returns above 20%, after a Low disk event
+
+#### To receive health notifications in email:
+
+The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipient` address. The following example registers a health email integration with two recipients.
+
+```bash
+magento-cloud integration:add --type health.email --from-address you@example.com --recipients them@example.com --recipients others@example.com
+```
+
+#### To receive health notifications in a Slack channel:
+
+Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot-user for your channel, or channels, save the API Token provided by Slack to register your integration, as follows:
+
+```bash
+magento-cloud integration:add --type health.slack --token SLACK_API_TOKEN --channel '#slack-channel-name'
+```

--- a/guides/v2.1/cloud/integrations/health-notifications.md
+++ b/guides/v2.1/cloud/integrations/health-notifications.md
@@ -34,7 +34,7 @@ magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --chan
 
 ## PagerDuty notifications
 
-PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key as known as the _routing key_ to register your integration.
+PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key, or _routing key_, to register your integration.
 
 #### To register health notifications for PagerDuty:
 

--- a/guides/v2.1/cloud/integrations/health-notifications.md
+++ b/guides/v2.1/cloud/integrations/health-notifications.md
@@ -10,7 +10,7 @@ functional_areas:
 
 -  **Warning**—available disk space drops below 20%
 -  **Critical**—available disk space drops below 10%
--  **All-clear**—available disk space returns above 20%, after a Low disk event
+-  **All-clear**—available disk space returns above 20%, after a low-disk event
 
 ## Email notifications
 

--- a/guides/v2.2/cloud/integrations/health-notifications.md
+++ b/guides/v2.2/cloud/integrations/health-notifications.md
@@ -1,0 +1,1 @@
+../../../v2.1/cloud/integrations/health-notifications.md

--- a/guides/v2.3/cloud/integrations/health-notifications.md
+++ b/guides/v2.3/cloud/integrations/health-notifications.md
@@ -1,0 +1,1 @@
+../../../v2.2/cloud/integrations/health-notifications.md


### PR DESCRIPTION
Added Health notifications to the Integrations for Cloud.

- Updated the Integrations landing page to include more than Git-hosting
- Added the new Health notifications topic
- Moved Integrations further down the navigation so it appears after local development setup
- Initially, I thought this would go in the configure notifications sections, but I realized this was not the case. There are a few minor changes, such as fixing a reference to the sample env YAML file, which doesn't exist.

These changes affect:
https://devdocs.magento.com/guides/v2.2/cloud/integrations/cloud-integrations.html
https://devdocs.magento.com/guides/v2.2/cloud/integrations/health-notifications.html

whatsnew
Added [Health notifications](https://devdocs.magento.com/guides/v2.2/cloud/integrations/health-notifications.html) to [Integrations](https://devdocs.magento.com/guides/v2.2/cloud/integrations/cloud-integrations.html) for Cloud.