### PR TITLE
Corrected default value of list widget options

### DIFF
--- a/guides/v2.1/javascript-dev-guide/widgets/widget_list.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_list.md
@@ -37,7 +37,7 @@ Selector for the element used for item adding.
 
 **Type**: String
 
-**Default value**: `[data-button=remove]`
+**Default value**: `[data-button=add]`
 
 ### `destinationSelector` {#l_destinationSelector}
 Content destination selector.
@@ -72,7 +72,7 @@ Alert message displayed when maximum limit is reached.
 
 **Type**: String
 
-**Default value**: `[data-button=remove]`
+**Default value**: `null`
 
 ### `removeButton` {#l_removeButton}
 Selector for the element used for item removing. 
@@ -93,7 +93,7 @@ Class attached to the template wrapper.
 
 **Type**: String
 
-**Default value**: `[data-role=container]`
+**Default value**: `null`
 
 ### `templateWrapper` {#l_templateWrapper}
 Element holding the template.

--- a/guides/v2.1/javascript-dev-guide/widgets/widget_list.md
+++ b/guides/v2.1/javascript-dev-guide/widgets/widget_list.md
@@ -105,9 +105,9 @@ Element holding the template.
 ## Methods {#list_methods}
 
 The list widget has the following methods:
--   [addItem](#list_addItem)
+-   [addItem()](#list_addItem)
 -   [checkLimit()](#list_checkLimit)
--   [handleAdd](#list_handleAdd)
+-   [handleAdd()](#list_handleAdd)
 -   [removeItem()](#list_removeItem)
 
 ### `addItem()` {#list_addItem}


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->
Corrected the default value of following list widget options:

- `addButton`:  `[data-button=add]`
- `maxItemsAlert`: `null`
- `templateClass`: `null`


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/widgets/widget_list.html
- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/widgets/widget_list.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_list.html


## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- *Magento 2.1:* https://github.com/magento/magento2/blob/2.1/lib/web/mage/list.js#L20
- *Magento 2.2:* https://github.com/magento/magento2/blob/2.2/lib/web/mage/list.js#L24
- *Magento 2.3:* https://github.com/magento/magento2/blob/2.3/lib/web/mage/list.js#L24


<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
