### PR TITLE
GraphQL: Update query examples

### DIFF
--- a/guides/v2.3/graphql/search-pagination.md
+++ b/guides/v2.3/graphql/search-pagination.md
@@ -59,9 +59,9 @@ Magento GraphQL clause | SQL equivalent
 
 Magento's GraphQL implementation of pagination uses offsets so that it operates in the same manner as REST and SOAP requests.
 
-The `page_size` attribute specifies the maximum number of items to return. If no value is specified, 20 items are returned. 
+The `pageSize` attribute specifies the maximum number of items to return. If no value is specified, 20 items are returned. 
 
-The `current_page` attribute specifies which page of results to return. If no value is specified, the first page is returned. If you specify a value that is greater than the number of available pages, an error is returned.
+The `currentPage` attribute specifies which page of results to return. If no value is specified, the first page is returned. If you specify a value that is greater than the number of available pages, an error is returned.
 
 You can include the `total_pages` attribute in the `page_info` section of the output definition to indicate how many pages were returned for the query.
 

--- a/guides/v2.3/graphql/search-pagination.md
+++ b/guides/v2.3/graphql/search-pagination.md
@@ -6,13 +6,13 @@ title: Searches and pagination in GraphQL
 A GraphQL search query can contain the following components:
 
 * A full text search keyword
-* Filters (search criteria).
+* Filters (search criteria)
 * Pagination information
 * Sorting instructions
 
 ## Specifying full text search keywords
 
-The `search` element causes Magento to perform a full text search on the specified keywords. (This is the same type of search that is performed from the storefront. If multiple keywords are specified, each keyword is evaluated separately.
+The `search` element causes Magento to perform a full text search on the specified keywords. (This is the same type of search that is performed from the storefront. If multiple keywords are specified, each keyword is evaluated separately.)
 
 The `search` element is optional, but it can be used with or without filters. Each query must contain a `search` or `filter` element.
 
@@ -57,11 +57,13 @@ Magento GraphQL clause | SQL equivalent
 
 ## Specifying pagination
 
-Currently, Magento's GraphQL implementation of pagination uses offsets so that it operates in the same manner as REST and SOAP requests.
+Magento's GraphQL implementation of pagination uses offsets so that it operates in the same manner as REST and SOAP requests.
 
-The `pageSize` attribute specifies the maximum number of items to return. If no value is specified, 20 items are returned. 
+The `page_size` attribute specifies the maximum number of items to return. If no value is specified, 20 items are returned. 
 
-The `currentPage` attribute specifies which page of results to return. If no value is specified, the first page is returned. If you specify a value that is greater than the number of available pages, an error is returned.
+The `current_page` attribute specifies which page of results to return. If no value is specified, the first page is returned. If you specify a value that is greater than the number of available pages, an error is returned.
+
+You can include the `total_pages` attribute in the `page_info` section of the output definition to indicate how many pages were returned for the query.
 
 ## Sorting instructions
 
@@ -88,6 +90,7 @@ The following search returns items that contain the word `yoga` or `pants`. The 
 {
     products(
       search: "Yoga pants"
+      page_size: 10
     )
     {
         total_count
@@ -106,6 +109,7 @@ The following search returns items that contain the word `yoga` or `pants`. The 
         page_info {
           page_size
           current_page
+          total_pages
         }
       }
 }
@@ -125,38 +129,39 @@ The response for each item includes the `name`, `sku`, `price` and `description`
 
 ``` json
 {
-    products(
-      search: "Messenger"
-      filter: {
-             sku: {like: "24-MB%"}
-             price: {lt: "50"}
-             }
-        pageSize: 25
-          sort: {
-          price: DESC
+  products(
+    search: "Messenger"
+    filter: {
+      sku: {like: "24-MB%"}
+      price: {lt: "50"}
+    }
+    pageSize: 25
+    sort: {
+      price: DESC
+    }
+  )
+  {
+    items
+      {
+        name
+        sku
+        description {
+          html
         }
-    )
-    {
-      items
-      	{
-          name
-          sku
-          description
-          price {
-            regularPrice {
-              amount {
-                value
-                currency
-              }
+        price {
+          regularPrice {
+            amount {
+              value
+              currency
             }
           }
-
         }
-        total_count
-        page_info {
-            page_size
-        }
+      }
+    total_count
+    page_info {
+      page_size
     }
+  }
 }
 ```
 
@@ -170,7 +175,9 @@ The query returns the following:
         {
           "name": "Wayfarer Messenger Bag",
           "sku": "24-MB05",
-          "description": "<p>Perfect for class, work or the gym, the Wayfarer Messenger Bag is packed with pockets. The dual-buckle flap closure reveals an organizational panel, and the roomy main compartment has spaces for your laptop and a change of clothes. An adjustable shoulder strap and easy-grip handle promise easy carrying.</p>\n<ul>\n<li>Multiple internal zip pockets.</li>\n<li>Made of durable nylon.</li>\n</ul>",
+          "description": {
+            "html": "<p>Perfect for class, work or the gym, the Wayfarer Messenger Bag is packed with pockets. The dual-buckle flap closure reveals an organizational panel, and the roomy main compartment has spaces for your laptop and a change of clothes. An adjustable shoulder strap and easy-grip handle promise easy carrying.</p>\n<ul>\n<li>Multiple internal zip pockets.</li>\n<li>Made of durable nylon.</li>\n</ul>"
+          },
           "price": {
             "regularPrice": {
               "amount": {
@@ -183,7 +190,9 @@ The query returns the following:
         {
           "name": "Rival Field Messenger",
           "sku": "24-MB06",
-          "description": "<p>The Rival Field Messenger packs all your campus, studio or trail essentials inside a unique design of soft, textured leather - with loads of character to spare. Two exterior pockets keep all your smaller items handy, and the roomy interior offers even more space.</p>\n<ul>\n<li>Leather construction.</li>\n<li>Adjustable fabric carry strap.</li>\n<li>Dimensions: 18\" x 10\" x 4\".</li>\n</ul>",
+          "description": {
+            "html": "<p>The Rival Field Messenger packs all your campus, studio or trail essentials inside a unique design of soft, textured leather - with loads of character to spare. Two exterior pockets keep all your smaller items handy, and the roomy interior offers even more space.</p>\n<ul>\n<li>Leather construction.</li>\n<li>Adjustable fabric carry strap.</li>\n<li>Dimensions: 18\" x 10\" x 4\".</li>\n</ul>"
+          },
           "price": {
             "regularPrice": {
               "amount": {
@@ -209,34 +218,34 @@ The following search finds all products that were added after the specified time
 
 ``` json
 {
-    products(
-      filter: {
-          created_at: {gt: "2017-11-01 00:00:00"}
-        }
-        pageSize: 25
-          sort: {
-          price: DESC
-        }
+  products(
+    filter: {
+        created_at: {gt: "2017-11-01 00:00:00"}
+      }
+      pageSize: 25
+      sort: {
+        price: DESC
+      }
     )
     {
-        total_count
-        items {
-          name
-          sku
-          price {
-            regularPrice {
-              amount {
-                value
-                currency
-              }
+      total_count
+      items {
+        name
+        sku
+        price {
+          regularPrice {
+            amount {
+              value
+              currency
             }
           }
         }
-        page_info {
-          page_size
-          current_page
-        }
       }
+      page_info {
+        page_size
+        current_page
+      }
+  }
 }
 ```
 
@@ -246,37 +255,37 @@ The following example searches for all products whose `sku` begins with the stri
 
 ``` json
 {
-    products(
-      filter: {
-          or: {
-            sku: {like: "24-MB%"}
-            name: {like: "%Bag"}
-						}
-       	 }
-        pageSize: 25
-          sort: {
-          price: DESC
-        }
-    )
-    {
-        total_count
-        items {
-          name
-          sku
-          price {
-            regularPrice {
-              amount {
-                value
-                currency
-              }
-            }
+  products(
+    filter: {
+      or: {
+        sku: {like: "24-MB%"}
+        name: {like: "%Bag"}
+      }
+    }
+    pageSize: 25
+      sort: {
+      price: DESC
+    }
+  )
+  {
+    total_count
+    items {
+      name
+      sku
+      price {
+        regularPrice {
+          amount {
+            value
+            currency
           }
         }
-        page_info {
-          page_size
-          current_page
-        }
       }
+    }
+    page_info {
+      page_size
+      current_page
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, the `total_pages` attribute will be added to the GraphQL documentation. 

I tested the examples, and I found one that no longer works. I updated that example. I eliminated unnecessary indentations in several examples.

## Additional information

List all affected URLs 
https://devdocs.magento.com/guides/v2.3/graphql/search-pagination.html
