### PR TITLE
Updating Actions reference for MFTF 2.3.13

### DIFF
--- a/mftf/2.3/include/note-2.2-docs.md
+++ b/mftf/2.3/include/note-2.2-docs.md
@@ -1,3 +1,19 @@
-{: .bs-callout .bs-callout-info }
+<div class="bs-callout bs-callout-info" markdown="1">
 [Find out your version](./introduction.html#find-version) of the MFTF.
 If your version is 2.2, see the [MFTF 2.2 documentation]({{site.baseurl}}/mftf/2.2/introduction.html).
+
+{% assign packages_2_3 = site.data.codebase.v2_3.open-source.composer_lock.packages-dev %}
+{% assign packages_2_2 = site.data.codebase.v2_2.open-source.composer_lock.packages-dev %}
+
+{% for package in packages_2_3 %}
+{% if package.name contains 'magento2-functional-testing-framework'  %}
+The latest Magento 2.2 release supports MFTF {{ package.version }}.
+{% endif %}
+{% endfor %}
+
+{% for package in packages_2_2 %}
+{% if package.name contains 'magento2-functional-testing-framework'  %}
+The latest Magento 2.3 release supports MFTF {{ package.version }}.
+{% endif %}
+{% endfor %}
+</div>

--- a/mftf/2.3/introduction.md
+++ b/mftf/2.3/introduction.md
@@ -1,5 +1,5 @@
 ---
-mftf-release: 2.3.12
+mftf-release: 2.3.13
 redirect_from: /guides/v2.3/magento-functional-testing-framework/2.3/introduction.html
 ---
 

--- a/mftf/2.3/test/actions.md
+++ b/mftf/2.3/test/actions.md
@@ -2529,6 +2529,83 @@ Attribute|Type|Use|Description
 <!-- Wait up to 30 seconds for the current page to fully load before continuing. -->
 <waitForPageLoad stepKey="waitForPageLoad"/>
 ```
+### waitForPwaElementNotVisibleType
+
+Waits up to given time for a PWA Element to disappear from the screen.
+
+Attribute|Type|Use|Description
+---|---|---|---
+`time`|string|optional| Number of seconds to wait for the element to disappear.
+`selector`|string|required| The selector identifying the corresponding HTML element.
+`stepKey`|string|required| A unique identifier of the action.
+`skipReadiness`|boolean|optional| A flag to skip the readiness check.
+`before`|string|optional| `stepKey` of action that must be executed next.
+`after`|string|optional| `stepKey` of preceding action.
+
+#### Example
+
+```xml
+<!-- Wait for the PWA element to disappear. -->
+<waitForPwaElementNotVisibleType time="1" stepKey="waitForPwaElementNotVisibleType"/>
+```
+### waitForPwaElementVisibleType
+
+Waits up to given time for a PWA Element to appear on the screen.
+
+Attribute|Type|Use|Description
+---|---|---|---
+`time`|string|optional| Number of seconds to wait for the selected element.
+`selector`|string|required| The selector identifying the corresponding HTML element.
+`stepKey`|string|required| A unique identifier of the action.
+`skipReadiness`|boolean|optional| A flag to skip the readiness check.
+`before`|string|optional| `stepKey` of action that must be executed next.
+`after`|string|optional| `stepKey` of preceding action.
+
+#### Example
+
+```xml
+<!-- Wait for the selected element to appear. -->
+<waitForPwaElementVisibleType stepKey="waitForPwaElementVisibleType"/>
+```
+
+### waitForPwaElementNotVisibleType
+
+Waits for a PWA Element to disappear from the screen.
+
+Attribute|Type|Use|Description
+---|---|---|---
+`time`|string|optional| Number of seconds to wait for the element to disappear.
+`selector`|string|optional| The selector identifying the corresponding HTML element.
+`stepKey`|string|required| A unique identifier of the action.
+`skipReadiness`|boolean|optional| A flag to skip the readiness check.
+`before`|string|optional| `stepKey` of action that must be executed next.
+`after`|string|optional| `stepKey` of preceding action.
+
+#### Example
+
+```xml
+<!-- Wait up to 5 seconds for the element to disappear. -->
+<waitForPwaElementNotVisibleType time="5" stepKey="waitForPwaElementNotVisibleType"/>
+```
+### waitForPwaElementVisibleType
+
+Waits for a PWA Element to appear on the screen..
+
+Attribute|Type|Use|Description
+---|---|---|---
+`time`|string|optional| Number of seconds to wait for the element to appear.
+`selector`|string|optional| The selector identifying the corresponding HTML element.
+`stepKey`|string|required| A unique identifier of the action.
+`skipReadiness`|boolean|optional| A flag to skip the readiness check.
+`before`|string|optional| `stepKey` of action that must be executed next.
+`after`|string|optional| `stepKey` of preceding action.
+
+#### Example
+
+```xml
+<!-- Wait up to 5 seconds for the element to appear. -->
+<waitForPwaElementVisibleType stepKey="waitForPwaElementVisibleType"/>
+```
 
 ### waitForText
 

--- a/mftf/2.3/test/actions.md
+++ b/mftf/2.3/test/actions.md
@@ -2550,7 +2550,7 @@ Attribute|Type|Use|Description
 ```
 ### waitForPwaElementVisibleType
 
-Waits up to given time for a PWA Element to appear on the screen.
+Waits up to the given 'time' for a PWA Element to appear on the screen.
 
 Attribute|Type|Use|Description
 ---|---|---|---

--- a/mftf/2.3/test/actions.md
+++ b/mftf/2.3/test/actions.md
@@ -2568,45 +2568,6 @@ Attribute|Type|Use|Description
 <waitForPwaElementVisibleType stepKey="waitForPwaElementVisibleType"/>
 ```
 
-### waitForPwaElementNotVisibleType
-
-Waits for a PWA Element to disappear from the screen.
-
-Attribute|Type|Use|Description
----|---|---|---
-`time`|string|optional| Number of seconds to wait for the element to disappear.
-`selector`|string|optional| The selector identifying the corresponding HTML element.
-`stepKey`|string|required| A unique identifier of the action.
-`skipReadiness`|boolean|optional| A flag to skip the readiness check.
-`before`|string|optional| `stepKey` of action that must be executed next.
-`after`|string|optional| `stepKey` of preceding action.
-
-#### Example
-
-```xml
-<!-- Wait up to 5 seconds for the element to disappear. -->
-<waitForPwaElementNotVisibleType time="5" stepKey="waitForPwaElementNotVisibleType"/>
-```
-### waitForPwaElementVisibleType
-
-Waits for a PWA Element to appear on the screen.
-
-Attribute|Type|Use|Description
----|---|---|---
-`time`|string|optional| Number of seconds to wait for the element to appear.
-`selector`|string|optional| The selector identifying the corresponding HTML element.
-`stepKey`|string|required| A unique identifier of the action.
-`skipReadiness`|boolean|optional| A flag to skip the readiness check.
-`before`|string|optional| `stepKey` of action that must be executed next.
-`after`|string|optional| `stepKey` of preceding action.
-
-#### Example
-
-```xml
-<!-- Wait up to 5 seconds for the element to appear. -->
-<waitForPwaElementVisibleType stepKey="waitForPwaElementVisibleType"/>
-```
-
 ### waitForText
 
 See [waitForText docs on codeception.com](http://codeception.com/docs/modules/WebDriver#waitForText){:target="_blank"}.


### PR DESCRIPTION
## This PR is a:
-  Content update

## Summary

When this pull request is merged, it will...

Add new PWA Actions to reference.

whatsnew
Adds two new PWA actions to the Actions reference guide for the MFTF 2.3.13 release.
[waitforPwaElementNotVisibleType](https://devdocs.magento.com/mftf/2.3/test/actions.html#waitforpwaelementnotvisibletype)
[waitforPwaElementVisibleType](https://devdocs.magento.com/mftf/2.3/test/actions.html#waitforpwaelementvisibletype)