### PR TITLE
MAGECLOUD-3150 Cron changes for Cloud Docker

### DIFF
--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -62,7 +62,7 @@ The Cron container is based on PHP-CLI images, and executes operations in the ba
 #### View cron log
 
 ```bash
-docker-compose run deploy bash -c "cat /var/www/magento/var/log/magento.cron.log"
+docker-compose run deploy bash -c "cat /var/www/magento/var/cron.log"
 ```
 
 ### Database container

--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -57,7 +57,7 @@ The configured state is not ideal
 
 ### Cron container
 
-The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`cron` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`crons` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
 #### View cron log
 

--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -57,7 +57,7 @@ The configured state is not ideal
 
 ### Cron container
 
-The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start.
+The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`cron` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
 #### View cron log
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -30,6 +30,10 @@ The release notes include:
 -   {:.new}New features
 -   {:.fix}Fixes and improvements
 
+## v2002.0.18
+
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -32,7 +32,7 @@ The release notes include:
 
 ## v2002.0.18
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
 ## v2002.0.17
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
 ## v2002.0.17
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -34,6 +34,8 @@ The release notes include:
 
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
 ## v2002.0.17
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -34,6 +34,8 @@ The release notes include:
 
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.9 and later 2.2.x versions and on v2.3.2 and later. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
+-   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [cron property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
The cron container uses the custom configuration defined in the `crons` property of the .magento.app.yaml file.

Added release notes, too.

whatsnew
The Cloud Docker [cron container](https://devdocs.magento.com/guides/v2.2/cloud/docker/docker-development.html#cron-container) supports custom cron configuration.