### PR TITLE
Removed extra slashes

### DIFF
--- a/guides/v2.1/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.1/javascript-dev-guide/javascript/custom_js.md
@@ -31,7 +31,7 @@ To use a custom implementation of an existing Magento JS component:
 Place the custom component source file in one of the following
 locations:
 
-- Your theme JS files: \`/web/js\` or \`/\_/web/js\`
+- Your theme JS files: `/web/js` or `/_/web/js`
 - Your module view JS files: `<module_dir>/view/frontend/web/js`
 
 Create a RequireJS configuration file `requirejs-config.js`, having
@@ -149,7 +149,7 @@ For information about how to initialize your custom JS component in a `.phtml` t
 To disable the auto-loading of default Magento JS components and widget
 initialization:
 
-1. Create a `requirejs-config.js` file with the following content: `var config = { deps: \[ \] };`
+1. Create a `requirejs-config.js` file with the following content: `var config = { deps: [ ] };`
 2. Put the `requirejs-config.js` file in one of the following
   locations:
     - Your custom theme files: `<theme_dir>`


### PR DESCRIPTION
## Purpose of this pull request

- Removed extra slashes from javascript code and folder paths

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/custom_js.html
- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/custom_js.html
- https://devdocs.magento.com/guides/v2.1/javascript-dev-guide/javascript/custom_js.html

## Links to Magento source code
- https://github.com/magento/magento2/blob/2.3-develop/app/design/frontend/Magento/blank/Magento_Theme/requirejs-config.js

## Screenshots
![screenshot-devdocs magento com-2019 05 24-15-51-43](https://user-images.githubusercontent.com/783102/58321819-d5b42000-7e3c-11e9-9db4-0bb9c6501a08.png)
![screenshot-devdocs magento com-2019 05 24-15-52-17](https://user-images.githubusercontent.com/783102/58321823-d8af1080-7e3c-11e9-8104-9ef23fbe6dac.png)


