### PR TITLE
Fix TOC entry for new Poison Pill topic

### DIFF
--- a/_data/toc/php-developer-guide.yml
+++ b/_data/toc/php-developer-guide.yml
@@ -211,6 +211,7 @@ pages:
               url: /extension-dev-guide/message-queues/config-mq.html
 
             - label: Handling outdated in-memory object states
+              include_versions: ["2.3"]
               url: /extension-dev-guide/message-queues/refresh-config.html
             
             - label: Migrate message queue configuration


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) restricted new poison pill interface topic to 2.3 in the TOC to fix broken links.

## Additional info

PR #4428 added a new topic to the `develop` branch. After running tests and the `develop` branch while working on an unrelated issue, I discovered some broken links. I identified the issue causing broken links to be related to the TOC. Since the new topic only exists in 2.3, we should add the appropriate restrictio.internally linking to /guides/v2.1/extension-dev-guide/message-queues/refresh-config.html, which does not exist

Here's the error log for reference:

```
_site/guides/v2.1/extension-dev-guide/adapters.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/api-concepts.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/attributes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/bk-extension-dev-guide.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/XSD-XML-validation.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/build.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/component-registration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/composer-integration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/create_component.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/di-xml-file.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/enable-module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/module-file-structure.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/module-load-order.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/optimal-dev-environment.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/build/required-configuration-files.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/page-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/page-caching/private-content.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/page-caching/public-content.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/partial-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/partial-caching/create-cache-type.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cache/partial-caching/database-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cli-cmds/cli-add.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cli-cmds/cli-howto.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/cli-cmds/cli-naming-guidelines.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/code-generation.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/depend-inj.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/events-and-observers.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/extension_attributes/adding-attributes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/factories.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/indexing-custom.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/indexing-parent.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/indexing.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/intro/developers_roadmap.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/intro/intro-composer-gloss.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/intro/intro-composer.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/message-queues/config-mq.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/message-queues/message-queues.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/message-queues/queue-migration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/module-development.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/mq-parent.html (line 147) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/object-manager.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/package/package.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/package/package_mktpl.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/package/package_module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/plugins.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/prepare/dev-modtypes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/prepare/dev-summary.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/prepare/lifecycle.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/prepare/prepare.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/prepare/prepare_file-str.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/proxies.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/routing.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/security/non-secure-functions.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/service-contracts/design-patterns.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/service-contracts/service-contracts.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/service-contracts/service-to-web-service.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/staging.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/validate/test-module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/validate/validate.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/versioning/check-version.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/versioning/codebase-changes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/versioning/dependencies.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/extension-dev-guide/versioning/index.html (line 149) Handling outdated in-memory object states
_site/guides/v2.1/howdoi/php/php_clear-dirs.html (line 149) Handling outdated in-memory object states
internally linking to /guides/v2.2/extension-dev-guide/message-queues/refresh-config.html, which does not exist
_site/guides/v2.2/extension-dev-guide/adapters.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/api-concepts.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/attributes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/bk-extension-dev-guide.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/build.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/component-registration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/composer-integration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/create_component.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/di-xml-file.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/enable-module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/module-file-structure.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/module-load-order.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/optimal-dev-environment.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/build/required-configuration-files.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/page-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/page-caching/private-content.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/partial-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/partial-caching/create-cache-type.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cli-cmds/cli-add.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/code-generation.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/configuration/importers.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/depend-inj.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/events-and-observers.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/extension_attributes/adding-attributes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/factories.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/framework/serializer.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/indexer-batch.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/indexing-custom.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/indexing-parent.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/indexing.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/intro/developers_roadmap.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/intro/intro-composer-gloss.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/intro/intro-composer.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/message-queues/bulk-operations.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/message-queues/config-mq.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/message-queues/implement-bulk.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/message-queues/message-queues.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/message-queues/queue-migration.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/module-development.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/mq-parent.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/object-manager.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/package/package.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/package/package_mktpl.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/package/package_module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/plugins.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/prepare/dev-modtypes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/prepare/dev-summary.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/prepare/lifecycle.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/prepare/prepare.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/prepare/prepare_file-str.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/proxies.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/routing.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/searching-with-repositories.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/security/non-secure-functions.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/service-contracts/service-to-web-service.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/staging.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/validate/test-module.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/validate/validate.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/versioning/check-version.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/versioning/codebase-changes.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/versioning/dependencies.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/versioning/index.html (line 149) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/webapi/request-processor-pool.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/extension-dev-guide/xss-protection.html (line 147) Handling outdated in-memory object states
_site/guides/v2.2/howdoi/php/php_clear-dirs.html (line 149) Handling outdated in-memory object states```