### PR TITLE
Corrected Fastly CDN availability info on Starter

### DIFF
--- a/guides/v2.1/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.1/cloud/cdn/cloud-fastly.md
@@ -40,7 +40,7 @@ We highly recommend using Fastly for your CDN, security, and image optimization 
 
 ## Fastly CDN module for Magento 2
 
-Fastly services for {{ site.data.var.ece }} use the [Fastly CDN module for Magento 2](https://github.com/fastly/fastly-magento2) installed in the following environments: Pro Staging and Production, Starter Production (`master` branch). 
+Fastly services for {{ site.data.var.ece }} use the [Fastly CDN module for Magento 2](https://github.com/fastly/fastly-magento2) installed in the following environments: Pro Staging and Production, Starter Production (`master`) and Staging.
 
 On initial provisioning or upgrade of your {{ site. data.var.ece }} project, we install the latest version of the Fastly CDN module. When Fastly releases module updates, you receive notifications in the Magento Admin UI for your environments. We recommend that you update your environments to use the latest release. See [Upgrade Fastly]({{ page.baseurl}}/cloud/cdn/configure-fastly.html#upgrade).
 


### PR DESCRIPTION
## Purpose of this pull request

Per feedback from @jefflathan1: Corrected info about Fastly CDN availability on Starter Staging environment.


## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.1/cloud/cdn/cloud-fastly.html#fastly-cdn-module-for-magento-2
- https://devdocs.magento.com/guides/v2.2/cloud/cdn/cloud-fastly.html#fastly-cdn-module-for-magento-2
- https://devdocs.magento.com/guides/v2.3/cloud/cdn/cloud-fastly.html#fastly-cdn-module-for-magento-2
