### PR TITLE
Add magnifier widget options sample example using view.xml

### DIFF
--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -98,3 +98,19 @@ Possible values:
 
 * `outside`
 * `inside`
+
+## Configure magnifier options in `view.xml`
+
+Magnifier options can be set in the `view.xml` configuration file of a theme. The file is conventionally located in `<theme_dir>/etc`.
+
+The general magnifier options are set as follows:
+
+```xml
+<var name="magnifier">
+    <var name="%magnifier_option1%">%option1_value%</var>
+    <var name="%magnifier_option2%">%option2_value%</var>
+...
+</var>
+```
+
+For illustration of setting gallery option in `view.xml`, you can reference to the [view.xml of the Blank theme]({{ site.mage2000url }}app/design/frontend/Magento/blank/etc/view.xml#L225).

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -101,7 +101,7 @@ Possible values:
 
 ## Configure magnifier options in `view.xml`
 
-Magnifier options can be set in the `view.xml` configuration file of a theme. The file is conventionally located in `<theme_dir>/etc`.
+Magnifier options can be set in the `view.xml` configuration file of a theme. The file is conventionally located in the `<theme_dir>/etc/` directory.
 
 The general magnifier options are set as follows:
 
@@ -113,4 +113,4 @@ The general magnifier options are set as follows:
 </var>
 ```
 
-For illustration of setting gallery option in `view.xml`, you can reference to the [view.xml of the Blank theme]({{ site.mage2000url }}app/design/frontend/Magento/blank/etc/view.xml#L225).
+For an example of setting the gallery option, see the [view.xml]({{ site.mage2000url }}app/design/frontend/Magento/blank/etc/view.xml#L225) file in the Blank theme.

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -113,4 +113,4 @@ The general magnifier options are set as follows:
 </var>
 ```
 
-For an example of setting the gallery option, see the [view.xml]({{ site.mage2000url }}app/design/frontend/Magento/blank/etc/view.xml#L225) file in the Blank theme.
+For an example of setting the gallery option, see the [view.xml]({{ site.mage2100url }}app/design/frontend/Magento/blank/etc/view.xml#L225) file in the Blank theme.


### PR DESCRIPTION
## Purpose of this PR

<!-- REQUIRED Describe the goal and the type of changes this PR covers. -->

This PR improves the magnifier widget documentation with some useful content which can be used on widget's initialization with different parameter using view.xml file.

## Affected URLs

<!-- REQUIRED List the URLs you are changing. Not needed for large numbers of files. -->

- v2.3 https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.html
- v2.2 https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/widgets/widget_gallery_mg.html
- v2.1 https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/widgets/widget_gallery_mg.html

<!-- 
If you are fixing a Github issue, note it in the following format and the issue will automatically close when this PR is merged:
Fixes #<IssueNumber>

`master` is the default branch. PRs to this branch should be for current devdocs content. Merged PRs to master go live on the site automatically. Work for future releases generally goes in the `develop` branch. Work with the devdocs team if you are unsure where to submit your PR.
-->

## Links to source code

<!--  REMOVE THIS SECTION IF NOT USED. If this PR references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/2.1/app/design/frontend/Magento/blank/etc/view.xml#L213

whatsnew
Added an example of configuring the initialization of the [magnifier widget](https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.html) with different parameters using the `view.xml` file.