### PR TITLE
made bcmath required for open source

### DIFF
--- a/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/guides/v2.3/install-gde/system-requirements-tech.md
@@ -47,7 +47,7 @@ Magento, with assistance from our community, is implementing PHP 7.2 compatibili
 {:.bs-callout .bs-callout-info}
 The [PHP installation instructions](prereq/php-centos-ubuntu.html) include a step for installing these extensions.
 
-*	[bc-math](http://php.net/manual/en/book.bc.php){:target="_blank"} ({{site.data.var.ee}} only)
+*	[bc-math](http://php.net/manual/en/book.bc.php){:target="_blank"}
 * [ctype](http://php.net/manual/en/book.ctype.php){:target="_blank"}
 *	[curl](http://php.net/manual/en/book.curl.php){:target="_blank"}
 * [dom](http://php.net/manual/en/book.dom.php){:target="_blank"}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will correctly state that the bcmath PHP extension is also required for Magento Open Source.

## Additional information

- https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html

`Magento_Framework` requires the bcmath extension independent from the Magento version:

https://github.com/magento/magento2/blob/f4c1d7526f05bdfb1327b0701cc345f94aadcaed/lib/internal/Magento/Framework/composer.json#L23