### PR TITLE
Add importing config file as final step for Cloud transfer

### DIFF
--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -17,8 +17,7 @@
 1.  Transfer the `config.local.php` file to your local workstation.
 
     ```bash
-    rsync ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
-:app/etc/config.local.php ./app/etc/config.local.php
+    rsync server@ssh.magentosite.cloud:app/etc/config.local.php ./app/etc/config.local.php
     ```
 
 1.  Test to ensure a successful transfer by importing the configuration file to your local environment.

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -1,28 +1,27 @@
 #### To create and transfer `config.local.php`:
 
-1.	On your local workstation, find the integration server SSH URL.
+1.  On your local workstation, find the integration server SSH URL.
 
-            magento-cloud environment:ssh --pipe
+    ```bash
+    magento-cloud environment:ssh --pipe
+    ```
 
-2.	Create `config.local.php` on the integration server.
+1.  Create the `config.local.php` file on the integration server.
 
-		ssh <SSH URL> "php bin/magento magento-cloud:scd-dump"
+    ```bash
+    ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
+    ```
 
-	For example,
+1.  Change to the project root directory.
 
-		ssh itnu84v4m4e5k-master-ouhx5wq@ssh.us.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
+1.  Transfer the `config.local.php` file to your local workstation.
 
-	<!-- A message similar to the following displays if you have any sensitive settings configured in your system:
+    ```bash
+    rsync <SSH URL>:app/etc/config.local.php ./app/etc/config.local.php
+    ```
 
-	<pre class="no-copy">
-	The configuration file doesn't contain the sensitive data by security reason. The sensitive data can be stored in the next environment variables:
-	CONFIG__DEFAULT__DEV__RESTRICT__ALLOW_IPS for dev/restrict/allow_ips</pre> -->
-5.	Change to the project root directory.
+1.  Test to ensure a successful transfer by importing the configuration file to your local environment.
 
-6.	Transfer the `config.local.php` file to your local workstation.
-
-		rsync <SSH URL>:app/etc/config.local.php ./app/etc/config.local.php
-
-7.	You can then test to ensure the transfer was successful by importing the config file to your local environment.
-
-		php bin/magento app:config:import
+    ```bash
+    php bin/magento app:config:import
+    ```

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -22,3 +22,7 @@
 6.	Transfer the `config.local.php` file to your local workstation.
 
 		rsync <SSH URL>:app/etc/config.local.php ./app/etc/config.local.php
+
+7.	You can then test to ensure the transfer was successful by importing the config file to your local environment.
+
+		php bin/magento app:config:import

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -17,7 +17,8 @@
 1.  Transfer the `config.local.php` file to your local workstation.
 
     ```bash
-    rsync <SSH URL>:app/etc/config.local.php ./app/etc/config.local.php
+    rsync ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
+:app/etc/config.local.php ./app/etc/config.local.php
     ```
 
 1.  Test to ensure a successful transfer by importing the configuration file to your local environment.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [X] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Add importing the config file as the final step for completing the config transfer from Cloud. This both ensures that the config file has been transferred successfully, but also adds clarity as to what to do with that config file locally.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/cloud/live/sens-data-initial.html
- https://devdocs.magento.com/guides/v2.1/cloud/live/sens-data-initial.html
