### PR TITLE
correct path to magento command

### DIFF
--- a/_includes/config/message-queue-consumers.md
+++ b/_includes/config/message-queue-consumers.md
@@ -21,7 +21,7 @@ async.operations.all
 To start message queue consumers:
 
 ```bash
-/bin/magento queue:consumers:start [--max-messages=<value>] [--batch-size=<value>] [--pid-file-path=<value>] <consumer_name>
+bin/magento queue:consumers:start [--max-messages=<value>] [--batch-size=<value>] [--pid-file-path=<value>] <consumer_name>
 ```
 
 The following table explains this command’s options, parameters, and values.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will correct a command line example that listed the wrong path to the `magento` command.
