### PR TITLE
Fix links: Tech Bulletins

### DIFF
--- a/_config.checks.yml
+++ b/_config.checks.yml
@@ -14,12 +14,8 @@ html-proofer:
     :in_processes: 3
   :file_ignore:
   - !ruby/regexp /guides\/m1x/
-  - !ruby/regexp /magento-techbull\.html/
-  - !ruby/regexp /swagger/
   - !ruby/regexp /template\.html/
   - !ruby/regexp /videos/
   - !ruby/regexp /whats-new\.html/
   :url_ignore:
   - !ruby/regexp /guides\/v2\.0/
-  # - !ruby/regexp /mrg/
-  

--- a/magento-techbull.md
+++ b/magento-techbull.md
@@ -14,9 +14,10 @@ This page lists technical bulletins for the Magento application.
 
 ## Magento 2.0.x and 2.1.x
 
-[USPS Service Name Change (September 7, 2017)]({{ page.baseurl }}/release-notes/tech_bull_USPS-patch-Sept2017.html)
+[USPS Service Name Change (September 7, 2017)](https://devdocs.magento.com/guides/v2.1/release-notes/tech_bull_USPS-patch-Sept2017.html)
 
-[Transport Layer Security (TLS) 1.1+ requirement for repo.magento.com (June 30, 2016)]({{ page.baseurl }}/release-notes/tech_bull_tls-repo.html)
+[Transport Layer Security (TLS) 1.1+ requirement for repo.magento.com (June 30, 2016)](https://devdocs.magento.com/guides/v2.1/release-notes/tech_bull_tls-repo.html)
+
 
 ## Magento 2.0.x
 


### PR DESCRIPTION
## This PR is a:

Bug fix or improvement

## Summary

When this pull request is merged, it will fix broken links on the tech bulletin page and remove entries from the `file_ignore:` list that do not have broken links.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/magento-techbull.html