### PR TITLE
Update created vanilla Magento instance name.

### DIFF
--- a/guides/v2.1/contributor-guide/contributing.md
+++ b/guides/v2.1/contributor-guide/contributing.md
@@ -154,7 +154,7 @@ For `version`, the currently supported values are [version tags](https://github.
 
 **Admin access:**
 
-- http://i-xxx.engcom.dev.magento.com/admin
+- https://pr-{$id_pr}.instances.magento-community.engineering/admin
 - Admin Credentials:
     - Username: admin
     - Password: 123123q

--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -156,7 +156,7 @@ For `version`, the currently supported values are [version tags](https://github.
 
 **Admin access:**
 
-- http://i-xxx.engcom.dev.magento.com/admin
+- https://i-{$number}-{$version}.instances.magento-community.engineering/admin
 - Admin Credentials:
     - Username: admin
     - Password: 123123q

--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -156,7 +156,7 @@ For `version`, the currently supported values are [version tags](https://github.
 
 **Admin access:**
 
-- https://i-{$number}-{$version}.instances.magento-community.engineering/admin
+- https://pr-{$id_pr}.instances.magento-community.engineering/admin
 - Admin Credentials:
     - Username: admin
     - Password: 123123q

--- a/guides/v2.3/contributor-guide/contributing.md
+++ b/guides/v2.3/contributor-guide/contributing.md
@@ -155,7 +155,7 @@ For `version`, the currently supported values are [version tags](https://github.
 
 **Admin access:**
 
-- http://i-xxx.engcom.dev.magento.com/admin
+- https://pr-{$id_pr}.instances.magento-community.engineering/admin
 - Admin Credentials:
     - Username: admin
     - Password: 123123q


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will show actual vanilla magento instance name pattern.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html

But seems that files for urls below should be updated also:
- https://devdocs.magento.com/guides/v2.1/contributor-guide/contributing.html
- https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html

<!-- (OPTIONAL) What other information can you provide about this PR? -->
Seems that the other urls for magento instanses should be updated too.

And btw, why common blocks from pages by urls above not separated into common included blocks?