### PR TITLE
Change upgrade script link to release branch

### DIFF
--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -313,7 +313,7 @@ If the application fails with a  `We're sorry, an error has occurred while gener
 [custom maintenance mode page]: {{ page.baseurl }}/comp-mgr/trouble/cman/maint-mode.html
 [Enable or disable maintenance mode]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html
 [file system ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-system-perms.html
-[script]: https://raw.githubusercontent.com/magento/magento2/2.3-develop/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
+[script]: https://raw.githubusercontent.com/magento/magento2/2.3.0/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
 {:target="_blank"}
 [system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html
 [System Upgrade utility]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will update the link to the upgrade script to point to the release branch instead of the development branch.

Suggested by @pdohogne-magento. 

We won't be able to publish docs until the new link resolves because our doc tests will fail.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#download-the-script
