### PR TITLE
MAGECLOUD-3046: [Cloud Docker] Remove deprecated CLI container

### DIFF
--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -33,22 +33,21 @@ The [Magento Cloud Docker repository](https://github.com/magento/magento-cloud-d
 
 The web container works with the [PHP-FPM](https://php-fpm.org) to serve PHP code, the **DB** image for the local database, and the **Varnish** image to send requests and cache the results.
 
-### CLI container
+### CLI containers
 
-The CLI container is based on a PHP-CLI image that provides `magento-cloud` and `{{site.data.var.ct}}` commands to perform file system operations. The CLI container depends on the **DB** image for the local database and the **Redis** image.
+There are few CLI containers based on a PHP-CLI image that provides `magento-cloud` and `{{site.data.var.ct}}` commands to perform file system operations.
 
 -  `build`—extends the CLI container to perform operations with writable filesystem, similar to the build phase
+-  `deploy`—extends the CLI container to use read-only file system, similar to the deploy phase
 -  `cron`—extends the CLI container to run cron
 
     -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environment
     -  Cron only works with CLI container to run `./bin/magento cron:run` command
 
--  `deploy`—extends the CLI container to use read-only file system, similar to the deploy phase
-
 As an example, to run the `{{site.data.var.ct}}` ideal-state command:
 
 ```bash
-docker-compose run cli ece-command wizard:ideal-state
+docker-compose run deploy ece-command wizard:ideal-state
 ...
  - Your application does not have the "post_deploy" hook enabled.
 The configured state is not ideal
@@ -61,7 +60,7 @@ The Cron container is based on PHP-CLI images, and executes operations in the ba
 #### View cron log
 
 ```bash
-docker-compose run cli bash -c "cat /var/www/magento/var/log/magento.cron.log"
+docker-compose run deploy bash -c "cat /var/www/magento/var/log/magento.cron.log"
 ```
 
 ### Database container

--- a/guides/v2.1/cloud/docker/docker-quick-reference.md
+++ b/guides/v2.1/cloud/docker/docker-quick-reference.md
@@ -13,9 +13,9 @@ Action | Command
 Build and start Docker environment | `docker-compose up -d`
 Build environment | `docker-compose run build cloud-build`
 Deploy environment | `docker-compose run deploy cloud-deploy`
-Connect to CLI container | `docker-compose run cli bash`
-Use `{{site.data.var.ct}}` command | `docker-compose run cli ece-command <command>`
-Use Magento command | `docker-compose run cli magento <command>`
+Connect to CLI container | `docker-compose run deploy bash`
+Use `{{site.data.var.ct}}` command | `docker-compose run deploy ece-command <command>`
+Use Magento command | `docker-compose run deploy magento <command>`
 Stop and remove Docker environment (removes volumes) | `docker-compose down -v`
 Stop Docker environment without destroying containers | `docker-compose stop`
 Resume Docker environment | `docker-compose start`


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Removes CLI container which is deprecated and will be removed.

https://magento2.atlassian.net/browse/MAGECLOUD-3046

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://github.com/magento/ece-tools/pull/405

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
