### PR TITLE
MAGECLOUD-2879: Added ENABLE_GOOGLE_ANALYTICS deploy variable

### DIFF
--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -108,19 +108,21 @@ stage:
 
 ### `ENABLE_GOOGLE_ANALYTICS`
 
--  **Default**—_false_
+-  **Default**—`false`
 -  **Version**—Magento 2.1.4 and later
-
-```yaml
-stage:
-  deploy:
-   ENABLE_GOOGLE_ANALYTICS: false 
-```
 
 Enables or disables Google Analytics when deploying to Staging and Integration environments.
 
 -   **`true`**—Enables Google Analytics on Staging and Integration environments.
 -   **`false`**—Disables Google Analytics on Staging and Integration environments.
+
+The following example enables Google Analytics when deploying to a Staging or Integration environment.
+
+```yaml
+stage:
+  deploy:
+    ENABLE_GOOGLE_ANALYTICS: true 
+```
 
 {:.bs-callout .bs-callout-info}
 The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -106,6 +106,25 @@ stage:
       _merge: true
 ```
 
+### `ENABLE_GOOGLE_ANALYTICS`
+
+-  **Default**—_false_
+-  **Version**—Magento 2.1.4 and later
+
+```yaml
+stage:
+  deploy:
+   ENABLE_GOOGLE_ANALYTICS: false 
+```
+
+Enables or disables Google Analytics when deploying to Staging and Integration environments.
+
+-   **`true`**—Enables Google Analytics on Staging and Integration environments.
+-   **`false`**—Disables Google Analytics on Staging and Integration environments.
+
+{:.bs-callout .bs-callout-info}
+The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.
+
 ### `GENERATED_CODE_SYMLINK`
 
 -  **Default**—`true`

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -125,7 +125,7 @@ stage:
 ```
 
 {:.bs-callout .bs-callout-info}
-The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.
+The {{ site.data.var.ece }} deploy process always enables Google Analytics on Production environments.
 
 ### `GENERATED_CODE_SYMLINK`
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -37,7 +37,7 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
 
-    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Production environments.
+    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Integration environments.
 
 #### Resolved Issues
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -33,11 +33,9 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2799 -->Added a [Cron container]({{page.baseurl}}/cloud/docker/docker-development.html#cron-container) based on the PHP-CLI image.
 
--  **Environment variable updates**
+-  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
 
-    -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
-
-    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Integration environments.
+-  <!--MAGECLOUD-2879-->**Environment variable update**—Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) environment variable to enable or disable Google Analytics when deploying to Staging and Integration environments.
 
 #### Resolved Issues
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -33,7 +33,11 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2799 -->Added a [Cron container]({{page.baseurl}}/cloud/docker/docker-development.html#cron-container) based on the PHP-CLI image.
 
--  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
+-  **Environment variable updates**
+
+    -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
+
+    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Production environments.
 
 #### Resolved Issues
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -134,19 +134,21 @@ stage:
 
 ### `ENABLE_GOOGLE_ANALYTICS`
 
--  **Default**—_false_
+-  **Default**—`false`
 -  **Version**—Magento 2.1.4 and later
-
-```yaml
-stage:
-  deploy:
-   ENABLE_GOOGLE_ANALYTICS: false 
-```
 
 Enables or disables Google Analytics when deploying to Staging and Integration environments.
 
 -   **`true`**—Enables Google Analytics on Staging and Integration environments
 -   **`false`**—Disables Google Analytics on Staging and Integration environments.
+
+The following example enables Google Analytics when deploying to a Staging or Integration environment.
+
+```yaml
+stage:
+  deploy:
+    ENABLE_GOOGLE_ANALYTICS: true 
+```
 
 {:.bs-callout .bs-callout-info}
 The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -132,6 +132,25 @@ stage:
       _merge: true
 ```
 
+### `ENABLE_GOOGLE_ANALYTICS`
+
+-  **Default**—_false_
+-  **Version**—Magento 2.1.4 and later
+
+```yaml
+stage:
+  deploy:
+   ENABLE_GOOGLE_ANALYTICS: false 
+```
+
+Enables or disables Google Analytics when deploying to Staging and Integration environments.
+
+-   **`true`**—Enables Google Analytics on Staging and Integration environments
+-   **`false`**—Disables Google Analytics on Staging and Integration environments.
+
+{:.bs-callout .bs-callout-info}
+The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.
+
 ### `MYSQL_USE_SLAVE_CONNECTION`
 
 -  **Default**—`false`

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -139,7 +139,7 @@ stage:
 
 Enables or disables Google Analytics when deploying to Staging and Integration environments.
 
--   **`true`**—Enables Google Analytics on Staging and Integration environments
+-   **`true`**—Enables Google Analytics on Staging and Integration environments.
 -   **`false`**—Disables Google Analytics on Staging and Integration environments.
 
 The following example enables Google Analytics when deploying to a Staging or Integration environment.
@@ -151,7 +151,7 @@ stage:
 ```
 
 {:.bs-callout .bs-callout-info}
-The {{ site.data.var.ece }} deploy process always enables Google Analytics when deploying to Production environments.
+The {{ site.data.var.ece }} deploy process always enables Google Analytics on Production environments.
 
 ### `MYSQL_USE_SLAVE_CONNECTION`
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -33,11 +33,9 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2799 -->Added a [Cron container]({{page.baseurl}}/cloud/docker/docker-development.html#cron-container) based on the PHP-CLI image.
 
--  **Environment variable updates**
+-  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
 
-    -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
-
-    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Integration environments.
+-  <!--MAGECLOUD-2879-->**Environment variable update**—Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) environment variable to enable or disable Google Analytics when deploying to Staging and Integration environments.
 
 
 #### Resolved Issues

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -33,7 +33,12 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2799 -->Added a [Cron container]({{page.baseurl}}/cloud/docker/docker-development.html#cron-container) based on the PHP-CLI image.
 
--  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
+-  **Environment variable updates**
+
+    -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
+
+    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Production environments.
+
 
 #### Resolved Issues
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -37,7 +37,7 @@ The following updates describe the latest improvements to the `{{site.data.var.c
 
     -  <!-- MAGECLOUD- 2575 -->**Configure with PHP constants**—Added support for PHP constants in the `.magento.env.yaml` configuration file.
 
-    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Production environments.
+    -  <!--MAGECLOUD-2879-->Added the [ENABLE_GOOGLE_ANALYTICS]({{page.baseurl}}/cloud/env/variables-deploy.html##enable_google_analytics) deploy environment variable to enable or disable Google Analytics on Staging and Integration environments.
 
 
 #### Resolved Issues


### PR DESCRIPTION
## This PR is a:

- [x ] Content update

whatsnew
Added the [`ENABLE_GOOGLE_ANALYTICS`](https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html#enable-google-analytics) environment variable to enable or disable Google Analytics when deploying Magento Commerce Cloud to Staging and Integration environments.

Affected URLs:

- https://devdocs.magento.com/guides/v2.1/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html