### PR TITLE
Add backup enable info to devdocs

### DIFF
--- a/_includes/comp-man/backup.md
+++ b/_includes/comp-man/backup.md
@@ -6,6 +6,9 @@ After you pass all readiness checks, you can back up:
 
 Backups are stored in the `var/backups` directory and can be restored at any time using the [`magento setup:rollback`]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall-mods.html#instgde-cli-uninst-mod-roll) or using the Magento Admin.
 
+{:.bs-callout .bs-callout-note}
+Magento backup features must be enabled. For more information and commands, see [Enable backups]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html#enable-backups).
+
 To back up:
 
 1.	Select the checkbox of each item to back up and click **Create Backup**.
@@ -25,4 +28,4 @@ The following page displays to confirm a successful backup.
 
 ![A page displays to confirm your backup was a success]({{ site.baseurl }}/common/images/extensman_backup-success.png){:width="650px"}
 
-If errors display, see [Troubleshoot backups]({{ page.baseurl }}/comp-mgr/trouble/cman/tshoot_backup.html)
+If errors display, see [Troubleshoot backups]({{ page.baseurl }}/comp-mgr/trouble/cman/tshoot_backup.html).

--- a/guides/v2.1/comp-mgr/trouble/cman/tshoot_backup.md
+++ b/guides/v2.1/comp-mgr/trouble/cman/tshoot_backup.md
@@ -15,7 +15,24 @@ A backup can fail for any of the following reasons:
 *	[An operating system error](#trouble-backup-os)
 *	[Backup fails](#trouble-backup-all)
 
-### Insufficient disk space {#trouble-backup-space}
+## Backup disabled
+
+If the Magento backup functionality does not start or displays the following message, you need to enable the feature prior to backing up. 
+
+```
+Backup functionality is disabled.
+Backup functionality is currently disabled. Please use other means for backups.
+```
+
+Enter the following CLI command:
+
+``` bash
+php bin/magento config:set system/backup/functionality_enabled 1
+```
+
+For additional information on backups, see [Back up and roll back the file system, media, and database]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html).
+
+## Insufficient disk space {#trouble-backup-space}
 
 If the backup failed because of insufficient disk space, you should typically free up disk space by moving some files to another storage device or drive. However, there might be other ways to resolve the issue. See one of the following resources for tips:
 
@@ -23,7 +40,7 @@ If the backup failed because of insufficient disk space, you should typically fr
 *	[serverfault: df says disk is full, but it is not](http://serverfault.com/questions/315181/df-says-disk-is-full-but-it-is-not){:target="_blank"}
 *	[unix.stackexchange.com: Tracking down where disk space has gone on Linux?](http://unix.stackexchange.com/questions/125429/tracking-down-where-disk-space-has-gone-on-linux){:target="_blank"}
 
-### Operating system error {#trouble-backup-os}
+## Operating system error {#trouble-backup-os}
 
 Unfortunately, we can't recommend anything specific because of the variety of errors you might encounter. We can suggest, however, you:
 
@@ -31,7 +48,7 @@ Unfortunately, we can't recommend anything specific because of the variety of er
 *	Search public forums like [Stack Exchange](http://unix.stackexchange.com){:target="_blank"} or [Stack Overflow](http://stackoverflow.com){:target="_blank"}
 *	Open a [GitHub issue](https://github.com/magento/magento2/issues){:target="_blank"} and we'll try to help
 
-### Backup fails {#trouble-backup-all}
+## Backup fails {#trouble-backup-all}
 
 If the backup fails or if all backup tests fail, it's possible the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/apache-user.html) doesn't have sufficient privileges and ownership of the Magento file system. For example, another user might own the files or the files might be read-only.
 

--- a/guides/v2.1/install-gde/install/cli/install-cli-backup.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-backup.md
@@ -31,7 +31,7 @@ In addition to the command arguments discussed here, see [Common arguments]({{ p
 The Magento backup feature is disabled by default. To enable, enter the following CLI command:
 
 ``` bash
-php bin/magento config:set system/backup/functionality_enabled 1
+bin/magento config:set system/backup/functionality_enabled 1
 ```
 
 {:.bs-callout .bs-callout-warning}

--- a/guides/v2.1/install-gde/install/cli/install-cli-backup.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-backup.md
@@ -34,6 +34,11 @@ The Magento backup feature is disabled by default. To enable, enter the followin
 php bin/magento config:set system/backup/functionality_enabled 1
 ```
 
+{:.bs-callout .bs-callout-warning}
+**Deprecation Notice**
+Magento backup functionality is deprecated as of 2.1.16, 2.2.7, 2.3.0. We recommend investigating additional backup technologies and binary backup tools (for example, Percona XtraBackup).
+
+
 ## Set ulimit for the web server user {#instgde-cli-ulimit}
 {% include install/ulimit.md %}
 

--- a/guides/v2.1/install-gde/install/cli/install-cli-backup.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-backup.md
@@ -26,6 +26,14 @@ After backing up, you can [roll back](#instgde-cli-uninst-roll) at a later time.
 {% include install/first-steps-cli.md %}
 In addition to the command arguments discussed here, see [Common arguments]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands.html#instgde-cli-subcommands-common).
 
+## Enable backups
+
+The Magento backup feature is disabled by default. To enable, enter the following CLI command:
+
+``` bash
+php bin/magento config:set system/backup/functionality_enabled 1
+```
+
 ## Set ulimit for the web server user {#instgde-cli-ulimit}
 {% include install/ulimit.md %}
 

--- a/guides/v2.1/install-gde/install/cli/install-cli-backup.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-backup.md
@@ -36,7 +36,6 @@ bin/magento config:set system/backup/functionality_enabled 1
 
 {:.bs-callout .bs-callout-warning}
 **Deprecation Notice**
-**Deprecation Notice**
 Magento backup functionality is deprecated as of 2.1.16, 2.2.7, and 2.3.0. We recommend investigating additional backup technologies and binary backup tools (such as Percona XtraBackup).
 
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [X] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Internal ticket MAGEDOC-3299
Add info on enabling Backup feature via Command line. Affects multiple files. 
Includes command for enabling and deprecation notice.

whats new
Magento backup feature is deprecated as of v2.1.16, v2.2.7, and v2.3.0. Added content to enable the backup feature in [Back up and roll back the file system, media, and database](https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-backup.html), [Step 3. Back up the file system and database](https://devdocs.magento.com/guides/v2.3/comp-mgr/upgrader/upgrade-backup.html), [Step 2. Back up the file system and database](https://devdocs.magento.com/guides/v2.3/comp-mgr/module-man/compman-backup.html), and [Troubleshoot backups](https://devdocs.magento.com/guides/v2.3/comp-mgr/trouble/cman/tshoot_backup.html).