### PR TITLE
Improve GraphQL Customer mutation requests indentation

### DIFF
--- a/guides/v2.3/graphql/reference/customer.md
+++ b/guides/v2.3/graphql/reference/customer.md
@@ -239,7 +239,7 @@ mutation {
       firstname: "Rob"
       email: "robloblaw@example.com"
     }
-    ) {
+  ) {
     customer {
       firstname
       email
@@ -269,7 +269,7 @@ mutation {
 
 Use these mutations to create or modify the customer's address.
 
-#### Manage customer address attibutes
+#### Manage customer address attributes
 
 Attribute |  Data Type | Description
 --- | --- | ---
@@ -327,10 +327,10 @@ The following call creates an address for the specified customer.
 mutation {
   createCustomerAddress(input: {
     region: {
-        region: "Arizona"
-        region_id: 4
-        region_code: "AZ"
-      }
+      region: "Arizona"
+      region_id: 4
+      region_code: "AZ"
+    }
     country_id: US
     street: ["123 Main Street"]
     telephone: "7777777777"
@@ -340,7 +340,7 @@ mutation {
     lastname: "Loblaw"
     default_shipping: true
     default_billing: false
-    }) {
+  }) {
     id
     customer_id
     region {
@@ -484,12 +484,12 @@ The following call creates a new customer token.
 
 ``` text
 mutation {
-	generateCustomerToken(
+  generateCustomerToken(
     email: "bobloblaw@example.com"
     password: "b0bl0bl@w"
-    ) {
+  ) {
     token
-    }
+  }
 }
 ```
 
@@ -533,7 +533,7 @@ mutation {
 {
   "data": {
     "revokeCustomerToken": {
-    "result": true
+      "result": true
     }
   }
 }


### PR DESCRIPTION
## Purpose of this pull request

- Improve _Create customer address_ mutation request syntax indentation.
- Improve _Generate a customer token_ mutation request syntax indentation.
- Fix `attibutes` misspelling.
- Improve `json` response indentation.

The idea is leaving the request example as clean as possible, so with a simple look, we can understand where the _mutation_ starts and get done.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/reference/customer.html#create-customer-address
- https://devdocs.magento.com/guides/v2.3/graphql/reference/customer.html#generate-a-customer-token
<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
