### PR TITLE
MAGEDOC-3741: Google Shopping ads Channel GA docs

### DIFF
--- a/_data/compatibility.yml
+++ b/_data/compatibility.yml
@@ -1,4 +1,5 @@
 versions:
+  - 2.2.4+
   - 2.3.0
   - 2.3.1
 extension:
@@ -8,6 +9,7 @@ extension:
       -
         name: 1.1.1
         support:
+          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -16,11 +18,13 @@ extension:
       - 
         name: 1.4.6
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.5.1
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -29,11 +33,13 @@ extension:
       - 
         name: 1.1.0
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.0.3
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -42,5 +48,6 @@ extension:
       - 
         name: 1.0.0
         support:
+          2.2.4+: not supported
           2.3.0: open beta
           2.3.1: general availability

--- a/_data/compatibility.yml
+++ b/_data/compatibility.yml
@@ -1,18 +1,30 @@
 versions:
+  - 2.2.4+
   - 2.3.0
   - 2.3.1
 extension:
+  - 
+    name: Google Shopping ads Channel
+    versions:
+      -
+        name: 1.1.1
+        support:
+          2.2.4+: general availability
+          2.3.0: general availability
+          2.3.1: general availability
   -
     name: Magento Shipping
     versions:
       - 
         name: 1.4.6
         support:
+          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.5.1
         support:
+          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -21,11 +33,13 @@ extension:
       - 
         name: 1.1.0
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.0.3
         support:
+          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -34,5 +48,6 @@ extension:
       - 
         name: 1.0.0
         support:
+          2.2.4+: not supported
           2.3.0: open beta
           2.3.1: general availability

--- a/_data/compatibility.yml
+++ b/_data/compatibility.yml
@@ -1,5 +1,4 @@
 versions:
-  - 2.2.4+
   - 2.3.0
   - 2.3.1
 extension:
@@ -9,7 +8,6 @@ extension:
       -
         name: 1.1.1
         support:
-          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -18,13 +16,11 @@ extension:
       - 
         name: 1.4.6
         support:
-          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.5.1
         support:
-          2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -33,13 +29,11 @@ extension:
       - 
         name: 1.1.0
         support:
-          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
       - 
         name: 1.0.3
         support:
-          2.2.4+: not supported
           2.3.0: general availability
           2.3.1: general availability
   -
@@ -48,6 +42,5 @@ extension:
       - 
         name: 1.0.0
         support:
-          2.2.4+: not supported
           2.3.0: open beta
           2.3.1: general availability

--- a/_data/toc/release-notes.yml
+++ b/_data/toc/release-notes.yml
@@ -268,7 +268,11 @@ pages:
 
         - label: Magento Commerce Cloud packages
           url: /release-notes/packages-cloud.html
-    
+
+    - label: GraphQL
+      url: /graphql/release-notes.html
+      exclude_versions: ["2.0", "2.1", "2.2"]
+
     - label: Inventory management
       url: /inventory/release-notes.html
       exclude_versions: ["2.0", "2.1", "2.2"]
@@ -277,7 +281,15 @@ pages:
       url: /page-builder/docs/release-notes.html
       exclude_versions: ["2.0", "2.1", "2.2"]
       versionless: true
+    
+    - label: Sales Channels
+      exclude_versions: ["2.0", "2.1",]  
+      children:
+      
+        - label: Amazon
+          url: /extensions/amazon-sales/release-notes/
+          versionless: true
 
-    - label: GraphQL
-      url: /graphql/release-notes.html
-      exclude_versions: ["2.0", "2.1", "2.2"]
+        - label: Google Shopping ads
+          url: /extensions/google-shopping-ads/release-notes/
+          versionless: true

--- a/_includes/layout/after-site-header.html
+++ b/_includes/layout/after-site-header.html
@@ -4,12 +4,6 @@
 </div>
 {% endif %}
 
-{% if page.title contains "Google Shopping ads Channel" %}
-<div class="message-banner">
-  This is the pre-release version of Google Shopping ads Channel documentation. Content in this version is subject to change.
-</div>
-{% endif %}
-
 {% if page.title contains "Amazon Sales Channel" %}
 <div class="message-banner">
   This is the pre-release version of Amazon Sales Channel documentation. Content in this version is subject to change.

--- a/extensions/google-shopping-ads/index.md
+++ b/extensions/google-shopping-ads/index.md
@@ -7,7 +7,7 @@ The Google Shopping ads extension installs and adds Google Shopping features to 
 
 ## Requirements
 
-- **Magento Instance**: Google Shopping ads Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.X and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
+- **Magento Instance**: Google Shopping ads Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
 - **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
 - **API Key**: Get a Google Shopping ads API key through your Magento web account. The following instructions include these steps.
 - **Google accounts**: During onboarding, you will create and configure any required Google accounts and settings. Consider using email accounts for your business as the account will be the primary owner (admin) of the Google, Google Merchant Center and Google Ads accounts you set in this integration.

--- a/extensions/google-shopping-ads/index.md
+++ b/extensions/google-shopping-ads/index.md
@@ -7,7 +7,7 @@ The Google Shopping ads extension installs and adds Google Shopping features to 
 
 ## Requirements
 
-- **Magento Instance**: Google Shopping ads Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
+- **Magento Instance**: Google Shopping ads Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.x. We do not support the extension on Magento 2.1 or Magento 1.
 - **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
 - **API Key**: Get a Google Shopping ads API key through your Magento web account. The following instructions include these steps.
 - **Google accounts**: During onboarding, you will create and configure any required Google accounts and settings. Consider using email accounts for your business as the account will be the primary owner (admin) of the Google, Google Merchant Center and Google Ads accounts you set in this integration.

--- a/extensions/google-shopping-ads/release-notes/index.md
+++ b/extensions/google-shopping-ads/release-notes/index.md
@@ -3,7 +3,7 @@ group: extensions
 title: Google Shopping ads Channel Release Notes
 ---
 
-**Google Shopping ads Channel** is now available for version 2.2.x and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}. Merchants can use this extension to integrate with Google Merchant Center (GMC) and Google Ads accounts to advertize and sell Magento products.
+**Google Shopping ads Channel** is now generally available for versions 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}. Merchants can use this extension to integrate with Google Merchant Center (GMC) and Google Ads accounts to advertize and sell Magento products.
 
 See the following documentation:
 
@@ -16,9 +16,9 @@ The release notes include:
 -   {:.new}New features
 -   {:.fix}Fixes and improvements
 
-### v1.0.0
+### v1.1.1
 
-Google Shopping ads Channel 1.0.0 is compatible with version 2.2.x and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
+Google Shopping ads Channel 1.1.1 is generally available for versions 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
 - {:.new} **Simplified Onboarding and Maintenance**: Add GMC accounts with ease through a step-by-step process with detailed instructions available through the Magento Admin.
 

--- a/release/index.md
+++ b/release/index.md
@@ -18,12 +18,12 @@ The following table describes the status of Magento software availability and wh
 | **Magento Shipping**                            | Available now                                                                                                                                        | Merchants on Magento 2.2.2+ can use the [onboarding process](https://account.magento.com/shipping/onboarding/start)          |
 | **Page Builder**                                | Available now                                                                                                                                        | Bundled with {{site.data.var.ee}} 2.3.x                                                                                      |
 | **Amazon Sales Channel**                        | Early access closed<br><br>Regional availability May 10, 2019 (US, Canada, Mexico)<br><br>EMEA and APAC availability expected in second half of 2019 | Magento Marketplace                                                                                                          |
-| **Google Shopping ads Channel**                 | Available now                                                                                                                                        | [Magento Marketplace](http://marketplace.magento.com/magento-google-shopping-ads.html)                                       |
+| **Google Shopping ads Channel 1.1.1**           | Available now for {{site.data.var.ece}} 2.2.4+ and 2.3.x                                                                                             | [Magento Marketplace](http://marketplace.magento.com/magento-google-shopping-ads.html)                                       |
 
 ## Compatibility
 
 Magento modules that have been built to be decoupled from the {{site.data.var.ee}} core release process; this allows us to release iterations of these modules faster to merchants who are willing to accept a little risk in exchange for earlier access to new features.
 
-The following table shows the release status of Magento extension versions relative to the 2.3.x release line of {{site.data.var.ee}}.
+The following table shows the release status of Magento extension versions relative to the 2.3.x release line of {{site.data.var.ee}} only.
 
 {% include compatibility.html data=site.data.compatibility %}

--- a/release/index.md
+++ b/release/index.md
@@ -24,6 +24,6 @@ The following table describes the status of Magento software availability and wh
 
 Magento modules that have been built to be decoupled from the {{site.data.var.ee}} core release process; this allows us to release iterations of these modules faster to merchants who are willing to accept a little risk in exchange for earlier access to new features.
 
-The following table shows the release status of Magento extension versions relative to the 2.3.x release line of {{site.data.var.ee}} only.
+The following table shows the release status of Magento extension versions relative to {{site.data.var.ee}}.
 
 {% include compatibility.html data=site.data.compatibility %}

--- a/release/index.md
+++ b/release/index.md
@@ -18,7 +18,7 @@ The following table describes the status of Magento software availability and wh
 | **Magento Shipping**                            | Available now                                                                                                                                        | Merchants on Magento 2.2.2+ can use the [onboarding process](https://account.magento.com/shipping/onboarding/start)          |
 | **Page Builder**                                | Available now                                                                                                                                        | Bundled with {{site.data.var.ee}} 2.3.x                                                                                      |
 | **Amazon Sales Channel**                        | Early access closed<br><br>Regional availability May 10, 2019 (US, Canada, Mexico)<br><br>EMEA and APAC availability expected in second half of 2019 | Magento Marketplace                                                                                                          |
-| **Google Shopping ads Channel**                 | Early access closed<br><br>General availability April 30, 2019                                                                                       | Magento Marketplace                                                                                                          |
+| **Google Shopping ads Channel**                 | Available now                                                                                                                                        | [Magento Marketplace](http://marketplace.magento.com/magento-google-shopping-ads.html)                                       |
 
 ## Compatibility
 


### PR DESCRIPTION
## Purpose of this PR

**Staging build in progress**

This PR does the following:

- [x] Update Google Shopping ads Channel availability to "Available now"
- [x] Add a link to the Magento Marketplace listing for "Where to get it"
- [x] Add the extension and version to the compatibility matrix
- [x] Remove the beta banner from Google topics
- [x] Add a new section to the main release notes TOC for "Sales Channels" and add Google and Amazon
- [x] Change 1.0.0 to 1.1.1 in google release notes

## Affected URLs

- https://devdocs.magento.com/release/
- https://devdocs.magento.com/extensions/google-shopping-ads/
- https://devdocs.magento.com/extensions/google-shopping-ads/release-notes/
- https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html