### PR TITLE
GH-3162: Fix links in list items so they show

### DIFF
--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -314,9 +314,9 @@ Extending layout:
 
 In layout files you can change the elements order on a page. This can be done using one of the following:
 
-* [`<move>` instruction]: allows changing elements' order and parent.
-* [`before` and `after` attributes of `<block>`]: allows changing elements' order within one parent.
-
+* [`<move>` instruction]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv): allows changing elements' order and parent.
+* [`before` and `after` attributes of `<block>`]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_xml-instrux_before-after
+): allows changing elements' order within one parent.
 
 Example of `<move>` usage:
 put the stock availability and SKU blocks next to the product price on a product page.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will fix the list items in the Rearrange Elements sections for v2.2 and v2.3 so that they actually show.

Fixes #3162 

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html
- https://devdocs.magento.com/guides/v2.23/frontend-dev-guide/layouts/xml-manage.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
