### PR TITLE
[WiP] Use git worktree for devdocs versioning

### DIFF
--- a/Docfile.yml
+++ b/Docfile.yml
@@ -1,9 +1,7 @@
 content_map:
 -
   directory: guides/v2.0
-  repository: magento/devdocs
   branch: 2.0
-  filter: false
 -
   directory: guides/m1x
   repository: magento/devdocs-m1

--- a/rakelib/multirepo.rake
+++ b/rakelib/multirepo.rake
@@ -12,7 +12,11 @@ namespace :multirepo do
 
     content_map = DocConfig.new.content_map
     content_map.each do |subrepo|
-      sh "./scripts/docs-from-code.sh #{subrepo['directory']} #{protocol}#{subrepo['repository']}.git #{subrepo['branch']} #{subrepo['filter']}"
+      if subrepo['repository']
+        sh "./scripts/docs-from-repo.sh #{subrepo['directory']} #{protocol}#{subrepo['repository']}.git #{subrepo['branch']} #{subrepo['filter']}"
+      else
+        sh "./scripts/docs-from-branch.sh #{subrepo['directory']} #{subrepo['branch']}"
+      end
     end
   end
 

--- a/rakelib/update.rake
+++ b/rakelib/update.rake
@@ -68,8 +68,6 @@ namespace :update do
     puts 'Updating Magento 2.0 docs:'.magenta
     abort 'Cannot find the "guides/v2.0" directory' unless Dir.exist? 'guides/v2.0'
     Dir.chdir 'guides/v2.0' do
-      sh 'git remote -v'
-      sh 'git checkout 2.0'
       sh 'git pull'
       sh 'git status -sb'
     end

--- a/scripts/docs-from-branch.sh
+++ b/scripts/docs-from-branch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+dir=$1
+branch=$2
+
+echo "Planting a worktree of the $branch branch at the $dir directory"
+git worktree add --force "$dir" "$branch"

--- a/scripts/docs-from-repo.sh
+++ b/scripts/docs-from-repo.sh
@@ -9,7 +9,7 @@ echo "Creating a directory: $dir"
 mkdir -p "$dir"
 cd "$dir" || exit
 
-echo 'Initiating git in the directory'
+echo "Initiating git in the $dir directory"
 git init
 
 echo "Adding a remote repository: $repo"
@@ -19,7 +19,7 @@ if $sparse; then
   echo 'Enabling sparse checkout'
   git config core.sparseCheckout true
 
-  echo 'Adding /docs/* to sparse checkout'
+  echo 'Adding /docs/* to .git/info/sparse-checkout'
   echo '/docs/*' >> .git/info/sparse-checkout
 fi
 


### PR DESCRIPTION
**This pull request is on hold until devdocs CICD is appropriately configured for using `git worktree`.**

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request updates the devdocs projects initialization to use [git-worktree](https://git-scm.com/docs/git-worktree) to checkout and track 2.0 branch of the root project at the `guides/v2.0`. This allows to reuse existing devdocs repository for `guides/v2.x` content from its branches.

## Additional information
### Testing
To test the implementation locally:
1. Remove (or temporary rename) `guides/v2.0`
2. Run the updated initialization task `rake init`
3. Ensure that the directory exists and contains files `ls guides/v2.0` 
### Related resources
Internal ticket: MAGEDOC-3787