### PR TITLE
Fixing "Mangento" typo in cloud guide

### DIFF
--- a/guides/v2.0/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.0/cloud/before/before-workspace-cloud-account.md
@@ -12,7 +12,7 @@ menu_node:
 #### Previous step:
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
-To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Mangento Enterprise Cloud Edition account](https://accounts.magento.cloud){:target="_blank"}. The account provides access to your project for Magento development and deployment across all supported environments.
+To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Enterprise Cloud Edition account](https://accounts.magento.cloud){:target="_blank"}. The account provides access to your project for Magento development and deployment across all supported environments.
 
 You should receive an e-mail invitation to verify and access the account. If you don't see the invitation, check your junk e-mail folder. Click the **Verify my account** option in the email to verify and access your account.
 

--- a/guides/v2.1/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.1/cloud/before/before-workspace-cloud-account.md
@@ -10,7 +10,7 @@ menu_node:
 #### Previous step:
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
-To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Mangento Enterprise Cloud Edition account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.
+To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Enterprise Cloud Edition account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.
 
 You should receive an e-mail invitation to verify and access the account. If you do not see the invitation, check your junk e-mail folder. Click the **Verify my account** option in the email to verify and access your account.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix the Mangento typo in cloud guide.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/cloud/before/before-workspace-cloud-account.html
- https://devdocs.magento.com/guides/v2.2/cloud/before/before-workspace-cloud-account.html
- https://devdocs.magento.com/guides/v2.1/cloud/before/before-workspace-cloud-account.html
- https://devdocs.magento.com/guides/v2.0/cloud/before/before-workspace-cloud-account.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
