### PR TITLE
MAGECLOUD-3258 warm cache with multiple pages

### DIFF
--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -20,25 +20,47 @@ stage:
 -  **Default**— `index.php`
 -  **Version**—Magento 2.1.4 and later
 
-Customize the list of pages used to preload the cache in the `post_deploy` stage.
+Customize the list of pages used to preload the cache in the `post_deploy` stage. You must configure the post-deploy hook. See the [hooks section][] of the `.magento.app.yaml` file.
 
-```yaml
-stage:
-  post-deploy: 
-    WARM_UP_PAGES:
-      - "index.php"
-      - "index.php/customer/account/create"
-```
+-   **single pages**—Specify a single page to add to the cache. You do not have to indicate the default base URL. The following example caches the `BASE_URL/index.php` page:
 
-You must configure the post-deploy hook. See [hooks section of the `.magento.app.yaml` file]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html#hooks).
+    ```yaml
+    stage:
+      post-deploy: 
+        WARM_UP_PAGES:
+          - "index.php"
+    ```
 
-Also, you can configure the cache to preload pages for [multiple domains]({{ page.baseurl }}/cloud/project/project-multi-sites.html).
+-   **multiple domains**—List multiple URLs. The following example caches pages from two domains:
 
-```yaml
-stage:
-  post-deploy:
-    WARM_UP_PAGES:
-      - 'test'
-      - 'http://example1.com/test'
-      - 'http://example2.com/test'
-```
+    ```yaml
+    stage:
+      post-deploy:
+        WARM_UP_PAGES:
+          - 'http://example1.com/test'
+          - 'http://example2.com/test'
+    ```
+
+-   **multiple pages**—Use the following format to cache multiple pages according to a specific pattern:
+
+    ```terminal
+    <entity_type>:<store_id>:<pattern>
+    ```
+
+    -  `entity_type`: Choose `category` or `cms-page`
+    -  `store_id`: Use the ID of the store or an asterisk (\*) for all stores
+    -  `pattern`: Use a `regexp` pattern to filter the URLs or an asterisk (\*) for all pages 
+
+    The following example caches all `category` pages and `cms` pages:
+
+    ```yaml
+    stage:
+      post-deploy: 
+        WARM_UP_PAGES:
+          - category:*:*
+          - cms-page:*:*
+    ```
+
+[hooks section]: {{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
+[CMS]: https://glossary.magento.com/cms/
+[Content elements]: https://docs.magento.com/m2/ce/user_guide/cms/content-elements.html

--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -41,7 +41,7 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
           - 'http://example2.com/test'
     ```
 
--   **multiple pages**—Use the following format to cache multiple pages according to a specific pattern:
+-   **multiple pages**—Use the following format to cache multiple pages according to a specific regular expression pattern:
 
     ```terminal
     <entity_type>:<store_id>:<pattern>
@@ -51,13 +51,15 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
     -  `store_id`: Use the ID of the store or an asterisk (\*) for all stores
     -  `pattern`: Use a `regexp` pattern to filter the URLs or an asterisk (\*) for all pages 
 
-    The following example caches all `category` pages and `cms` pages:
+    The following example caches all category pages for store 1, any category pages that begin with `car_` and do not end with `html` for store 2, any category pages that begin with `tires_` for store 3, and all `cms` pages:
 
     ```yaml
     stage:
       post-deploy: 
         WARM_UP_PAGES:
-          - category:*:*
+          - "category:1:*"
+          - "category:2:|car_.*?\.html|"
+          - "category:3:|tires_.*|"
           - cms-page:*:*
     ```
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -34,6 +34,8 @@ The release notes include:
 
 -   {:.new}**Environment variable updates**—
 
+    -   {:.fix}<!-- MAGECLOUD-3258 -->You can configure the **WARM_UP_PAGES** environment variable to cache single pages, multiple domains, and multiple pages. See the expanded definition in the [post-deploy variables]({{page.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) content.
+
     -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,9 @@ The release notes include:
 
 -   {:.new}**Environment variable updates**—
 
-    -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+    -   {:.fix}<!-- MAGECLOUD-3258 -->You can configure the **WARM_UP_PAGES** environment variable to cache single pages, multiple domains, and multiple pages. See the expanded definition in the [post-deploy variables]({{page.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) content.
+
+    -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#force_update_urls) content.
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -34,7 +34,9 @@ The release notes include:
 
 -   {:.new}**Environment variable updates**—
 
-    -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
+    -   {:.fix}<!-- MAGECLOUD-3258 -->You can configure the **WARM_UP_PAGES** environment variable to cache single pages, multiple domains, and multiple pages. See the expanded definition in the [post-deploy variables]({{page.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) content.
+
+    -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#force_update_urls) content.
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 


### PR DESCRIPTION
This pull request update the Post-deploy variables topic to show examples for how to warm the cache with single pages, multiple pages, and multiple domains. The newest information is the pattern for specifying multiple pages.

Also added release note.