### PR TITLE
fixes wrong escaping

### DIFF
--- a/guides/v2.1/javascript-dev-guide/javascript/js_init.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js_init.md
@@ -55,9 +55,9 @@ Depending on the type of the inserted JS component, processing is performed as f
 return function(config, element) { ... };
 ```
 
-- If neither a function nor an object with the `"component_name&gt;"` key are returned, then the initializer tries to search for <code>"&lt;component_name&gt;"</code> in the jQuery prototype. If found, the initializer applies it as `$(element).&lt;component_name&gt;(config)`. For example:
+- If neither a function nor an object with the `"<component_name>"` key are returned, then the initializer tries to search for <code>"<component_name>"</code> in the jQuery prototype. If found, the initializer applies it as `$(element).&lt;component_name&gt;(config)`. For example:
     ```javascript
-    $.fn.&lt;component_name&gt; = function() { ... };
+    $.fn.<component_name> = function() { ... };
     return;
     ```
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix wrong escaping

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/js_init.html
- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/javascript/js_init.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->