### PR TITLE
Fix create-project URL for 2.1, 2.2 docs

### DIFF
--- a/guides/v2.1/install-gde/composer.md
+++ b/guides/v2.1/install-gde/composer.md
@@ -41,12 +41,12 @@ To get the Magento metapackage:
 
     **{{site.data.var.ce}}**
     ```bash
-    composer create-project --repository=https://repo.magento.com/magento/project-community-edition:<version-tag> <install-directory-name>
+    composer create-project --repository=https://repo.magento.com magento/project-community-edition:<version-tag> <install-directory-name>
     ```
 
     **{{site.data.var.ee}}**
     ```bash
-    composer create-project --repository=https://repo.magento.com/magento/project-enterprise-edition:<version-tag> <install-directory-name>
+    composer create-project --repository=https://repo.magento.com magento/project-enterprise-edition:<version-tag> <install-directory-name>
     ```
 
     When prompted, enter your Magento authentication keys. Your _public key_ is your username; your _private key_ is your password.


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [x] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

When this pull request is merged, it will fix the `composer create-project` command for Magento docs for 2.1 and 2.2 (they are symlinked.)

## Additional information

List all affected URLs 

- https://devdocs.magento.com/guides/v2.2/install-gde/install/cli/install-cli-install.html
- https://devdocs.magento.com/guides/v2.1/install-gde/install/cli/install-cli-install.html