### PR TITLE
Add warning related to MQ configuration

### DIFF
--- a/guides/v2.2/extension-dev-guide/message-queues/config-mq.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/config-mq.md
@@ -237,6 +237,9 @@ The `connection` element is a subnode of the `publisher` element. There must not
 | exchange             | The name of the exchange to publish to. The default system exchange name is `magento`. |
 | disabled             | Determines whether this queue is disabled. The default value is `false`. |
 
+{: .bs-callout .bs-callout-warning }
+Be aware, that for each `topic` only one `publisher` can be enabled at the same time
+
 ### Updating `queue.xml` {#updatequeuexml}
 
 See [Migrate message queue configuration]({{ page.baseurl }}/extension-dev-guide/message-queues/queue-migration.html) for information about upgrading from Magento 2.0 or 2.1.

--- a/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
@@ -231,6 +231,9 @@ The `connection` element is a subnode of the `publisher` element. There must not
 | exchange             | The name of the exchange to publish to. The default system exchange name is `magento`. |
 | disabled             | Determines whether this queue is disabled. The default value is `false`. |
 
+{: .bs-callout .bs-callout-warning }
+Be aware, that for each `topic` only one `publisher` can be enabled at the same time
+
 ### Updating `queue.xml` {#updatequeuexml}
 
 See [Migrate message queue configuration]({{page.baseurl}}/extension-dev-guide/message-queues/queue-migration.html) for information about upgrading from Magento 2.0 or 2.1.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Today during some debugging i found that there are not information about "disabled" state usage in Magento Queue configuration.

I added warning for users with limitation of use publishers. 