### PR TITLE
MAGECLOUD-2973 db table prefixes

### DIFF
--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -91,6 +91,16 @@ stage:
       some_config: 'some_value'
 ```
 
+You can configure table prefixes; the following example uses the prefix `ece_`:
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      some_config: 'some_value'
+      table_prefix: 'ece_'
+```
+
 {% include cloud/merge-configuration.md %}
 
 The following example merges new values to an existing configuration:

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -91,16 +91,6 @@ stage:
       some_config: 'some_value'
 ```
 
-You can configure table prefixes; the following example uses the prefix `ece_`:
-
-```yaml
-stage:
-  deploy:
-    DATABASE_CONFIGURATION:
-      some_config: 'some_value'
-      table_prefix: 'ece_'
-```
-
 {% include cloud/merge-configuration.md %}
 
 The following example merges new values to an existing configuration:
@@ -112,6 +102,47 @@ stage:
       some_config: 'some_new_value'
       _merge: true
 ```
+
+Also, you can configure a table prefix. 
+
+{: .bs-callout .bs-callout-warning}
+If you do not use the merge option with the table prefix, you must provide default connection settings or the deploy fails validation.
+
+The following example uses the `ece_` table prefix with default connection settings instead of using the `_merge` option:
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      connection:
+        default:
+          username: user 
+          host: host
+          dbname: magento
+          password: password
+      table_prefix: 'ece_'
+```
+
+Sample output:
+
+```terminal
+MariaDB [main]> SHOW TABLES;
++-------------------------------------+
+| Tables_in_main                      |
++-------------------------------------+
+| ece_admin_passwords                 |
+| ece_admin_system_messages           |
+| ece_admin_user                      |
+| ece_admin_user_session              |
+| ece_adminnotification_inbox         |
+| ece_amazon_customer                 |
+| ece_authorization_rule              |
+| ece_cache                           |
+| ece_cache_tag                       |
+| ece_captcha_log                     |
+.....
+```
+{: .no-copy}
 
 ### `ENABLE_GOOGLE_ANALYTICS`
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -32,6 +32,7 @@ The release notes include:
 
 ## v2002.0.19
 
+-   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 
 ## v2002.0.18
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -98,8 +98,9 @@ By default, the deployment process overwrites all settings in the `env.php` file
 
 #### To see a list of message queue consumers:
 
-    ./bin/magento queue:consumers:list
-
+```bash
+./bin/magento queue:consumers:list
+```
 ### `CRYPT_KEY`
 
 -  **Default**—_Not set_
@@ -121,16 +122,6 @@ stage:
       some_config: 'some_value'
 ```
 
-You can configure table prefixes; the following example uses the prefix `ece_`:
-
-```yaml
-stage:
-  deploy:
-    DATABASE_CONFIGURATION:
-      some_config: 'some_value'
-      table_prefix: 'ece_'
-```
-
 {% include cloud/merge-configuration.md %}
 
 The following example merges new values to an existing configuration:
@@ -142,6 +133,48 @@ stage:
       some_config: 'some_new_value'
       _merge: true
 ```
+
+Also, you can configure a table prefix. 
+
+{: .bs-callout .bs-callout-warning}
+If you do not use the merge option with the table prefix, you must provide default connection settings or the deploy fails validation.
+
+The following example uses the `ece_` table prefix with default connection settings instead of using the `_merge` option:
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      connection:
+        default:
+          username: user 
+          host: host
+          dbname: magento
+          password: password
+      table_prefix: 'ece_'
+```
+
+Sample output:
+
+```terminal
+MariaDB [main]> SHOW TABLES;
++-------------------------------------+
+| Tables_in_main                      |
++-------------------------------------+
+| ece_admin_passwords                 |
+| ece_admin_system_messages           |
+| ece_admin_user                      |
+| ece_admin_user_session              |
+| ece_adminnotification_inbox         |
+| ece_amazon_customer                 |
+| ece_authorization_rule              |
+| ece_cache                           |
+| ece_cache_tag                       |
+| ece_captcha_log                     |
+.....
+```
+{: .no-copy}
+
 
 ### `ELASTICSUITE_CONFIGURATION`
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -121,6 +121,16 @@ stage:
       some_config: 'some_value'
 ```
 
+You can configure table prefixes; the following example uses the prefix `ece_`:
+
+```yaml
+stage:
+  deploy:
+    DATABASE_CONFIGURATION:
+      some_config: 'some_value'
+      table_prefix: 'ece_'
+```
+
 {% include cloud/merge-configuration.md %}
 
 The following example merges new values to an existing configuration:

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -32,7 +32,7 @@ The release notes include:
 
 ## v2002.0.19
 
-
+-   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 
 ## v2002.0.18
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -32,6 +32,7 @@ The release notes include:
 
 ## v2002.0.19
 
+-   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 
 ## v2002.0.18
 


### PR DESCRIPTION
Added the `table_prefix` configuration option to the DATABASE_CONFIGURATION environment variable.

Updated release notes.

This PR needs:

- [x] Technical review

Link check passed.