### PR TITLE
Create topic for queue subcommands

### DIFF
--- a/_data/toc/configuration-guide.yml
+++ b/_data/toc/configuration-guide.yml
@@ -103,6 +103,10 @@ pages:
         - label: Set the Magento mode
           url: /config-guide/cli/config-cli-subcommands-mode.html
 
+        - label: Start message queue consumers
+          include_versions: ["2.3"]
+          url: /config-guide/cli/config-cli-subcommands-queue.html
+
         - label: URN highlighter
           url: /config-guide/cli/config-cli-subcommands-urn.html
 

--- a/_includes/config/message-queue-consumers.md
+++ b/_includes/config/message-queue-consumers.md
@@ -1,0 +1,41 @@
+## View a list of available message queue consumers
+
+To view a list of all consumers:
+
+```bash
+bin/magento queue:consumers:list
+```
+
+The list displays as follows:
+
+```
+sharedCatalogUpdatePrice
+sharedCatalogUpdateCategoryPermissions
+quoteItemCleaner
+inventoryQtyCounter
+async.operations.all
+```
+
+## Start message queue consumers
+
+To start message queue consumers:
+
+```bash
+/bin/magento queue:consumers:start [--max-messages=<value>] [--batch-size=<value>] [--pid-file-path=<value>] <consumer_name>
+```
+
+The following table explains this command’s options, parameters, and values.
+
+Parameter | Value | Required?
+--- | --- | ---
+`--max-messages=<value>` | The maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously. | No
+`--batch-size=<value>` | The number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue. | No
+`--pid-file-path=<value>` | The file path for saving PID of consumer process. | No
+`<consumer_name>` | The consumer to start. | Yes
+{:style="table-layout:auto;"}
+
+After consuming all available messages, the command terminates. You can run the command again manually or with a cron job. You can also run multiple instances of the `magento queue:consumers:start` command to process large message queues. For example, you can append `&` to the command to run it in the background, return to a prompt, and continue running commands:
+
+```bash
+bin/magento queue:consumers:start <consumer_name> &
+```

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.md
@@ -1,0 +1,19 @@
+---
+group: configuration-guide
+title: Start message queue consumers
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+{% include config/cli-intro.md %}
+
+You must start a message queue consumer to enable asynchronous operations such as Inventory Management mass actions and REST bulk and asynchronous endpoints. To enable B2B functionality, you must start multiple consumers. Third-party modules might also require that you start a custom consumer. 
+
+{% include config/message-queue-consumers.md %}
+
+## Related topics
+
+* [Message queues overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
+* [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)

--- a/guides/v2.3/config-guide/mq/manage-mysql.md
+++ b/guides/v2.3/config-guide/mq/manage-mysql.md
@@ -1,1 +1,70 @@
-../../../v2.2/config-guide/mq/manage-mysql.md
+---
+group: configuration-guide
+title: Manage message queues
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+
+If you don't want to implement the RabbitMQ solution, you can manage message queues with cron jobs (or an external process manager) and the command line to ensure that consumers are retrieving messages.
+
+## Process management
+
+Cron jobs are the default mechanism to restart consumers. Processes started by `cron` consume the specified number of messages and then terminate. Re-running `cron` restarts the consumer.
+
+The following shows a `crontab` configuration for running consumers in our implementation, it is the example for understanding how it works:
+
+*/app/code/Magento/MessageQueue/etc/crontab.xml*
+
+```xml
+...
+<job name="consumers_runner" instance="Magento\MessageQueue\Model\Cron\ConsumersRunner" method="run">
+    <schedule>* * * * *</schedule>
+</job>
+...
+```
+
+{:.bs-callout .bs-callout-info}
+How often you check message queues depends on your business logic and available system resources. In general, you'll probably want to check for newly created customers and send welcome emails more frequently than a more resource intensive process (e.g., updating your catalog). You should define `cron` schedules according to your business needs.<br><br>It can be configured in Admin Panel **Stores > Configuration > Advanced > System > Cron configuration options for group: consumers**<br><br>See [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html) for more information about using `cron` with Magento.
+
+You can also use a process manager such as [Supervisor](http://supervisord.org/index.html) to monitor the status of processes. The manager can use the command line to restart the processes as needed.
+
+### Configuration
+
+#### Behavior by default
+
+* Cron job `consumers_runner` is enabled
+* Cron job `consumers_runner` runs all defined consumers
+* Each consumer process 10000 messages and then terminate
+
+#### Specific configuration
+
+Edit */app/etc/env.php* file for configure cron job `consumers_runner`
+
+{% highlight php %}
+...
+    'cron_consumers_runner' => array(
+        'cron_run' => false,
+        'max_messages' => 20000,
+        'consumers' => array(
+            'consumer1',
+            'consumer2',
+        )
+    ),
+...
+{% endhighlight %}
+
+* `cron_run` - the option for enabling/disabling cron job `consumers_runner`, by default is true.
+* `max_messages` - the maximum number of messages for each consumer that must be processed before consumer terminate, by default is 1000. If it is 0, then the consumer never stops working.
+* `consumers` - the list of consumers which will be run, by default is empty array (all consumers are allowed to be run).
+
+{% include config/message-queue-consumers.md %}
+
+#### Related Topics
+
+*   [Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
+*   [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)
+*   [Command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
+*   [Message Queues]({{ page.baseurl }}/extension-dev-guide/message-queues/message-queues.html)


### PR DESCRIPTION
## This PR is a:

- [x] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will create a separate topic in the Config guide for the `magento queue:consumers` command. Previously, they were buried in https://devdocs.magento.com/guides/v2.3/config-guide/mq/manage-mysql.html
