### PR TITLE
Removed MC-5465 from 2-3-1 release notes

### DIFF
--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
@@ -4,7 +4,7 @@ title: Magento Commerce 2.3.1 Release Notes
 ---
 
 
-*Release notes published on March 26, 2019 and last edited on April 5, 2019.*
+*Release notes published on March 26, 2019 and last edited on April 18, 2019.*
 
 We are pleased to present Magento Commerce 2.3.1.  This release includes over 200 functional fixes to the core product, over 500 pull requests contributed by the community, and  over 30 security enhancements. 
 
@@ -87,9 +87,6 @@ The Multi-Source Inventory (MSI) community project has added multiple new featur
 
 ### Improved developer experience
 
-#### Automation of upgrade process dependency assessment
-
-A new composer plugin `magento/composer-root-update-plugin` automatically updates all dependencies in `composer.json` during a Magento 2.x upgrade. Previously, developers performed this step manually by running the `https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#upgrade-cli-script` upgrade script. <!--- MC-5465-->
 
 
 
@@ -222,7 +219,6 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 <!--- MC-6275-->* The commands to enable and disable debug logging have changed to `bin/magento setup:config:set --enable-debug-logging=true | false`. The previous commands, `bin/magento config:set dev/debug/debug_logging 0 | 1` are no longer supported.  See [Logging](https://devdocs.magento.com/guides/v2.3/config-guide/logging.html). 
 
-<!--- MC-5465-->* A new composer plugin `magento/composer-root-update-plugin` automatically updates all dependencies in `composer.json` during a Magento 2.x upgrade. 
 
 <!--- ENGCOM-3291-->* Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
@@ -4,7 +4,7 @@ title: Magento Open Source 2.3.1 Release Notes
 ---
 
 
-*Release notes published on March 26, 2019 and last edited on April 5, 2019.*
+*Release notes published on March 26, 2019 and last edited on April 18, 2019.*
 
 
 We are pleased to present Magento Open Source 2.3.1. This release includes over 200 functional fixes to the core product, over 500 pull requests contributed by the community, and  over 30 security enhancements. 
@@ -72,9 +72,6 @@ The Multi-Source Inventory (MSI) community project has added multiple new featur
 
 ### Improved developer experience
 
-#### Automation of upgrade process dependency assessment
-
-A new composer plugin `magento/composer-root-update-plugin` automatically updates all dependencies in `composer.json` during a Magento 2.x upgrade.  <!--- MC-5465-->
 
 
 
@@ -198,7 +195,6 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Installation, upgrade, deployment
 
-<!--- MC-5465-->* A new composer plugin `magento/composer-root-update-plugin` automatically updates all dependencies in `composer.json` during a Magento 2.x upgrade. Previously, developers had to perform this step manually by running the `https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#upgrade-cli-script` upgrade script. 
 
 <!--- ENGCOM-3291-->* Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 


### PR DESCRIPTION
## Purpose of this PR
Removes reference to magento/composer-root-update-plugin from 2.3.1 release notes.
<!-- 	-->

This PR ...

## Affected URLs

<!-- REQUIRED List the URLs you are changing. Not needed for large numbers of files. -->


- https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.html
- https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.html

## Links to source code

<!--  REMOVE THIS SECTION IF NOT USED. If this PR references a file in a Magento codebase repository, add it here. -->


<!-- 
If you are fixing a Github issue, note it in the following format and the issue will automatically close when this PR is merged:
Fixes #<IssueNumber>

`master` is the default branch. PRs to this branch should be for current devdocs content. Merged PRs to master go live on the site automatically. Work for future releases generally goes in the `develop` branch. Work with the devdocs team if you are unsure where to submit your PR.
-->
