### PR TITLE
Fix explanation of old setup scripts process

### DIFF
--- a/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
@@ -5,12 +5,11 @@ title: Configure declarative schema
 
 Before Magento 2.3, extension developers were required to write code (PHP scripts) to change the database schema. The following types of scripts existed before Magento 2.3:
 
-* InstallData and InstallSchema scripts, which are executed on a clean (empty) database
-* UpgradeData and UpgradeSchema incremental scripts, which supplement an existing Magento database
-* Recurring scripts, which are executed each time you install or upgrade Magento
+* InstallData and InstallSchema scripts, which are executed the first time a module is installed.
+* UpgradeData and UpgradeSchema incremental scripts, which supplement an existing module schema.
+* Recurring scripts, which are executed each time you install or upgrade Magento.
 
-Each script iteratively adds changes. During the installation process, Magento applies only those changes that have not been applied yet. For example, if you have Magento 2.1.8 installed and the latest version is 2.1.11, then the upgrade scripts for
-2.1.9, 2.1.10, and 2.1.11 will be applied, in order, when you upgrade to 2.1.11. That procedure is called _migration setup_ or _migration scripts_.
+Each script iteratively adds changes. During the installation process, upgrade scripts apply only those changes that have not been applied yet. For example, if you have a module with version 2.1.8 installed and the latest version is 2.1.11, then the upgrade script changes for 2.1.9, 2.1.10, and 2.1.11 will be applied, in order, when you upgrade to 2.1.11. Each upgrade script is responsible for checking the required version for each change to apply. The Magento installation only knows that a module has an upgrade script, not what versions it affected. That procedure is called _migration setup_ or _migration scripts_.
 
 The main disadvantage of this approach is that Magento applies changes blindly. For example, in one version a new database column might be introduced, only to be removed in the next. _Declarative setup_ eliminates this type of unnecessary work.
 


### PR DESCRIPTION
The description of the old Setup Script based process described it as it was in Magento 1.x, with a separate upgrade script for each version. In Magento 2 however a single UpgradeData and UpgradeSchema script existed per module, and each script was responsible for checking version constraints of changes.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will enhance the explanation of the old setup script approach in Magento 2.

## Additional information

Affected URL:
https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.html
