### PR TITLE
GraphQL: add the option_id parameter for customizable options

### DIFF
--- a/guides/v2.3/graphql/reference/customizable-option-interface.md
+++ b/guides/v2.3/graphql/reference/customizable-option-interface.md
@@ -21,6 +21,7 @@ Magento has not implemented all possible customizable product options for GraphQ
 
 Field | Type | Description
 --- | --- | ---
+`option_id` | Int |  The ID assigned to the option
 `required` | Boolean | Indicates whether the option is required
 `sort_order` | Int | The order in which the option is displayed
 `title` |  String | The display name for this option
@@ -147,3 +148,27 @@ Field | Type | Description
 `sku` | String | The Stock Keeping Unit for this option
 `sort_order` | Int | The order in which the option is displayed
 `title` | String | The display name for this option
+
+## Example usage
+
+The following query returns information about the customizable options configured for the product with a `sku` of `xyz`.
+
+```json
+  products(filter: {sku: {eq: "xyz"}}) {
+    items {
+      id
+      name
+      sku
+      type_id
+      ... on CustomizableProductInterface {
+        options {
+          title
+          required
+          sort_order
+          option_id
+        }
+      }
+    }
+  }
+}
+```

--- a/guides/v2.3/graphql/reference/customizable-option-interface.md
+++ b/guides/v2.3/graphql/reference/customizable-option-interface.md
@@ -153,7 +153,7 @@ Field | Type | Description
 
 The following query returns information about the customizable options configured for the product with a `sku` of `xyz`.
 
-```json
+```text
   products(filter: {sku: {eq: "xyz"}}) {
     items {
       id


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add the `option_id` parameter to the CustomizableOptionInterface topic.

I also added an example, which was previously missing.

Note:  This work was originally done under #3308, but moved here for ease of maintenance.

Source: https://github.com/magento/graphql-ce/pull/247

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 
https://devdocs.magento.com/guides/v2.3/graphql/reference/customizable-option-interface.html
