### PR TITLE
Canonical URLs to point to the 2.3 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: f864973ba8a063a7ad3da4ecfe47fa978a230f17
+  revision: 0e79c05df09199cef3a0a863933c01770c21290d
   branch: devdocs-stable
   specs:
     devdocs (0.0.1)
@@ -291,4 +291,4 @@ DEPENDENCIES
   launchy
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/_includes/layout/footer-links.html
+++ b/_includes/layout/footer-links.html
@@ -1,6 +1,6 @@
 {% assign items = site.data.footer-links %}
 
-<ul class="nav footer-links">
+<ul class="nav footer-links" role="menu">
 {% for item in items %}
   {% include layout/nav-item.html section=item %}
 {% endfor %}

--- a/_includes/layout/header-styles.html
+++ b/_includes/layout/header-styles.html
@@ -1,2 +1,8 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/common/css/devdocs.css" />
 <link rel="alternate" type="application/rss+xml" title="Magento DevDocs RSS" href="/feed.xml" />
+
+{% if page.canonical_url != nil %}
+<link rel="canonical" href="{{ page.canonical_url }}" />
+{% else %}
+<link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url | replace_first: 'guides/v2.2', 'guides/v2.3' | replace_first: 'guides/v2.1', 'guides/v2.3' | replace_first: 'guides/v2.0', 'guides/v2.3' }}" />
+{% endif %}

--- a/_includes/layout/header-styles.html
+++ b/_includes/layout/header-styles.html
@@ -3,6 +3,4 @@
 
 {% if page.canonical_url != nil %}
 <link rel="canonical" href="{{ page.canonical_url }}" />
-{% else %}
-<link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url | replace_first: 'guides/v2.2', 'guides/v2.3' | replace_first: 'guides/v2.1', 'guides/v2.3' | replace_first: 'guides/v2.0', 'guides/v2.3' }}" />
 {% endif %}

--- a/_includes/layout/page-info.html
+++ b/_includes/layout/page-info.html
@@ -13,7 +13,7 @@
 
     {% if page.github_link %}
     <div class="github-link">
-      <a class="improve-page" href="{{ page.github_files }}{{ page.path }}" target="_blank">
+      <a class="improve-page" href="{{ page.github_files }}{{ page.path }}" target="_blank" rel="noopener">
         Edit this page on GitHub
       </a>
     </div>
@@ -21,7 +21,7 @@
 
     {% if page.feedback_link %}
     <div class="new-issue">
-      <a href="{{ page.github_repo }}issues/new?title=Feedback on page: {{ page.url }}" target="_blank">
+      <a href="{{ page.github_repo }}issues/new?title=Feedback on page: {{ page.url }}" target="_blank" rel="noopener">
         Give us feedback
       </a>
     </div>


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will make all canonical URLs to point to the 2.3 version.
It also adds the ability to set the `canonical_url` variable for any page to overwrite the automatic `rel="canonical"`
`canonical_url` needs to be ABSOLUTE url, like this "https://devdocs.magento.com/url/of/page/"

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs: all

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
