### PR TITLE
Add absolute URL to sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,5 @@
+---
+layout: null
+---
 User-agent: *
-Sitemap: /sitemap.xml
+Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will make link to the sitemap.xml to adhere to Google requirements, it will have to be an absolute URL.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- robots.txt only

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
