### PR TITLE
Correct usage of "Recovery Time Objective" term

### DIFF
--- a/guides/v2.0/cloud/architecture/pro-architecture.md
+++ b/guides/v2.0/cloud/architecture/pro-architecture.md
@@ -141,7 +141,7 @@ Weeks 12 to 22 | One backup per month
 {{site.data.var.ece}} creates the backup using snapshots to encrypted elastic block storage (EBS) volumes. An EBS snapshot is immediate, but the time it takes to write to the simple storage service (S3) depends on the volume of changes.
 
 -  **Recovery Point Objective (RPO)**—is 6 hours (maximum time to last backup).
--  **Recover Time Objective (RTO)**—depends on the size of the storage. Large EBS volumes take more time to restore.
+-  **Recovery Time Objective (RTO)**—depends on the size of the storage. Large EBS volumes take more time to restore.
 
 ### Production technology stack
 

--- a/guides/v2.1/cloud/architecture/pro-architecture.md
+++ b/guides/v2.1/cloud/architecture/pro-architecture.md
@@ -150,7 +150,7 @@ Weeks 12 to 22 | One backup per month
 
 -  **Recovery Point Objective (RPO)**—is 1 hour for the first 24 hours; after
 the initial period, the RPO is 6 hours (maximum time to last backup).
--  **Recover Time Objective (RTO)**—depends on the size of the storage. Large
+-  **Recovery Time Objective (RTO)**—depends on the size of the storage. Large
 EBS volumes take more time to restore.
 
 ### Production technology stack


### PR DESCRIPTION
Also submitted a PR for the 2.1 version of this page: https://github.com/magento/devdocs/pull/3769

## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will... Update the page to use the proper term. See [Wikipedia for verification](https://en.wikipedia.org/wiki/Disaster_recovery#Recovery_time_objective).

## Additional information

Affects https://devdocs.magento.com/guides/v2.2/cloud/architecture/pro-architecture.html