### PR TITLE
MAGEDOC-2761: Fix WEBSITES env var syntax

### DIFF
--- a/guides/v2.1/config-guide/prod/config-reference-var-name.md
+++ b/guides/v2.1/config-guide/prod/config-reference-var-name.md
@@ -107,7 +107,7 @@ The following table summarizes how to find website or store view value in the Ad
 | Description  | Path in Magento Admin | Variable name |
 |--------------|--------------|----------------------|
 | Create, edit, delete store views | **Stores** > **All Stores** | `CONFIG__STORES__<STORE_VIEW_CODE>__<SYSTEM__VARIABLE__NAME>`  |
-| Create, edit, delete websites | **Stores** > **All Stores**  | `CONFIG__WEBSITE__<WEBSITE_CODE>__<SYSTEM__VARIABLE__NAME>` |
+| Create, edit, delete websites | **Stores** > **All Stores**  | `CONFIG__WEBSITES__<WEBSITE_CODE>__<SYSTEM__VARIABLE__NAME>` |
 
 For example, to find a website or store view scope value in the Admin:
 
@@ -203,10 +203,10 @@ To find the variable name for the shipping country origin:
 
 	Find the scope in the [database](#deploy-system-vars-scopes) as discussed in Step 1: Find the website or store view scope value. (You can also find the value in the Admin as shown in the [table in Step 2: Set global, website, or store view variables](#cloud-system-vars-sys).
 
-	For example, the scope might be `CONFIG__WEBSITE__DEFAULT`.
+	For example, the scope might be `CONFIG__WEBSITES__DEFAULT`.
 2.	The rest of the variable name is `SHIPPING__ORIGIN__COUNTRY_ID`.
 
-**Result**: The variable name is `CONFIG__WEBSITE__DEFAULT__SHIPPING__ORIGIN__COUNTRY_ID`
+**Result**: The variable name is `CONFIG__WEBSITES__DEFAULT__SHIPPING__ORIGIN__COUNTRY_ID`
 
 ## How to use environment variables
 

--- a/guides/v2.2/config-guide/prod/config-reference-var-name.md
+++ b/guides/v2.2/config-guide/prod/config-reference-var-name.md
@@ -103,7 +103,7 @@ The following table summarizes how to find website or store view value in the Ad
 | Description  | Path in Magento Admin | Variable name |
 |--------------|--------------|----------------------|
 | Create, edit, delete store views | **Stores** > **All Stores** | `CONFIG__STORES__<STORE_VIEW_CODE>__<SYSTEM__VARIABLE__NAME>`  |
-| Create, edit, delete websites | **Stores** > **All Stores**  | `CONFIG__WEBSITE__<WEBSITE_CODE>__<SYSTEM__VARIABLE__NAME>` |
+| Create, edit, delete websites | **Stores** > **All Stores**  | `CONFIG__WEBSITES__<WEBSITE_CODE>__<SYSTEM__VARIABLE__NAME>` |
 
 For example, to find a website or store view scope value in the Admin:
 
@@ -199,10 +199,10 @@ To find the variable name for the shipping country origin:
 
 	Find the scope in the [database](#deploy-system-vars-scopes) as discussed in Step 1: Find the website or store view scope value. (You can also find the value in the Admin as shown in the [table in Step 2: Set global, website, or store view variables](#cloud-system-vars-sys).
 
-	For example, the scope might be `CONFIG__WEBSITE__DEFAULT`.
+	For example, the scope might be `CONFIG__WEBSITES__DEFAULT`.
 2.	The rest of the variable name is `SHIPPING__ORIGIN__COUNTRY_ID`.
 
-**Result**: The variable name is `CONFIG__WEBSITE__DEFAULT__SHIPPING__ORIGIN__COUNTRY_ID`
+**Result**: The variable name is `CONFIG__WEBSITES__DEFAULT__SHIPPING__ORIGIN__COUNTRY_ID`
 
 ## How to use environment variables
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix an inconsistency in the naming convention for WEBSITES scope environment variable names. The scope must be the plural form of the word "WEBSITES"; not the singular "WEBSITE".

This entire topic could use a rewrite, but that would take a lot longer than fixing this bug.
<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/config-guide/prod/config-reference-var-name.html#find-a-website-or-store-view-scope-in-the-magento-admin
- https://devdocs.magento.com/guides/v2.2/config-guide/prod/config-reference-var-name.html#find-a-website-or-store-view-scope-in-the-magento-admin
- https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-var-name.html#find-a-website-or-store-view-scope-in-the-magento-admin

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
