### PR TITLE
Changed kramdown wording

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The DevDocs team and Maintainers will review the PR and help with formatting and
 
 ## Contribution guidelines
 
-Write content using [Kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use Kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
+Write content using [kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use Kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
 
 You can update existing or add new topics in their respective Magento 2 versioned directories (2.1, 2.2, 2.3, and onward). If you need help finding a directory for your content, we can help in your PR.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The DevDocs team and Maintainers will review the PR and help with formatting and
 
 ## Contribution guidelines
 
-Write content using [kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use Kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
+Write content using [kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
 
 You can update existing or add new topics in their respective Magento 2 versioned directories (2.1, 2.2, 2.3, and onward). If you need help finding a directory for your content, we can help in your PR.
 

--- a/community/resources/multi-repo-docs.md
+++ b/community/resources/multi-repo-docs.md
@@ -28,7 +28,7 @@ The DevDocs team :
 ![Multi-Repo and Writing Content]({{ site.baseurl }}/common/images/remote-doc-repo-developer.png) 
 
 1. Create a `docs` directory in the root of your public repository. If you have images, add an `images` sudirectory.
-1. Write simple markdown (`.md`) files using [Kramdown](https://kramdown.gettalong.org/syntax.html).
+1. Write simple markdown (`.md`) files using [kramdown](https://kramdown.gettalong.org/syntax.html).
 1. Contact [Lori Krell](mailto:lkrell@adobe.com) in Community Engineering with the following details:
     - Project name or feature
     - GitHub Repository link
@@ -41,7 +41,7 @@ The DevDocs team :
 
 The DevDocs team will help get your content ready for publication:
 
-1. Review and edit your content, including Kramdown formatting, Liquid tags, grammar, and more.
+1. Review and edit your content, including kramdown formatting, Liquid tags, grammar, and more.
 1. Connect your content to DevDocs navigation including custom table of contents and search facets.
 1. Configure automation for generating documentation on an automated cycle.
 


### PR DESCRIPTION
## This PR is a:

- [x] Bug fix or improvement

## Summary

This PR fixes the wording of kramdown tool. The tool's name should be presented as a lower case since it's a part of the name's idea. Take a look at https://kramdown.gettalong.org/index.html and check the definition:

> kramdown (sic, not Kramdown or KramDown, just kramdown) is a free MIT-licensed Ruby library for parsing and converting a superset of Markdown.

## Additional information

List all affected URLs 

- https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

