### PR TITLE
Change required varnish version info to 5.x

### DIFF
--- a/guides/v2.2/config-guide/varnish/config-varnish.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish.md
@@ -27,7 +27,7 @@ functional_areas:
 ## Overview of the Varnish solution {#config-varnish-over}
 [Varnish Cache] is an open source web application accelerator (also referred to as an *HTTP accelerator* or *caching HTTP reverse proxy*). Varnish stores (or caches) files or fragments of files in memory; this enables Varnish to reduce the response time and network bandwidth consumption on future, equivalent requests. Unlike web servers like Apache and nginx, Varnish was designed for use exclusively with the HTTP protocol.
 
-Magento 2 supports Varnish 4.x and 5.0.
+Magento 2 supports Varnish 4.x and 5.x
 
 {:.bs-callout .bs-callout-warning}
 We _strongly recommend_ you use Varnish in production. The built-in full-page caching (to either the file system or [database]) is much slower than Varnish, and Varnish is designed to accelerate HTTP traffic.


### PR DESCRIPTION
In the overview of the varnish section the required version is written as 5.0
The installation section of the documentation states that we should check that the version is 5.x . 
https://devdocs.magento.com/guides/v2.2/config-guide/varnish/config-varnish-install.html

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will change the required varnish version from 5.0 to 5.x

## Additional information

List all affected URLs 

https://devdocs.magento.com/guides/v2.2/config-guide/varnish/config-varnish.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->
Going one page further into this varnish magento 2 documentation to https://devdocs.magento.com/guides/v2.2/config-guide/varnish/config-varnish-install.html
it already says 5.x instead of 5.0

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
