### PR TITLE
Fix routes.yaml file using tabs vs spaces

### DIFF
--- a/guides/v2.1/cloud/project/project-multi-sites.md
+++ b/guides/v2.1/cloud/project/project-multi-sites.md
@@ -42,21 +42,23 @@ For Pro, you must create a [Support ticket]({{ page.baseurl }}/cloud/trouble/tro
 
 1.  Replace the contents with the following:
 
-	"http://{default}/":
-	    type: upstream
-	    upstream: "mymagento:php"
+    ```yaml
+    "http://{default}/":
+        type: upstream
+	upstream: "mymagento:php"
 
-	"https://{default}/":
-	    type: upstream
-	    upstream: "mymagento:php"
+    "https://{default}/":
+	type: upstream
+	upstream: "mymagento:php"
 
-	"http://*.{default}/":
-	    type: upstream
-	    upstream: "mymagento:php"
+    "http://*.{default}/":
+	type: upstream
+	upstream: "mymagento:php"
 
-	"https://*.{default}/":
-	    type: upstream
-	    upstream: "mymagento:php"
+    "https://*.{default}/":
+	type: upstream
+	upstream: "mymagento:php"
+    ```
 
 1.  Save your changes to the `routes.yaml` file.
 

--- a/guides/v2.1/cloud/project/project-multi-sites.md
+++ b/guides/v2.1/cloud/project/project-multi-sites.md
@@ -45,19 +45,19 @@ For Pro, you must create a [Support ticket]({{ page.baseurl }}/cloud/trouble/tro
     ```yaml
     "http://{default}/":
         type: upstream
-	upstream: "mymagento:php"
+        upstream: "mymagento:php"
 
     "https://{default}/":
-	type: upstream
-	upstream: "mymagento:php"
+        type: upstream
+        upstream: "mymagento:php"
 
     "http://*.{default}/":
-	type: upstream
-	upstream: "mymagento:php"
+        type: upstream
+        upstream: "mymagento:php"
 
     "https://*.{default}/":
-	type: upstream
-	upstream: "mymagento:php"
+        type: upstream
+        upstream: "mymagento:php"
     ```
 
 1.  Save your changes to the `routes.yaml` file.

--- a/guides/v2.1/cloud/project/project-multi-sites.md
+++ b/guides/v2.1/cloud/project/project-multi-sites.md
@@ -42,21 +42,21 @@ For Pro, you must create a [Support ticket]({{ page.baseurl }}/cloud/trouble/tro
 
 1.  Replace the contents with the following:
 
-		"http://{default}/":
-    		type: upstream
-    		upstream: "mymagento:php"
+	"http://{default}/":
+	    type: upstream
+	    upstream: "mymagento:php"
 
-		"https://{default}/":
-    		type: upstream
-    		upstream: "mymagento:php"
+	"https://{default}/":
+	    type: upstream
+	    upstream: "mymagento:php"
 
-		"http://*.{default}/":
-    		type: upstream
-    		upstream: "mymagento:php"
+	"http://*.{default}/":
+	    type: upstream
+	    upstream: "mymagento:php"
 
-		"https://*.{default}/":
-    		type: upstream
-    		upstream: "mymagento:php"
+	"https://*.{default}/":
+	    type: upstream
+	    upstream: "mymagento:php"
 
 1.  Save your changes to the `routes.yaml` file.
 


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ x ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

This PR replaces tab usage with spaces. Tabs cause an error when pushing to Magento cloud:

```> git push
Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 12 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (8/8), 1.07 KiB | 1.07 MiB/s, done.
Total 8 (delta 3), reused 0 (delta 0)

Validating submodules

Validating configuration files

E: Error parsing configuration files:
    - routes: Error loading file: while scanning for the next token
        found character that cannot start any token
          in ".magento/routes.yaml", line 2, column 1
To git.us-3.magento.cloud:foo.git
 ! [remote rejected] foo -> foo (invalid configuration files)
error: failed to push some refs to 'foo@git.us-3.magento.foo.git'
```

Change to spaces eliminates this error from happening, allowing a git push to occur.
