### PR TITLE
Escape special symbols in regexs

### DIFF
--- a/_config.checks.yml
+++ b/_config.checks.yml
@@ -13,28 +13,28 @@ html-proofer:
   :parallel:
     :in_processes: 3
   :file_ignore:
-  - !ruby/regexp /404.html/
-  - !ruby/regexp /action-groups.html/
-  - !ruby/regexp /cloud-fastly.html/
+  - !ruby/regexp /404\.html/
+  - !ruby/regexp /action-groups\.html/
+  - !ruby/regexp /cloud-fastly\.html/
   - !ruby/regexp /codelinks/
-  - !ruby/regexp /contributing.html/
-  - !ruby/regexp /css-preprocess.html/
-  - !ruby/regexp /es-overview.html/
+  - !ruby/regexp /contributing\.html/
+  - !ruby/regexp /css-preprocess\.html/
+  - !ruby/regexp /es-overview\.html/
   - !ruby/regexp /guides\/m1x/
-  - !ruby/regexp /index.html/
-  - !ruby/regexp /magento-third-party.html/
-  - !ruby/regexp /magento-techbull.html/
+  - !ruby/regexp /index\.html/
+  - !ruby/regexp /magento-third-party\.html/
+  - !ruby/regexp /magento-techbull\.html/
   - !ruby/regexp /pattern-library/
   - !ruby/regexp /release-notes/
-  - !ruby/regexp /search.html/
+  - !ruby/regexp /search\.html/
   - !ruby/regexp /swagger/
-  - !ruby/regexp /template.html/
-  - !ruby/regexp /theme_dictionary.html/
+  - !ruby/regexp /template\.html/
+  - !ruby/regexp /theme_dictionary\.html/
   - !ruby/regexp /videos/
-  - !ruby/regexp /whats-new.html/
+  - !ruby/regexp /whats-new\.html/
   :url_ignore:
   - !ruby/regexp /frontend-dev-guide/
-  - !ruby/regexp /guides\/v2.0/
+  - !ruby/regexp /guides\/v2\.0/
   - !ruby/regexp /mrg/
   - !ruby/regexp /pattern-library/
   - !ruby/regexp /release-notes/

--- a/_plugins/html-check-hook.rb
+++ b/_plugins/html-check-hook.rb
@@ -8,23 +8,25 @@ require 'html-proofer'
 require 'yaml'
 
 Jekyll::Hooks.register :site, :post_write do |site|
-
-  # If 'jekyll serve' has been run, read options for html-proofer
-  # in '_config.checks.yml' and merge the 'url_ignore' list with 'excludes'
-  # from Jekyll configurtiuon
+  # If 'jekyll serve' is run, read options for html-proofer
+  # in '_config.checks.yml' and add 'excludes' from Jekyll configurtiuon
+  # to the 'url_ignore' list if it exists.
   #
   if site.config['serving'] == true
     begin
       checks_config = YAML.load_file('_config.checks.yml')
-      jekyll_excludes = site.config['exclude']
-      jekyll_excludes_as_regex = jekyll_excludes.map { |item| /#{item}/ }
-      checks_config['html-proofer'][:url_ignore].push(jekyll_excludes_as_regex).flatten!.uniq!
+      url_ignore = checks_config.dig('html-proofer', :url_ignore)
+      unless url_ignore.nil?
+        jekyll_excludes = site.config['exclude']
+        jekyll_excludes_as_regex = jekyll_excludes.map { |item| Regexp.new Regexp.escape(item) }
+        url_ignore.push(jekyll_excludes_as_regex).flatten!.uniq!
+        checks_config['html-proofer'][:url_ignore] = url_ignore
+      end
       options = checks_config['html-proofer']
       # Run html-proofer to check the jekyll destination directory
       HTMLProofer.check_directory(site.dest, options).run
-    rescue
-      puts
-      puts 'Fix the broken links before you commit the changes.'.blue
+    rescue StandardError
+      puts 'Fix the broken links before you push the changes to remote branch.'.blue
     end
   end
 end


### PR DESCRIPTION
## This PR is a:

Improvement

## Summary

When this pull request is merged, it will add escaping for special symbols to regexs in ignore lists of html-proofer config.