### PR TITLE
Add spell check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,10 +65,21 @@ desc 'Optimize images in modified files, or by path (rake image_optim path=path/
 task :image_optim do
   path = ENV['path']
   unless path
-    staged_files = `git ls-files --modified --others --exclude-standard`.split("\n")
-    # staged_md_files = staged_files.select { |file| File.extname(file) == '.md' }
-    abort 'Didn\'t find any modified files.'.blue if staged_files.empty?
-    path = staged_files.join(' ')
+    modified_files = `git ls-files --modified --others --exclude-standard`.split("\n")
+    abort 'Didn\'t find any modified files.'.blue if modified_file.empty?
+    path = modified_file.join(' ')
   end
   system "bin/image_optim --no-pngout --no-svgo --recursive #{path}"
+end
+
+desc 'Pull docs from external repositories'
+task :spellcheck do
+  path = ENV['path']
+  unless path
+    modified_files = `git ls-files --modified --others --exclude-standard`.split("\n")
+    modified_md_files = modified_files.select { |file| File.extname(file).match?(/.(md|rb)/) }
+    abort 'Didn\'t find any modified Markdown or Ruby files.'.blue if modified_md_files.empty?
+    path = modified_md_files.join(' ')
+  end
+  system "forspell #{path}"
 end

--- a/forspell.dict
+++ b/forspell.dict
@@ -1,0 +1,8 @@
+Changelog
+Chocolatey
+codebase
+Codeception
+decrypted: encrypted
+Homebrew
+Magento
+subdirectory: directory


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request adds a rake task `rake spellcheck` that runs the [forspell](https://github.com/kkuprikov/forspell) spell checker (which uses [Hunspell](https://en.wikipedia.org/wiki/Hunspell)). If the task is run without arguments it will check all the recently changed but not committed `.md` and `.rb` files.
If the `path` argument is added, the corresponding path will be checked recursively.

The forspell tool cannot be installed as a part of Gemfile because of conflicting dependencies with Jekyll. The tool uses kramdown 2 and Jekyll uses kramdown 1. Hope this will be resolved in the next Jekyll 4. Thus, the rake task uses `forspell` as a separately installed tool.

Install the forspell gem to enable spell checking:

```
gem install forspell
```

Custom dictionary is specified in the `forspell.dict` file. For more details about dictionaries, refer to [forspell dictionaries](https://github.com/kkuprikov/forspell#dictionaries) 

## Testing

1. Edit and save one or more Markdown files in the repository.
2. Run `rake spellcheck`
3. Add words you want to exclude from detection to `forspell.dict`
4. Run `rake spellcheck` and ensure that the excluded words are not in the list now
5. Run `rake spellcheck path=community` to check topics in the `community` folder
6. Exclude more words and ensure that they are not detected in the next run of the task