### PR TITLE
update release page for google patch 1.1.2

### DIFF
--- a/_data/compatibility.yml
+++ b/_data/compatibility.yml
@@ -16,6 +16,12 @@ extension:
     name: Google Shopping ads Channel
     versions:
       -
+        name: 1.1.2
+        support:
+          2.2.4+: general availability
+          2.3.0: general availability
+          2.3.1: general availability
+    
         name: 1.1.1
         support:
           2.2.4+: general availability

--- a/release/index.md
+++ b/release/index.md
@@ -18,7 +18,7 @@ The following table describes the status of Magento software availability and wh
 | **Magento Shipping**                            | Available now                                                                                                                                        | Merchants on Magento 2.2.2+ can use the [onboarding process](https://account.magento.com/shipping/onboarding/start)          |
 | **Page Builder**                                | Available now                                                                                                                                        | Bundled with {{site.data.var.ee}} 2.3.x                                                                                      |
 | **Amazon Sales Channel 2.0.0**                        | Available now for {{site.data.var.ece}} 2.2.4+ and 2.3.x (US, Canada, Mexico)<br><br>EMEA and APAC availability expected in second half of 2019 | Magento Marketplace                                                                                                          |
-| **Google Shopping ads Channel 1.1.1**           | Available now for {{site.data.var.ece}} 2.2.4+ and 2.3.x                                                                                             | [Magento Marketplace](http://marketplace.magento.com/magento-google-shopping-ads.html)                                       |
+| **Google Shopping ads Channel 1.1.2**           | Available now for {{site.data.var.ece}} 2.2.4+ and 2.3.x                                                                                             | [Magento Marketplace](http://marketplace.magento.com/magento-google-shopping-ads.html)                                       |
 
 ## Compatibility
 


### PR DESCRIPTION
replace 1.1.1 with 1.1.2  in availability and add 1.1.2 in compatibility table

## Purpose of this pull request

This pull request (PR) is to update the Releases page with the information for the Google Shopping ads Channel 1.1.2 patch.

## Affected DevDocs pages

- https://devdocs.magento.com/release/

whatsnew
Updated the [Releases](https://devdocs.magento.com/release/) page to include the Google Shopping ads Channel v1.1.2.