### PR TITLE
MAGECLOUD-3237: Update Elasticsearch support info

### DIFF
--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -20,7 +20,7 @@ The `{{site.data.var.ct}}` package v2002.0.13 or later deploys to a read-only fi
 | PHP           | `--php`    | 7.1           | 7.0, 7.1, 7.2
 | NGINX         | `--nginx`  | latest        | 1.9, latest
 | MariaDB       | `--db`     | 10            | 10.0, 10.1, 10.2
-| Elasticsearch | `--es`     | 2.4           | 1.7, 2.4, 5.2
+| Elasticsearch | `--es`     | 2.4           | 1.7, 2.4, 5.2, 6.5
 | RabbitMQ      | `--rmq`    | 3.5           | 3.5, 3.7
 | Redis         | `--redis`  | 3.2           | 3.0, 3.2, 4.0
 {:style="table-layout:auto;"}

--- a/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services-elastic.md
@@ -14,7 +14,7 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-We support Elasticsearch versions 1.4, 1.7, and 2.4. The default version is 1.7. We support Elasticsearch for all environments starting with {{site.data.var.ece}} 2.1 and later. Refer to [Elasticsearch information]({{ site.baseurl }}/guides/v2.1/config-guide/elasticsearch/es-overview.html) to learn more.
+We support Elasticsearch versions 1.4, 1.7, and 2.4. The recommended version is 2.4. We support Elasticsearch for all environments starting with {{site.data.var.ece}} 2.1 and later. Refer to [Elasticsearch information]({{ site.baseurl }}/guides/v2.1/config-guide/elasticsearch/es-overview.html) to learn more.
 
 {:.bs-callout .bs-callout-info}
 If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
@@ -30,7 +30,7 @@ To enable Elasticsearch, add the following code with your installed version and 
 
 ```yaml
 elasticsearch:
-   type: elasticsearch:1.7
+   type: elasticsearch:2.4
    disk: 1024
 ```
 
@@ -49,7 +49,7 @@ Optionally, you can add the plugins through the `.magento/services.yaml` file. F
 
 ```yaml
 elasticsearch:
-   type: elasticsearch:1.7
+   type: elasticsearch:2.4
    disk: 1024
    configuration:
     plugins:

--- a/guides/v2.1/cloud/project/project-conf-files_services.md
+++ b/guides/v2.1/cloud/project/project-conf-files_services.md
@@ -34,10 +34,6 @@ mysql:
 
 redis:
     type: redis:3.0
-
-solr:
-    type: solr:4.10
-    disk: 1024
 ```
 
 Modify this file to use specific and additional services in your deployment. See the [`type`](#cloud-yaml-services-type) section to see the services we support and deploy for you if you add them to the file.
@@ -46,26 +42,32 @@ Modify this file to use specific and additional services in your deployment. See
 
 To add a service, you add the following data to `services.yaml`:
 
-  name:
-     type: name:version
-     disk: value
+```yaml
+name:
+    type: name:version
+    disk: value
+```
 
 For example:
 
-  mysql:
-     type: mysql:10.0
-     disk: 2048
+```yaml
+mysql:
+    type: mysql:10.0
+    disk: 2048
+```
 
 ### `name` {#cloud-yaml-services-name}
 `name` identifies the service in the project. The `name` can consist only of lower case alphanumeric characters: `a`&ndash;`z` and `0`&ndash;`9`. For example, Redis is entered as redis.
 
 You can have multiple instances of each service type. For example, you could have multiple Redis instances. For example, we use multiple Redis instances, one for session and one for cache.
 
-  redis:
-     type: redis:3.0
+```yaml
+redis:
+    type: redis:3.0
 
-  redis2:
-     type: redis:3.0
+redis2:
+    type: redis:3.0
+```
 
 Be aware, if you rename a service in `services.yaml`, the following is **permanently removed**:
 
@@ -77,10 +79,10 @@ The `type` of your service in the format `type:version`
 
 We support and deploy the following services:
 
-*	[`mysql`]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html) version `10.0`
-*	[`redis`]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html) versions `2.8` and `3.0`
-*	[`elasticsearch`]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html) version `1.4`, `1.7`, and `2.4`
-*	[`rabbitmq`]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html) version `3.5`
+*	[`mysql`]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html)
+*	[`redis`]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
+*	[`elasticsearch`]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
+*	[`rabbitmq`]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
 
 ### `disk` {#cloud-yaml-services-disk}
 

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -14,7 +14,7 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-We support Elasticsearch versions 1.4, 1.7, 2.4, and 5.2. The default version is 2.4. We support Elasticsearch for all environments starting with {{site.data.var.ece}} 2.1 and later. See [Elasticsearch information]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html).
+We support Elasticsearch versions 1.4, 1.7, 2.4, 5.2. The default version is 5.2. We support Elasticsearch for all environments starting with {{site.data.var.ece}} 2.1 and later. See [Elasticsearch information]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html).
 
 {:.bs-callout .bs-callout-info}
 Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
@@ -55,7 +55,7 @@ Optionally, you can add plugins with the `.magento/services.yaml` file. For exam
 
 ```yaml
 elasticsearch:
-   type: elasticsearch:2.4
+   type: elasticsearch:5.2
    disk: 1024
    configuration:
     plugins:

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -14,10 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-We support Elasticsearch versions 1.4, 1.7, 2.4, 5.2. The default version is 5.2. We support Elasticsearch for all environments starting with {{site.data.var.ece}} 2.1 and later. See [Elasticsearch information]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html).
+We support Elasticsearch versions 1.4, 1.7, 2.4, and 5.2. The recommended version is 5.2.
 
 {:.bs-callout .bs-callout-info}
-Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
+Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html).
 
 {:.bs-callout .bs-callout-warning}
 If you prefer using an existing search service, such as Elasticsearch, instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
@@ -28,15 +28,15 @@ If you prefer using an existing search service, such as Elasticsearch, instead o
 
     ```yaml
     elasticsearch:
-        type: elasticsearch:5.2
-        disk: 1024
+       type: elasticsearch:5.2
+       disk: 1024
     ```
 
 1.  Set the `relationships` property in the `.magento.app.yaml` file.
 
     ```yaml
     relationships:
-        elasticsearch: "elasticsearch:elasticsearch"
+       elasticsearch: "elasticsearch:elasticsearch"
     ```
 
 1.  Add, commit, and push code changes.

--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -14,13 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-We support Elasticsearch versions 1.4, 1.7, 2.4, and 5.2. The recommended version is 5.2.
+{{site.data.var.ee}} supports [Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) versions 1.4, 1.7, 2.4, and 5.2 (requires {{site.data.var.ee}} v2.2.3 or later). The recommended version is 5.2.
 
 {:.bs-callout .bs-callout-info}
-Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html).
-
-{:.bs-callout .bs-callout-warning}
-If you prefer using an existing search service, such as Elasticsearch, instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
+If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration to replace Solr with Elasticsearch as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
 
 #### To enable Elasticsearch:
 

--- a/guides/v2.2/cloud/project/project-conf-files_services.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services.md
@@ -27,12 +27,14 @@ To install and update services in Pro Staging and Production environments (IaaS)
 
 Your Git branch includes the following default `services.yaml` file:
 
-	mysql:
-	   type: mysql:10.0
-	   disk: 2048
+```yaml
+mysql:
+   type: mysql:10.0
+   disk: 2048
 
-	redis:
-	   type: redis:3.0
+redis:
+   type: redis:3.0
+```
 
 Modify this file to use specific and additional services in your deployment. See the [`type`](#cloud-yaml-services-type) section to see the services we support and deploy for you if you add them to the file.
 
@@ -40,26 +42,32 @@ Modify this file to use specific and additional services in your deployment. See
 
 To add a service, you add the following data to services.yaml:
 
-  name:
-     type: name:version
-     disk: value
+```yaml
+name:
+   type: name:version
+   disk: value
+```
 
 For example:
 
-  mysql:
-     type: mysql:10.0
-     disk: 2048
+```yaml
+mysql:
+   type: mysql:10.0
+   disk: 2048
+```
 
 ### `name` {#cloud-yaml-services-name}
 `name` identifies the service in the project. The `name` can consist only of lower case alphanumeric characters: `a`&ndash;`z` and `0`&ndash;`9`. For example, Redis is entered as redis.
 
 You can have multiple instances of each service type. For example, you could have multiple Redis instances. For example, we use multiple Redis instances, one for session and one for cache.
 
-  redis:
-     type: redis:3.0
+```yaml
+redis:
+   type: redis:3.0
 
-  redis2:
-     type: redis:3.0
+redis2:
+   type: redis:3.0
+```
 
 Be aware, if you rename a service in `services.yaml`, the following is **permanently removed**:
 
@@ -71,10 +79,10 @@ The `type` of your service in the format `type:version`
 
 We support and deploy the following services for you:
 
-*	[`mysql`]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html) version `10.0`
-*	[`redis`]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html) versions `2.8` and `3.0`
-*	[`elasticsearch`]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html) version `1.4`, `1.7`, `2.4`, and `5.2`
-*	[`rabbitmq`]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html) version `3.5`
+*	[`mysql`]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html) version
+*	[`redis`]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
+*	[`elasticsearch`]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html) version
+*	[`rabbitmq`]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html) version
 
 ### `disk` {#cloud-yaml-services-disk}
 

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -14,7 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-{{site.data.var.ee}} v2.3 supports Elasticsearch version 5.2. {{site.data.var.ee}}v2.3.1 and later supports Elasticsearch version 6.x. For additional details, see [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
+{{site.data.var.ee}} supports Elasticsearch version 5.2 and 6.x (requires v2.3.1 or later).
+
+{:.bs-callout .bs-callout-info}
+Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
 
 {:.bs-callout .bs-callout-warning}
 If you prefer to use an existing search service instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
@@ -25,7 +28,7 @@ If you prefer to use an existing search service instead of relying on the defaul
 
     ```yaml
     elasticsearch:
-        type: elasticsearch:6.5
+        type: elasticsearch:5.2
         disk: 1024
     ```
 
@@ -52,7 +55,7 @@ Optionally, you can add plugins with the `.magento/services.yaml` file. For exam
 
 ```yaml
 elasticsearch:
-   type: elasticsearch:6.5
+   type: elasticsearch:5.2
    disk: 1024
    configuration:
     plugins:

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -14,13 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-{{site.data.var.ee}} supports Elasticsearch version 5.2 and 6.x (requires v2.3.1 or later).
+{{site.data.var.ee}} supports Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) version 5.2 and 6.x (requires v2.3.1 or later).
 
 {:.bs-callout .bs-callout-info}
-Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
-
-{:.bs-callout .bs-callout-warning}
-If you prefer to use an existing search service instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
+If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
 
 #### To enable Elasticsearch:
 

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -14,10 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-{{site.data.var.ee}} supports Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) version 5.2 and 6.x (requires v2.3.1 or later).
+{{site.data.var.ee}} supports [Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) version 5.2 and 6.x (requires v2.3.1 or later).
 
 {:.bs-callout .bs-callout-info}
-If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
+If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es).
 
 #### To enable Elasticsearch:
 

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -14,13 +14,10 @@ functional_areas:
 *   Supports stop words and synonyms
 *   Indexing does not impact customers until the reindex operation completes
 
-{{site.data.var.ee}} supports Elasticsearch version 5.2.
-
-{:.bs-callout .bs-callout-info}
-Elasticsearch 5.2 is only available for 2.2.3 and later. If you are upgrading to {{site.data.var.ee}} 2.1.3, you must change your configuration as discussed in [the 2.1.3 Release Notes]({{ site.baseurl }}/guides/v2.1/cloud/release-notes/CloudReleaseNotes2.1.3.html#cloud-rn-213-es). See [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
+{{site.data.var.ee}} v2.3 supports Elasticsearch version 5.2. {{site.data.var.ee}}v2.3.1 and later supports Elasticsearch version 6.x. For additional details, see [Elasticsearch information]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html) to learn more.
 
 {:.bs-callout .bs-callout-warning}
-If you prefer using an existing search service, such as Elasticsearch, instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
+If you prefer to use an existing search service instead of relying on the default Cloud configuration, you can use the [`SEARCH_CONFIGURATION`]({{ page.baseurl }}/cloud/env/variables-deploy.html#search_configuration) environment variable to connect it to your site.
 
 #### To enable Elasticsearch:
 
@@ -28,7 +25,7 @@ If you prefer using an existing search service, such as Elasticsearch, instead o
 
     ```yaml
     elasticsearch:
-        type: elasticsearch:5.2
+        type: elasticsearch:6.5
         disk: 1024
     ```
 
@@ -55,7 +52,7 @@ Optionally, you can add plugins with the `.magento/services.yaml` file. For exam
 
 ```yaml
 elasticsearch:
-   type: elasticsearch:5.2
+   type: elasticsearch:6.5
    disk: 1024
    configuration:
     plugins:
@@ -66,7 +63,7 @@ elasticsearch:
 {:.bs-callout .bs-callout-info}
 Magento does not support the ElasticSuite third-party plugin.
 
-See [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/5.2/index.html).
+See [Elasticsearch plugin documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html).
 
 ## Verify relationships
 


### PR DESCRIPTION
## This PR is a:

- [x] Content update

## Summary
- Updated ElasticSearch version support for v2.3.1 to add 6.x.
- Changed "default" to "recommended" for versions since Cloud requires you to configure the Elasticsearch version
- Removed version numbers from the service type list on the [Services](https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services.html) page to reduce content maintenance.
- Miscellaneous edits

<!-- (REQUIRED) What does this PR change? -->


*Affected URLs*

- https://devdocs.magento.com/guides/v2.1/cloud/project/project-conf-files_services.html
- https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_services.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services.html
- https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_services-elastic.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-elastic.html
- https://devdocs.magento.com/guides/v2.3/cloud/docker/docker-config.html


#whatsnew
 Updated Elasticsearch version requirements for Magento Commerce Cloud to include v6.x support available in Magento Commerce version 2.3.1 and later.