### PR TITLE
Update JsTestDriver info for 2.2 and remove for 2.3

### DIFF
--- a/_data/toc/testing.yml
+++ b/_data/toc/testing.yml
@@ -40,9 +40,6 @@ pages:
         - label: Jasmine
           url: /test/js/jasmine.html
 
-        - label: JsTestDriver
-          url: /test/js/test_js-unit.html
-
     - label: PHP Unit Testing
       children:
 

--- a/_data/toc/testing.yml
+++ b/_data/toc/testing.yml
@@ -40,6 +40,10 @@ pages:
         - label: Jasmine
           url: /test/js/jasmine.html
 
+        - label: JsTestDriver
+          versions: ["2.1"]
+          url: /test/js/test_js-unit.html
+
     - label: PHP Unit Testing
       children:
 

--- a/_data/toc/testing.yml
+++ b/_data/toc/testing.yml
@@ -41,7 +41,7 @@ pages:
           url: /test/js/jasmine.html
 
         - label: JsTestDriver
-          versions: ["2.1"]
+          include_versions: ["2.1"]
           url: /test/js/test_js-unit.html
 
     - label: PHP Unit Testing

--- a/guides/v2.1/mtf/mtf_introduction.md
+++ b/guides/v2.1/mtf/mtf_introduction.md
@@ -74,7 +74,7 @@ For other tests please see the following topics:
 
 - [How to run unit and integration tests using `bin/magento` in continuous integration.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html)
 
-- [More information about JavaScript unit tests.]({{ page.baseurl }}/test/js/test_js-unit.html)
+- [More information about JavaScript unit tests.]({{ page.baseurl }}/test/js/jasmine.html)
 
 - [More information about performance testing.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-perf-data.html)
 

--- a/guides/v2.1/test/js/test_js-unit.md
+++ b/guides/v2.1/test/js/test_js-unit.md
@@ -272,4 +272,4 @@ Complete these steps to use PhpStorm to run unit tests:
 [`run_js_tests.php` script]: #process-overview
 [PhpStorm]: #phpstorm
 [Start the JsTestDriver server]: #start-jstestdriver-server
-[Jasmine]: ./jasmine.html
+[Jasmine]: {{page.baseurl}}/test/js/jasmine.html

--- a/guides/v2.1/test/js/test_js-unit.md
+++ b/guides/v2.1/test/js/test_js-unit.md
@@ -6,6 +6,10 @@ functional_areas:
   - test
 ---
 
+{: .bs-callout .bs-callout-warning }
+JsTestDriver was removed in Magento 2.2.4.
+It is recommended that [Jasmine][] be used instead.
+
 ## Preface
 
 Magento {% glossarytooltip 312b4baf-15f7-4968-944e-c814d53de218 %}JavaScript{% endglossarytooltip %} unit tests use the external [JsTestDriver test library]. The tests are implemented using the external [JsTestDriver API] and have their own [jsunit.requirejsUtil framework].
@@ -268,3 +272,4 @@ Complete these steps to use PhpStorm to run unit tests:
 [`run_js_tests.php` script]: #process-overview
 [PhpStorm]: #phpstorm
 [Start the JsTestDriver server]: #start-jstestdriver-server
+[Jasmine]: ./jasmine.html

--- a/guides/v2.2/test/testing.md
+++ b/guides/v2.2/test/testing.md
@@ -143,7 +143,7 @@ MFTF tests are kept within its respective Module folder:
 [Web API Functional]: https://devdocs.magento.com/guides/v2.3/get-started/web-api-functional-testing.html
 [Integration]: https://devdocs.magento.com/guides/v2.3/test/integration/integration_test_execution.html
 [performance toolkit]: https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-perf-data.html
-[JavaScript]: https://devdocs.magento.com/guides/v2.3/test/js/test_js-unit.html
+[JavaScript]: https://devdocs.magento.com/guides/v2.3/test/js/jasmine.html
 [PhpCs]: https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-sniffers.html
 [PhpMd]: https://phpmd.org/
 [Magento backward compatibility policy]: https://devdocs.magento.com/guides/v2.3/contributor-guide/backward-compatible-development/
@@ -151,7 +151,7 @@ MFTF tests are kept within its respective Module folder:
 [Magento Functional Testing Framework]: {{ site.baseurl }}/mftf/2.2/introduction.html
 [Web API functional testing]: {{ page.baseurl }}/get-started/web-api-functional-testing.html
 [Running Integration Tests]: {{ page.baseurl }}/test/integration/integration_test_execution.html
-[Extension Developer Guide on JavaScript Tests]: {{ page.baseurl }}/test/js/test_js-unit.html
+[Extension Developer Guide on JavaScript Tests]: {{ page.baseurl }}/test/js/jasmine.html
 [`magento dev:tests:run`]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html
 [test-driven development]: https://en.wikipedia.org/wiki/Test-driven_development
 [Running Unit Tests]: {{ page.baseurl }}/test/unit/unit_test_execution.html

--- a/guides/v2.3/test/js/test_js-unit.md
+++ b/guides/v2.3/test/js/test_js-unit.md
@@ -1,1 +1,0 @@
-../../../v2.2/test/js/test_js-unit.md


### PR DESCRIPTION
## This PR is a:

- Content fix or rewrite

## Summary

JsTestDriver support was  deprecated for 2.2 and removed from 2.3.
This PR:

- Removes the TOC entry.
- Tells 2.2 users to use Jasmine.
- Removes the topic from 2.3 via deleted symlink.

Closes #3869 