### PR TITLE
Update the debug logging commands

### DIFF
--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -11,14 +11,31 @@ functional_areas:
 
 ## Debug logging
 
-By default, Magento writes debug logs to the `var/log/debug.log` file inside the Magento application directory.
+By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento config:set --enable-debug-logging=true | false` command to change the default value.
 
-To enable debug logging:
+{:.bs-callout .bs-callout-info}
+As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
-1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `1`.
+#### To enable debug logging:
+
+1. Use the `config:set` command to enable debug logging for the current mode.
 
     ```bash
-    bin/magento config:set dev/debug/debug_logging 1
+    bin/magento config:set --enable-debug-logging=true
+    ```
+
+2. Flush the cache.
+
+    ```bash
+    bin/magento cache:flush
+    ```
+
+#### To disable debug logging:
+
+1. Use the `config:set` command to disable debug logging for the current mode.
+
+    ```bash
+    bin/magento config:set --enable-debug-logging=false
     ```
 
 1. Flush the cache.
@@ -27,19 +44,6 @@ To enable debug logging:
     bin/magento cache:flush
     ```
 
-To disable debug logging:
-
-1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `0`.
-
-    ```bash
-    bin/magento config:set dev/debug/debug_logging 0
-    ```
-
-1. Flush the cache.
-
-    ```bash
-    bin/magento cache:flush
-    ```
 
 ## Database logging
 
@@ -56,7 +60,7 @@ To enable database logging:
     bin/magento dev:query-log:disable
     ```
 
-1. Flush the cache.
+2. Flush the cache.
 
     ```bash
     bin/magento cache:flush

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -11,17 +11,20 @@ functional_areas:
 
 ## Debug logging
 
-By default, Magento writes debug logs to the `var/log/debug.log` file inside the Magento application directory.
+By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento config:set --enable-debug-logging=true | false` command to change the default value.
+
+{:.bs-callout .bs-callout-info}
+As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
 #### To enable debug logging:
 
-1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `1`.
+1. Use the `config:set` command to enable debug logging for the current mode.
 
     ```bash
-    bin/magento config:set dev/debug/debug_logging 1
+    bin/magento config:set --enable-debug-logging=true
     ```
 
-1. Flush the cache.
+2. Flush the cache.
 
     ```bash
     bin/magento cache:flush
@@ -29,10 +32,10 @@ By default, Magento writes debug logs to the `var/log/debug.log` file inside the
 
 #### To disable debug logging:
 
-1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `0`.
+1. Use the `config:set` command to disable debug logging for the current mode.
 
     ```bash
-    bin/magento config:set dev/debug/debug_logging 0
+    bin/magento config:set --enable-debug-logging=false
     ```
 
 1. Flush the cache.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

This PR updates the parameters that can be used with the `magento config:set` command.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 
https://devdocs.magento.com/guides/v2.2/config-guide/cli/logging.html
https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html
- ...
- ...

whatsnew
Use the `bin/magento config:set --enable-debug-logging=true | false` command  to change whether [debug logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html) is enabled for the current mode. The previous parameter, `dev/debug/debug_logging 0 | 1` is no longer supported. This is a breaking change.