### PR TITLE
Fix links: JavaScript Developer Guide

### DIFF
--- a/guides/v2.1/javascript-dev-guide/javascript/js_practice.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js_practice.md
@@ -135,7 +135,7 @@ var config = {
 
 [Page source search result]: {{site.baseurl}}/common/images/fdg_js_pr1.png
 [`gallery.js`]: {{site.mage2100url}}lib/web/mage/gallery/gallery.js
-[can be reached from the page source view or from the file system]: {{page.baseurl}}/javascript-dev-guide/javascript/custom_js.html#config_file
+[can be reached from the page source view or from the file system]: {{page.baseurl}}/javascript-dev-guide/javascript/custom_js.html#extend_js
 [RequireJS config file]: {{site.baseurl}}/common/images/fdg_pr_2.png
 [jCarousel widget]: http://sorgalla.com/jcarousel/
 [`gallery.js`]: {{site.mage2100url}}lib/web/mage/gallery/gallery.js

--- a/rakelib/proofer.rb
+++ b/rakelib/proofer.rb
@@ -32,7 +32,6 @@ module Proofer
     github.com
     guides/v2.0
     howdoi
-    javascript-dev-guide
     mariadb.com
     mftf
     mrg


### PR DESCRIPTION
Fixes #3251 

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix broken links to JavaScript Developer Guide pages.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/javascript/js_practice.html
- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/js_practice.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/js_practice.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
