### PR TITLE
Fix array formatting for config settings

### DIFF
--- a/guides/v2.1/cloud/live/sens-data-initial.md
+++ b/guides/v2.1/cloud/live/sens-data-initial.md
@@ -79,36 +79,30 @@ This procedure corresponds to step 2 in the [recommended procedure]({{ page.base
 The following snippet from `config.local.php` shows an example of changing the default locale to `en_GB` and changing static file optimization settings:
 
 <pre class="no-copy">
- 'general' =>
-      array (
-        'locale' =>
-        array (
-          'code' => 'en_GB',
-          'timezone' => 'UTC',
-        ),
+ 'general' => [
+   'locale' => [
+     'code' => 'en_GB',
+     'timezone' => 'UTC',
+   ],
 
-        ... more ...
+   ... more ...
 
- 'dev' =>
-      'template' =>
-        array (
-          'allow_symlink' => '0',
-          'minify_html' => '0',
-        ),
+ 'dev' => [
+   'template' => [
+     'allow_symlink' => '0',
+     'minify_html' => '0',
+   ],
+   'js' => [
+     'merge_files' => '0',
+     'enable_js_bundling' => '0',
+     'minify_files' => '0',
+   ],
+   'css' => [
+     'merge_css_files' => '0',
+     'minify_files' => '0',
+   ],
 
-        ... more ...
-
-        'js' =>
-        array (
-          'merge_files' => '0',
-          'enable_js_bundling' => '0',
-          'minify_files' => '0',
-        ),
-        'css' =>
-        array (
-          'merge_css_files' => '0',
-          'minify_files' => '0',
-        ),
+   ... more ...
 </pre>
 
 ## Push and deploy config.local.php to environments {#deploy}

--- a/guides/v2.1/cloud/live/sens-data-initial.md
+++ b/guides/v2.1/cloud/live/sens-data-initial.md
@@ -80,29 +80,29 @@ The following snippet from `config.local.php` shows an example of changing the d
 
 <pre class="no-copy">
  'general' => [
-   'locale' => [
-     'code' => 'en_GB',
-     'timezone' => 'UTC',
-   ],
+     'locale' => [
+         'code' => 'en_GB',
+         'timezone' => 'UTC',
+     ],
 
-   ... more ...
+     ... more ...
 
  'dev' => [
-   'template' => [
-     'allow_symlink' => '0',
-     'minify_html' => '0',
-   ],
-   'js' => [
-     'merge_files' => '0',
-     'enable_js_bundling' => '0',
-     'minify_files' => '0',
-   ],
-   'css' => [
-     'merge_css_files' => '0',
-     'minify_files' => '0',
-   ],
+     'template' => [
+         'allow_symlink' => '0',
+         'minify_html' => '0',
+     ],
+     'js' => [
+         'merge_files' => '0',
+         'enable_js_bundling' => '0',
+         'minify_files' => '0',
+     ],
+     'css' => [
+         'merge_css_files' => '0',
+         'minify_files' => '0',
+     ],
 
-   ... more ...
+     ... more ...
 </pre>
 
 ## Push and deploy config.local.php to environments {#deploy}

--- a/guides/v2.2/cloud/live/sens-data-initial.md
+++ b/guides/v2.2/cloud/live/sens-data-initial.md
@@ -96,29 +96,29 @@ The following snippet from `config.php` shows an example of changing the default
 
 <pre class="no-copy">
  'general' => [
-   'locale' => [
-     'code' => 'en_GB',
-     'timezone' => 'UTC',
-   ],
+     'locale' => [
+         'code' => 'en_GB',
+         'timezone' => 'UTC',
+     ],
 
-   ... more ...
+     ... more ...
 
  'dev' => [
-   'template' => [
-     'allow_symlink' => '0',
-     'minify_html' => '0',
-   ],
-   'js' => [
-     'merge_files' => '0',
-     'enable_js_bundling' => '0',
-     'minify_files' => '0',
-   ],
-   'css' => [
-     'merge_css_files' => '0',
-     'minify_files' => '0',
-   ],
+     'template' => [
+         'allow_symlink' => '0',
+         'minify_html' => '0',
+     ],
+     'js' => [
+         'merge_files' => '0',
+         'enable_js_bundling' => '0',
+         'minify_files' => '0',
+     ],
+     'css' => [
+         'merge_css_files' => '0',
+         'minify_files' => '0',
+     ],
 
-   ... more ...
+     ... more ...
 </pre>
 
 ## Push and deploy config.php to environments {#deploy}

--- a/guides/v2.2/cloud/live/sens-data-initial.md
+++ b/guides/v2.2/cloud/live/sens-data-initial.md
@@ -95,36 +95,30 @@ To create and transfer `config.php`:
 The following snippet from `config.php` shows an example of changing the default locale to `en_GB` and changing static file optimization settings:
 
 <pre class="no-copy">
- 'general' =>
-      array (
-        'locale' =>
-        array (
-          'code' => 'en_GB',
-          'timezone' => 'UTC',
-        ),
+ 'general' => [
+   'locale' => [
+     'code' => 'en_GB',
+     'timezone' => 'UTC',
+   ],
 
-        ... more ...
+   ... more ...
 
- 'dev' =>
-      'template' =>
-        array (
-          'allow_symlink' => '0',
-          'minify_html' => '0',
-        ),
+ 'dev' => [
+   'template' => [
+     'allow_symlink' => '0',
+     'minify_html' => '0',
+   ],
+   'js' => [
+     'merge_files' => '0',
+     'enable_js_bundling' => '0',
+     'minify_files' => '0',
+   ],
+   'css' => [
+     'merge_css_files' => '0',
+     'minify_files' => '0',
+   ],
 
-        ... more ...
-
-        'js' =>
-        array (
-          'merge_files' => '0',
-          'enable_js_bundling' => '0',
-          'minify_files' => '0',
-        ),
-        'css' =>
-        array (
-          'merge_css_files' => '0',
-          'minify_files' => '0',
-        ),
+   ... more ...
 </pre>
 
 ## Push and deploy config.php to environments {#deploy}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Fix the array formatting for exported config settings in the cloud. As of ece-tools v2002.0.14, short-array syntax is now used to comply with Magento coding standards.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/cloud/live/sens-data-initial.html
- https://devdocs.magento.com/guides/v2.1/cloud/live/sens-data-initial.html
