### PR TITLE
magento/devdocs#1455: Document default/core cookies

### DIFF
--- a/guides/v2.3/config-guide/cookie-reference.md
+++ b/guides/v2.3/config-guide/cookie-reference.md
@@ -1,0 +1,103 @@
+---
+group: configuration-guide
+title: Cookie Reference
+---
+
+A list of Magento 2 default cookies and descriptions. 
+
+## Cookie Reference
+
+<table>
+  <tr>
+    <th>Cookie Name</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>PHPSESSID</code></td>
+    <td>PHP's unique session identification string</td>
+  </tr>
+  <tr>
+    <td><code>X-Magento-Vary</code></td>
+    <td>X-Magento-Vary cookie is used to highlight that version of a page requested by a user has been changed. It allows having different versions of the same page stored in cache e.g. Varnish.</td>
+  </tr>
+  <tr>
+    <td><code>guest-view</code></td>
+    <td>Stores the Order ID that guest shoppers use to retrieve their order status.</td>
+  </tr>
+  <tr>
+    <td><code>form_key</code></td>
+    <td>A security measure that appends a random string to all form submissions to protect the data from Cross-Site Request Forgery (CSRF).</td>
+  </tr>
+  <tr>
+    <td><code>mage-cache-sessid</code></td>
+    <td>Facilitates caching of content on the browser to make pages load faster.</td>
+  </tr>
+  <tr>
+    <td><code>mage-cache-storage</code></td>
+    <td>The value of this cookie triggers the cleanup of local cache storage. When the cookie is removed by the backend application, the Admin cleans up local storage, and sets the cookie value to “true.”</td>
+  </tr>
+  <tr>
+    <td><code>mage-cache-storage-section-invalidation</code></td>
+    <td>Forces local storage of specific content sections that should be invalidated.</td>
+  </tr>
+  <tr>
+    <td><code>mage-messages</code></td>
+    <td>Tracks error messages and other notifications that are shown to the user, such as the cookie consent message, and various error messages, The message is deleted from the cookie after it is shown to the shopper.</td>
+  </tr>
+  <tr>
+    <td><code>mage-translation-file-version</code></td>
+    <td>Facilitates translation of content to other languages.</td>
+  </tr>
+  <tr>
+    <td><code>mage-translation-storage</code></td>
+    <td>Stores translated content when requested by the shopper.</td>
+  </tr>
+  <tr>
+    <td><code>persistent_shopping_cart</code></td>
+    <td>Stores the key (ID) of persistent cart to make it possible to restore the cart for an anonymous shopper.</td>
+  </tr>
+  <tr>
+    <td><code>private_content_version</code></td>
+    <td>Appends a random, unique number and time to pages with customer content to prevent them from being cached on the server.</td>
+  </tr>
+  <tr>
+    <td><code>product_data_storage</code></td>
+    <td>Stores configuration for product data related to Recently Viewed / Compared Products.</td>
+  </tr>
+  <tr>
+    <td><code>recently_compared_product</code></td>
+    <td>Stores product IDs of recently compared products.</td>
+  </tr>
+  <tr>
+    <td><code>recently_compared_product_previous</code></td>
+    <td>Stores product IDs of previously compared products for easy navigation.</td>
+  </tr>
+  <tr>
+    <td><code>recently_viewed_product</code></td>
+    <td>Stores product IDs of recently viewed products for easy navigation.</td>
+  </tr>
+  <tr>
+    <td><code>recently_viewed_product_previous</code></td>
+    <td>Stores product IDs of recently previously viewed products for easy navigation.</td>
+  </tr>
+  <tr>
+    <td><code>section_data_ids</code></td>
+    <td>Stores customer-specific information related to shopper-initiated actions such as display wish list, checkout information, etc.</td>
+  </tr>
+  <tr>
+    <td><code>store</code></td>
+    <td>Tracks the specific store view / locale selected by the shopper.</td>
+  </tr>
+  <tr>
+    <td><code>stf</code></td>
+    <td>Records the time messages are sent by the SendFriend (Email a Friend) module.</td>
+  </tr>
+  <tr>
+    <td><code>amz_auth_err</code></td>
+    <td>(Used by Amazon Pay) Value “1’ indicates an authorization error.</td>
+  </tr>
+  <tr>
+    <td><code>amz_auth_logout</code></td>
+    <td>(Used by Amazon Pay) Value “1” indicates that the user should be logged out.</td>
+  </tr>
+</table>

--- a/guides/v2.3/config-guide/cookie-reference.md
+++ b/guides/v2.3/config-guide/cookie-reference.md
@@ -7,97 +7,27 @@ A list of Magento 2 default cookies and descriptions.
 
 ## Cookie Reference
 
-<table>
-  <tr>
-    <th>Cookie Name</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td><code>PHPSESSID</code></td>
-    <td>PHP's unique session identification string</td>
-  </tr>
-  <tr>
-    <td><code>X-Magento-Vary</code></td>
-    <td>X-Magento-Vary cookie is used to highlight that version of a page requested by a user has been changed. It allows having different versions of the same page stored in cache e.g. Varnish.</td>
-  </tr>
-  <tr>
-    <td><code>guest-view</code></td>
-    <td>Stores the Order ID that guest shoppers use to retrieve their order status.</td>
-  </tr>
-  <tr>
-    <td><code>form_key</code></td>
-    <td>A security measure that appends a random string to all form submissions to protect the data from Cross-Site Request Forgery (CSRF).</td>
-  </tr>
-  <tr>
-    <td><code>mage-cache-sessid</code></td>
-    <td>Facilitates caching of content on the browser to make pages load faster.</td>
-  </tr>
-  <tr>
-    <td><code>mage-cache-storage</code></td>
-    <td>The value of this cookie triggers the cleanup of local cache storage. When the cookie is removed by the backend application, the Admin cleans up local storage, and sets the cookie value to “true.”</td>
-  </tr>
-  <tr>
-    <td><code>mage-cache-storage-section-invalidation</code></td>
-    <td>Forces local storage of specific content sections that should be invalidated.</td>
-  </tr>
-  <tr>
-    <td><code>mage-messages</code></td>
-    <td>Tracks error messages and other notifications that are shown to the user, such as the cookie consent message, and various error messages, The message is deleted from the cookie after it is shown to the shopper.</td>
-  </tr>
-  <tr>
-    <td><code>mage-translation-file-version</code></td>
-    <td>Facilitates translation of content to other languages.</td>
-  </tr>
-  <tr>
-    <td><code>mage-translation-storage</code></td>
-    <td>Stores translated content when requested by the shopper.</td>
-  </tr>
-  <tr>
-    <td><code>persistent_shopping_cart</code></td>
-    <td>Stores the key (ID) of persistent cart to make it possible to restore the cart for an anonymous shopper.</td>
-  </tr>
-  <tr>
-    <td><code>private_content_version</code></td>
-    <td>Appends a random, unique number and time to pages with customer content to prevent them from being cached on the server.</td>
-  </tr>
-  <tr>
-    <td><code>product_data_storage</code></td>
-    <td>Stores configuration for product data related to Recently Viewed / Compared Products.</td>
-  </tr>
-  <tr>
-    <td><code>recently_compared_product</code></td>
-    <td>Stores product IDs of recently compared products.</td>
-  </tr>
-  <tr>
-    <td><code>recently_compared_product_previous</code></td>
-    <td>Stores product IDs of previously compared products for easy navigation.</td>
-  </tr>
-  <tr>
-    <td><code>recently_viewed_product</code></td>
-    <td>Stores product IDs of recently viewed products for easy navigation.</td>
-  </tr>
-  <tr>
-    <td><code>recently_viewed_product_previous</code></td>
-    <td>Stores product IDs of recently previously viewed products for easy navigation.</td>
-  </tr>
-  <tr>
-    <td><code>section_data_ids</code></td>
-    <td>Stores customer-specific information related to shopper-initiated actions such as display wish list, checkout information, etc.</td>
-  </tr>
-  <tr>
-    <td><code>store</code></td>
-    <td>Tracks the specific store view / locale selected by the shopper.</td>
-  </tr>
-  <tr>
-    <td><code>stf</code></td>
-    <td>Records the time messages are sent by the SendFriend (Email a Friend) module.</td>
-  </tr>
-  <tr>
-    <td><code>amz_auth_err</code></td>
-    <td>(Used by Amazon Pay) Value “1’ indicates an authorization error.</td>
-  </tr>
-  <tr>
-    <td><code>amz_auth_logout</code></td>
-    <td>(Used by Amazon Pay) Value “1” indicates that the user should be logged out.</td>
-  </tr>
-</table>
+|Cookie Name|Description|
+|--- |--- |
+|PHPSESSID|PHP's unique session identification string|
+|X-Magento-Vary|X-Magento-Vary cookie is used to highlight that version of a page requested by a user has been changed. It allows having different versions of the same page stored in cache e.g. Varnish.|
+|guest-view|Stores the Order ID that guest shoppers use to retrieve their order status.|
+|form_key|A security measure that appends a random string to all form submissions to protect the data from Cross-Site Request Forgery (CSRF).|
+|mage-cache-sessid|Facilitates caching of content on the browser to make pages load faster.|
+|mage-cache-storage|The value of this cookie triggers the cleanup of local cache storage. When the cookie is removed by the backend application, the Admin cleans up local storage, and sets the cookie value to “true.”|
+|mage-cache-storage-section-invalidation|Forces local storage of specific content sections that should be invalidated.|
+|mage-messages|Tracks error messages and other notifications that are shown to the user, such as the cookie consent message, and various error messages, The message is deleted from the cookie after it is shown to the shopper.|
+|mage-translation-file-version|Facilitates translation of content to other languages.|
+|mage-translation-storage|Stores translated content when requested by the shopper.|
+|persistent_shopping_cart|Stores the key (ID) of persistent cart to make it possible to restore the cart for an anonymous shopper.|
+|private_content_version|Appends a random, unique number and time to pages with customer content to prevent them from being cached on the server.|
+|product_data_storage|Stores configuration for product data related to Recently Viewed / Compared Products.|
+|recently_compared_product|Stores product IDs of recently compared products.|
+|recently_compared_product_previous|Stores product IDs of previously compared products for easy navigation.|
+|recently_viewed_product|Stores product IDs of recently viewed products for easy navigation.|
+|recently_viewed_product_previous|Stores product IDs of recently previously viewed products for easy navigation.|
+|section_data_ids|Stores customer-specific information related to shopper-initiated actions such as display wish list, checkout information, etc.|
+|store|Tracks the specific store view / locale selected by the shopper.|
+|stf|Records the time messages are sent by the SendFriend (Email a Friend) module.|
+|amz_auth_err|(Used by Amazon Pay) Value “1’ indicates an authorization error.|
+|amz_auth_logout|(Used by Amazon Pay) Value “1” indicates that the user should be logged out.|


### PR DESCRIPTION
## This PR is a:

- [X] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary
Added a document to have a table where each cookie set by the Magento 2 core application is documented with a short description. See issue magento/devdocs#1455

When this pull request is merged, it will add a cookie reference table to the devdocs.

<!-- (REQUIRED) What does this PR change? -->

## Additional information
This is a new document. I did not know where in the menu this document should be put?

<!-- (REQUIRED) The Url that this PR will modify -->
I am not sure what the URL should be?
<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
whatsnew
Added a [new reference topic](https://devdocs.magento.com/guides/v2.3/config-guide/cookie-reference.md) about cookies set by Magento 2.