### PR TITLE
MFTF 2.3.12: Add description for the array value element in metadata

### DIFF
--- a/mftf/2.3/metadata.md
+++ b/mftf/2.3/metadata.md
@@ -469,7 +469,7 @@ It contains one or more `value` elements.
 
 ### value {#value-tag}
 
-The `type` of the `array` item or the entity property of the `array` item. 
+Defines the data type of the array elements. Possible values can be primitive data types supported by operation schema, custom data types define in meta data, or a `field` of a custom data type.
 
 Examples:
 ```xml

--- a/mftf/2.3/metadata.md
+++ b/mftf/2.3/metadata.md
@@ -469,8 +469,26 @@ It contains one or more `value` elements.
 
 ### value {#value-tag}
 
-An item in `array`.
+The `type` of the `array` item or the entity property of the `array` item. 
 
+Examples:
+```xml
+<array key="tax_rate_ids">
+    <value>integer</value>
+</array>
+```
+or
+```xml
+<array key="product_options">
+    <value>product_option</value>
+</array>
+```
+or
+```xml
+<array key="tax_rate_ids">
+    <value>tax_rate.id</value>
+</array>
+``` 
 ### header {#header-tag}
 
 An additional parameter in REST API request.


### PR DESCRIPTION
## This PR is a:

- Content update

## Summary

When this pull request is merged, it will add a description for the array value element in metadata.

## Additional information

Internal ticket: MQE-911

whatsnew
Added documentation for [`<value>`](https://devdocs.magento.com/mftf/2.3/metadata.html#value-tag) in metadata.