### PR TITLE
Add notes about mutations not being supported in 2.3.1

### DIFF
--- a/guides/v2.3/graphql/reference/configurable-product.md
+++ b/guides/v2.3/graphql/reference/configurable-product.md
@@ -3,10 +3,10 @@ group: graphql
 title: ConfigurableProduct endpoint
 ---
 
-The `ConfigurableProduct` endpoint defines a mutation for adding configurable products to a cart. It also extends the `ProductInterface` so that attributes that are specific to configurable products can be queried in a `products` search.
+The `ConfigurableProduct` endpoint extends the `ProductInterface` so that attributes that are specific to configurable products can be queried in a `products` search.
 
 {:.bs-callout .bs-callout-tip}
-The mutations defined in this topic are not supported in Magento 2.3.1, but will be supported in a future release.
+The mutation defined in this topic is not supported in Magento 2.3.1, but will be supported in a future release.
 
 ## Query
 The `products` query returns configurable product-specific information when you perform a `products` search.

--- a/guides/v2.3/graphql/reference/configurable-product.md
+++ b/guides/v2.3/graphql/reference/configurable-product.md
@@ -5,6 +5,9 @@ title: ConfigurableProduct endpoint
 
 The `ConfigurableProduct` endpoint defines a mutation for adding configurable products to a cart. It also extends the `ProductInterface` so that attributes that are specific to configurable products can be queried in a `products` search.
 
+{:.bs-callout .bs-callout-tip}
+The mutations defined in this topic are not supported in Magento 2.3.1, but will be supported in a future release.
+
 ## Query
 The `products` query returns configurable product-specific information when you perform a `products` search.
 

--- a/guides/v2.3/graphql/reference/configurable-product.md
+++ b/guides/v2.3/graphql/reference/configurable-product.md
@@ -6,7 +6,7 @@ title: ConfigurableProduct endpoint
 The `ConfigurableProduct` endpoint extends the `ProductInterface` so that attributes that are specific to configurable products can be queried in a `products` search.
 
 {:.bs-callout .bs-callout-tip}
-The mutation defined in this topic is not supported in Magento 2.3.1, but will be supported in a future release.
+The mutation defined in this topic is not supported in Magento 2.3.1 and earlier, but will be supported in a future release.
 
 ## Query
 The `products` query returns configurable product-specific information when you perform a `products` search.

--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -10,7 +10,7 @@ A quote represents the contents of a customer's shopping cart. It is responsible
 * Calculating subtotals, computing additional costs, applying coupons, and determining the payment method
 
 {:.bs-callout .bs-callout-tip}
-Except for `createEmptyCart`, the mutations defined in this topic are not supported in Magento 2.3.1, but will be supported in a future release.
+Except for `createEmptyCart`, the mutations defined in this topic are not supported in Magento 2.3.1 and earlier, but will be supported in a future release.
 
 ## Query
 Use the `Cart` query to retrieve information about a particular cart.

--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -9,6 +9,9 @@ A quote represents the contents of a customer's shopping cart. It is responsible
 * Determining estimated shipping costs
 * Calculating subtotals, computing additional costs, applying coupons, and determining the payment method
 
+{:.bs-callout .bs-callout-tip}
+Except for `createEmptyCart`, the mutations defined in this topic are not supported in Magento 2.3.1, but will be supported in a future release.
+
 ## Query
 Use the `Cart` query to retrieve information about a particular cart.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will clarify that certain mutations are not supported in 2.3.1, but will be in a future release. This is in response to the following PR that pulled mutations from the quote and configurable-product endpoints:
https://github.com/magento/magento2ce/pull/3844

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/reference/configurable-product.html
- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html