### PR TITLE
Recommend ECMAScript 5.1 instead of 5, and remove abbreviation of ECMAScript for clarity

### DIFF
--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -624,7 +624,7 @@ We are reviewing this section and will publish it soon.
 
 10.5. ESLint [rules][rules] SHOULD BE followed.
 
-10.5.1. ES5 SHOULD be used as a JS standard.
+10.5.1. ECMAScript 5.1 SHOULD be used as a JS standard.
 
 10.5.2. Language features (closures) MUST be used for scope management. There SHOULD be no `_` (underscore) naming convention for private properties.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will clarify language around compatible JavaScript (ECMAScript) target version.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

- ECMAScript 5.1 was only editorial changes from 5, but worth being explicit.
- Removed abbreviation as many won't know what `ES` means on its own