### PR TITLE
Fix typo:  _>Module> to _<Module>

### DIFF
--- a/guides/v2.1/frontend-dev-guide/layouts/layout-types.md
+++ b/guides/v2.1/frontend-dev-guide/layouts/layout-types.md
@@ -371,7 +371,7 @@ Generic layouts define the contents and detailed structure inside the `<body>` s
 Conventionally generic layout files must be located as follows:
 
 - Module generic layouts: `<module_dir>/view/frontend/layout`
-- Theme generic layouts: `<theme_dir>/<Namespace>_>Module>/layout`
+- Theme generic layouts: `<theme_dir>/<Namespace>_<Module>/layout`
 
 ### Generic layout structure and allowed layout instructions
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix typo.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-types.html

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
