### PR TITLE
Alphabetize GraphQL attributes

### DIFF
--- a/guides/v2.3/graphql/reference/bundle-product.md
+++ b/guides/v2.3/graphql/reference/bundle-product.md
@@ -9,38 +9,38 @@ The `BundleProduct` endpoint defines which bundle product-specific attributes ar
 
 Field | Type | Description
 --- | --- | ---
-`price_view` | PriceViewEnum | One of PRICE_RANGE or AS_LOW_AS
 `dynamic_price` | Boolean | Indicates whether the bundle product has a dynamic price
 `dynamic_sku` | Boolean | Indicates whether the bundle product has a dynamic SKU
-`ship_bundle_items` | ShipBundleItemsEnum | Indicates whether to ship bundle items together or individually
 `dynamic_weight` | Boolean | Indicates whether the bundle product has a dynamically calculated weight
 `items` | BundleItem | An array containing information about individual bundle items
+`price_view` | PriceViewEnum | One of PRICE_RANGE or AS_LOW_AS
+`ship_bundle_items` | ShipBundleItemsEnum | Indicates whether to ship bundle items together or individually
 
 ## BundleItem object
 
 Field | Type | Description
 --- | --- | ---
 `option_id` | Int | An ID assigned to each type of item in a bundle product
-`title` | String | The display name of the item
-`required` | Boolean | Indicates whether the item must be included in the bundle
-`type` | String | The input type that the customer uses to select the item. Examples include radio button and checkbox.
-`position` | Int | The relative position of this item compared to the other bundle items
-`sku` | String | The SKU of the bundle product
 `options`  | BundleItemOption | An array of additional options for this bundle item
+`position` | Int | The relative position of this item compared to the other bundle items
+`required` | Boolean | Indicates whether the item must be included in the bundle
+`sku` | String | The SKU of the bundle product
+`title` | String | The display name of the item
+`type` | String | The input type that the customer uses to select the item. Examples include radio button and checkbox.
 
 ##  BundleItemOption object
 
 Field | Type | Description
 --- | --- | ---
-`id` | Int | The ID assigned to the bundled item option
-`label` | String | The text that identifies the bundled item option
-`qty` | Float | Indicates the quantity of this specific bundle item
-`position` | Int | When a bundle item contains multiple options, the relative position of this option compared to the other options
-`is_default` | Boolean | Indicates whether this option is the default option
-`price` | Float | The price of the selected option
-`price_type` | PriceTypeEnum | One of FIXED, PERCENT, or DYNAMIC
 `can_change_quantity` | Boolean | Indicates whether the customer can change the number of items for this option
+`id` | Int | The ID assigned to the bundled item option
+`is_default` | Boolean | Indicates whether this option is the default option
+`label` | String | The text that identifies the bundled item option
+`position` | Int | When a bundle item contains multiple options, the relative position of this option compared to the other options
+`price_type` | PriceTypeEnum | One of FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price of the selected option
 `product` | ProductInterface | The ProductInterface object, which contains details about this product option
+`qty` | Float | Indicates the quantity of this specific bundle item
 
 ## Sample Query
 

--- a/guides/v2.3/graphql/reference/categories.md
+++ b/guides/v2.3/graphql/reference/categories.md
@@ -3,7 +3,7 @@ group: graphql
 title: category endpoint
 ---
 
-The `category` endpoint allows you to search for a single category definition or the entire category tree. To return multiple category levels in a single call, define the response so that it contains up to ten nested `children` options. You cannot return the entire category tree if it contains more than 10 sublevels unless the `queryDepth` parameter in the GraphQL `di.xml` file has been reconfigured. 
+The `category` endpoint allows you to search for a single category definition or the entire category tree. To return multiple category levels in a single call, define the response so that it contains up to ten nested `children` options. You cannot return the entire category tree if it contains more than 10 sublevels unless the `queryDepth` parameter in the GraphQL `di.xml` file has been reconfigured.
 
 ## Query structure
 
@@ -25,22 +25,22 @@ The query returns a `CategoryTree` object, which implements `CategoryInterface`.
 
 Attribute | Data type | Description
 --- | --- | ---
-`id` | Int | An ID that uniquely identifies the category
-`description`| String | An optional description of the category
-`name`| String | The display name of the category
-`path`| String | The path to the category, as a string of category IDs, separated by slashes (/). For example, `1/2/20`
-`path_in_store`| String | Category path in the store
-`url_key`| String | The url key assigned to the category
-`url_path`| String | The url path assigned to the category
-`position`| Int | The position of the category relative to other categories at the same level in tree
-`level` | Int | Indicates the depth of the category within the tree
-`created_at`| String | Timestamp indicating when the category was created
-`updated_at`| String | Timestamp indicating when the category was updated
-`product_count`| Int | The number of products in the category
-`default_sort_by`| String | The attribute to use for sorting
-`products(<attributes>)` | `CategoryProducts` | The list of products assigned to the category
 `breadcrumbs` | `Breadcrumb` | A `Breadcrumb` object contains information the categories that comprise the breadcrumb trail for the specified category
 `children` | `CategoryTree` | A `CategoryTree` object that contains information about a child category. You can specify up to 10 levels of child categories.
+`created_at`| String | Timestamp indicating when the category was created
+`default_sort_by`| String | The attribute to use for sorting
+`description`| String | An optional description of the category
+`id` | Int | An ID that uniquely identifies the category
+`level` | Int | Indicates the depth of the category within the tree
+`name`| String | The display name of the category
+`path_in_store`| String | Category path in the store
+`path`| String | The path to the category, as a string of category IDs, separated by slashes (/). For example, `1/2/20`
+`position`| Int | The position of the category relative to other categories at the same level in tree
+`product_count`| Int | The number of products in the category
+`products(<attributes>)` | `CategoryProducts` | The list of products assigned to the category
+`updated_at`| String | Timestamp indicating when the category was updated
+`url_key`| String | The url key assigned to the category
+`url_path`| String | The url path assigned to the category
 
 
 #### CategoryProducts object
@@ -49,8 +49,8 @@ The `products` attribute can contain the following attributes:
 
 Attribute | Data type | Description
 --- | --- | ---
-`pageSize` | Int | Specifies the maximum number of results to return at once. This attribute is optional. The default value is 20.
 `currentPage` | Int |  Specifies which page of results to return. The default value is 1.
+`pageSize` | Int | Specifies the maximum number of results to return at once. This attribute is optional. The default value is 20.
 `sort` | `ProductSortInput` | Specifies which attribute to sort on, and whether to return the results in ascending or descending order. [Searches and pagination in GraphQL]({{ page.baseurl }}/graphql/search-pagination.html) describes sort orders.
 
 The `CategoryProducts` object contains the following attributes:
@@ -70,8 +70,8 @@ store.
 Attribute | Data type | Description
 --- | --- | ---
 `category_id` | Int | An ID that uniquely identifies the category
-`category_name` | String |  The display name of the category
 `category_level` | Int | Indicates the depth of the category within the tree
+`category_name` | String |  The display name of the category
 `category_url_key` | String | The url key assigned to the category
 
 #### CategoryTree object

--- a/guides/v2.3/graphql/reference/configurable-product.md
+++ b/guides/v2.3/graphql/reference/configurable-product.md
@@ -16,14 +16,14 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`id` | Int | The configurable option ID number assigned by the system
-`attribute_id` | String | The ID assigned to the attribute
 `attribute_code` | String | A string that identifies the attribute
+`attribute_id` | String | The ID assigned to the attribute
+`id` | Int | The configurable option ID number assigned by the system
+`is_use_default` | Boolean | Indicates whether the option is the default
 `label` | String | A string that describes the configurable product option. It is displayed on the UI.
 `position` | Int | A number that indicates the order in which the attribute is displayed
-`is_use_default` | Boolean | Indicates whether the option is the default
-`values` | ConfigurableProductOptionsValues | An array that defines the value_index codes assigned to the configurable product
 `product_id` | Int | This is the same as a product's 'id' field
+`values` | ConfigurableProductOptionsValues | An array that defines the value_index codes assigned to the configurable product
 
 ## ConfigurableProductOptionsValues
 
@@ -35,7 +35,7 @@ Field | Type | Description
 
 The following query returns information about configurable product `WH01`, which is defined in the sample data.
 
-{% highlight json %}
+```text
 {
   products(filter: {sku: {eq: "WH01"}}) {
     items {
@@ -103,4 +103,4 @@ The following query returns information about configurable product `WH01`, which
     }
   }
 }
-{% endhighlight %}
+```

--- a/guides/v2.3/graphql/reference/custom-attribute-metadata.md
+++ b/guides/v2.3/graphql/reference/custom-attribute-metadata.md
@@ -10,9 +10,9 @@ The `customAttributeMetadata` endpoint returns the attribute type, given an attr
 Attribute |  Data Type | Description
 --- | --- | ---
 `attribute_code` | String | The unique identifier for an attribute code. This value should be in lowercase letters without spaces.
-`entity_type` | String | The type of entity that defines the attribute
-`attribute_type` | String | The data type of the attribute (Response only)
 `attribute_options` | `AttributeOption` | A list of attribute options
+`attribute_type` | String | The data type of the attribute (Response only)
+`entity_type` | String | The type of entity that defines the attribute
 {:style="table-layout:auto;"}
 
 ### AttributeOption object
@@ -29,7 +29,7 @@ The following query returns the attribute type for various custom and EAV attrib
 
 **Request**
 
-{% highlight json %}
+```text
 {
  customAttributeMetadata(
    attributes: {
@@ -48,11 +48,11 @@ The following query returns the attribute type for various custom and EAV attrib
    }
  }
 }
- {% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+```json
 {
   "data": {
     "customAttributeMetadata": {
@@ -128,4 +128,4 @@ The following query returns the attribute type for various custom and EAV attrib
     }
   }
 }
-{% endhighlight %}
+```

--- a/guides/v2.3/graphql/reference/customizable-option-interface.md
+++ b/guides/v2.3/graphql/reference/customizable-option-interface.md
@@ -21,9 +21,9 @@ Magento has not implemented all possible customizable product options for GraphQ
 
 Field | Type | Description
 --- | --- | ---
-`title` |  String | The display name for this option
 `required` | Boolean | Indicates whether the option is required
 `sort_order` | Int | The order in which the option is displayed
+`title` |  String | The display name for this option
 
 ## CustomizableAreaOption object
 
@@ -31,8 +31,8 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`value` | `CustomizableAreaValue` | An object that defines a text area
 `product_sku` | String | The Stock Keeping Unit of the base product
+`value` | `CustomizableAreaValue` | An object that defines a text area
 
 ### CustomizableAreaValue object
 
@@ -40,10 +40,10 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`price` | Float | The price assigned to this option
-`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
-`sku` | String | The Stock Keeping Unit for this option
 `max_characters` | Int | The maximum number of characters that can be entered for this customizable option
+`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price assigned to this option
+`sku` | String | The Stock Keeping Unit for this option
 
 ## CustomizableDateOption object
 
@@ -51,8 +51,8 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`value` | `CustomizableDateValue` | An object that defines a date field in a customizable option.
 `product_sku` | String | The Stock Keeping Unit of the base product
+`value` | `CustomizableDateValue` | An object that defines a date field in a customizable option.
 
 ### CustomizableDateValue object
 
@@ -79,11 +79,11 @@ Field | Type | Description
 Field | Type | Description
 --- | --- | ---
 `option_type_id` | Int | The ID assigned to the value
-`price` | Float | The price assigned to this option
 `price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price assigned to this option
 `sku` | String | The Stock Keeping Unit for this option
-`title` | String | The display name for this option
 `sort_order` | Int | The order in which the option is displayed
+`title` | String | The display name for this option
 
 ## CustomizableFieldOption object
 
@@ -91,8 +91,8 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`value` | `CustomizableFieldValue` | An object that defines a text field
 `product_sku` | String | The Stock Keeping Unit of the base product
+`value` | `CustomizableFieldValue` | An object that defines a text field
 
 ### CustomizableFieldValue object
 
@@ -100,10 +100,10 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`price` | Float | The price of the custom value
-`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
-`sku` | String | The Stock Keeping Unit for this option
 `max_characters` | Int | The maximum number of characters that can be entered for this customizable option
+`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price of the custom value
+`sku` | String | The Stock Keeping Unit for this option
 
 ## CustomizableFileOption object
 
@@ -111,8 +111,8 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`value` | `CustomizableFileValue` | An object that defines a file name
 `product_sku` | String | The Stock Keeping Unit of the base product
+`value` | `CustomizableFileValue` | An object that defines a file name
 
 ### CustomizableFileValue object
 
@@ -120,12 +120,12 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`price` | Float | The price assigned to this option
-`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
-`sku` | String | The Stock Keeping Unit for this option
 `file_extension` | String | The file extension to accept
 `image_size_x` | Int | The maximum width of an image
 `image_size_y` | Int | The maximum height of an image
+`price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price assigned to this option
+`sku` | String | The Stock Keeping Unit for this option
 
 ## CustomizableRadioOption object
 
@@ -142,10 +142,8 @@ Field | Type | Description
 Field | Type | Description
 --- | --- | ---
 `option_type_id` | Int | The ID assigned to the value
-`price` | Float | The price assigned to this option
 `price_type` | PriceTypeEnum | FIXED, PERCENT, or DYNAMIC
+`price` | Float | The price assigned to this option
 `sku` | String | The Stock Keeping Unit for this option
-`title` | String | The display name for this option
 `sort_order` | Int | The order in which the option is displayed
-
-## Example usage
+`title` | String | The display name for this option

--- a/guides/v2.3/graphql/reference/downloadable-product.md
+++ b/guides/v2.3/graphql/reference/downloadable-product.md
@@ -9,8 +9,8 @@ The `DownloadableProduct` endpoint defines which downloadable product-specific a
 
 Field | Type | Description
 --- | --- | ---
-`downloadable_product_samples` | `DownloadableProductSamples` | An array containing information about samples of this downloadable product
 `downloadable_product_links` | `DownloadableProductLinks` | An array containing information about the links for this downloadable product
+`downloadable_product_samples` | `DownloadableProductSamples` | An array containing information about samples of this downloadable product
 `links_purchased_separately` | Int | A value of 1 indicates that each link in the array must be purchased separately
 `links_title` | String | The heading above the list of downloadable products
 
@@ -19,32 +19,32 @@ Field | Type | Description
 Field | Type | Description
 --- | --- | ---
 `id` | Int | The unique ID for the downloadable product sample
-`title` | String | The display name of the sample
-`sort_order` | Int | A number indicating the sort order
-`sample_type` | DownloadableFileTypeEnum | Either FILE or URL
 `sample_file` | String | The relative path to the downloadable sample
+`sample_type` | DownloadableFileTypeEnum | Either FILE or URL
 `sample_url` | String | The relative URL to the downloadable sample
+`sort_order` | Int | A number indicating the sort order
+`title` | String | The display name of the sample
 
 ## DownloadableProductLinks object
 
 Field | Type | Description
 --- | --- | ---
 `id` | Int | The unique ID for the link to the downloadable product
-`title` | String | The display name of the link
-`sort_order` | Int | A number indicating the sort order
 `is_shareable` | Boolean | Indicates whether the link is shareable
-`price` | Float | The price of the downloadable product
-`number_of_downloads` | Int | The maximum number of times the product can be downloaded. A value of 0 means unlimited.
 `link_type` | DownloadableFileTypeEnum | Either FILE or URL
-`sample_type` | DownloadableFileTypeEnum | Either FILE or URL
+`number_of_downloads` | Int | The maximum number of times the product can be downloaded. A value of 0 means unlimited.
+`price` | Float | The price of the downloadable product
 `sample_file` | String | The relative path to the downloadable sample
+`sample_type` | DownloadableFileTypeEnum | Either FILE or URL
 `sample_url` | String | The relative URL to the downloadable sample
+`sort_order` | Int | A number indicating the sort order
+`title` | String | The display name of the link
 
 ## Sample Query
 
 The following query returns information about downloadable product `240-LV04`, which is defined in the sample data.
 
-{% highlight json %}
+```text
 {
   products(filter:
     {sku: {eq:"240-LV04"}}
@@ -89,4 +89,4 @@ The following query returns information about downloadable product `240-LV04`, w
        }
    }
 }
-{% endhighlight %}
+```

--- a/guides/v2.3/graphql/reference/gift-card-product.md
+++ b/guides/v2.3/graphql/reference/gift-card-product.md
@@ -9,34 +9,34 @@ The `GiftCardProduct` endpoint defines which gift card-specific attributes are r
 
 Field | Type | Description
 --- | --- | ---
-`giftcard_amounts` |  `GiftCardAmounts` | An array that contains information about the values and ID of a gift card.
+`allow_message` | Boolean | Indicates whether the customer can provide a message to accompany the gift card.
 `allow_open_amount` | Boolean | Indicates whether customers have the ability to set the value of the gift card.
-`open_amount_min` | Float | The minimum acceptable value of an open amount gift card.
-`open_amount_max` | Float | The maximum acceptable value of an open amount gift card.
+`color` | Int | The color of the product
+`giftcard_amounts` |  `GiftCardAmounts` | An array that contains information about the values and ID of a gift card.
 `giftcard_type`"  | `GiftCardTypeEnum` | Either VIRTUAL, PHYSICAL, or COMBINED
 `is_redeemable` | Boolean | Indicates whether the customer can redeem the value on the card for cash.
 `lifetime` | Int | The number of days after purchase until the gift card expires. A null value means there is no limit.
-`allow_message` | Boolean | Indicates whether the customer can provide a message to accompany the gift card.
-`message_max_length` | Int | The maximum number of characters a gift card message can contain
-`color` | Int | The color of the product
-`size` |  String | The size of the product
 `manufacturer` | Int | The manufacturer of the product
+`message_max_length` | Int | The maximum number of characters a gift card message can contain
+`open_amount_max` | Float | The maximum acceptable value of an open amount gift card.
+`open_amount_min` | Float | The minimum acceptable value of an open amount gift card.
+`size` |  String | The size of the product
 
 ## GiftCardAmounts object
 
 Field | Type | Description
 --- | --- | ---
-`value_id` | Int | An ID that is  assigned to each unique gift card amount.
-website_id` | Int | ID of the website that generated the gift card
-`value` | Float | The value of the gift card
 `attribute_id` | Int | An internal attribute ID.
+`value_id` | Int | An ID that is  assigned to each unique gift card amount.
+`value` | Float | The value of the gift card
 `website_value` | Float |The value of the gift card
+`website_id` | Int | ID of the website that generated the gift card
 
 ## Sample Query
 
 The following query returns information about gift card product `GiftCard25`. (It is not defined in the sample data.)
 
-{% highlight json %}
+``` text
 {
    products(filter: {sku: {eq: "GiftCard25"}})
    {
@@ -65,4 +65,4 @@ The following query returns information about gift card product `GiftCard25`. (I
        }
    }
 }
-{% endhighlight %}
+```

--- a/guides/v2.3/graphql/reference/grouped-product.md
+++ b/guides/v2.3/graphql/reference/grouped-product.md
@@ -15,15 +15,15 @@ Field | Type | Description
 
 Field | Type | Description
 --- | --- | ---
-`qty` | Float | The quantity of this grouped product item
 `position` | Int | The relative position of this item compared to the other group items
 `product` | `ProductInterface` | The ProductInterface object, which contains details about this product option
+`qty` | Float | The quantity of this grouped product item
 
 ## Sample Query
 
 The following query returns information about downloadable product `24-WG085_Group`, which is defined in the sample data.
 
-{% highlight json %}
+``` text
 {
   products(filter:
     {sku: {eq: "24-WG085_Group"}}
@@ -49,4 +49,4 @@ The following query returns information about downloadable product `24-WG085_Gro
     }
   }
 }
-{% endhighlight %}
+```

--- a/guides/v2.3/graphql/reference/url-resolver.md
+++ b/guides/v2.3/graphql/reference/url-resolver.md
@@ -13,17 +13,17 @@ where:
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.
 `EntityUrl` | `EntityUrl` | An output object containing the `id`, `relative_url`, and `type` attributes.
 `id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
 `relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
+`url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.
 
 ## Example usage
 
 **Request**
 
-{% highlight json %}
+``` text
 {
  urlResolver(url:"joust-duffle-bag.html") {
    id
@@ -31,11 +31,11 @@ Attribute |  Data Type | Description
    type
  }
 }
-{% endhighlight %}
+```
 
 **Response**
 
-{% highlight json %}
+``` json
 {
   "data": {
     "urlResolver": {
@@ -45,4 +45,4 @@ Attribute |  Data Type | Description
     }
   }
 }
-{% endhighlight %}
+```


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary
GraphQL PR https://github.com/magento/graphql-ce/pull/104 causes all attributes to be alphabetized in a GraphQL browser. (Previously, they were displayed in the order they were defined. This PR alphabetizes the attributes so that they don't appear to be in a random order. 

Related Issue: #2405 

I also updated the code highlighting markup.