### PR TITLE
Updated wrong class mentioned in the customer service web API example as per codebase

### DIFF
--- a/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -231,7 +231,7 @@ If a service method argument is called `item`, there will be a problem during SO
     </route>
 ...
     <route url="/V1/customers/me/billingAddress" method="GET">
-        <service class="Magento\Customer\Service\V1\CustomerAddressServiceInterface" method="getDefaultBillingAddress"/>
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="getDefaultBillingAddress"/>
         <resources>
             <resource ref="self"/>
         </resources>

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -225,7 +225,7 @@ If a service method argument is called `item`, there will be a problem during SO
     </route>
 ...
     <route url="/V1/customers/me/billingAddress" method="GET">
-        <service class="Magento\Customer\Service\V1\CustomerAddressServiceInterface" method="getDefaultBillingAddress"/>
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="getDefaultBillingAddress"/>
         <resources>
             <resource ref="self"/>
         </resources>


### PR DESCRIPTION
## This PR is a:

- [x] Content fix or rewrite

## Summary

When this pull request is merged, it will update the wrong class mentioned in the customer service web API example as per codebase.

<!-- (REQUIRED) What does this PR change? -->

## Additional information

Codebase: https://github.com/magento/magento2/blob/08fbdf1c1c7d6c3474186de77276004777d31b1c/app/code/Magento/Customer/etc/webapi.xml#L248

List all affected URLs 

https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-to-web-service.html
https://devdocs.magento.com/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.html
https://devdocs.magento.com/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.html