### PR TITLE
Corrected `Region` class name

### DIFF
--- a/guides/v2.3/graphql/reference/directory.md
+++ b/guides/v2.3/graphql/reference/directory.md
@@ -11,7 +11,7 @@ The `country` object provides the following attributes:
 
 Attribute | Data type | Description
 --- | --- | ---
-`available_regions` | [[region]](#region) | An array of regions within a particular country
+`available_regions` | [[Region]](#region) | An array of regions within a particular country
 `full_name_english` | String | The name of the country in English
 `full_name_locale` | String | The locale name of the country
 `id` | String | A unique ID for the country
@@ -21,7 +21,7 @@ Attribute | Data type | Description
 
 ### Region attributes {#region}
 
-The `region` object provides the following attributes:
+The `Region` object provides the following attributes:
 
 Attribute | Data type | Description
 --- | --- | ---


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

The class name should be `Region` instead of `region`. The actual schema is:
```
type Region {
    id: Int
    code: String
    name: String
}
```

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/reference/directory.html


<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
