### PR TITLE
Missing slash with bin/magento path

### DIFF
--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -90,11 +90,11 @@ To reindex using the command line:
 
 	Enter the following command to reindex the catalog search index only:
 
-		php <your Magento install dir>/bin magento indexer:reindex catalogsearch_fulltext
+		php <your Magento install dir>/bin/magento indexer:reindex catalogsearch_fulltext
 
 	Enter the following command to reindex all indexers:
 
-		php <your Magento install dir>/bin magento indexer:reindex
+		php <your Magento install dir>/bin/magento indexer:reindex
 
 3.	Wait while the reindexing completes.
 

--- a/guides/v2.0/config-guide/solr/solr-magento.md
+++ b/guides/v2.0/config-guide/solr/solr-magento.md
@@ -194,11 +194,11 @@ To reindex using the command line:
 1.	Log in to your Magento server as, or switch to, the <a href="{{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html">Magento file system owner</a>.
 2.	Enter the following command to reindex all indexers:
 
-		php <your Magento install dir>/bin magento indexer:reindex
+		php <your Magento install dir>/bin/magento indexer:reindex
 
 	Enter the following command to reindex the catalog search index only:
 
-		php <your Magento install dir>/bin magento indexer:reindex catalogsearch_fulltext
+		php <your Magento install dir>/bin/magento indexer:reindex catalogsearch_fulltext
 
 3.	Wait while the indexers are reindexed.
 

--- a/guides/v2.1/config-guide/solr/solr-magento.md
+++ b/guides/v2.1/config-guide/solr/solr-magento.md
@@ -185,11 +185,11 @@ To reindex using the command line:
 1.	Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 2.	Enter the following command to reindex all indexers:
 
-		php <your Magento install dir>/bin magento indexer:reindex
+		php <your Magento install dir>/bin/magento indexer:reindex
 
 	Enter the following command to reindex the catalog search index only:
 
-		php <your Magento install dir>/bin magento indexer:reindex catalogsearch_fulltext
+		php <your Magento install dir>/bin/magento indexer:reindex catalogsearch_fulltext
 
 3.	Wait while the indexers are reindexed.
 


### PR DESCRIPTION
## This PR is a:

- [x] Content fix or rewrite

## Summary

When this pull request is merged, it will describe properly the path to `bin/magento` used for reindex

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/configure-magento.html#es-reindex
- https://devdocs.magento.com/guides/v2.2/config-guide/elasticsearch/configure-magento.html#es-reindex
- https://devdocs.magento.com/guides/v2.1/config-guide/elasticsearch/configure-magento.html#es-reindex
