### PR TITLE
MAGECLOUD-3491: Document validations on docker

### DIFF
--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -22,7 +22,9 @@ The `{{site.data.var.ct}}` package v2002.0.13 or later deploys to a read-only fi
 | MariaDB       | `--db`     | 10.0, 10.1, 10.2
 | Elasticsearch | `--es`     | 1.7, 2.4, 5.2, 6.5
 | RabbitMQ      | `--rmq`    | 3.5, 3.7
-| Redis         | `--redis`  | 3.0, 3.2, 4.0, 5.0
+| Redis         | `--redis`  | 3.2, 4.0, 5.0
+
+The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
 There is a `docker:config:convert` command to convert PHP configuration files to Docker ENV files.
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request covers changed made in https://magento2.atlassian.net/browse/MAGECLOUD-3251
that docker:build CLI command works in interactive mode and validates service versions

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magedevteam.com/346/guides/v2.1/cloud/docker/docker-config.html
- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...
- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
