### PR TITLE
Remove obsolete and overly restrictive rule

### DIFF
--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -634,9 +634,7 @@ We are reviewing this section and will publish it soon.
 
 10.5.5. Modules MUST NOT have external side effects.
 
-10.5.6. Function declarations MUST be used for private functions instead of function expressions.
-
-10.5.7. Re-declaration of function names MUST NOT be used.
+10.5.6. Re-declaration of function names MUST NOT be used.
 
 ## 11. Testing
 


### PR DESCRIPTION
The purpose of this rule is not clear.
Private methods should be considered an implementation detail.
Hoisting of nested functions was not defined prior to ES2015 and generally discouraged, which makes this rule problematic.
@DrewML assumed it was to help produce cleaner stack traces without `(anonymous)` function names, but since ES2015 function names are derived for function expressions automatically, so if that was the original purpose of the rule, that no longer is a problem.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- ...
- ...

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
