### PR TITLE
Extension Dev Guide > Fixing highlights for PHP

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The DevDocs team and Maintainers will review the PR and help with formatting and
 
 ## Contribution guidelines
 
-Write content using [Kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use Kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
+Write content using [kramdown](https://kramdown.gettalong.org/), which is a simple markup language. We use kramdown, Liquid, and [Jekyll](https://jekyllrb.com/) to generate a static site hosted through [GH Pages](https://help.github.com/articles/what-is-github-pages/). Check [Templates](#templates) for examples of styles and markdown.
 
 You can update existing or add new topics in their respective Magento 2 versioned directories (2.1, 2.2, 2.3, and onward). If you need help finding a directory for your content, we can help in your PR.
 

--- a/_includes/install/flow-diagram.md
+++ b/_includes/install/flow-diagram.md
@@ -9,6 +9,7 @@ The diagram shows the following:
 	*	[2.0.x system requirements]({{ site.gdeurl }}install-gde/system-requirements.html)
 	*	[2.1.x system requirements]({{ site.gdeurl21 }}install-gde/system-requirements-tech.html)
 	*	[2.2.x system requirements]({{ site.gdeurl22 }}install-gde/system-requirements-tech.html)
+	*	[2.3.x system requirements]({{ site.gdeurl23 }}install-gde/system-requirements-tech.html)	
 
 2.	Get the Magento software.
 

--- a/community/resources/multi-repo-docs.md
+++ b/community/resources/multi-repo-docs.md
@@ -28,7 +28,7 @@ The DevDocs team :
 ![Multi-Repo and Writing Content]({{ site.baseurl }}/common/images/remote-doc-repo-developer.png) 
 
 1. Create a `docs` directory in the root of your public repository. If you have images, add an `images` sudirectory.
-1. Write simple markdown (`.md`) files using [Kramdown](https://kramdown.gettalong.org/syntax.html).
+1. Write simple markdown (`.md`) files using [kramdown](https://kramdown.gettalong.org/syntax.html).
 1. Contact [Lori Krell](mailto:lkrell@adobe.com) in Community Engineering with the following details:
     - Project name or feature
     - GitHub Repository link
@@ -41,7 +41,7 @@ The DevDocs team :
 
 The DevDocs team will help get your content ready for publication:
 
-1. Review and edit your content, including Kramdown formatting, Liquid tags, grammar, and more.
+1. Review and edit your content, including kramdown formatting, Liquid tags, grammar, and more.
 1. Connect your content to DevDocs navigation including custom table of contents and search facets.
 1. Configure automation for generating documentation on an automated cycle.
 

--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -65,7 +65,7 @@ You can use before methods to change the arguments of an observed method by retu
 
 Below is an example of a before method modifying the `$name` argument before passing it on to the observed `setName` method.
 
-``` PHP
+```php
 namespace My\Module\Plugin;
 
 class ProductAttributesUpdater
@@ -85,7 +85,7 @@ You can use these methods to change the result of an observed method by modifyin
 
 Below is an example of an after method modifying the return value `$result` of an observed methods call.
 
-``` PHP
+```php
 
 namespace My\Module\Plugin;
 
@@ -102,7 +102,7 @@ After methods have access to all the arguments of their observed methods. When t
 
 Below is an example of an after method that accepts the `null` result and arguments from the observed `login` method for [`Magento\Backend\Model\Auth`]({{ site.mage2100url }}app/code/Magento/Backend/Model/Auth.php){:target="_blank"}:
 
-``` PHP
+```php
 namespace My\Module\Plugin;
 
 class AuthLogger
@@ -132,7 +132,7 @@ After methods do not need to declare all the arguments of their observed methods
 
 The following example is a class with an after method for [`\Magento\Catalog\Model\Product\Action::updateWebsites($productIds, $websiteIds, $type)`]({{ site.mage2100url }}app/code/Magento/Catalog/Model/Product/Action.php){:target="_blank"}:
 
-``` PHP
+```php
 
 class WebsitesLogger
 {
@@ -172,7 +172,7 @@ If the around method does not call the `callable`, it will prevent the execution
 
 Below is an example of an around method adding behavior before and after an observed method:
 
-``` PHP
+```php
 namespace My\Module\Plugin;
 
 class ProductAttributesUpdater
@@ -199,7 +199,7 @@ When you wrap a method which accepts arguments, your plugin must also accept tho
 
 For example, the following code defines a parameter of type <code>SomeType</code> which is nullable:
 
-``` PHP
+```php
 namespace My\Module\Model;
 
 class MyUtility
@@ -213,7 +213,7 @@ class MyUtility
 
 You should wrap this method with a plugin like below:
 
-``` PHP
+```php
 namespace My\Module\Plugin;
 
 class MyUtilityUpdater
@@ -229,7 +229,7 @@ Note if you miss <code>= null</code> and Magento calls the original method with 
 
 You are responsible for forwarding the arguments from the plugin to the <code>proceed</code> callable. If you are not using/modifying the arguments, you could use variadics and argument unpacking to achieve this:
 
-``` PHP
+```php
 namespace My\Module\Plugin;
 
 class MyUtilityUpdater


### PR DESCRIPTION
## This PR is a:

- Bug fix or improvement

## Summary

The page about Extension Dev Guide is not using the PHP syntax as the page about Event and Observer for example

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html

<img width="1219" alt="Screenshot 2019-03-20 15 41 28" src="https://user-images.githubusercontent.com/610598/54714129-a58f8e80-4b26-11e9-851f-5aa2a5ec0031.png">
