### PR TITLE
 Fix #3261 Broken links in release-notes

### DIFF
--- a/_config.checks.yml
+++ b/_config.checks.yml
@@ -16,7 +16,6 @@ html-proofer:
   - !ruby/regexp /guides\/m1x/
   - !ruby/regexp /magento-techbull\.html/
   - !ruby/regexp /pattern-library/
-  - !ruby/regexp /release-notes/
   - !ruby/regexp /swagger/
   - !ruby/regexp /template\.html/
   - !ruby/regexp /videos/
@@ -26,4 +25,3 @@ html-proofer:
   - !ruby/regexp /guides\/v2\.0/
   - !ruby/regexp /mrg/
   - !ruby/regexp /pattern-library/
-  - !ruby/regexp /release-notes/

--- a/_data/toc/release-notes.yml
+++ b/_data/toc/release-notes.yml
@@ -357,15 +357,12 @@ pages:
             - label: Magento Commerce 2.1 Release Candidate 1 (RC1) Release Notes
               url: /release-notes/ReleaseNotes2.1_RC1EE.html
 
-
-
     - label: Third-party extension contact information
+      include_versions: ["2.2"]
       children:
 
         - label: Contact Information for Third-Party Extensions
           url: /release-notes/cbe-support-info.html
-
-
 
     - label: Backward incompatible changes
       url: /release-notes/backward-incompatible-changes/index.html
@@ -380,7 +377,6 @@ pages:
         - label: Magento Commerce for B2B changes
           url: /release-notes/changes/b2b_changes.html
           include_versions: ["2.2"]
-
 
     - label: Third-party licenses
       children:

--- a/_includes/install/releasenotes/ce_install_21.md
+++ b/_includes/install/releasenotes/ce_install_21.md
@@ -55,4 +55,4 @@ Developers who contribute to the Open Source codebase can [upgrade manually]({{ 
 ### Other upgrades {#upgrade-other}
 {:.no_toc}
 
-Other types of upgrades are discussed in [Upgrade to Magento version 2.1 (June 22, 2016)](http://devdocs.magento.com/guides/v2.1/release-notes/tech_bull_21-upgrade.html).
+Other types of upgrades are discussed in [Upgrade to Magento version 2.1 (June 22, 2016)]({{ site.baseurl }}/guides/v2.1/release-notes/tech_bull_21-upgrade.html).

--- a/_includes/install/releasenotes/ee_install_21.md
+++ b/_includes/install/releasenotes/ee_install_21.md
@@ -40,4 +40,4 @@ After you get the Commerce software:
 
 ## Upgrade from an earlier version
 
-To upgrade to Magento Commerce 2.1 from an earlier version, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ page.baseurl }}/release-notes/tech_bull_21-upgrade.html).
+To upgrade to Magento Commerce 2.1 from an earlier version, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ site.baseurl }}/guides/v2.1/release-notes/tech_bull_21-upgrade.html).

--- a/guides/v2.0/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.0/comp-mgr/cli/cli-upgrade.md
@@ -23,7 +23,7 @@ You can upgrade Magento from the command line if you installed the software usin
 </div>
 
 <div class="bs-callout bs-callout-warning" markdown="1">
-* If you're upgrading to version 2.1, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ site.baseurl }}/guides/v2.1/release-notes/tech_bull_21-upgrade.html).
+* If you're upgrading to version 2.1, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ page.baseurl }}/release-notes/tech_bull_21-upgrade.html).
 * If you're upgrading from {{site.data.var.ce}} or {{site.data.var.ee}} 2.0.0 or 2.0.1, you must first perform the tasks discussed in the [Technical Bulletin (1/28/16)]({{ page.baseurl }}/release-notes/tech_bull_201-upgrade.html).
 </div>
 

--- a/guides/v2.0/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.0/comp-mgr/cli/cli-upgrade.md
@@ -23,7 +23,7 @@ You can upgrade Magento from the command line if you installed the software usin
 </div>
 
 <div class="bs-callout bs-callout-warning" markdown="1">
-* If you're upgrading to version 2.1, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ page.baseurl }}/release-notes/tech_bull_21-upgrade.html).
+* If you're upgrading to version 2.1, see [Upgrade to Magento version 2.1 (June 22, 2016)]({{ site.baseurl }}/guides/v2.1/release-notes/tech_bull_21-upgrade.html).
 * If you're upgrading from {{site.data.var.ce}} or {{site.data.var.ee}} 2.0.0 or 2.0.1, you must first perform the tasks discussed in the [Technical Bulletin (1/28/16)]({{ page.baseurl }}/release-notes/tech_bull_201-upgrade.html).
 </div>
 


### PR DESCRIPTION
Bug fix or improvement

I applied a version constraint to an item in the release-notes TOC.
I updated a couple in include files with version-specific links. 

This seems to have fixed the links that were broken for the release-notes section of the docs.

Fixes #3261 