### PR TITLE
Fixed request json error in setBillingAddressOnCart mutation

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -289,7 +289,7 @@ mutation {
           postcode: "78758"
           country_code: "US"
           telephone: "8675309"
-          save_in_address_book: False
+          save_in_address_book: false
         }
       }
     }


### PR DESCRIPTION
## Purpose of this PR

<!-- REQUIRED Describe the goal and the type of changes this PR covers. -->

This PR will fix "In field 'save_in_address_book': Expected type 'Boolean', found False" error in request json
## Affected URLs

<!-- REQUIRED List the URLs you are changing. Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html#set-the-billing-address-on-a-cart

## Links to source code

<!--  REMOVE THIS SECTION IF NOT USED. If this PR references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/graphql-ce/blob/6a394d17d9b3df723aedbb8a02ecea8bda97371c/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L17

<!-- 
If you are fixing a Github issue, note it in the following format and the issue will automatically close when this PR is merged:
Fixes #<IssueNumber>

`master` is the default branch. PRs to this branch should be for current devdocs content. Merged PRs to master go live on the site automatically. Work for future releases generally goes in the `develop` branch. Work with the devdocs team if you are unsure where to submit your PR.
-->
