### PR TITLE
Replace find by chmod to set permissions

### DIFF
--- a/_includes/install/sampledata/file-sys-perms-digest.md
+++ b/_includes/install/sampledata/file-sys-perms-digest.md
@@ -13,10 +13,7 @@ If you run the Magento application as one user (which is typical of shared hosti
 cd <your Magento install dir>
 ```
 ```bash
-find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
-```
-```bash
-find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} +
+chmod -R g+w var vendor pub/static pub/media app/etc
 ```
 ```bash
 chmod u+x bin/magento


### PR DESCRIPTION
Instead of use:
```
find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} +
```
Is the same way to use `chmod` and more faster

## This PR is a:

- [ ] New topic
- [x] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will apply a much faster way to add permissions to folders and files with right permissions suggested by platform.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/comp-mgr/upgrader/upgrade.html
- https://devdocs.magento.com/guides/v2.2/comp-mgr/upgrader/upgrade.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
