### PR TITLE
Cloud Elasticsearch yaml problem

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -55,9 +55,9 @@ elasticsearch:
     type: elasticsearch:5.2
     disk: 1024
     configuration:
-    plugins:
-        - analysis-icu
-        - lang-python
+        plugins:
+            - analysis-icu
+            - lang-python
 ```
 
 The following are supported Elasticsearch plugins for version 2.4:

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -52,9 +52,9 @@ elasticsearch:
     type: elasticsearch:6.5
     disk: 1024
     configuration:
-    plugins:
-        - analysis-icu
-        - lang-python
+        plugins:
+            - analysis-icu
+            - lang-python
 ```
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
Corrected a YAML formatting bug that was missed in the previous Cloud guide fix. Elasticsearch was one of the few topics that was NOT symlinked.

This fixes the formatting for 2.2 and 2.3 files:
https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_services-elastic.html