### PR TITLE
MAGECLOUD-3491 Docker build options

### DIFF
--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -13,9 +13,24 @@ functional_areas:
 
 The `{{site.data.var.ct}}` package (version 2002.0.13 or later) deploys to a read-only file system in the Docker container, which mirrors the read-only file system deployed in the Production environment. You can use the `docker:build` command in the `{{site.data.var.ct}}` package to generate the Docker Compose configuration and deploy {{site.data.var.ece}} in a Docker container.
 
+## Launch modes
+
+Mode is an additional configuration option for the Docker configuration generator (the `docker:build` command). You can launch your Docker environment in one of two modes:
+
+-   **production**—Production mode is the default for launching the Docker environment. This builds the Docker environment and verifies configured service versions.
+-   **developer**—Developer mode supports active development with full, writable filesystem permissions. This mode is slower than production mode because of additional file synchronization operations. This builds the Docker environment in developer mode and verifies configured service versions.
+
+For example, the following command starts the Docker configuration generator for the developer mode:
+
+```bash
+./vendor/bin/ece-tools docker:build --mode="developer"
+```
+
+To skip the interactive mode, use the `-n, --no-interaction` option.
+
 ## Service versions
 
-{{site.data.var.ece}} references the `.magento.app.yaml` and `.magento/services.yaml` configuration files to determine the services you need. When you start the Docker configuration generator, you can overwrite a service version with the following optional parameters:
+{{site.data.var.ece}} references the `.magento.app.yaml` and `.magento/services.yaml` configuration files to determine the services you need. When you start the Docker configuration generator (the `docker:build` command), you can overwrite a service version with the following optional parameters:
 
 | Service       | Key        | Available versions
 | ------------- | ---------- | ------------------
@@ -26,20 +41,11 @@ The `{{site.data.var.ct}}` package (version 2002.0.13 or later) deploys to a rea
 | RabbitMQ      | `--rmq`    | 3.5, 3.7
 | Redis         | `--redis`  | 3.0, 3.2, 4.0, 5.0
 
-## Launch modes
-
-Mode is an additional configuration option for the `docker:build` command. You can launch your Docker environment in one of two modes:
-
--   **production**—Production mode is the default for launching the Docker environment. This builds the Docker environment and verifies configured service versions.
--   **developer**—Developer mode supports active development with full, writable filesystem permissions. This mode is slower than production mode because of additional file synchronization operations.
-
 For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2:
 
 ```bash
 ./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2
 ```
-
-To skip the interactive mode, use the `-n, --no-interaction` option.
 
 ### Prerequisites
 

--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -17,8 +17,8 @@ The `{{site.data.var.ct}}` package (version 2002.0.13 or later) deploys to a rea
 
 Mode is an additional configuration option for the Docker configuration generator (the `docker:build` command). You can launch your Docker environment in one of two modes:
 
--   **production**—Production mode is the default for launching the Docker environment. This builds the Docker environment and verifies configured service versions.
--   **developer**—Developer mode supports active development with full, writable filesystem permissions. This mode is slower than production mode because of additional file synchronization operations. This builds the Docker environment in developer mode and verifies configured service versions.
+-   **production**—Production mode is the default configuration setting for launching the Docker environment. This option builds the Docker environment in production mode and verifies configured service versions.
+-   **developer**—Developer mode supports an active development environment with full, writable filesystem permissions. This option builds the Docker environment in developer mode and verifies configured service versions. System performance is slower in developer mode because of additional file synchronization operations.
 
 For example, the following command starts the Docker configuration generator for the developer mode:
 

--- a/guides/v2.1/cloud/docker/docker-config.md
+++ b/guides/v2.1/cloud/docker/docker-config.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Launch Docker configuration
+title: Launch Docker
 redirect_from:
   - /guides/v2.1/cloud/reference/docker-config.html
   - /guides/v2.2/cloud/reference/docker-config.html
@@ -11,7 +11,9 @@ functional_areas:
   - Configuration
 ---
 
-The `{{site.data.var.ct}}` package v2002.0.13 or later deploys to a read-only file system in the Docker container, which mirrors the read-only file system deployed in the Production environment. You can use the `docker:build` command in the `{{site.data.var.ct}}` package to generate the Docker compose configuration and deploy {{site.data.var.ece}} in a Docker container. 
+The `{{site.data.var.ct}}` package (version 2002.0.13 or later) deploys to a read-only file system in the Docker container, which mirrors the read-only file system deployed in the Production environment. You can use the `docker:build` command in the `{{site.data.var.ct}}` package to generate the Docker Compose configuration and deploy {{site.data.var.ece}} in a Docker container.
+
+## Service versions
 
 {{site.data.var.ece}} references the `.magento.app.yaml` and `.magento/services.yaml` configuration files to determine the services you need. When you start the Docker configuration generator, you can overwrite a service version with the following optional parameters:
 
@@ -24,15 +26,22 @@ The `{{site.data.var.ct}}` package v2002.0.13 or later deploys to a read-only fi
 | RabbitMQ      | `--rmq`    | 3.5, 3.7
 | Redis         | `--redis`  | 3.0, 3.2, 4.0, 5.0
 
-To adjust additional configuration, use next options:
+## Launch modes
 
-| Option       | Key              | Available values
-| ------------ | ---------------- | ------------------
-| Mode         | `--mode`, `-m`   | production, developer
+Mode is an additional configuration option for the `docker:build` command. You can launch your Docker environment in one of two modes:
 
-There is a `docker:config:convert` command to convert PHP configuration files to Docker ENV files.
+-   **production**—Production mode is the default for launching the Docker environment. This builds the Docker environment and verifies configured service versions.
+-   **developer**—Developer mode supports active development with full, writable filesystem permissions. This mode is slower than production mode because of additional file synchronization operations.
 
-#### Prerequisites
+For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2:
+
+```bash
+./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2
+```
+
+To skip the interactive mode, use the `-n, --no-interaction` option.
+
+### Prerequisites
 
 You must have the following software installed on your local workstation:
 
@@ -41,6 +50,7 @@ You must have the following software installed on your local workstation:
     -  [php@7.2](https://formulae.brew.sh/formula/php@7.2)
 -  [Composer](https://getcomposer.org)
 -  [Docker](https://www.docker.com/get-started)
+-  [docker-sync](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html)—file synchronization is required for developer mode
 
 Before you begin, you must add the following hostname to your `/etc/hosts` file:
 
@@ -60,7 +70,11 @@ Before you begin, you must add the following hostname to your `/etc/hosts` file:
     composer install
     ```
 
-##### Production mode (default)
+1.  Continue with steps for [Production mode](#production-mode) or [Developer mode](#developer-mode).
+
+### Production mode
+
+Continue launching your Docker environment in the default _production_ mode.
 
 1.  In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to specify a version.
 
@@ -79,6 +93,7 @@ Before you begin, you must add the following hostname to your `/etc/hosts` file:
     ```bash
     ./vendor/bin/ece-tools docker:config:convert
     ```
+
     This command generates the following Docker ENV files:
 
     * `docker/config.env`
@@ -94,7 +109,7 @@ Before you begin, you must add the following hostname to your `/etc/hosts` file:
     docker-compose up -d
     ```
 
-1. Install Magento in your Docker environment.
+1.  Install Magento in your Docker environment.
 
     - Build Magento in the Docker container:
 
@@ -111,14 +126,11 @@ Before you begin, you must add the following hostname to your `/etc/hosts` file:
     {: .bs-callout .bs-callout-info}
     For `{{site.data.var.ct}}` v2002.0.12, install Magento with the `docker-compose run cli magento-installer` command.
 
-##### Developer mode (`--mode="developer"`)
+### Developer mode
 
-This mode is designed to support active development on your local environment. It requires manual installation of `docker-sync` for file synchronization.
-In this mode you will have full writable filesystem permissions. It generally may be slower than default mode because of additional file synchronization operations.
+Continue launching your Docker environment in the _developer_ mode. The developer mode supports active development on your local environment.
 
-1.  Install `docker-sync`
-
-    [Follow instruction](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html)
+1.  Install the `docker-sync` tool using the [Installation instructions](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html). If you have it installed, continue to the next step.
 
 1.  In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to specify a version.
 
@@ -132,11 +144,12 @@ In this mode you will have full writable filesystem permissions. It generally ma
     cp docker/config.php.dist docker/config.php
     ```
 
-1. _Optional_: Convert the PHP configuration files to Docker ENV files.
+1.  _Optional_: Convert the PHP configuration files to Docker ENV files.
 
     ```bash
     ./vendor/bin/ece-tools docker:config:convert
     ```
+
     This command generates the following Docker ENV files:
 
     * `docker/config.env`
@@ -146,7 +159,7 @@ In this mode you will have full writable filesystem permissions. It generally ma
 
 1.  _Optional_: Configure the Docker global variables in the `docker-compose.yaml` file. For example, you can [enable and configure Xdebug]({{ page.baseurl }}/cloud/docker/docker-development-debug.html).
 
-1. Run `docker-sync`
+1.  Start the file synchronization.
 
     ```bash
     docker-sync start
@@ -162,35 +175,33 @@ In this mode you will have full writable filesystem permissions. It generally ma
 
     - Deploy Magento in the Docker container:
 
-    ```bash
-    docker-compose up -d && \
-    docker-compose run deploy cloud-deploy && \
-    docker-compose run deploy magento-command deploy:mode:set developer && \
-    docker-compose run deploy magento-command cache:clean
-    ```
-    
+        ```bash
+        docker-compose up -d && \
+        docker-compose run deploy cloud-deploy && \
+        docker-compose run deploy magento-command deploy:mode:set developer && \
+        docker-compose run deploy magento-command cache:clean
+        ```
+
     {: .bs-callout .bs-callout-info}
-    This mode does note require `build` operation.
+    Developer mode does not require the `build` operation.
 
-#### Access your local Magento Cloud template by opening one of the following secure URLs in a browser:
+## Access local Magento Cloud template
+ 
+ by opening one of the following secure URLs in a browser:
 
-    -  [`http://magento2.docker`](http://magento2.docker)
+-  [`http://magento2.docker`](http://magento2.docker)
 
-    -  [`https://magento2.docker`](https://magento2.docker)
+-  [`https://magento2.docker`](https://magento2.docker)
 
-#### To stop containers and restore them afterwards:
+## Stop and start containers
 
-Suspend containers to continue your work later.
+You can stop containers and restore them afterwards using the following methods.
 
-```bash
-docker-compose stop
-```
-
-Start containers from suspended state.
-
-```bash
-docker-compose start
-```
+Action | Command
+------ | -------
+Suspend containers to continue your work later | `docker-compose stop`
+Start containers from a suspended state | `docker-compose start`
+Stop the synchronization daemon | `docker-sync stop`
 
 #### To stop and remove the Docker configuration:
 

--- a/guides/v2.1/cloud/docker/docker-quick-reference.md
+++ b/guides/v2.1/cloud/docker/docker-quick-reference.md
@@ -20,7 +20,7 @@ Stop and remove Docker environment (removes volumes) | `docker-compose down -v`
 Stop Docker environment without destroying containers | `docker-compose stop`
 Resume Docker environment | `docker-compose start`
 List images | `docker-compose images`
-List containers and ports | `docker-compose ps`
+List containers and ports | `docker-compose ps`, or `docker ps`
 
 ## ece-tools
 

--- a/guides/v2.1/cloud/docker/docker-quick-reference.md
+++ b/guides/v2.1/cloud/docker/docker-quick-reference.md
@@ -24,7 +24,13 @@ List containers and ports | `docker-compose ps`
 
 ## ece-tools
 
-The following example lists the `{{site.data.var.ct}}` commands that relate to [launching a Docker development environment]({{page.baseurl}}/cloud/docker/docker-config.html):
+Action | Command
+:----- | :------
+Builds the docker environment in production mode by default and verifies configured service versions. | `docker:build`
+Builds the docker environment in developer mode. | `docker:build --mode="developer"`
+Convert PHP configuration files to Docker ENV files. | `docker:config:convert`
+
+The following example lists the `{{site.data.var.ct}}` Docker commands:
 
 ```bash
 php ./vendor/bin/ece-tools list | grep docker
@@ -32,7 +38,15 @@ php ./vendor/bin/ece-tools list | grep docker
 
 ```terminal
  docker
-  docker:build             Build docker configuration
-  docker:config:convert    Convert raw config to .env files configuration
+  docker:build              Build docker configuration
+  docker:build:integration  Build test docker configuration
+  docker:config:convert     Convert raw config to .env files configuration
 ```
 {: .no-copy}
+
+### Build options
+
+| Option       | Key              | Available values
+| ------------ | ---------------- | ------------------
+| Mode         | `--mode`, `-m`   | production, developer
+

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -32,16 +32,19 @@ The release notes include:
 
 ## v2002.0.18
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+-   **Docker Updates**—
 
--   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
+    -   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
+    -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
+
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+
+    -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
 
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
 
--   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
-
 -   {:.fix}<!-- MAGECLOUD-3382 -->Changed the **SCD_THREAD** environment variable default values to automatically determine the optimal value based on the detected CPU thread count. See the updated definitions in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#scd_threads) and the [build variables]({{ page.baseurl }}/cloud/env/variables-build.html#scd_threads).
-
 
 ## v2002.0.17
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -38,7 +38,7 @@ The release notes include:
 
     -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
 
-    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config.html#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
 
     -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -38,7 +38,7 @@ The release notes include:
 
     -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
 
-    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config.html#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
 
     -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -32,15 +32,19 @@ The release notes include:
 
 ## v2002.0.18
 
+-   **Docker Updates**—
+
+    -   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
+    -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
+
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+
+    -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
+
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the **MAGENTO_CLOUD_LOCKS_DIR** environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} version 2.2.5 and later. See the definition in [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
-
--   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
-
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
-
--   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
 
 -   {:.new}<!-- MAGECLOUD-3205 -->**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -38,7 +38,7 @@ The release notes include:
 
     -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
 
-    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config.html#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
 
     -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -32,15 +32,19 @@ The release notes include:
 
 ## v2002.0.18
 
+-   **Docker Updates**—
+
+    -   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
+
+    -   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
+
+    -   {:.new}<!-- MAGECLOUD-3152 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{page.baseurl}}/cloud/docker/docker-config#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+
+    -   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error.
+
 -   {:.new}<!-- MAGECLOUD-3135 -->**New environment variable**—Added the **MAGENTO_CLOUD_LOCKS_DIR** environment variable to configure the path to the mount point for the lock provider on the cloud infrastructure. The lock provider prevents the launch of duplicate cron jobs and cron groups. This variable is supported on {{ site.data.var.ee }} version 2.2.5 and later. See the definition in [Cloud variables]({{ page.baseurl }}/cloud/env/variables-cloud.html).
 
--   {:.new}<!-- MAGECLOUD-3150 -->Now, the Docker environment supports the cron configuration defined in the [crons property of the .magento.app.yaml file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
-
--   {:.new}<!-- MAGECLOUD-2890 -->**New Docker Container**—Added a [TLS termination proxy container]({{page.baseurl}}/cloud/docker/docker-development.html#varnish-container) to facilitate the Varnish SSL termination over HTTPS.
-
 -   {:.fix}<!-- MAGECLOUD-3172 -->Fixed an issue that assigned Redis `session`, `default`, and `page_cache` cache storage to the same database ID.
-
--   {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue with Docker deploy failing if the cache is configured for a service that is not available. Now, you can remove a service from the `.magento/services.yaml` file and deploy without a _service not known_ error. 
 
 -   {:.new}<!-- MAGECLOUD-3205 -->**New environment variable**—The new **ELASTICSUITE\_CONFIGURATION** environment variable retains your customized service settings between deployments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#elasticsuite_configuration) content.
 


### PR DESCRIPTION
Updated the Launch Docker topic to include the new build options. I changed the order of sections so that there is a flow to the launch information before the steps begin. You can "choose your own adventure" in the build process according to the Launch mode and the Services chosen.

Also updated the Docker quick reference to include the build options and added Docker release notes section.

There is a preview available, but it is an older one. I launch a new preview and will provide a link later today.