### PR TITLE
Fix the $ dissapearing from the `bash` code blocks

### DIFF
--- a/common/css/devdocs.css
+++ b/common/css/devdocs.css
@@ -1,1 +1,1 @@
-.home-contributors{margin-bottom:2em}.message-banner{margin:0}redoc[spec-url] table{table-layout:auto}redoc[spec-url] .menu-subitems .menu-item-title{text-transform:none}
+.home-contributors{margin-bottom:2em}.message-banner{margin:0}redoc[spec-url] table{table-layout:auto}redoc[spec-url] .menu-subitems .menu-item-title{text-transform:none}.language-bash.highlighter-rouge code:before{display:inline;content:'$';margin-right:5px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}

--- a/scss/devdocs.scss
+++ b/scss/devdocs.scss
@@ -13,3 +13,12 @@ redoc[spec-url] table {
 redoc[spec-url] .menu-subitems .menu-item-title{
   text-transform: none;
 }
+
+// Add $ to the bash code examples
+// TODO: remove this and use theme css after refactoring
+.language-bash.highlighter-rouge code:before {
+  display: inline;
+  content: '$';
+  margin-right: 5px;
+  user-select: none;
+}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will add back the `$` symbol to the bash code blocks.
Ideally, this code should live in the theme, and after we move all the code blocks to backticks markdown syntax, i will move it.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- all with the `bash` code block

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
