### PR TITLE
Fixed wrong info on Graphql CMS endpoints page

### DIFF
--- a/guides/v2.3/graphql/reference/cms.md
+++ b/guides/v2.3/graphql/reference/cms.md
@@ -33,9 +33,9 @@ Attribute | Data type | Description
 `content` | String | The content of the CMS page in raw HTML
 `meta_description` | String | A brief description of the page for search results listings
 `meta_keywords` | String | A set of keywords that search engines can use to index the page
-`meta_title` | String | The title that appears in the browser title bar and tab
+`meta_title` | String | A page title that is being indexed by search engines, appears in search results listings
 `page_layout` | String | The design layout of the page, indicating the number of columns and navigation features used on the page
-`title` | String | The name that appears in the breadcrumb trail navigation
+`title` | String | The name that appears in the breadcrumb trail navigation and in the browser title bar and tab
 `url_key` |String | The URL key of the CMS page, which is often based on the `content_heading`
 
 

--- a/guides/v2.3/graphql/reference/cms.md
+++ b/guides/v2.3/graphql/reference/cms.md
@@ -33,7 +33,7 @@ Attribute | Data type | Description
 `content` | String | The content of the CMS page in raw HTML
 `meta_description` | String | A brief description of the page for search results listings
 `meta_keywords` | String | A set of keywords that search engines can use to index the page
-`meta_title` | String | A page title that is being indexed by search engines, appears in search results listings
+`meta_title` | String | A page title that is indexed by search engines and appears in search results listings
 `page_layout` | String | The design layout of the page, indicating the number of columns and navigation features used on the page
 `title` | String | The name that appears in the breadcrumb trail navigation and in the browser title bar and tab
 `url_key` |String | The URL key of the CMS page, which is often based on the `content_heading`


### PR DESCRIPTION
## Purpose of this PR
This PR fixes wrong info about CMS page Title/Meta Title on Graphql CMS endpoints page

## Affected URLs
https://devdocs.magento.com/guides/v2.3/graphql/reference/cms.html#cmspage-output-attributes

## Links to source code
