### PR TITLE
Fixed incorrect code sample for doc inheritance

### DIFF
--- a/guides/v2.1/coding-standards/docblock-standard-general.md
+++ b/guides/v2.1/coding-standards/docblock-standard-general.md
@@ -559,7 +559,7 @@ interface MutableInterface
      * Get value
      *
      * Returns 0, if no value is available
-     *
+     * 
      * @return int
      */
     public function getVal();
@@ -592,7 +592,8 @@ class LimitedMutableClass implements MutableInterface
     /**
      * Set value
      *
-     * Sets 0 in case the value is bigger than max allowed value. {@inheritdoc}
+     * Sets 0 in case the value is bigger than max allowed value.
+     * @inheritdoc
      */
     public function setVal($value)
     {


### PR DESCRIPTION
Fixes issue #3498.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Fix the code sample for doc inheritance in the lLimitedMutableClass:setVal example.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

https://devdocs.magento.com/guides/v2.1/coding-standards/docblock-standard-general.html#inheritdoc
https://devdocs.magento.com/guides/v2.2/coding-standards/docblock-standard-general.html#inheritdoc
https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html#inheritdoc

