### PR TITLE
Added new available slack channel URLs

### DIFF
--- a/community/resources/resources.md
+++ b/community/resources/resources.md
@@ -1,7 +1,7 @@
 ---
 group: community
 title: Community Resources
-redirect_from: 
+redirect_from:
   - /community/resources/index.html
 ---
 
@@ -37,14 +37,19 @@ We have channels for each project. These channels are recommended for new member
 - [github][]: Support for GitHub issues, pull requests, and processes
 - [public-backlog][]: Discussions of the Magento 2 backlog
 - [devdocs][]: Documentation contribution support
+- [cloud][]: Open chat for cloud questions
+- [graphql][]: Open chat for graphql contribution
+- [pwa][]: Open chat for Progressive Web Applications contribution
+- [msi][]: Open chat for Multi-Source Inventory contribution
+- [mftf][]: Open chat for Magento Functional Testing Framework(MFTF) contribution
 
 ## Resources and guides
 
 - *Video* [How to contribute during Magento Contribution Days][57] by [Max Pronko][35]
 - *GitHub* [Magento Resources][23] curated list by [Alessandro Ronchi][30]
 - *Blog posts* [Thoughts on Magento, PHP, JavaScript, Laravel, React, Docker, and user interface design][56] by [Mark Shust][38]
-- *Videos* [Mage2.tv][24] 
-- *Podcast* [MageTalk][25] by [Phillip Jackson and Kalen][27] 
+- *Videos* [Mage2.tv][24]
+- *Podcast* [MageTalk][25] by [Phillip Jackson and Kalen][27]
 - *Vlog* [eCommerceAholic][26] by [TJ Gamble][28]
 - *Statistics* [Magestats][32] by [Marcel Hauri][33]
 - *Videos* [Magento Dev Channel with Max Pronko][34] by [Max Pronko][35]
@@ -92,7 +97,7 @@ We have channels for each project. These channels are recommended for new member
 
 ## Performance
 
--  *Presentation* [Premium performance with PHP 7 and Varnish][15] by Miguel Balparda 
+-  *Presentation* [Premium performance with PHP 7 and Varnish][15] by Miguel Balparda
 
 [contribute]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [technical guidelines]: https://devdocs.magento.com/guides/v2.3/coding-standards/technical-guidelines.html
@@ -103,10 +108,15 @@ We have channels for each project. These channels are recommended for new member
 [github]: https://magentocommeng.slack.com/messages/C7KB93M32
 [public-backlog]: https://magentocommeng.slack.com/messages/CCV3J3RV5
 [devdocs]: https://magentocommeng.slack.com/messages/CAN932A3H
+[cloud]: https://magentocommeng.slack.com/messages/C8CBB6K9V
+[graphql]: https://magentocommeng.slack.com/messages/C8076E0KS
+[pwa]: https://magentocommeng.slack.com/messages/C71HNKYS2
+[msi]: https://magentocommeng.slack.com/messages/C5FU5E2HY
+[mftf]: https://magentocommeng.slack.com/messages/C82DDUSNP
 [appdesign]: https://magentocommeng.slack.com/messages/CBSL1DF8B
 [coding-standards]: https://magentocommeng.slack.com/messages/CFC88F1C6
 [announcements]: https://magentocommeng.slack.com/messages/C7FA71S3V
-[0]: https://github.com/DavidLambauer/awesome-magento2 
+[0]: https://github.com/DavidLambauer/awesome-magento2
 [1]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [2]: http://www.slideshare.net/StaceyWhitney1/mage-titans-usa-2016-joshua-warren-magento-2-integrations
 [3]: http://www.slideshare.net/vrann/mage-titans-usa-2016-magentofacebookrabbitmq

--- a/community/resources/resources.md
+++ b/community/resources/resources.md
@@ -28,7 +28,7 @@ See our collection of best and leading practices, common solutions, and more in 
 To connect with Magento and the Community, join us on the [Magento Community Engineering Slack][]. If you are interested in joining Slack, or a specific channel, send us a request at [engcom@adobe.com](mailto:engcom@adobe.com) or [self signup][].
 
 
-We have channels for each project. These channels are recommended for new members:
+We have [channels][channels] for each project. These channels are recommended for new members:
 
 - [announcements][]: Introduce yourself and get quick updates for Magento Community Engineering
 - [general][]: Open chat for introductions and Magento 2 questions
@@ -37,11 +37,6 @@ We have channels for each project. These channels are recommended for new member
 - [github][]: Support for GitHub issues, pull requests, and processes
 - [public-backlog][]: Discussions of the Magento 2 backlog
 - [devdocs][]: Documentation contribution support
-- [cloud][]: Open chat for cloud questions
-- [graphql][]: Open chat for graphql contribution
-- [pwa][]: Open chat for Progressive Web Applications contribution
-- [msi][]: Open chat for Multi-Source Inventory contribution
-- [mftf][]: Open chat for Magento Functional Testing Framework(MFTF) contribution
 
 ## Resources and guides
 
@@ -108,11 +103,6 @@ We have channels for each project. These channels are recommended for new member
 [github]: https://magentocommeng.slack.com/messages/C7KB93M32
 [public-backlog]: https://magentocommeng.slack.com/messages/CCV3J3RV5
 [devdocs]: https://magentocommeng.slack.com/messages/CAN932A3H
-[cloud]: https://magentocommeng.slack.com/messages/C8CBB6K9V
-[graphql]: https://magentocommeng.slack.com/messages/C8076E0KS
-[pwa]: https://magentocommeng.slack.com/messages/C71HNKYS2
-[msi]: https://magentocommeng.slack.com/messages/C5FU5E2HY
-[mftf]: https://magentocommeng.slack.com/messages/C82DDUSNP
 [appdesign]: https://magentocommeng.slack.com/messages/CBSL1DF8B
 [coding-standards]: https://magentocommeng.slack.com/messages/CFC88F1C6
 [announcements]: https://magentocommeng.slack.com/messages/C7FA71S3V
@@ -174,3 +164,4 @@ We have channels for each project. These channels are recommended for new member
 [55]: https://alanstorm.com/
 [56]: https://markshust.com/
 [57]: https://www.youtube.com/watch?v=ceNeYpCEmys
+[channels]: https://github.com/magento/magento2/wiki/Slack-Channels

--- a/community/resources/resources.md
+++ b/community/resources/resources.md
@@ -48,7 +48,7 @@ We have channels for each project. These channels are recommended for new member
 - *Video* [How to contribute during Magento Contribution Days][57] by [Max Pronko][35]
 - *GitHub* [Magento Resources][23] curated list by [Alessandro Ronchi][30]
 - *Blog posts* [Thoughts on Magento, PHP, JavaScript, Laravel, React, Docker, and user interface design][56] by [Mark Shust][38]
-- *Videos* [Mage2.tv][24]
+- *Videos* [Mage2.tv][24] by [Vinai Kopp][48]
 - *Podcast* [MageTalk][25] by [Phillip Jackson and Kalen][27]
 - *Vlog* [eCommerceAholic][26] by [TJ Gamble][28]
 - *Statistics* [Magestats][32] by [Marcel Hauri][33]

--- a/community/resources/resources.md
+++ b/community/resources/resources.md
@@ -28,7 +28,7 @@ See our collection of best and leading practices, common solutions, and more in 
 To connect with Magento and the Community, join us on the [Magento Community Engineering Slack][]. If you are interested in joining Slack, or a specific channel, send us a request at [engcom@adobe.com](mailto:engcom@adobe.com) or [self signup][].
 
 
-We have [channels][channels] for each project. These channels are recommended for new members:
+We have [channels][] for each project, but the following channels are recommended for new members:
 
 - [announcements][]: Introduce yourself and get quick updates for Magento Community Engineering
 - [general][]: Open chat for introductions and Magento 2 questions


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will show slack channel URLs for the `cloud, graphql, pwa, msi, mftf`

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/community/resources/resources.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
