### PR TITLE
Added missing details of full screen config options for gallery widget

### DIFF
--- a/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_gallery.md
@@ -362,6 +362,25 @@ Sliding direction of thumbnails in the fullscreen view.
 - `vertical`
 - `horizontal`
 
+#### `fullscreen/navarrows` {#full_navarrows}
+
+Show/hide arrows in thumb navigation.
+
+**Type**: Boolean
+
+**Default value**: `true`
+
+#### `fullscreen/navtype` {#full_navtype}
+
+Type of navigation.
+
+**Possible values**:
+
+- `thumbs`
+- `slides`
+
+**Default value**: `thumbs`
+
 #### `fullscreen/navigation_carousel` {#full_carousel}
 
 Display navigation thumbnails as carousel in the fullscreen view.


### PR DESCRIPTION
## Purpose of this PR

Related PR: #4218 

Added the explanation for the following two properties of the gallery widget.
- `fullscreen / navarrows`
- `fullscreen / navtype`

## Affected URLs

<!-- REQUIRED List the URLs you are changing. Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.html

## Links to source code
- https://github.com/magento/magento2/blob/2.2-develop/lib/web/fotorama/fotorama.js#L631-L636

<!-- 
If you are fixing a Github issue, note it in the following format and the issue will automatically close when this PR is merged:
Fixes #<IssueNumber>

`master` is the default branch. PRs to this branch should be for current devdocs content. Merged PRs to master go live on the site automatically. Work for future releases generally goes in the `develop` branch. Work with the devdocs team if you are unsure where to submit your PR.
-->
