### PR TITLE
Fix incorrect composer command for MFTF.

### DIFF
--- a/mftf/2.3/getting-started.md
+++ b/mftf/2.3/getting-started.md
@@ -92,7 +92,7 @@ If you want to set up the MFTF as a standalone tool, refer to [Set up a standalo
 Install the MFTF.
 
 ```bash
-composer install -d dev/tests/acceptance/
+composer install
 ```
 
 ### Step 1. Build the project   {#build-project}


### PR DESCRIPTION
## This PR is a:

- Content fix or rewrite

## Summary

When this pull request is merged, it will...
Fix the incorrect composer command for MFTF.

whatsnew
Fixed the incorrect `composer install` command in [Set up an Embedded MFTF](https://devdocs.magento.com/mftf/2.3/getting-started.html#setup-framework).