### PR TITLE
Update language around async code

### DIFF
--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -628,7 +628,7 @@ We are reviewing this section and will publish it soon.
 
 10.5.2. Language features (closures) MUST be used for scope management. There SHOULD be no `_` (underscore) naming convention for private properties.
 
-10.5.3. All asynchronous operations MUST be represented with JQuery AJAX calls.
+10.5.3. All uses of XMLHttpRequest (including jQuery's `$.ajax`) MUST be asynchronous.
 
 10.5.4. Global properties (window.*) MUST NOT be used. A module system SHOULD be used for shared objects.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will clarify language around asynchronous operations.

It's clear that `10.5.3` was added with the intention of enforcing async ajax requests. However, the current language enforces everyone to model _any_ async code with an HTTP request, which doesn't make any sense.

As an example, `setTimeout` from the W3C spec can be used for timing and scheduling of async operations, but has nothing to do with external requests.