### PR TITLE
Amazon Magento Module not found URL

### DIFF
--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -3,7 +3,7 @@ group: extensions
 title: Install Amazon Sales Channel
 ---
 
-The Amazon Sales Channel extension installs and adds features to integrate your Magento catalog with Amazon Seller Accounts to sell through the Amazon Marketplace. To review additional information, see the [Amazon Sales Channel Marketplace page](http://marketplace.magento.com/magento-module-amazon.html).
+The Amazon Sales Channel extension installs and adds features to integrate your Magento catalog with Amazon Seller Accounts to sell through the Amazon Marketplace. To review additional information, see the Amazon Sales Channel Marketplace page.
 
 ## Requirements
 

--- a/extensions/amazon-sales/release-notes/index.md
+++ b/extensions/amazon-sales/release-notes/index.md
@@ -9,7 +9,7 @@ See the following documentation:
 
 - [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
 - [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
-- [Amazon Sales Channel Marketplace page](http://marketplace.magento.com/magento-module-amazon.html)
+- Amazon Sales Channel Marketplace page
 
 The release notes include:
 


### PR DESCRIPTION
Amazon Magento Module not found URL

## Purpose of this pull request

Amazon Magento Module not found URL removed

This pull request (PR) ...

## Affected DevDocs pages
https://devdocs.magento.com/extensions/amazon-sales/


<!--
See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
