### PR TITLE
Add rake tasks for the mftf subrepo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,8 @@ defaults:
       path: mftf/docs
     values:
       group: mftf
+      github_files: https://github.com/magento/magento2-functional-testing-framework/blob/develop/
+      github_repo: https://github.com/magento/magento2-functional-testing-framework/
       functional_areas:
         - Test
 

--- a/_plugins/page-versions.rb
+++ b/_plugins/page-versions.rb
@@ -24,7 +24,7 @@ Jekyll::Hooks.register :pages, :pre_render do |page, config|
   # Select pages that do not have name 'redirect.html' and their URL
   # starts with '/guides/v'. Get 'url' of each page and store them as an array.
   urls_filtered_by_pattern =
-    pages.filter do |site_page|
+    pages.select do |site_page|
       next if site_page.name == 'redirect.html'
       site_page.url.start_with? filtering_pattern
     end.map(&:url)
@@ -40,7 +40,7 @@ Jekyll::Hooks.register :pages, :pre_render do |page, config|
 
   # Get URLs for all versions of the topic
   versioned_urls =
-    urls_filtered_by_pattern.filter { |path| path.match full_path_pattern }
+    urls_filtered_by_pattern.select { |path| path.match full_path_pattern }
 
   # Define a regular expression to get a version number from URL
   # to the 'version_from_path' variable

--- a/rakelib/multirepo.rake
+++ b/rakelib/multirepo.rake
@@ -1,10 +1,9 @@
 namespace :multirepo do
   desc 'Add content from external repositories'
   task :init do
-    # sh './scripts/docs-from-code.sh mftf git@github.com:magento/magento2-functional-testing-framework.git master'
-    # sh './scripts/docs-from-code.sh page-builder git@github.com:magento/magento2-page-builder.git master'
     sh './scripts/docs-from-code.sh mbi git@github.com:magento/devdocs-mbi.git master'
     sh './scripts/docs-from-code.sh page-builder git@github.com:magento-devdocs/magento2-page-builder.git develop'
+    sh './scripts/docs-from-code.sh mftf git@github.com:magento/magento2-functional-testing-framework.git develop'
 
     # The last argument 'false' disables content filtering by sparse checkout.
     # It covers cases when we need entire repository, not only the '/docs/' directory.

--- a/rakelib/update.rake
+++ b/rakelib/update.rake
@@ -39,6 +39,16 @@ namespace :update do
     end
   end
 
+  desc 'Update MFTF docs'
+  task :mftf do
+    puts 'Updating MFTF docs'.magenta
+    abort 'Cannot find the "mftf" directory' unless Dir.exist? 'mftf'
+    Dir.chdir 'mftf' do
+      sh 'git remote -v'
+      sh 'git pull'
+    end
+  end
+
   desc 'Update devdocs master'
   task :devdocs do
     puts 'Updating devdocs'.magenta
@@ -49,8 +59,8 @@ namespace :update do
   end
 
   desc 'Update devodcs and subrepositories'
-  task all: %w[devdocs m1 mbi pb]
+  task all: %w[devdocs subrepos]
 
   desc 'Update subrepositories only'
-  task subrepos: %w[m1 mbi pb]
+  task subrepos: %w[m1 mbi pb mftf]
 end


### PR DESCRIPTION
## This PR is a:

Improvement

## Summary

When this pull request is merged, it will add `mftf` as a subrepository to `rake init` and `rake update` tasks.

## Additional information

- added `rake update:mftf` task
- fixed the **Edit this page on GitHub** and **Give us feedback** links in the MFTF guide
- fixed the Ruby version incompatibility bug in the page versions plugin