### PR TITLE
Update module-load-order.md

### DIFF
--- a/guides/v2.1/extension-dev-guide/build/module-load-order.md
+++ b/guides/v2.1/extension-dev-guide/build/module-load-order.md
@@ -41,10 +41,10 @@ For each particular scenario, files of the same type are loaded from different c
 
 In another scenario, let's say you want to load all of the {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} files with the name `default.xml`. __Component A__ specifies __component B__ in `<sequence>`. The files load in the following order:
 
-42. `component X/view/frontend/layout/default.xml`&mdash;Either we don't care about when component X loads or perhaps component B requires it to be loaded before it.
+42. `component X/view/frontend/layout/default.xml` &mdash; Either we don't care about when component X loads or perhaps component B requires it to be loaded before it.
 42. `component B/view/frontend/layout/default.xml`
-42. `component A/view/frontend/layout/default.xml`&mdash;Loads after __component B__ because __component B__ is listed in __component A's__ `<sequence>` tag.
-42. `component Z/view/frontend/layout/default.xml`&mdash;Either we don't care about the sequence for component Z or perhaps component Z requires component A files to be loaded before it.
+42. `component A/view/frontend/layout/default.xml` &mdash; Loads after __component B__ because __component B__ is listed in __component A's__ `<sequence>` tag.
+42. `component Z/view/frontend/layout/default.xml` &mdash; Either we don't care about the sequence for component Z or perhaps component Z requires component A files to be loaded before it.
 
 There are no limitations&mdash;you can specify any valid component in `<sequence>`.
 


### PR DESCRIPTION
Spacing after code block

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will at spaces after code block on one line for better readability

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

https://devdocs.magento.com/guides/v2.1/extension-dev-guide/build/module-load-order.html
https://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-load-order.html
https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/module-load-order.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
