### PR TITLE
MAGECLOUD-2664 connect to database

### DIFF
--- a/_data/main-nav.yml
+++ b/_data/main-nav.yml
@@ -1,27 +1,35 @@
 - label: Cloud
   children:
 
-    - label: Cloud Guide
-      url: /cloud/bk-cloud.html
+    - label: Cloud basics
+      children:
+        - label: Cloud Guide
+          url: /cloud/bk-cloud.html
 
-    - label: Cloud Architecture
-      url: /cloud/architecture/cloud-architecture.html
+        - label: Cloud Architecture
+          url: /cloud/architecture/cloud-architecture.html
 
-    - label: Local Development
-      url: /cloud/setup/first-time-setup.html
+        - label: Upgrades and Patches
+          url: /cloud/project/project-upgrade-parent.html
 
-    - label: Docker quick reference
-      url: /cloud/docker/docker-quick-reference.html
+        - label: Release Notes
+          url: /cloud/release-notes/cloud-tools.html
 
-    - label: Configure Environments
-      url: /cloud/env/environments.html
+    - label: Cloud development
+      children:
+        - label: Local development
+          url: /cloud/setup/first-time-setup.html
 
-    - label: Upgrades and Patches
-      url: /cloud/project/project-upgrade-parent.html
+        - label: Launch Docker
+          url: /cloud/docker/docker-config.html
+          exclude_versions: ["2.0"]
 
-    - label: Release Notes
-      url: /cloud/release-notes/cloud-tools.html
-      exclude_versions: ['2.0']
+        - label: Docker quick reference
+          url: /cloud/docker/docker-quick-reference.html
+          exclude_versions: ["2.0"]
+
+        - label: Configure Environments
+          url: /cloud/env/environments.html
 
 - label: Setup
   children:

--- a/_data/toc/cloud-guide.yml
+++ b/_data/toc/cloud-guide.yml
@@ -65,19 +65,6 @@ pages:
     - label: Local development setup
       url: /cloud/setup/first-time-setup.html
       children:
-        - label: Docker development
-          url: /cloud/docker/docker-development.html
-          exclude_versions: ["2.0"]
-          children:
-            - label: Launch Docker
-              url: /cloud/docker/docker-config.html
-
-            - label: Configure Xdebug for Docker
-              url: /cloud/docker/docker-development-debug.html
-
-            - label: Docker quick reference
-              url: /cloud/docker/docker-quick-reference.html
-
         - label: Prepare for manual setup
           url: /cloud/before/before-workspace.html
           children:
@@ -99,11 +86,27 @@ pages:
             - label: First time deployment
               url: /cloud/setup/first-time-deploy.html
 
+        - label: Optional - Configure Xdebug
+          url: /cloud/howtos/debug.html
+
         - label: Optional - Install sample data
           url: /cloud/howtos/sample-data.html
 
-        - label: Optional - Configure Xdebug
-          url: /cloud/howtos/debug.html
+    - label: Docker development
+      url: /cloud/docker/docker-development.html
+      exclude_versions: ["2.0"]
+      children:
+        - label: Launch Docker
+          url: /cloud/docker/docker-config.html
+
+        - label: Configure Xdebug for Docker
+          url: /cloud/docker/docker-development-debug.html
+
+        - label: Connect to the database
+          url: /cloud/docker/docker-database.html
+
+        - label: Docker quick reference
+          url: /cloud/docker/docker-quick-reference.html
 
     - label: Integrations
       url: /cloud/integrations/cloud-integrations.html

--- a/guides/v2.1/cloud/docker/docker-database.md
+++ b/guides/v2.1/cloud/docker/docker-database.md
@@ -7,7 +7,7 @@ functional_areas:
   - Configuration
 ---
 
-There are two ways to connect to the database. Before you begin, you can find the database credentials in the `database` section of the `docker/config.php` file. The examples below use the following default credentials:
+There are two ways to connect to the database. Before you begin, you can find the database credentials in the `database` section of the `docker/config.php` file. The examples use the following default credentials:
 
 > Filename: `docker/config.php`
 
@@ -43,7 +43,7 @@ return [
     mysql --host=db --user=magento2 --password=magento2
     ```
 
-1.  Verify the connection.
+1.  Verify the version of the database service.
 
     ```mysql
     SELECT VERSION();
@@ -78,4 +78,14 @@ return [
     mysql -h127.0.0.1 -p32769 -umagento2 -pmagento2
     ```
 
-1.  Verify the connection.
+1.  Verify the version of the database service.
+
+    ```mysql
+    SELECT VERSION();
+    +--------------------------+
+    | VERSION()                |
+    +--------------------------+
+    | 10.0.38-MariaDB-1~xenial |
+    +--------------------------+
+    ```
+    {: .no-copy}

--- a/guides/v2.1/cloud/docker/docker-database.md
+++ b/guides/v2.1/cloud/docker/docker-database.md
@@ -1,0 +1,81 @@
+---
+group: cloud-guide
+title: Connect to the database
+functional_areas:
+  - Cloud
+  - Docker
+  - Configuration
+---
+
+There are two ways to connect to the database. Before you begin, you can find the database credentials in the `database` section of the `docker/config.php` file. The examples below use the following default credentials:
+
+> Filename: `config.php`
+
+```php
+<?php
+
+return [
+    'MAGENTO_CLOUD_RELATIONSHIPS' => base64_encode(json_encode([
+        'database' => [
+            [
+                'host' => 'db',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ],
+        ],
+    ...
+```
+{: .no-copy}
+
+#### To connect to the database using Docker commands:
+
+1.  Connect to the CLI container.
+
+    ```bash
+    docker-compose run deploy bash
+    ```
+
+1.  Connect to the database with a username and password.
+
+    ```bash
+    mysql --host=db --user=magento2 --password=magento2
+    ```
+
+1.  Verify the connection.
+
+    ```mysql
+    SELECT VERSION();
+    +--------------------------+
+    | VERSION()                |
+    +--------------------------+
+    | 10.0.38-MariaDB-1~xenial |
+    +--------------------------+
+    ```
+    {: .no-copy}
+
+#### To connect to the database in local workstation:
+
+1.  Find the port used by the database.
+
+    ```bash
+    docker-compose ps
+    ```
+
+    Sample response:
+
+    ```terminal
+              Name                         Command               State               Ports            
+    --------------------------------------------------------------------------------------------------
+    mc-master_db_1              docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp   
+    ```
+    {: .no-copy}
+
+1.  Connect to the database with port information from the previous step.
+
+    ```bash
+    mysql -h127.0.0.1 -p32769 -umagento2 -pmagento2
+    ```
+
+1.  Verify the connection.

--- a/guides/v2.1/cloud/docker/docker-database.md
+++ b/guides/v2.1/cloud/docker/docker-database.md
@@ -9,7 +9,7 @@ functional_areas:
 
 There are two ways to connect to the database. Before you begin, you can find the database credentials in the `database` section of the `docker/config.php` file. The examples below use the following default credentials:
 
-> Filename: `config.php`
+> Filename: `docker/config.php`
 
 ```php
 <?php
@@ -55,9 +55,9 @@ return [
     ```
     {: .no-copy}
 
-#### To connect to the database in local workstation:
+#### To connect to the database:
 
-1.  Find the port used by the database.
+1.  Find the port used by the database. The port may change each time you restart Docker.
 
     ```bash
     docker-compose ps

--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -31,20 +31,21 @@ The web container works with the [PHP-FPM](https://php-fpm.org) to serve PHP cod
 
 ## CLI containers
 
-There are few CLI containers based on a PHP-CLI image that provides `magento-cloud` and `{{site.data.var.ct}}` commands to perform file system operations.
+The following CLI containers, which are based on a PHP-CLI image, provide `magento-cloud` and `{{site.data.var.ct}}` commands to perform file system operations:
 
 -  `build`—extends the CLI container to perform operations with writable filesystem, similar to the build phase
 -  `deploy`—extends the CLI container to use read-only file system, similar to the deploy phase
 -  `cron`—extends the CLI container to run cron
 
     -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environment
-    -  Cron only works with CLI container to run `./bin/magento cron:run` command
+    -  Cron only works with the CLI container to run the `./bin/magento cron:run` command
 
 #### To run the `{{site.data.var.ct}}` ideal-state command:
 
 ```bash
 docker-compose run deploy ece-command wizard:ideal-state
 ```
+
 Sample response:
 
 ```terminal

--- a/guides/v2.1/cloud/docker/docker-development.md
+++ b/guides/v2.1/cloud/docker/docker-development.md
@@ -1,22 +1,20 @@
 ---
 group: cloud-guide
-title: Docker development environment
+title: Docker container architecture
 functional_areas:
   - Cloud
-  - Setup
+  - Docker
   - Configuration
 ---
 
 {{site.data.var.ece}} provides a Docker environment option for those who use their local environment for development, test, or automation tasks. The {{site.data.var.ece}} Docker environment requires three, essential components: a {{site.data.var.ee}} v2 template, Docker Compose, and {{site.data.var.ece}} `{{site.data.var.ct}}` package.
 
-## Container architecture
-
 The [Magento Cloud Docker repository](https://github.com/magento/magento-cloud-docker) contains build information for the following Docker images:
 
-Image | Docker link | Version
------ | ----------- | ----------
-**DB** | mariadb:10.0 | 10
-**FPM** | [magento/magento-cloud-docker-php](https://hub.docker.com/r/magento/magento-cloud-docker-php) | PHP-CLI: version 7<br>PHP-FPM: version 7
+Image | Docker link | Tag
+:---- | :---------- | ----------
+**DB** | [mariadb:10.0](https://hub.docker.com/_/mariadb) | 10
+**FPM**<br>PHP-CLI: version 7<br>PHP-FPM: version 7 | [magento/magento-cloud-docker-php](https://hub.docker.com/r/magento/magento-cloud-docker-php)
 **ElasticSearch** | [magento/magento-cloud-docker-elasticsearch](https://hub.docker.com/r/magento/magento-cloud-docker-elasticsearch) | 1.7
 **NGINX** |[magento/magento-cloud-docker-nginx](https://hub.docker.com/r/magento/magento-cloud-docker-nginx) | 1.9
 **RabbitMQ** | [rabbitmq](https://hub.docker.com/_/rabbitmq) | 3.5
@@ -27,11 +25,11 @@ Image | Docker link | Version
 {:.bs-callout .bs-callout-info}
 See the [service version values available]({{page.baseurl}}/cloud/docker/docker-config.html) for use when launching Docker.
 
-### Web container
+## Web container
 
 The web container works with the [PHP-FPM](https://php-fpm.org) to serve PHP code, the **DB** image for the local database, and the **Varnish** image to send requests and cache the results.
 
-### CLI containers
+## CLI containers
 
 There are few CLI containers based on a PHP-CLI image that provides `magento-cloud` and `{{site.data.var.ct}}` commands to perform file system operations.
 
@@ -42,16 +40,21 @@ There are few CLI containers based on a PHP-CLI image that provides `magento-clo
     -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environment
     -  Cron only works with CLI container to run `./bin/magento cron:run` command
 
-As an example, to run the `{{site.data.var.ct}}` ideal-state command:
+#### To run the `{{site.data.var.ct}}` ideal-state command:
 
 ```bash
 docker-compose run deploy ece-command wizard:ideal-state
+```
+Sample response:
+
+```terminal
 ...
  - Your application does not have the "post_deploy" hook enabled.
 The configured state is not ideal
 ```
+{: .no-copy}
 
-### Cron container
+## Cron container
 
 The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`crons` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
@@ -61,17 +64,17 @@ The Cron container is based on PHP-CLI images, and executes operations in the ba
 docker-compose run deploy bash -c "cat /var/www/magento/var/cron.log"
 ```
 
-### Database container
+## Database container
 
 The database container is based on the `mariadb:10` image.
 
-#### Importing a database dump
+### Importing a database dump
 
 To import a database dump, place the SQL file into the `docker/mysql/docker-entrypoint-initdb.d` folder. The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command.
 
 Although it is a more complex approach, you can use GZIP by _sharing_ the `.sql.gz` file using the `docker/mnt` directory and importing it inside the Docker container.
 
-### Varnish container
+## Varnish container
 
 The Varnish container is based on the `magento-cloud-docker-varnish` image. Varnish works on port 80.
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -38,6 +38,8 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
 
+-   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.2/cloud/docker/docker-database.md
+++ b/guides/v2.2/cloud/docker/docker-database.md
@@ -1,0 +1,1 @@
+../../../v2.1/cloud/docker/docker-database.md

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -40,6 +40,8 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
 
+-   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.3/cloud/docker/docker-database.md
+++ b/guides/v2.3/cloud/docker/docker-database.md
@@ -1,0 +1,1 @@
+../../../v2.2/cloud/docker/docker-database.md

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -40,6 +40,8 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
 
+-   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
Docker experience improvements

- Navigation improvements: moved Docker development to main nav; added new column to top nav
- Added release note for MAGECLOUD-3369 related to configuring services
- Fixed some formatting on the Docker container architecture topic
- Added a new topic about connecting to the database (I expect the topic to grow with more database information.)