### PR TITLE
added commands PHP7.1-FPM for Centos 7.1, nginx user

### DIFF
--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -215,6 +215,8 @@ Magento requires several [PHP extensions](php-centos-ubuntu.html) to function pr
 1. Install `php-fpm`:
 
 		yum -y install php70w-fpm
+   If you are on Centos 7.1 and want to install PHP7.1-FPM:
+   		`yum install -y php71u-fpm`
 
 2. Open the `/etc/php.ini` file in an editor.
 
@@ -259,12 +261,12 @@ We recommend setting the memory limit to 2G when testing Magento. Refer to [Requ
 11. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
 		mkdir -p /var/lib/php/session/
-		chown -R apache:apache /var/lib/php/
+		chown -R nginx:nginx /var/lib/php/
 
 12. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
 		mkdir -p /run/php-fpm/
-		chown -R apache:apache /run/php-fpm/
+		chown -R nginx:nginx /run/php-fpm/
 
 13. Start the `php-fpm` service and configure it to start at boot time:
 


### PR DESCRIPTION
added command to install PHP7.1-FPM for Centos 7.1

## This PR is a:

- [ x] New topic
- [√ ] Content update
- [ x] Content fix or rewrite
- [x ] Bug fix or improvement

## Summary

1. Added command to install PHP7.1-FPM on Centos 7
2. Updated `nginx` user and group.

<!-- (REQUIRED) What does this PR change? -->

This PR will
1. Add command to install PHP7.1-FPM on Centos 7.
2. Update `nginx` user and group.