### PR TITLE
Update Magento Release Info with link to Cloud release notes

### DIFF
--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -17,7 +17,7 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 ## {{site.data.var.ece}}
 
-The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
+The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and {{site.data.var.ece}} commands to help manage your code and automatically build and deploy your projects. 
 
 See [Release Notes for ece-tools]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about {{site.data.var.ece}} upgrades and patches.
 

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -15,13 +15,14 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 *	Overview of [backward-incompatible changes]({{page.baseurl}}/release-notes/backward-incompatible-changes/index.html) between the 2.2 and 2.3 releases
 
-## {{site.data.var.ece}}
+## {{site.data.var.ece}}{#cloud-updates}
 
-The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and {{site.data.var.ece}} commands to help manage your code and automatically build and deploy your projects. 
+The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, verify environment packages, and more. The package also contains scripts and {{site.data.var.ece}} commands to help manage your code and automate the project build and deploy process.
 
 See [Release Notes for ece-tools]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about {{site.data.var.ece}} upgrades and patches.
 
-{: .bs-callout .bs-callout-info } We recommend installing full {{site.data.var.ece}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
+{: .bs-callout .bs-callout-info }
+We recommend installing full {{site.data.var.ece}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 
 
 ## Third-party license agreements

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -17,9 +17,11 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 ## {{site.data.var.ece}}
 
-The ece-tools package is a scalable deployment tool that simplifies the Cloud upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
+The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
 
 See [Release Notes for ece-tools]{{ page.baseurl }}/cloud/release-not4es/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
+
+{: .bs-callout .bs-callout-info } We recommend installing full [{{site.data.var.ece}} upgrades]({{ site.baseurl }}/guides/v2.3/cloud/project/project-upgrade.html) for important security updates. Full upgrades include all associated patches and hotfixes.
 
 
 ## Third-party license agreements

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -19,7 +19,7 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
 
-See [Release Notes for ece-tools]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
+See [Release Notes for ece-tools]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about {{site.data.var.ece}} upgrades and patches.
 
 {: .bs-callout .bs-callout-info } We recommend installing full {{site.data.var.ece}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -15,14 +15,12 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 *	Overview of [backward-incompatible changes]({{page.baseurl}}/release-notes/backward-incompatible-changes/index.html) between the 2.2 and 2.3 releases
 
-## {{site.data.var.ece}} Composer packages
+## {{site.data.var.ece}}
 
-[{{site.data.var.ece}} Composer package updates]({{ site.baseurl }}/guides/v2.2/cloud/composer-packages/patch-notes.html) allow you to apply patches without a full product installation or upgrade.
+The ece-tools package is a scalable deployment tool that simplifies the Cloud upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
 
-You can apply patches as they become available to update Magento Commerce (Cloud). We recommend using a new active branch and Integration environment for applying and testing the patch prior to fully deploying across all environments. We strongly recommend you test patches locally so you can identify and resolve any issues.
+See [Release Notes for ece-tools]{{ page.baseurl }}/cloud/release-not4es/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
 
-{: .bs-callout .bs-callout-info }
-We recommend installing full [{{site.data.var.ece}} upgrades]({{ site.baseurl }}/guides/v2.3/cloud/project/project-upgrade.html) for important security updates. Full upgrades include all associated patches and hotfixes.
 
 ## Third-party license agreements
 

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -21,7 +21,7 @@ The ece-tools package is a scalable deployment tool that simplifies the {{ sit
 
 See [Release Notes for ece-tools]{{ page.baseurl }}/cloud/release-not4es/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
 
-{: .bs-callout .bs-callout-info } We recommend installing full [{{site.data.var.ece}} upgrades]({{ site.baseurl }}/guides/v2.3/cloud/project/project-upgrade.html) for important security updates. Full upgrades include all associated patches and hotfixes.
+{: .bs-callout .bs-callout-info } We recommend installing full {{site.data.var.ece}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 
 
 ## Third-party license agreements

--- a/guides/v2.3/release-notes/bk-release-notes.md
+++ b/guides/v2.3/release-notes/bk-release-notes.md
@@ -19,7 +19,7 @@ Interested in the Magento 2.1.x and 2.2.x releases? Check out the [2.1.x]({{ sit
 
 The ece-tools package is a scalable deployment tool that simplifies the {{ site.data.var.ece }} upgrade process by providing commands to backup the database, apply custom patches, and verify environment packages, and more. The package also contains scripts and Magento Commerce Cloud commands to help manage your code and automatically build and deploy your projects. 
 
-See [Release Notes for ece-tools]{{ page.baseurl }}/cloud/release-not4es/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
+See [Release Notes for ece-tools]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html) for the latest updates and improvements to the ece-tools package as well as information about Magento Commerce Cloud upgrades and patches.
 
 {: .bs-callout .bs-callout-info } We recommend installing full {{site.data.var.ece}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will replace outdated information about Magento Commerce Cloud releases, upgrades, and patches with link to the current *Release notes for ece-tools* topic.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

*List all affected URLs*

- https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html

whatsnew
Updated the Magento Commerce Cloud Release Information with link to Magento Commerce Cloud release information in the [Release Notes for ece-tools](https://devdocs.magento.com/guides/v2.3/cloud/release-notes/cloud-tools.html) topic.
