### PR TITLE
Use build number instead of branch name on staging

### DIFF
--- a/rakelib/lib/link-checker.rb
+++ b/rakelib/lib/link-checker.rb
@@ -11,7 +11,7 @@ module LinkChecker
   # Ignore baseurl if $branch is available in environment
   def self.options
     config = YAML.load_file('_config.checks.yml')
-    baseurl = ENV['branch']
+    baseurl = ENV['BUILD_NUMBER']
     return config['html-proofer'] unless baseurl
     url_swap = { url_swap: { %r{\A/#{baseurl}} => '' } }
     config['html-proofer'].merge(url_swap)


### PR DESCRIPTION
## This PR is a:

- Improvement

## Summary

When this pull request is merged, it will update link checker to use a build number instead of branch name for a baseurl to test on staging.