### PR TITLE
Remove duplicated "No changes" in BICs reference topics

### DIFF
--- a/_includes/backward-incompatible-changes/commerce/2.0.0-2.0.1.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.0-2.0.1.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-200-201">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.1-2.0.2.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.1-2.0.2.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-201-202">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.10-2.0.11.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.10-2.0.11.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2010-2011">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.12-2.0.13.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.12-2.0.13.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2012-2013">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.13-2.0.14.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.13-2.0.14.html
@@ -1,2 +1,1 @@
-<h3 id="no-changes-2013-2014">No changes</h3>
-<p>No backward incompatible changes.</p>
+

--- a/_includes/backward-incompatible-changes/commerce/2.0.14-2.0.15.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.14-2.0.15.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2014-2015">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.15-2.0.16.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.15-2.0.16.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.0.15-2.0.16">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.17-2.0.18.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.17-2.0.18.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.0.17-2.0.18">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.2-2.0.3.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.2-2.0.3.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-202-203">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.3-2.0.4.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.3-2.0.4.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-203-204">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.4-2.0.5.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.4-2.0.5.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-204-205">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.5-2.0.6.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.5-2.0.6.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-205-206">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.6-2.0.7.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.6-2.0.7.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-206-207">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.7-2.0.8.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.7-2.0.8.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-207-208">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.8-2.0.9.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.8-2.0.9.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-208-209">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.0.9-2.0.10.html
+++ b/_includes/backward-incompatible-changes/commerce/2.0.9-2.0.10.html
@@ -1,2 +1,1 @@
-<h3 id="no-changes-209-2010">No changes</h3>
-<p>No backward incompatible changes.</p>
+

--- a/_includes/backward-incompatible-changes/commerce/2.1.0-2.1.1.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.0-2.1.1.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-210-211">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.1-2.1.2.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.1-2.1.2.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-211-212">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.11-2.1.12.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.11-2.1.12.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.1.11-2.1.12">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.12-2.1.13.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.12-2.1.13.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.1.12-2.1.13">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.13-2.1.14.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.13-2.1.14.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.1.13-2.1.14">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.14-2.1.15.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.1.14-2.1.15">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.15-2.1.16.md
+++ b/_includes/backward-incompatible-changes/commerce/2.1.15-2.1.16.md
@@ -1,3 +1,0 @@
-### No changes   {#changes-2115-2116}
-
-No backward incompatible changes.

--- a/_includes/backward-incompatible-changes/commerce/2.1.16-2.1.17.md
+++ b/_includes/backward-incompatible-changes/commerce/2.1.16-2.1.17.md
@@ -1,3 +1,0 @@
-### No changes   {#changes-2116-2117}
-
-No backward incompatible changes.

--- a/_includes/backward-incompatible-changes/commerce/2.1.3-2.1.4.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.3-2.1.4.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-213-214">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.4-2.1.5.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.4-2.1.5.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-214-215">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.5-2.1.6.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.5-2.1.6.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-215-216">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.6-2.1.7.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.6-2.1.7.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-216-217">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.8-2.1.9.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.8-2.1.9.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-219-218">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.1.9-2.1.10.html
+++ b/_includes/backward-incompatible-changes/commerce/2.1.9-2.1.10.html
@@ -1,2 +1,0 @@
-<h3 id="no-changes-2.1.9-2.1.10">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.2.1-2.2.2.html
+++ b/_includes/backward-incompatible-changes/commerce/2.2.1-2.2.2.html
@@ -1,2 +1,0 @@
-<h3 id="changes-221-222">No changes</h3>
-<p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/commerce/2.2.4-2.2.5.html
+++ b/_includes/backward-incompatible-changes/commerce/2.2.4-2.2.5.html
@@ -1,4 +1,4 @@
-<h3 id="ee-classes-2.2.4-2.2.5">{{ site.data.var.ee }} only changes in classes</h3>
+<h3 id="ee-classes-224-225">{{ site.data.var.ee }} only changes in classes</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/commerce/2.2.5-2.2.6.html
+++ b/_includes/backward-incompatible-changes/commerce/2.2.5-2.2.6.html
@@ -1,4 +1,4 @@
-<h3 id="ee-classes-2.2.5-2.2.6">{{ site.data.var.ee }} only changes in classes</h3>
+<h3 id="ee-classes-225-226">{{ site.data.var.ee }} only changes in classes</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/open-source/2.0.15-2.0.16.html
+++ b/_includes/backward-incompatible-changes/open-source/2.0.15-2.0.16.html
@@ -1,2 +1,2 @@
-<h3 id="no-changes-2.0.15-2.0.16">No changes</h3>
+<h3 id="no-changes-2015-2016">No changes</h3>
 <p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.0.16-2.0.17.html
+++ b/_includes/backward-incompatible-changes/open-source/2.0.16-2.0.17.html
@@ -1,2 +1,2 @@
-<h3 id="no-changes-2.0.16-2.0.17">No changes</h3>
+<h3 id="no-changes-2016-2017">No changes</h3>
 <p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.0.17-2.0.18.html
+++ b/_includes/backward-incompatible-changes/open-source/2.0.17-2.0.18.html
@@ -1,2 +1,2 @@
-<h3 id="no-changes-2.0.17-2.0.18">No changes</h3>
+<h3 id="no-changes-2017-2018">No changes</h3>
 <p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.1.11-2.1.12.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.11-2.1.12.html
@@ -1,2 +1,2 @@
-<h3 id="no-changes-2.1.11-2.1.12">No changes</h3>
+<h3 id="no-changes-2111-2112">No changes</h3>
 <p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.1.12-2.1.13.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.12-2.1.13.html
@@ -1,4 +1,4 @@
-<h3 id="interfaces-2.1.12-2.1.13">Changes in interfaces</h3>
+<h3 id="interfaces-2112-2113">Changes in interfaces</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/open-source/2.1.13-2.1.14.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.13-2.1.14.html
@@ -1,4 +1,4 @@
-<h3 id="classes-2.1.13-2.1.14">Changes in classes</h3>
+<h3 id="classes-2113-2114">Changes in classes</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.14-2.1.15.html
@@ -1,4 +1,4 @@
-<h3 id="interfaces-2.1.14-2.1.15">Changes in interface</h3>
+<h3 id="interfaces-2114-2115">Changes in interface</h3>
 <table><tbody>
     <tr>
         <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/open-source/2.1.9-2.1.10.html
+++ b/_includes/backward-incompatible-changes/open-source/2.1.9-2.1.10.html
@@ -1,2 +1,2 @@
-<h3 id="no-changes-2.1.9-2.1.10">No changes</h3>
+<h3 id="no-changes-219-2110">No changes</h3>
 <p>No backward incompatible changes.</p>

--- a/_includes/backward-incompatible-changes/open-source/2.2.4-2.2.5.html
+++ b/_includes/backward-incompatible-changes/open-source/2.2.4-2.2.5.html
@@ -1,4 +1,4 @@
-<h3 id="classes-2.2.4-2.2.5">Changes in classes</h3>
+<h3 id="classes-224-225">Changes in classes</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>
@@ -102,7 +102,7 @@
     </tr>
 </tbody></table>
 
-<h3 id="interfaces-2.2.4-2.2.5">Changes in interfaces</h3>
+<h3 id="interfaces-224-225">Changes in interfaces</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>

--- a/_includes/backward-incompatible-changes/open-source/2.2.5-2.2.6.html
+++ b/_includes/backward-incompatible-changes/open-source/2.2.5-2.2.6.html
@@ -1,4 +1,4 @@
-<h3 id="classes-2.2.5-2.2.6">Changes in classes</h3>
+<h3 id="classes-225-226">Changes in classes</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>
@@ -250,7 +250,7 @@
     </tr>
 </tbody></table>
 
-<h3 id="interfaces-2.2.5-2.2.6">Changes in interfaces</h3>
+<h3 id="interfaces-225-226">Changes in interfaces</h3>
 <table><tbody>
 <tr>
     <th>What Changed</th>


### PR DESCRIPTION
## Purpose of this PR

This PR removes redundant _No changes_ text that is added from included files at `_includes/backward-incompatible-changes/commerce/`.

## Affected URLs

<!-- REQUIRED List the URLs you are changing. Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.0/release-notes/backward-incompatible-changes/reference.html
- https://devdocs.magento.com/guides/v2.1/release-notes/backward-incompatible-changes/reference.html
- https://devdocs.magento.com/guides/v2.2/release-notes/backward-incompatible-changes/reference.html
- https://devdocs.magento.com/guides/v2.3/release-notes/backward-incompatible-changes/reference.html

## Additional information

Fixed non-working anchor links with periods.