### PR TITLE
module-load-order.md #3649

### DIFF
--- a/guides/v2.1/extension-dev-guide/build/module-load-order.md
+++ b/guides/v2.1/extension-dev-guide/build/module-load-order.md
@@ -23,7 +23,7 @@ If you change the component load order using `<sequence>`, you must regenerate t
 
 Assume you have a component that needs a configuration file from another component:
 
-__Component A__ introduces `gadgetlayout.xml`, which updates block `gadgetBlock` from __component B__. In this case, layout files from __component A__ should be loaded before __component B__, so you should specify that in __component B's__ `<sequence>` entry in {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %}.xml. In other words, __component B__ is dependent on __component A__. That is to say:
+__Component A__ introduces `gadgetlayout.xml`, which updates block `gadgetBlock` from __component B__. In this case, layout files from __component B__ should be loaded before __component A__, so you should specify that in __component A's__ `<sequence>` entry in {% glossarytooltip c1e4242b-1f1a-44c3-9d72-1d5b1435e142 %}module{% endglossarytooltip %}.xml. In other words, __component A__ is dependent on __component B__. That is to say:
 
 {% highlight XML %}
 <?xml version="1.0"?>


### PR DESCRIPTION
Fixes #3649 

## This PR is a:

- Content fix or rewrite

## Summary

The first example given to explain module load order was not correct. Rectified this example as per #3649 author suggested.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/module-load-order.html

<!-- (REQUIRED) The Url that this PR will modify -->
https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/module-load-order.html
