### PR TITLE
Clarify language around redeclaration of JS identifiers

### DIFF
--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -634,7 +634,7 @@ We are reviewing this section and will publish it soon.
 
 10.5.5. Modules MUST NOT have external side effects.
 
-10.5.6. Re-declaration of function names MUST NOT be used.
+10.5.6. Code MUST NOT re-declare any identifiers already declared in a reachable scope (re-assignment is acceptable).
 
 ## 11. Testing
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will clarify language around re-declaration of JS identifiers.

`10.5.6` is currently written to only restrict re-declaring identifiers used for function declarations (and maybe expressions?). Limiting this to just identifiers used to declare functions doesn't make much sense, so widening to all identifiers.