### PR TITLE
Added chcon for /generated folder

### DIFF
--- a/guides/v2.2/install-gde/prereq/security.md
+++ b/guides/v2.2/install-gde/prereq/security.md
@@ -1,1 +1,66 @@
-../../../v2.1/install-gde/prereq/security.md
+---
+group: installation-guide
+subgroup: Prerequisites
+title: SELinux and iptables
+menu_title: SELinux and iptables
+menu_order: 200
+functional_areas:
+  - Install
+  - System
+  - Setup
+---
+
+## SELinux {#install-prereq-selinux}
+[Security Enhanced Linux (SELinux)](http://selinuxproject.org/page/Main_Page){:target="_blank"} enables CentOS and Ubuntu administrators greater access control over their servers. If you're using SELinux _and_ Apache to initiate a connection to another host, you must run the commands discussed in this section.
+
+{:.bs-callout .bs-callout-info}
+  Magento has no recommendation about using SELinux; you can use it for enhanced security if you wish. If you use SELinux, you must configure it properly or the Magento application will function unpredictably. If you choose to use SELinux, consult a resource like [the CentOS wiki](http://wiki.centos.org/HowTos/SELinux){:target="_blank"} to set up rules to enable communication.
+
+### Suggestion for installing the Magento software with Apache
+
+If you choose to enable SELinux, you might have issues running the installer unless you change the *security context* of some directories as follows:
+
+	chcon -R --type httpd_sys_rw_content_t <your Magento install dir>/app/etc
+	chcon -R --type httpd_sys_rw_content_t <your Magento install dir>/var
+	chcon -R --type httpd_sys_rw_content_t <your Magento install dir>/pub/media
+	chcon -R --type httpd_sys_rw_content_t <your Magento install dir>/pub/static
+  chcon -R --type httpd_sys_rw_content_t <your Magento install dir>/generated
+
+The preceding commands work only with the Apache web server. Because of the variety of configurations and security requirements, we don't guarantee these commands work in all situations. For more information, see:
+
+*	[man page](http://linux.die.net/man/8/httpd_selinux){:target="_blank"}
+*	[serverlab](http://www.serverlab.ca/tutorials/linux/web-servers-linux/configuring-selinux-policies-for-apache-web-servers/){:target="_blank"}
+
+### Enable inter-server communication
+
+If Apache and the database server are on the same host, you can skip this section and continue with [Opening Ports In Your Firewall](#install-iptables).
+
+To enable Apache to initiate a connection to another host with SELinux enabled:
+
+1.	To determine if SELinux is enabled, use the following command:
+
+		getenforce
+
+	`Enforcing` displays to confirm that SELinux is running.
+
+2.	Enter one of the following commands:
+
+	CentOS: `setsebool -P httpd_can_network_connect=1`
+
+	Ubuntu: `setsebool -P apache2_can_network_connect=1`
+
+## Opening Ports In Your Firewall {#install-iptables}
+
+Depending on your security requirements, you might find it necessary to open port 80 and other ports in your firewall. Because of the sensitive nature of networking security, Magento strongly recommends you consult with your IT department before proceeding. Following are some suggested references:
+
+*	Ubuntu: [Ubuntu documentation page](https://help.ubuntu.com/community/IptablesHowTo){:target="_blank"}.
+*	CentOS: [CentOS how-to](http://wiki.centos.org/HowTos/Network/IPTables){:target="_blank"} and [CentOS reference page](http://www.centos.org/docs/4/4.5/Security_Guide/s1-firewall-ipt-basic.html){:target="_blank"}.
+
+#### Related topics:
+
+*	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
+*	[PHP 5.5, 5.6, or 7.0—Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
+*	[PHP 5.5, 5.6, or 7.0—CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)
+*	[MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
+*	[Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)
+*	[How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)


### PR DESCRIPTION
Duplicated the 2.1 version (2.2 version was just a sym-link to 2.1) and added an additional row to the chcon list, adding <your Magento install dir>/generated
With thanks to Zefiryn on stackexchange for the suggestion: https://magento.stackexchange.com/questions/205875/cant-create-directory-magento-2-2-1

## This PR is a:

- [ ] New topic
- [ X ] Content update
- [ ] Content fix or rewrite
- [ X ] Bug fix or improvement

## Summary

When this pull request is merged, it will add a missing piece of the selinux security changes required for magento 2.2.
This adds an additional row to the chcon list, adding <your Magento install dir>/generated

## Additional information

List all affected URLs 
- https://devdocs.magento.com/guides/v2.2/install-gde/prereq/security.html

selinux will prevent Magento from running without this additional change.
The error I was seeing in the exception log:
tail /opt/magento/public_html/var/log/exception.log
[2018-11-12 05:25:37] main.CRITICAL: Can't create directory /opt/magento/public_html/generated/code/Magento/Framework/App/Http/.
Class Magento\Framework\App\Http\Interceptor generation error: The requested class did not generate properly, because the 'generated' directory permission is read-only. If --- after running the 'bin/magento setup:di:compile' CLI command when the 'generated' directory permission is set to write --- the requested class did not generate properly, then you must add the generated class object to the signature of the related construct method, only. {"exception":"[object] (RuntimeException(code: 0): Can't create directory /opt/magento/public_html/generated/code/Magento/Framework/App/Http/.
Class Magento\\Framework\\App\\Http\\Interceptor generation error: The requested class did not generate properly, because the 'generated' directory permission is read-only. If --- after running the 'bin/magento setup:di:compile' CLI command when the 'generated' directory permission is set to write --- the requested class did not generate properly, then you must add the generated class object to the signature of the related construct method, only. at /opt/magento/public_html/vendor/magento/framework/Code/Generator.php:135)"} []

whatsnew
Updated the [instructions for working with SELinux](https://devdocs.magento.com/guides/v2.2/install-gde/prereq/security.html) and Magento 2.2.