### PR TITLE
Fix Grunt config path example

### DIFF
--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -63,7 +63,7 @@ To use a custom file for Grunt configuration:
 
 
        {
-           "themes": "dev/tools/grunt/configs/local-themes/themes"
+           "themes": "dev/tools/grunt/configs/local-themes"
        }
 This path is also added to your .gitignore by default
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Fix the Grunt config path example, as it is incorrect and may confuse people as to what their default config should look like.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/tools/using_grunt.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html
