### PR TITLE
MERGE IN 2.3.2: Fixed table structure with removing space and removed deprecated attribute.

### DIFF
--- a/guides/v2.3/graphql/reference/url-resolver.md
+++ b/guides/v2.3/graphql/reference/url-resolver.md
@@ -19,8 +19,8 @@ The `EntityUrl` output object contains the `id`, `canonical_url`, and `type` att
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
+`relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
 `url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.
 

--- a/guides/v2.3/graphql/reference/url-resolver.md
+++ b/guides/v2.3/graphql/reference/url-resolver.md
@@ -19,8 +19,7 @@ The `EntityUrl` output object contains the `id`, `canonical_url`, and `type` att
 
 Attribute |  Data Type | Description
 --- | --- | ---
-
-`canonical_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
+`relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
 `url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.

--- a/guides/v2.3/graphql/reference/url-resolver.md
+++ b/guides/v2.3/graphql/reference/url-resolver.md
@@ -23,6 +23,7 @@ Attribute |  Data Type | Description
 `relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
 `url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.
+{:style="table-layout:auto;"}
 
 ### UrlRewrite object {#UrlRewrite}
 
@@ -54,7 +55,7 @@ The following query returns information about the URL containing `joust-duffle-b
 {
   urlResolver(url: "joust-duffle-bag.html") {
     id
-    canonical_url
+    relative_url
     type
   }
 }
@@ -62,12 +63,12 @@ The following query returns information about the URL containing `joust-duffle-b
 
 **Response**
 
-``` text
+``` json
 {
   "data": {
     "urlResolver": {
       "id": 1,
-      "canonical_url": "catalog/product/view/id/1",
+      "relative_url": "catalog/product/view/id/1",
       "type": "PRODUCT"
     }
   }
@@ -98,7 +99,7 @@ The following product query returns URL rewrite information about the Joust Duff
 
 **Response**
 
-```text
+```json
 {
   "data": {
     "products": {


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will fix table structure and removed deprecated attribute "canonical_url", added "relative_url".

<!-- (REQUIRED) What does this PR change? -->

## Additional information
Codebase:
https://github.com/magento/graphql-ce/blob/6cc68c64c91aee7bc1f4a66a3892b94843df78a6/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls#L10

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
