### PR TITLE
Add warning regarding GTID consistency

### DIFF
--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -32,8 +32,8 @@ Magento _strongly_ recommends you observe the following standard when you set up
 
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
-implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
+implementations utilizing GTID-based replication, such as
+[Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -30,6 +30,12 @@ Magento _strongly_ recommends you observe the following standard when you set up
 *	Familiarize yourself with [these potential MySQL trigger limitations](http://dev.mysql.com/doc/mysql-reslimits-excerpt/5.1/en/stored-program-restrictions.html){:target="_blank"} before you continue.
 *	If you use MySQL database replication, be aware that Magento does _not_ support MySQL statement-based replication. Make sure you use _only_ [row-based replication](http://dev.mysql.com/doc/refman/5.1/en/replication-formats.html){:target="_blank"}.
 
+{:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
+which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
+implementations utilizing GTID-based replication.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
+[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).
 

--- a/guides/v2.1/install-gde/prereq/mysql.md
+++ b/guides/v2.1/install-gde/prereq/mysql.md
@@ -33,8 +33,7 @@ Magento _strongly_ recommends you observe the following standard when you set up
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
 implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
-[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -29,8 +29,7 @@ Magento _strongly_ recommends you observe the following standard when you set up
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
 implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
-[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -28,8 +28,8 @@ Magento _strongly_ recommends you observe the following standard when you set up
 
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
-implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
+implementations utilizing GTID-based replication, such as
+[Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -26,6 +26,12 @@ Magento _strongly_ recommends you observe the following standard when you set up
 *	Familiarize yourself with [these potential MySQL trigger limitations](http://dev.mysql.com/doc/mysql-reslimits-excerpt/5.1/en/stored-program-restrictions.html){:target="_blank"} before you continue.
 *	If you use MySQL database replication, be aware that Magento does _not_ support MySQL statement-based replication. Make sure you use _only_ [row-based replication](http://dev.mysql.com/doc/refman/5.1/en/replication-formats.html){:target="_blank"}.
 
+{:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
+which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
+implementations utilizing GTID-based replication.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
+[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html).
 

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -29,8 +29,7 @@ Magento _strongly_ recommends you observe the following standard when you set up
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
 implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
-[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -28,8 +28,8 @@ Magento _strongly_ recommends you observe the following standard when you set up
 
 {:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
 which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
-implementations utilizing GTID-based replication.
-(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).)
+implementations utilizing GTID-based replication, such as
+[Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).
 
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html).

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -26,6 +26,12 @@ Magento _strongly_ recommends you observe the following standard when you set up
 *	Familiarize yourself with [these potential MySQL trigger limitations](http://dev.mysql.com/doc/mysql-reslimits-excerpt/5.1/en/stored-program-restrictions.html){:target="_blank"} before you continue.
 *	If you use MySQL database replication, be aware that Magento does _not_ support MySQL statement-based replication. Make sure you use _only_ [row-based replication](http://dev.mysql.com/doc/refman/5.1/en/replication-formats.html){:target="_blank"}.
 
+{:.bs-callout .bs-callout-warning} Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions,
+which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database
+implementations utilizing GTID-based replication.
+(E.g., [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences).) See
+[this ticket](https://github.com/magento/magento2/issues/15209) for further information.
+
 {:.bs-callout .bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html).
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will add a warning to users of MySQL regarding Magento's dependency on a `TRIGGER` statement that is incompatible with GTID-based replication.

Refs https://github.com/magento/magento2/issues/15209

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/install-gde/prereq/mysql.html
- https://devdocs.magento.com/guides/v2.2/install-gde/prereq/mysql.html
- https://devdocs.magento.com/guides/v2.1/install-gde/prereq/mysql.html
- https://devdocs.magento.com/guides/v2.0/install-gde/prereq/mysql.html