### PR TITLE
Updates the URI to the Centos 7 PHP repository

### DIFF
--- a/guides/v2.3/install-gde/prereq/php-centos-ubuntu.md
+++ b/guides/v2.3/install-gde/prereq/php-centos-ubuntu.md
@@ -82,7 +82,7 @@ To install PHP 7.1 on CentOS 6 or 7:
 
 *CentOS 7*. Enter the following commands:
 
-  yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm
+  yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-15.ius.centos7.noarch.rpm
   yum -y update
 
 1. Install all [required PHP extensions]({{page.baseurl}}/install-gde/system-requirements-tech.html#required-php-extensions):


### PR DESCRIPTION
The existing link to the ius-release-1.0-14.ius.centos7.noarch.rpm is now 404'ing. There is an update ius-release-1.0-15.ius.centos7.noarch.rpm to which I have updated the link in the docs.

## Purpose of this pull request

This pull request (PR) fixes a link that is now 404'ing to the RPM file that installs the PHP repository. The URI referenced in the documents no longer exists. I have updated the link to point to an update to the file referenced in the docs.

## Affected DevDocs pages

- guides/v2.3/install-gde/prereq/php-centos-ubuntu.md

