### PR TITLE
fix zero downtime statements

### DIFF
--- a/guides/v2.1/cloud/deploy/reduce-downtime.md
+++ b/guides/v2.1/cloud/deploy/reduce-downtime.md
@@ -16,10 +16,11 @@ Use the following steps to reduce the amount of time it takes your store to depl
 1.  [Upgrade to the `{{site.data.var.ct}}` package]({{page.baseurl}}/cloud/project/ece-tools-upgrade-project.html) or [update the `{{site.data.var.ct}}` version]({{page.baseurl}}/cloud/project/ece-tools-update.html)  
     Your {{site.data.var.ece}} project must have the latest `{{site.data.var.ct}}` package so that you have the tools available to configure an optimal deployment. If you have the latest `{{site.data.var.ct}}`, continue to the next step.
 
+    {:.bs-callout .bs-callout-info}
+    Even though it is a best practice to use the latest `{{site.data.var.ct}}` package, the zero-downtime deployment method works with `{{site.data.var.ct}}` [version 2002.0.13]({{page.baseurl}}/cloud/release-notes/cloud-tools.html#v2002013) and later.
+
 1.  [Configure static content deployment]({{page.baseurl}}/cloud/deploy/static-content-deployment.html)  
     If static content deployment fails in the deploy phase, your site gets stuck in maintenance mode. When a failure occurs during the build phase, the process avoids downtime because it never begins the deploy phase. [Generating static content during the build phase with minified HTML]({{page.baseurl}}/cloud/deploy/static-content-deployment.html#setting-the-scd-on-build), also known as the ideal state, is the optimal configuration for zero-downtime deployments and _prevents_ downtime if a failure occurs.
-
-    You can validate your project configuration by [running the ideal state wizard]({{page.baseurl}}/cloud/deploy/smart-wizards.html#verifying-an-ideal-configuration).
 
 1.  [Configure the post-deploy hook]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks)  
     You must configure the post-deploy hook to clean and warm the cache. By default, cache clean occurs during the deploy phase when the site is down. Moving the cache clean to the post-deploy phase means that your cache remains live until the deploy phase is complete, and then you can safely clean the cache.
@@ -32,3 +33,6 @@ Use the following steps to reduce the amount of time it takes your store to depl
 1.  [Speed up static content deployment]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_threads)  
     You can speed up the deployment process by updating the  SCD\_THREADS environment variable to increase the number of threads for static content deployment.
 
+
+{:.bs-callout .bs-callout-info}
+You can validate your project configuration for optimal deployment by [running the ideal state wizard]({{page.baseurl}}/cloud/deploy/smart-wizards.html#verifying-an-ideal-configuration).


### PR DESCRIPTION
fix #4255
fix #4252

Addresses some concerns about the [zero downtime deployment](https://devdocs.magento.com/guides/v2.2/cloud/deploy/reduce-downtime.html) topic and whether it is clear about which version of ece-tools works with this suggestion and whether the validation includes all pieces of the ideal state.

I added a note for each.