### PR TITLE
Update Magento version in gateway command description

### DIFF
--- a/guides/v2.2/payments-integrations/payment-gateway/gateway-command.md
+++ b/guides/v2.2/payments-integrations/payment-gateway/gateway-command.md
@@ -37,7 +37,7 @@ In the following example the `BraintreeAuthorizeCommand` gateway command is adde
 </virtualType>
 {% endhighlight %}
 
-(The code sample is from {{site.data.var.ce}} v2.1. Although the payment provider gateway was added in v2.0, the particular default implementation using the gateway were added in v2.1)
+(The code sample is from {{site.data.var.ce}} v2.2. Although the payment provider gateway was added in v2.0, the particular default implementation using the gateway were added in v2.1)
 
 A gateway command must be configured with the following arguments:
 


### PR DESCRIPTION
## This PR is a:

- Update Magento version in BraintreeAuthorizeCommand gateway description.
- Reference PR: https://github.com/magento/devdocs/pull/4190

## Summary

When this pull request is merged, it will update show correct Magento version in description.

## Additional information

List all affected URLs 

1. https://devdocs.magento.com/guides/v2.2/payments-integrations/payment-gateway/gateway-command.html
2. https://devdocs.magento.com/guides/v2.3/payments-integrations/payment-gateway/gateway-command.html