### PR TITLE
fixes wrongly usage of define function in example

### DIFF
--- a/guides/v2.1/javascript-dev-guide/javascript/js_init.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/js_init.md
@@ -154,7 +154,7 @@ In a similar way, you can initialize any JS component that a returns callback fu
 For example:
 
 ```javascript
-define ([
+require ([
     'jquery',
     'mage/gallery/gallery'
 ], function ($, Gallery) {


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix a code example that wrongly shows 'define' instead of 'require'

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/js_init.html
- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/javascript/js_init.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->