### PR TITLE
Update theme to be from master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'devdocs', :git => 'https://github.com/magento-devdocs/devdocs-theme.git', :branch => 'devdocs-stable'
+gem 'devdocs', :git => 'https://github.com/magento-devdocs/devdocs-theme.git', :branch => 'master'
 
 gem 'wdm' if Gem.win_platform?
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: 0e79c05df09199cef3a0a863933c01770c21290d
-  branch: devdocs-stable
+  revision: 81e20298c5c8445e5752f5a58080b73dea798a7a
+  branch: master
   specs:
     devdocs (0.0.1)
       jekyll (~> 3.3)


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will update the theme and will no longer depend on the theme `devdocs-stable` branch, but instead it will depend on `master` branch.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs: none

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
