### PR TITLE
MAGEDOC-3553: Make 'Edit this page on GitHub' work in docs from subrepos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ defaults:
       path: mbi
     values:
       group: mbi
-      github_link: false
+      github_files: https://github.com/magento/devdocs-mbi/blob/master/
       feedback_link: false
 
   -

--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ defaults:
     values:
       group: mbi
       github_files: https://github.com/magento/devdocs-mbi/blob/master/
-      feedback_link: false
+      github_repo: https://github.com/magento/devdocs-mbi/
 
   -
     scope:

--- a/_includes/layout/page-info.html
+++ b/_includes/layout/page-info.html
@@ -13,7 +13,7 @@
 
     {% if page.github_link %}
     <div class="github-link">
-      <a class="improve-page" href="{{ page.github_files }}{{ page.path }}" target="_blank" rel="noopener">
+      <a class="improve-page" href="{{ page.github_files }}{{ page.github_path }}" target="_blank" rel="noopener">
         Edit this page on GitHub
       </a>
     </div>

--- a/_plugins/github-path.rb
+++ b/_plugins/github-path.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 #
-# This custom plugin dynamically sets the 'last_modified_at' parameter
+# This custom plugin dynamically sets the 'github_path' parameter
 # for each page except 'redirect.html' pages.
 # A value of the pararmeter is available as {{ page.last_modified_at }}.
-# The parameter contains date and time of the last commit that changed
-# the original file.
-# For available date formats, refer to https://git-scm.com/docs/git-log#git-log---dateltformatgt
+# The parameter contains a file path relative to its repository.
 #
 Jekyll::Hooks.register :pages, :post_init do |page|
-  # Do nothing in serving mode
   # Process only files with 'md' and 'html' extensions
   next unless File.extname(page.path).match?(/md|html/)
   # Do nothing for redirects
@@ -18,8 +15,8 @@ Jekyll::Hooks.register :pages, :post_init do |page|
   dir = File.dirname page.path
   filename = File.basename page.path
 
-  # Read date of the last committ and assign it to last_modified_at parameter
-  # of the page.
+  # Change to the parent directory of the page and read full file path
+  # from git index.
   page.data['github_path'] =
     `cd #{dir} && git ls-files --full-name #{filename}`.strip
 end

--- a/_plugins/github-path.rb
+++ b/_plugins/github-path.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#
+# This custom plugin dynamically sets the 'last_modified_at' parameter
+# for each page except 'redirect.html' pages.
+# A value of the pararmeter is available as {{ page.last_modified_at }}.
+# The parameter contains date and time of the last commit that changed
+# the original file.
+# For available date formats, refer to https://git-scm.com/docs/git-log#git-log---dateltformatgt
+#
+Jekyll::Hooks.register :pages, :post_init do |page|
+  # Do nothing in serving mode
+  # Process only files with 'md' and 'html' extensions
+  next unless File.extname(page.path).match?(/md|html/)
+  # Do nothing for redirects
+  next if page.name == 'redirect.html'
+
+  dir = File.dirname page.path
+  filename = File.basename page.path
+
+  # Read date of the last committ and assign it to last_modified_at parameter
+  # of the page.
+  page.data['github_path'] =
+    `cd #{dir} && git ls-files --full-name #{filename}`.strip
+end


### PR DESCRIPTION
## This PR is a:

Bug fix

## Summary

When this pull request is merged, it will add support of 'Edit this page on GitHub' to docs from sub repositories such as `mbi`.

## Additional information

Added the github-path plugin that generates `page.github_path` parameter.
Enabled the **Give us feedback** link in the MBI docs.
