### PR TITLE
delete outdated text

### DIFF
--- a/guides/v2.2/comp-mgr/upgrader/ce-ee-upgrade-start.md
+++ b/guides/v2.2/comp-mgr/upgrader/ce-ee-upgrade-start.md
@@ -16,11 +16,6 @@ You must be authorized for {{site.data.var.ee}} to perform the tasks discussed i
 
 Before continuing, complete all tasks discussed in [Prerequisites].
 
-In addition, you might need to install the {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} [`bcmath`] extension, which is required by {{site.data.var.ee}}. Examples follow:
-
-*	CentOS (using the `webtatic` repository): `yum -y install php56w-bcmath`
-*	Ubuntu (using the `ppa:ondrej/php5-5.6` repository): `apt-get -y install php5-bcmath`
-
 {:.bs-callout .bs-callout-info}
 Make sure you are authorized for {{site.data.var.ee}} access before you continue. Contact [Magento Support](http://support.magentocommerce.com){:target="_blank"} if you have questions.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

[Upgrade from Open Source to Commerce](https://devdocs.magento.com/guides/v2.3/comp-mgr/upgrader/ce-ee-upgrade-start.html) contains references to an outdated PHP bcmath extension. Per @melnikovi 's suggestion, I deleted the reference, since the readiness check will determine whether any extensions need to be installed.

When this pull request is merged, it will remove the outdated references. 
