### PR TITLE
Add redirect for Inventory front page

### DIFF
--- a/guides/v2.3/inventory/index.md
+++ b/guides/v2.3/inventory/index.md
@@ -2,6 +2,7 @@
 group: inventory
 title: Inventory Management overview
 landing-page: Inventory
+redirect_from: /guides/v2.3/inventory/overview.html
 ---
 
 Magento Open Source and Commerce v2.3 include new and expanded features and APIs for Inventory Management. Inventory Management replaces all core APIs in the Open Source `CatalogInventory` module and the `ScalableInventory` module in Commerce. It also provides additional APIs to extend and add functionality.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, readers will be redirected from https://devdocs.magento.com/guides/v2.3/inventory/overview.html to https://devdocs.magento.com/guides/v2.3/inventory/index.html

