### PR TITLE
Added missing full-screen options in gallery widget example

### DIFF
--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
@@ -39,7 +39,6 @@ Example of declarative initialization:
 ```javascript
 <script type="text/x-magento-init">
     {
-         {
         "<element_selector>": {
             "mage/gallery/gallery": {
                 "data": [{
@@ -71,6 +70,8 @@ Example of declarative initialization:
                     "nav": "<false/thumbs/dots>",
                     "loop": <true/false>,
                     "navdir": "<horizontal/vertical>",
+                    "navarrows": <true/false>,
+                    "navtype": "<slides/thumbs>",
                     "arrows": <true/false>,
                     "showCaption": <true/false>,
                     "transitionduration": <number>,


### PR DESCRIPTION
## Scope of this PR

- Technical: Changes to technical content/code/processes/naming conventions (any change to technical content)

## Purpose of this PR (required)

- Added missing full-screen options in gallery widget example.
- Removed extra opening curly braces.

## Affected URLs (required)

- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.html

## Links to source code (remove if unused)

If this PR references a file in a Magento codebase repository, add it here.

- **Magento 2.2:** https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml

- **Magento 2.3:** https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Block/Product/View/GalleryOptions.php


<!-- 
If you are fixing a Github issue, note it in the following format and the issue will automatically close when this PR is merged:
Fixes #<IssueNumber>

`master` is the default branch. PRs to this branch should be for current devdocs content. Merged PRs to master go live on the site automatically. Work for future releases generally goes in the `develop` branch. Work with the devdocs team if you are unsure where to submit your PR.
-->
