### PR TITLE
MAGEDOC-3133: Algolia index config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -180,7 +180,7 @@ algolia:
     - redoc
   # Index HTML elements, especially code samples.
   nodes_to_index: 'p,li,td,code'
-  # Override 10KB default and use our aloowed max of 20KB
+  # Override 10KB default and use our allowed max of 20KB
   max_record_size: 20000
 
 google:

--- a/_config.yml
+++ b/_config.yml
@@ -180,8 +180,8 @@ algolia:
     - redoc
   # Index HTML elements, especially code samples.
   nodes_to_index: 'p,li,td,code'
-  # Indexing fails if this isn't set because some of our records are very large.
-  max_record_size: 400000
+  # Override 10KB default and use our aloowed max of 20KB
+  max_record_size: 20000
 
 google:
   analytics: UA-66243208-1

--- a/_plugins/algolia.rb
+++ b/_plugins/algolia.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  module Algolia
+    module Hooks
+      def self.before_indexing_each(record, node, context)
+        # Do not index records larger thatn 20000 bytes
+        return nil if record.to_s.bytesize > 20000
+        
+        record
+      end
+    end
+  end
+end

--- a/_plugins/algolia.rb
+++ b/_plugins/algolia.rb
@@ -2,7 +2,7 @@ module Jekyll
   module Algolia
     module Hooks
       def self.before_indexing_each(record, node, context)
-        # Do not index records larger thatn 20000 bytes
+        # Do not index records larger than 20000 bytes
         return nil if record.to_s.bytesize > 20000
         
         record


### PR DESCRIPTION
## This PR is a:

- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add custom plugin to restrict Algolia indexing to files less than or equal to 20kb.

<!-- (REQUIRED) What does this PR change? -->
<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
