### PR TITLE
New GraphQL topics for the GiftCard object

### DIFF
--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -105,7 +105,7 @@ pages:
                 - label: createEmptyCart mutation
                   url: /graphql/reference/quote-create-cart.html
 
-                - label: giftCardAccount endpoint
+                - label: giftCardAccount query
                   url: /graphql/reference/quote-giftcard-account.html
 
                 - label: placeOrder mutation

--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -138,6 +138,9 @@ pages:
                 - label: updateCartItems mutation
                   url: /graphql/reference/quote-update-cart-items.html
 
+            - label: redeemGiftCardBalanceAsStoreCredit mutation
+              url: /graphql/reference/redeem-giftcard-balance.html
+
             - label: Sales endpoint
               url: /graphql/reference/sales.html
 

--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -99,14 +99,23 @@ pages:
                 - label: applyCouponToCart mutation
                   url: /graphql/reference/quote-apply-coupon.html
 
+                - label: applyGiftCardToCart mutation
+                  url: /graphql/reference/quote-apply-giftcard.html
+
                 - label: createEmptyCart mutation
                   url: /graphql/reference/quote-create-cart.html
+
+                - label: giftCardAccount endpoint
+                  url: /graphql/reference/quote-giftcard-account.html
 
                 - label: placeOrder mutation
                   url: /graphql/reference/quote-place-order.html
 
                 - label: removeCouponFromCart mutation
                   url: /graphql/reference/quote-remove-coupon.html
+
+                - label: removeGiftCardFromCart mutation
+                  url: /graphql/reference/quote-remove-giftcard.html
 
                 - label: removeItemFromCart mutation
                   url: /graphql/reference/quote-remove-item.html

--- a/_includes/graphql/cart-object.md
+++ b/_includes/graphql/cart-object.md
@@ -1,7 +1,7 @@
 Attribute |  Data Type | Description
 --- | --- | ---
 `applied_coupon` | [`AppliedCoupon`][AppliedCoupon] | The `AppliedCoupon` object contains the `code` text attribute, which specifies the coupon code
-`applied_gift_cards` | [`AppliedGiftCard`][AppliedGiftCard] | The `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
+`applied_gift_cards` | [[`AppliedGiftCard`]][AppliedGiftCard] | An array of `AppliedGiftCard` objects. An `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
 `available_payment_methods` | [AvailablePaymentMethod][AvailablePaymentMethod] | Available payment methods
 `billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
 `email` | String | The customer's email address

--- a/_includes/graphql/cart-object.md
+++ b/_includes/graphql/cart-object.md
@@ -1,6 +1,7 @@
 Attribute |  Data Type | Description
 --- | --- | ---
 `applied_coupon` | [`AppliedCoupon`][AppliedCoupon] | The `AppliedCoupon` object contains the `code` text attribute, which specifies the coupon code
+`applied_gift_cards` | [`AppliedGiftCard`][AppliedGiftCard] | The `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
 `available_payment_methods` | [AvailablePaymentMethod][AvailablePaymentMethod] | Available payment methods
 `billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
 `email` | String | The customer's email address
@@ -10,6 +11,7 @@ Attribute |  Data Type | Description
 `shipping_addresses` | [ShippingCartAddress][ShippingCartAddress] | Contains one or more shipping addresses
 
 [AppliedCoupon]: {{page.baseurl}}/graphql/reference/quote.html#AppliedCoupon
+[AppliedGiftCard]: {{page.baseurl}}/graphql/reference/quote.html#AppliedGiftCard
 [AvailablePaymentMethod]: {{page.baseurl}}/graphql/reference/quote.html#AvailablePaymentMethod
 [BillingCartAddress]: {{page.baseurl}}/graphql/reference/quote.html#BillingCartAddress
 [CartItemInterface]: {{page.baseurl}}/graphql/reference/quote.html#CartItemInterface

--- a/guides/v2.3/graphql/reference/quote-apply-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-apply-giftcard.md
@@ -12,7 +12,7 @@ The `applyGiftCardToCart` mutation applies a pre-defined gift card code to the s
 
 ## Example usage
 
-The following example adds a gift card code called `049XDMZ6L81X` to a cart.
+The following example adds a gift card with the code `0330CEIVTLB4` to the cart. The gift card has a value of $20.
 
 **Request**
 
@@ -20,13 +20,22 @@ The following example adds a gift card code called `049XDMZ6L81X` to a cart.
 mutation {
   applyGiftCardToCart(
     input: {
-      cart_id: "lOeLKsVkZ1PEvA8A7EaCvmEAk4JRBR7A"
-      gift_card_code: "049XDMZ6L81X"
+      cart_id: "lY8PnKhlHBGc4WS5v0Y3dWjxiA5PvvgY"
+      gift_card_code: "0330CEIVTLB4"
     }
   ) {
     cart {
       applied_gift_cards {
+        applied_balance {
+          value
+          currency
+        }
         code
+        current_balance {
+          value
+          currency
+        }
+        expiration_date
       }
     }
   }
@@ -42,7 +51,16 @@ mutation {
       "cart": {
         "applied_gift_cards": [
           {
-            "code": "049XDMZ6L81X"
+            "applied_balance": {
+              "value": 20,
+              "currency": "USD"
+            },
+            "code": "0330CEIVTLB4",
+            "current_balance": {
+              "value": 20,
+              "currency": "USD"
+            },
+            "expiration_date": null
           }
         ]
       }

--- a/guides/v2.3/graphql/reference/quote-apply-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-apply-giftcard.md
@@ -12,28 +12,28 @@ The `applyGiftCardToCart` mutation applies a pre-defined gift card code to the s
 
 ## Example usage
 
- The following example adds a gift card code called `048FQEGYUA73` to a cart.
+The following example adds a gift card code called `048FQEGYUA73` to a cart.
 
 **Request**
 
- ``` text
+``` text
 mutation {
-   applyGiftCardToCart(
+   applyGiftCardToCart( input: {
       cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
       gift_card_code: "048FQEGYUA73"
-   ) {
+   }
+)  {
     cart {
-    applied_gift_cards {
-        code
+       applied_gift_cards {
+          code
       }
     }
-  }
+}
 ```
 
 **Response**
 
- ```json
-
+```json
 {
  "applyGiftCardToCart": {
       "cart": {
@@ -50,7 +50,7 @@ mutation {
 
 ## Input attributes
 
- The `applyGiftCardToCart` mutation requires the `cart_id` and `gift_card_code`.
+The `applyGiftCardToCart` mutation requires the `cart_id` and `gift_card_code`.
 
 ### ApplyGiftCardToCartInput object {#ApplyGiftCardToCartInput}
 
@@ -73,4 +73,4 @@ Attribute |  Data Type | Description
 
  {% include graphql/cart-object.md %}
 
- [Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.
+[Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.

--- a/guides/v2.3/graphql/reference/quote-apply-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-apply-giftcard.md
@@ -12,22 +12,24 @@ The `applyGiftCardToCart` mutation applies a pre-defined gift card code to the s
 
 ## Example usage
 
-The following example adds a gift card code called `048FQEGYUA73` to a cart.
+The following example adds a gift card code called `049XDMZ6L81X` to a cart.
 
 **Request**
 
 ``` text
 mutation {
-   applyGiftCardToCart( input: {
-      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
-      gift_card_code: "048FQEGYUA73"
-   }
-)  {
+  applyGiftCardToCart(
+    input: {
+      cart_id: "lOeLKsVkZ1PEvA8A7EaCvmEAk4JRBR7A"
+      gift_card_code: "049XDMZ6L81X"
+    }
+  ) {
     cart {
-       applied_gift_cards {
-          code
+      applied_gift_cards {
+        code
       }
     }
+  }
 }
 ```
 
@@ -35,16 +37,17 @@ mutation {
 
 ```json
 {
- "applyGiftCardToCart": {
+  "data": {
+    "applyGiftCardToCart": {
       "cart": {
-          "applied_gift_cards": [
-              {
-                "code": "048FQEGYUA73"
-                 }
-                ]
-            }
-        }
+        "applied_gift_cards": [
+          {
+            "code": "049XDMZ6L81X"
+          }
+        ]
+      }
     }
+  }
 }
 ```
 
@@ -67,7 +70,7 @@ The `ApplyGiftCardToCartOutput` object contains the `Cart` object.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
 
 ### Cart object {#CartObject}
 

--- a/guides/v2.3/graphql/reference/quote-apply-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-apply-giftcard.md
@@ -1,0 +1,76 @@
+---
+group: graphql
+title: applyGiftCardToCart mutation
+ee_only: True
+---
+
+The `applyGiftCardToCart` mutation applies a pre-defined gift card code to the specified cart.
+
+## Syntax
+
+ `mutation: applyGiftCardToCart(input: ApplyGiftCardToCartInput): ApplyGiftCardToCartOutput`
+
+## Example usage
+
+ The following example adds a gift card code called `048FQEGYUA73` to a cart.
+
+**Request**
+
+ ``` text
+mutation {
+   applyGiftCardToCart(
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
+      gift_card_code: "048FQEGYUA73"
+   ) {
+    cart {
+    applied_gift_cards {
+        code
+      }
+    }
+  }
+```
+
+**Response**
+
+ ```json
+
+{
+ "applyGiftCardToCart": {
+      "cart": {
+          "applied_gift_cards": [
+              {
+                "code": "048FQEGYUA73"
+                 }
+                ]
+            }
+        }
+    }
+}
+```
+
+## Input attributes
+
+ The `applyGiftCardToCart` mutation requires the `cart_id` and `gift_card_code`.
+
+### ApplyGiftCardToCartInput object {#ApplyGiftCardToCartInput}
+
+The `ApplyGiftCardToCartInput` object must contain the following attributes:
+
+Attribute | Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+The `ApplyGiftCardToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+ {% include graphql/cart-object.md %}
+
+ [Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.

--- a/guides/v2.3/graphql/reference/quote-giftcard-account.md
+++ b/guides/v2.3/graphql/reference/quote-giftcard-account.md
@@ -12,13 +12,13 @@ The `giftCardAccount` query returns information for a specific gift card.
 
 ## Example usage
 
-The following example returns information about the `048FQEGYUA73` gift card code.
+The following example returns information about the `01PNC9L76H4H` gift card code.
 
 **Request**
 
 ``` text
 query {
-  giftCardAccount(input: {gift_card_code: "048FQEGYUA73"}){
+  giftCardAccount(input: {gift_card_code: "01PNC9L76H4H"}){
     code
     balance {
       currency
@@ -33,13 +33,14 @@ query {
 
 ```json
 {
+  "data": {
     "giftCardAccount": {
-      "code": "048FQEGYUA73",
+      "code": "01PNC9L76H4H",
       "balance": {
         "currency": "USD",
-        "value": 50
+        "value": 25
       },
-      "expiration_date": "2019-06-25"
+      "expiration_date": null
     }
   }
 }

--- a/guides/v2.3/graphql/reference/quote-giftcard-account.md
+++ b/guides/v2.3/graphql/reference/quote-giftcard-account.md
@@ -1,6 +1,6 @@
 ---
 group: graphql
-title: giftCardAccount endpoint
+title: giftCardAccount query
 ee_only: True
 ---
 

--- a/guides/v2.3/graphql/reference/quote-giftcard-account.md
+++ b/guides/v2.3/graphql/reference/quote-giftcard-account.md
@@ -12,11 +12,11 @@ The `giftCardAccount` query returns information for a specific gift card.
 
 ## Example usage
 
- The following example returns information about the `00MP4BZTB4NV` gift card code.
+The following example returns information about the `048FQEGYUA73` gift card code.
 
 **Request**
 
- ``` text
+``` text
 query {
   giftCardAccount(input: {gift_card_code: "048FQEGYUA73"}){
     code
@@ -31,7 +31,7 @@ query {
 
 **Response**
 
- ```json
+```json
 {
     "giftCardAccount": {
       "code": "048FQEGYUA73",
@@ -47,7 +47,7 @@ query {
 
 ## Input attributes
 
- The `giftCardAccount` query requires the `gift_card_code`.
+The `giftCardAccount` query requires the `gift_card_code`.
 
 ### GiftCardAccount object {#GiftCardAccount}
 

--- a/guides/v2.3/graphql/reference/quote-giftcard-account.md
+++ b/guides/v2.3/graphql/reference/quote-giftcard-account.md
@@ -1,0 +1,68 @@
+---
+group: graphql
+title: giftCardAccount endpoint
+ee_only: True
+---
+
+The `giftCardAccount` query returns information for a specific gift card.
+
+## Syntax
+
+ `giftCardAccount(code: String!): GiftCardAccount`
+
+## Example usage
+
+ The following example returns information about the `00MP4BZTB4NV` gift card code.
+
+**Request**
+
+ ``` text
+query {
+  giftCardAccount(input: {gift_card_code: "048FQEGYUA73"}){
+    code
+    balance {
+      currency
+      value
+    }
+    expiration_date
+  }
+}
+```
+
+**Response**
+
+ ```json
+{
+    "giftCardAccount": {
+      "code": "048FQEGYUA73",
+      "balance": {
+        "currency": "USD",
+        "value": 50
+      },
+      "expiration_date": "2019-06-25"
+    }
+  }
+}
+```
+
+## Input attributes
+
+ The `giftCardAccount` query requires the `gift_card_code`.
+
+### GiftCardAccount object {#GiftCardAccount}
+
+The `GiftCardAccount` object must contain the following attribute:
+
+Attribute | Data Type | Description
+--- | --- | ---
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+The `GiftCardAccount` object returns the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`balance` | Money | Returns the currency and remaining balance of the gift card
+`code` | String | Returns the gift card code
+`expiration_date` | String | Returns the date when the gift card expires, if any

--- a/guides/v2.3/graphql/reference/quote-remove-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-remove-giftcard.md
@@ -20,8 +20,8 @@ The `removeGiftCardFromCart` mutation removes a previously-applied gift card fro
 mutation {
   removeGiftCardFromCart(
     input: {
-      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
-      gift_card_code: "048FQEGYUA73"
+      cart_id: "lOeLKsVkZ1PEvA8A7EaCvmEAk4JRBR7A"
+      gift_card_code: "049XDMZ6L81X"
     }
   ) {
     cart {
@@ -37,12 +37,13 @@ mutation {
 
  ```json
 {
-   "removeGiftCardFromCart": {
-     "cart": {
-       "applied_gift_cards": []
-     }
-   }
- }
+  "data": {
+    "removeGiftCardFromCart": {
+      "cart": {
+        "applied_gift_cards": []
+      }
+    }
+  }
 }
 ```
 

--- a/guides/v2.3/graphql/reference/quote-remove-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-remove-giftcard.md
@@ -14,22 +14,22 @@ The `removeGiftCardFromCart` mutation removes a previously-applied gift card fro
 
  The following example removes a gift card from the cart.
 
- **Request**
+**Request**
 
  ``` text
 mutation {
- removeGiftCardFromCart(input:
-   {
-    cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
-     gift_card_code: "048FQEGYUA73"
-   })
- {
-   cart {
-     applied_gift_cards {
-       code
-     }
-   }
- }
+  removeGiftCardFromCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
+      gift_card_code: "048FQEGYUA73"
+    }
+  ) {
+    cart {
+      applied_gift_cards {
+        code
+      }
+    }
+  }
 }
 ```
 
@@ -48,22 +48,22 @@ mutation {
 
 ## Input attributes
 
- The `removeGiftCardFromCart` mutation requires the `cart_id` attribute.
+The `removeGiftCardFromCart` mutation requires the `cart_id` attribute.
 
 ### removeGiftCardFromCart object {#removeGiftCardFromCart}
 
- The `removeGiftCardFromCart` object must contain the following attributes:
+The `removeGiftCardFromCart` object must contain the following attributes:
 
- Attribute |  Data Type | Description
+Attribute |  Data Type | Description
 --- | --- | ---
 `cart_id` | String! | The unique ID that identifies the customer's cart
 `gift_card_code` | String! | The gift card code
 
 ## Output attributes
 
- The `removeGiftCardFromCart` object contains the `Cart` object.
+The `removeGiftCardFromCart` object contains the `Cart` object.
 
- Attribute |  Data Type | Description
+Attribute |  Data Type | Description
 --- | --- | ---
 `cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
 
@@ -71,4 +71,4 @@ mutation {
 
  {% include graphql/cart-object.md %}
 
- [Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.
+[Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.

--- a/guides/v2.3/graphql/reference/quote-remove-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-remove-giftcard.md
@@ -65,7 +65,7 @@ The `removeGiftCardFromCart` object contains the `Cart` object.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
 
 ### Cart object {#CartObject}
 

--- a/guides/v2.3/graphql/reference/quote-remove-giftcard.md
+++ b/guides/v2.3/graphql/reference/quote-remove-giftcard.md
@@ -1,0 +1,74 @@
+---
+group: graphql
+title: removeGiftCardFromCart mutation
+ee_only: True
+---
+
+The `removeGiftCardFromCart` mutation removes a previously-applied gift card from the cart.
+
+## Syntax
+
+ `mutation: removeGiftCardFromCart(input: RemoveGiftCardFromCartInput): RemoveGiftCardFromCartOutput`
+
+## Example usage
+
+ The following example removes a gift card from the cart.
+
+ **Request**
+
+ ``` text
+mutation {
+ removeGiftCardFromCart(input:
+   {
+    cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+     gift_card_code: "048FQEGYUA73"
+   })
+ {
+   cart {
+     applied_gift_cards {
+       code
+     }
+   }
+ }
+}
+```
+
+**Response**
+
+ ```json
+{
+   "removeGiftCardFromCart": {
+     "cart": {
+       "applied_gift_cards": []
+     }
+   }
+ }
+}
+```
+
+## Input attributes
+
+ The `removeGiftCardFromCart` mutation requires the `cart_id` attribute.
+
+### removeGiftCardFromCart object {#removeGiftCardFromCart}
+
+ The `removeGiftCardFromCart` object must contain the following attributes:
+
+ Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+ The `removeGiftCardFromCart` object contains the `Cart` object.
+
+ Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+ {% include graphql/cart-object.md %}
+
+ [Cart query output]({{page.baseurl}}/graphql/reference/quote.html#cart-output) provides more information about the `Cart` object.

--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -427,11 +427,14 @@ Attribute |  Data Type | Description
 
 #### AppliedGiftCard object {#AppliedGiftCard}
 
-The `AppliedGiftCard` object must contain the following attributes:
+The `AppliedGiftCard` object can contain the following attributes:
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`code` | String! | The gift card code applied to the order
+`applied_balance` | Money | Applied balance to the current cart
+`code` | String | The gift card code applied to the order
+`current_balance` | Money | Current balance remaining on the gift card
+`expiration_date` | String | Gift card expiration date
 
 #### AvailablePaymentMethod object {#AvailablePaymentMethod}
 

--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -417,7 +417,6 @@ The `Cart` object can contain the following attributes:
 
 {% include graphql/cart-object.md %}
 
-
 #### AppliedCoupon object {#AppliedCoupon}
 
 The `AppliedCoupon` object must contain the following attributes:
@@ -425,6 +424,14 @@ The `AppliedCoupon` object must contain the following attributes:
 Attribute |  Data Type | Description
 --- | --- | ---
 `code` | String! | The coupon code applied to the order
+
+#### AppliedGiftCard object {#AppliedGiftCard}
+
+The `AppliedGiftCard` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`code` | String! | The gift card code applied to the order
 
 #### AvailablePaymentMethod object {#AvailablePaymentMethod}
 

--- a/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
+++ b/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
@@ -15,14 +15,14 @@ Run this mutation on behalf of logged-in customers only. [Get customer authoriza
 
 ## Example usage
 
-The following example redeems the gift card with code `“00SBOLF4LJDY”`.
+The following example redeems the gift card with code `“056MHP57TJ5C”`.
 
 **Request**
 
 ``` text
 mutation {
   redeemGiftCardBalanceAsStoreCredit(
-    input : { gift_card_code: “00SBOLF4LJDY”}
+    input : { gift_card_code: “056MHP57TJ5C”}
   ) {
     balance {
       currency
@@ -38,16 +38,16 @@ mutation {
 
 ```json
 {
- “data”: {
-   “redeemGiftCardBalanceAsStoreCredit”: {
-     “balance”: {
-       “currency”: “USD”,
-       “value”: 0
-     },
-     “code”: “00SBOLF4LJDY”,
-     “expiration_date”: null
-   }
- }
+  "data": {
+    "redeemGiftCardBalanceAsStoreCredit": {
+      "balance": {
+        "currency": "USD",
+        "value": 0
+      },
+      "code": "056MHP57TJ5C",
+      "expiration_date": null
+    }
+  }
 }
 ```
 

--- a/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
+++ b/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
@@ -4,10 +4,10 @@ title: redeemGiftCardBalanceAsStoreCredit mutation
 ee_only: True
 ---
 
-The `redeemGiftCardBalanceAsStoreCredit` mutation converts the entire balance of a gift card to store credit. As a result, the remaining balance on the gift card is 0.
+The `redeemGiftCardBalanceAsStoreCredit` mutation converts the entire balance of a gift card to store credit. The gift card must be redeemable and cannot have a balance of 0 at the time you run the mutation. After successfully running the mutation, the value of the gift card changes to 0.
 
 {:.bs-callout .bs-callout-info}
-Run this mutation on behalf of logged-in customers only.
+Run this mutation on behalf of logged-in customers only. [Get customer authorization token]({{page.baseurl}}/graphql/get-customer-authorization-token.html) describes how to send a request as a customer.
 
 ## Syntax
 
@@ -15,26 +15,21 @@ Run this mutation on behalf of logged-in customers only.
 
 ## Example usage
 
-The following example redeems the gift card with code `BFR1345Q05`.
+The following example redeems the gift card with code `“00SBOLF4LJDY”`.
 
 **Request**
 
 ``` text
 mutation {
   redeemGiftCardBalanceAsStoreCredit(
-    input: {
-      gift_card_code: "BFR1345Q05"
-    }
+    input : { gift_card_code: “00SBOLF4LJDY”}
   ) {
-    GiftCardAccount {
-      balance {
-        currency
-        value
-      }
-      code
-      expiration_date
-      }
+    balance {
+      currency
+      value
     }
+    code
+    expiration_date
   }
 }
 ```
@@ -43,14 +38,16 @@ mutation {
 
 ```json
 {
-  "GiftCardAccount": {
-    "code": "BFR1345Q05",
-    "balance": {
-      "currency": "USD",
-      "value": 0
-    },
-    "expiration_date": ""
-  }
+ “data”: {
+   “redeemGiftCardBalanceAsStoreCredit”: {
+     “balance”: {
+       “currency”: “USD”,
+       “value”: 0
+     },
+     “code”: “00SBOLF4LJDY”,
+     “expiration_date”: null
+   }
+ }
 }
 ```
 

--- a/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
+++ b/guides/v2.3/graphql/reference/redeem-giftcard-balance.md
@@ -1,0 +1,75 @@
+---
+group: graphql
+title: redeemGiftCardBalanceAsStoreCredit mutation
+ee_only: True
+---
+
+The `redeemGiftCardBalanceAsStoreCredit` mutation converts the entire balance of a gift card to store credit. As a result, the remaining balance on the gift card is 0.
+
+{:.bs-callout .bs-callout-info}
+Run this mutation on behalf of logged-in customers only.
+
+## Syntax
+
+ `mutation: redeemGiftCardBalanceAsStoreCredit(input: GiftCardAccountInput): GiftCardAccount`
+
+## Example usage
+
+The following example redeems the gift card with code `BFR1345Q05`.
+
+**Request**
+
+``` text
+mutation {
+  redeemGiftCardBalanceAsStoreCredit(
+    input: {
+      gift_card_code: "BFR1345Q05"
+    }
+  ) {
+    GiftCardAccount {
+      balance {
+        currency
+        value
+      }
+      code
+      expiration_date
+      }
+    }
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "GiftCardAccount": {
+    "code": "BFR1345Q05",
+    "balance": {
+      "currency": "USD",
+      "value": 0
+    },
+    "expiration_date": ""
+  }
+}
+```
+
+## Input attributes
+
+### GiftCardAccountInput object {#GiftCardAccountInput}
+
+The `GiftCardAccountInput` object must contain the following attribute:
+
+Attribute | Data Type | Description
+--- | --- | ---
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+The `GiftCardAccount` object contains the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`balance` | Money | The remaining balance of the gift card, including the currency
+`code` | String | The gift card code
+`expiration_date` | String | The date when the gift card expires, if any


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds GraphQL documentation for the gift card query and mutations under the quote endpoint.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html

## Links to Magento source code

whatsnew
GraphQL supports gift cards. Added the [giftCardAccount query](https://devdocs.magento.com/guides/v2.3/graphql/reference/quote-giftcard-account.html), [applyGiftCardToCart mutation](https://devdocs.magento.com/guides/v2.3/graphql/reference/quote-apply-giftcard.html), [removeGiftCardFromCart mutation](https://devdocs.magento.com/guides/v2.3/graphql/reference/quote-remove-giftcard.html), and [redeemGiftCardBalanceAsStoreCredit mutation](https://devdocs.magento.com/guides/v2.3/graphql/reference/redeem-giftcard-balance.html).