### PR TITLE
MAGEDOC-3489 Cron logging updates

### DIFF
--- a/guides/v2.1/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.1/config-guide/cli/config-cli-subcommands-static-view.md
@@ -15,9 +15,9 @@ The static view files deployment command enables you to write {% glossarytooltip
 
 The term *static view file* refers to the following:
 
--   "Static" means it can be cached for a site (that is, the file is not dynamically generated).
+_ "Static" means it can be cached for a site (that is, the file is not dynamically generated).
     Examples include images and {% glossarytooltip 6c5cb4e9-9197-46f2-ba79-6147d9bfe66d %}CSS{% endglossarytooltip %} generated from LESS.
--   "View" refers to the presentation layer (from MVC).
+- "View" refers to the presentation layer (from MVC).
 
 Static view files are located in the `<your Magento install dir>/pub/static` directory, and some are cached in the `<your Magento install dir>/var/view_preprocessed` directory as well.
 
@@ -50,220 +50,29 @@ Command options:
 
 The following table explains this command's parameters and values.
 
-<table>
-    <col width="25%" />
-    <col width="60%" />
-    <col width="10%" />
-    <col width="10%" />
-    <tbody>
-    <tr>
-        <th>Option</th>
-        <th>Description</th>
-        <th>Required?</th>
-    </tr>
-    <tr>
-        <td>&lt;languages&gt;</td>
-        <td>
-            <p>Space-separated list of <a href="http://www.loc.gov/standards/iso639-2/php/code_list.php">ISO-639</a> language codes for which to output static view files. (Default is
-                <code>en_US</code>.)</p>
-            <p>You can find the list by running <code>bin/magento info:language:list</code>.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--language (-l)</td>
-        <td>
-            <p>Generate files only for the specified languages. The default, with no option specified, is to generate files for all <a href="http://www.loc.gov/standards/iso639-2/php/code_list.php">ISO-639</a> language codes. You can specify the name of one language code at a time. Default value is <b>all</b>.</p>
-            <p>For example, <code>--language en_US --language es_ES</code></p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--exclude-language</td>
-        <td>
-            <p>Generate files for the specified language codes. The default, with no option specified, is to exclude nothing. You can specify the name of one language code or a comma-separated list of language codes. Default value is <b>none</b>.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--theme &lt;theme&gt;</td>
-        <td>
-            <p>Themes for which to deploy static content. Default value is <b>all</b>.</p>
-            <p>For example, <code>--theme Magento/blank --theme Magento/luma</code></p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--exclude-theme &lt;theme&gt;</td>
-        <td>
-            <p>Themes to exclude when deploying static content. Default value is <b>none</b>.</p>
-            <p>For example, <code>--exclude-theme Magento/blank</code></p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--area (-a)</td>
-        <td>
-            <p>Generate files only for the specified areas. The default, with no option specified, is to generate files for all areas. Valid values are <code>adminhtml</code> and <code>frontend</code>. Default value is <b>all</b>.</p>
-            <p>For example, <code>--area adminhtml</code></p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--exclude-area</td>
-        <td>
-            <p>Do not generate files for the specified areas. The default, with no option specified, is to exclude nothing. Default value is <b>none</b>.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--jobs (-j)</td>
-        <td>
-            <p>Enable parallel processing using the specified number of jobs. The default is 0 (do not run in parallel processes). Default value is <b>0</b>.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--symlink-locale</td>
-        <td>
-            <p>Create symlinks for the files of those locales, which are passed for deployment, but have no customizations.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--content-version=CONTENT-VERSION</td>
-        <td>
-            <p>Custom version of static content can be used if running deployment on multiple nodes to ensure that static content version is identical and caching works properly.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-javascript</td>
-        <td>
-            <p>Do not deploy JavaScript files</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-css</td>
-        <td>
-            <p>Do not deploy CSS files.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-less</td>
-        <td>
-            <p>Do not deploy LESS files.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-images</td>
-        <td>
-            <p>Do not deploy images.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-fonts</td>
-        <td>
-            <p>Do not deploy font files.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <p>--no-html</p>
-        </td>
-        <td>
-            <p>Do not deploy HTML files.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-misc</td>
-        <td>
-            <p>Do not deploy other types of files (that is <code>.md</code>, <code>.jbf</code>, <code>.csv</code>, <code>.json</code>, <code>.txt</code>, <code>.htc</code>, or <code>.swf</code> files).</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--no-html-minify</td>
-        <td>
-            <p>Do not minify HTML files.</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            -s
-            <ul>
-                <li>-s quick</li>
-                <li>-s standard</li>
-                <li>-s compact</li>
-            </ul>
-        </td>
-        <td>
-            Define the deployment strategy. Use these options only if you have more than one locale.
-            <ul>
-                <li>Use the <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html#static-file-quick">quick strategy</a> to minimize deployment time. This is the default command option if not specified.</li>
-                <li>Use the <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html#static-file-standard">standard strategy</a> to deploy all static view files for all packages.</li>
-                <li>Use the <a href="{{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-deploy-strategies.html#static-file-compact">compact strategy</a> to conserve disk space on the server.
-                </li>
-            </ul>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    <tr>
-        <td>--force (-f)</td>
-        <td>
-            <p>Deploy files in any mode. (by default, the static content deployment tool can be run only in production mode. Use this option to run it in default or developer mode).</p>
-        </td>
-        <td>
-            <p>No</p>
-        </td>
-    </tr>
-    </tbody>
-</table> 
+|Option|Description|Default|Required?|
+|--- |--- |--- |
+|-languages|Space-separated list of ISO-639 language codes for which to output static view files. You can find the list by running bin/magento info:language:list.|en_US|No|
+|--language (-l)|Generate files only for the specified languages. The default, with no option specified, is to generate files for all ISO-639 language codes. You can specify the name of one language code at a time. <br />For example, --language es_ES|all|No|
+|--exclude-language|Generate files for the specified language codes. The default, with no option specified, is to exclude nothing. You can specify the name of one language code or a comma-separated list of language codes.|none|No|
+|--theme theme|Themes for which to deploy static content. <br />For example, --theme Magento/blank --theme Magento/luma|all|No|
+|--exclude-theme theme|Themes to exclude when deploying static content.<br />For example, --exclude-theme Magento/blank|none|No|
+|--area (-a)|Generate files only for the specified areas. The default, with no option specified, is to generate files for all areas. Valid values are adminhtml and frontend.<br />For example, --area adminhtml|all|No|
+|--exclude-area|Do not generate files for the specified areas. The default, with no option specified, is to exclude nothing.|none|No|
+|--jobs (-j)|Enable parallel processing using the specified number of jobs.|0|No|
+|--symlink-locale|Create symlinks for the files of those locales, which are passed for deployment, but have no customizations.| |No|
+|--content-version=CONTENT-VERSION|Custom version of static content can be used if running deployment on multiple nodes to ensure that static content version is identical and caching works properly.| |No|
+|--no-javascript|Do not deploy JavaScript files| |No|
+|--no-css|Do not deploy CSS files.| |No|
+|--no-less|Do not deploy LESS files.| |No|
+|--no-images|Do not deploy images.| |No|
+|--no-fonts|Do not deploy font files.| |No|
+|--no-html|Do not deploy HTML files.| |No|
+|--no-misc|Do not deploy other types of files (that is .md, .jbf, .csv, .json, .txt, .htc, or .swf files).| |No|
+|--no-html-minify|Do not minify HTML files.| |No|
+|-s<br />-s quick<br />-s standard<br />-s compact|Define the deployment strategy. Use these options only if you have more than one locale. <br />Use the quick strategy to minimize deployment time. <br />Use the standard strategy to deploy all static view files for all packages. <br />Use the compact strategy to conserve disk space on the server.|quick|No|
+|--force (-f)|Deploy files in any mode. By default, the static content deployment tool can be run only in production mode. Use this option to run it in default or developer mode.|production|No|
+{:style="table-layout:auto;"}
 
 {: .bs-callout .bs-callout-info}
 If you specify values for both `<languages>` and `--language`, `<languages>` takes precedence.

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
@@ -29,8 +29,7 @@ To remove the Magento crontab:
 1.  Log in as or switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 2.  Change to the Magento installation directory.
 3.  Enter the following command:
-
-        php bin/magento cron:remove
+      `php bin/magento cron:remove`
 
 {:.bs-callout .bs-callout-info}
 This command has no effect on cron jobs outside the `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
@@ -39,7 +38,9 @@ This command has no effect on cron jobs outside the `#~ MAGENTO START` and `#~ M
 
 Command options:
 
+```bash
   bin/magento cron:run [--group="<cron group name>"]
+```
 
 where `--group` specifies the cron group to run (omit this option to run cron for all groups)
 
@@ -47,11 +48,9 @@ To run the indexing cron job, enter:
 
 `php bin/magento cron:run --group index`
 
-
 To run the default cron job, enter:
 
 `php bin/magento cron:run --group default`
-
 
 To set up custom cron jobs and groups, see [Configure custom cron jobs and cron groups]({{ page.baseurl }}/config-guide/cron/custom-cron.html).
 
@@ -60,25 +59,27 @@ You must run cron twice: the first time to discover tasks to run and the second 
 
 ## Logging
 
-System logs provide detailed information for debugging. The following attributes apply to Magento cron logs:
+With Magento 2.3.1, `cron` job information was moved from `system.log` and into a separate `cron.log`.
+By default, the cron information can be found at `/var/log/cron.log`. 
+All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQueueObserver::execute`.
 
--   All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQueueObserver::execute`.
+In addition to being logged in `cron.log`:
 
--   Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<your Magento install dir>/var/log` directory.
+- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<your Magento install dir>/var/log` directory.
 
--   Jobs with an `ERROR` status are always logged as `CRITICAL` in `<your Magento install dir>/var/log/exception.log`.
+- Jobs with an `ERROR` status are always logged as `CRITICAL` in `<your Magento install dir>/var/log/exception.log`.
 
--   Jobs with a `MISSED` status are logged as `INFO` in the `<your Magento install dir>/var/log` directory (developer mode only).
+- Jobs with a `MISSED` status are logged as `INFO` in the `<your Magento install dir>/var/log` directory (developer mode only).
 
 {%
 include note.html
 type='info'
 content='All cron data is also written to the `cron_schedule` table in the Magento database. The table provides a history of cron jobs, including:
--   Job ID and code
--   Status
--   Created date
--   Scheduled date
--   Executed date
--   Finished date
+- Job ID and code
+- Status
+- Created date
+- Scheduled date
+- Executed date
+- Finished date
 To see records in the table, log in to the Magento database on the command line and enter `SELECT * from cron_schedule;`.'
 %}

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
@@ -59,17 +59,17 @@ You must run cron twice: the first time to discover tasks to run and the second 
 
 ## Logging
 
-With Magento 2.3.1, `cron` job information was moved from `system.log` and into a separate `cron.log`.
-By default, the cron information can be found at `/var/log/cron.log`. 
+With Magento 2.3.1, `cron` job information is moved from `system.log` and into a separate `cron.log`.
+By default, the cron information can be found at `<install_directory>/var/log/cron.log`. 
 All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQueueObserver::execute`.
 
 In addition to being logged in `cron.log`:
 
-- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<your Magento install dir>/var/log` directory.
+- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<install_directory>/var/log` directory.
 
-- Jobs with an `ERROR` status are always logged as `CRITICAL` in `<your Magento install dir>/var/log/exception.log`.
+- Jobs with an `ERROR` status are always logged as `CRITICAL` in `<install_directory>/var/log/exception.log`.
 
-- Jobs with a `MISSED` status are logged as `INFO` in the `<your Magento install dir>/var/log` directory (developer mode only).
+- Jobs with a `MISSED` status are logged as `INFO` in the `<install_directory>/var/log` directory (developer mode only).
 
 {%
 include note.html

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
@@ -29,7 +29,7 @@ To remove the Magento crontab:
 1.  Log in as or switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 2.  Change to the Magento installation directory.
 3.  Enter the following command:
-      `php bin/magento cron:remove`
+      `bin/magento cron:remove`
 
 {:.bs-callout .bs-callout-info}
 This command has no effect on cron jobs outside the `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
@@ -46,11 +46,11 @@ where `--group` specifies the cron group to run (omit this option to run cron fo
 
 To run the indexing cron job, enter:
 
-`php bin/magento cron:run --group index`
+`bin/magento cron:run --group index`
 
 To run the default cron job, enter:
 
-`php bin/magento cron:run --group default`
+`bin/magento cron:run --group default`
 
 To set up custom cron jobs and groups, see [Configure custom cron jobs and cron groups]({{ page.baseurl }}/config-guide/cron/custom-cron.html).
 
@@ -65,11 +65,11 @@ All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQ
 
 In addition to being logged in `cron.log`:
 
-- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<install_directory>/var/log` directory.
+- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<install_directory>/var/log/support_report.log`.
 
 - Jobs with an `ERROR` status are always logged as `CRITICAL` in `<install_directory>/var/log/exception.log`.
 
-- Jobs with a `MISSED` status are logged as `INFO` in the `<install_directory>/var/log` directory (developer mode only).
+- Jobs with a `MISSED` status are logged as `INFO` in the `<install_directory>/var/log/debug.log` directory (developer mode only).
 
 {%
 include note.html

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
@@ -59,7 +59,7 @@ You must run cron twice: the first time to discover tasks to run and the second 
 
 ## Logging
 
-With Magento 2.3.1, `cron` job information is moved from `system.log` and into a separate `cron.log`.
+All `cron` job information has moved from `system.log` into a separate `cron.log`.
 By default, the cron information can be found at `<install_directory>/var/log/cron.log`. 
 All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQueueObserver::execute`.
 
@@ -75,11 +75,13 @@ In addition to being logged in `cron.log`:
 include note.html
 type='info'
 content='All cron data is also written to the `cron_schedule` table in the Magento database. The table provides a history of cron jobs, including:
+
 - Job ID and code
 - Status
 - Created date
 - Scheduled date
 - Executed date
 - Finished date
+
 To see records in the table, log in to the Magento database on the command line and enter `SELECT * from cron_schedule;`.'
 %}

--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -1,6 +1,7 @@
 ---
 group: configuration-guide
 title: Logging
+
 functional_areas:
   - Configuration
   - System
@@ -44,12 +45,11 @@ As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug
     bin/magento cache:flush
     ```
 
-
 ## Database logging
 
 By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
 
-To enable database logging:
+#### To enable database logging:
 
 1. Use the `dev:query-log` command to enable or disable database logging.
 
@@ -60,7 +60,47 @@ To enable database logging:
     bin/magento dev:query-log:disable
     ```
 
+1. Flush the cache.
+
+    ```bash
+    bin/magento cache:flush
+    ```
+
+## Cron logging
+
+With the release of version 2.3.1, Magento now creates a separate `cron` log. 
+Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
+Moving `cron` info to a dedicated log makes both logs easier to read.
+
+By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`.
+
+## Syslog logging
+
+By default, Magento writes _syslog_ logs to the operating system `syslog` file.
+
+#### To enable syslog logging:
+
+1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `1`.
+
+    ```bash
+    bin/magento config:set dev/syslog/syslog_logging 1
+    ```
+
 2. Flush the cache.
+
+    ```bash
+    bin/magento cache:flush
+    ```
+
+#### To disable syslog logging:
+
+1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `0`.
+
+    ```bash
+    bin/magento config:set dev/syslog/syslog_logging 0
+    ```
+
+1. Flush the cache.
 
     ```bash
     bin/magento cache:flush

--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -12,7 +12,7 @@ functional_areas:
 
 ## Debug logging
 
-By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
+By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or developer mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
 As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
@@ -68,7 +68,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 ## Cron logging
 
-With the release of version 2.3.1, Magento now creates a separate `cron` log. 
+With the release of version 2.2.8, Magento now creates a separate `cron` log. 
 Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
 Moving `cron` info to a dedicated log makes both logs easier to read.
 

--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -17,7 +17,7 @@ By default, Magento writes to the debug log (`<install_directory>/var/log/debug.
 {:.bs-callout .bs-callout-info}
 As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
-#### To enable debug logging:
+### To enable debug logging
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
@@ -31,7 +31,7 @@ As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug
     bin/magento cache:flush
     ```
 
-#### To disable debug logging:
+### To disable debug logging
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
@@ -49,7 +49,7 @@ As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug
 
 By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
 
-#### To enable database logging:
+### To enable database logging
 
 1. Use the `dev:query-log` command to enable or disable database logging.
 
@@ -68,8 +68,8 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 ## Cron logging
 
-With the release of version 2.2.8, Magento now creates a separate `cron` log. 
-Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
+With the release of version 2.2.8, Magento now creates a separate `cron` log.
+Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably.
 Moving `cron` info to a dedicated log makes both logs easier to read.
 
 By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`.
@@ -78,12 +78,12 @@ By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`
 
 By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
-#### To enable syslog logging:
+### To enable syslog logging
 
-1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `1`.
+1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 
     ```bash
-    bin/magento config:set dev/syslog/syslog_logging 1
+    bin/magento setup:config:set --enable-syslog-logging=true
     ```
 
 2. Flush the cache.
@@ -92,12 +92,12 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
     bin/magento cache:flush
     ```
 
-#### To disable syslog logging:
+### To disable syslog logging
 
-1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `0`.
+1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `false`.
 
     ```bash
-    bin/magento config:set dev/syslog/syslog_logging 0
+    bin/magento setup:config:set --enable-syslog-logging=false
     ```
 
 1. Flush the cache.

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -11,14 +11,14 @@ functional_areas:
 
 {% include config/cli-intro.md %}
 
-## Debug logging
+## Cron logging
 
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
 As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
-#### To enable debug logging:
+By default, Magento writes `cron` info to `/var/log/cron.log`.
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
@@ -32,7 +32,7 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
     bin/magento cache:flush
     ```
 
-#### To disable debug logging:
+## Debug logging
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
@@ -46,19 +46,12 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
     bin/magento cache:flush
     ```
 
-## Database logging
+### To disable debug logging:
 
-By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
-
-#### To enable database logging:
-
-1. Use the `dev:query-log` command to enable or disable database logging.
+1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `0`.
 
     ```bash
-    bin/magento dev:query-log:enable
-    ```
-    ```bash
-    bin/magento dev:query-log:disable
+    bin/magento config:set dev/debug/debug_logging 0
     ```
 
 1. Flush the cache.
@@ -71,7 +64,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
-#### To enable syslog logging:
+### To enable syslog logging:
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `1`.
 
@@ -85,7 +78,7 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
     bin/magento cache:flush
     ```
 
-#### To disable syslog logging:
+### To disable syslog logging:
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `0`.
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -84,7 +84,7 @@ The setting in the Magento Admin has been removed.
 
 ### To enable syslog logging
 
-Logging to `syslog` is always enabled for developer and default modes, but disabled for production mode; even on Cloud where only production mode is supported.
+Logging to `syslog` is disabled by default.
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -11,14 +11,14 @@ functional_areas:
 
 {% include config/cli-intro.md %}
 
-## Cron logging
+## Debug logging
 
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
 As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
-By default, Magento writes `cron` info to `/var/log/cron.log`.
+#### To enable debug logging:
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
@@ -32,7 +32,7 @@ By default, Magento writes `cron` info to `/var/log/cron.log`.
     bin/magento cache:flush
     ```
 
-## Debug logging
+#### To disable debug logging:
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
@@ -46,12 +46,19 @@ By default, Magento writes `cron` info to `/var/log/cron.log`.
     bin/magento cache:flush
     ```
 
-### To disable debug logging:
+## Database logging
 
-1. Use the `config:set` command to change the `dev/debug/debug_logging` database value to `0`.
+By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
+
+#### To enable database logging:
+
+1. Use the `dev:query-log` command to enable or disable database logging.
 
     ```bash
-    bin/magento config:set dev/debug/debug_logging 0
+    bin/magento dev:query-log:enable
+    ```
+    ```bash
+    bin/magento dev:query-log:disable
     ```
 
 1. Flush the cache.
@@ -60,11 +67,19 @@ By default, Magento writes `cron` info to `/var/log/cron.log`.
     bin/magento cache:flush
     ```
 
+## Cron logging
+
+With the release of version 2.3.1, Magento now creates a separate `cron` log. 
+Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
+Moving `cron` info to a dedicated log will make both logs easier to read.
+
+By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`.
+
 ## Syslog logging
 
 By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
-### To enable syslog logging:
+#### To enable syslog logging:
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `1`.
 
@@ -78,7 +93,7 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
     bin/magento cache:flush
     ```
 
-### To disable syslog logging:
+#### To disable syslog logging:
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `0`.
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -18,7 +18,7 @@ By default, Magento writes to the debug log (`<install_directory>/var/log/debug.
 {:.bs-callout .bs-callout-info}
 As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
 
-#### To enable debug logging:
+### To enable debug logging
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
@@ -32,7 +32,7 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
     bin/magento cache:flush
     ```
 
-#### To disable debug logging:
+### To disable debug logging
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
@@ -50,14 +50,14 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
 
 By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
 
-#### To enable database logging:
+### To enable database logging
 
 1. Use the `dev:query-log` command to enable or disable database logging.
 
     ```bash
     bin/magento dev:query-log:enable
     ```
-    
+
     ```bash
     bin/magento dev:query-log:disable
     ```
@@ -70,8 +70,8 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 ## Cron logging
 
-With the release of version 2.3.1, Magento now creates a separate `cron` log. 
-Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
+With the release of version 2.3.1, Magento now creates a separate `cron` log. \
+Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably.
 Moving `cron` info to a dedicated log makes both logs easier to read.
 
 By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`.
@@ -82,14 +82,14 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 As of Magento 2.3.1, you must use the `magento` command to enable or disable the syslog.
 The setting in the Magento Admin has been removed.
 
-#### To enable syslog logging:
+### To enable syslog logging
 
 Logging to `syslog` is always enabled for developer and default modes, but disabled for production mode; even on Cloud where only production mode is supported.
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 
     ```bash
-    bin/magento setup:config:set --enable-syslog-logging=true 
+    bin/magento setup:config:set --enable-syslog-logging=true
     ```
 
 2. Flush the cache.
@@ -98,12 +98,12 @@ Logging to `syslog` is always enabled for developer and default modes, but disab
     bin/magento cache:flush
     ```
 
-#### To disable syslog logging:
+### To disable syslog logging
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `false`.
 
     ```bash
-    bin/magento setup:config:set --enable-syslog-logging=false 
+    bin/magento setup:config:set --enable-syslog-logging=false
     ```
 
 1. Flush the cache.

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -82,10 +82,14 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
 #### To enable syslog logging:
 
-1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `1`.
+As of Magento 2.3.1, enabling the syslog must be done via the Magento CLI. 
+The setting in the Admin panel has been removed.
+Logging to `syslog` is always enabled for developer and default modes, but disabled for production mode; even on Cloud where only production mode is supported.
+
+1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 
     ```bash
-    bin/magento config:set dev/syslog/syslog_logging 1
+    bin/magento setup:config:set --enable-syslog-logging=true 
     ```
 
 2. Flush the cache.
@@ -96,10 +100,10 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
 #### To disable syslog logging:
 
-1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `0`.
+1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `false`.
 
     ```bash
-    bin/magento config:set dev/syslog/syslog_logging 0
+    bin/magento setup:config:set --enable-syslog-logging=false 
     ```
 
 1. Flush the cache.

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -57,6 +57,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
     ```bash
     bin/magento dev:query-log:enable
     ```
+    
     ```bash
     bin/magento dev:query-log:disable
     ```
@@ -71,7 +72,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 With the release of version 2.3.1, Magento now creates a separate `cron` log. 
 Magento recently made cron logging more verbose, which provided more information but lengthened the `system.log` considerably. 
-Moving `cron` info to a dedicated log will make both logs easier to read.
+Moving `cron` info to a dedicated log makes both logs easier to read.
 
 By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`.
 
@@ -87,7 +88,7 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
     bin/magento config:set dev/syslog/syslog_logging 1
     ```
 
-1. Flush the cache.
+2. Flush the cache.
 
     ```bash
     bin/magento cache:flush

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -79,11 +79,11 @@ By default, Magento writes `cron` info to `<install_directory>/var/log/cron.log`
 ## Syslog logging
 
 By default, Magento writes _syslog_ logs to the operating system `syslog` file.
+As of Magento 2.3.1, you must use the `magento` command to enable or disable the syslog.
+The setting in the Magento Admin has been removed.
 
 #### To enable syslog logging:
 
-As of Magento 2.3.1, enabling the syslog must be done via the Magento CLI. 
-The setting in the Admin panel has been removed.
 Logging to `syslog` is always enabled for developer and default modes, but disabled for production mode; even on Cloud where only production mode is supported.
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.


### PR DESCRIPTION
## This PR is a:

- Content update

## Summary

When this pull request is merged, it will...

Add info about the new cron.log workflow.

Fixes #MAGEDOC-3489 

whatsnew
Added information about the new `cron.log` file to [Logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html) and [Configure and run cron](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.html).