### PR TITLE
Add required value to safe-mode and data-restore

### DIFF
--- a/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
@@ -82,9 +82,9 @@ To help prevent data loss, you can specify command line options that dump all th
 
 Magento provides options to the `setup:install` and `setup:upgrade` commands that enable safe installations and rollbacks:
 
-`--safe-mode` - Creates a data dump during the installation or upgrade process.
+`--safe-mode=1` - Creates a data dump during the installation or upgrade process.
 
-`--data-restore` - (Used with the `setup:upgrade` command only.) Performs a rollback. Before you rollback, you must first check out code to the previous version of Magento. Then run `setup:upgrade  --data-restore`.
+`--data-restore=1` - (Used with the `setup:upgrade` command only.) Performs a rollback. Before you rollback, you must first check out code to the previous version of Magento. Then run `setup:upgrade  --data-restore=1`.
 
 
 Several types of operations have an effect on data dumps and rollbacks.


### PR DESCRIPTION
Using the `--safe-mode` and `--data-restore` arguments as boolean options without a value has no effect.
They have to be specified with an `=1` value (like for `--dry-run=1`.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will show the proper usage of the `--safe-mode` and `--data-restore` `setup:upgrade` arguments.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.html
