### PR TITLE
Fix typo magento-cloud snapshots:list to magento-cloud snapshot:list

### DIFF
--- a/guides/v2.1/cloud/project/project-webint-snap.md
+++ b/guides/v2.1/cloud/project/project-webint-snap.md
@@ -86,7 +86,7 @@ We provide two methods for creating and managing snapshots:
 1.  List all available snapshots.
 
     ```
-    magento-cloud snapshots:list
+    magento-cloud snapshot:list
     ```
 
     The list returns information about the available snapshots:


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [X] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

The command `magento-cloud snapshots:list` is a typo -- it should be `magento-cloud snapshot:list`

