### PR TITLE
Fix message for developer mode

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
@@ -129,7 +129,7 @@ When you change from production to developer mode, you should clear generated cl
 
 	The following message displays:
 
-		Switched to developer mode.
+		Enabled developer mode.
 
 ### Change to default mode
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, the documentation will properly reflect what's printed to stdout when switching modes.

Currently when switching to developer mode `Enabled developer mode.` is displayed and no longer `Switched to developer mode.`

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.html