### PR TITLE
Update search-pagination.md

### DIFF
--- a/guides/v2.3/graphql/search-pagination.md
+++ b/guides/v2.3/graphql/search-pagination.md
@@ -109,7 +109,6 @@ The following search returns items that contain the word `yoga` or `pants`. The 
     page_info {
       page_size
       current_page
-      total_pages
     }
   }
 }
@@ -148,9 +147,7 @@ The response for each item includes the `name`, `sku`, `price` and `description`
     items {
       name
       sku
-      description {
-        html
-      }
+      description
       price {
         regularPrice {
           amount {


### PR DESCRIPTION
Solved below issue
"message": "Cannot query field \"total_pages\" on type \"SearchResultPageInfo\".",
"message": "Field \"description\" of type \"String\" must not have a sub selection."

## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [X] Bug fix or improvement

## Summary

When this pull request is merged, it will...

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 
https://devdocs.magento.com/guides/v2.3/graphql/search-pagination.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
