### PR TITLE
Fix #3697 legacy architecture note

### DIFF
--- a/_includes/cloud/note-pro-legacy.md
+++ b/_includes/cloud/note-pro-legacy.md
@@ -1,2 +1,2 @@
 {: .bs-callout .bs-callout-warning}
-For Pro projects **created before October 23, 2017**, the architecture is slightly different. See [Pro architecture (legacy)]({{ page.baseurl }}/cloud/architecture/pro-architecture-legacy.html).
+Originally, Pro projects were provisioned using a [different architecture]({{ page.baseurl }}/cloud/architecture/pro-architecture-legacy.html). To upgrade a Pro project that was **created before October 23, 2017**, contact your Customer Success Manager.

--- a/guides/v2.1/cloud/trouble/pro-env-management.md
+++ b/guides/v2.1/cloud/trouble/pro-env-management.md
@@ -8,7 +8,7 @@ Previously, you accessed Pro Staging and Production environments by using an SSH
 To add these environments to the Project Web Interface, review this entire document, complete a few preparatory steps, and submit a ticket. Your ticket is added to a queue for updating _existing_ Pro projects. The process may take time to complete, so check your ticket for details, timing, and other important information.
 
 {:.bs-callout .bs-callout-info}
-The Staging and Production environments for **New projects provisioned October 23, 2017 and later** are in the Project Web Interface. You must contact your Customer Success Manager to convert a project created before this date.
+The Staging and Production environments for **New projects provisioned October 23, 2017 and later** are in the Project Web UI. You must contact your Customer Success Manager to convert a project created before this date.
  
 ## New Features
 

--- a/guides/v2.1/cloud/trouble/pro-env-management.md
+++ b/guides/v2.1/cloud/trouble/pro-env-management.md
@@ -7,8 +7,9 @@ Previously, you accessed Pro Staging and Production environments by using an SSH
 
 To add these environments to the Project Web Interface, review this entire document, complete a few preparatory steps, and submit a ticket. Your ticket is added to a queue for updating _existing_ Pro projects. The process may take time to complete, so check your ticket for details, timing, and other important information.
 
-{% include note.html type="info" content="The Staging and Production environments for **New projects provisioned October 23, 2017 and later** are in the Project Web Interface. You must submit a ticket to convert a project created before this date." %}
-
+{:.bs-callout .bs-callout-info}
+The Staging and Production environments for **New projects provisioned October 23, 2017 and later** are in the Project Web Interface. You must contact your Customer Success Manager to convert a project created before this date.
+ 
 ## New Features
 
 The new Project Web Interface provides the following features for the Pro plan Staging and Production environments:


### PR DESCRIPTION
Updated a repeating note about the legacy architecture, per request in GitHub issue 3697.
Corrected an instance where submit a ticket phrase was not entirely appropriate.

The note appears in the [Pro Architecture topic](https://devdocs.magento.com/guides/v2.2/cloud/architecture/pro-architecture.html).