### PR TITLE
Add Feature availability and Command-line upgrade info to release notes

### DIFF
--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -22,7 +22,7 @@ There are two ways to upgrade your Magento application to the 2.3 version:
 The upgrade scenario is the same for each of these options (both utilize Composer and a command line interface) from the system's point of view. However, if you upgrade using the script several of the steps are automated.
 
 {:.bs-callout .bs-callout-warning}
-Both scenarios require that you comply with the [Pre-upgrade checklist].
+Both scenarios require that you comply with the [Prerequisites].
 
 {:.bs-callout .bs-callout-info}
 If you cloned the Magento 2 GitHub repository, you **cannot** use this method to upgrade. Instead, see [Update the Magento application] for upgrade instructions.
@@ -321,5 +321,5 @@ If the application fails with a  `We're sorry, an error has occurred while gener
 [Update the Magento application]: {{ page.baseurl }}/install-gde/install/cli/dev_update-magento.html
 [Upgrade using the command line]: #upgrade-cli-upgr
 [Upgrade using the script]: #upgrade-cli-script
-[Pre-upgrade checklist]: #pre-upgrade-checklist
+[Prerequisites]: #prerequisites
 [the manual process]: #upgrade-cli-upgr

--- a/guides/v2.3/release-notes/2.3.0-install.md
+++ b/guides/v2.3/release-notes/2.3.0-install.md
@@ -5,7 +5,11 @@ redirect_from:
   - /guides/v2.3/release-notes/2.3.0-alpha-install.html
 ---
 
-## Prerequisites 
+## Prerequisites
+
+<div class="bs-callout bs-callout-tip" markdown="1">
+Do you already have a {{ site.data.var.ce }} instance installed? You can directly upgrade to {{ site.data.var.ee }} with our [Command-line upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#pre-upgrade-checklist) instructions.
+</div>
 
 In addition to the [standard Magento prerequisites]({{ site.baseurl }}/guides/v2.3/install-gde/prereq/prereq-overview.html), make sure you have obtained and installed:
 

--- a/guides/v2.3/release-notes/2.3.0-install.md
+++ b/guides/v2.3/release-notes/2.3.0-install.md
@@ -9,6 +9,8 @@ redirect_from:
 
 <div class="bs-callout bs-callout-tip" markdown="1">
 Do you already have a {{ site.data.var.ce }} instance installed? You can directly upgrade to {{ site.data.var.ee }} with our [Command-line upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#pre-upgrade-checklist) instructions.
+
+See the availability of features and releases on our [Magento 2.3 product availability page](https://devdocs.magento.com/availability.html).
 </div>
 
 In addition to the [standard Magento prerequisites]({{ site.baseurl }}/guides/v2.3/install-gde/prereq/prereq-overview.html), make sure you have obtained and installed:

--- a/guides/v2.3/release-notes/2.3.0-quick-start.md
+++ b/guides/v2.3/release-notes/2.3.0-quick-start.md
@@ -5,7 +5,10 @@ title: 2.3.0 Beta Quick Start Guide
 
 We are pleased to present the Magento 2.3.0 Open Source and Commerce Beta Release. This Quick Start guide provides the basic information you need to start participating in our Magento 2.3.0 Beta evaluation program.
 
-Need to proceed immediately to Magento 2.3.0 Beta? Sign the [Magento Pre-Release Software Agreement](https://bit.ly/2yGI58T) now! 
+See our [Magento 2.3 product availability page](https://devdocs.magento.com/availability.html) for more information on feature and release availability.
+
+{:.bs-callout .bs-callout-tip}
+Need to proceed immediately to Magento 2.3.0 Beta? Sign the [Magento Pre-Release Software Agreement](https://bit.ly/2yGI58T) and [install]({{page.baseurl}}/release-notes/2.3.0-install.html) Magento 2.3.0  Beta.
 
 
 This guide covers:
@@ -16,19 +19,14 @@ This guide covers:
 
 * **Submit comments on Magento 2.3.0 Beta code** on [GitHub](https://github.com/magento/magento2/issues)
 
-* **Readiness status of individual code components**. Magento 2.3.0 pre-release code is a work in progress. Consequently, parts of the code base are more mature than others. You can see an overview of component status at [Component Status]({{page.baseurl}}/release-notes/component-status.html). Note that we will update this information weekly during the Release evaluation period.
-
-
-{:.bs-callout .bs-callout-note}
-PageBuilder Beta code will be available in 2018 Q4. Registered participants will be able to install PageBuilder Beta on Magento 2.3.0 Commerce code.  Watch this space for more information about participating in the PageBuilder Beta program plus installation instructions. 
-
+* **Readiness status of individual code components**. Magento 2.3.0 pre-release code is a work in progress. Consequently, parts of the code base are more mature than others. You can see an overview of component status at [Component Status]({{page.baseurl}}/release-notes/component-status.html). Note that we will update this information weekly during the Release evaluation period. 
 
 ## Welcome to the Magento 2.3.0 Beta code
 
 Magento 2.3.0 Beta code will include bugs and incomplete features. It provides a snapshot of the current 2.3.0 codebase, and consequently an early peek into the new features that 2.3.0 will provide in more robust form.
 
-
-Note: We will publish new Beta code weekly.
+{:.bs-callout .bs-callout-tip}
+We will publish new Beta code weekly.
 
 ### What has changed since Alpha?
 
@@ -111,5 +109,3 @@ We anticipate the following changes to the 2.3.0 Beta code:
 The Magento Developer documentation has been updated with the latest 2.3 information.  Visit [Magento 2.3 Pre-release Developer Documentation]({{site.baseurl}}/guides/v2.3/) for a peek at our updated 2.3.0 developer documentation.
 
 The [Magento Open Source 2.3.0 Beta Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.3.0OpenSource.html) and [Magento Commerce 2.3.0 Beta Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.3.0Commerce.html) describe code fixes, known issues, and feature highlights. 
-
-Ready to [install]({{page.baseurl}}/release-notes/2.3.0-install.html) Magento 2.3.0  Beta?


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [X] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will:
* Move the pre-release/install info to top section
* Remove note about impending beta code because it is currently available
* Revise Prerequisites link in Command-line upgrade doc, it was broken
* Add a note to the top of the 2.3 install guide about the Command-line upgrade instructions

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#pre-upgrade-checklist
- https://devdocs.magento.com/guides/v2.3/release-notes/2.3.0-quick-start.html
- https://devdocs.magento.com/guides/v2.3/release-notes/2.3.0-install.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
