### PR TITLE
Fix for listens property

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -118,8 +118,8 @@ For an example of `links` usage in Magento code see [`text.js`, line 19]({{ site
 ## `listens` property
 The `listens` property is used to track the changes of a component's property. `listens`'s value is an object, composed of the following:
 
-  - `key`: name of the observable property or method which is tracked for changes. 
-  - `value`: name of the internal method or property which listens to the changes. Can use [string templates](#string_templ).
+  - `key`: name of the observable property or method which is tracked for changes. Can use [string templates](#string_templ).
+  - `value`: name of the internal method or property which listens to the changes.
 
 Example of using `listens` in a component's `.js` file :
 


### PR DESCRIPTION
Fix for listens property where key can use string templates but not value.

## Purpose of this pull request

This pull request (PR) fix description for listens property.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_linking_concept.html (sym link to the next page in the list)
- https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html
- not https://devdocs.magento.com/guides/v2.1/ui_comp_guide/concepts/ui_comp_linking_concept.html (it has the right description)