### PR TITLE
Ken google 1.1.2 rel notes

### DIFF
--- a/extensions/google-shopping-ads/release-notes/index.md
+++ b/extensions/google-shopping-ads/release-notes/index.md
@@ -16,6 +16,12 @@ The release notes include:
 -   {:.new}New features
 -   {:.fix}Fixes and improvements
 
+### v1.1.2
+
+Google Shopping ads Channel 1.1.2 is generally available for versions 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
+
+- {:.fix} **Intermittent Load Error**: Resolved an intermittent error preventing Google Shopping ads Channel UI from loading after install.
+
 ### v1.1.1
 
 Google Shopping ads Channel 1.1.1 is generally available for versions 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.

--- a/extensions/google-shopping-ads/release-notes/index.md
+++ b/extensions/google-shopping-ads/release-notes/index.md
@@ -20,7 +20,7 @@ The release notes include:
 
 Google Shopping ads Channel 1.1.2 is generally available for versions 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
-- {:.fix} **Intermittent Load Error**: Resolved an intermittent error preventing Google Shopping ads Channel UI from loading after install.
+- {:.fix} **Intermittent Load Error**: Resolved an intermittent error preventing Google Shopping ads Channel from loading after install.
 
 ### v1.1.1
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds rel notes for a quick patch 1.1.2 that corrects a google shopping ui load error. Patch is already live in marketplace

## Affected DevDocs pages

- https://devdocs.magento.com/extensions/google-shopping-ads/release-notes/

whatsnew
Added [release notes](https://devdocs.magento.com/extensions/google-shopping-ads/release-notes/) for Google Shopping ads Channel patch 1.1.2.

