### PR TITLE
Added redirect for old ece-tools update topic

### DIFF
--- a/guides/v2.1/cloud/project/ece-tools-update.md
+++ b/guides/v2.1/cloud/project/ece-tools-update.md
@@ -4,6 +4,8 @@ title: Update ece-tools version
 redirect_from:
   - guides/v2.1/cloud/composer-packages/ece-tools.html
   - guides/v2.2/cloud/composer-packages/ece-tools.html
+  - guides/v2.1/cloud/composer-packages/ece-tools-update.html
+  - guides/v2.2/cloud/composer-packages/ece-tools-update.html
 functional_areas:
   - Cloud
   - Upgrade


### PR DESCRIPTION
For the ece-tools update topic, Zendesk Support ticket footers are pointing to  this URL :   https://devdocs.magento.com/guides/v2.2/cloud/composer-packages/ece-tools-update.html
which returns `Page Not Found`.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Updated the current ece-tools update topic to add a redirect for the older version of the topic.

**Affected URLs**
https://devdocs.magento.com/guides/v2.1/cloud/project/ece-tools-update.html
https://devdocs.magento.com/guides/v2.2/cloud/project/ece-tools-update.html
https://devdocs.magento.com/guides/v2.3/cloud/project/ece-tools-update.html



