### PR TITLE
Fixing the broken "Example 2" collspsible element

### DIFF
--- a/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
@@ -38,8 +38,6 @@ We recommend specifying JavaScript resources in the templates rather than in the
 
 JS resources are accessed using relative paths.
 
-Examples:
-
 **Example 1**
 
 - File actual location: `app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js`
@@ -51,7 +49,7 @@ Examples:
     ```
 
 
-{% collapsible Example 2 %}
+**Example 2**
 
 - File actual location: `app/code/design/frontend/Magento/blank/web/js/theme.js`
 - File published to `pub/static`: `pub/static/frontend/Magento/<theme>/<locale>/js/theme.js`
@@ -60,10 +58,10 @@ Examples:
     require(["js/theme.js"], function(){
        });
     ```
-{% endcollapsible %}
 
 
-{% collapsible Example 3 %}
+**Example**
+
 - File actual location: `lib/web/jquery.js`
 - File published to `pub/static`: `pub/static/<area>/Magento/<theme>/<locale>/jquery.js`
 - Called in script:
@@ -71,7 +69,7 @@ Examples:
     require(["jquery"], function($){
        });
     ```
-{% endcollapsible %}
+
 
 These relative paths are also used in for [mapping and setting `paths` in requirejs-config.js configuration files]({{ page.baseurl }}/javascript-dev-guide/javascript/requirejs_concept.html).
 

--- a/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
@@ -50,6 +50,7 @@ Examples:
        });
     ```
 
+
 {% collapsible Example 2 %}
 
 - File actual location: `app/code/design/frontend/Magento/blank/web/js/theme.js`

--- a/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js-resources.md
@@ -60,7 +60,7 @@ JS resources are accessed using relative paths.
     ```
 
 
-**Example**
+**Example 3**
 
 - File actual location: `lib/web/jquery.js`
 - File published to `pub/static`: `pub/static/<area>/Magento/<theme>/<locale>/jquery.js`


### PR DESCRIPTION
The "Example 2" is rendered as "Example 1" list item and has "</ul> </div> </div>" tags displayed after.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/javascript/js-resources.html
- versions 2.2 and 2.3 are symlinked

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
