### PR TITLE
updating magento command for docker based on description in issue #4514

### DIFF
--- a/guides/v2.1/cloud/docker/docker-quick-reference.md
+++ b/guides/v2.1/cloud/docker/docker-quick-reference.md
@@ -15,7 +15,7 @@ Build environment | `docker-compose run build cloud-build`
 Deploy environment | `docker-compose run deploy cloud-deploy`
 Connect to CLI container | `docker-compose run deploy bash`
 Use `{{site.data.var.ct}}` command | `docker-compose run deploy ece-command <command>`
-Use Magento command | `docker-compose run deploy magento <command>`
+Use Magento command | `docker-compose run deploy magento-command <command>`
 Stop and remove Docker environment (removes volumes) | `docker-compose down -v`
 Stop Docker environment without destroying containers | `docker-compose stop`
 Resume Docker environment | `docker-compose start`


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request is created to resolve the issue #4514 i.e

docker-compose run deploy magento is wrong when we run this it is showing
/docker-entrypoint.sh: line 39: exec: magento: not found

Have tried this command docker-compose run deploy magento cache:flush which throws above error

currently as per document docker-compose run deploy magento in this we just have to replace the with any Magento command like cache:clean, setup:di:compile etc, but it is throwing error

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/cloud/docker/docker-quick-reference.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...
- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->