### PR TITLE
Set correct pattern of layout file's naming

### DIFF
--- a/guides/v2.1/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.1/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -216,7 +216,7 @@ These files belong in the `view/adminhtml` directory because the Magento admin a
 
 This file defines the {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} and structure of the index page for the HelloWorld controller. It sets the title to "Greetings" and instructs Magento to use the `helloworld.phtml` template as the content in a `Magento\Backend\Block\Template` block class.
 
-The name of this file uses the following pattern: *frontName*\_*controller*\_*action*.xml
+The name of this file uses the following pattern: *routeId*\_*controller*\_*action*.xml
 
 {% collapsible File content for exampleadminnewpage_helloworld_index.xml %}
   {% highlight xml %}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

The naming of layout files is based on the route Id, controller and action.
For example, we have this route configs:
```
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
    <router id="admin">
        <route id="custom2" frontName="custom">
            <module name="Vendor_Custom"/>
        </route>
    </router>
</config>
```
The name of layout file should be _custom2_helloworld_index.xml_.

Checked on Magento 2.2 Commerce.

This PR fixes the pattern of layout file's name.
## Additional information
Seems like a bug, because it would be more logical if names will contain frontName instead of route Id.