### PR TITLE
DO NOT MERGE UNTIL 2.3.1. GraphQL: add the option_id parameter for customizable options

### DIFF
--- a/guides/v2.3/graphql/reference/customizable-option-interface.md
+++ b/guides/v2.3/graphql/reference/customizable-option-interface.md
@@ -24,6 +24,7 @@ Field | Type | Description
 `title` |  String | The display name for this option
 `required` | Boolean | Indicates whether the option is required
 `sort_order` | Int | The order in which the option is displayed
+`option_id` | Int |  The ID assigned to the option
 
 ## CustomizableAreaOption object
 
@@ -149,3 +150,25 @@ Field | Type | Description
 `sort_order` | Int | The order in which the option is displayed
 
 ## Example usage
+
+The following query returns information about the customizable options configured for the product with a `sku` of `xyz`.
+
+```json
+  products(filter: {sku: {eq: "xyz"}}) {
+    items {
+      id
+      name
+      sku
+      type_id
+      ... on CustomizableProductInterface {
+        options {
+          title
+          required
+          sort_order
+          option_id
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add the `option_id` parameter to the CustomizableOptionInterface topic. 

I also added an example, which was previously missing.

Source: https://github.com/magento/graphql-ce/pull/247

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 
https://devdocs.magento.com/guides/v2.3/graphql/reference/customizable-option-interface.html
