### PR TITLE
Update install-roadmap_cli.html

### DIFF
--- a/guides/v2.2/install-gde/install-roadmap_cli.md
+++ b/guides/v2.2/install-gde/install-roadmap_cli.md
@@ -20,7 +20,7 @@ Do you know what a "terminal" application is? Do you know what operating system 
 Topics include:
 
 *	[Choose how to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
-*	[System requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+*	[System requirements]({{ page.baseurl }}/install-gde/system-requirements2.html)
 *	[Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html)
 *	[The Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
 


### PR DESCRIPTION
## This PR is a:

- Content fix or rewrite

## Summary

When this pull request is merged, it will...
Change url of "System requirements" page to correct one, that is needed for current Magento version and correct file.

## Additional information
Steps to reproduce:
1. Open page:
https://devdocs.magento.com/guides/v2.3/install-gde/install-roadmap_cli.html
2. Click and open link "System requirements"  in  "Installation part 1: Getting started" chapter.

Actual Result:
It will open "System 2.2.x requirements" page (on v. 2.2):
https://devdocs.magento.com/guides/v2.2/install-gde/system-requirements2.html
It is not correct. 

Expected result:
It should open "System 2.3.x requirements" page (on v. 2.3):
https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html

## List all affected URLs 
https://devdocs.magento.com/guides/v2.2/install-gde/install-roadmap_cli.html
https://devdocs.magento.com/guides/v2.3/install-gde/install-roadmap_cli.html