### PR TITLE
Adding the service's node attributes defined in webapi.xsd

### DIFF
--- a/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -302,6 +302,13 @@ If a service method argument is called `item`, there will be a problem during SO
 <p>The <code>webapi.xml</code> file for your module must specify an XML schema file for validation. Your <code>webapi.xml</code> file can specify the default or a customized XML schema file.</p>
 <p>The default <code>webapi.xsd</code> XML schema file can be found in the <code>app/code/Magento/Webapi/etc</code> directory.</p>
 
+The following table defines the `service` node attributes:
+
+Attribute name | Required | Description
+--- | --- | ---
+`class` | Yes | The interface responsible for handling the API request.
+`method` | Yes | The interface's method which handles the execution of the web API.
+
 ## Forcing Request Parameters {#forced-parameters}
 
 <p>Parameters in the <code>webapi.xml</code> can be forced. This ensures that on specific routes, a specific value is

--- a/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -20,22 +20,21 @@ Users can make REST or SOAP calls to access the {% glossarytooltip 377dc0a3-b8a7
 
 To configure a web API, read these topics:
 
--   [Configure a web API](#configure-webapi)
+- [Configure a web API](#configure-webapi)
 
--   [webapi.xml configuration options](#configuration-options)
+- [webapi.xml configuration options](#configuration-options)
 
--   [Sample webapi.xml file](#sample-webapi)
+- [Sample webapi.xml file](#sample-webapi)
 
--   [webapi.xsd XML schema file](#validate-webapi)
+- [webapi.xsd XML schema file](#validate-webapi)
 
--   [Forcing Request Parameters](#forced-parameters)
+- [Forcing Request Parameters](#forced-parameters)
 
 ## Configure a web API {#configure-webapi}
 
-<p>To configure a web API for a service, you define XML elements and attributes in the
-   <code>app/code/Magento/&lt;MODULE&gt;/etc/webapi.xml</code> file, where <code>&lt;MODULE&gt;</code> is the module name.
-   For example, the web API for the Customer service is defined in the <code>app/code/Magento/Customer/etc/webapi.xml</code> configuration file.
-</p>
+To configure a web API for a service, you define XML elements and attributes in the
+   `app/code/Magento/&lt;MODULE&gt;/etc/webapi.xml` file, where `&lt;MODULE&gt;` is the module name.
+   For example, the web API for the Customer service is defined in the `app/code/Magento/Customer/etc/webapi.xml` configuration file.
 
 ## Service Interface Requirements {#service-interface-requirements}
 
@@ -49,45 +48,47 @@ To do this conversion, the Magento application must know information about both 
 
 For SOAP and REST to work correctly, the following rules must be followed by the service interface's doc block:
 
-*   All methods exposed by the web API must follow these rules
-*   All methods on objects expected as parameters or returned must follow these rules
-*   Parameters must be defined in the doc block as
+- All methods exposed by the web API must follow these rules
+- All methods on objects expected as parameters or returned must follow these rules
+- Parameters must be defined in the doc block as
 
-        * @param type $paramName
-*   Return type must be defined in the doc block as
+  - @param type $paramName
 
-        * @return type
-*   Valid scalar types include: `mixed` (or `anyType`), `bool` (or `boolean`), `str` (or `string`), `integer` (or `int`), `float`, and `double`.
-*   Valid object types include a fully qualified class name or a fully qualified interface name.
-*   Any parameters or return values of type array can be denoted by following any of the previous types by an empty set of square brackets `[]`
+- Return type must be defined in the doc block as
+
+  - @return type
+
+- Valid scalar types include: `mixed` (or `anyType`), `bool` (or `boolean`), `str` (or `string`), `integer` (or `int`), `float`, and `double`.
+- Valid object types include a fully qualified class name or a fully qualified interface name.
+- Any parameters or return values of type array can be denoted by following any of the previous types by an empty set of square brackets `[]`
 
 Following are some examples of various types and what they would look like in the doc block:
 
-*   A parameter $types which can be an array of strings:
+- A parameter $types which can be an array of strings:
 
-        * @param string[] $types
-*   A parameter $id which can be an integer:
+  - @param string[] $types
+- A parameter $id which can be an integer:
 
-        * @param int $id
-*   A parameter $customer which is an object of class `\Magento\Customer\Api\Data\CustomerInterface`:
+  - @param int $id
 
-        * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+- A parameter $customer which is an object of class `\Magento\Customer\Api\Data\CustomerInterface`:
+
+  - @param \Magento\Customer\Api\Data\CustomerInterface $customer
 
     Note that even if the class `\Magento\Customer\Api\Data\CustomerInterface` is in the same namespace (or a sub-namespace) of the current class or a use statement has exists at the top of the class, the fully qualified namespace must be used or the web API throws an exception.
 
-*   A return which is an array of objects of type `\Magento\Customer\Api\Data\CustomerInterface`:
+- A return which is an array of objects of type `\Magento\Customer\Api\Data\CustomerInterface`:
 
-        * @return \Magento\Customer\Api\Data\CustomerInterface[]
-
+  - @return \Magento\Customer\Api\Data\CustomerInterface[]
 
 {: .bs-callout .bs-callout-info }
 If a service method argument is called `item`, there will be a problem during SOAP processing. All item nodes are removed during SOAP request processing. This is done to unwrap array items that are wrapped by the SOAP server into an `item` element.
 
 ## webapi.xml configuration options {#configuration-options}
 
-<p>To define web API components, set these attributes on these XML elements in the
-   <code>webapi.xml</code> configuration file, as follows:
-</p>
+To define web API components, set these attributes on these XML elements in the
+   `webapi.xml` configuration file, as follows:
+
 <table style="width:100%">
    <tr bgcolor="lightgray">
       <th>XML element</th>
@@ -96,7 +97,7 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;routes&gt;</code></p>
+         <p>`&lt;routes&gt;`</p>
       </td>
       <td>
          <p>Required. Root element that defines the namespace and location of the XML schema file.</p>
@@ -104,61 +105,61 @@ If a service method argument is called `item`, there will be a problem during SO
       <td>
          <ul>
             <li>
-               <p><code>xmlns:xsi</code>. Required. Defines the namespace for the XML schema instance.</p>
+               <p>`xmlns:xsi`. Required. Defines the namespace for the XML schema instance.</p>
             </li>
             <li>
-               <p><code>xsi:noNamespaceSchemaLocation</code>. Required. Defines the path and file name of the XML schema file to use to validate the web API.</p>
+               <p>`xsi:noNamespaceSchemaLocation`. Required. Defines the path and file name of the XML schema file to use to validate the web API.</p>
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;route&gt;</code></p>
+         <p>`&lt;route&gt;`</p>
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;routes&gt;</code>. Defines the HTTP route for the web API method.</p>
+         <p>Required. Child element of `&lt;routes&gt;`. Defines the HTTP route for the web API method.</p>
       </td>
       <td>
          <ul>
             <li>
-               <p><code>method</code>. Required. String. HTTP method. Valid values are GET, POST, PUT, and DELETE.</p>
+               <p>`method`. Required. String. HTTP method. Valid values are GET, POST, PUT, and DELETE.</p>
             </li>
             <li>
-               <p><code>url</code>. Required. String.
+               <p>`url`. Required. String.
                   Magento resource. Optionally, one or more template parameters.
                </p>
             </li>
             <li>
-               <p><code>secure</code>. Optional. Boolean. Indicates that the route is accessible over only HTTPS. Any attempts to access this route over non-secure causes an exception.</p>
+               <p>`secure`. Optional. Boolean. Indicates that the route is accessible over only HTTPS. Any attempts to access this route over non-secure causes an exception.</p>
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;service&gt;</code></p>
+         <p>`&lt;service&gt;`</p>
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;route&gt;</code>. Defines the implemented interface and the web API method name.</p>
+         <p>Required. Child element of `&lt;route&gt;`. Defines the implemented interface and the web API method name.</p>
       </td>
       <td>
          <ul>
             <li>
-               <p><code>class</code>. Required. String. Location and name of implemented interface.</p>
+               <p>`class`. Required. String. Location and name of implemented interface.</p>
             </li>
             <li>
-               <p><code>method</code>. Required. String. Web API method name.</p>
+               <p>`method`. Required. String. Web API method name.</p>
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;resources&gt;</code></p>
+         <p>`&lt;resources&gt;`</p>
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;route&gt;</code>. Container for one or more resource definitions.</p>
+         <p>Required. Child element of `&lt;route&gt;`. Container for one or more resource definitions.</p>
       </td>
       <td>
          <p>None.</p>
@@ -166,18 +167,18 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;resource&gt;</code></p>
+         <p>`&lt;resource&gt;`</p>
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;resources&gt;</code>. Defines a resource to which the caller must have access.</p>
+         <p>Required. Child element of `&lt;resources&gt;`. Defines a resource to which the caller must have access.</p>
       </td>
       <td>
          <ul>
             <li>
-               <p><code>ref</code>.
-                  Required. Referenced resource. Valid values are <code>self</code>, <code>anonymous</code>, or a Magento resource, such as <code>Magento_Customer::group</code>.
+               <p>`ref`.
+                  Required. Referenced resource. Valid values are `self`, `anonymous`, or a Magento resource, such as `Magento_Customer::group`.
                </p>
-               <p><strong>Note</strong>:The Magento web API framework enables guest users to access resources that are configured with <code>anonymous</code> permission.</p>
+               <p><strong>Note</strong>:The Magento web API framework enables guest users to access resources that are configured with `anonymous` permission.</p>
                   <p>Any user that the framework cannot authenticate through existing <a href="{{ page.baseurl }}/get-started/authentication/gs-authentication.html">authentication
                      mechanisms</a> is considered a guest user.</p>
 
@@ -187,10 +188,10 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;data&gt;</code></p>
+         <p>`&lt;data&gt;`</p>
       </td>
       <td>
-         <p>Optional. Child element of <code>&lt;route&gt;</code>. Container for one or more parameter definitions.</p>
+         <p>Optional. Child element of `&lt;route&gt;`. Container for one or more parameter definitions.</p>
       </td>
       <td>
          <p>None.</p>
@@ -198,18 +199,18 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;parameter&gt;</code></p>
+         <p>`&lt;parameter&gt;`</p>
       </td>
       <td>
-         <p>Required if <code>&lt;data&gt;</code> is specified. Child element of <code>&lt;data&gt;</code>. Defines a parameter.</p>
+         <p>Required if `&lt;data&gt;` is specified. Child element of `&lt;data&gt;`. Defines a parameter.</p>
       </td>
       <td>
          <ul>
             <li>
-               <p><code>name</code>. String. Parameter name.</p>
+               <p>`name`. String. Parameter name.</p>
             </li>
             <li>
-               <p><code>force</code>. Boolean. <a href="#forced-parameters">Forcing Request Parameters</a></p>
+               <p>`force`. Boolean. <a href="#forced-parameters">Forcing Request Parameters</a></p>
             </li>
          </ul>
       </td>
@@ -218,7 +219,8 @@ If a service method argument is called `item`, there will be a problem during SO
 
 ## Sample webapi.xml file {#sample-webapi}
 
-<p>This excerpt is from the <code>webapi.xml</code> file that defines the Customer service web API:</p>
+This excerpt is from the `webapi.xml` file that defines the Customer service web API:
+
 ```xml
 <?xml version="1.0"?>
     <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
@@ -241,7 +243,8 @@ If a service method argument is called `item`, there will be a problem during SO
     </route>
 </routes>
 ```
-<p>In this <code>webapi.xml</code> example:</p>
+
+In this `webapi.xml` example:
 <table style="width:100%">
    <tr bgcolor="lightgray">
       <th>Line</th>
@@ -253,8 +256,8 @@ If a service method argument is called `item`, there will be a problem during SO
       </td>
       <td>
          <p>The XML schema file that is used to validate the XML.</p>
-         <p>The XML schema file is <code>xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd</code>.</p>
+         <p>The XML schema file is `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd`.</p>
       </td>
    </tr>
    <tr>
@@ -264,7 +267,7 @@ If a service method argument is called `item`, there will be a problem during SO
       <td>
          <p>The HTTP method and web resource through which to access the route.</p>
          <p>The HTTP method is GET.</p>
-         <p>The resource is <code>/V1/customerGroups/:id</code>. Users must substitute a customer ID for the <code>id</code> template parameter.</p>
+         <p>The resource is `/V1/customerGroups/:id`. Users must substitute a customer ID for the `id` template parameter.</p>
       </td>
    </tr>
    <tr>
@@ -273,8 +276,8 @@ If a service method argument is called `item`, there will be a problem during SO
       </td>
       <td>
          <p>The interface that the route implements and the name of the web API method.</p>
-         <p>The route implements the <code>Magento\Customer\Api\GroupRepositoryInterface</code> interface.</p>
-         <p>The web API method name is <code>getById</code>.</p>
+         <p>The route implements the `Magento\Customer\Api\GroupRepositoryInterface` interface.</p>
+         <p>The web API method name is `getById`.</p>
       </td>
    </tr>
    <tr>
@@ -283,7 +286,7 @@ If a service method argument is called `item`, there will be a problem during SO
       </td>
       <td>
          <p>The resource to which the caller must have access.</p>
-         <p>The caller must have access to <code>Magento_Customer::group</code> resource.</p>
+         <p>The caller must have access to `Magento_Customer::group` resource.</p>
       </td>
    </tr>
    <tr>
@@ -292,15 +295,15 @@ If a service method argument is called `item`, there will be a problem during SO
       </td>
       <td>
          <p>A required parameter.</p>
-         <p>The <code>id</code> parameter is required on GET calls to <code>/V1/customers/me/billingAddress</code>.</p>
+         <p>The `id` parameter is required on GET calls to `/V1/customers/me/billingAddress`.</p>
       </td>
    </tr>
 </table>
 
 ## webapi.xsd XML schema file {#validate-webapi}
 
-<p>The <code>webapi.xml</code> file for your module must specify an XML schema file for validation. Your <code>webapi.xml</code> file can specify the default or a customized XML schema file.</p>
-<p>The default <code>webapi.xsd</code> XML schema file can be found in the <code>app/code/Magento/Webapi/etc</code> directory.</p>
+The `webapi.xml` file for your module must specify an XML schema file for validation. Your `webapi.xml` file can specify the default or a customized XML schema file.
+The default `webapi.xsd` XML schema file can be found in the `app/code/Magento/Webapi/etc` directory.
 
 The following table defines the `service` node attributes:
 
@@ -311,13 +314,12 @@ Attribute name | Required | Description
 
 ## Forcing Request Parameters {#forced-parameters}
 
-<p>Parameters in the <code>webapi.xml</code> can be forced. This ensures that on specific routes, a specific value is
-   always used. For instance, in the example "/V1/customers/me/billingAddress" route above, the <code>customerId</code>
-   parameter is forced to match the ID of the currently logged in user.</p>
-<p>Additional parameter overrides can be registered via <code>di.xml</code> by adding new items to the
-   <code>paramOverriders</code> argument for <code>\Magento\Webapi\Controller\Rest\ParamsOverrider</code>. Parameter
-   overriders must implement <code>\Magento\Framework\Webapi\Rest\Request\ParamOverriderInterface</code>. An
-   example excerpt from <code>di.xml</code></p>
+Parameters in the `webapi.xml` can be forced. This ensures that on specific routes, a specific value is always used. For instance, in the example "/V1/customers/me/billingAddress" route above, the `customerId` parameter is forced to match the ID of the currently logged in user.
+Additional parameter overrides can be registered via `di.xml` by adding new items to the
+`paramOverriders` argument for `\Magento\Webapi\Controller\Rest\ParamsOverrider`. Parameter
+overriders must implement `\Magento\Framework\Webapi\Rest\Request\ParamOverriderInterface`. An
+example excerpt from `di.xml`
+
 ```xml
 <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
     <arguments>
@@ -327,9 +329,11 @@ Attribute name | Required | Description
     </arguments>
 </type>
 ```
-<p>The above example create a new parameter override available for use in <code>webapi.xml</code>. The value passed for
-   <code>%my_value%</code> will be the return value of
-   <code>\VENDOR\MODULE\Controller\Rest\ParamOverriderMyValue::getOverriddenValue</code>. Example:</p>
+
+The above example create a new parameter override available for use in `webapi.xml`. The value passed for
+   `%my_value%` will be the return value of
+   `\VENDOR\MODULE\Controller\Rest\ParamOverriderMyValue::getOverriddenValue`. Example:
+
 ```xml
 <route url="/V1/example/me/service" method="GET">
     ...

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -296,6 +296,13 @@ If a service method argument is called `item`, there will be a problem during SO
 <p>The <code>webapi.xml</code> file for your module must specify an XML schema file for validation. Your <code>webapi.xml</code> file can specify the default or a customized XML schema file.</p>
 <p>The default <code>webapi.xsd</code> XML schema file can be found in the <code>app/code/Magento/Webapi/etc</code> directory.</p>
 
+The following table defines the `service` node attributes:
+
+Attribute name | Required | Description
+--- | --- | ---
+`class` | Yes | The responsible class for handling the API request.
+`method` | Yes | The class' method which handles the execution of the API.
+
 ## Forcing Request Parameters {#forced-parameters}
 
 <p>Parameters in the <code>webapi.xml</code> can be forced. This ensures that on specific routes, a specific value is

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.md
@@ -17,15 +17,15 @@ Users can make REST or SOAP calls to access the {% glossarytooltip 377dc0a3-b8a7
 
 To configure a web API, read these topics:
 
--   [Configure a web API](#configure-webapi)
+- [Configure a web API](#configure-webapi)
 
--   [webapi.xml configuration options](#configuration-options)
+- [webapi.xml configuration options](#configuration-options)
 
--   [Sample webapi.xml file](#sample-webapi)
+- [Sample webapi.xml file](#sample-webapi)
 
--   [webapi.xsd XML schema file](#validate-webapi)
+- [webapi.xsd XML schema file](#validate-webapi)
 
--   [Forcing Request Parameters](#forced-parameters)
+- [Forcing Request Parameters](#forced-parameters)
 
 ## Configure a web API {#configure-webapi}
 
@@ -43,45 +43,48 @@ To do this conversion, the Magento application must know information about both 
 
 For SOAP and REST to work correctly, the following rules must be followed by the service interface's doc block:
 
-*   All methods exposed by the web API must follow these rules
-*   All methods on objects expected as parameters or returned must follow these rules
-*   Parameters must be defined in the doc block as
+- All methods exposed by the web API must follow these rules
+- All methods on objects expected as parameters or returned must follow these rules
+- Parameters must be defined in the doc block as
 
-        * @param type $paramName
-*   Return type must be defined in the doc block as
+  - @param type $paramName
 
-        * @return type
-*   Valid scalar types include: `mixed` (or `anyType`), `bool` (or `boolean`), `str` (or `string`), `integer` (or `int`), `float`, and `double`.
-*   Valid object types include a fully qualified class name or a fully qualified interface name.
-*   Any parameters or return values of type array can be denoted by following any of the previous types by an empty set of square brackets `[]`
+- Return type must be defined in the doc block as
+
+  - @return type
+
+- Valid scalar types include: `mixed` (or `anyType`), `bool` (or `boolean`), `str` (or `string`), `integer` (or `int`), `float`, and `double`.
+- Valid object types include a fully qualified class name or a fully qualified interface name.
+- Any parameters or return values of type array can be denoted by following any of the previous types by an empty set of square brackets `[]`
 
 Following are some examples of various types and what they would look like in the doc block:
 
-*   A parameter $types which can be an array of strings:
+- A parameter $types which can be an array of strings:
 
-        * @param string[] $types
-*   A parameter $id which can be an integer:
+  - @param string[] $types
 
-        * @param int $id
-*   A parameter $customer which is an object of class `\Magento\Customer\Api\Data\CustomerInterface`:
+- A parameter $id which can be an integer:
 
-        * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+  - @param int $id
+
+- A parameter $customer which is an object of class `\Magento\Customer\Api\Data\CustomerInterface`:
+
+  - @param \Magento\Customer\Api\Data\CustomerInterface $customer
 
     Note that even if the class `\Magento\Customer\Api\Data\CustomerInterface` is in the same namespace (or a sub-namespace) of the current class or a use statement has exists at the top of the class, the fully qualified namespace must be used or the web API throws an exception.
 
-*   A return which is an array of objects of type `\Magento\Customer\Api\Data\CustomerInterface`:
+- A return which is an array of objects of type `\Magento\Customer\Api\Data\CustomerInterface`:
 
-        * @return \Magento\Customer\Api\Data\CustomerInterface[]
-
+  - @return \Magento\Customer\Api\Data\CustomerInterface[]
 
 {: .bs-callout .bs-callout-info }
 If a service method argument is called `item`, there will be a problem during SOAP processing. All item nodes are removed during SOAP request processing. This is done to unwrap array items that are wrapped by the SOAP server into an `item` element.
 
 ## webapi.xml configuration options {#configuration-options}
 
-<p>To define web API components, set these attributes on these XML elements in the
-   <code>webapi.xml</code> configuration file, as follows:
-</p>
+To define web API components, set these attributes on these XML elements in the
+   `webapi.xml` configuration file, as follows:
+
 <table style="width:100%">
    <tr bgcolor="lightgray">
       <th>XML element</th>
@@ -90,90 +93,88 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;routes&gt;</code></p>
+         `&lt;routes&gt;`
       </td>
       <td>
-         <p>Required. Root element that defines the namespace and location of the XML schema file.</p>
+         Required. Root element that defines the namespace and location of the XML schema file.
       </td>
       <td>
          <ul>
             <li>
-               <p><code>xmlns:xsi</code>. Required. Defines the namespace for the XML schema instance.</p>
+               `xmlns:xsi`. Required. Defines the namespace for the XML schema instance.
             </li>
             <li>
-               <p><code>xsi:noNamespaceSchemaLocation</code>. Required. Defines the path and file name of the XML schema file to use to validate the web API.</p>
+               `xsi:noNamespaceSchemaLocation`. Required. Defines the path and file name of the XML schema file to use to validate the web API.
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;route&gt;</code></p>
+         `&lt;route&gt;`
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;routes&gt;</code>. Defines the HTTP route for the web API method.</p>
+         Required. Child element of `&lt;routes&gt;`. Defines the HTTP route for the web API method.
       </td>
       <td>
          <ul>
             <li>
-               <p><code>method</code>. Required. String. HTTP method. Valid values are GET, POST, PUT, and DELETE.</p>
+               `method`. Required. String. HTTP method. Valid values are GET, POST, PUT, and DELETE.
             </li>
             <li>
-               <p><code>url</code>. Required. String.
-                  The URL to the Magento resource. The string must begin with <code>/V1</code> (or <code>/V&lt;integer&gt;</code>) to indicate the version number. You must prepend any template parameters with a colon. Example: <code>/V1/products/:sku</code>
-               </p>
+               `url`. Required. String.
+                  The URL to the Magento resource. The string must begin with `/V1` (or `/V&lt;integer&gt;`) to indicate the version number. You must prepend any template parameters with a colon. Example: `/V1/products/:sku
             </li>
             <li>
-               <p><code>secure</code>. Optional. Boolean. Indicates that the route is accessible over only HTTPS. Any attempts to access this route over non-secure causes an exception.</p>
+               `secure`. Optional. Boolean. Indicates that the route is accessible over only HTTPS. Any attempts to access this route over non-secure causes an exception.
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;service&gt;</code></p>
+         `&lt;service&gt;`
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;route&gt;</code>. Defines the implemented interface and the web API method name.</p>
+         Required. Child element of `&lt;route&gt;`. Defines the implemented interface and the web API method name.
       </td>
       <td>
          <ul>
             <li>
-               <p><code>class</code>. Required. String. Location and name of implemented interface.</p>
+               `class`. Required. String. Location and name of implemented interface.
             </li>
             <li>
-               <p><code>method</code>. Required. String. Web API method name.</p>
+               `method`. Required. String. Web API method name.
             </li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;resources&gt;</code></p>
+         `&lt;resources&gt;`
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;route&gt;</code>. Container for one or more resource definitions.</p>
+         Required. Child element of `&lt;route&gt;`. Container for one or more resource definitions.
       </td>
       <td>
-         <p>None.</p>
+         None.
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;resource&gt;</code></p>
+         `&lt;resource&gt;`
       </td>
       <td>
-         <p>Required. Child element of <code>&lt;resources&gt;</code>. Defines a resource to which the caller must have access.</p>
+         Required. Child element of `&lt;resources&gt;`. Defines a resource to which the caller must have access.
       </td>
       <td>
          <ul>
             <li>
-               <p><code>ref</code>.
-                  Required. Referenced resource. Valid values are <code>self</code>, <code>anonymous</code>, or a Magento resource, such as <code>Magento_Customer::group</code>.
-               </p>
-               <p><strong>Note</strong>:The Magento web API framework enables guest users to access resources that are configured with <code>anonymous</code> permission.</p>
-                  <p>Any user that the framework cannot authenticate through existing <a href="{{ page.baseurl }}/get-started/authentication/gs-authentication.html">authentication
-                     mechanisms</a> is considered a guest user.</p>
+               `ref`.
+                  Required. Referenced resource. Valid values are `self`, `anonymous`, or a Magento resource, such as `Magento_Customer::group`.
+               <strong>Note</strong>:The Magento web API framework enables guest users to access resources that are configured with `anonymous` permission.
+                  Any user that the framework cannot authenticate through existing <a href="{{ page.baseurl }}/get-started/authentication/gs-authentication.html">authentication
+                     mechanisms</a> is considered a guest user.
 
             </li>
          </ul>
@@ -181,29 +182,29 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p><code>&lt;data&gt;</code></p>
+         `&lt;data&gt;`
       </td>
       <td>
-         <p>Optional. Child element of <code>&lt;route&gt;</code>. Container for one or more parameter definitions.</p>
+         Optional. Child element of `&lt;route&gt;`. Container for one or more parameter definitions.
       </td>
       <td>
-         <p>None.</p>
+         None.
       </td>
    </tr>
    <tr>
       <td>
-         <p><code>&lt;parameter&gt;</code></p>
+         `&lt;parameter&gt;`
       </td>
       <td>
-         <p>Required if <code>&lt;data&gt;</code> is specified. Child element of <code>&lt;data&gt;</code>. Defines a parameter.</p>
+         Required if `&lt;data&gt;` is specified. Child element of `&lt;data&gt;`. Defines a parameter.
       </td>
       <td>
          <ul>
             <li>
-               <p><code>name</code>. String. Parameter name.</p>
+               `name`. String. Parameter name.
             </li>
             <li>
-               <p><code>force</code>. Boolean. <a href="#forced-parameters">Forcing Request Parameters</a></p>
+               `force`. Boolean. <a href="#forced-parameters">Forcing Request Parameters</a>
             </li>
          </ul>
       </td>
@@ -212,7 +213,8 @@ If a service method argument is called `item`, there will be a problem during SO
 
 ## Sample webapi.xml file {#sample-webapi}
 
-<p>This excerpt is from the <code>webapi.xml</code> file that defines the Customer service web API:</p>
+This excerpt is from the `webapi.xml` file that defines the Customer service web API:
+
 ```xml
 <?xml version="1.0"?>
     <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
@@ -235,7 +237,8 @@ If a service method argument is called `item`, there will be a problem during SO
     </route>
 </routes>
 ```
-<p>In this <code>webapi.xml</code> example:</p>
+
+In this `webapi.xml` example:
 <table style="width:100%">
    <tr bgcolor="lightgray">
       <th>Line</th>
@@ -243,58 +246,58 @@ If a service method argument is called `item`, there will be a problem during SO
    </tr>
    <tr>
       <td>
-         <p>3</p>
+         3
       </td>
       <td>
-         <p>The XML schema file that is used to validate the XML.</p>
-         <p>The XML schema file is <code>xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd</code>.</p>
-      </td>
-   </tr>
-   <tr>
-      <td>
-         <p>5</p>
-      </td>
-      <td>
-         <p>The HTTP method and web resource through which to access the route.</p>
-         <p>The HTTP method is GET.</p>
-         <p>The resource is <code>/V1/customerGroups/:id</code>. Users must substitute a customer ID for the <code>id</code> template parameter.</p>
+         The XML schema file that is used to validate the XML.
+         The XML schema file is `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd`.
       </td>
    </tr>
    <tr>
       <td>
-         <p>6</p>
+         5
       </td>
       <td>
-         <p>The interface that the route implements and the name of the web API method.</p>
-         <p>The route implements the <code>Magento\Customer\Api\GroupRepositoryInterface</code> interface.</p>
-         <p>The web API method name is <code>getById</code>.</p>
-      </td>
-   </tr>
-   <tr>
-      <td>
-         <p>8</p>
-      </td>
-      <td>
-         <p>The resource to which the caller must have access.</p>
-         <p>The caller must have access to <code>Magento_Customer::group</code> resource.</p>
+         The HTTP method and web resource through which to access the route.
+         The HTTP method is GET.
+         The resource is `/V1/customerGroups/:id`. Users must substitute a customer ID for the `id` template parameter.
       </td>
    </tr>
    <tr>
       <td>
-         <p>18</p>
+         6
       </td>
       <td>
-         <p>A required parameter.</p>
-         <p>The <code>id</code> parameter is required on GET calls to <code>/V1/customers/me/billingAddress</code>.</p>
+         The interface that the route implements and the name of the web API method.
+         The route implements the `Magento\Customer\Api\GroupRepositoryInterface` interface.
+         The web API method name is `getById`.
+      </td>
+   </tr>
+   <tr>
+      <td>
+         8
+      </td>
+      <td>
+         The resource to which the caller must have access.
+         The caller must have access to `Magento_Customer::group` resource.
+      </td>
+   </tr>
+   <tr>
+      <td>
+         18
+      </td>
+      <td>
+         A required parameter.
+         The `id` parameter is required on GET calls to `/V1/customers/me/billingAddress`.
       </td>
    </tr>
 </table>
 
 ## webapi.xsd XML schema file {#validate-webapi}
 
-<p>The <code>webapi.xml</code> file for your module must specify an XML schema file for validation. Your <code>webapi.xml</code> file can specify the default or a customized XML schema file.</p>
-<p>The default <code>webapi.xsd</code> XML schema file can be found in the <code>app/code/Magento/Webapi/etc</code> directory.</p>
+The `webapi.xml` file for your module must specify an XML schema file for validation. Your `webapi.xml` file can specify the default or a customized XML schema file.
+The default `webapi.xsd` XML schema file can be found in the `app/code/Magento/Webapi/etc` directory.
 
 The following table defines the `service` node attributes:
 
@@ -305,13 +308,14 @@ Attribute name | Required | Description
 
 ## Forcing Request Parameters {#forced-parameters}
 
-<p>Parameters in the <code>webapi.xml</code> can be forced. This ensures that on specific routes, a specific value is
-   always used. For instance, in the example "/V1/customers/me/billingAddress" route above, the <code>customerId</code>
-   parameter is forced to match the ID of the currently logged in user.</p>
-<p>Additional parameter overrides can be registered via <code>di.xml</code> by adding new items to the
-   <code>paramOverriders</code> argument for <code>\Magento\Webapi\Controller\Rest\ParamsOverrider</code>. Parameter
-   overriders must implement <code>\Magento\Framework\Webapi\Rest\Request\ParamOverriderInterface</code>. An
-   example excerpt from <code>di.xml</code></p>
+Parameters in the `webapi.xml` can be forced. This ensures that on specific routes, a specific value is
+always used. For instance, in the example "/V1/customers/me/billingAddress" route above, the `customerId`
+parameter is forced to match the ID of the currently logged in user.
+Additional parameter overrides can be registered via `di.xml` by adding new items to the
+`paramOverriders` argument for `\Magento\Webapi\Controller\Rest\ParamsOverrider`. Parameter
+overriders must implement `\Magento\Framework\Webapi\Rest\Request\ParamOverriderInterface`. An
+example excerpt from `di.xml`
+
 ```xml
 <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
     <arguments>
@@ -321,9 +325,11 @@ Attribute name | Required | Description
     </arguments>
 </type>
 ```
-<p>The above example create a new parameter override available for use in <code>webapi.xml</code>. The value passed for
-   <code>%my_value%</code> will be the return value of
-   <code>\VENDOR\MODULE\Controller\Rest\ParamOverriderMyValue::getOverriddenValue</code>. Example:</p>
+
+The above example create a new parameter override available for use in `webapi.xml`. The value passed for
+   `%my_value%` will be the return value of
+   `\VENDOR\MODULE\Controller\Rest\ParamOverriderMyValue::getOverriddenValue`. Example:
+
 ```xml
 <route url="/V1/example/me/service" method="GET">
     ...


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) is adding some missing information related to the node attributes for the API service, by adding some info about their purpose and that they are required. 

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.html
- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-to-web-service.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.3/app/code/Magento/Webapi/etc/webapi.xsd#L39

whatsnew
Added 'webapi.xsd XML schema file' section to [Configure services as web APIs](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-to-web-service.html#validate-webapi).