### PR TITLE
Update getting-started.md (2.2)

### DIFF
--- a/mftf/2.2/getting-started.md
+++ b/mftf/2.2/getting-started.md
@@ -96,7 +96,7 @@ In the _magento2/dev/tests/acceptance_ directory, edit the `.env` file to match 
 * `MAGENTO_BASE_URL` must contain a domain name of the Magento instance that will be tested.
 Example: `MAGENTO_BASE_URL=http://magento.test`
 
-* `MAGENTO_BACKEND_NAME` must contain a relative pass of the Admin area.
+* `MAGENTO_BACKEND_NAME` must contain the relative path to the Admin area.
 Example: `MAGENTO_BACKEND_NAME=admin`
 
 * `MAGENTO_ADMIN_USERNAME` must contain the username required for authorization in the Admin area.


### PR DESCRIPTION
typofix - this is a path, not a password.

## This PR is a:

- [ ] Content fix or rewrite

## Summary

When this pull request is merged, it will...

Change 'ss' to 'th' and fix up surrounding grammar. Line describes path, not password.

## Additional information

List all affected URLs 
- https://devdocs.magento.com/mftf/2.2/getting-started.html

2.3 version will be separate PR because I can't github.