### PR TITLE
 Remove {% highlight %} from guides

### DIFF
--- a/_videos/fundamentals/add-a-javascript-module.md
+++ b/_videos/fundamentals/add-a-javascript-module.md
@@ -27,10 +27,10 @@ Let’s go through each step.
 
 We will create a new module called Learning_Js:
 
-```
-$ cd <magento2_root>
-$ mkdir app/code/Learning
-$ mkdir app/code/Learning/Js
+```bash
+cd <magento2_root>
+mkdir app/code/Learning
+mkdir app/code/Learning/Js
 ```
 
 Now create two files:
@@ -39,44 +39,46 @@ Now create two files:
 
 {% collapsible Show source code %}
 
-  {% highlight php startinline=true %}
+```php?start_inline=1
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
     'Learning_Js',
     __DIR__
 );
-  {% endhighlight %}
+```
 
 {% endcollapsible %}
 
-<br/>
 
 `app/code/Learning/Js/etc/module.xml`
 
 {% collapsible Show source code  %}
-  {%highlight xml %}
+
+```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Learning_Js" setup_version="0.0.1">
     </module>
 </config>
-  {% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Step 2: Create a requirejs-config.js and a JavaScript module file
 
 Next, we’ll create a view folder:
 
-```
-$ cd <magento2_root>
-$ mkdir app/code/Learning/Js/view
-$ mkdir app/code/Learning/Js/view/frontend
+```bash
+cd <magento2_root>
+mkdir app/code/Learning/Js/view
+mkdir app/code/Learning/Js/view/frontend
 ```
 
 Add the file `app/code/Learning/Js/view/frontend/requirejs-config.js`:
 
 {% collapsible Show source code %}
-  {% highlight javascript %}
+
+```js
 var config = {
     map: {
         '*': {
@@ -84,20 +86,22 @@ var config = {
         }
     }
 };
-  {% endhighlight %}
+```
+
 {% endcollapsible %}
 
 Then add the JavaScript module:
 
-```
-$ mkdir app/code/Learning/Js/view/frontend/web
-$ mkdir app/code/Learning/Js/view/frontend/web/js
+```bash
+mkdir app/code/Learning/Js/view/frontend/web
+mkdir app/code/Learning/Js/view/frontend/web/js
 ```
 
 And finally, add the file `app/code/Learning/Js/view/frontend/web/js/hello.js`:
 
 {% collapsible Show source code %}
-  {% highlight javascript %}
+
+```js
 define([
     "jquery"
 ], function($){
@@ -107,24 +111,25 @@ define([
         }
     }
 )
-  {% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Step 3: Create a layout update to add a template that will enable the JavaScript module
 
 First, we need to create the layout folder:
 
-```
-$ cd <magento2_root>
-$ mkdir app/code/Learning/Js/view/frontend
-$ mkdir app/code/Learning/Js/view/frontend/layout
+```bash
+cd <magento2_root>
+mkdir app/code/Learning/Js/view/frontend
+mkdir app/code/Learning/Js/view/frontend/layout
 ```
 
 And the add the file `catalog_product_view.xml`:
 
 {% collapsible Show source code %}
-  {% highlight xml %}
 
+```xml
 <?xml version="1.0"?>
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
@@ -133,27 +138,29 @@ And the add the file `catalog_product_view.xml`:
         </referenceContainer>
     </body>
 </page>
+```
 
-  {% endhighlight %}
 {% endcollapsible %}
 
 ## Step 4: Create a template file
 
 Now, we’ll create the template that will enable JavaScript.
 
-```
-$ cd <magento2_root>
-$ mkdir app/code/Learning/Js/view/frontend/templates
+```bash
+cd <magento2_root>
+mkdir app/code/Learning/Js/view/frontend/templates
 ```
 
 In the templates directory, add the file `app/code/Learning/Js/view/frontend/templates/hello.phtml`:
 
 {% collapsible Show source code %}
-  {% highlight html %}
+
+```html
 <div data-mage-init='{"hello": {"message": "HELLO WORLD!"}}'>
     Content
 </div>
-  {% endhighlight %}
+```
+
 {% endcollapsible %}
 
 This code enables our module.
@@ -171,10 +178,10 @@ Other popular options for executing JavaScript code in Magento 2 include applyin
 
 Finally, let’s add our module and test the result.
 
-```
-$ cd <magento2_root>
-$ bin/magento setup:upgrade
-$ bin/magento cache:clean
+```bash
+cd <magento2_root>
+bin/magento setup:upgrade
+bin/magento cache:clean
 ```
 
 Now we’ll go to any product view page, and we should see the “HELLO WORLD!” message.

--- a/_videos/fundamentals/add-a-new-table-to-database.md
+++ b/_videos/fundamentals/add-a-new-table-to-database.md
@@ -39,10 +39,10 @@ Create a new module called `Learning_GreetingMessage`.
 
 Navigate to the `app/code` folder and create the folders `Learning` and `Learning/GreetingMessage`:
 
-```
-$ cd <magento2_root>/app/code
-$ mkdir Learning
-$ mkdir Learning/GreetingMessage
+```bash
+cd <magento2_root>/app/code
+mkdir Learning
+mkdir Learning/GreetingMessage
 ```
 
 Now create two files:
@@ -50,7 +50,8 @@ Now create two files:
 `Learning/GreetingMessage/registration.php`
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php?start_inline=1
 /**
 * Copyright © 2016 Magento. All rights reserved.
 * See COPYING.txt for license details.
@@ -61,15 +62,16 @@ Now create two files:
   'Learning_GreetingMessage',
   __DIR__
 );
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
-<br/>
 
 `Learning/GreetingMessage/etc/module.xml`
 
 {% collapsible Show code %}
-{% highlight xml %}
+
+```xml
 <?xml version="1.0"?>
 <!--
 /**
@@ -81,22 +83,24 @@ xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
   <module name="Learning_GreetingMessage" setup_version="0.0.1">
   </module>
 </config>
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Step 2: Create an InstallSchema script
 
 To create an InstallSchema script, navigate to the `app/code/Learning/GreetingMessage` folder and create a `Setup` folder.
 
-```
-$ cd <magento2_root>/app/code/Learning/GreetingMessage
-$ mkdir Setup
+```bash
+cd <magento2_root>/app/code/Learning/GreetingMessage
+mkdir Setup
 ```
 
 Create the file `Setup/InstallSchema.php`.
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php?start_inline=1
 /**
 * Copyright © 2016 Magento. All rights reserved.
 * See COPYING.txt for license details.
@@ -140,7 +144,8 @@ class InstallSchema implements InstallSchemaInterface
           $setup->getConnection()->createTable($table);
       }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 Let’s take a minute to look at the code.
@@ -159,7 +164,8 @@ You can find various examples of DDL in the Magento 2 core code.
 Let’s create the `Setup/InstallData.php` file:
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -198,17 +204,17 @@ class InstallData implements InstallDataInterface
           }
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ## Step 4: Add a new module and verify that a table with data was created
 
 Run the `setup:upgrade` script to verify that a table with the initial data is there:
 
-```
-$ cd <magento2_root>
-$ php bin/magento setup:upgrade
+```bash
+cd <magento2_root>
+php bin/magento setup:upgrade
 ```
 
 You should see a long list of modules that contain `Learning_GreetingMessage`.
@@ -267,8 +273,8 @@ First, change the version in the `etc/module.xml` file to 0.0.2:
 Then create the file `Setup/UpgradeSchema.php`:
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
 
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -307,7 +313,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
         $setup->endSetup();
     }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 Review the “version_compare” line.
@@ -320,7 +327,8 @@ That’s why we put upgrades into “if” clauses.
 To create the `Setup/UpgradeData.php` file:
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -358,16 +366,17 @@ class UpgradeData implements UpgradeDataInterface
         $setup->endSetup();
     }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Step 7: Run the upgrade scripts and verify that the table has changed
 
 Run the SetupUpgrade script again:
 
-```
-$ cd <magento2_root>
-$ php bin/magento setup:upgrade
+```bash
+cd <magento2_root>
+php bin/magento setup:upgrade
 ```
 
 We can now connect to the database and verify that our changes are there:

--- a/_videos/fundamentals/add-new-product-attribute.md
+++ b/_videos/fundamentals/add-new-product-attribute.md
@@ -33,10 +33,10 @@ Let’s go through each step.
 
 As Magento is modular based, we start the process by creating a new module called `Learning_ClothingMaterial`.
 
-```
-$ cd <magento2_root>/app/code
-$ mkdir Learning
-$ mkdir Learning/ClothingMaterial
+```bash
+cd <magento2_root>/app/code
+mkdir Learning
+mkdir Learning/ClothingMaterial
 ```
 
 Now, create two files:
@@ -44,7 +44,8 @@ Now, create two files:
 `etc/module.xml`
 
 {% collapsible Show code %}
-{% highlight xml %}
+
+```xml
 <?xml version="1.0"?>
 <!--
 /**
@@ -57,15 +58,15 @@ xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
   <module name="Learning_ClothingMaterial" setup_version="0.0.1">
   </module>
 </config>
-{% endhighlight %}
-{% endcollapsible %}
+```
 
-<br/>
+{% endcollapsible %}
 
 `registration.php`
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -75,7 +76,8 @@ xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     'Learning_ClothingMaterial',
     __DIR__
 );
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Step 2 Create an InstallData script
@@ -87,8 +89,8 @@ Therefore we use InstallData instead of InstallSchema.
 Create the file `app/code/Learning/ClothingMaterial/Setup/InstallData.php`:
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
 
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -153,10 +155,9 @@ class InstallData implements InstallDataInterface
         );
     }
 }
-{% endhighlight %}
-{% endcollapsible %}
+```
 
-<br/>
+{% endcollapsible %}
 
 Let’s take a minute to look at the code.
 
@@ -194,8 +195,8 @@ Next, we need to create the source model:
 `app/code/Learning/ClothingMaterial/Model/Attribute/Source/Material.php`
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
 
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -224,11 +225,9 @@ class Material extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
         return $this->_options;
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
-
-<br/>
 
 As the name implies, the `getAllOptions` method provides a list of all available options.
 
@@ -239,8 +238,8 @@ Now we will create a backend model:
 `app/code/Learning/ClothingMaterial/Model/Attribute/Backend/Material.php`
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
 
+```php?start_inline=1
 /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -267,11 +266,9 @@ class Material extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacke
         return true;
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
-
-<br/>
 
 In our example, we implement only the `validate()` method.
 
@@ -287,7 +284,8 @@ Make sure to check the `eav_attribute_set` table for the right ID.
 And finally, we create a frontend model to make our value bold:
 
 {% collapsible Show code %}
-{% highlight php startinline=true %}
+
+```php?start_inline=1
 namespace Learning\ClothingMaterial\Model\Attribute\Frontend;
 
 class Material extends \Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend
@@ -298,10 +296,9 @@ class Material extends \Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFron
         return "<b>$value</b>";
     }
 }
-{% endhighlight %}
-{% endcollapsible %}
+```
 
-<br/>
+{% endcollapsible %}
 
 As with the backend model, this is also a very simple class.
 
@@ -309,9 +306,9 @@ As with the backend model, this is also a very simple class.
 
 Now we can run our code and check the results:
 
-```
-$ cd <magento2_root>
-$ php bin/magento setup:upgrade
+```bash
+cd <magento2_root>
+php bin/magento setup:upgrade
 ```
 
 After you run this, the new attribute should have been added to the database.

--- a/_videos/fundamentals/create-a-new-module.md
+++ b/_videos/fundamentals/create-a-new-module.md
@@ -57,20 +57,20 @@ Dependencies. If one module depends on another, the `module.xml` file will have 
 
 Using the following command-line code, create the folder `app/code/Learning/FirstUnit/etc`:
 
-```
+```bash
 mkdir app/code/Learning/FirstUnit/etc
 ```
 
 Then put the following code into it:
 
-{% highlight xml %}
+```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 <module name="Learning_FirstUnit" setup_version="0.0.1"> <sequence>
 <module name="Magento_Catalog"/> </sequence>
     </module>
 </config>
-{% endhighlight %}
+```
 
 
 Note that in the XML file we specified:
@@ -84,12 +84,12 @@ Note that in the XML file we specified:
 Each module must have this file, which tells Magento how to locate the module. Continuing our example, create the file
 `app/code/Learning/FirstUnit/registration.php`. Then put the following content into it:
 
-{% highlight php %}
+```php
 <?php \Magento\Framework\Component\ComponentRegistrar::register(
 \Magento\Framework\Component\ComponentRegistrar::MODULE, 'Learning_FirstUnit',
 __DIR__
 );
-{% endhighlight %}
+```
 
 The `registration.php` is a standardized file that follows the same pattern for all modules.
 
@@ -99,7 +99,7 @@ The only thing that varies is the module name, which in our case is `Learning_Fi
 
 Running this command makes your new module active, notifying Magento of its presence.
 
-```
+```bash
 php bin/magento setup:upgrade
 ```
 
@@ -111,7 +111,7 @@ So far, we haven't added any useful code to our module – it is still empty (an
 
 Never change this list manually!
 
-```
+```bash
 grep Learning_FirstUnit app/etc/config.php
 ```
 

--- a/_videos/fundamentals/create-a-new-page.md
+++ b/_videos/fundamentals/create-a-new-page.md
@@ -36,30 +36,31 @@ Let’s go through each step.
 
 We will create a new module called `Learning_HelloPage`
 
-```
-$ cd <magento2_root>/app/code
-$ mkdir Learning
-$ mkdir Learning/HelloPage
+```bash
+cd <magento2_root>/app/code
+mkdir Learning
+mkdir Learning/HelloPage
 ```
 
 Now create two files:
-{% highlight console %}
+
+```console
 Learning/HelloPage/registration.php
 Learning/HelloPage/etc/module.xml
-{% endhighlight %}
+```
 
 #### registration.php
-{% highlight php %}
+```php
 <?php /**
 * Copyright © 2016 Magento. All rights reserved. * See COPYING.txt for license details.
 */
 \Magento\Framework\Component\ComponentRegistrar::register( \Magento\Framework\Component\ComponentRegistrar::MODULE, 'Learning_HelloPage',
 __DIR__
 );
-{% endhighlight %}
+```
 
 #### module.xml
-{% highlight xml %}
+```xml
 <?xml version="1.0"?>
 <!--
 /**
@@ -70,7 +71,7 @@ __DIR__
     <module name="Learning_HelloPage" setup_version="0.0.1">
     </module>
 </config>
-{% endhighlight %}
+```
 
 ## Add a routes.xml file
 
@@ -80,7 +81,7 @@ So, we should register it in the `routes.xml` file and associate it with a modul
 
 Now, since we’re working in the frontend area, we’ll add the `etc/frontend/routes.xml` file for our `Learning_HelloPage` module:
 
-{% highlight xml %}
+```xml
 <?xml version="1.0"?>
 <!--
 /**
@@ -94,7 +95,7 @@ Now, since we’re working in the frontend area, we’ll add the `etc/frontend/r
         </route>
     </router>
 </config>
-{% endhighlight %}
+```
 
 We added a new route here called “learning” (note it does not have to match the module name) and a new `frontName`. Often the route and `frontName` are the same – for example, “catalog” – but it is not required.
 When Magento 2 sees a URL like `test/chunk2/chunk3`, it will check whether our module `Learning_HelloPage` has a folder, `Controller/Chunk2`, and an action file, `Chunk3.php`.
@@ -105,15 +106,15 @@ Our route will be `test/page/view`.
 
 Let’s add the controller now.
 
-```
-$ cd <magento2_root>/app/code/Learning/HelloPage
-$ mkdir Controller
-$ mkdir Controller/Page
+```bash
+cd <magento2_root>/app/code/Learning/HelloPage
+mkdir Controller
+mkdir Controller/Page
 ```
 
 Let’s create an action file `Controller/Page/View.php`:
 
-{% highlight php %}
+```php
 <?php /**
  * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
@@ -148,18 +149,18 @@ class View extends \Magento\Framework\App\Action\Action
 
 return $result->setData($data);
 } }
-{% endhighlight %}
+```
 
 Note we created a JSON-type page. This can be seen in the results factory that we specify in our constructor. In order to activate our module and our page we should run the Magento setup upgrade:
 
-```
-$ cd <magento2_root>
-$ php bin/magento setup:upgrade
+```bash
+cd <magento2_root>
+php bin/magento setup:upgrade
 ```
 
 Now we need to verify that `Learning_HelloPage` is present in the output. If you examine the `/test/page/view` page, you should see the message:
 
-```
+```console
 {"message":"Hello world!"}
 ```
 

--- a/guides/v2.0/rest/modules/catalog.md
+++ b/guides/v2.0/rest/modules/catalog.md
@@ -44,8 +44,7 @@ Third-party modules may define other custom attributes.
 
 The following example uses the `POST V1/categories` call to assign four custom attributes to the "My New Category" category.
 
-{% highlight json %}
-
+```json
 {
 "category": {
     "parent_id": 2,
@@ -77,4 +76,4 @@ The following example uses the `POST V1/categories` call to assign four custom a
       ]
     }
 }
-{% endhighlight %}
+```

--- a/guides/v2.0/rest/performing-searches.md
+++ b/guides/v2.0/rest/performing-searches.md
@@ -9,11 +9,11 @@ POST, PUT, and DELETE requests to the REST Web {% glossarytooltip 786086f2-622b-
 
 For search APIs that invoke a `*Repository::getList(SearchCriteriaInterface *)` call, the searchCriteria must be specified in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %} of the GET request. The basic pattern for specifying the criteria is
 
-{% highlight html %}
+```
 searchCriteria[filter_groups][<index>][filters][<index>][field]=<field_name>
 searchCriteria[filter_groups][<index>][filters][<index>][value]=<search_value>
 searchCriteria[filter_groups][<index>][filters][<index>][condition_type]=<operator>
-{% endhighlight %}
+```
 
 where:
 
@@ -57,16 +57,16 @@ The following sections provide examples of each type of search. These examples u
 
 The {{site.data.var.ce}} sample data uses the `category_gear` field to describe the categories for each item listed under Gear on sample store. Each item can be assigned to multiple categories. Electronics are assigned the code 86. The following example returns all gear tagged as electronics.
 
-{% highlight html %}
+```
 GET http://<magento_host>/rest/V1/products/?
 searchCriteria[filter_groups][0][filters][0][field]=category_gear&
 searchCriteria[filter_groups][0][filters][0][value]=86&
 searchCriteria[filter_groups][0][filters][0][condition_type]=finset
-{% endhighlight %}
+```
 
 The system creates an array, as shown in the following pseudo-code.
 
-<pre class="no-copy">
+```
 searchCriteria => [
   'filterGroups' => [
     0 => [
@@ -79,7 +79,8 @@ searchCriteria => [
       ]
     ]
   ]
-</pre>
+```
+{: .no-copy}
 
 The query returns 9 items.
 
@@ -87,18 +88,18 @@ The query returns 9 items.
 
 The following search finds all invoices created after the specified time (midnight, July 1 2016). You can set up a similar search to run periodically to poll for changes.
 
-{% highlight html %}
+```html
 GET http://<magento_host>/rest/V1/invoices?
 searchCriteria[filter_groups][0][filters][0][field]=created_at&
 searchCriteria[filter_groups][0][filters][0][value]=2016-07-01 00:00:00&
 searchCriteria[filter_groups][0][filters][0][condition_type]=gt
-{% endhighlight %}
+```
 
 ### Logical OR search
 
 The following example searches for all products whose names contain the string `Leggings` or `Parachute`. The instances of `%25` in the example are converted into the SQL wildcard character `%`.
 
-{% highlight html %}
+```
 GET http://<magento_host>/index.php/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=name&
 searchCriteria[filter_groups][0][filters][0][value]=%25Leggings%25&
@@ -106,11 +107,11 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=like&
 searchCriteria[filter_groups][0][filters][1][field]=name&
 searchCriteria[filter_groups][0][filters][1][value]=%25Parachute%25&
 searchCriteria[filter_groups][0][filters][1][condition_type]=like
-{% endhighlight %}
+```
 
 The system creates an array, as shown in the following pseudo-code.
 
-<pre class="no-copy">
+```
 searchCriteria => [
   'filterGroups' => [
     0 => [
@@ -128,7 +129,8 @@ searchCriteria => [
       ]
     ]
   ]
-</pre>
+```
+{: .no-copy}
 
 The search returns 14 products that contain the string `Leggings` in the `name` field and 14 products that contain the string `Parachute`.
 
@@ -136,7 +138,7 @@ The search returns 14 products that contain the string `Leggings` in the `name` 
 
 This sample searches for women's shorts that are size 31 and costs less than $30. In the CE sample data, women's shorts have a `sku` value that begins with `WSH`. The `sku` also contains the size and color, such as `WSH02-31-Yellow`.
 
-{% highlight html %}
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2531%25&
@@ -144,11 +146,11 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=like&
 searchCriteria[filter_groups][1][filters][0][field]=price&
 searchCriteria[filter_groups][1][filters][0][value]=30&
 searchCriteria[filter_groups][1][filters][0][condition_type]=lt
-{% endhighlight %}
+```
 
 The system creates an array, as shown in the following pseudo-code.
 
-<pre class="no-copy">
+```
 searchCriteria => [
   'filterGroups' => [
     0 => [
@@ -168,14 +170,16 @@ searchCriteria => [
       ]
     ]
   ]
-</pre>
+```
+{: .no-copy}
+
 The query returns 9 items.
 
 ### Logical AND and OR search
 
 This sample is similar the Logical AND sample. It searches the `sku`s for women's shorts (WSH%) or pants (WP%)in size 29. The system performs two logical ANDs to restrict the results to those that cost from $40 to $49.99
 
-{% highlight html %}
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2529%25&
@@ -189,7 +193,7 @@ searchCriteria[filter_groups][1][filters][0][condition_type]=from&
 searchCriteria[filter_groups][2][filters][0][field]=price&
 searchCriteria[filter_groups][2][filters][0][value]=49.99&
 searchCriteria[filter_groups][2][filters][0][condition_type]=to
-{% endhighlight %}
+```
 
 The query returns 37 items.
 

--- a/guides/v2.0/rest/retrieve-filtered-responses.md
+++ b/guides/v2.0/rest/retrieve-filtered-responses.md
@@ -26,7 +26,6 @@ On POST and PUT requests, Magento ignores the `fields` parameter as input, but t
 # Examples
 {:.no_toc}
 
-
 All examples use {{site.data.var.ce}} sample data.
 
 ## Simple fields
@@ -36,13 +35,15 @@ The following example returns only the `sku`, `price`, and `name` for the specif
 `GET http://<host>/rest/default/V1/products/24-MB01?fields=sku,price,name`
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 {
   "sku": "24-MB01"
   "name": "Joust Duffle Bag"
   "price": 24.99
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Simple fields and top-level objects with all fields
@@ -52,7 +53,8 @@ The following example returns only the customer first name, last name, and the e
 `GET http:/<host>/rest/default/V1/orders/2?fields=billing_address,customer_firstname,customer_lastname`
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 {
 "customer_firstname": "Veronica"
 "customer_lastname": "Costello"
@@ -74,7 +76,8 @@ The following example returns only the customer first name, last name, and the e
   "telephone": "(555) 229-3326"
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Top-level object with selected fields
@@ -84,7 +87,8 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 `GET http://<host>/rest/default/V1/shipment/2?fields=items[name,qty,sku]`
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 "items": [
    {
      "name": "Minerva LumaTech&trade; V-Tee-XS-Blue",
@@ -92,8 +96,9 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
      "sku": "WS08-XS-Blue",
    }
  ]
- {% endhighlight %}
- {% endcollapsible %}
+```
+
+{% endcollapsible %}
 
 ## Nested objects
 
@@ -106,7 +111,8 @@ This example returns only the following:
 `GET http://<host>/rest/default/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 {
   "sku": "MT12"
   "name": "Cassius Sparring Tank"
@@ -121,7 +127,8 @@ This example returns only the following:
       }
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## POST operation
@@ -130,23 +137,25 @@ The following POST operation and payload creates a {% glossarytooltip 8d40d668-4
 
 `POST http://<host>/rest/V1/categories?fields=id,parent_id,name`
 
-{% highlight json %}
+```json
 {
   "category": {
     "name": "New Category",
     "is_active": true
   }
 }
-{% endhighlight %}
+```
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 {
 "id": 43
 "parent_id": 2
 "name": "New Category"
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Using with searchCriteria
@@ -158,7 +167,8 @@ The following query returns only the `sku` and `name` parameters for product ite
 `GET http://<host>/rest/V1/products/?searchCriteria[filter_groups][0][filters][0][field]=category_gear&searchCriteria[filter_groups][0][filters][0][value]=86&searchCriteria[filter_groups][0][filters][0][condition_type]=finset&fields=items[sku,name]`
 
 {% collapsible Sample output %}
-{% highlight json %}
+
+```json
 {
 "items":
   {
@@ -198,7 +208,8 @@ The following query returns only the `sku` and `name` parameters for product ite
     "name": "Didi Sport Watch"
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Related topics

--- a/guides/v2.0/ui-components/ui-secondary-pagination.md
+++ b/guides/v2.0/ui-components/ui-secondary-pagination.md
@@ -22,7 +22,7 @@ Example:
 
 `<Magento_Cms_module_dir>/view/adminhtml/ui_component/cms_page_listing.xml`
 
-{% highlight xml %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <container name="page_listing_top">
         <paging name="listing_paging">
@@ -38,7 +38,7 @@ Example:
         </paging>
     </container>
 </listing>
-{% endhighlight %}
+```
 
 The configuration of the component can include:
 

--- a/guides/v2.0/ui-components/ui-secondary-uploader.md
+++ b/guides/v2.0/ui-components/ui-secondary-uploader.md
@@ -86,7 +86,7 @@ UI File Uploader component is an {% glossarytooltip edb42858-1ff8-41f9-80a6-edf0
 
 Here is an example of how File Uploader component integrates with [Form]({{ page.baseurl }}/ui-components/ui-form.html) component:
 
-{% highlight xml %}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     ...
     <fieldset name="foo">
@@ -110,4 +110,4 @@ Here is an example of how File Uploader component integrates with [Form]({{ page
         </field>
     </fieldset>
 </form>
-{% endhighlight %}
+```

--- a/guides/v2.1/rest/modules/catalog.md
+++ b/guides/v2.1/rest/modules/catalog.md
@@ -44,8 +44,7 @@ Third-party modules may define other custom attributes.
 
 The following example uses the `POST V1/categories` call to assign four custom attributes to the "My New Category" category.
 
-{% highlight json %}
-
+```json
 {
 "category": {
     "parent_id": 2,
@@ -77,4 +76,4 @@ The following example uses the `POST V1/categories` call to assign four custom a
       ]
     }
 }
-{% endhighlight %}
+```

--- a/guides/v2.1/rest/performing-searches.md
+++ b/guides/v2.1/rest/performing-searches.md
@@ -8,11 +8,11 @@ POST, PUT, and DELETE requests to the REST Web {% glossarytooltip 786086f2-622b-
 
 For search APIs that invoke a `*Repository::getList(SearchCriteriaInterface *)` call, the searchCriteria must be specified in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %} of the GET request. The basic pattern for specifying the criteria is
 
-{% highlight html %}
+```
 searchCriteria[filter_groups][<index>][filters][<index>][field]=<field_name>
 searchCriteria[filter_groups][<index>][filters][<index>][value]=<search_value>
 searchCriteria[filter_groups][<index>][filters][<index>][condition_type]=<operator>
-{% endhighlight %}
+```
 
 where:
 
@@ -57,7 +57,7 @@ The following sections provide examples of each type of search. These examples u
 
 The {{site.data.var.ce}} sample data uses the `category_gear` field to describe the categories for each item listed under Gear on sample store. Each item can be assigned to multiple categories. Electronics are assigned the code 86. The following example returns all gear tagged as electronics.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products/?
 searchCriteria[filter_groups][0][filters][0][field]=category_gear&
 searchCriteria[filter_groups][0][filters][0][value]=86&
@@ -87,7 +87,7 @@ The query returns 9 items.
 
 The following search finds all invoices created after the specified time (midnight, July 1 2016). You can set up a similar search to run periodically to poll for changes.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/invoices?
 searchCriteria[filter_groups][0][filters][0][field]=created_at&
 searchCriteria[filter_groups][0][filters][0][value]=2016-07-01 00:00:00&
@@ -98,7 +98,7 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gt
 
 The following example searches for all products whose names contain the string `Leggings` or `Parachute`. The instances of `%25` in the example are converted into the SQL wildcard character `%`.
 
-``` html
+```
 GET http://<magento_host>/index.php/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=name&
 searchCriteria[filter_groups][0][filters][0][value]=%25Leggings%25&
@@ -136,7 +136,7 @@ The search returns 14 products that contain the string `Leggings` in the `name` 
 
 This sample searches for women's shorts that are size 31 and costs less than $30. In the CE sample data, women's shorts have a `sku` value that begins with `WSH`. The `sku` also contains the size and color, such as `WSH02-31-Yellow`.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2531%25&
@@ -176,7 +176,7 @@ The query returns 9 items.
 
 This sample is similar the Logical AND sample. It searches the `sku`s for women's shorts (WSH%) or pants (WP%)in size 29. The system performs two logical ANDs to restrict the results to those that cost from $40 to $49.99
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2529%25&

--- a/guides/v2.1/rest/retrieve-filtered-responses.md
+++ b/guides/v2.1/rest/retrieve-filtered-responses.md
@@ -31,7 +31,7 @@ The following example returns only the `sku`, `price`, and `name` for the specif
 
 `GET http://<host>/rest/default/V1/products/24-MB01?fields=sku,price,name`
 
-``` json
+```json
 {
   "sku": "24-MB01"
   "name": "Joust Duffle Bag"
@@ -47,26 +47,26 @@ The following example returns only the customer first name, last name, and the e
 
 ```json
 {
-"customer_firstname": "Veronica"
-"customer_lastname": "Costello"
-"billing_address": {
-  "address_type": "billing"
-  "city": "Calder"
-  "country_id": "US"
-  "customer_address_id": 1
-  "email": "roni_cost@example.com"
-  "entity_id": 4
-  "firstname": "Veronica"
-  "lastname": "Costello"
-  "parent_id": 2
-  "postcode": "49628-7978"
-  "region": "Michigan"
-  "region_code": "MI"
-  "region_id": 33
-  "street": "6146 Honey Bluff Parkway"
-  "telephone": "(555) 229-3326"
+  "customer_firstname": "Veronica"
+  "customer_lastname": "Costello"
+  "billing_address": {
+    "address_type": "billing"
+    "city": "Calder"
+    "country_id": "US"
+    "customer_address_id": 1
+    "email": "roni_cost@example.com"
+    "entity_id": 4
+    "firstname": "Veronica"
+    "lastname": "Costello"
+    "parent_id": 2
+    "postcode": "49628-7978"
+    "region": "Michigan"
+    "region_code": "MI"
+    "region_id": 33
+    "street": "6146 Honey Bluff Parkway"
+    "telephone": "(555) 229-3326"
+    }
   }
-}
 ```
 
 ## Top-level object with selected fields
@@ -75,7 +75,7 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 
 `GET http://<host>/rest/default/V1/shipment/2?fields=items[name,qty,sku]`
 
-{% highlight json %}
+```json
 "items": [
    {
      "name": "Minerva LumaTech&trade; V-Tee-XS-Blue",
@@ -83,7 +83,7 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
      "sku": "WS08-XS-Blue",
    }
  ]
- {% endhighlight %}
+```
 
 ## Nested objects
 
@@ -95,7 +95,7 @@ This example returns only the following:
 
 `GET http://<host>/rest/default/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
-{% highlight json %}
+```json
 {
   "sku": "MT12"
   "name": "Cassius Sparring Tank"
@@ -110,7 +110,7 @@ This example returns only the following:
       }
   }
 }
-{% endhighlight %}
+```
 
 ## POST operation
 
@@ -133,9 +133,9 @@ The following POST operation and payload creates a {% glossarytooltip 8d40d668-4
 
 ```json
 {
-"id": 43
-"parent_id": 2
-"name": "New Category"
+  "id": 43,
+  "parent_id": 2,
+  "name": "New Category"
 }
 ```
 
@@ -147,7 +147,7 @@ The following query returns only the `sku` and `name` parameters for product ite
 
 `GET http://<host>/rest/V1/products/?searchCriteria[filter_groups][0][filters][0][field]=category_gear&searchCriteria[filter_groups][0][filters][0][value]=86&searchCriteria[filter_groups][0][filters][0][condition_type]=finset&fields=items[sku,name]`
 
-``` json
+```json
 {
 "items":
   {

--- a/guides/v2.1/rest/tutorials/orders/order-add-items.md
+++ b/guides/v2.1/rest/tutorials/orders/order-add-items.md
@@ -40,7 +40,7 @@ The following example adds an orange medium-sized Radiant women's t-shirt (`sku`
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "cartItem": {
     "sku": "WS12-M-Orange",
@@ -48,11 +48,11 @@ The following example adds an orange medium-sized Radiant women's t-shirt (`sku`
     "quote_id": "4"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "item_id": 7,
   "sku": "WS12-M-Orange",
@@ -61,7 +61,7 @@ The following example adds an orange medium-sized Radiant women's t-shirt (`sku`
   "product_type": "simple",
   "quote_id": "4"
 }
-{% endhighlight %}
+```
 
 ### Add a downloadable product to a cart {#add-downloadable}
 
@@ -81,7 +81,7 @@ The following example adds the downloadable product Advanced Pilates & Yoga (`sk
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "cartItem": {
     "sku": "240-LV08",
@@ -89,11 +89,11 @@ The following example adds the downloadable product Advanced Pilates & Yoga (`sk
     "quote_id": "4"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "item_id": 8,
   "sku": "240-LV08",
@@ -112,7 +112,7 @@ The following example adds the downloadable product Advanced Pilates & Yoga (`sk
     }
   }
 }
-{% endhighlight %}
+```
 
 ### Add a configurable product to a cart {#add-configurable}
 
@@ -122,7 +122,7 @@ In this example, we'll add the Chaz Kangeroo Hoodie (`sku: MH01`) configurable p
 
 The `GET /V1/configurable-products/:sku/children` call returns information about each combination of color and size, 15 in all for `MH01`. The following sample shows the returned values for `size` and `color` for a small gray Chaz Kangeroo Hoodie.
 
-{% highlight json %}
+```json
 {
   "custom_attributes": [
     {
@@ -135,7 +135,7 @@ The `GET /V1/configurable-products/:sku/children` call returns information about
     }
   ]
 }
-{% endhighlight %}
+```
 
 We now know the values for `option_value` for `size` and `color` are `168` and `52`, so we're ready to add the product to the cart.
 
@@ -151,7 +151,7 @@ We now know the values for `option_value` for `size` and `color` are `168` and `
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "cartItem": {
     "sku": "MH01",
@@ -174,11 +174,11 @@ We now know the values for `option_value` for `size` and `color` are `168` and `
     "extension_attributes": {}
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
     "item_id": 13,
     "sku": "MH01-S-Gray",
@@ -202,7 +202,7 @@ We now know the values for `option_value` for `size` and `color` are `168` and `
         }
     }
 }
-{% endhighlight %}
+```
 
 ### Add a bundle product to a cart {#add-bundle}
 
@@ -218,7 +218,8 @@ To add a bundle product to a cart, you must specify the `sku` of the bundle prod
 The `GET http://<host>/rest/default/V1/bundle-products/24-WG080/options/all` call returns `id` values, as shown in the following simplified response:
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 [
   {
     "option_id": 1,
@@ -309,7 +310,8 @@ The `GET http://<host>/rest/default/V1/bundle-products/24-WG080/options/all` cal
     ]
   }
 ]
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 For this example, we'll configure the Sprite Yoga Companion Kit as follows:
@@ -333,8 +335,8 @@ For this example, we'll configure the Sprite Yoga Companion Kit as follows:
 **Payload**
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
     "cartItem": {
         "sku": "24-WG080",
@@ -368,14 +370,15 @@ For this example, we'll configure the Sprite Yoga Companion Kit as follows:
         }
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
   "item_id": 9,
   "sku": "24-WG080-24-WG084-24-WG088-24-WG082-blue-24-WG086",
@@ -419,7 +422,8 @@ For this example, we'll configure the Sprite Yoga Companion Kit as follows:
     }
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ### Verify this step {#verify-step}

--- a/guides/v2.1/rest/tutorials/orders/order-admin-token.md
+++ b/guides/v2.1/rest/tutorials/orders/order-admin-token.md
@@ -64,12 +64,12 @@ See [Token-based authentication]({{ page.baseurl }}/get-started/authentication/g
 
 **Payload**
 
-{% highlight json %}
+```json
 {
-"username": "admin",
-"password": "123123q"
+  "username": "admin",
+  "password": "123123q"
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.1/rest/tutorials/orders/order-create-invoice.md
+++ b/guides/v2.1/rest/tutorials/orders/order-create-invoice.md
@@ -37,12 +37,12 @@ where `3` is the `orderid`
 `Authorization` `Bearer <administrator token>`
 
 **Payload**
-{% highlight json %}
+```json
 {
   "capture": true,
   "notify": true
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -71,8 +71,8 @@ Not applicable
 You will use the `order_item_id` values to create a {% glossarytooltip c8f00e9d-7f70-4561-9773-60da604ba5c9 %}shipment{% endglossarytooltip %} in the next step.
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
     "base_currency_code": "USD",
     "base_discount_amount": 0,
@@ -288,8 +288,8 @@ You will use the `order_item_id` values to create a {% glossarytooltip c8f00e9d-
     ],
     "comments": []
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ### Verify this step {#verify-step}

--- a/guides/v2.1/rest/tutorials/orders/order-create-order.md
+++ b/guides/v2.1/rest/tutorials/orders/order-create-order.md
@@ -37,8 +37,8 @@ When you submit payment information, Magento creates an order and sends an order
 **Payload**
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
 	"paymentMethod": {
     	    	"method": "banktransfer"
@@ -57,7 +57,8 @@ When you submit payment information, Magento creates an order and sends an order
     	    	"lastname": "Doe"
 	 }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 **Response**
@@ -87,8 +88,8 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
     "applied_rule_ids": "1",
     "base_currency_code": "USD",
@@ -1569,8 +1570,8 @@ Not applicable
         ]
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ### Verify this step {#verify-step}

--- a/guides/v2.1/rest/tutorials/orders/order-create-shipment.md
+++ b/guides/v2.1/rest/tutorials/orders/order-create-shipment.md
@@ -42,8 +42,8 @@ where `3` is the order id.
 The `tracks` array optionally allows you to include one or more tracking numbers for the {% glossarytooltip c8f00e9d-7f70-4561-9773-60da604ba5c9 %}shipment{% endglossarytooltip %}.
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
   "items": [
     {
@@ -67,8 +67,8 @@ The `tracks` array optionally allows you to include one or more tracking numbers
     }
   ]
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 **Response**

--- a/guides/v2.1/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.1/rest/tutorials/orders/order-issue-refund.md
@@ -46,7 +46,7 @@ The `return_to_stock_items` array specifies which `order_item_id`s can be return
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "items": [
     {
@@ -66,7 +66,7 @@ The `return_to_stock_items` array specifies which `order_item_id`s can be return
     }
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.1/ui_comp_guide/components/ui-exportbutton.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-exportbutton.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: ExportButton component
-menu_title: ExportButton component
 ---
 
 The ExportButton component implements the ability to export grid data to the specified data format (cvs, xml, and so on).
@@ -65,7 +63,7 @@ The ExportButton component implements the ability to export grid data to the spe
 
 To enable the ExportButton component, add the `exportButton` element with a `selectProvider` item to the listing configuration file.
 
-{% highlight XML %}
+```xml
 <exportButton name="export_button">
     <argument name="data" xsi:type="array">
         <item name="config" xsi:type="array">
@@ -73,13 +71,13 @@ To enable the ExportButton component, add the `exportButton` element with a `sel
         </item>
     </argument>
 </exportButton>
-{% endhighlight %}
+```
 
 ### Use `sales_order_grid.xml`
 
 Example: `<Magento_Sales_module_dir>/view/adminhtml/ui_component/sales_order_grid.xml`
 
-{% highlight XML %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <container name="listing_top">
         <exportButton name="export_button">
@@ -91,7 +89,7 @@ Example: `<Magento_Sales_module_dir>/view/adminhtml/ui_component/sales_order_gri
         </exportButton>
     </container>
 </listing>
-{% endhighlight %}
+```
 
 By default Magento allows {% glossarytooltip 6341499b-ead9-4836-9794-53d95eb48ea5 %}CSV{% endglossarytooltip %} and Excel {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} export data formats.
 

--- a/guides/v2.1/ui_comp_guide/components/ui-fileuploader.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-fileuploader.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: FileUploader component
-menu_title: FileUploader component
 ---
 
 The File Uploader component is an {% glossarytooltip edb42858-1ff8-41f9-80a6-edf0d86d7e10 %}adapter{% endglossarytooltip %} for the [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload/wiki) plugin used in Magento. This component integrates file upload functionality with UI components.
@@ -181,7 +179,7 @@ The File Uploader component is an {% glossarytooltip edb42858-1ff8-41f9-80a6-edf
 
 Here is an example of how File Uploader component integrates with [Form]({{ site.baseurl }}/guides/v2.1/ui_comp_guide/components/ui-form.html) component:
 
-{% highlight xml %}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     ...
     <fieldset name="foo">
@@ -205,7 +203,7 @@ Here is an example of how File Uploader component integrates with [Form]({{ site
         </field>
     </fieldset>
 </form>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.1/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-form.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: Form component
-menu_title: Form component
 redirect_from: /guides/v2.1/ui-components/ui-form.html
 ---
 
@@ -215,7 +213,7 @@ To create an instance of the Form component, you need to do the following:
 
 Example:
 
-{% highlight xml %}
+```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
@@ -224,7 +222,7 @@ Example:
         </referenceContainer>
     </body>
 </page>
-{% endhighlight %}
+```
 
 ### Configure component
 
@@ -235,7 +233,7 @@ Component could be configured in two ways:
 
 Create configuration file: `<your module root dir>view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -250,7 +248,7 @@ Create configuration file: `<your module root dir>view/base/ui_component/custome
             <item name="navContainerName" xsi:type="string">left</item>
         </item>
 ...
-{% endhighlight%}
+```
 
 Nodes are optional and contain parameters required for component:
 
@@ -262,7 +260,7 @@ Nodes are optional and contain parameters required for component:
 
 Add a description of the fields in the form using components and Field Fieldset:
 
-{%highlight xml%}
+```xml
 ...
 <fieldset name="customer">
    <argument name="data" xsi:type="array">
@@ -281,11 +279,11 @@ Add a description of the fields in the form using components and Field Fieldset:
         </argument>
     </field>
 …
-{% endhighlight%}
+```
 
 To group components you can use the component container as in example below:
 
-{% highlight xml%}
+```xml
 <container name="container_group">
     <argument name="data" xsi:type="array">
         <item name="type" xsi:type="string">group</item>
@@ -306,7 +304,7 @@ To group components you can use the component container as in example below:
     ...
     </field>
 </container>
-{% endhighlight %}
+```
 
 ### Configure DataSource
 
@@ -316,7 +314,7 @@ DataSource aggregates an object of class implements the interface `\Magento\Fram
 
 An example of the configuration of the DataSource object:
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         ...
@@ -356,7 +354,7 @@ An example of the configuration of the DataSource object:
         </argument>
     </dataSource>
 </form>
-{% endhighlight %}
+```
 
 Component configuration:
 
@@ -379,7 +377,7 @@ To replace all instances of a UI Form with a custom implementation redefine link
 
 `app/code/Magento/Ui/view/base/ui_component/etc/definition.xml`
 
-{% highlight xml%}
+```xml
 <form class="Magento\Ui\Component\Form">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -387,7 +385,7 @@ To replace all instances of a UI Form with a custom implementation redefine link
         </item>
     </argument>
 </form>
-{% endhighlight %}
+```
 
 #### Single replacement
 
@@ -395,7 +393,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
 
 `app/code/Magento/Customer/view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Ui/etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -403,7 +401,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
         </item>
     </argument>
 </form>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.1/ui_comp_guide/components/ui-listing-grid.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-listing-grid.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: Listing (grid) component
-menu_title: Listing (grid) component
 ---
 
 Listing is a [basic component]({{ page.baseurl }}/ui_comp_guide/bk-ui_comps.html#general-structure) that implements grids, lists, and tiles with filtering, pagination, sorting, and other features.
@@ -15,8 +13,7 @@ Example configuration of Listing component instance:
 
 `<your module root dir>/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml`
 
-
-{% highlight xml%}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="context" xsi:type="configurableObject">
         <argument name="class" xsi:type="string">Magento\Framework\View\Element\UiComponent\Context</argument>
@@ -40,7 +37,7 @@ Example configuration of Listing component instance:
         </item>
     </argument>
 </listing>
-{% endhighlight %}
+```
 
 ### Configure DataSource
 
@@ -50,7 +47,7 @@ The listing component requires the data source to be properly configured and ass
 
 `<your module root dir>/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml`
 
-{% highlight xml %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <dataSource name="cms_page_listing_data_source">
         <argument name="dataProvider" xsi:type="configurableObject">
@@ -70,7 +67,7 @@ The listing component requires the data source to be properly configured and ass
         </argument>
     </dataSource>
 </listing>    
-{% endhighlight %}    
+``` 
 
 ## Source files
 

--- a/guides/v2.1/ui_comp_guide/components/ui-massactions.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-massactions.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: MassActions component
-menu_title: MassActions component
 ---
 
 The MassActions component allows performing actions with multiple selected items. Must be a child of the [Listing component]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html).
@@ -97,7 +95,7 @@ Dependency on the following components:
 
 ### Redefine the link to the template
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -106,11 +104,11 @@ Dependency on the following components:
         </item>
     </argument>
 </massaction>
-{% endhighlight %}
+```
 
 ### Specify action with confirmation
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -128,13 +126,13 @@ Dependency on the following components:
         </argument>
     </action>
 </massaction>
-{% endhighlight %}
+```
 
 ### Action with a custom callback
 
 Callback is provided by another component.
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -152,13 +150,13 @@ Callback is provided by another component.
         </argument>
     </action>
 </massaction>
-{% endhighlight %}
+```
 
 ### Instance replacement (one instance of a component)
 
 Redefine link to constructor.
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -166,7 +164,7 @@ Redefine link to constructor.
         </item>
     </argument>
 </massaction>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.1/ui_comp_guide/components/ui-multiselectcolumn.md
+++ b/guides/v2.1/ui_comp_guide/components/ui-multiselectcolumn.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: MultiselectColumn component
-menu_title: MultiselectColumn component
 ---
 
 The MultiselectColumn component implements a column with checkboxes for selecting records. It also provides controls for selecting multiple records.
@@ -70,7 +68,7 @@ Sample of code where component configurations are performed:
 
 Current implementation:
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -82,13 +80,13 @@ Current implementation:
          </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 Example of configuration modifications:
 
 * Redefining the link to the template
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -97,11 +95,11 @@ Example of configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 * Redefining the name of the property which represents record identifier
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -110,11 +108,11 @@ Example of configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 * Redefining a property data source
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -125,7 +123,7 @@ Example of configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 ### Add a new component
 
@@ -133,7 +131,7 @@ Instance Replacement: One Instance of a Component
 
 * Redefine the link to constructor:
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -141,7 +139,7 @@ Instance Replacement: One Instance of a Component
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.1/ui_comp_guide/concepts/ui_comp_data_source.md
+++ b/guides/v2.1/ui_comp_guide/concepts/ui_comp_data_source.md
@@ -1,9 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: concepts
 title: The DataSource Component
-menu_title: Providing Data to UI Components
-menu_order: 20
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
 ---
@@ -20,14 +17,14 @@ The DataSource UI component can be included with the `<dataSource />` node in th
 
 The component's data provider class is declared inside `<dataSource />`. The following provides an example and demonstrates what nodes are required.
 
-{% highlight xml%}
+```xml
 <argument name="dataProvider" xsi:type="configurableObject">
     <argument name="class" xsi:type="string">[YourNameSpace]\[YourModule]\Ui\DataProvider\[YourComponentName]DataProvider</argument>
     <argument name="name" xsi:type="string">[YourComponentName]_data_source</argument>
     <argument name="primaryFieldName" xsi:type="string">entity_id</argument>
     <argument name="requestFieldName" xsi:type="string">id</argument>
 </argument>
-{% endhighlight %}
+```
 
 In the block of code above, [YourNameSpace]\[YourModule] would be the directory that contains all of the module's files and directories. [YourComponentName] is the name of this instance of a component, which should be the file name as well.
 
@@ -43,13 +40,13 @@ A JavaScript "component" is actually a JavaScript file loaded through RequireJS.
 
 Include the Form Provider JavaScript component by adding this inside the `<dataSource />` node:
 
-{% highlight xml%}
+```xml
 <argument name="data" xsi:type="array">
     <item name="js_config" xsi:type="array">
         <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
     </item>
 </argument>
-{% endhighlight %}
+```
 
 This will include [`Magento/Ui/view/base/web/js/form/provider.js`]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/form/provider.js) on the page as part of this DataSource component. The Form Provider javascript can also be extended if the functionality doesn't do what is necessary in your case.
 
@@ -57,11 +54,11 @@ Remember that this data provider is still, technically speaking, a completely se
 
 A good way to keep configuration data out of the javascript is to declare a "provider" in the base component's XML so it will be able to find that data provider component. Under the `<argument name="data" />` node, add a node like this (where `[ComponentName]` is the name of the component):
 
-{% highlight xml%}
+```xml
 <item name="config" xsi:type="array">
     <item name="provider" xsi:type="string">[ComponentName].[ComponentName]_data_source</item>
 </item>
-{% endhighlight %}
+```
 
 This example declares the name of the data provider class and will be output in the JSON that contains the UI component's configuration. It can then be used to locate the data source component. This is essentially declaring a variable that will be available to a javascript class.
 

--- a/guides/v2.1/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.1/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -1,9 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: concepts
 title: Linking properties of UI components
-menu_title: Linking properties of UI components
-menu_order: 100
 ---
 
 ## Linking properties implementation
@@ -31,19 +28,19 @@ If the local value is a ko of io-es5 observable, the external entity will also b
 
 Example of setting `exports` in a component's `.js` file:
 
-{% highlight js%}
+```js
 {
   'exports': {
    'visible': '${ $.provider }:visibility'
   }
 }
-{% endhighlight js%}
+```
 
 Here `visible` is the `key`, `${ $.provider }:visibility` is the `value`. The value of the local `visible` property is assigned to the `visibility` property of the `provider` component. The latter is changed automatically if the value of `visible` changes if the local `visible` property is observable (which it isn't given only the code example above).
 
 Example of setting `exports` in a component's configuration `.xml` file:
 
-{% highlight xml%}
+```xml
 <argument name="data" xsi:type="array">
     <item name="config" xsi:type="array">
         <item name="exports" xsi:type="array">
@@ -51,11 +48,12 @@ Example of setting `exports` in a component's configuration `.xml` file:
         </item>
     </item>
 </argument>
-{% endhighlight xml%}
+```
 
 For an example of `exports` usage in Magento code see [`product_form.xml`, line 81]({{ site.mage2100url }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L81)
 
-### `imports` 
+### `imports`
+
 The `imports` property is used for tracking changes of an external entity property. `imports`'s value is an object, composed of the following:
 
   - `key`: name of the internal property or method that receives the value. 
@@ -63,19 +61,19 @@ The `imports` property is used for tracking changes of an external entity proper
 
 Example of using `imports` in a component's `.js` file:
 
-{% highlight js%}
+```js
 {
   'imports': {
    'visible': '${ $.provider }:visibility'
   }
 }
-{% endhighlight js%}
+```
 
 Here the value of the `visibility` property of the `provider` component is assigned to the local `visible` property. If the latter is a ko or ko-es5 observable, the local property is automatically updated if `visibility` changes.
 
 Example of using `imports` in a component's configuration `.xml` file:
 
-{% highlight xml%}
+```xml
 <argument name="data" xsi:type="array">
     <item name="config" xsi:type="array">
         <item name="imports" xsi:type="array">
@@ -83,7 +81,7 @@ Example of using `imports` in a component's configuration `.xml` file:
         </item>
     </item>
 </argument>
-{% endhighlight xml%}
+```
 
 For an example of `imports` usage in Magento code see [`product_form.xml`, line 103]({{ site.mage2100url }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L103)
 
@@ -96,19 +94,19 @@ The `links` property is used for cross tracking properties changes: both linked 
 
 Example of using `links` in a component's `.js` file:
 
-{% highlight js%}
+```js
 {
   'links': {
    'visible': '${ $.provider }:visibility'
   }
 }
-{% endhighlight js%}
+```
 
 Here the local `visible` property is linked with the `visibility`  property of the provider component. If any of them is a ko or ko-es5 observable and changes, the other is changed automatically. If a non-observable linked property is changed the other is not updated automatically.
 
 Example of using `links` in a component's configuration `.xml` file:
 
-{% highlight xml%}
+```xml
 <argument name="data" xsi:type="array">
     <item name="config" xsi:type="array">
         <item name="links" xsi:type="array">
@@ -116,11 +114,12 @@ Example of using `links` in a component's configuration `.xml` file:
         </item>
     </item>
 </argument>
-{% endhighlight xml%}
+```
 
 For an example of `links` usage in Magento code see [`text.js`, line 19]({{ site.mage2100url }}app/code/Magento/Ui/view/base/web/js/form/element/text.js#L19)
 
 ### `listens`
+
 The `listens` property is used to track the changes of a component's property. `listens`'s value is an object, composed of the following:
 
   - `key`: name of the observable property or method which is tracked for changes. Can use [string templates](#string_templ).
@@ -128,13 +127,13 @@ The `listens` property is used to track the changes of a component's property. `
 
 Example of using `listens` in a component's `.js` file :
 
-{% highlight js%}
+```js
 {
   'listens': {
    '${ $.provider }:visibility': 'visibilityChanged'
   }
 }
-{% endhighlight js%}
+```
 
 Here the local `visibilityChanged` property is a method that will be called when the `visibility` property of the `provider` component changes. It receives the new value as an argument. If the local property is not a function, it will be set to the new value.
 The external property has to be an observable in order for `listens` to have any effect.
@@ -142,7 +141,7 @@ The external property has to be an observable in order for `listens` to have any
 
 Example of using `listens` in a component's configuration `.xml` file:
 
-{% highlight xml%}
+```xml
 <argument name="data" xsi:type="array">
     <item name="config" xsi:type="array">
         <item name="listens" xsi:type="array">
@@ -150,7 +149,7 @@ Example of using `listens` in a component's configuration `.xml` file:
         </item>
     </item>
 </argument>
-{% endhighlight xml%}
+```
 
 For example of `listens` usage in Magento code see [`new_category_form.xml`, line 92]({{ site.mage2100url }}app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L92)
 

--- a/guides/v2.1/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+++ b/guides/v2.1/ui_comp_guide/concepts/ui_comp_modifier_concept.md
@@ -1,9 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: concepts
 title: About PHP modifiers in UI components
-menu_title: About PHP modifiers in UI components
-menu_order: 40
 ---
 
 ## What's in this topic
@@ -29,8 +26,7 @@ In your custom module, add a class that implements [`\Magento\Ui\DataProvider\Mo
 
 Sample modifier:
 
-{% highlight php%}
-
+```php
 <?php
 
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
@@ -82,13 +78,13 @@ class Example extends AbstractModifier
         return $data;
     }
 }
-{%endhighlight%}
+```
 
 **Step 2**
 
 Declare your modifier in your module Di configuration `<Your_Module_dir>/etc/adminhtml/di.xml`. This declaration looks like the following:
 
-{% highlight xml %}
+```xml
 <virtualType name="%YourNamespace\YourModule\DataProvider\Modifier\Pool%" type="Magento\Ui\DataProvider\Modifier\Pool">
      <arguments>
          <argument name="modifiers" xsi:type="array">
@@ -99,7 +95,7 @@ Declare your modifier in your module Di configuration `<Your_Module_dir>/etc/adm
          </argument>
      </arguments>
 </virtualType>
-{% endhighlight %}
+```
 
 Where `YourNamespace\YourModule\DataProvider\Modifier\Pool` is a [virtual class]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#dependency-types).
 

--- a/guides/v2.1/ui_comp_guide/howto/add_category_attribute.md
+++ b/guides/v2.1/ui_comp_guide/howto/add_category_attribute.md
@@ -1,9 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: how tos
 title: Add a category attribute
-menu_title: Create and display a category attribute with UI components
-menu_order: 3
 contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
 ---
@@ -14,7 +11,7 @@ Category attributes were automatically displayed in the {% glossarytooltip 29ddb
 
 The following is a full example of an install script that creates a {% glossarytooltip 50e49338-1e6c-4473-8527-9e401d67ea2b %}category{% endglossarytooltip %} attribute. If you already have a category attribute, it is not necessary.
 
-{% highlight php startinline=true %}
+```php?start_inline=1
 // File: Namespace/Module/Setup/InstallData.php
 
 use Magento\Framework\Setup\{
@@ -50,7 +47,7 @@ class InstallData implements InstallDataInterface
         ]);
     }
 }
-{% endhighlight %}
+```
 
 ## Step #2: Display the Attribute
 
@@ -58,7 +55,7 @@ The category UI Component is rendered with configuration from the `category_form
 
 Here is a full example of adding a field under the "Display Settings" group. It is important to note that `attribute_id` should match the ID of the attribute that you created in the install script.
 
-{% highlight xml %}
+```xml
 <!-- Namespace/Module/view/adminhtml/ui_component/category_form.xml -->
 <?xml version="1.0"?>
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
@@ -80,7 +77,7 @@ Here is a full example of adding a field under the "Display Settings" group. It 
         </field>
     </fieldset>
 </form>
-{% endhighlight %}
+```
 
 ## Step #3: Upgrade and Run
 

--- a/guides/v2.2/b2b/company-structures.md
+++ b/guides/v2.2/b2b/company-structures.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Manage company structures
-menu_title: Manage company structures
-menu_order: 15
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: company
+ee_only: true
 functional_areas:
   - B2B
   - Integration
@@ -24,13 +19,13 @@ Company teams allow you to group company users by location, job responsibilities
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 POST /V1/team/:companyId
 PUT /V1/team/:teamId
 GET /V1/team/:teamId
 DELETE /V1/team/:teamId
 GET /V1/team/
-{% endhighlight %}
+```
 
 
 **Company team parameters**
@@ -51,14 +46,14 @@ A newly-created team is placed under Company Admin in the company hierarchy.
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "team": {
     "name": "Western District",
     "description": "Buyers from the California office"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -74,14 +69,14 @@ You can only change the name or description of a team.
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "team": {
   	"id": 4,
     "name": "Western Region"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -101,13 +96,13 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 4,
   "name": "Western Region",
   "description": "Buyers from the California office"
 }
-{% endhighlight %}
+```
 
 ### Delete a team
 
@@ -141,7 +136,7 @@ Not applicable
 
 **Response**
 {% collapsible Show code sample %}
-{% highlight json %}
+```json
 {
     "items": [
         {
@@ -170,7 +165,8 @@ Not applicable
     },
     "total_count": 2
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Company hierarchies
@@ -185,10 +181,10 @@ You can use REST endpoints to retrieve the current structure and move teams and 
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 GET /V1/hierarchy/:id
 PUT /V1/hierarchy/move/:id
-{% endhighlight %}
+```
 
 ### Return all information about the company hierarchy
 
@@ -216,7 +212,7 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+```json
 
 [
   {
@@ -262,7 +258,8 @@ Not applicable
     "structure_parent_id": 0
   }
 
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ### Assign a new parent to teams and company users
@@ -275,11 +272,11 @@ The following example moves Bryce Martin (`structure_id = 4`) to the West team (
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "newParentId": 7
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.2/b2b/company-structures.md
+++ b/guides/v2.2/b2b/company-structures.md
@@ -19,7 +19,7 @@ Company teams allow you to group company users by location, job responsibilities
 
 **REST Endpoints**
 
-```json
+```
 POST /V1/team/:companyId
 PUT /V1/team/:teamId
 GET /V1/team/:teamId
@@ -136,6 +136,7 @@ Not applicable
 
 **Response**
 {% collapsible Show code sample %}
+
 ```json
 {
     "items": [
@@ -181,7 +182,7 @@ You can use REST endpoints to retrieve the current structure and move teams and 
 
 **REST Endpoints**
 
-```json
+```
 GET /V1/hierarchy/:id
 PUT /V1/hierarchy/move/:id
 ```
@@ -212,8 +213,8 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-```json
 
+```json
 [
   {
     "structure_id": 6,
@@ -257,7 +258,6 @@ Not applicable
     "entity_type": "customer",
     "structure_parent_id": 0
   }
-
 ```
 
 {% endcollapsible %}

--- a/guides/v2.2/b2b/company-users.md
+++ b/guides/v2.2/b2b/company-users.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Manage company users
-menu_title: Manage company users
-menu_order: 13
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: company
+ee_only: true
 functional_areas:
   - B2B
   - Integration
@@ -27,10 +22,10 @@ This section describes the REST endpoints used to manage company users.
 
 **REST Endpoints**
 
-{% highlight json %}
+```
 POST /V1/customers/
 PUT /V1/customers/:customerId
-{% endhighlight %}
+```
 
 **Company user parameters**
 
@@ -56,8 +51,7 @@ The `POST /V1/customers` call creates a Magento customer. B2B extends the `custo
 
 Add the `company_attributes` code block to the payload that is required to create a standard customer.
 
-{% highlight json %}
-
+```json
 "extension_attributes": {
    "company_attributes": {
    "company_id": 2,
@@ -66,11 +60,11 @@ Add the `company_attributes` code block to the payload that is required to creat
    "telephone": "512-555-3322"
    }
 }
-{% endhighlight %}
+```
 
 Full example:
 
-{% highlight json %}
+```json
 {
 	"customer": {
 		"email": "mshaw@example.com",
@@ -86,11 +80,11 @@ Full example:
 		}
 	}
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 13,
   "group_id": 1,
@@ -114,7 +108,7 @@ Full example:
     }
   }
 }
-{% endhighlight %}
+```
 
 ### Modify a company user
 
@@ -129,7 +123,7 @@ If you change the `status` to inactive, the account is locked. If the company us
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "customer": {
     "id": 13,
@@ -145,11 +139,11 @@ If you change the `status` to inactive, the account is locked. If the company us
       }
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 13,
   "group_id": 1,
@@ -171,7 +165,7 @@ If you change the `status` to inactive, the account is locked. If the company us
     }
   }
 }
-{% endhighlight %}
+```
 
 ### Delete a company user
 

--- a/guides/v2.2/b2b/credit-manage.md
+++ b/guides/v2.2/b2b/credit-manage.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Manage company credit
-menu_title: Manage company credit
-menu_order: 18
-level3_menu_node: level3child
-level3_subgroup: credit
-ee_only: True
+ee_only: true
 functional_areas:
   - B2B
   - Integration
@@ -26,12 +21,12 @@ When you create a company, the credit limit is set to 0. Use the `PUT /V1/compan
 
 **REST Endpoints**
 
-{% highlight json %}
+```
 PUT /V1/companyCredits/:id
 GET /V1/companyCredits/:creditId
 GET /V1/companyCredits/company/:companyId
 GET /V1/companyCredits/
-{% endhighlight %}
+```
 
 **Company credit parameters**
 
@@ -60,7 +55,7 @@ This call changes the company's credit limit to $1000. The `available_limit` par
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "creditLimit": {
   "id": 2,
@@ -69,11 +64,11 @@ This call changes the company's credit limit to $1000. The `available_limit` par
   "currency_code": "USD"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
     "id": 2,
     "company_id": 2,
@@ -83,7 +78,7 @@ This call changes the company's credit limit to $1000. The `available_limit` par
     "exceed_limit": false,
     "available_limit": 1000
 }
-{% endhighlight %}
+```
 
 ### Get details about a company's credit limit using credit ID
 
@@ -103,7 +98,7 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 2,
   "company_id": 2,
@@ -113,7 +108,7 @@ Not applicable
   "exceed_limit": false,
   "available_limit": 500
 }
-{% endhighlight %}
+```
 
 ### Get details about a company's credit limit using company ID
 
@@ -133,7 +128,7 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 2,
   "company_id": 2,
@@ -143,7 +138,7 @@ Not applicable
   "exceed_limit": false,
   "available_limit": 500
 }
-{% endhighlight %}
+```
 
 ### Search credit IDs
 
@@ -162,7 +157,8 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
     "items": [
         {
@@ -207,7 +203,8 @@ Not applicable
     },
     "total_count": 3
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Balance operations
@@ -220,10 +217,10 @@ The company's outstanding balance can be updated as the buyer makes payments, pu
 
 **REST Endpoints**
 
-{% highlight json %}
+```
 POST /V1/companyCredits/:creditId/decreaseBalance
 POST /V1/companyCredits/:creditId/increaseBalance
-{% endhighlight %}
+```
 
 **Balance Parameters**
 
@@ -254,14 +251,14 @@ This call increases the company credit with an Allocate, Update, Refund, Revert,
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "value": 250,
   "currency": "USD",
   "operationType": 2,
   "comment": "update limit"
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -277,14 +274,14 @@ This call decreases the company credit with an Update (operation type = 2), Purc
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "value": 250,
   "currency": "USD",
   "operationType": 4,
   "comment": "issue refund"
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -298,10 +295,10 @@ A Reimburse transaction can be updated to include a purchase order and comment.
 `companyCreditCreditHistoryManagementV1`
 
 **REST Endpoints**
-{% highlight json %}
+```
 GET /V1/companyCredits/history
 PUT /V1/companyCredits/history/:historyId
-{% endhighlight %}
+```
 
 ### Save the credit history
 
@@ -313,12 +310,12 @@ This call updates the credit history to specify a purchase order number.
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "purchaseOrder": "A12345",
   "comment": "Adding PO info"
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -340,7 +337,8 @@ See [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html) f
 Not applicable
 
 **Response**
-{% highlight json %}
+
+```json
 {
     "items": [
         {
@@ -394,7 +392,7 @@ Not applicable
     },
     "total_count": 2
 }
-{% endhighlight %}
+```
 
 ## Related information
 

--- a/guides/v2.2/b2b/negotiable-checkout.md
+++ b/guides/v2.2/b2b/negotiable-checkout.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Negotiable quote checkout
-menu_title: Negotiable quote checkout
-menu_order: 34
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: nq
+ee_only: true
 functional_areas:
   - B2B
   - Integration
@@ -28,11 +23,11 @@ A negotiated quote can be initiated without a shipping address. However, before 
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 POST /V1/negotiable-carts/:cartId/estimate-shipping-methods
 POST /V1/negotiable-carts/:cartId/estimate-shipping-methods-by-address-id
 POST /V1/negotiable-carts/:cartId/shipping-information
-{% endhighlight %}
+```
 
 ### Estimate shipping costs specifying an address
 
@@ -48,7 +43,7 @@ This call takes a full shipping address as input and estimates shipping fees. It
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "address": {
   "street": [
@@ -64,11 +59,11 @@ This call takes a full shipping address as input and estimates shipping fees. It
   "lastname": "Doe"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 [
   {
     "carrier_code": "flatrate",
@@ -83,8 +78,7 @@ This call takes a full shipping address as input and estimates shipping fees. It
     "price_incl_tax": 5
   }
 ]
-
-{% endhighlight %}
+```
 
 ### Estimate shipping costs specifying an address ID
 
@@ -100,15 +94,15 @@ This call takes an address ID as input and estimates shipping fees. It returns a
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "addressId": 2
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 [
   {
     "carrier_code": "flatrate",
@@ -123,8 +117,7 @@ This call takes an address ID as input and estimates shipping fees. It returns a
     "price_incl_tax": 5
   }
 ]
-
-{% endhighlight %}
+```
 
 ### Set the shipping and billing information
 
@@ -140,7 +133,7 @@ In this call, you specify the shipping and billing addresses, as well as the sel
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "addressInformation": {
 	  "shipping_address": {
        "region": "California",
@@ -174,12 +167,13 @@ In this call, you specify the shipping and billing addresses, as well as the sel
   "shipping_method_code": "flatrate"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
   "payment_methods": [
     {
@@ -338,7 +332,8 @@ In this call, you specify the shipping and billing addresses, as well as the sel
     }
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Manage billing addresses
@@ -351,10 +346,10 @@ If the billing address isn't provided through another call, use the `POST /V1/ne
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 POST /V1/negotiable-carts/:cartId/billing-address
 GET /V1/negotiable-carts/:cartId/billing-address
-{% endhighlight %}
+```
 
 ### Set the billing address
 
@@ -366,7 +361,7 @@ This call assigns a billing address to the specified negotiable quote.
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "address": {
       "region": "New York",
       "region_id": 43,
@@ -385,7 +380,7 @@ This call assigns a billing address to the specified negotiable quote.
       "same_as_billing": 1
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -405,7 +400,7 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "id": 192,
   "region": "New York",
@@ -425,7 +420,7 @@ Not applicable
   "same_as_billing": 0,
   "save_in_address_book": 0
 }
-{% endhighlight %}
+```
 
 ## Manage cart coupons
 
@@ -437,10 +432,10 @@ B2B allows coupons to be used toward payment.
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 PUT /V1/negotiable-carts/:cartId/coupons/:couponCode
 DELETE /V1/negotiable-carts/:cartId/coupons
-{% endhighlight %}
+```
 
 ### Apply a coupon to a negotiable quote
 
@@ -468,10 +463,10 @@ B2B allows gift cards to be used as payment.
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 POST /V1/negotiable-carts/:cartId/giftCards
 DELETE /V1/negotiable-carts/:cartId/giftCards/:giftCardCode
-{% endhighlight %}
+```
 
 ### Apply a gift card to a negotiable quote
 
@@ -483,7 +478,7 @@ If the initial quote applies a gift card to the totals, Magento ignores the gift
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "giftCardAccountData": {
     "gift_cards": [
@@ -491,7 +486,7 @@ If the initial quote applies a gift card to the totals, Magento ignores the gift
     ]
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -523,11 +518,11 @@ When you submit payment information, Magento creates an order and sends an order
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 POST /V1/negotiable-carts/:cartId/payment-information
 GET /V1/negotiable-carts/:cartId/payment-information
 POST /V1/negotiable-carts/:cartId/set-payment-information
-{% endhighlight %}
+```
 
 ### Set payment information without placing the order
 
@@ -539,7 +534,7 @@ This call sets payment information and the billing address for the negotiable qu
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "paymentMethod": {
    "po_number": "A123456",
    "method": "checkmo"
@@ -560,7 +555,7 @@ This call sets payment information and the billing address for the negotiable qu
     "telephone": "512-555-1111"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -576,7 +571,7 @@ This call sets payment information and the billing address for the negotiable qu
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "paymentMethod": {
     "po_number": "A123456",
     "method": "checkmo"
@@ -597,7 +592,7 @@ This call sets payment information and the billing address for the negotiable qu
     "telephone": "512-555-1111"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -618,7 +613,8 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
   "payment_methods": [
     {
@@ -777,7 +773,8 @@ Not applicable
     }
   }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ## Review cart totals
@@ -790,9 +787,9 @@ This call is similar to `GET /V1/negotiable-carts/:cartId/payment-information`, 
 
 **REST Endpoints**
 
-{% highlight json %}
+```json
 GET /V1/negotiable-carts/:cartId/totals
-{% endhighlight %}
+```
 
 **Sample Usage**
 
@@ -805,7 +802,8 @@ Not applicable
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
   "totals": {
     "grand_total": 5.95,
@@ -958,8 +956,8 @@ Not applicable
     }
   }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ## Related information

--- a/guides/v2.2/b2b/negotiable-order-workflow.md
+++ b/guides/v2.2/b2b/negotiable-order-workflow.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Place a negotiable quote order
-menu_title: Place a negotiable quote order
-menu_order: 35
 ee_only: true
-level3_menu_node: level3child
-level3_subgroup: nq
 ---
 
 This topic describes how REST calls can be used to place items in a shopping cart, initiate and complete the process of negotiating a quote, and reimbursing the buyer's credit upon receipt of payment.
@@ -60,7 +55,8 @@ Authorization Bearer <customer token>
 ```
 
 **Payload 1**
-{% highlight json %}
+
+```json
 {
   "cartItem": {
     "sku": "24-UG02",
@@ -68,11 +64,11 @@ Authorization Bearer <customer token>
     "quote_id": "5"
   }
 }
-{% endhighlight %}
+```
 
 **Response 1**
 
-{% highlight json %}
+```json
 {
     "item_id": 12,
     "sku": "24-UG02",
@@ -82,11 +78,11 @@ Authorization Bearer <customer token>
     "product_type": "simple",
     "quote_id": "5"
 }
-{% endhighlight %}
+```
 
 **Payload 2**
 
-{% highlight json %}
+```json
 {
   "cartItem": {
     "sku": "24-UG03",
@@ -94,12 +90,12 @@ Authorization Bearer <customer token>
     "quote_id": "5"
   }
 }
-{% endhighlight %}
+```
 
 
 **Response 2**
 
-{% highlight json %}
+```json
 {
     "item_id": 13,
     "sku": "24-UG03",
@@ -109,7 +105,7 @@ Authorization Bearer <customer token>
     "product_type": "simple",
     "quote_id": "5"
 }
-{% endhighlight %}
+```
 
 ### Set the shipping address
 
@@ -128,7 +124,7 @@ Authorization Bearer <customer token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "address": {
       "region": "California",
       "region_id": 12,
@@ -147,11 +143,11 @@ Authorization Bearer <customer token>
       "same_as_billing": 1
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 [
     {
         "carrier_code": "flatrate",
@@ -178,7 +174,7 @@ Authorization Bearer <customer token>
         "price_incl_tax": 5
     }
 ]
-{% endhighlight %}
+```
 
 ### Set shipping and billing information
 
@@ -190,7 +186,7 @@ You can also set shipping and billing information after initiating a negotiable 
 
 **Payload**
 
-{% highlight json %}
+```json
 {
 "addressInformation": {
   "shipping_address": {
@@ -227,12 +223,13 @@ You can also set shipping and billing information after initiating a negotiable 
   "shipping_method_code": "bestway"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
     "payment_methods": [
         {
@@ -378,7 +375,8 @@ You can also set shipping and billing information after initiating a negotiable 
         }
     }
 }
-{% endhighlight %}
+```
+
 {% endcollapsible %}
 
 ### View the cart
@@ -403,8 +401,8 @@ None
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
     "id": 5,
     "created_at": "2017-09-14 21:14:15",
@@ -582,8 +580,8 @@ None
         }
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ## Complete a Negotiable Quote
@@ -612,13 +610,13 @@ Authorization Bearer <admin token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "quoteId": 5,
   "quoteName": "Discount request",
   "comment": "Requesting a 2.5% discount"
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -641,7 +639,7 @@ Authorization Bearer <admin token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "quote": {
       "id": 5,
@@ -653,7 +651,7 @@ Authorization Bearer <admin token>
       }
     }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -678,12 +676,12 @@ Authorization Bearer <admin token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "quoteId": 5,
   "comment": "We have applied a 2.5% discount to your order."
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -711,8 +709,8 @@ None
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
 
+```json
 {
     "id": 4,
     "created_at": "2017-09-14 20:30:38",
@@ -926,8 +924,8 @@ None
         }
     }
 }
+```
 
-{% endhighlight %}
 {% endcollapsible %}
 
 ### Set the payment information and place the order
@@ -947,13 +945,13 @@ Authorization Bearer <admin token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {  "paymentMethod": {
     "po_number": "12345",
     "method": "companycredit"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -979,14 +977,14 @@ Authorization Bearer <admin token>
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "value": 363.80,
   "currency": "USD",
   "operationType": 4,
   "comment": "Order #3 reimbursed"
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.2/b2b/negotiable-update.md
+++ b/guides/v2.2/b2b/negotiable-update.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Update a negotiable quote
-menu_title: Update a negotiable quote
-menu_order: 33
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: nq
+ee_only: true
 functional_areas:
   - B2B
   - Integration
@@ -65,7 +60,7 @@ The `negotiated_price_type` can have one of the following values:
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "quote": {
       "id": 6,
@@ -77,7 +72,7 @@ The `negotiated_price_type` can have one of the following values:
       }
     }
 }
-{% endhighlight %}
+```
 
 ### Add a new quote item to the negotiable quote
 
@@ -92,7 +87,7 @@ The buyer can add, update, or delete items from the quote under the following co
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "cartItem": {
     "sku": "24-MB01",
@@ -100,11 +95,11 @@ The buyer can add, update, or delete items from the quote under the following co
     "quote_id": "7"
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
     "item_id": 18,
     "sku": "24-MB01",
@@ -122,7 +117,7 @@ The buyer can add, update, or delete items from the quote under the following co
         }
     }
 }
-{% endhighlight %}
+```
 
 ### Change the quote expiration date
 
@@ -132,7 +127,7 @@ The buyer can add, update, or delete items from the quote under the following co
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "quote": {
       "id": 6,
@@ -143,7 +138,7 @@ The buyer can add, update, or delete items from the quote under the following co
       }
     }
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.2/b2b/shared-cat-company.md
+++ b/guides/v2.2/b2b/shared-cat-company.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Assign companies to a shared catalog
-menu_title: Assign companies
-menu_order: 24
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: shared
+ee_only: true
 functional_areas:
   - B2B
   - Catalog
@@ -22,11 +17,11 @@ A shared catalog must be assigned to one or more companies before it can be acce
 
 **REST endpoints**
 
-{% highlight json %}
+```
 POST /V1/sharedCatalog/:sharedCatalogId/assignCompanies
 POST /V1/sharedCatalog/:sharedCatalogId/unassignCompanies
 GET  /V1/sharedCatalog/:sharedCatalogId/companies
-{% endhighlight %}
+```
 
 **Company parameters**
 
@@ -49,8 +44,7 @@ If a specified company is already assigned to a different shared catalog, this r
 
 **Payload**
 
-{% highlight json %}
-
+```json
 {
   "companies": [
     {
@@ -61,7 +55,7 @@ If a specified company is already assigned to a different shared catalog, this r
     }
   ]
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -77,7 +71,7 @@ When you unassign a company from a custom catalog, the system automatically assi
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "companies": [
     {
@@ -85,7 +79,7 @@ When you unassign a company from a custom catalog, the system automatically assi
     }
   ]
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.2/b2b/shared-cat-manage.md
+++ b/guides/v2.2/b2b/shared-cat-manage.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Manage shared catalogs
-menu_title: Manage shared catalogs
-menu_order: 22
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: shared
+ee_only: true
 functional_areas:
   - B2B
   - Catalog
@@ -23,13 +18,13 @@ functional_areas:
 
 **REST Endpoints**
 
-{% highlight json %}
+```
 POST /V1/sharedCatalog
 PUT  /V1/sharedCatalog/:id
 GET  /V1/sharedCatalog/:sharedCatalogId
 DELETE  /V1/sharedCatalog/:sharedCatalogId
 GET  /V1/sharedCatalog/
-{% endhighlight %}
+```
 
 **Shared catalog parameters**
 
@@ -54,7 +49,7 @@ When B2B is enabled, the system creates a public shared catalog named `Default (
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "sharedCatalog": {
     "name": "Test",
@@ -63,7 +58,7 @@ When B2B is enabled, the system creates a public shared catalog named `Default (
     "tax_class_id": 3
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -77,8 +72,7 @@ You cannot change the `type` from public (`1`) to custom (`0`). If you need to r
 
 `PUT  /V1/sharedCatalog/2`
 
-{% highlight json %}
-
+```json
 {
   "sharedCatalog": {
     "id": 2,
@@ -89,7 +83,7 @@ You cannot change the `type` from public (`1`) to custom (`0`). If you need to r
     "tax_class_id": 3
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -109,7 +103,7 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 {
     "id": 2,
     "name": "Custom shared catalog",
@@ -121,7 +115,7 @@ Not applicable
     "store_id": 0,
     "tax_class_id": 3
 }
-{% endhighlight %}
+```
 
 ### Delete a shared catalog
 
@@ -155,8 +149,7 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
-
+```json
 {
     "items": [
         {
@@ -186,8 +179,7 @@ Not applicable
     },
     "total_count": 1
 }
-
-{% endhighlight %}
+```
 
 ## Related information
 

--- a/guides/v2.2/b2b/shared-cat-product-assign.md
+++ b/guides/v2.2/b2b/shared-cat-product-assign.md
@@ -1,12 +1,7 @@
 ---
 group: b2b-developer-guide
-subgroup: 10_REST
 title: Assign categories and products to a shared catalog
-menu_title: Assign categories and products
-menu_order: 23
-ee_only: True
-level3_menu_node: level3child
-level3_subgroup: shared
+ee_only: true
 functional_areas:
   - B2B
   - Catalog
@@ -32,11 +27,11 @@ Products that are defined within a category are not included when you assign a c
 
 **REST Endpoints**
 
-{% highlight json %}
+```
 POST /V1/sharedCatalog/:id/assignCategories
 POST /V1/sharedCatalog/:id/unassignCategories
 GET  /V1/sharedCatalog/:id/categories
-{% endhighlight %}
+```
 
 **Category parameters**
 
@@ -57,7 +52,7 @@ The following example adds the Luma Gear category (`id=3`) as well as its subcat
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "categories": [
     {
@@ -74,7 +69,7 @@ The following example adds the Luma Gear category (`id=3`) as well as its subcat
     }
   ]
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -92,7 +87,7 @@ The following example removes two categories from the shared catalog.
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "categories": [
     {
@@ -104,7 +99,7 @@ The following example removes two categories from the shared catalog.
     }
   ]
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -124,14 +119,14 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 [
   3,
   4,
   5,
   6
 ]
-{% endhighlight %}
+```
 
 ## Assign products
 
@@ -143,11 +138,11 @@ The `sharedCatalogProductManagementV1` service is based on `catalogProductManage
 
 **REST endpoints**
 
-{% highlight json %}
+```
 POST  /V1/sharedCatalog/:id/assignProducts
 POST  /V1/sharedCatalog/:id/unassignProducts
 GET  /V1/sharedCatalog/:id/products
-{% endhighlight %}
+```
 
 **Category parameters**
 
@@ -168,7 +163,7 @@ The following example adds two products each in the Bags, Fitness Equipment, and
 
 **Payload**
 
-{% highlight json %}
+```json
 {
 	"products": [
     	{
@@ -191,7 +186,7 @@ The following example adds two products each in the Bags, Fitness Equipment, and
     	}
 	]
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -206,7 +201,8 @@ Unassigning a product does not remove it from its category or categories.
 `POST /V1/sharedCatalog/2/unassignProducts`
 
 **Payload**
-{% highlight json %}
+
+```json
 {
   "products": [
   	{
@@ -214,7 +210,7 @@ Unassigning a product does not remove it from its category or categories.
   	}
   ]
 }
-{% endhighlight %}
+```
 
 **Response**
 
@@ -234,15 +230,15 @@ Not applicable
 
 **Response**
 
-{% highlight json %}
+```json
 [
-    "24-MB01",
-    "24-MB04",
-    "24-UG06",
-    "24-UG07",
-    "24-MG04"
+  "24-MB01",
+  "24-MB04",
+  "24-UG06",
+  "24-UG07",
+  "24-MG04"
 ]
-{% endhighlight %}
+```
 
 ## Related information
 

--- a/guides/v2.2/frontend-dev-guide/themes/js-bundling.md
+++ b/guides/v2.2/frontend-dev-guide/themes/js-bundling.md
@@ -54,7 +54,7 @@ The following code snippet from [Magento's Luma theme][luma-view-xml] shows the 
 
 {% collapsible Show example %}
 
-{% highlight xml %}
+```xml
 <vars module="Js_Bundle">
     <var name="bundle_size">1MB</var>
 </vars>
@@ -108,7 +108,7 @@ The following code snippet from [Magento's Luma theme][luma-view-xml] shows the 
     <item type="directory">Lib::mage/adminhtml</item>
     <item type="directory">Lib::mage/backend</item>
 </exclude>
-{% endhighlight %}
+```
 
 {% endcollapsible %}
 

--- a/guides/v2.2/rest/modules/catalog.md
+++ b/guides/v2.2/rest/modules/catalog.md
@@ -44,8 +44,7 @@ Third-party modules may define other custom attributes.
 
 The following example uses the `POST V1/categories` call to assign four custom attributes to the "My New Category" category.
 
-{% highlight json %}
-
+```json
 {
 "category": {
     "parent_id": 2,
@@ -77,4 +76,4 @@ The following example uses the `POST V1/categories` call to assign four custom a
       ]
     }
 }
-{% endhighlight %}
+```

--- a/guides/v2.2/rest/performing-searches.md
+++ b/guides/v2.2/rest/performing-searches.md
@@ -8,11 +8,11 @@ POST, PUT, and DELETE requests to the REST Web {% glossarytooltip 786086f2-622b-
 
 For search APIs that invoke a `*Repository::getList(SearchCriteriaInterface *)` call, the searchCriteria must be specified in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %} of the GET request. The basic pattern for specifying the criteria is
 
-{% highlight html %}
+```
 searchCriteria[filter_groups][<index>][filters][<index>][field]=<field_name>
 searchCriteria[filter_groups][<index>][filters][<index>][value]=<search_value>
 searchCriteria[filter_groups][<index>][filters][<index>][condition_type]=<operator>
-{% endhighlight %}
+```
 
 where:
 
@@ -57,7 +57,7 @@ The following sections provide examples of each type of search. These examples u
 
 The {{site.data.var.ce}} sample data uses the `category_gear` field to describe the categories for each item listed under Gear on sample store. Each item can be assigned to multiple categories. Electronics are assigned the code 86. The following example returns all gear tagged as electronics.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products/?
 searchCriteria[filter_groups][0][filters][0][field]=category_gear&
 searchCriteria[filter_groups][0][filters][0][value]=86&
@@ -87,7 +87,7 @@ The query returns 9 items.
 
 The following search finds all invoices created after the specified time (midnight, July 1 2016). You can set up a similar search to run periodically to poll for changes.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/invoices?
 searchCriteria[filter_groups][0][filters][0][field]=created_at&
 searchCriteria[filter_groups][0][filters][0][value]=2016-07-01 00:00:00&
@@ -98,7 +98,7 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gt
 
 The following example searches for all products whose names contain the string `Leggings` or `Parachute`. The instances of `%25` in the example are converted into the SQL wildcard character `%`.
 
-``` html
+```
 GET http://<magento_host>/index.php/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=name&
 searchCriteria[filter_groups][0][filters][0][value]=%25Leggings%25&
@@ -136,7 +136,7 @@ The search returns 14 products that contain the string `Leggings` in the `name` 
 
 This sample searches for women's shorts that are size 31 and costs less than $30. In the CE sample data, women's shorts have a `sku` value that begins with `WSH`. The `sku` also contains the size and color, such as `WSH02-31-Yellow`.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2531%25&
@@ -176,7 +176,7 @@ The query returns 9 items.
 
 This sample is similar the Logical AND sample. It searches the `sku`s for women's shorts (WSH%) or pants (WP%)in size 29. The system performs two logical ANDs to restrict the results to those that cost from $40 to $49.99
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2529%25&

--- a/guides/v2.2/rest/retrieve-filtered-responses.md
+++ b/guides/v2.2/rest/retrieve-filtered-responses.md
@@ -75,7 +75,7 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 
 `GET http://<host>/rest/default/V1/shipment/2?fields=items[name,qty,sku]`
 
-{% highlight json %}
+```json
 "items": [
    {
      "name": "Minerva LumaTech&trade; V-Tee-XS-Blue",
@@ -83,7 +83,7 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
      "sku": "WS08-XS-Blue",
    }
  ]
- {% endhighlight %}
+```
 
 ## Nested objects
 
@@ -95,7 +95,7 @@ This example returns only the following:
 
 `GET http://<host>/rest/default/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
-{% highlight json %}
+```json
 {
   "sku": "MT12"
   "name": "Cassius Sparring Tank"
@@ -110,7 +110,7 @@ This example returns only the following:
       }
   }
 }
-{% endhighlight %}
+```
 
 ## POST operation
 

--- a/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
@@ -34,7 +34,7 @@ Before you using this code sample, verify that the attribute values are the same
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "product": {
     "sku": "MS-Champ-S",
@@ -93,13 +93,13 @@ Before you using this code sample, verify that the attribute values are the same
     ]
   }
 }
-
-{% endhighlight  %}
+```
 
 **Response**
 
 {% collapsible Show code sample %}
-{% highlight json %}
+
+```json
 {
     "id": 2079,
     "sku": "MS-Champ-S",
@@ -214,7 +214,8 @@ Before you using this code sample, verify that the attribute values are the same
         }
     ]
 }
-{% endhighlight  %}
+```
+
 {% endcollapsible %}
 
 ## Create the other simple products

--- a/guides/v2.2/ui_comp_guide/components/ui-expandable-column.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-expandable-column.md
@@ -43,7 +43,7 @@ The Expandable Column component can be used in {% glossarytooltip 29ddb393-ca22-
 
 Component's options are set in the configuration `.xml` file as follows:
 
-{% highlight xml %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         <item name="options" xsi:type="object">Magento\Catalog\Model\Product\Attribute\Source\Status</item>
@@ -54,7 +54,7 @@ Component's options are set in the configuration `.xml` file as follows:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 ## Dependencies
 

--- a/guides/v2.2/ui_comp_guide/components/ui-exportbutton.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-exportbutton.md
@@ -69,7 +69,7 @@ The ExportButton component implements the ability to export grid data to the spe
 
 To enable the ExportButton component, add the `exportButton` element with a `selectProvider` item to the listing configuration file:
 
-{% highlight XML %}
+```xml
 <exportButton name="export_button">
     <argument name="data" xsi:type="array">
         <item name="config" xsi:type="array">
@@ -77,12 +77,12 @@ To enable the ExportButton component, add the `exportButton` element with a `sel
         </item>
     </argument>
 </exportButton>
-{% endhighlight %}
+```
 
 
 The following is an example of configuring the component using the`sales_order_grid` `selectProvider` item, `<Magento_Sales_module_dir>/view/adminhtml/ui_component/sales_order_grid.xml`. 
 
-{% highlight XML %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <container name="listing_top">
         <exportButton name="export_button">
@@ -94,7 +94,7 @@ The following is an example of configuring the component using the`sales_order_g
         </exportButton>
     </container>
 </listing>
-{% endhighlight %}
+```
 
 By default Magento allows {% glossarytooltip 6341499b-ead9-4836-9794-53d95eb48ea5 %}CSV{% endglossarytooltip %} and Excel {% glossarytooltip 8c0645c5-aa6b-4a52-8266-5659a8b9d079 %}XML{% endglossarytooltip %} export data formats.
 

--- a/guides/v2.2/ui_comp_guide/components/ui-fileuploader.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-fileuploader.md
@@ -197,7 +197,7 @@ The File Uploader component is an {% glossarytooltip edb42858-1ff8-41f9-80a6-edf
 
 Here is an example of how File Uploader component integrates with [Form]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html) component:
 
-{% highlight xml %}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     ...
     <fieldset name="foo">
@@ -221,7 +221,7 @@ Here is an example of how File Uploader component integrates with [Form]({{ page
         </field>
     </fieldset>
 </form>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.2/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-form.md
@@ -217,7 +217,7 @@ To create an instance of the Form component, you need to do the following:
 3. Create the DataProvider class for the entity that implements DataProviderInterface
 * Add a component in Magento {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} as a node: `<uiComponent name="customer_form"/>`
 
-{% highlight xml %}
+```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
@@ -226,7 +226,7 @@ To create an instance of the Form component, you need to do the following:
         </referenceContainer>
     </body>
 </page>
-{% endhighlight %}
+```
 
 ### Configure the component
 
@@ -237,7 +237,7 @@ Component could be configured in two ways:
 
 Create configuration file: `<your module root dir>view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -252,7 +252,7 @@ Create configuration file: `<your module root dir>view/base/ui_component/custome
             <item name="navContainerName" xsi:type="string">left</item>
         </item>
 ...
-{% endhighlight%}
+```
 
 Nodes are optional and contain parameters required for component:
 
@@ -264,7 +264,7 @@ Nodes are optional and contain parameters required for component:
 
 Add a description of the fields in the form using components and Field Fieldset:
 
-{%highlight xml%}
+```xml
 ...
 <fieldset name="customer">
    <argument name="data" xsi:type="array">
@@ -283,11 +283,11 @@ Add a description of the fields in the form using components and Field Fieldset:
         </argument>
     </field>
 …
-{% endhighlight%}
+```
 
 To group components you can use the component container as in example below:
 
-{% highlight xml%}
+```xml
 <container name="container_group">
     <argument name="data" xsi:type="array">
         <item name="type" xsi:type="string">group</item>
@@ -308,7 +308,7 @@ To group components you can use the component container as in example below:
     ...
     </field>
 </container>
-{% endhighlight %}
+```
 
 ### Configure DataSource
 
@@ -318,7 +318,7 @@ DataSource aggregates an object of class implements the interface `\Magento\Fram
 
 An example of the configuration of the DataSource object:
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         ...
@@ -358,7 +358,7 @@ An example of the configuration of the DataSource object:
         </argument>
     </dataSource>
 </form>
-{% endhighlight %}
+```
 
 Component configuration:
 
@@ -381,7 +381,7 @@ To replace all instances, globally, of a UI Form with a custom implementation re
 
 `app/code/Magento/Ui/view/base/ui_component/etc/definition.xml`
 
-{% highlight xml%}
+```xml
 <form class="Magento\Ui\Component\Form">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -389,7 +389,7 @@ To replace all instances, globally, of a UI Form with a custom implementation re
         </item>
     </argument>
 </form>
-{% endhighlight %}
+```
 
 #### Single replacement
 
@@ -397,7 +397,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
 
 `app/code/Magento/Customer/view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Ui/etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -405,7 +405,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
         </item>
         </argument>
 </form>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.2/ui_comp_guide/components/ui-listing-grid.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-listing-grid.md
@@ -13,8 +13,7 @@ Example configuration of Listing component instance:
 
 `<your module root dir>/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml`
 
-
-{% highlight xml%}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="context" xsi:type="configurableObject">
         <argument name="class" xsi:type="string">Magento\Framework\View\Element\UiComponent\Context</argument>
@@ -38,7 +37,7 @@ Example configuration of Listing component instance:
         </item>
     </argument>
 </listing>
-{% endhighlight %}
+```
 
 ## Configure DataSource
 
@@ -48,7 +47,7 @@ The listing component requires the data source to be properly configured and ass
 
 `<your module root dir>/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml`
 
-{% highlight xml %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <dataSource name="cms_page_listing_data_source">
         <argument name="dataProvider" xsi:type="configurableObject">
@@ -68,7 +67,7 @@ The listing component requires the data source to be properly configured and ass
         </argument>
     </dataSource>
 </listing>    
-{% endhighlight %}    
+```
 
 ## Source files
 

--- a/guides/v2.2/ui_comp_guide/components/ui-massactions.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-massactions.md
@@ -95,7 +95,7 @@ The MassActions component has dependencies on the following components:
 
 ### Redefine the link to the template
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -104,11 +104,11 @@ The MassActions component has dependencies on the following components:
         </item>
     </argument>
 </massaction>
-{% endhighlight %}
+```
 
 ### Specify action with confirmation
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -126,13 +126,13 @@ The MassActions component has dependencies on the following components:
         </argument>
     </action>
 </massaction>
-{% endhighlight %}
+```
 
 ### Action with a custom callback
 
 Callback is provided by another component.
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         ...
@@ -150,13 +150,13 @@ Callback is provided by another component.
         </argument>
     </action>
 </massaction>
-{% endhighlight %}
+```
 
 ### Instance replacement (one instance of a component)
 
 Redefine link to constructor:
 
-{% highlight xml %}
+```xml
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -164,7 +164,7 @@ Redefine link to constructor:
         </item>
     </argument>
 </massaction>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
@@ -1,8 +1,6 @@
 ---
 group: ui-components-guide
-subgroup: components
 title: MultiselectColumn component
-menu_title: MultiselectColumn component
 ---
 
 The MultiselectColumn component implements a column with checkboxes for selecting records. It also provides controls for selecting multiple records.
@@ -70,7 +68,7 @@ Sample of code where component configurations are performed:
 
 Current implementation:
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -82,13 +80,13 @@ Current implementation:
          </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 Example configuration modifications:
 
 * Redefining the link to the template
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -97,11 +95,11 @@ Example configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 * Redefining the name of the property which represents record identifier
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -110,11 +108,11 @@ Example configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 * Redefining a property data source
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         ...
@@ -125,7 +123,7 @@ Example configuration modifications:
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 ### Add a new component
 
@@ -133,7 +131,7 @@ Instance Replacement: One Instance of a Component
 
 * Redefine the link to constructor:
 
-{% highlight javascript %}
+```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -141,7 +139,7 @@ Instance Replacement: One Instance of a Component
         </item>
     </argument>
 </column>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.3/rest/performing-searches.md
+++ b/guides/v2.3/rest/performing-searches.md
@@ -8,11 +8,11 @@ POST, PUT, and DELETE requests to the REST Web {% glossarytooltip 786086f2-622b-
 
 For search APIs that invoke a `*Repository::getList(SearchCriteriaInterface *)` call, the searchCriteria must be specified in the {% glossarytooltip a05c59d3-77b9-47d0-92a1-2cbffe3f8622 %}URL{% endglossarytooltip %} of the GET request. The basic pattern for specifying the criteria is
 
-{% highlight html %}
+```
 searchCriteria[filter_groups][<index>][filters][<index>][field]=<field_name>
 searchCriteria[filter_groups][<index>][filters][<index>][value]=<search_value>
 searchCriteria[filter_groups][<index>][filters][<index>][condition_type]=<operator>
-{% endhighlight %}
+```
 
 where:
 
@@ -57,7 +57,7 @@ The following sections provide examples of each type of search. These examples u
 
 The {{site.data.var.ce}} sample data uses the `category_gear` field to describe the categories for each item listed under Gear on sample store. Each item can be assigned to multiple categories. Electronics are assigned the code 86. The following example returns all gear tagged as electronics.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products/?
 searchCriteria[filter_groups][0][filters][0][field]=category_gear&
 searchCriteria[filter_groups][0][filters][0][value]=86&
@@ -87,7 +87,7 @@ The query returns 9 items.
 
 The following search finds all invoices created after the specified time (midnight, July 1 2016). You can set up a similar search to run periodically to poll for changes.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/invoices?
 searchCriteria[filter_groups][0][filters][0][field]=created_at&
 searchCriteria[filter_groups][0][filters][0][value]=2016-07-01 00:00:00&
@@ -98,7 +98,7 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gt
 
 The following example searches for all products whose names contain the string `Leggings` or `Parachute`. The instances of `%25` in the example are converted into the SQL wildcard character `%`.
 
-``` html
+```
 GET http://<magento_host>/index.php/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=name&
 searchCriteria[filter_groups][0][filters][0][value]=%25Leggings%25&
@@ -136,7 +136,7 @@ The search returns 14 products that contain the string `Leggings` in the `name` 
 
 This sample searches for women's shorts that are size 31 and costs less than $30. In the CE sample data, women's shorts have a `sku` value that begins with `WSH`. The `sku` also contains the size and color, such as `WSH02-31-Yellow`.
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2531%25&
@@ -176,7 +176,7 @@ The query returns 9 items.
 
 This sample is similar the Logical AND sample. It searches the `sku`s for women's shorts (WSH%) or pants (WP%)in size 29. The system performs two logical ANDs to restrict the results to those that cost from $40 to $49.99
 
-``` html
+```
 GET http://<magento_host>/rest/V1/products?
 searchCriteria[filter_groups][0][filters][0][field]=sku&
 searchCriteria[filter_groups][0][filters][0][value]=WSH%2529%25&

--- a/guides/v2.3/rest/retrieve-filtered-responses.md
+++ b/guides/v2.3/rest/retrieve-filtered-responses.md
@@ -75,15 +75,15 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 
 `GET http://<host>/rest/default/V1/shipment/2?fields=items[name,qty,sku]`
 
-{% highlight json %}
+```json
 "items": [
    {
      "name": "Minerva LumaTech&trade; V-Tee-XS-Blue",
      "qty": 1,
      "sku": "WS08-XS-Blue",
    }
- ]
- {% endhighlight %}
+]
+```
 
 ## Nested objects
 
@@ -95,7 +95,7 @@ This example returns only the following:
 
 `GET http://<host>/rest/default/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
-{% highlight json %}
+```json
 {
   "sku": "MT12"
   "name": "Cassius Sparring Tank"
@@ -110,7 +110,7 @@ This example returns only the following:
       }
   }
 }
-{% endhighlight %}
+```
 
 ## POST operation
 

--- a/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
@@ -45,7 +45,7 @@ The `return_to_stock_items` array specifies which `order_item_id`s can be return
 
 **Payload**
 
-{% highlight json %}
+```json
 {
   "items": [
     {
@@ -65,7 +65,7 @@ The `return_to_stock_items` array specifies which `order_item_id`s can be return
     }
   }
 }
-{% endhighlight %}
+```
 
 **Response**
 

--- a/guides/v2.3/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-form.md
@@ -217,7 +217,7 @@ To create an instance of the Form component, you need to do the following:
 3. Create the DataProvider class for the entity that implements DataProviderInterface
 * Add a component in Magento {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} as a node: `<uiComponent name="customer_form"/>`
 
-{% highlight xml %}
+```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
@@ -226,7 +226,7 @@ To create an instance of the Form component, you need to do the following:
         </referenceContainer>
     </body>
 </page>
-{% endhighlight %}
+```
 
 ### Configure the component
 
@@ -237,7 +237,7 @@ Component could be configured in two ways:
 
 Create configuration file: `<your module root dir>view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -252,7 +252,7 @@ Create configuration file: `<your module root dir>view/base/ui_component/custome
             <item name="navContainerName" xsi:type="string">left</item>
         </item>
 ...
-{% endhighlight%}
+```
 
 Nodes are optional and contain parameters required for component:
 
@@ -264,7 +264,7 @@ Nodes are optional and contain parameters required for component:
 
 Add a description of the fields in the form using components and Field Fieldset:
 
-{%highlight xml%}
+```xml
 ...
 <fieldset name="customer">
    <argument name="data" xsi:type="array">
@@ -283,11 +283,11 @@ Add a description of the fields in the form using components and Field Fieldset:
         </argument>
     </field>
 …
-{% endhighlight%}
+```
 
 To group components you can use the component container as in example below:
 
-{% highlight xml%}
+```xml
 <container name="container_group">
     <argument name="data" xsi:type="array">
         <item name="type" xsi:type="string">group</item>
@@ -308,7 +308,7 @@ To group components you can use the component container as in example below:
     ...
     </field>
 </container>
-{% endhighlight %}
+```
 
 ### Configure DataSource
 
@@ -318,7 +318,7 @@ DataSource aggregates an object of class implements the interface `\Magento\Fram
 
 An example of the configuration of the DataSource object:
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         ...
@@ -358,7 +358,7 @@ An example of the configuration of the DataSource object:
         </argument>
     </dataSource>
 </form>
-{% endhighlight %}
+```
 
 Component configuration:
 
@@ -381,7 +381,7 @@ To replace all instances, globally, of a UI Form with a custom implementation re
 
 `app/code/Magento/Ui/view/base/ui_component/etc/definition.xml`
 
-{% highlight xml%}
+```xml
 <form class="Magento\Ui\Component\Form">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -389,7 +389,7 @@ To replace all instances, globally, of a UI Form with a custom implementation re
         </item>
     </argument>
 </form>
-{% endhighlight %}
+```
 
 #### Single replacement
 
@@ -397,7 +397,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
 
 `app/code/Magento/Customer/view/base/ui_component/customer_form.xml`
 
-{% highlight xml%}
+```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Ui/etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
@@ -405,7 +405,7 @@ To replace one instance of a UI Form Component redefine link to a constructor in
         </item>
         </argument>
 </form>
-{% endhighlight %}
+```
 
 ## Source files
 

--- a/guides/v2.3/ui_comp_guide/components/ui-secondary-uiselect.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-secondary-uiselect.md
@@ -28,38 +28,40 @@ content="You must create a controller for `searchUrl`. If you'd like to use othe
   <tr>
     <td><code>imports</code></td>
     <td>Defines from where the component receives its data</td>
-    <td>
-    {% highlight javascript %}imports: {
-        options: '${ $.optionsConfig.name }:options'
-    }{% endhighlight %}</td>
+<td markdown="1">
+```js
+imports: {
+    options: '${ $.optionsConfig.name }:options'
+}
+```
+</td>
     <td>Yes</td>
   </tr>
   <tr>
     <td><code>actions</code></td>
     <td>Modifies the default actions by renaming their storefront labels</td>
-    <td><code>
-        {% highlight javascript %}
-        actions: [
-            {
-                value: 'selectAll',
-                label: $t('Select all')
-            },
-            {
-                value: 'deselectAll',
-                label: $t('Deselect all')
-            }, 
-            {
-                value: 'selectPage',
-                label: $t('Select all on this page')
-            },
-            {
-                value: 'deselectPage',
-                label: $t('Deselect all on this page')
-            }
-        ]
-        {% endhighlight %}
-        </code>
-    </td>
+<td markdown="1">
+```js
+actions: [
+    {
+        value: 'selectAll',
+        label: $t('Select all')
+    },
+    {
+        value: 'deselectAll',
+        label: $t('Deselect all')
+    }, 
+    {
+        value: 'selectPage',
+        label: $t('Select all on this page')
+    },
+    {
+        value: 'deselectPage',
+        label: $t('Deselect all on this page')
+    }
+]
+```
+</td>
     <td>Yes</td>
   </tr>  
 </table>
@@ -129,24 +131,23 @@ The following configuration can be passed in as arguments:
 
 > `<Magento_Cms>/view/adminhtml/ui_component/cms_page_listing.xml`
 
-{% highlight xml %}
+```xml
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-            <filterSelect name="uiSelect">
-                <argument name="optionsProvider" xsi:type="configurableObject">
-                    <argument name="class" xsi:type="string">Magento\Cms\Model\Page\Source\PageLayout</argument>
-                </argument>
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="component" xsi:type="string">Magento_Ui/js/form/element/ui-select</item>
-                        <item name="template" xsi:type="string">ui/grid/filters/elements/ui-select</item>
-                        <item name="dataScope" xsi:type="string">uiSelect</item>
-                        <item name="label" xsi:type="string" translate="true">uiSelect</item>
-                    </item>
-                </argument>
-            </filterSelect>
+    <filterSelect name="uiSelect">
+        <argument name="optionsProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Magento\Cms\Model\Page\Source\PageLayout</argument>
+        </argument>
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/element/ui-select</item>
+                <item name="template" xsi:type="string">ui/grid/filters/elements/ui-select</item>
+                <item name="dataScope" xsi:type="string">uiSelect</item>
+                <item name="label" xsi:type="string" translate="true">uiSelect</item>
+            </item>
+        </argument>
+    </filterSelect>
 </listing>
-{% endhighlight %}
-
+```
 
 ### Configured select component view
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will remove the {% highlight %} from some guides and replace it with markdown backticks syntax. Also some small content fixes where appropriate.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- Videos
- B2B
- REST
- UI components 

More guides to come in future PR's!

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
