### PR TITLE
Clarify language around globals

### DIFF
--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -630,7 +630,7 @@ We are reviewing this section and will publish it soon.
 
 10.5.3. All asynchronous operations MUST be represented with JQuery AJAX calls.
 
-10.5.4. Global properties (window.*) MUST NOT be used. A module system SHOULD be used for shared objects.
+10.5.4. New global properties MUST not be added (either through explicit `window` assignment or `var` in the top scope). The RequireJS module system SHOULD be used for shared objects.
 
 10.5.5. Modules MUST NOT have external side effects.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will clarify language around usage of global variables.

The intent of `10.5.4` seems to be to prevent sharing of data through global variables. However, the current language forbids _reads_ of any global, which is not achievable (many built-ins are globals).