### PR TITLE
Add information about IN-query limit

### DIFF
--- a/guides/v2.3/rest/performing-searches.md
+++ b/guides/v2.3/rest/performing-searches.md
@@ -26,7 +26,7 @@ Condition | Notes
 `from` | The beginning of a range. Must be used with `to`
 `gt` | Greater than
 `gteq` |  Greater than or equal
-`in` | In. The `value` can contain a comma-separated list of values.
+`in` | In. The `value` can contain a comma-separated list of up 250 values.
 `like` | Like. The `value` can contain the SQL wildcard characters when `like` is specified.
 `lt` | Less than
 `lteq` | Less than or equal

--- a/guides/v2.3/rest/performing-searches.md
+++ b/guides/v2.3/rest/performing-searches.md
@@ -26,7 +26,7 @@ Condition | Notes
 `from` | The beginning of a range. Must be used with `to`
 `gt` | Greater than
 `gteq` |  Greater than or equal
-`in` | In. The `value` can contain a comma-separated list of up 250 values.
+`in` | In. The `value` can contain a comma-separated list of up to 250 values.
 `like` | Like. The `value` can contain the SQL wildcard characters when `like` is specified.
 `lt` | Less than
 `lteq` | Less than or equal


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds missing information about query limit of up to 250 values to devdocs page.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/rest/performing-searches.html