### PR TITLE
Disable link checking hook for 'jekyll serve'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,12 @@ task preview: %w[install clean] do
   puts 'Generating devdocs locally ... '.magenta
   if File.exist?('_config.local.yml')
     print 'enabled the additional configuration parameters from _config.local.yml: $ '.magenta
-    sh 'bundle exec jekyll serve --incremental --open-url --livereload --trace --config _config.yml,_config.local.yml'
+    sh 'bundle exec jekyll serve --incremental \
+                                 --open-url \
+                                 --livereload \
+                                 --trace \
+                                 --config _config.yml,_config.local.yml \
+                                 --plugins _plugins,_checks'
   else
     Rake::Task['preview:all'].invoke
   end

--- a/_checks/html-check-hook.rb
+++ b/_checks/html-check-hook.rb
@@ -1,5 +1,5 @@
 # The hook runs html-proofer with options defined in the
-#  _checks/html-check-config.yml file
+#  _config.checks.yml file
 #
 # For more details about html-proofer, refer to: https://github.com/gjtorikian/html-proofer
 # For more details about Jekyll hooks, refer to: https://jekyllrb.com/docs/plugins/hooks/
@@ -9,9 +9,6 @@ require 'yaml'
 require_relative '../rakelib/double-slash-check.rb'
 
 Jekyll::Hooks.register :site, :post_write do |site|
-  # Do nothing unless serving mode is enabled
-  next unless site.config['serving']
-
   # Do nothing unless 'site.check_links' is set
   next unless site.config['check_links']
 

--- a/rakelib/preview.rake
+++ b/rakelib/preview.rake
@@ -4,6 +4,10 @@ namespace :preview do
   desc 'Preview the entire devdocs locally'
   task all: %w[install clean] do
     print 'Enabled the default configuration: $ '.magenta
-    sh 'bundle exec jekyll serve --incremental --open-url --livereload --trace'
+    sh 'bundle exec jekyll serve --incremental \
+                                 --open-url \
+                                 --livereload \
+                                 --trace \
+                                 --plugins _plugins,_checks'
   end
 end


### PR DESCRIPTION
## This PR is a:

- Improvement

## Summary

When this pull request is merged, it will disable link checking hook for `jekyll serve` command.

## Additional information

Link checking in a preview mode is still available using `rake`, `rake preview`, `rake preview:all` commands.