### PR TITLE
Adding additional information regarding InstallData and a reference to data patches for 2.3.

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-actionscolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-actionscolumn.md
@@ -41,7 +41,7 @@ The ActionsColumns component implements a table's column responsible for display
   <tr>
     <td><code>templates.actions</code></td>
     <td>A list of actions that will be displayed in column's fields.</td>
-    <td>{[name: String]: <code>ActionItem</code>}</code></td>
+    <td>{[name: String]: <code>ActionItem</code>}</td>
     <td>-</td>
   </tr>
 </table>

--- a/guides/v2.3/extension-dev-guide/attributes.md
+++ b/guides/v2.3/extension-dev-guide/attributes.md
@@ -1,1 +1,0 @@
-../../v2.2/extension-dev-guide/attributes.md

--- a/guides/v2.3/extension-dev-guide/webapi/attributes.md
+++ b/guides/v2.3/extension-dev-guide/webapi/attributes.md
@@ -38,7 +38,7 @@ The `Customer` module does not treat its EAV attributes in a special manner. As 
 
 ### Adding Customer EAV attribute for backend only {#customer-eav-attribute}
 
-Customer EAV attributes, are created using a [data patches]({{ page.baseurl }}/extension-dev-guide/declarative-schema/data-patches.html).
+Customer EAV attributes are created using a [data patches]({{ page.baseurl }}/extension-dev-guide/declarative-schema/data-patches.html).
 
 {: .bs-callout .bs-callout-warning }
 Both the `save()` and `getResource()` methods for `Magento\Framework\Model\AbstractModel` have been marked as `@deprecated` since 2.1 and should no longer be used.
@@ -218,6 +218,7 @@ The following [code sample]({{ site.mage2000url }}app/code/Magento/CatalogInvent
 
 In this example, the `stock_item` attribute is restricted to only the users who have the `Magento_CatalogInventory::cataloginventory` permission. As a result, an anonymous or unauthenticated user issuing a `GET <host>/rest/<store_code>/V1/products/<sku>` request will receive product information similar to the following:
 
+```json
     {
       "sku": "tshirt1",
       "price": "20.00",
@@ -229,9 +230,11 @@ In this example, the `stock_item` attribute is restricted to only the users who 
         "artist": "James Smith"
       }
     }
+```
 
 However, an authenticated user with the permission `Magento_CatalogInventory::cataloginventory` receives the additional `stock_item` field:
 
+```json
     {
       "sku": "tshirt1",
       "price": "20.00",
@@ -247,6 +250,7 @@ However, an authenticated user with the permission `Magento_CatalogInventory::ca
         "artist": "James Smith"
       }
     }
+```
 
 This only works for extension attributes (those attributes defined in an `extension_attributes.xml` file). There are no permission restrictions on the rest of the returned data. For example, there is no way to restrict `custom_attributes`.
 

--- a/guides/v2.3/extension-dev-guide/webapi/attributes.md
+++ b/guides/v2.3/extension-dev-guide/webapi/attributes.md
@@ -38,7 +38,7 @@ The `Customer` module does not treat its EAV attributes in a special manner. As 
 
 ### Adding Customer EAV attribute for backend only {#customer-eav-attribute}
 
-Customer EAV attributes are created using a [data patches]({{ page.baseurl }}/extension-dev-guide/declarative-schema/data-patches.html).
+Customer EAV attributes are created using a [data patches](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.html).
 
 {: .bs-callout .bs-callout-warning }
 Both the `save()` and `getResource()` methods for `Magento\Framework\Model\AbstractModel` have been marked as `@deprecated` since 2.1 and should no longer be used.


### PR DESCRIPTION
https://github.com/magento/devdocs/issues/3700

## Purpose of this pull request
This pull request seeks to satisfy the suggestions and comments in #3700.  It adds clarity around InstallData/UpgradeData scripts in relation to customer EAV attributes.  Since this method of attribute adding does not exist in 2.3, the 2.3 documentation was update to include information about data patch files.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/attributes.html
- https://devdocs.magento.com/guides/v2.1/extension-dev-guide/attributes.html


whatsnew
Added clarity for `InstallData`/`UpgradeData` in relation to customer EAV attributes for [EAV and extension attributes](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/attributes.html) for all versions.