### PR TITLE
[2.3.3 - 2.2.10] Update contributors guide due to Travis CI disable

### DIFF
--- a/guides/v2.2/contributor-guide/contributing.md
+++ b/guides/v2.2/contributor-guide/contributing.md
@@ -71,7 +71,7 @@ Please review the following supported and accepted pull request rules. We define
   * Proposed [documentation](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md){:target="_blank"} updates. [Documentation]({{site.baseurl}}/){:target="_blank"} contributions can be submitted [here](https://github.com/magento/devdocs){:target="_blank"}.
 1. For large features or changes, please [open an issue](https://github.com/magento/magento2/issues){:target="_blank"} and discuss it with us first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
 1. To report a bug, please [open an issue](https://github.com/magento/magento2/issues){:target="_blank"}, and follow these [guidelines about bugfix issues](https://github.com/magento/magento2/wiki/Issue-reporting-guidelines){:target="_blank"}.
-1. All automated tests must pass successfully (all builds on [Travis CI](https://travis-ci.org/magento/magento2){:target="_blank"} must be green).
+1. All automated tests must pass successfully (all [Pull Request checks](https://github.com/magento/magento2/wiki/Magento-Automated-Testing){:target="_blank"} must be green).
 
 ## Fork a repository {#fork}
 

--- a/guides/v2.3/contributor-guide/contributing.md
+++ b/guides/v2.3/contributor-guide/contributing.md
@@ -70,7 +70,7 @@ Please review the following supported and accepted pull request rules. We define
   * Proposed [documentation](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md){:target="_blank"} updates. [Documentation]({{site.baseurl}}/){:target="_blank"} contributions can be submitted [here](https://github.com/magento/devdocs){:target="_blank"}.
 1. For large features or changes, please [open an issue](https://github.com/magento/magento2/issues){:target="_blank"} and discuss it with us first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
 1. To report a bug, please [open an issue](https://github.com/magento/magento2/issues){:target="_blank"}, and follow these [guidelines about bugfix issues](https://github.com/magento/magento2/wiki/Issue-reporting-guidelines){:target="_blank"}.
-1. All automated tests must pass successfully (all builds on [Travis CI](https://travis-ci.org/magento/magento2){:target="_blank"} must be green).
+1. All automated tests must pass successfully (all [Pull Request checks](https://github.com/magento/magento2/wiki/Magento-Automated-Testing){:target="_blank"} must be green).
 
 ## Fork a repository {#fork}
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

Travis CI was disabled recently.
Changes were introduced in next PRs for milestones 2.3.3 and 2.2.10:
- https://github.com/magento/magento2/pull/22798
- https://github.com/magento/magento2/pull/22799

Current PR removes links to the Travis CI

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html#requirements
- https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#requirements


