### PR TITLE
Added a link to the ChromeiQL extension + typo fix

### DIFF
--- a/guides/v2.1/install-gde/install/cli/install-cli-subcommands-admin.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-subcommands-admin.md
@@ -41,7 +41,7 @@ Where the following table defines parameters and values:
 |`--admin-email`|Magento administrator user's e-mail address.|Yes|
 |`--admin-user`|Magento administrator username.|Yes|
 |`--admin-password`|Magento administrator user password. The password must be at least 7 characters in length and must include at least one alphabetic and at least one numeric character. <br><br>We recommend a longer, more complex password. Enclose the entire password string in single quotes. For example, `--admin-password='A0b9%t3g'`.|Yes|
-|`--magento-init-params`|Add to any command to customize Magneto initialization parameters<br/><br/>For example: `MAGE_MODE=developer&MAGE_DIRS[base][path]=/var/www/example.com&MAGE_DIRS[cache][path]=/var/tmp/cache`|No|
+|`--magento-init-params`|Add to any command to customize Magento initialization parameters<br/><br/>For example: `MAGE_MODE=developer&MAGE_DIRS[base][path]=/var/www/example.com&MAGE_DIRS[cache][path]=/var/tmp/cache`|No|
 {:style="table-layout:auto;"}
 
 ## Unlock an administrator account

--- a/guides/v2.3/graphql/index.md
+++ b/guides/v2.3/graphql/index.md
@@ -47,7 +47,7 @@ In the near future, we'll roll out the following features:
 
 ## How to access GraphQL
 
-GraphiQL is an in-browser tool for writing, validating, and testing GraphQL queries. You can download an extension from your browser's app store. The following image shows a sample query, its response, and the GraphQL browser
+GraphiQL is an in-browser tool for writing, validating, and testing GraphQL queries. You can download an extension from your browser's app store. For the Google Chrome browser, the [ChromeiQL extension](https://chrome.google.com/webstore/detail/chromeiql/fkkiamalmpiidkljmicmjfbieiclmeij?hl=en) will do the job. The following image shows a sample query, its response, and the GraphQL browser
 
 ![GraphiQL browser]({{ page.baseurl }}/graphql/images/graphql-browser.png)
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add a link to the ChromeiQL browser extension to the GraphQL overview page + fixed a typo Magneto -> Magento

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/
- https://devdocs.magento.com/guides/v2.1/install-gde/install/cli/install-cli-subcommands-admin.html