### PR TITLE
Zero downtime clarification

### DIFF
--- a/_data/toc/cloud-guide.yml
+++ b/_data/toc/cloud-guide.yml
@@ -307,7 +307,7 @@ pages:
         - label: Cloud deployment process
           url: /cloud/deploy/cloud-deployment-process.html
 
-        - label: Reduce downtime
+        - label: Zero downtime deployment
           url: /cloud/deploy/reduce-downtime.html
 
         - label: Static content deployment

--- a/guides/v2.1/cloud/deploy/optimize-cloud-deployment.md
+++ b/guides/v2.1/cloud/deploy/optimize-cloud-deployment.md
@@ -14,11 +14,11 @@ The following topics can help you to better understand how to optimize the deplo
 -  [Cloud deployment process]({{page.baseurl}}/cloud/deploy/cloud-deployment-process.html)  
     There are three phases in the Cloud deployment process, and you can use the strengths and weaknesses of each phase to your advantage.
 
+-  [Zero downtime deployment]({{page.baseurl}}/cloud/deploy/reduce-downtime.html)  
+    Understand what happens during deployment and how to reduce the amount of downtime your store experiences during an update to the Production environment.
+
 -  [Static content deployment]({{page.baseurl}}/cloud/deploy/static-content-deployment.html)  
     The best way to optimize your Cloud deployment is to control how and when to generate static content.
-
--  [Reduce downtime]({{page.baseurl}}/cloud/deploy/reduce-downtime.html)  
-    Understand what happens during deployment and how to reduce the amount of downtime your store experiences during an update to the Production environment.
 
 -  [Smart wizards]({{page.baseurl}}/cloud/deploy/smart-wizards.html)  
     The `{{site.data.var.ct}}` package provides the smart wizard commands to quickly evaluate your project configuration.

--- a/guides/v2.1/cloud/deploy/reduce-downtime.md
+++ b/guides/v2.1/cloud/deploy/reduce-downtime.md
@@ -1,15 +1,15 @@
 ---
 group: cloud-guide
-title: Reduce downtime
+title: Zero downtime deployment
 functional_areas:
   - Cloud
   - Deploy
   - SCD
 ---
 
-{{site.data.var.ece}} runs Magento in [_maintenance_ mode]({{page.baseurl}}/config-guide/bootstrap/magento-modes.html#maintenance-mode) during the deploy phase, which takes your site offline until the deployment is complete. The length of time your Production site is in maintenance mode depends on the size of the site, the number of changes applied during the deployment, and the configuration for static content deployment.
+{{site.data.var.ece}} runs Magento in [_maintenance_ mode]({{page.baseurl}}/config-guide/bootstrap/magento-modes.html#maintenance-mode) during the deploy phase, which takes your site offline until the deployment is complete. The length of time your Production site is in maintenance mode depends on the size of the site, the number of changes applied during the deployment, and the configuration for static content deployment. It is possible to configure your project so that it deploys with a **zero** downtime effect.
 
-During the deployment process, all connections queue for up to 5 minutes preserving any active sessions and pending actions, such as adding to cart or checkout. After deployment, the queue is released and connections continue without interruption. To use this _connection hold_ to your advantage and reduce downtime to **zero**, you must configure your project to use the most efficient deploy strategy.
+During the deployment process, all connections queue for up to 5 minutes preserving any active sessions and pending actions, such as adding to cart or checkout. After deployment, the queue is released and connections continue without interruption. To use this _connection hold_ to your advantage and reduce deployment to _zero_ downtime, you must configure your project to use the most efficient deploy strategy.
 
 Use the following steps to reduce the amount of time it takes your store to deploy an update to Production:
 


### PR DESCRIPTION
This is a quick fix to change `Reduce downtime` to say `Zero downtime` and focus more on the term zero to match marketing. 

