### PR TITLE
Update search-pagination.md

### DIFF
--- a/guides/v2.3/graphql/search-pagination.md
+++ b/guides/v2.3/graphql/search-pagination.md
@@ -20,7 +20,7 @@ The `search` element is optional, but it can be used with or without filters. Ea
 
 The `filter` element defines which search criteria to use to find the desired results. As with a REST call, each filter defines the field to be searched, the condition type, and the search value.
 
-Search filters are logically ANDed unless an `or` statement is specified. The search query can contain unlimited number of nested `or` clauses. However, you cannot perform a logical `or` across two `and` clauses, such as (A AND B) OR (X AND Y).
+Search filters are logically ANDed unless an `OR` statement is specified. The search query can contain unlimited number of nested `OR` clauses. However, you cannot perform a logical `OR` across two `AND` clauses, such as (A AND B) OR (X AND Y).
 
 ### Search fields
 
@@ -47,17 +47,16 @@ Magento GraphQL clause | SQL equivalent
 `gt: "value"`	| <code><i>field</i> > 'value'</code>
 `gteq: "value"`	| <code><i>field</i> >= 'value'</code>
 `lteq: "value"`	| <code><i>field</i> <= 'value'</code>
-`moreq: "value"` | <code><i>field</i> >= 'value'</code>
 `from: "value1"` `to: "value2"` | <code><i>field</i> BETWEEN 'value1' AND 'value2'</code>
 `finset: [1, 2, 3]`	| <code>FINSET(<i>field</i>, '1, 2, 3')</code>
 
 `to` and `from` must always be used together. These condition types can be used in the same search term. For example, `qty: {from: "10" to: "20"}`.
 
-`gt` and `lt` can be used in the same search term. For example, `qty: {lt: "10" gt: "20"}`.
+`gt` and `lt` can be used in the same search term. For example, `qty: {gt: "10" lt: "20"}`.
 
 ## Specifying pagination
 
-Magento's GraphQL implementation of pagination uses offsets so that it operates in the same manner as REST and SOAP requests.
+Magento's GraphQL implementation of pagination uses offsets so that it operates in the same manner as REST and SOAP API requests.
 
 The `pageSize` attribute specifies the maximum number of items to return. If no value is specified, 20 items are returned. 
 

--- a/guides/v2.3/graphql/search-pagination.md
+++ b/guides/v2.3/graphql/search-pagination.md
@@ -20,7 +20,7 @@ The `search` element is optional, but it can be used with or without filters. Ea
 
 The `filter` element defines which search criteria to use to find the desired results. As with a REST call, each filter defines the field to be searched, the condition type, and the search value.
 
-Search filters are logically ANDed unless an `OR` statement is specified. The search query can contain unlimited number of nested `OR` clauses. However, you cannot perform a logical `OR` across two `AND` clauses, such as (A AND B) OR (X AND Y).
+Search filters are logically ANDed unless an `or` statement is specified. The search query can contain unlimited number of nested `or` clauses. However, you cannot perform a logical `or` across two AND clauses, such as (A AND B) OR (X AND Y).
 
 ### Search fields
 
@@ -47,6 +47,7 @@ Magento GraphQL clause | SQL equivalent
 `gt: "value"`	| <code><i>field</i> > 'value'</code>
 `gteq: "value"`	| <code><i>field</i> >= 'value'</code>
 `lteq: "value"`	| <code><i>field</i> <= 'value'</code>
+`moreq: "value"` | <code><i>field</i> >= 'value'</code>
 `from: "value1"` `to: "value2"` | <code><i>field</i> BETWEEN 'value1' AND 'value2'</code>
 `finset: [1, 2, 3]`	| <code>FINSET(<i>field</i>, '1, 2, 3')</code>
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

1.Logical OR , AND in caps.
2.Removed `moreq` clause because it is dublicate clause for `gteq`
3.Updated `qty: {gt: "10" lt: "20"}` example and make it even like previous example `qty: {from: "10" to: "20"}` which looks more clear than the previous version.
4.REST and SOAP API (both are APIs)

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/search-pagination.html

<!-- (REQUIRED) The Url that this PR will modify -->

https://devdocs.magento.com/guides/v2.3/graphql/search-pagination.html

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
