### PR TITLE
MAGECLOUD-2925: Added release item for logging updates

### DIFF
--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -20,8 +20,7 @@ stage:
 -  **Default**— `index.php`
 -  **Version**—Magento 2.1.4 and later
 
-Customize the list of pages used to preload the cache in the `post_deploy` stage.
-
+Customize the list of pages used to preload the cache in the `post_deploy` stage. 
 ```yaml
 stage:
   post-deploy: 
@@ -29,3 +28,5 @@ stage:
        - "index.php"
        - "index.php/customer/account/create"
 ```
+
+If your project is configured with [multiple domains]({{ page.baseurl }}/cloud/project/project-multi-sites.html), the cache is preloaded for pages on all domains.

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -46,6 +46,8 @@ The release notes include:
     
 -   {:.new}<!-- MAGECLOUD-2392 -->**Upgrade improvement**—Added validation to confirm that the `autoload` property in the `composer.json` file contains required configuration changes before upgrading to {{ site.data.var.ee }} v2.3. See [Upgrade Magento version]({{site.baseurl }}/guides/v2.3/cloud/project/project-upgrade.html).
 
+-   {:.fix}<!-- MAGECLOUD-3104 -->Fixed a compression issue when generating assets during builds by moving the compression task to the beginning of the `build:transfer` section of the build phase.
+
 -   {:.fix}<!-- MAGECLOUD-3035 -->Fixed a database connection error that occurred during deployment immediately after configuring an additional database and service relationship.
 
 -   {:.fix}<!-- MAGECLOUD-3003 -->Fixed a validation issue with the database configuration that caused the deploy process to fail.

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -65,16 +65,20 @@ The release notes include:
     -   Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use environment variables (`ADMIN_EMAIL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`) to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
 
     -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
+	
+-  {:.new}**New environment variables**—
+
+    -  <!-- MAGECLOUD-3026 & MAGECLOUD-2963-->**[RESOURCE_CONFIGURATION deploy environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#resource_configuration)**—Use this variable to map a resource name to a database connection. 
+
+    -  <!-- MAGECLOUD-3048 -->**[X_FRAME_CONFIGURATION global environment variable]({{ page.baseurl }}/cloud/env/variables-global.html#x_frame_configuration)**—Use this variable to change the `X-Frame-Options` header configuration for rendering a {{ site.data.var.ee }} page in a `<frame>`, `<iframe>`, or `<object>`.
 
 -   {:.fix}**Environment variable updates**—Changed the following environment variables:
 
-    -  {:.new}<!-- MAGECLOUD-3026 & MAGECLOUD-2963-->Added the [RESOURCE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#resource_configuration) to map a resource name to a database connection.
+    -  <!-- MAGECLOUD-2466 -->**[WARM_UP_PAGES post-deploy variable]({{ page.baseurl}}/cloud/env/variables-post-deploy.html)**—Added the capability to preload the cache for specified pages on all domains defined for a {{ site.data.var.ee }} store. Previously, if your site was configured with multiple domains, the post-deploy process failed to preload the cache for the specified pages on non-default domains and returned the following error in the post-deploy log: `ERROR: Warming up failed: <uri>`. 
 
-    -  {:.new}<!-- MAGECLOUD-3048 -->Added the [X_FRAME_CONFIGURATION environment variable]({{ page.baseurl }}/cloud/env/variables-global.html#X_FRAME_CONFIGURATION) to change the `X-Frame-Options` header configuration for rendering a {{ site.data.var.ee }} page in a `<frame>`, `<iframe>`, or `<object>`.
+    -   <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
 
-    -   <!-- MAGECLOUD-2823 -->Updated the `SCD_COMPRESSION_LEVEL` environment variable default values for the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{page.baseurl}}/cloud/env/variables-deploy.html).
-
-    -   <!-- MAGECLOUD-2904 -->Fixed the validation process to prevent a problem that occurred when SCD_MATRIX ignored a theme value that contained different character cases.
+    -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
 
 ## v2002.0.15
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -82,11 +82,11 @@ The release notes include:
 
     -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
 	
-    -   <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
-		
-		-  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+    -  <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
 
-       -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
+       -  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+
+        -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
 
 ## v2002.0.15
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -60,11 +60,13 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-2747 -->Fixed a connection error that occurred during deployment immediately after disabling the Redis service.
 
--   {:.fix}<!-- MAGECLOUD-2573/MAGECLOUD-2848 -->**Changes to ADMIN environment variable behavior**- 
+-   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the [log level]({{ page.baseurl }}/cloud//env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
 
-    -   Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use environment variables (`ADMIN_EMAIL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`) to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
-
-    -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
+    -  Begin and end of the process for reconciling installed modules in `composer.json` with shared configuration settings in the ` app/etc/config.php` file
+	
+	-  Begin and end of the configuration validation process
+	
+	-  Begin and end of the `setup:di:compile` process for generating classes
 	
 -  {:.new}**New environment variables**—
 
@@ -79,6 +81,12 @@ The release notes include:
     -   <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
 
     -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
+	
+    -   <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
+		
+		-  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+
+       -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
 
 ## v2002.0.15
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -60,7 +60,7 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-2747 -->Fixed a connection error that occurred during deployment immediately after disabling the Redis service.
 
--   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the [log level]({{ page.baseurl }}/cloud//env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
+-   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the [log level]({{ page.baseurl }}/cloud/env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
 
     -  Begin and end of the process for reconciling installed modules in `composer.json` with shared configuration settings in the ` app/etc/config.php` file
 	

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -59,12 +59,13 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-2747 -->Fixed a connection error that occurred during deployment immediately after disabling the Redis service.
 
--   {:.fix}<!-- MAGECLOUD-2573/MAGECLOUD-2848 -->**Changes to ADMIN environment variable behavior**—
+-   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the Updated the [log level]({{ page.baseurl }}/cloud//env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
 
-    -   Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use environment variables (`ADMIN_EMAIL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`) to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
-
-    -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
-
+    -  Begin and end of the process for reconciling installed modules in `composer.json` with shared configuration settings in the ` app/etc/config.php` file
+	
+	-  Begin and end of the configuration validation process
+	
+	-  Begin and end of the `setup:di:compile` process for generating classes
 
 -  {:.new}**New environment variables**—
 
@@ -79,6 +80,13 @@ The release notes include:
     -   <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
 
     -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
+	
+    -   <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
+		
+		-  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+
+       -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
+
 
 ## v2002.0.15
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -77,15 +77,15 @@ The release notes include:
 
     -  <!-- MAGECLOUD-2466 -->**[WARM_UP_PAGES post-deploy variable]({{ page.baseurl}}/cloud/env/variables-post-deploy.html)**—Added the capability to preload the cache for specified pages on all domains defined for a {{ site.data.var.ee }} store. Previously, if your site was configured with multiple domains, the post-deploy process failed to preload the cache for the specified pages on non-default domains and returned the following error in the post-deploy log: `ERROR: Warming up failed: <uri>`. 
 
-    -   <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
+    -  <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
 
-    -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
-	
-    -   <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
-		
-		-  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+    -  <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
 
-       -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
+    -  <!--MAGECLOUD-2573/MAGECLOUD-2848 --> **ADMIN variables**—
+
+       -  Improved security when managing credentials for the Magento Admin user using environment variables. You can no longer use the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` environment variables to override admin credentials during upgrades. If you cannot access the Admin panel, use the *Forgot password* feature or the Magento CLI `admin:user:create` command to create a new admin user. See [Access your Magento Admin panel]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin).
+
+        -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
 
 
 ## v2002.0.15

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -65,15 +65,20 @@ The release notes include:
 
     -   ADMIN_EMAIL is no longer required when upgrading or applying patches.
 
+
+-  {:.new}**New environment variables**—
+
+    -  <!-- MAGECLOUD-3026 & MAGECLOUD-2963-->**[RESOURCE_CONFIGURATION deploy environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#resource_configuration)**—Use this variable to map a resource name to a database connection. 
+
+    -  <!-- MAGECLOUD-3048 -->**[X_FRAME_CONFIGURATION global environment variable]({{ page.baseurl }}/cloud/env/variables-global.html#x_frame_configuration)**—Use this variable to change the `X-Frame-Options` header configuration for rendering a {{ site.data.var.ee }} page in a `<frame>`, `<iframe>`, or `<object>`.
+
 -   {:.fix}**Environment variable updates**—Changed the following environment variables:
 
-    -  {:.new}<!-- MAGECLOUD-3026 & MAGECLOUD-2963-->Added the [RESOURCE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#resource_configuration) to map a resource name to a database connection.
+    -  <!-- MAGECLOUD-2466 -->**[WARM_UP_PAGES post-deploy variable]({{ page.baseurl}}/cloud/env/variables-post-deploy.html)**—Added the capability to preload the cache for specified pages on all domains defined for a {{ site.data.var.ee }} store. Previously, if your site was configured with multiple domains, the post-deploy process failed to preload the cache for the specified pages on non-default domains and returned the following error in the post-deploy log: `ERROR: Warming up failed: <uri>`. 
 
-    -  {:.new}<!-- MAGECLOUD-3048 -->Added the [X_FRAME_CONFIGURATION environment variable]({{ page.baseurl }}/cloud/env/variables-global.html#X_FRAME_CONFIGURATION) to change the `X-Frame-Options` header configuration for rendering a {{ site.data.var.ee }} page in a `<frame>`, `<iframe>`, or `<object>`.
+    -   <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL build and deploy variable**—Updated the default values for SCD compression level on the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{ page.baseurl }}/cloud/env/variables-deploy.html).
 
-    -   <!-- MAGECLOUD-2823 -->Updated the `SCD_COMPRESSION_LEVEL` environment variable default values for the [build stage]({{page.baseurl}}/cloud/env/variables-build.html) and the [deploy stage]({{page.baseurl}}/cloud/env/variables-deploy.html).
-
-    -   <!-- MAGECLOUD-2904 -->Fixed the validation process to prevent a problem that occurred when SCD_MATRIX ignored a theme value that contained different character cases.
+    -   <!-- MAGECLOUD-2904 -->**SCD_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases.
 
 ## v2002.0.15
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -59,7 +59,7 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-2747 -->Fixed a connection error that occurred during deployment immediately after disabling the Redis service.
 
--   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the Updated the [log level]({{ page.baseurl }}/cloud//env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
+-   {:.new}<!--MAGECLOUD-2925-->**Logging changes**—Updated the Updated the [log level]({{ page.baseurl }}/cloud/env/log-handlers.html#log-levels) for the following build and deploy process events from `Info` to `Notice`:
 
     -  Begin and end of the process for reconciling installed modules in `composer.json` with shared configuration settings in the ` app/etc/config.php` file
 	

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -45,6 +45,8 @@ The release notes include:
 
 -   {:.new}<!-- MAGECLOUD-2392 -->**Upgrade improvement**—Added validation to confirm that the `autoload` property in the `composer.json` file contains required configuration changes before upgrading to {{ site.data.var.ee }} v2.3. See [Upgrade Magento version]({{site.baseurl }}/guides/v2.3/cloud/project/project-upgrade.html).
 
+-   {:.fix}<!-- MAGECLOUD-3104 -->Fixed a compression issue when generating assets during the build phase by moving the compression task to the beginning of the `build:transfer` section of the build phase.
+
 -   {:.fix}<!-- MAGECLOUD-3035 -->Fixed a database connection error that occurred during deployment immediately after configuring an additional database and service relationship.
 
 -   {:.fix}<!-- MAGECLOUD-3003 -->Fixed a validation issue with the database configuration that caused the deploy process to fail.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

Adds release note for Magento Commerce Cloud logging updates in ece-tools v 2002.0.16.

*Affected URLs*
- https://devdocs.magento.com/guides/v2.1/cloud/release-notes/cloud-tools.html
- https://devdocs.magento.com/guides/v2.2/cloud/release-notes/cloud-tools.html
- https://devdocs.magento.com/guides/v2.3/cloud/release-notes/cloud-tools.html