### PR TITLE
MAGECLOUD-3482/3382 scd thread update

### DIFF
--- a/guides/v2.1/cloud/env/variables-build.md
+++ b/guides/v2.1/cloud/env/variables-build.md
@@ -95,7 +95,7 @@ stage:
 -  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
+Sets the number of threads for static content deployment. The default value is set based on the detected CPU thread count and does not exceed a value of 4. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set the thread value, for example:
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/env/variables-build.md
+++ b/guides/v2.1/cloud/env/variables-build.md
@@ -92,18 +92,18 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**: 
-    -  `1`—Starter environments and Pro Integration environments
-    -  `3`—Pro Staging and Production environments
+-  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down.
+Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
 
 ```yaml
 stage:
   build:
     SCD_THREADS: 2
 ```
+
+For Magento version 2.1.11 and earlier, the default value is 1.
 
 To further reduce deployment time, we recommend using [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) with the `scd-dump` command to move static deployment into the build phase.
 

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -307,7 +307,7 @@ stage:
 -  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
+Sets the number of threads for static content deployment. The default value is set based on the detected CPU thread count and does not exceed a value of 4. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set the thread value, for example:
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -304,18 +304,18 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**:
-    -  `1`—Starter environments and Pro Integration environments
-    -  `3`—Pro Staging and Production environments
--  **Version**—Available in all versions
+-  **Default**—Automatic
+-  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down.
+Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
 
 ```yaml
 stage:
   deploy:
     SCD_THREADS: 2
 ```
+
+For Magento version 2.1.11 and earlier, the default value is 1.
 
 To further reduce deployment time, we recommend using [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) with the `scd-dump` command to move static deployment into the build phase.
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -40,6 +40,9 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
 
+-   {:.fix}<!-- MAGECLOUD-3382 -->Changed the **SCD_THREAD** environment variable default values to automatically determine the optimal value based on the detected CPU thread count. See the updated definitions in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_threads) and the [build variables]({{ page.baseurl }}/cloud/env/variables-build.html#scd_threads).
+
+
 ## v2002.0.17
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -130,12 +130,10 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**: 
-    -  `1`—Starter environments and Pro Integration environments
-    -  `3`—Pro Staging and Production environments
+-  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down.
+Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -133,7 +133,7 @@ stage:
 -  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
+Sets the number of threads for static content deployment. The default value is set based on the detected CPU thread count and does not exceed a value of 4. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set the thread value, for example:
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -394,12 +394,10 @@ stage:
 
 ### `SCD_THREADS`
 
--  **Default**:
-    -  `1`—Starter environments and Pro Integration environments
-    -  `3`—Pro Staging and Production environments
+-  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down.
+Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -397,7 +397,7 @@ stage:
 -  **Default**—Automatic
 -  **Version**—Magento 2.1.4 and later
 
-Sets the number of threads for static content deployment. The default value is set based on detected CPU threads. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set a thread value within the range from 1 to 4. For example:
+Sets the number of threads for static content deployment. The default value is set based on the detected CPU thread count and does not exceed a value of 4. Increasing the number of threads speeds up static content deployment; decreasing the number of threads slows it down. You can set the thread value, for example:
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -32,7 +32,7 @@ The release notes include:
 
 ## v2002.0.18
 
--   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.5 and later versions. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
+-   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the **MAGENTO_CLOUD_LOCKS_DIR** environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} version 2.2.5 and later. See the definition in [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
 -   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
@@ -42,7 +42,9 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
 
--   {:.new}**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
+-   {:.new}<!-- MAGECLOUD-3205 -->**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
+
+-   {:.fix}<!-- MAGECLOUD-3382 -->Changed the **SCD_THREAD** environment variable default values to automatically determine the optimal value based on the detected CPU thread count. See the updated definitions in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_threads) and the [build variables]({{ page.baseurl }}/cloud/env/variables-build.html#scd_threads).
 
 ## v2002.0.17
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -32,7 +32,7 @@ The release notes include:
 
 ## v2002.0.18
 
--   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the `MAGENTO_CLOUD_LOCKS_DIR` environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} 2.2.5 and later versions. See [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
+-   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the **MAGENTO_CLOUD_LOCKS_DIR** environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} version 2.2.5 and later. See the definition in [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
 -   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
@@ -42,7 +42,9 @@ The release notes include:
 
 -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
 
--   {:.new}**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
+-   {:.new}<!-- MAGECLOUD-3205 -->**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
+
+-   {:.fix}<!-- MAGECLOUD-3382 -->Changed the **SCD_THREAD** environment variable default values to automatically determine the optimal value based on the detected CPU thread count. See the updated definitions in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_threads) and the [build variables]({{ page.baseurl }}/cloud/env/variables-build.html#scd_threads).
 
 ## v2002.0.17
 


### PR DESCRIPTION
Updated the SCD_THREADS environment variable default value. Added associated release note.
Affects both, build and deploy, variables.

Affects
Build: /cloud/env/variables-build.html#scd_strategy
Deploy: /cloud/env/variables-deploy.html#scd_strategy