### PR TITLE
magento/devdocs#: Add info about @escapeNotVerified

### DIFF
--- a/guides/v2.2/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-security.md
@@ -120,6 +120,8 @@ It covers the following cases:
 
 * `/* @noEscape */` before output. Output doesn't require escaping. Test is green.
 
+* `/* @escapeNotVerified */` before output. Output escaping is not checked and should be verified. Test is green.
+
 * Methods which contain `"html"` in their names (for example `echo $object->{suffix}Html{postfix}()`). Data is ready for the HTML output. Test is green.
 
 * AbstractBlock methods `escapeHtml`, `escapeHtmlAttr`, `escapeUrl`, `escapeJs` are allowed. Test is green.

--- a/guides/v2.3/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.3/frontend-dev-guide/templates/template-security.md
@@ -120,6 +120,8 @@ It covers the following cases:
 
 * `/* @noEscape */` before output. Output doesn't require escaping. Test is green.
 
+* `/* @escapeNotVerified */` before output. Output escaping is not checked and should be verified. Test is green.
+
 * Methods which contain `"html"` in their names (for example `echo $object->{suffix}Html{postfix}()`). Data is ready for the HTML output. Test is green.
 
 * AbstractBlock methods `escapeHtml`, `escapeHtmlAttr`, `escapeUrl`, `escapeJs` are allowed. Test is green.


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) adds info about `@escapeNotVerified` static test directive.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-security.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-security.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://devdocs.magento.com/guides/v2.1/frontend-dev-guide/templates/template-security.html

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!