### PR TITLE
Replaced deprecated field with new one

### DIFF
--- a/guides/v2.3/graphql/reference/directory.md
+++ b/guides/v2.3/graphql/reference/directory.md
@@ -48,8 +48,8 @@ Attribute | Data type | Description
 `available_currency_codes` | [String] | An array of currencies accepted by the store
 `base_currency_code` | String | The base currency set for the store, such as USD
 `base_currency_symbol` | String | The symbol for the specified base currency, such as $
-`default_display_currecy_code` | String | Specifies if the currency code is set as the store's default
-`default_display_currecy_symbol` | String | Specifies if the currency symbol is set as the store's default
+`default_display_currency_code` | String | Specifies if the currency code is set as the store's default
+`default_display_currency_symbol` | String | Specifies if the currency symbol is set as the store's default
 `exchange_rates` | [[ExchangeRate]](#exchangeRateAttributes) | An array of exchange rates specified in the store
 {:style="table-layout:auto;"}
 
@@ -298,8 +298,8 @@ query {
     currency {
         base_currency_code
         base_currency_symbol
-        default_display_currecy_code
-        default_display_currecy_symbol
+        default_display_currency_code
+        default_display_currency_symbol
         available_currency_codes
         exchange_rates {
             currency_to
@@ -317,8 +317,8 @@ query {
     "currency": {
       "base_currency_code": "USD",
       "base_currency_symbol": "$",
-      "default_display_currecy_code": null,
-      "default_display_currecy_symbol": null,
+      "default_display_currency_code": "USD",
+      "default_display_currency_symbol": "$",
       "available_currency_codes": [
         "USD"
       ],


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

The fields `default_display_currecy_code` and `default_display_currecy_symbol` are no longer in use and returns `null` value so instead use `default_display_currency_code` and `default_display_currency_symbol`

<!-- (REQUIRED) What does this PR change? -->

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/reference/directory.html

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
