### PR TITLE
Add FORCE_UPDATE_URLS deploy variable doc

### DIFF
--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -424,7 +424,10 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment, replace Magento base URLs in the database with project URLs. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
+On deployment, replace Magento base URLs in the database the project URLs specified in the `MAGENTO_CLOUD_ROUTES` variable. This is useful for local development, where base URLs are set up for your local environment. 
+When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
+
+To update URLs when deploying to staging or production environments,                             use the `FORCE_UPDATE_URLS` variable. 
 
 ```yaml
 stage:
@@ -432,7 +435,18 @@ stage:
     UPDATE_URLS: false
 ```
 
-You should set this variable to `false` _only_ in Staging or Production environments, where the base URLs cannot change. For Pro, we already set this to `false` for you.
+### `FORCE_UPDATE_URLS`
+
+-  **Default**—`true`
+-  **Version**—Magento 2.1.4 and later
+
+On deployment to staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified in the `MAGENTO_CLOUD_ROUTES` variable. Use this setting to override the default behavior of the UPDATE_URLS variable which is ignored when deploying to staging or production environments. 
+
+```yaml
+stage:
+  deploy:
+    FORCE_UPDATE_URLS: true
+```
 
 ### `VERBOSE_COMMANDS`
 

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -129,7 +129,7 @@ The {{ site.data.var.ece }} deploy process always enables Google Analytics on Pr
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment to Pro and Starter staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified in the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) variable which is ignored when deploying to staging and production environments. 
+On deployment to Pro and Starter staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) variable which is ignored when deploying to staging and production environments. 
 
 ```yaml
 stage:
@@ -437,10 +437,10 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment, replace Magento base URLs in the database with the project URLs specified in the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl }}/cloud/env/variables-cloud.html) variable. This is useful for local development, where base URLs are set up for your local environment. 
+On deployment, replace Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl }}/cloud/env/variables-cloud.html) variable. This is useful for local development, where base URLs are set up for your local environment. 
 When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
 
-If you need to update URLs when deploying to staging or production environments,                  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
+If you need to update URLs when deploying to Pro or Starter staging and production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/env/variables-deploy.md
+++ b/guides/v2.1/cloud/env/variables-deploy.md
@@ -124,6 +124,19 @@ stage:
 {:.bs-callout .bs-callout-info}
 The {{ site.data.var.ece }} deploy process always enables Google Analytics on Production environments.
 
+### `FORCE_UPDATE_URLS`
+
+-  **Default**—`true`
+-  **Version**—Magento 2.1.4 and later
+
+On deployment to Pro and Starter staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified in the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) variable which is ignored when deploying to staging and production environments. 
+
+```yaml
+stage:
+  deploy:
+    FORCE_UPDATE_URLS: true
+```
+
 ### `GENERATED_CODE_SYMLINK`
 
 -  **Default**—`true`
@@ -424,28 +437,15 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment, replace Magento base URLs in the database the project URLs specified in the `MAGENTO_CLOUD_ROUTES` variable. This is useful for local development, where base URLs are set up for your local environment. 
+On deployment, replace Magento base URLs in the database with the project URLs specified in the [`MAGENTO_CLOUD_ROUTES`]({{ page.baseurl }}/cloud/env/variables-cloud.html) variable. This is useful for local development, where base URLs are set up for your local environment. 
 When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
 
-To update URLs when deploying to staging or production environments,                             use the `FORCE_UPDATE_URLS` variable. 
+If you need to update URLs when deploying to staging or production environments,                  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
 
 ```yaml
 stage:
   deploy:
     UPDATE_URLS: false
-```
-
-### `FORCE_UPDATE_URLS`
-
--  **Default**—`true`
--  **Version**—Magento 2.1.4 and later
-
-On deployment to staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified in the `MAGENTO_CLOUD_ROUTES` variable. Use this setting to override the default behavior of the UPDATE_URLS variable which is ignored when deploying to staging or production environments. 
-
-```yaml
-stage:
-  deploy:
-    FORCE_UPDATE_URLS: true
 ```
 
 ### `VERBOSE_COMMANDS`

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -32,6 +32,9 @@ The release notes include:
 
 ## v2002.0.19
 
+-  {:.new}**Environment variable updates**—
+
+    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
 ## v2002.0.18
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -  {:.new}**Environment variable updates**—
 
-    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+    -  {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
 ## v2002.0.18
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -512,7 +512,9 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment, replace Magento base URLs in the database with project URLs. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
+On deployment, replace Magento base URLs in the database with the project URLs specified by the `MAGENTO_CLOUD_ROUTES` variable. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
+
+To update URLs when deploying to staging or production environments,                            use the `FORCE_UPDATE_URLS` variable. 
 
 ```yaml
 stage:
@@ -520,7 +522,18 @@ stage:
     UPDATE_URLS: false
 ```
 
-You should set this variable to `false` _only_ in Staging or Production environments, where the base URLs cannot change. For Pro, we already set this to `false` for you.
+### `FORCE_UPDATE_URLS`
+
+-  **Default**—`true`
+-  **Version**—Magento 2.1.4 and later
+
+On deployment to staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the `MAGENTO_CLOUD_ROUTES` variable. Use this setting to override the default behavior of the UPDATE_URLS variable which is ignored when deploying to staging or production environments. 
+
+```yaml
+stage:
+  deploy:
+    FORCE_UPDATE_URLS: true
+```
 
 ### `VERBOSE_COMMANDS`
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -527,7 +527,7 @@ stage:
 
 On deployment, replace Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
 
-If you need to update URLs when deploying to Pro and Starter staging or production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
+If you need to update URLs when deploying to Pro or Starter staging and production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -194,6 +194,19 @@ stage:
 {:.bs-callout .bs-callout-info}
 The {{ site.data.var.ece }} deploy process always enables Google Analytics on Production environments.
 
+### `FORCE_UPDATE_URLS`
+
+-  **Default**—`true`
+-  **Version**—Magento 2.1.4 and later
+
+On deployment to Pro or Starter staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) deploy variable which is ignored when deploying to staging or production environments. 
+
+```yaml
+stage:
+  deploy:
+    FORCE_UPDATE_URLS: true
+```
+
 ### `MYSQL_USE_SLAVE_CONNECTION`
 
 -  **Default**—`false`
@@ -512,27 +525,14 @@ stage:
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment, replace Magento base URLs in the database with the project URLs specified by the `MAGENTO_CLOUD_ROUTES` variable. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
+On deployment, replace Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. This is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
 
-To update URLs when deploying to staging or production environments,                            use the `FORCE_UPDATE_URLS` variable. 
+If you need to update URLs when deploying to Pro and Starter staging or production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
 
 ```yaml
 stage:
   deploy:
     UPDATE_URLS: false
-```
-
-### `FORCE_UPDATE_URLS`
-
--  **Default**—`true`
--  **Version**—Magento 2.1.4 and later
-
-On deployment to staging and production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the `MAGENTO_CLOUD_ROUTES` variable. Use this setting to override the default behavior of the UPDATE_URLS variable which is ignored when deploying to staging or production environments. 
-
-```yaml
-stage:
-  deploy:
-    FORCE_UPDATE_URLS: true
 ```
 
 ### `VERBOSE_COMMANDS`

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -  {:.new}**Environment variable updates**—
 
-    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to the following environments: Pro Production and Staging, Starter Production (`master` branch) and Staging. This setting overrides the default behavior of the `UPDATE_URLS` variable which is ignored when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+    -  {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
 ## v2002.0.18
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -32,7 +32,9 @@ The release notes include:
 
 ## v2002.0.19
 
+-  {:.new}**Environment variable updates**—
 
+    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to the following environments: Pro Production and Staging, Starter Production (`master` branch) and Staging. This setting overrides the default behavior of the `UPDATE_URLS` variable which is ignored when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
 ## v2002.0.18
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -  {:.new}**Environment variable updates**—
 
-    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
 
 ## v2002.0.18

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -32,6 +32,10 @@ The release notes include:
 
 ## v2002.0.19
 
+-  {:.new}**Environment variable updates**—
+
+    -  {:.new}<!-- MAGECLOUD-3026-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+
 
 ## v2002.0.18
 


### PR DESCRIPTION
## Purpose of this pull request

Added documentation for the FORCE_UPDATE_URLS deploy variable to update URLs when deploying Magento Commerce Cloud projects to staging and production environments.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html
- https://devdocs.magento.com/guides/v2.3/cloud/release-notes/cloud-tools.html

## Links to Magento source code

https://github.com/magento/ece-tools/blob/develop/dist/.magento.env.yaml#L189

whatsnew
Added the [FORCE_UPDATE_URLS](https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html) deploy variable to update Magento base URLs when deploying Magento Commerce Cloud projects to production and staging environments.


