### PR TITLE
[GraphQl] Fixed response for removeCouponFromCart mutation

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -491,7 +491,7 @@ mutation {
     "removeCouponFromCart": {
       "cart": {
         "applied_coupon": {
-          "code": "test2019"
+          "code": ""
         }
       }
     }

--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -490,9 +490,7 @@ mutation {
   "data": {
     "removeCouponFromCart": {
       "cart": {
-        "applied_coupon": {
-          "code": ""
-        }
+        "applied_coupon": null
       }
     }
   }


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary
This PR introduces a fix for response of `removeCouponFromCart` mutation documented in https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html. After coupon is removed from the shopping cart, the response contains no coupon code (currently the response contains the same coupon code that was previously applied).

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html
