### PR TITLE
Fixed wrong data type of quantity field

### DIFF
--- a/guides/v2.2/rest/modules/catalog-pricing.md
+++ b/guides/v2.2/rest/modules/catalog-pricing.md
@@ -220,7 +220,7 @@ Name | Description | Format | Requirements
 `sku` | The SKU of the product | string | Required to set, update, or delete a tier price
 `skus` | An array of SKU values that is specified when retrieving a list of tier prices | array | Required for retrievals
 `customer_group` |  A specific customer group that qualifies to receive the tier price discount | string | Required to set, update, or delete a tier price
-`quantity` | The quantity that must be purchased to receive the tier price | integer | Required to set, update, or delete a tier price
+`quantity` | The quantity that must be purchased to receive the tier price | float | Required to set, update, or delete a tier price
 {:style="table-layout:auto;"}
 
 ### Set tier prices


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will show correct data type of quantity field on Manage special prices.
[Codebase File 2.2](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Api/Data/TierPriceInterface.php#L114)
[Codebase File 2.3](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Api/Data/TierPriceInterface.php#L114)
<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/rest/modules/catalog-pricing.html#manage-tier-prices
- https://devdocs.magento.com/guides/v2.3/rest/modules/catalog-pricing.html#manage-tier-prices

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
