### PR TITLE
Fix command reference

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
@@ -33,11 +33,11 @@ Performance-tuning enhancements focus on catalog indexing and include:   
 
 <!-- MAGETWO-87430 -->* Category product indexer logic has been optimized, and re-indexing time has decreased up to 98%, from 40 minutes to one minute for 100,000 categories.  Previously, when your store contained many categories (100,0000), Magento could take up to 40 minutes to re-index product catalogs. 
 
-<!-- MAGETWO-91164 -->* The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
+<!-- MAGETWO-91164 -->* The `catalog:images:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
 
     * Remove   `pub/media/catalog/product/cache` . (Removing this folder frees up space.)
 
-    * Run `bin/magento catalog:image:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
+    * Run `bin/magento catalog:images:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
 
 <!-- MAGETWO-47320 -->* The catalog rule re-indexing operation has been optimized, and the average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes. 
 


### PR DESCRIPTION
`catalog:image:resize` was incorrect the command should be `catalog:images:resize`

## This PR is a:

- [ ] New topic
- [x] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->
After being merged the release notes will have the correct command for resizing images.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
