### PR TITLE
Fix theme inheritance layout files load order - Issue #2796

### DIFF
--- a/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
+++ b/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
@@ -122,9 +122,9 @@ You can find out what exactly code changes are required to perform this and othe
 The layouts processing mechanism does not involve fallback. The system collects {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} files in the following order:
 
 1. All modules layout files in sequence defined in `app/etc/config.php` respecting the [component load order]({{ page.baseurl }}/extension-dev-guide/build/module-load-order.html). For each module:
-- Layouts files for the `base` area: `<module_dir>/view/base/layout/`
+- Layout files for the `base` area: `<module_dir>/view/base/layout/`
 - Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
-1. Ancestor themes layouts, starting from the most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
+1. Ancestor theme layouts, starting from the most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
 2. Current theme layouts: `<theme_dir>/<Vendor>_<Module>/layout/`
 
 Unlike templates or images, layout can be not only overridden, but also extended. And the recommended way to customize layout is to extend it by creating theme extending layout files.

--- a/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
+++ b/guides/v2.1/frontend-dev-guide/themes/theme-inherit.md
@@ -121,13 +121,13 @@ You can find out what exactly code changes are required to perform this and othe
 
 The layouts processing mechanism does not involve fallback. The system collects {% glossarytooltip 73ab5daa-5857-4039-97df-11269b626134 %}layout{% endglossarytooltip %} files in the following order:
 
-1. Current theme layouts: `<theme_dir>/<Vendor>_<Module>/layout/`
-2. Ancestor themes layouts, starting from the  most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
-3. Module layouts for the `frontend` area: `<module_dir>/view/frontend/layout/`
-4. Module layouts for the `base` area: `<module_dir>/view/base/layout/`
+1. All modules layout files in sequence defined in `app/etc/config.php` respecting the [component load order]({{ page.baseurl }}/extension-dev-guide/build/module-load-order.html). For each module:
+- Layouts files for the `base` area: `<module_dir>/view/base/layout/`
+- Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
+1. Ancestor themes layouts, starting from the most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
+2. Current theme layouts: `<theme_dir>/<Vendor>_<Module>/layout/`
 
 Unlike templates or images, layout can be not only overridden, but also extended. And the recommended way to customize layout is to extend it by creating theme extending layout files.
-
 
 To add an extending layout file:
 


### PR DESCRIPTION
## Purpose of this pull request
Fix the topic Extend layouts load XML files order

https://github.com/magento/devdocs/issues/2796

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-inherit.html

whatsnew
Updated information for XML file order for [Theme inheritance](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-inherit.html).