### PR TITLE
Fix target="_blank" space & code indentation

### DIFF
--- a/guides/v2.1/extension-dev-guide/cache/page-caching/public-content.md
+++ b/guides/v2.1/extension-dev-guide/cache/page-caching/public-content.md
@@ -133,10 +133,10 @@ Use the `X-Magento-Vary` cookie to transfer context on the HTTP layer. HTTP prox
 
 ```
 sub vcl_hash {
-if (req.http.cookie ~ "X-Magento-Vary=") {
-hash_data(regsub(req.http.cookie, "^.?X-Magento-Vary=([^;]+);.*$", "\1"));
-}
-... more ...
+    if (req.http.cookie ~ "X-Magento-Vary=") {
+        hash_data(regsub(req.http.cookie, "^.*?X-Magento-Vary=([^;]+);*.*$", "\1"));
+    }
+    ... more ...
 }
 ```
 
@@ -188,6 +188,6 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
 Magento uses cache tags for link creation. The performance of cache storage has a direct dependency on the number of tags per cache record, so try to minimize the number of tags and use them only for entities that are used in production mode. In other words, don't use invalidation for actions related to store setup.
 
 {: .bs-callout .bs-callout-warning }
-Use only HTTP POST or PUT methods to change state (e.g., adding to a shopping cart, adding to a wishlist, etc.) and don't expect to see caching on these methods. Using GET or HEAD methods might trigger caching and prevent updates to private content. For more information about caching, see [RFC-2616 section 13](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html) {:target="_blank"}
+Use only HTTP POST or PUT methods to change state (e.g., adding to a shopping cart, adding to a wishlist, etc.) and don't expect to see caching on these methods. Using GET or HEAD methods might trigger caching and prevent updates to private content. For more information about caching, see [RFC-2616 section 13](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html){:target="_blank"}
 
 {% include cache/page-cache-checklists.md%}


### PR DESCRIPTION
## Purpose of this pull request

- Improve Varnish code example & indentation.
- Fix `{:target="_blank"}` space at the _Warning block area (RFC-2616 section 13)_.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.1/extension-dev-guide/cache/page-caching/public-content.html
- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cache/page-caching/public-content.html

## Links to Magento source code
- https://github.com/magento/magento2/blob/2.0/app/code/Magento/PageCache/etc/varnish4.vcl#L63-L68

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
