### PR TITLE
Rewrite "bad code" example to "good"

### DIFF
--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -211,21 +211,21 @@ class MyUtility
 }
 ```
 
-If you wrapped this method with a plugin like below:
+You should wrap this method with a plugin like below:
 
 ``` PHP
 namespace My\Module\Plugin;
 
 class MyUtilityUpdater
 {
-    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, SomeType $obj)
+    public function aroundSave(\My\Module\Model\MyUtility $subject, callable $proceed, SomeType $obj = null)
     {
       //do something
     }
 }
 ```
 
-Note the missing <code>= null</code>. Now, if Magento calls the original method with <code>null</code>, {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} would throw a fatal error as your plugin does not accept <code>null</code>.
+Note if you miss <code>= null</code> and Magento calls the original method with <code>null</code>, {% glossarytooltip bf703ab1-ca4b-48f9-b2b7-16a81fd46e02 %}PHP{% endglossarytooltip %} would throw a fatal error as your plugin does not accept <code>null</code>.
 
 You are responsible for forwarding the arguments from the plugin to the <code>proceed</code> callable. If you are not using/modifying the arguments, you could use variadics and argument unpacking to achieve this:
 


### PR DESCRIPTION
Rewrite "bad code" example to "good" for Around methods example.

## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will have right version for exmple for "Around methods" for methods with default null value.

At the moment there is no any visual differense batween right and bad (with mistakes) code (like cross out text or color hilight). Therefore imho it would be better to have in docs only good code exmples, with noting about possible mistakes (to not confuse developers with bad code exmpled that could be copy-pasted from by mistake).

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/plugins.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html
