### PR TITLE
Add note about starting the message queue consumer for bulk/async calls

### DIFF
--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -9,6 +9,9 @@ functional_areas:
 
 An asynchronous web endpoint intercepts messages to a Web API and writes them to the message queue. Each time the system accepts such an API request, it generates a UUID identifier. Magento includes this UUID when it adds the message to the queue. Then, a consumer reads the messages from the queue and executes them one-by-one.
 
+{:.bs-callout .bs-callout-tip}
+Use the `bin/magento queue:consumer:start async.operations.all` command to enable asynchronous requests.
+
 Magento supports the following types of asynchronous requests:
 
 * POST

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -10,7 +10,7 @@ functional_areas:
 An asynchronous web endpoint intercepts messages to a Web API and writes them to the message queue. Each time the system accepts such an API request, it generates a UUID identifier. Magento includes this UUID when it adds the message to the queue. Then, a consumer reads the messages from the queue and executes them one-by-one.
 
 {:.bs-callout .bs-callout-tip}
-Use the `bin/magento queue:consumer:start async.operations.all` command to enable asynchronous requests.
+Use the `bin/magento queue:consumers:start async.operations.all` command to enable asynchronous requests.
 
 Magento supports the following types of asynchronous requests:
 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -10,7 +10,7 @@ functional_areas:
 Bulk API endpoints differ from other REST endpoints in that they combine multiple calls of the same type into an array and execute them as a single request. The endpoint handler splits the array into individual entities and writes them as separate messages to the message queue. 
 
 {:.bs-callout .bs-callout-tip}
-Use the `bin/magento queue:consumer:start async.operations.all` command to enable bulk endpoint processing.
+Use the `bin/magento queue:consumers:start async.operations.all` command to enable bulk endpoint processing.
 
 ### Routes
 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -7,10 +7,10 @@ functional_areas:
   - Integration
 ---
 
-Bulk API endpoints differ from other endpoints in that they combine multiple calls of the same type into an array and execute them as a single request. The endpoint handler splits the array into individual entities and writes them as separate messages to the message queue.
+Bulk API endpoints differ from other REST endpoints in that they combine multiple calls of the same type into an array and execute them as a single request. The endpoint handler splits the array into individual entities and writes them as separate messages to the message queue. 
 
 {:.bs-callout .bs-callout-tip}
-GET requests are not supported.
+Use the `bin/magento queue:consumer:start async.operations.all` command to enable bulk endpoint processing.
 
 ### Routes
 
@@ -32,6 +32,8 @@ Synchronous route | Bulk route
 `POST /V1/carts/:quoteId/items` | `POST async/bulk/V1/carts/byQuoteId/items`
 `DELETE /V1/customers/:customerId` | `DELETE async/bulk/V1/customers/byCustomerId`
 
+{:.bs-callout .bs-callout-info}
+GET requests are not supported.
 
 ### Payloads
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, the bulk/async REST documentation will state that the `queue:consumers:start async.operations.all` must be run.

Affected topics:

https://devdocs.magento.com/guides/v2.3/rest/asynchronous-web-endpoints.html
https://devdocs.magento.com/guides/v2.3/rest/bulk-endpoints.html