### PR TITLE
Revert "Update the Magento third party licenses topic"

### DIFF
--- a/magento-third-party.md
+++ b/magento-third-party.md
@@ -8,6 +8,7 @@ menu_order: 1
 menu_node: parent
 ---
 
+## Magento third party licenses
 
 This page lists third party license agreements for the Magento application.
 
@@ -20,13 +21,3 @@ This page lists third party license agreements for the Magento application.
 
 *	[{{site.data.var.ce}} third-party licenses]({{ site.gdeurl21 }}release-notes/thirdparty_ce.html)
 *	[{{site.data.var.ee}} third-party licenses]({{ site.gdeurl21 }}release-notes/thirdparty_ee.html)
-
-## Magento 2.2.x
-
-*	[{{site.data.var.ce}} third-party licenses]({{ site.gdeurl22 }}release-notes/thirdparty_ce.html)
-*	[{{site.data.var.ee}} third-party licenses]({{ site.gdeurl22 }}release-notes/thirdparty_ee.html)
-
-## Magento 2.3.x
-
-*	[{{site.data.var.ce}} third-party licenses]({{ site.gdeurl23 }}release-notes/thirdparty_ce.html)
-*	[{{site.data.var.ee}} third-party licenses]({{ site.gdeurl23 }}release-notes/thirdparty_ee.html)


### PR DESCRIPTION
Reverts magento/devdocs#3971

Now that we have a separate release_notes directory, we should actually delete this topic and perhaps create a redirect to the 2.3 Open Source 3rd-party page.