### PR TITLE
Wrong API example added in doc

### DIFF
--- a/guides/v2.2/rest/bulk-endpoints.md
+++ b/guides/v2.2/rest/bulk-endpoints.md
@@ -22,14 +22,14 @@ POST /async/bulk/V1/products
 POST /async/bulk/V1/customers
 ```
 
-Endpoint routes that contain input parameters require additional changes. For example, `PUT /V1/product/:sku/options/:optionId` contains the `:sku` and `:optionId` input parameters. The route of a bulk request cannot contain input parameters, so you must change the route so that it does not contain any. To do this, replace the colon (`:`) with `by` and change the first letter of the parameter to uppercase. 
+Endpoint routes that contain input parameters require additional changes. For example, `PUT /V1/products/:sku/media/:entryId` contains the `:sku` and `:entryId` input parameters. The route of a bulk request cannot contain input parameters, so you must change the route so that it does not contain any. To do this, replace the colon (`:`) with `by` and change the first letter of the parameter to uppercase.
 
  
 The following table provides several examples:
  
 Synchronous route | Bulk route
 --- | ---
-`PUT /V1/product/:sku/options/:optionId` | `PUT async/bulk/V1/product/bySku/options/byOptionId`
+`PUT /V1/products/:sku/media/:entryId` | `PUT async/bulk/V1/products/bySku/media/byEntryId`
 `POST /V1/carts/:quoteId/items` | `POST async/bulk/V1/carts/byQuoteId/items`
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -21,14 +21,14 @@ POST /async/bulk/V1/products
 POST /async/bulk/V1/customers
 ```
 
-Endpoint routes that contain input parameters require additional changes. For example, `PUT /V1/product/:sku/options/:optionId` contains the `:sku` and `:optionId` input parameters. The route of a bulk request cannot contain input parameters, so you must change the route so that it does not contain any. To do this, replace the colon (`:`) with `by` and change the first letter of the parameter to uppercase. 
+Endpoint routes that contain input parameters require additional changes. For example, `PUT /V1/products/:sku/media/:entryId` contains the `:sku` and `:entryId` input parameters. The route of a bulk request cannot contain input parameters, so you must change the route so that it does not contain any. To do this, replace the colon (`:`) with `by` and change the first letter of the parameter to uppercase.
 
  
 The following table provides several examples:
  
 Synchronous route | Bulk route
 --- | ---
-`PUT /V1/product/:sku/options/:optionId` | `PUT async/bulk/V1/product/bySku/options/byOptionId`
+`PUT /V1/products/:sku/media/:entryId` | `PUT async/bulk/V1/products/bySku/media/byEntryId`
 `POST /V1/carts/:quoteId/items` | `POST async/bulk/V1/carts/byQuoteId/items`
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will update API example which exists in code.

<!-- (REQUIRED) What does this PR change? -->

## Additional information
`PUT /V1/product/:sku/options/:optionId` - API does not exists in code.

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/rest/bulk-endpoints.html
- https://devdocs.magento.com/guides/v2.2/rest/bulk-endpoints.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
