### PR TITLE
There is no crontab.xml in cron

### DIFF
--- a/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
+++ b/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
@@ -83,7 +83,7 @@ Refer to [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql
 
 ### Add message consumers to cron
 
-You may also add these two message consumers to the cron job (optional). For this, add these lines in your `crontab.xml`:
+You may also add these two message consumers to the cron job (optional). For this, add these lines in your `crontab`:
 
 {%highlight xml%}
 * * * * * ps ax | grep [s]haredCatalogUpdateCategoryPermissions >>/dev/null 2>&1 || nohup php /var/www/html/magento2/bin/magento queue:consumers:start sharedCatalogUpdateCategoryPermissions &


### PR DESCRIPTION
crontab.xml is wrong destination for adding following lines. These lines can be added to the cron by using linix cli tool `crontab`. Example command is:
```
crontab -e
```
Detailed information see https://docs.oracle.com/cd/E19455-01/805-7229/6j6q8svfo/index.html

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, there will be no confusion where put crontab lines

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/comp-mgr/install-extensions/b2b-installation.html
- https://devdocs.magento.com/guides/v2.3/comp-mgr/install-extensions/b2b-installation.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
