### PR TITLE
[GraphQl] Fixed response for removeCouponFromCart mutation

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -490,9 +490,7 @@ mutation {
   "data": {
     "removeCouponFromCart": {
       "cart": {
-        "applied_coupon": {
-          "code": "test2019"
-        }
+        "applied_coupon": null
       }
     }
   }


### PR DESCRIPTION
## Purpose of this PR

This PR introduces a fix for response of removeCouponFromCart mutation documented in https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html. After coupon is removed from the shopping cart, the response contains no coupon code (currently the response contains the same coupon code that was previously applied).

## Affected URLs

https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html

## Links to source code

https://github.com/magento/magento2/blob/1d1c2ea4381bcda5b1baec7360dfc33b0b6569c9/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L267

The `removeCouponFromCart` mutation returns `Cart` type which includes `applied_coupon` type. If no coupon is applied to the shopping cart the `applied_coupon` field of the `Cart` object is `null`