### PR TITLE
Fixed incorrect curl command

### DIFF
--- a/guides/v2.1/cloud/cdn/trouble-fastly.md
+++ b/guides/v2.1/cloud/cdn/trouble-fastly.md
@@ -251,7 +251,7 @@ Verify if you have the correct Fastly Service ID and API token in your environme
 
 If the credentials are correct, you may have issues with your VCLs. To list and review your VCLs per service, enter the following API call in a terminal:
 
-	curl -X GET -s https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/<Editable Version #>/snippet/ -H "Fastly-Key: <FASTLY_API_TOKEN>"
+	curl -X GET -s https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/<Editable Version #>/snippet -H "Fastly-Key: <FASTLY_API_TOKEN>"
 
 Review the list of VCLs. If you have issues with the default VCLs from Fastly, you can upload again or verify the content per the [Fastly default VCLs](https://github.com/fastly/fastly-magento2/tree/master/etc/vcl_snippets). For editing your custom VCLs, see [Custom Fastly VCL snippets]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html).
 


### PR DESCRIPTION
Removed trailing slash from command to get VCL snippets.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary
Fixed error in command for retrieving VCL snippets

## Affected URLs

https://devdocs.magento.com/guides/v2.1/cloud/cdn/trouble-fastly.html
https://devdocs.magento.com/guides/v2.2/cloud/cdn/trouble-fastly.html
https://devdocs.magento.com/guides/v2.3/cloud/cdn/


