### PR TITLE
Defining the zip attributes based on the xsd schema

### DIFF
--- a/guides/v2.1/howdoi/checkout/checkout_zip.md
+++ b/guides/v2.1/howdoi/checkout/checkout_zip.md
@@ -23,6 +23,12 @@ The following table defines the `zip` node attributes:
 --- | --- | ---
 `countryCode` | Yes | The country code (Alpha-2 format) for which the zip is defined
 
+```xml
+    <zip countryCode="US">
+        <!-- Here we add the zip codes -->
+    </zip>
+```
+
 The following table defines the `code` node attributes:
 
  Attribute name | Required | Description

--- a/guides/v2.1/howdoi/checkout/checkout_zip.md
+++ b/guides/v2.1/howdoi/checkout/checkout_zip.md
@@ -17,6 +17,28 @@ When a shopper specifies the country and ZIP code in the shipping address during
 In Magento the input masks for the **ZIP code** field are specified in the `<Magento_Directory_module_dir>/etc/zip_codes.xml`. Input masks are specified per country, and are entered in the form of regular expressions.
 The syntax of defined by the [zip_code.xsd]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Directory/etc/zip_codes.xsd) scheme.
 
+The following table defines the `zip` node attributes:
+
+ Attribute name | Required | Description
+--- | --- | ---
+`countryCode` | Yes | The country code (Alpha-2 format) for which the zip is defined
+
+The following table defines the `code` node attributes:
+
+ Attribute name | Required | Description
+--- | --- | ---
+`id` | Yes | A random unique name within the same list.
+`example` | Yes | An example of the allowed pattern.
+`active` | No | Defines if this zip pattern is active or not.
+
+You can define several zip `code` patterns for the same country, by passing a list of `codes`.
+```xml
+    <codes>
+        <code id="pattern_1" active="true" example="12345">^[0-9]{5}$</code>
+        <code id="pattern_2" active="true" example="AB1234">^[a-zA-z]{2}[0-9]{4}$</code>
+    </codes>
+```
+
 For the sake of compatibility, upgradability, and easy maintenance, do not edit the default Magento code. Add your customizations in a separate, custom module. For your ZIP code input mask customization to be applied correctly, your custom module should depend on the `Magento_Directory` module. Do not use `Ui` for your custom module name, because `%Vendor%_Ui` notation, required when specifying paths, might cause issues.
 
 ## Add custom ZIP code input masks {#add}


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) provides more info regarding the zip attributes which are allowed on defining the allowed zip code patterns for some countries. It also provides a small example how to pass multiple zip patterns for the same country. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.1/howdoi/checkout/checkout_zip.html
- https://devdocs.magento.com/guides/v2.2/howdoi/checkout/checkout_zip.html
- https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_zip.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.1/app/code/Magento/Directory/etc/zip_codes.xsd


<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added reference documentation for [ZIP code attributes](https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_zip.html), including a new code sample showing how to pas multiple ZIP code patterns for the same country