### PR TITLE
Corrected name of staging and prod deploy log

### DIFF
--- a/guides/v2.1/cloud/project/project-start.md
+++ b/guides/v2.1/cloud/project/project-start.md
@@ -78,14 +78,14 @@ You can review these logs via SSH into the environment. Change to the directorie
 Logs from the deploy hook are located on the server in the following locations:
 
 *	Integration: `/var/log/deploy.log`
-*	Staging: `/var/log/platform/<project ID>/post_deploy.log`
-*	Production: `/var/log/platform/{1|2|3}.<project ID>/post_deploy.log`
+*	Staging: `/var/log/platform/<project ID>/deploy.log`
+*	Production: `/var/log/platform/{1|2|3}.<project ID>/deploy.log`
 
 The value of `<project ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
 
 For example, on the Staging environment for project `yw1unoukjcawe`, the deploy log is located at `/var/log/platform/yw1unoukjcawe_stg/deploy.log`.
 
-For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/post_deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/deploy.log`.
+For Production, you have a three node structure. Logs are available with specific information for that node. For example, on the Production environment for project `yw1unoukjcawe`, the deploy log is located at node 1 `/var/log/platform/1.yw1unoukjcawe/deploy.log`, node 2 `/var/log/platform/2.yw1unoukjcawe/deploy.log`, and node 3 `/var/log/platform/3.yw1unoukjcawe/deploy.log`.
 
 Logs for all deployments that have occurred on this environment are appended to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment.
 

--- a/guides/v2.2/cloud/project/project-start.md
+++ b/guides/v2.2/cloud/project/project-start.md
@@ -73,16 +73,16 @@ After pushing changes to your environment, you can observe the build results in 
 You can review the logs from the deploy hook in the following directories:
 
 -  **Integration**: `/var/log/deploy.log`
--  **Staging**: `/var/log/platform/<project-ID>_stg/post_deploy.log`
--  **Production**: `/var/log/platform/<node-{1|2|3}>.<project-ID>/post_deploy.log`
+-  **Staging**: `/var/log/platform/<project-ID>_stg/deploy.log`
+-  **Production**: `/var/log/platform/<node-{1|2|3}>.<project-ID>/deploy.log`
 
-The value of `<project-ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`. Using that example, the deploy log is: `/var/log/platform/yw1unoukjcawe_stg/post_deploy.log`
+The value of `<project-ID>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`. Using that example, the deploy log is: `/var/log/platform/yw1unoukjcawe_stg/deploy.log`
 
 Pro projects have a three-node structure and each node contains logs with specific information for that node. For example, on the Production environment for the `yw1unoukjcawe` project, the deploy logs have the following locations:
 
--  **Node 1**: `/var/log/platform/1.yw1unoukjcawe/post_deploy.log`
--  **Node 2**: `/var/log/platform/2.yw1unoukjcawe/post_deploy.log`
--  **Node 3**: `/var/log/platform/3.yw1unoukjcawe/post_deploy.log`
+-  **Node 1**: `/var/log/platform/1.yw1unoukjcawe/deploy.log`
+-  **Node 2**: `/var/log/platform/2.yw1unoukjcawe/deploy.log`
+-  **Node 3**: `/var/log/platform/3.yw1unoukjcawe/deploy.log`
 
 The log for each deployment appends to this file. Check the timestamps on log entries to verify and locate the logs you want for a specific deployment. The following is a condensed example of log output that you can use for troubleshooting:
 


### PR DESCRIPTION
Fixes #2708 
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Corrected the name of the deployment log for Magento Commerce Cloud staging and production environments.

## Additional information

**Affected URLs**

- https://devdocs.magento.com/guides/v2.1/cloud/project/project-start.html
- https://devdocs.magento.com/guides/v2.2/cloud/project/project-start.html
- https://devdocs.magento.com/guides/v2.1/cloud/project/project-start.html

whatsnew
Corrected the name of the {{site.data.var.ece}} Staging and Production deploy log.

