### PR TITLE
[GraphQl] Fixed response for GraphQl setShippingAddressesOnCart

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -365,7 +365,7 @@ mutation {
             postcode: "78758"
             country_code: "US"
             telephone: "8675309"
-            save_in_address_book: False
+            save_in_address_book: false
           }
         }
       ]
@@ -391,7 +391,24 @@ mutation {
 ```json
 {
   "data": {
-    "createEmptyCart": "6XZA7q1ooLEI0jLz8DfFrfruEqgxGzlt"
+    "setShippingAddressesOnCart": {
+      "cart": {
+        "shipping_addresses": [
+          {
+            "firstname": "Bob",
+            "lastname": "Roll",
+            "company": "Magento",
+            "street": [
+              "Magento Pkwy",
+              "Main Street"
+            ],
+            "city": "Austin",
+            "postcode": "78758",
+            "telephone": "8675309"
+          }
+        ]
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

This PR introduces a fix for GraphQl setShippingAddressesOnCart response. Currently it shows incorrect response since the request is not for creating empty cart. After implementing changes from PR setShippingAddressesOnCart mutation will have the correct response documented.


## Affected URLs

https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html

## Links to source code
https://github.com/magento/magento2/blob/1d1c2ea4381bcda5b1baec7360dfc33b0b6569c9/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L164