### PR TITLE
Fix incorrect link

### DIFF
--- a/guides/v2.1/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.1/cloud/cdn/cloud-fastly.md
@@ -130,6 +130,6 @@ settings or entering credentials.
 * Configure Fastly in Staging and Production, not in Integration or your local
 * Test Fastly for caching
 
-For instructions, see [Set up Fastly]({{ page.baseurl }}/cloud/cdn/cloud-fastly.html).
+For instructions, see [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
 After you have configured it, you can continue with advanced options including
 custom VCL snippets.


### PR DESCRIPTION
## Purpose of this pull request

The *Set up Fastly* link at the bottom of the topic links to the same page. It should link to configure-fastly.html topic.

This pull request (PR) ...

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/cloud/cdn/cloud-fastly.html

