### PR TITLE
Add required parameter in shipping carrier validation rule

### DIFF
--- a/guides/v2.1/howdoi/checkout/checkout_carrier.md
+++ b/guides/v2.1/howdoi/checkout/checkout_carrier.md
@@ -53,6 +53,9 @@ define(
                     },
                     'country_id': {
                         'required': true
+                    },
+                    'city': {
+                        'required': true
                     }
                 };
             }

--- a/guides/v2.1/howdoi/checkout/checkout_carrier.md
+++ b/guides/v2.1/howdoi/checkout/checkout_carrier.md
@@ -36,7 +36,7 @@ In your `<your_module_dir>/view/frontend/web/js/model` directory, create a `.js`
 
 The script must implement the `getRules()` method.
 
-For example, the FedEx shipping method requires only two fields of the shipping address to be filled: **Country** and **Zip Code**. This is how the validation rules for FedEx look:
+For example, the FedEx shipping method requires only two fields of the shipping address to be filled: **Country**, **Zip Code** and **City**. This is how the validation rules for FedEx look:
 
 > _<Magento_Fedex_dir>/view/frontend/web/js/model/shipping-rates-validation-rules.js_
 


### PR DESCRIPTION
## Scope of this PR

- __Technical__: Add Required parameter in shipping carrier validation rule

## Purpose of this PR

When this pull request is merged, it will add Required parameter in custom shipping carrier validation rule.

## Affected URLs

- https://devdocs.magento.com/guides/v2.1/howdoi/checkout/checkout_carrier.html
- https://devdocs.magento.com/guides/v2.2/howdoi/checkout/checkout_carrier.html
- https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_carrier.html

## Links to source code

Codebase Urls:

- https://github.com/magento/magento2/blob/2.1/app/code/Magento/Fedex/view/frontend/web/js/model/shipping-rates-validation-rules.js#L12
- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Fedex/view/frontend/web/js/model/shipping-rates-validation-rules.js#L12
- https://github.com/magento/magento2/blob/2.3/app/code/Magento/Fedex/view/frontend/web/js/model/shipping-rates-validation-rules.js#L13