### PR TITLE
MAGECLOUD-3054: Implement Database Locks using Zookeeper and flock for Reliable HA Support

### DIFF
--- a/guides/v2.2/cloud/env/variables-cloud.md
+++ b/guides/v2.2/cloud/env/variables-cloud.md
@@ -27,7 +27,7 @@ Variable | Description
 `MAGENTO_CLOUD_LOCKS_DIR` | Provides the path to the mount point for the lock provider on the Cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups.
 
 {:.bs-callout .bs-callout-warning}
-When attempting to [use environment variables to override configuration settings]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-var-name.html) using the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html#project-conf-env-var), you must prepend the variable name with `env:` as in the following example.
+To [add your own environment variables to override configuration settings]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-var-name.html) using the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html#project-conf-env-var), you must prepend the variable name with `env:` as in the following example.
 ![Environment variable example]({{ site.baseurl }}/common/images/cloud_env_var_example.png)
 
 Since values can change over time, it is best to inspect the variable at runtime and use it to configure your application. For example, we use the `MAGENTO_CLOUD_RELATIONSHIPS` variable to retrieve environment-related relationships as follows:

--- a/guides/v2.2/cloud/env/variables-cloud.md
+++ b/guides/v2.2/cloud/env/variables-cloud.md
@@ -24,7 +24,7 @@ Variable | Description
 `MAGENTO_CLOUD_ROUTES` | Describe the routes defined in the environment `.magento/routes.yaml` file.
 `MAGENTO_CLOUD_TREE_ID` | The tree ID for the application, which corresponds to the SHA of the tree in Git.
 `MAGENTO_CLOUD_VARIABLES` | A base64-encoded JSON object with key-value pairs, such as `"key":"value"`.
-`MAGENTO_CLOUD_LOCKS_DIR` | Contains the path to the mount point where using special File System for locks
+`MAGENTO_CLOUD_LOCKS_DIR` | Provides the path to the mount point for the lock provider on the Cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups.
 
 {:.bs-callout .bs-callout-warning}
 When attempting to [use environment variables to override configuration settings]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-var-name.html) using the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html#project-conf-env-var), you must prepend the variable name with `env:` as in the following example.

--- a/guides/v2.2/cloud/env/variables-cloud.md
+++ b/guides/v2.2/cloud/env/variables-cloud.md
@@ -24,6 +24,7 @@ Variable | Description
 `MAGENTO_CLOUD_ROUTES` | Describe the routes defined in the environment `.magento/routes.yaml` file.
 `MAGENTO_CLOUD_TREE_ID` | The tree ID for the application, which corresponds to the SHA of the tree in Git.
 `MAGENTO_CLOUD_VARIABLES` | A base64-encoded JSON object with key-value pairs, such as `"key":"value"`.
+`MAGENTO_CLOUD_LOCKS_DIR` | Contains the path to the mount point where using special File System for locks
 
 {:.bs-callout .bs-callout-warning}
 When attempting to [use environment variables to override configuration settings]({{ site.baseurl }}/guides/v2.2/config-guide/prod/config-reference-var-name.html) using the [Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-basic.html#project-conf-env-var), you must prepend the variable name with `env:` as in the following example.

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -30,6 +30,10 @@ The release notes include:
 -   {:.new}New features
 -   {:.fix}Fixes and improvements
 
+## v2002.0.18
+
+-   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/guides/v2.2/cloud/env/variables-cloud.html).
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -30,6 +30,10 @@ The release notes include:
 -   {:.new}New features
 -   {:.fix}Fixes and improvements
 
+## v2002.0.18
+
+-   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/guides/v2.2/cloud/env/variables-cloud.html).
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

See [ECE-Tools PR #437](https://github.com/magento/ece-tools/pull/437) for the associated source code.

<!-- (REQUIRED) What does this PR change? -->

*Affected URLs*
- https://devdocs.magento.com/guides/v2.2/cloud/env/variables-cloud.html
- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-cloud.html

whatsnew
Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on Magento version 2.2.9 and later 2.2.x versions and 2.3.2 and later.




