### PR TITLE
MAGECLOUD-2870: Static assets compression shouldn't break a deploy

### DIFF
--- a/guides/v2.1/cloud/env/variables-build.md
+++ b/guides/v2.1/cloud/env/variables-build.md
@@ -32,6 +32,19 @@ stage:
     SCD_COMPRESSION_LEVEL: 4
 ```
 
+### `SCD_COMPRESSION_TIMEOUT`
+
+-  **Default**—`600`
+-  **Version**—Magento 2.1.4 and later
+
+Specifies maximum execution time, in seconds, for static content compression command. Compression command will be interrupted if not finished until timeout.
+
+```yaml
+stage:
+  build:
+    SCD_COMPRESSION_TIMEOUT: 800
+```
+
 ### `SCD_EXCLUDE_THEMES`
 
 {: .bs-callout .bs-callout-warning }

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -242,6 +242,19 @@ stage:
     SCD_COMPRESSION_LEVEL: 5
 ```
 
+### `SCD_COMPRESSION_TIMEOUT`
+
+-  **Default**—`600`
+-  **Version**—Magento 2.1.4 and later
+
+Specifies maximum execution time, in seconds, for static content compression command. Compression command will be interrupted if not finished until timeout.
+
+```yaml
+stage:
+  deploy:
+    SCD_COMPRESSION_TIMEOUT: 800
+```
+
 ### `SCD_EXCLUDE_THEMES` 
 
 {: .bs-callout .bs-callout-warning }

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -37,6 +37,19 @@ stage:
     SCD_COMPRESSION_LEVEL: 4
 ```
 
+### `SCD_COMPRESSION_TIMEOUT`
+
+-  **Default**—`600`
+-  **Version**—Magento 2.1.4 and later
+
+Specifies maximum execution time, in seconds, for static content compression command. Compression command will be interrupted if not finished until timeout.
+
+```yaml
+stage:
+  build:
+    SCD_COMPRESSION_TIMEOUT: 800
+```
+
 ### `SCD_EXCLUDE_THEMES`
 
 {: .bs-callout .bs-callout-warning }

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -259,6 +259,19 @@ stage:
     SCD_COMPRESSION_LEVEL: 5
 ```
 
+### `SCD_COMPRESSION_TIMEOUT`
+
+-  **Default**—`600`
+-  **Version**—Magento 2.1.4 and later
+
+Specifies maximum execution time, in seconds, for static content compression command. Compression command will be interrupted if not finished until timeout.
+
+```yaml
+stage:
+  deploy:
+    SCD_COMPRESSION_TIMEOUT: 800
+```
+
 ### `SCD_EXCLUDE_THEMES`
 
 {: .bs-callout .bs-callout-warning }


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will add information about new variable SCD_COMPRESSION_TIMEOUT

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.1/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.1/cloud/env/variables-build.html
- https://devdocs.magento.com/guides/v2.2/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.2/cloud/env/variables-build.html
- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-build.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
