### PR TITLE
Fixed response for GraphQl setShippingAddressesOnCart

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -365,7 +365,7 @@ mutation {
             postcode: "78758"
             country_code: "US"
             telephone: "8675309"
-            save_in_address_book: False
+            save_in_address_book: false
           }
         }
       ]
@@ -391,7 +391,24 @@ mutation {
 ```text
 {
   "data": {
-    "createEmptyCart": "6XZA7q1ooLEI0jLz8DfFrfruEqgxGzlt"
+    "setShippingAddressesOnCart": {
+      "cart": {
+        "shipping_addresses": [
+          {
+            "firstname": "Bob",
+            "lastname": "Roll",
+            "company": "Magento",
+            "street": [
+              "Magento Pkwy",
+              "Main Street"
+            ],
+            "city": "Austin",
+            "postcode": "78758",
+            "telephone": "8675309"
+          }
+        ]
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

This PR introduces a fix for GraphQl setShippingAddressesOnCart response. Currently it shows incorrect response since the request is not for creating empty cart. After implementing changes from PR setShippingAddressesOnCart mutation will have the correct response documented.

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html
