### PR TITLE
Contributor assistance name changes

### DIFF
--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -143,7 +143,7 @@ When you need to verify an issue or pull request, enter a command to generate an
 **Command:** To deploy a vanilla Magento instance, add the following command as a comment to the GitHub Pull Request or Issue:
 
 ```
-@magento-engcom-team give me {$version} instance
+@magento give me {$version} instance
 ```
 
 For `version`, the currently supported values are [version tags](https://github.com/magento/magento2/tags) and develop branches starting with 2.2.0 and 2.2-develop.
@@ -172,7 +172,7 @@ To verify and test changes completed in a pull request, enter a command to gener
 **Command:** To deploy, [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members), a [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) member, or contributor under the existing Pull Request enters the following command as a comment to the pull request:
 
 ```
-@magento-engcom-team give me test instance
+@magento give me test instance
 ```
 
 **Actions:**
@@ -199,10 +199,10 @@ To optimize the pull request queue, enter a command with a series of related pul
 **Command:** To combine pull requests, a member of the [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members) or [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) under the existing Pull Request enters the following command:
 
 ```
-@magento-engcom-team combine {xxx} {yyy} {zzz}
+@magento combine {xxx} {yyy} {zzz}
 ```
 
-The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento-engcom-team combine 1234 1238 1239`
+The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento combine 1234 1238 1239`
 
 **actions:** When all conditions are passed, all related pull requests will be closed and merged to the current PR:
 

--- a/guides/v2.3/contributor-guide/contributing.md
+++ b/guides/v2.3/contributor-guide/contributing.md
@@ -142,7 +142,7 @@ When you need to verify an issue or pull request, enter a command to generate an
 **Command:** To deploy a vanilla Magento instance, add the following command as a comment to the GitHub Pull Request or Issue:
 
 ```
-@magento-engcom-team give me {$version} instance
+@magento give me {$version} instance
 ```
 
 For `version`, the currently supported values are [version tags](https://github.com/magento/magento2/tags) and develop branches starting with 2.2.0 and 2.2-develop.
@@ -171,7 +171,7 @@ To verify and test changes completed in a pull request, enter a command to gener
 **Command:** To deploy, [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members), a [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) member, or contributor under the existing Pull Request enters the following command as a comment to the pull request:
 
 ```
-@magento-engcom-team give me test instance
+@magento give me test instance
 ```
 
 **Actions:**
@@ -198,10 +198,10 @@ To optimize the pull request queue, enter a command with a series of related pul
 **Command:** To combine pull requests, a member of the [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members) or [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) under the existing Pull Request enters the following command:
 
 ```
-@magento-engcom-team combine {xxx} {yyy} {zzz}
+@magento combine {xxx} {yyy} {zzz}
 ```
 
-The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento-engcom-team combine 1234 1238 1239`
+The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento combine 1234 1238 1239`
 
 **actions:** When all conditions are passed, all related pull requests will be closed and merged to the current PR:
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

Recently was made small improvement into Contributor Assistant Bot.
Changes were made in all related tools and messages and related DevDocs pages should be updated as well.
 
Previously user could ask Bot to provide test Magento instances or combine PRs using next commands
```
@magento-engcom-team give me {$version} instance
@magento-engcom-team combine {xxx} {yyy} {zzz}
```

After improvement, these messages were simplified to:
```
@magento give me {$version} instance
@magento combine {xxx} {yyy} {zzz}
```
 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html
- https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html

