### PR TITLE
Added release notes for version 2.2.9

### DIFF
--- a/_data/toc/release-notes.yml
+++ b/_data/toc/release-notes.yml
@@ -27,6 +27,12 @@ pages:
       include_versions: ["2.2"]
       children:
 
+        - label: Magento Open Source 2.2.9 Release Notes
+          url: /release-notes/ReleaseNotes2.2.9CE.html
+
+        - label: Magento Commerce 2.2.9 Release Notes
+          url: /release-notes/ReleaseNotes2.2.9EE.html
+
         - label: Magento Open Source 2.2.8 Release Notes
           url: /release-notes/ReleaseNotes2.2.8CE.html
 

--- a/_includes/release-notes/engcomm-2-2-9-issues.md
+++ b/_includes/release-notes/engcomm-2-2-9-issues.md
@@ -1,0 +1,209 @@
+
+| Contributing community member | Pull Requests | Related GitHub Issues |
+| ------- | ------- | ------- |
+| [Yamaha32088](https://github.com/Yamaha32088) | [#19760](https://github.com/magento/magento2/pull/19760) | [7967](https://github.com/magento/magento2/issues/7967) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20443](https://github.com/magento/magento2/pull/20443) | [20427](https://github.com/magento/magento2/issues/20427) |
+| [shikhamis11](https://github.com/shikhamis11) | [#20737](https://github.com/magento/magento2/pull/20737) | [20282](https://github.com/magento/magento2/issues/20282) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20738](https://github.com/magento/magento2/pull/20738) | [20611](https://github.com/magento/magento2/issues/20611) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20885](https://github.com/magento/magento2/pull/20885) | [20631](https://github.com/magento/magento2/issues/20631) |
+| [torhoehn](https://github.com/torhoehn) | [#19943](https://github.com/magento/magento2/pull/19943) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20490](https://github.com/magento/magento2/pull/20490) | [20487](https://github.com/magento/magento2/issues/20487) |
+| [mageprince](https://github.com/mageprince) | [#20510](https://github.com/magento/magento2/pull/20510) | [17926](https://github.com/magento/magento2/issues/17926) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20554](https://github.com/magento/magento2/pull/20554) | [20193](https://github.com/magento/magento2/issues/20193) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20586](https://github.com/magento/magento2/pull/20586) | [20278](https://github.com/magento/magento2/issues/20278) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20640](https://github.com/magento/magento2/pull/20640) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20602](https://github.com/magento/magento2/pull/20602) | [20580](https://github.com/magento/magento2/issues/20580) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20646](https://github.com/magento/magento2/pull/20646) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20745](https://github.com/magento/magento2/pull/20745) | [20396](https://github.com/magento/magento2/issues/20396) |
+| [GovindaSharma](https://github.com/GovindaSharma) | [#20776](https://github.com/magento/magento2/pull/20776) | [19942](https://github.com/magento/magento2/issues/19942) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20782](https://github.com/magento/magento2/pull/20782) | [20723](https://github.com/magento/magento2/issues/20723) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20257](https://github.com/magento/magento2/pull/20257) | [20221](https://github.com/magento/magento2/issues/20221) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20589](https://github.com/magento/magento2/pull/20589) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20644](https://github.com/magento/magento2/pull/20644) | [19482](https://github.com/magento/magento2/issues/19482) |
+| [ccasciotti](https://github.com/ccasciotti) | [#18524](https://github.com/magento/magento2/pull/18524) |  |
+| [Nazar65](https://github.com/Nazar65) | [#20876](https://github.com/magento/magento2/pull/20876) | [9988](https://github.com/magento/magento2/issues/9988), [20716](https://github.com/magento/magento2/issues/20716) |
+| [ssp58bleuciel](https://github.com/ssp58bleuciel) | [#21078](https://github.com/magento/magento2/pull/21078) | [13309](https://github.com/magento/magento2/issues/13309) |
+| [eduard13](https://github.com/eduard13) | [#21110](https://github.com/magento/magento2/pull/21110) | [20786](https://github.com/magento/magento2/issues/20786) |
+| [speedy008](https://github.com/speedy008) | [#19333](https://github.com/magento/magento2/pull/19333) | [19328](https://github.com/magento/magento2/issues/19328) |
+| [tdgroot](https://github.com/tdgroot) | [#21081](https://github.com/magento/magento2/pull/21081) |  |
+| [XxXgeoXxX](https://github.com/XxXgeoXxX) | [#20566](https://github.com/magento/magento2/pull/20566) | [13675](https://github.com/magento/magento2/issues/13675) |
+| [mage2pratik](https://github.com/mage2pratik) | [#20845](https://github.com/magento/magento2/pull/20845) | [19139](https://github.com/magento/magento2/issues/19139) |
+| [mageprince](https://github.com/mageprince) | [#21123](https://github.com/magento/magento2/pull/21123) |  |
+| [irajneeshgupta](https://github.com/irajneeshgupta) | [#21124](https://github.com/magento/magento2/pull/21124) | [20382](https://github.com/magento/magento2/issues/20382) |
+| [eduard13](https://github.com/eduard13) | [#20821](https://github.com/magento/magento2/pull/20821) | [20497](https://github.com/magento/magento2/issues/20497) |
+| [eduard13](https://github.com/eduard13) | [#21155](https://github.com/magento/magento2/pull/21155) |  |
+| [eduard13](https://github.com/eduard13) | [#21156](https://github.com/magento/magento2/pull/21156) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20404](https://github.com/magento/magento2/pull/20404) | [20402](https://github.com/magento/magento2/issues/20402) |
+| [niravkrish](https://github.com/niravkrish) | [#20616](https://github.com/magento/magento2/pull/20616) | [20240](https://github.com/magento/magento2/issues/20240) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21114](https://github.com/magento/magento2/pull/21114) | [20157](https://github.com/magento/magento2/issues/20157) |
+| [janakbhimani](https://github.com/janakbhimani) | [#21140](https://github.com/magento/magento2/pull/21140) | [19714](https://github.com/magento/magento2/issues/19714) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21160](https://github.com/magento/magento2/pull/21160) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21161](https://github.com/magento/magento2/pull/21161) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21163](https://github.com/magento/magento2/pull/21163) | [20816](https://github.com/magento/magento2/issues/20816) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21169](https://github.com/magento/magento2/pull/21169) | [6960](https://github.com/magento/magento2/issues/6960) |
+| [gelanivishal](https://github.com/gelanivishal) | [#18866](https://github.com/magento/magento2/pull/18866) | [18357](https://github.com/magento/magento2/issues/18357), [18954](https://github.com/magento/magento2/issues/18954) |
+| [parag2jcommerce](https://github.com/parag2jcommerce) | [#20476](https://github.com/magento/magento2/pull/20476) | [20468](https://github.com/magento/magento2/issues/20468) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21157](https://github.com/magento/magento2/pull/21157) | [20906](https://github.com/magento/magento2/issues/20906) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21162](https://github.com/magento/magento2/pull/21162) | [20911](https://github.com/magento/magento2/issues/20911) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21159](https://github.com/magento/magento2/pull/21159) | [20989](https://github.com/magento/magento2/issues/20989) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21168](https://github.com/magento/magento2/pull/21168) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21172](https://github.com/magento/magento2/pull/21172) | [20800](https://github.com/magento/magento2/issues/20800) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21198](https://github.com/magento/magento2/pull/21198) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21199](https://github.com/magento/magento2/pull/21199) | [20555](https://github.com/magento/magento2/issues/20555) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20529](https://github.com/magento/magento2/pull/20529) | [20492](https://github.com/magento/magento2/issues/20492) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21166](https://github.com/magento/magento2/pull/21166) |  |
+| [eduard13](https://github.com/eduard13) | [#21224](https://github.com/magento/magento2/pull/21224) |  |
+| [eduard13](https://github.com/eduard13) | [#21238](https://github.com/magento/magento2/pull/21238) | [21101](https://github.com/magento/magento2/issues/21101) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21239](https://github.com/magento/magento2/pull/21239) | [6162](https://github.com/magento/magento2/issues/6162), [7974](https://github.com/magento/magento2/issues/7974), [21144](https://github.com/magento/magento2/issues/21144) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21240](https://github.com/magento/magento2/pull/21240) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21245](https://github.com/magento/magento2/pull/21245) | [17861](https://github.com/magento/magento2/issues/17861) |
+| [suryakant-krish](https://github.com/suryakant-krish) | [#21250](https://github.com/magento/magento2/pull/21250) | [21070](https://github.com/magento/magento2/issues/21070) |
+| [irajneeshgupta](https://github.com/irajneeshgupta) | [#20539](https://github.com/magento/magento2/pull/20539) | [20299](https://github.com/magento/magento2/issues/20299) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21261](https://github.com/magento/magento2/pull/21261) | [18347](https://github.com/magento/magento2/issues/18347) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21262](https://github.com/magento/magento2/pull/21262) | [18944](https://github.com/magento/magento2/issues/18944) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21263](https://github.com/magento/magento2/pull/21263) | [19561](https://github.com/magento/magento2/issues/19561) |
+| [tufahu](https://github.com/tufahu) | [#21273](https://github.com/magento/magento2/pull/21273) | [18158](https://github.com/magento/magento2/issues/18158) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21269](https://github.com/magento/magento2/pull/21269) |  |
+| [keyuremipro](https://github.com/keyuremipro) | [#21282](https://github.com/magento/magento2/pull/21282) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21287](https://github.com/magento/magento2/pull/21287) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20781](https://github.com/magento/magento2/pull/20781) | [20755](https://github.com/magento/magento2/issues/20755) |
+| [serhiyzhovnir](https://github.com/serhiyzhovnir) | [#20954](https://github.com/magento/magento2/pull/20954) | [18698](https://github.com/magento/magento2/issues/18698) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21164](https://github.com/magento/magento2/pull/21164) | [18525](https://github.com/magento/magento2/issues/18525) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21242](https://github.com/magento/magento2/pull/21242) |  |
+| [Dharmeshvaja91](https://github.com/Dharmeshvaja91) | [#21247](https://github.com/magento/magento2/pull/21247) |  |
+| [dipti2jcommerce](https://github.com/dipti2jcommerce) | [#20370](https://github.com/magento/magento2/pull/20370) | [20163](https://github.com/magento/magento2/issues/20163) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21173](https://github.com/magento/magento2/pull/21173) | [20760](https://github.com/magento/magento2/issues/20760) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21229](https://github.com/magento/magento2/pull/21229) | [18775](https://github.com/magento/magento2/issues/18775) |
+| [eduard13](https://github.com/eduard13) | [#21320](https://github.com/magento/magento2/pull/21320) | [21196](https://github.com/magento/magento2/issues/21196) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21243](https://github.com/magento/magento2/pull/21243) | [20299](https://github.com/magento/magento2/issues/20299) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21206](https://github.com/magento/magento2/pull/21206) | [21089](https://github.com/magento/magento2/issues/21089) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21208](https://github.com/magento/magento2/pull/21208) | [19891](https://github.com/magento/magento2/issues/19891) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21241](https://github.com/magento/magento2/pull/21241) | [20919](https://github.com/magento/magento2/issues/20919) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20743](https://github.com/magento/magento2/pull/20743) | [20518](https://github.com/magento/magento2/issues/20518) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#20970](https://github.com/magento/magento2/pull/20970) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21207](https://github.com/magento/magento2/pull/21207) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21202](https://github.com/magento/magento2/pull/21202) | [20010](https://github.com/magento/magento2/issues/20010) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21213](https://github.com/magento/magento2/pull/21213) |  |
+| [mageprince](https://github.com/mageprince) | [#21317](https://github.com/magento/magento2/pull/21317) |  |
+| [yogeshsuhagiya](https://github.com/yogeshsuhagiya) | [#21344](https://github.com/magento/magento2/pull/21344) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21357](https://github.com/magento/magento2/pull/21357) | [19274](https://github.com/magento/magento2/issues/19274) |
+| [maheshWebkul721](https://github.com/maheshWebkul721) | [#20866](https://github.com/magento/magento2/pull/20866) | [20380](https://github.com/magento/magento2/issues/20380) |
+| [eduard13](https://github.com/eduard13) | [#21423](https://github.com/magento/magento2/pull/21423) | [8479](https://github.com/magento/magento2/issues/8479), [16116](https://github.com/magento/magento2/issues/16116) |
+| [Nazar65](https://github.com/Nazar65) | [#21437](https://github.com/magento/magento2/pull/21437) | [19983](https://github.com/magento/magento2/issues/19983) |
+| [gwharton](https://github.com/gwharton) | [#18472](https://github.com/magento/magento2/pull/18472) | [11740](https://github.com/magento/magento2/issues/11740), [14945](https://github.com/magento/magento2/issues/14945), [14952](https://github.com/magento/magento2/issues/14952), [16355](https://github.com/magento/magento2/issues/16355) |
+| [Nazar65](https://github.com/Nazar65) | [#21325](https://github.com/magento/magento2/pull/21325) | [19166](https://github.com/magento/magento2/issues/19166) |
+| [shikhamis11](https://github.com/shikhamis11) | [#21513](https://github.com/magento/magento2/pull/21513) | [15059](https://github.com/magento/magento2/issues/15059) |
+| [dominicfernando](https://github.com/dominicfernando) | [#21537](https://github.com/magento/magento2/pull/21537) |  |
+| [mageprince](https://github.com/mageprince) | [#21538](https://github.com/magento/magento2/pull/21538) | [21398](https://github.com/magento/magento2/issues/21398) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21434](https://github.com/magento/magento2/pull/21434) | [13982](https://github.com/magento/magento2/issues/13982) |
+| [udovicic](https://github.com/udovicic) | [#19552](https://github.com/magento/magento2/pull/19552) |  |
+| [eduard13](https://github.com/eduard13) | [#21527](https://github.com/magento/magento2/pull/21527) | [21383](https://github.com/magento/magento2/issues/21383) |
+| [suneet64](https://github.com/suneet64) | [#19551](https://github.com/magento/magento2/pull/19551) | [18134](https://github.com/magento/magento2/issues/18134) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21531](https://github.com/magento/magento2/pull/21531) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21532](https://github.com/magento/magento2/pull/21532) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21570](https://github.com/magento/magento2/pull/21570) | [20310](https://github.com/magento/magento2/issues/20310) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21588](https://github.com/magento/magento2/pull/21588) | [21077](https://github.com/magento/magento2/issues/21077) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21568](https://github.com/magento/magento2/pull/21568) | [21425](https://github.com/magento/magento2/issues/21425) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21569](https://github.com/magento/magento2/pull/21569) | [21327](https://github.com/magento/magento2/issues/21327) |
+| [lisovyievhenii](https://github.com/lisovyievhenii) | [#21598](https://github.com/magento/magento2/pull/21598) | [14882](https://github.com/magento/magento2/issues/14882) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21652](https://github.com/magento/magento2/pull/21652) |  |
+| [rikwillems](https://github.com/rikwillems) | [#19098](https://github.com/magento/magento2/pull/19098) |  |
+| [wojtekn](https://github.com/wojtekn) | [#21528](https://github.com/magento/magento2/pull/21528) | [21294](https://github.com/magento/magento2/issues/21294) |
+| [eduard13](https://github.com/eduard13) | [#21691](https://github.com/magento/magento2/pull/21691) | [20527](https://github.com/magento/magento2/issues/20527) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21694](https://github.com/magento/magento2/pull/21694) | [21493](https://github.com/magento/magento2/issues/21493) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21695](https://github.com/magento/magento2/pull/21695) | [19276](https://github.com/magento/magento2/issues/19276) |
+| [david-fuehr](https://github.com/david-fuehr) | [#21699](https://github.com/magento/magento2/pull/21699) | [19117](https://github.com/magento/magento2/issues/19117) |
+| [Nazar65](https://github.com/Nazar65) | [#21080](https://github.com/magento/magento2/pull/21080) | [21073](https://github.com/magento/magento2/issues/21073) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21589](https://github.com/magento/magento2/pull/21589) | [20128](https://github.com/magento/magento2/issues/20128) |
+| [igor-imaginemage](https://github.com/igor-imaginemage) | [#20412](https://github.com/magento/magento2/pull/20412) |  |
+| [driskell](https://github.com/driskell) | [#21051](https://github.com/magento/magento2/pull/21051) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21433](https://github.com/magento/magento2/pull/21433) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21662](https://github.com/magento/magento2/pull/21662) | [21278](https://github.com/magento/magento2/issues/21278) |
+| [david-fuehr](https://github.com/david-fuehr) | [#21698](https://github.com/magento/magento2/pull/21698) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21759](https://github.com/magento/magento2/pull/21759) | [21419](https://github.com/magento/magento2/issues/21419) |
+| [VitaliyBoyko](https://github.com/VitaliyBoyko) | [#21793](https://github.com/magento/magento2/pull/21793) | [167](https://github.com/magento/magento2/issues/167) |
+| [ananth-iyer](https://github.com/ananth-iyer) | [#21800](https://github.com/magento/magento2/pull/21800) | [21384](https://github.com/magento/magento2/issues/21384) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21802](https://github.com/magento/magento2/pull/21802) | [13612](https://github.com/magento/magento2/issues/13612) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21804](https://github.com/magento/magento2/pull/21804) | [10645](https://github.com/magento/magento2/issues/10645) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21838](https://github.com/magento/magento2/pull/21838) | [21648](https://github.com/magento/magento2/issues/21648) |
+| [ccasciotti](https://github.com/ccasciotti) | [#21037](https://github.com/magento/magento2/pull/21037) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21435](https://github.com/magento/magento2/pull/21435) | [20773](https://github.com/magento/magento2/issues/20773) |
+| [eduard13](https://github.com/eduard13) | [#21849](https://github.com/magento/magento2/pull/21849) | [20924](https://github.com/magento/magento2/issues/20924) |
+| [eduard13](https://github.com/eduard13) | [#21859](https://github.com/magento/magento2/pull/21859) |  |
+| [mage2pratik](https://github.com/mage2pratik) | [#21872](https://github.com/magento/magento2/pull/21872) |  |
+| [novikor](https://github.com/novikor) | [#21543](https://github.com/magento/magento2/pull/21543) | [21062](https://github.com/magento/magento2/issues/21062) |
+| [ccasciotti](https://github.com/ccasciotti) | [#21576](https://github.com/magento/magento2/pull/21576) | [21510](https://github.com/magento/magento2/issues/21510) |
+| [Cyanoxide](https://github.com/Cyanoxide) | [#21661](https://github.com/magento/magento2/pull/21661) |  |
+| [eduard13](https://github.com/eduard13) | [#21845](https://github.com/magento/magento2/pull/21845) | [12396](https://github.com/magento/magento2/issues/12396) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21844](https://github.com/magento/magento2/pull/21844) | [21467](https://github.com/magento/magento2/issues/21467) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21864](https://github.com/magento/magento2/pull/21864) | [21750](https://github.com/magento/magento2/issues/21750) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21432](https://github.com/magento/magento2/pull/21432) | [14412](https://github.com/magento/magento2/issues/14412) |
+| [iGerchak](https://github.com/iGerchak) | [#21918](https://github.com/magento/magento2/pull/21918) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21920](https://github.com/magento/magento2/pull/21920) | [20825](https://github.com/magento/magento2/issues/20825) |
+| [Bartlomiejsz](https://github.com/Bartlomiejsz) | [#21719](https://github.com/magento/magento2/pull/21719) | [21692](https://github.com/magento/magento2/issues/21692) |
+| [afirlejczyk](https://github.com/afirlejczyk) | [#17371](https://github.com/magento/magento2/pull/17371) | [7283](https://github.com/magento/magento2/issues/7283) |
+| [vivekkumarcedcoss](https://github.com/vivekkumarcedcoss) | [#21561](https://github.com/magento/magento2/pull/21561) | [8086](https://github.com/magento/magento2/issues/8086), [18115](https://github.com/magento/magento2/issues/18115) |
+| [hiren0241](https://github.com/hiren0241) | [#21939](https://github.com/magento/magento2/pull/21939) | [21374](https://github.com/magento/magento2/issues/21374) |
+| [eduard13](https://github.com/eduard13) | [#21943](https://github.com/magento/magento2/pull/21943) |  |
+| [tuyennn](https://github.com/tuyennn) | [#21535](https://github.com/magento/magento2/pull/21535) | [21521](https://github.com/magento/magento2/issues/21521) |
+| [eduard13](https://github.com/eduard13) | [#21944](https://github.com/magento/magento2/pull/21944) | [18754](https://github.com/magento/magento2/issues/18754), [21281](https://github.com/magento/magento2/issues/21281) |
+| [gwharton](https://github.com/gwharton) | [#19488](https://github.com/magento/magento2/pull/19488) | [19485](https://github.com/magento/magento2/issues/19485) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21118](https://github.com/magento/magento2/pull/21118) | [20790](https://github.com/magento/magento2/issues/20790) |
+| [kisroman](https://github.com/kisroman) | [#21813](https://github.com/magento/magento2/pull/21813) | [21734](https://github.com/magento/magento2/issues/21734) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21892](https://github.com/magento/magento2/pull/21892) | [20809](https://github.com/magento/magento2/issues/20809) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22039](https://github.com/magento/magento2/pull/22039) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22069](https://github.com/magento/magento2/pull/22069) | [21805](https://github.com/magento/magento2/issues/21805) |
+| [lfluvisotto](https://github.com/lfluvisotto) | [#21512](https://github.com/magento/magento2/pull/21512) | [21499](https://github.com/magento/magento2/issues/21499) |
+| [larsroettig](https://github.com/larsroettig) | [#22037](https://github.com/magento/magento2/pull/22037) | [14926](https://github.com/magento/magento2/issues/14926), [18752](https://github.com/magento/magento2/issues/18752) |
+| [wojtekn](https://github.com/wojtekn) | [#22086](https://github.com/magento/magento2/pull/22086) | [21134](https://github.com/magento/magento2/issues/21134) |
+| [ihor-sviziev](https://github.com/ihor-sviziev) | [#21819](https://github.com/magento/magento2/pull/21819) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22070](https://github.com/magento/magento2/pull/22070) | [10893](https://github.com/magento/magento2/issues/10893) |
+| [XxXgeoXxX](https://github.com/XxXgeoXxX) | [#20392](https://github.com/magento/magento2/pull/20392) |  |
+| [eduard13](https://github.com/eduard13) | [#21945](https://github.com/magento/magento2/pull/21945) |  |
+| [hostep](https://github.com/hostep) | [#22140](https://github.com/magento/magento2/pull/22140) | [15972](https://github.com/magento/magento2/issues/15972) |
+| [denispapec](https://github.com/denispapec) | [#18980](https://github.com/magento/magento2/pull/18980) | [18580](https://github.com/magento/magento2/issues/18580) |
+| [mage2pratik](https://github.com/mage2pratik) | [#20844](https://github.com/magento/magento2/pull/20844) | [20614](https://github.com/magento/magento2/issues/20614) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22181](https://github.com/magento/magento2/pull/22181) |  |
+| [ilnytskyi](https://github.com/ilnytskyi) | [#22227](https://github.com/magento/magento2/pull/22227) | [10790](https://github.com/magento/magento2/issues/10790) |
+| [Nazar65](https://github.com/Nazar65) | [#22232](https://github.com/magento/magento2/pull/22232) | [21755](https://github.com/magento/magento2/issues/21755) |
+| [floorz](https://github.com/floorz) | [#20107](https://github.com/magento/magento2/pull/20107) | [20078](https://github.com/magento/magento2/issues/20078) |
+| [mage2pratik](https://github.com/mage2pratik) | [#21203](https://github.com/magento/magento2/pull/21203) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#21946](https://github.com/magento/magento2/pull/21946) | [20209](https://github.com/magento/magento2/issues/20209) |
+| [Nazar65](https://github.com/Nazar65) | [#22078](https://github.com/magento/magento2/pull/22078) | [7906](https://github.com/magento/magento2/issues/7906) |
+| [Nazar65](https://github.com/Nazar65) | [#22174](https://github.com/magento/magento2/pull/22174) | [18548](https://github.com/magento/magento2/issues/18548) |
+| [Den4ik](https://github.com/Den4ik) | [#22250](https://github.com/magento/magento2/pull/22250) | [21789](https://github.com/magento/magento2/issues/21789) |
+| [VitaliyBoyko](https://github.com/VitaliyBoyko) | [#22267](https://github.com/magento/magento2/pull/22267) | [22238](https://github.com/magento/magento2/issues/22238) |
+| [gwharton](https://github.com/gwharton) | [#18443](https://github.com/magento/magento2/pull/18443) |  |
+| [hostep](https://github.com/hostep) | [#21340](https://github.com/magento/magento2/pull/21340) | [5021](https://github.com/magento/magento2/issues/5021), [13902](https://github.com/magento/magento2/issues/13902) |
+| [hiren0241](https://github.com/hiren0241) | [#21961](https://github.com/magento/magento2/pull/21961) | [11358](https://github.com/magento/magento2/issues/11358), [19701](https://github.com/magento/magento2/issues/19701) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22295](https://github.com/magento/magento2/pull/22295) | [20366](https://github.com/magento/magento2/issues/20366) |
+| [crankycyclops](https://github.com/crankycyclops) | [#22072](https://github.com/magento/magento2/pull/22072) | [21753](https://github.com/magento/magento2/issues/21753) |
+| [JeroenVanLeusden](https://github.com/JeroenVanLeusden) | [#22369](https://github.com/magento/magento2/pull/22369) | [7623](https://github.com/magento/magento2/issues/7623), [11892](https://github.com/magento/magento2/issues/11892) |
+| [davidalger](https://github.com/davidalger) | [#22282](https://github.com/magento/magento2/pull/22282) | [15090](https://github.com/magento/magento2/issues/15090) |
+| [slackerzz](https://github.com/slackerzz) | [#22422](https://github.com/magento/magento2/pull/22422) | [21868](https://github.com/magento/magento2/issues/21868) |
+| [ilnytskyi](https://github.com/ilnytskyi) | [#22214](https://github.com/magento/magento2/pull/22214) | [19909](https://github.com/magento/magento2/issues/19909) |
+| [saphaljha](https://github.com/saphaljha) | [#22440](https://github.com/magento/magento2/pull/22440) | [22309](https://github.com/magento/magento2/issues/22309) |
+| [saphaljha](https://github.com/saphaljha) | [#22441](https://github.com/magento/magento2/pull/22441) | [22152](https://github.com/magento/magento2/issues/22152) |
+| [yogeshsuhagiya](https://github.com/yogeshsuhagiya) | [#22451](https://github.com/magento/magento2/pull/22451) |  |
+| [yogeshsuhagiya](https://github.com/yogeshsuhagiya) | [#22448](https://github.com/magento/magento2/pull/22448) |  |
+| [Ctucker9233](https://github.com/Ctucker9233) | [#22439](https://github.com/magento/magento2/pull/22439) | [15828](https://github.com/magento/magento2/issues/15828) |
+| [Nazar65](https://github.com/Nazar65) | [#22453](https://github.com/magento/magento2/pull/22453) | [6715](https://github.com/magento/magento2/issues/6715), [21960](https://github.com/magento/magento2/issues/21960) |
+| [serhiyzhovnir](https://github.com/serhiyzhovnir) | [#22108](https://github.com/magento/magento2/pull/22108) | [21786](https://github.com/magento/magento2/issues/21786) |
+| [saphaljha](https://github.com/saphaljha) | [#22465](https://github.com/magento/magento2/pull/22465) |  |
+| [ravi-chandra3197](https://github.com/ravi-chandra3197) | [#22471](https://github.com/magento/magento2/pull/22471) | [6272](https://github.com/magento/magento2/issues/6272) |
+| [niravkrish](https://github.com/niravkrish) | [#22473](https://github.com/magento/magento2/pull/22473) |  |
+| [bcerban](https://github.com/bcerban) | [#22415](https://github.com/magento/magento2/pull/22415) | [22370](https://github.com/magento/magento2/issues/22370) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22378](https://github.com/magento/magento2/pull/22378) | [21375](https://github.com/magento/magento2/issues/21375) |
+| [ihor-sviziev](https://github.com/ihor-sviziev) | [#22464](https://github.com/magento/magento2/pull/22464) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22358](https://github.com/magento/magento2/pull/22358) | [21715](https://github.com/magento/magento2/issues/21715) |
+| [keyuremipro](https://github.com/keyuremipro) | [#22499](https://github.com/magento/magento2/pull/22499) | [22474](https://github.com/magento/magento2/issues/22474) |
+| [shikhamis11](https://github.com/shikhamis11) | [#22523](https://github.com/magento/magento2/pull/22523) | [22223](https://github.com/magento/magento2/issues/22223) |
+| [niravkrish](https://github.com/niravkrish) | [#22533](https://github.com/magento/magento2/pull/22533) | [22402](https://github.com/magento/magento2/issues/22402) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22534](https://github.com/magento/magento2/pull/22534) | [22299](https://github.com/magento/magento2/issues/22299) |
+| [Wirson](https://github.com/Wirson) | [#22288](https://github.com/magento/magento2/pull/22288) | [22249](https://github.com/magento/magento2/issues/22249) |
+| [saphaljha](https://github.com/saphaljha) | [#22543](https://github.com/magento/magento2/pull/22543) | [21596](https://github.com/magento/magento2/issues/21596) |
+| [niravkrish](https://github.com/niravkrish) | [#22536](https://github.com/magento/magento2/pull/22536) | [9155](https://github.com/magento/magento2/issues/9155) |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22551](https://github.com/magento/magento2/pull/22551) |  |
+| [barbanet](https://github.com/barbanet) | [#22413](https://github.com/magento/magento2/pull/22413) |  |
+| [amol2jcommerce](https://github.com/amol2jcommerce) | [#22579](https://github.com/magento/magento2/pull/22579) | [21978](https://github.com/magento/magento2/issues/21978) |
+| [webkul-deepakkumar](https://github.com/webkul-deepakkumar) | [#22582](https://github.com/magento/magento2/pull/22582) | [20917](https://github.com/magento/magento2/issues/20917) |

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -10,7 +10,7 @@ title: Magento Open Source 2.2.9 Release Notes
 *Release notes published on June 26  2019.*
 
 
-We are pleased to present Magento Open Source 2.2.9. This release includes 75 critical enhancements to product security, over 150 core code fixes and enhancements, and  285 community-submitted pull requests. 
+We are pleased to present Magento Open Source 2.2.9. This release includes 75 critical enhancements to product security, over 100 core code fixes and enhancements, and  over 200 community-submitted pull requests. 
 
 
 
@@ -63,9 +63,6 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- ENGCOM-4229 -->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
-
-
-
 ### Bundle products
 
 <!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
@@ -74,12 +71,7 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- ENGCOM-4143 -->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
-
-
-
 <!-- MAGETWO-97226 -->*  Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
-
-
 
 
 ### Catalog
@@ -148,24 +140,9 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 s
 <!-- MAGETWO-98794 -->* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed this message, `The SKU was not found in the catalog.
 
-
-
-
-
-
-
-
-
 ### Cart and checkout
 
 <!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
-
-
-
-
-
-
-
 
 <!-- MAGETWO-98365 -->* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in. 
 
@@ -202,8 +179,6 @@ s
 
 
 
-
-
 ### Clean up and minor refactoring
 
 <!-- ENGCOM-4304 -->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
@@ -233,29 +208,20 @@ s
 
 <!-- ENGCOM-4470 -->* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
-
-
-
-
-
-
-
-
 ### CMS
 
-<!-- MAGETWO-99818 -->* Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
+<!-- MAGETWO-99818 -->
+* We have modified the required permissions for updating the `design` fieldset of categories, products, and CMS pages:
 
+  * Existing roles that have **save** permission for these entities can save everything.
 
+  * New roles must be granted permission to edit design manually.
 
+  * If you do not have permission to edit the `design` fieldset or use web API endpoints to update a category, Magento does not save your changes and the design properties remain unchanged.
 
 <!-- MAGETWO-98990 -->* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer  11.x. 
 
 <!-- ENGCOM-4200 -->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
-
-
-
-
-
 
 
 
@@ -282,17 +248,7 @@ s
 
 <!-- MAGETWO-97684 -->* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required. 
 
-
-
-
-
 <!-- MAGETWO-98044 -->* When loading an order for a customer already assigned to a customer group, Magento now shows the assigned customer group in the order information.  Additionally, Magento now saves the group assignment if you change it when creating a customer order. Previously, the customer group reverted to the default configured group assignment for customers with an existing group assignment. On new orders, if you changed the customer group during the ordering process, the new assignment was not saved. When you loaded the customer order, the customer group showed the default group instead of the group assignment applied during the ordering process.
-
-
-
-
-
-
 
 ### cron
 
@@ -340,12 +296,9 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 <!-- ENGCOM-4518 -->* Magento no longer throws an exception when the  `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 
-
-
 ### Email
 
 <!-- ENGCOM-4305 -->* Corrected problems with  disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
-
 
 
 ### Frameworks
@@ -363,28 +316,17 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 <!-- ENGCOM-4542 -->*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 
-
 #### Cache framework
 
 <!-- ENGCOM-4183 -->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
-
 
 #### JavaScript framework
 
 <!-- ENGCOM-4610 -->* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
-
-
-
-
-
-
 ### General
 
 <!-- ENGCOM-2667 -->* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
-
-
-
 
 <!-- ENGCOM-4548 -->* Product attribute labels are no longer translated but maintain their store-specific valu *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
@@ -438,7 +380,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 <!-- MAGETWO-96957 -->* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page
 
 
-
 ### Orders
 
 <!-- ENGCOM-4593 -->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
@@ -446,8 +387,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 ### Page Cache
 
 <!-- MAGETWO-90953 -->* Page caching is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode. 
-
-
 
 ### Payment methods
 
@@ -465,8 +404,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 <!-- MAGETWO-97464 -->* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update. 
 
-
-
 ### Pricing
 
 <!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
@@ -475,29 +412,15 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 <!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
 
-
-
-
 ### Quick Order
 
 <!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
-
-
-
-
 
 ### Reports
 
 <!-- MAGETWO-96883 -->* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites. 
 
 <!-- ENGCOM-4445 -->* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
-
-
-
-
-
-
-
 
 ### Review
 
@@ -515,10 +438,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 <!-- ENGCOM-4280 -->*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
-
-
-
-
 <!-- ENGCOM-3968 -->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
 
 <!-- ENGCOM-4403 -->* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
@@ -533,7 +452,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 ### Sales rule
 
-
 <!-- MAGETWO-98568 -->* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
 <!-- ENGCOM-4485 -->* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
@@ -541,7 +459,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 
 ### Search
-
 
 <!-- MAGETWO-97374 -->* Layered navigation results no longer includes price ranges that contain no products. 
 
@@ -554,9 +471,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 
 ### Shipping 
-
-
-
 
 <!-- MAGETWO-96001 -->* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
@@ -582,8 +496,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 <!-- MAGETWO-96870 -->* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
 <!-- MAGETWO-97975 -->* The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent  product. 
-
-
 
 
 ### Testing
@@ -617,9 +529,6 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 ###  URL rewrite
 
-
-
-
 <!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 
@@ -627,21 +536,9 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 <!-- ENGCOM-4224 -->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
-
-
 ### VAT ID
 
 <!-- ENGCOM-4232 -->* Greek VAT numbers can now be validated. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
-
-
-
-
-
-
-
-
-
-
 
 
 ### Wishlist
@@ -662,6 +559,7 @@ This release includes substantial community contributions: over 100 GitHub issue
 
 The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
 
+{% include release-notes/engcomm-2-2-9-issues.md %}
 
 
 ### Partner contributions

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -264,7 +264,7 @@ s
 
 	* `--lock-file-path=LOCK-FILE-PATH` The path where file locks will be saved.
 
-See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html
+See [Configure the lock provider](https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html).
 
 
 ### Customer custom attributes
@@ -408,13 +408,10 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 <!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
 
-<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
+<!-- MAGETWO-96062, 97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 <!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
 
-### Quick Order
-
-<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 ### Reports
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -7,48 +7,36 @@ title: Magento Open Source 2.2.9 Release Notes
 
 
 
-*Release notes published on  2019.*
+*Release notes published on June 26  2019.*
 
 
-We are pleased to present Magento Open Source 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and 285 community-submitted pull requests. 
+We are pleased to present Magento Open Source 2.2.9. This release includes 75 critical enhancements to product security, over 150 core code fixes and enhancements, and  285 community-submitted pull requests. 
 
 
-Although this release includes these security enhancements, no confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions, so we recommend that you upgrade your Magento software to the latest version as soon as possible.
-
-See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
 
 ## Highlights
 
 Look for the following highlights in this release:
 
-### Merchant tool enhancements
-
 
 ### Substantial security enhancements
 
-These releases include security enhancements that help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. All exploitable security issues fixed in this release (2.2.8) have been ported to 2.3.1, 2.1.17, 1.14.4.1, and 1.9.4.1, as appropriate.
+This release is focused on substantial security enhancements:
 
+* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+
+* **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
 
 ### Infrastructure improvements
 
- 
+This release contains 150 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements: 
 
+* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.  <!--- MAGETWO-98424-->
 
+* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**.The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947--> 
 
-### Bundled extension enhancements
-
-This release of Magento includes extensions developed by third-party vendors. 
-
-
-#### dotdigital Engagement Cloud (formerly dotmailer)
-
-
-#### Magento Shipping
-
-
-
-#### Vertex
+* **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 
 ## Functional fixes
@@ -56,57 +44,197 @@ This release of Magento includes extensions developed by third-party vendors.
 In addition to security enhancements, this release contains the following functional fixes. 
 
 
-## Fixes
-
-In addition to security enhancements, this release contains the following functional fixes. 
-
-
-
-<!-- MAGETWO- -->*
-
-
 ### Installation, setup, and deployment
 
+<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw this error under these conditions, `2436; Status: 0`.
 
-
+<!-- MAGETWO-76424 -->* Magento no longer displays an extraneous blank option in the country drop-down menu. 
 
 
 ### Backend
+
+<!-- ENGCOM-4517 -->* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+
+<!-- ENGCOM-4435 -->*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+
+<!-- ENGCOM-4121 -->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+
+<!-- ENGCOM-4142 -->* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+
+<!-- ENGCOM-4229 -->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
+
 
 
 
 ### Bundle products
 
+<!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+
+<!-- ENGCOM-4557 -->* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+
+<!-- ENGCOM-4143 -->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
 
 
-### CAPTCHA
 
+<!-- MAGETWO-97226 -->*  Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
 
 
 
 
 ### Catalog
 
+<!-- MAGETWO-94426 -->* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
+<!-- MAGETWO-74081 -->* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+
+<!-- MAGETWO-98626 -->* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404. 
+
+<!-- MAGETWO-74455 -->* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values. 
+
+<!-- MAGETWO-74037 -->* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+
+<!-- MAGETWO-73157 -->* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
+
+<!-- MAGETWO-72650 -->* Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
+
+<!-- MAGETWO-97472 -->* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level. 
+
+<!-- MAGETWO-97405 -->* You can now use storeview-level attributes to filter products on the products list.
+
+<!-- MAGETWO-97400 -->* The selected store scope view now affects the categories displayed on the product edit page's category tree. 
+
+<!-- MAGETWO-97973 -->* Magento now calculates and displays the correct tier price for bundle products.
+
+<!-- MAGETWO-95616 -->* Magento no longer permits you to change an attribute set if the new set does not have equivalent attributes as the original set. Previously, Magento sometimes threw this exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.` 
+
+<!-- MAGETWO-97380 -->* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
+
+<!-- MAGETWO-97425 -->* Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty. 
+
+<!-- MAGETWO-98470 -->* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave  special prices empty. 
+
+<!-- MAGETWO-95020 -->* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories. 
+
+<!-- ENGCOM-3697 -->* Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+
+<!-- ENGCOM-4245 -->* Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+
+<!-- ENGCOM-4030 -->* Fixed misalignment of product page tab content in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+
+<!-- ENGCOM-4254 -->* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+
+<!-- ENGCOM-4236 -->* Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+
+<!-- ENGCOM-4292 -->*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price  wrong. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+
+<!-- ENGCOM-4290 -->*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`.  *Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+
+<!-- ENGCOM-4327 -->* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+
+<!-- ENGCOM-4340 -->*  A  product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+
+<!-- ENGCOM-4429 -->*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, `MinimalTierPriceCalculator`  applied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+
+<!-- ENGCOM-4447 -->* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+
+<!-- ENGCOM-4182 -->* Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed this exception: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
+
+<!-- ENGCOM-4271 -->* You can now open a product's details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+
+<!-- ENGCOM-4020 -->* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+
+<!-- ENGCOM-4514 -->* We've fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
+has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.) *Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
+s
+<!-- MAGETWO-98794 -->* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed this message, `The SKU was not found in the catalog.
 
 
 
 
 
 
-### Catalog rule
 
 
 
 ### Cart and checkout
 
+<!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
+
+
+
+
+
+
+
+
+<!-- MAGETWO-98365 -->* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in. 
+
+<!-- MAGETWO-97950 -->* Magento now correctly updates the minicart if a selected product is disabled during the shopping session. 
+
+<!-- ENGCOM-4013, 4283 -->* Corrected misalignment of the order item details label and subtotal label  in mobile view. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+
+<!-- ENGCOM-4127 -->* The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+
+<!-- ENGCOM-4043 -->* Fixed issue displaying numbers that exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+	
+<!-- ENGCOM- 4133-->* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+
+<!-- ENGCOM-4205 -->* Fixed misalignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+
+<!-- ENGCOM-4390 -->* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
+
+<!-- ENGCOM-4421 -->* Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
+
+<!-- ENGCOM-4436 -->* The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+
+<!-- ENGCOM-4479 -->* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
+
+<!-- ENGCOM-4369 -->* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw this JavaScript error,  `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+
+<!-- ENGCOM-4630 -->* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
+
+<!-- ENGCOM-4622 -->* Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+
+
+### Checkout agreements
+
+<!-- ENGCOM-3989 -->*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
+
+
+
 
 
 ### Clean up and minor refactoring
 
+<!-- ENGCOM-4304 -->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+
+<!-- ENGCOM- 4123-->* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+
+<!-- ENGCOM-4204 -->* Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+
+<!-- ENGCOM-4230 -->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+
+<!-- ENGCOM-4239 -->* Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+
+<!-- ENGCOM-4247 -->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+
+<!-- ENGCOM- 4535-->* Added a missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 
 ### Configurable products
+
+<!-- MAGETWO-97271 -->* Configurable products can no longer be added as a variation of another configurable product in the Admin.
+
+<!-- MAGETWO-97332 -->* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
+
+<!-- ENGCOM-4308 -->* Fixed misalignment of fields on the Configure Product page that is accessed from the wishlist. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+
+<!-- ENGCOM-4092 -->* You can now  successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed this error, `Attribute with ID "Manufacturer" does not exist`.  *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
+
+<!-- ENGCOM-4470 -->* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
+
+
+
 
 
 
@@ -114,6 +242,16 @@ In addition to security enhancements, this release contains the following functi
 
 
 ### CMS
+
+<!-- MAGETWO-99818 -->* Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
+
+
+
+
+<!-- MAGETWO-98990 -->* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer  11.x. 
+
+<!-- ENGCOM-4200 -->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+
 
 
 
@@ -123,42 +261,119 @@ In addition to security enhancements, this release contains the following functi
 
 ### Customer
 
+<!-- MAGETWO-98334 -->* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks. 
 
+<!-- MAGETWO-72961 -->* Magento now uses the value of the  default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
+
+<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless  configued for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+
+
+<!-- ENGCOM-4132 -->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+
+<!-- ENGCOM-4187 -->* Removed an empty block on the My Account page sidebar. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+
+<!-- ENGCOM-4284 -->* The Customer Name Prefix on the customer configuration page no longer displays extraneous  white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+
+<!-- ENGCOM-4367 -->* The customer login block  (defined as `Magento\Customer\Block\Form\Login`)  no longer sets the page title. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
+
+<!-- ENGCOM-4476 -->* The default sort order for the shopping cart and customer orders page now begins with the latest create date and descends. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+
+<!-- ENGCOM-4213 -->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
+
+<!-- MAGETWO-97684 -->* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required. 
+
+
+
+
+
+<!-- MAGETWO-98044 -->* When loading an order for a customer already assigned to a customer group, Magento now shows the assigned customer group in the order information.  Additionally, Magento now saves the group assignment if you change it when creating a customer order. Previously, the customer group reverted to the default configured group assignment for customers with an existing group assignment. On new orders, if you changed the customer group during the ordering process, the new assignment was not saved. When you loaded the customer order, the customer group showed the default group instead of the group assignment applied during the ordering process.
+
+
+
+
+
+
+
+### cron
+
+<!-- MAGETWO-98843 -->* Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We've also added new options to configure locks during installation: 
+
+	* `--lock-provider=LOCK-PROVIDER` Lock provider name 
+
+	* `--lock-db-prefix=LOCK-DB-PREFIX` Installation specific lock prefix to avoid lock conflicts 
+
+	* `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`  Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181 
+
+	* `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH` The path where Zookeeper will save locks. The default path is /magento/locks 
+
+	* `--lock-file-path=LOCK-FILE-PATH` The path where file locks will be saved.
+
+See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html
 
 
 ### Customer custom attributes
 
+<!-- MAGETWO-97528 -->* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed this message, `Please enter a valid date`.
 
+<!-- MAGETWO-96265 -->* Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default. 
 
-
-
-### Developer
 
 
 
 ### Directory
 
+<!-- ENGCOM-4234 -->* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
 
 ### Downloadable
 
+<!-- ENGCOM- 4297-->* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw this error, `Something went wrong while getting the requested content`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+
+<!-- ENGCOM-4466 -->* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+
 
 
 ### EAV
+
+<!-- ENGCOM-4632 -->* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+
+<!-- ENGCOM-4518 -->* Magento no longer throws an exception when the  `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 
 
 
 ### Email
 
+<!-- ENGCOM-4305 -->* Corrected problems with  disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+
+
 
 ### Frameworks
 
+<!-- MAGETWO-98554 -->* Magento now sorts media directories alphabetically during image upload. 
 
+<!-- ENGCOM-4068 -->* Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+
+<!-- ENGCOM- 4286-->* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+
+<!-- ENGCOM-4354 -->* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
+
+<!-- ENGCOM-4395 -->* The module ranking in  `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
+
+<!-- ENGCOM-4542 -->*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 
 
 #### Cache framework
+
+<!-- ENGCOM-4183 -->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+
+
+#### JavaScript framework
+
+<!-- ENGCOM-4610 -->* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+
+
 
 
 
@@ -166,85 +381,116 @@ In addition to security enhancements, this release contains the following functi
 
 ### General
 
+<!-- ENGCOM-2667 -->* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
 
 
 
+<!-- ENGCOM-4548 -->* Product attribute labels are no longer translated but maintain their store-specific valu *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
-### Gift card
-
-
-
-
-### Gift registry
-
-
-
-
-### Google Analytics
-
-
-
-
-
-
-### Image
-
-
+<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
 
 
 
 ### Import/export
 
+<!-- MAGETWO-96895 -->* The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
+
+<!-- MAGETWO-98694 -->* Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors. 
 
 
+### Indexers
+
+<!-- ENGCOM-4555 -->* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list,  Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+ 
 
 
 ### Infrastructure
 
+<!-- ENGCOM-4570 -->* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+
+<!-- ENGCOM-4484 -->* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic.  *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
+
+<!-- ENGCOM-4587 -->* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+
+<!-- ENGCOM-4626 -->* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`. *Fix submitted by [Lars Roettig](https://github.com/larsroettig) in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
 
 
-### Integration
+
+### Logging
+
+<!-- MAGETWO-97595 -->* Editing a theme now creates an entry in the Admin action log as expected. 
 
 
 
-### Layered navigation
+### MSRP
 
-
-
-
-### Magento Shipping
-
-
+<!-- MAGETWO-73985 -->*  MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
 
 
 
 
 ### Newsletter
 
+<!-- ENGCOM-4303 -->* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
-### Offline shipping
+<!-- MAGETWO-96957 -->* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page
+
+
+
+### Orders
+
+<!-- ENGCOM-4593 -->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+
+### Page Cache
+
+<!-- MAGETWO-90953 -->* Page caching is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode. 
 
 
 
 ### Payment methods
 
+<!-- MAGETWO-98991 -->*   Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.  
 
+<!-- MAGETWO-98670 -->* Magento now displays the account owner name that you've specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified. 
+
+<!-- MAGETWO-98431 -->*  The PayPal  `securetoken` and `securetokenid`  are no longer vulnerable to compromise. 
+
+<!-- MAGETWO-96137 -->* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+
+<!-- ENGCOM-4328 -->* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+
+<!-- MAGETWO-98111 -->* You can now place an order using Cybersource payment from the Admin. 
+
+<!-- MAGETWO-97464 -->* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update. 
 
 
 
 ### Pricing
 
+<!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
+
+<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
+
+<!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
 
 
 
-### Quote
+
+### Quick Order
+
+<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
+
 
 
 
 
 ### Reports
+
+<!-- MAGETWO-96883 -->* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites. 
+
+<!-- ENGCOM-4445 -->* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
 
 
@@ -255,28 +501,55 @@ In addition to security enhancements, this release contains the following functi
 
 ### Review
 
+<!-- ENGCOM- 4006-->* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
-
-### Reward
-
-
-
-
-### RMA
-
+<!-- ENGCOM- 4539-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 
 
 ### Sales
+
+<!-- MAGETWO-97008 -->* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price (specifically, the  price column  contains the custom price excluding tax). Previously, the `sales_order_item` table's price column displayed the custom price including tax. 
+
+<!-- MAGETWO-97096 -->* Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted. 
+
+<!-- ENGCOM-4280 -->*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+
+
+
+
+
+<!-- ENGCOM-3968 -->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
+
+<!-- ENGCOM-4403 -->* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
+
+<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+
+<!-- ENGCOM-4285 -->* Fixed display of the Luma theme My Account Order status tabs in mobile view. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
+
+
 
 
 
 ### Sales rule
 
 
+<!-- MAGETWO-98568 -->* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
+
+<!-- ENGCOM-4485 -->* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
+
+
 
 ### Search
 
+
+<!-- MAGETWO-97374 -->* Layered navigation results no longer includes price ranges that contain no products. 
+
+<!-- ENGCOM-4082 -->* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
+
+<!-- ENGCOM-4209 -->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+
+<!-- ENGCOM-4559 -->* Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 
 
@@ -284,7 +557,8 @@ In addition to security enhancements, this release contains the following functi
 
 
 
-### Store
+
+<!-- MAGETWO-96001 -->* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 
 
@@ -292,34 +566,52 @@ In addition to security enhancements, this release contains the following functi
 
 ### Swatches
 
+<!-- MAGETWO-92495 -->* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed. 
 
-
-
-### TargetRule
-
-
+<!-- ENGCOM-4120 -->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
 
 
 
 ### Tax
 
+<!-- ENGCOM-4434 -->*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+
+<!-- ENGCOM-4439 -->* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+
+<!-- MAGETWO-96870 -->* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
+
+<!-- MAGETWO-97975 -->* The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent  product. 
+
+
 
 
 ### Testing
 
-
-
-### Theme
-
-
-
-
-
-
+<!-- ENGCOM-4415 -->* The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 
 ### UI
+
+<!-- ENGCOM-4427 -->* Form fields of type multiline now work as expwected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+
+<!-- ENGCOM-4598 -->* The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+
+<!-- ENGCOM-4088 -->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+
+<!-- ENGCOM-4011 -->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+
+<!-- ENGCOM-3974 -->* Fixed issue where the drop-down toggle arrow did not close as expected on product pages. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+
+<!-- ENGCOM-4311 -->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+
+<!-- ENGCOM-4317 -->* The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+
+<!-- ENGCOM-4366 -->* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw this error,  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+
+<!-- ENGCOM-4444 -->* Corrected tabbing issue on the product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
+
+
 
 
 
@@ -328,32 +620,42 @@ In addition to security enhancements, this release contains the following functi
 
 
 
-### Visual Merchandiser
+<!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+
+
+<!-- ENGCOM-4116 -->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+
+<!-- ENGCOM-4224 -->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 
 
-### Web API framework
+### VAT ID
+
+<!-- ENGCOM-4232 -->* Greek VAT numbers can now be validated. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 
 
-### Widget
+
+
+
+
+
+
 
 
 
 ### Wishlist
 
+<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesiraable and inaccurate changes in quantity
 
-### WYSIWG
+<!-- ENGCOM-4513 -->* Customer wishlists now include review summaries for included products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 
-
-## Known issues
 
 
 ## Community contributions
 
 This release includes substantial community contributions: over 100 GitHub issues resolved and over 350 pull requests merged. We are grateful to the wider Magento community for this effort and would like to acknowledge their contributions to this release.
-
 
 
 ### Individual contributor contributions

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -1,0 +1,381 @@
+---
+
+group: release-notes
+title: Magento Open Source 2.2.9 Release Notes
+
+---
+
+
+
+*Release notes published on  2019.*
+
+
+We are pleased to present Magento Open Source 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and 285 community-submitted pull requests. 
+
+
+Although this release includes these security enhancements, no confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions, so we recommend that you upgrade your Magento software to the latest version as soon as possible.
+
+See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+
+
+## Highlights
+
+Look for the following highlights in this release:
+
+### Merchant tool enhancements
+
+
+### Substantial security enhancements
+
+These releases include security enhancements that help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. All exploitable security issues fixed in this release (2.2.8) have been ported to 2.3.1, 2.1.17, 1.14.4.1, and 1.9.4.1, as appropriate.
+
+
+### Infrastructure improvements
+
+ 
+
+
+
+### Bundled extension enhancements
+
+This release of Magento includes extensions developed by third-party vendors. 
+
+
+#### dotdigital Engagement Cloud (formerly dotmailer)
+
+
+#### Magento Shipping
+
+
+
+#### Vertex
+
+
+## Functional fixes
+
+In addition to security enhancements, this release contains the following functional fixes. 
+
+
+## Fixes
+
+In addition to security enhancements, this release contains the following functional fixes. 
+
+
+
+<!-- MAGETWO- -->*
+
+
+### Installation, setup, and deployment
+
+
+
+
+
+### Backend
+
+
+
+### Bundle products
+
+
+
+
+### CAPTCHA
+
+
+
+
+
+### Catalog
+
+
+
+
+
+
+
+### Catalog rule
+
+
+
+### Cart and checkout
+
+
+
+### Clean up and minor refactoring
+
+
+
+### Configurable products
+
+
+
+
+
+
+### CMS
+
+
+
+
+
+
+
+### Customer
+
+
+
+
+### Customer custom attributes
+
+
+
+
+
+### Developer
+
+
+
+### Directory
+
+
+
+### Downloadable
+
+
+
+### EAV
+
+
+
+
+### Email
+
+
+### Frameworks
+
+
+
+
+
+#### Cache framework
+
+
+
+
+
+### General
+
+
+
+
+
+
+### Gift card
+
+
+
+
+### Gift registry
+
+
+
+
+### Google Analytics
+
+
+
+
+
+
+### Image
+
+
+
+
+
+### Import/export
+
+
+
+
+
+### Infrastructure
+
+
+
+
+### Integration
+
+
+
+### Layered navigation
+
+
+
+
+### Magento Shipping
+
+
+
+
+
+
+### Newsletter
+
+
+### Offline shipping
+
+
+
+### Payment methods
+
+
+
+
+
+### Pricing
+
+
+
+
+### Quote
+
+
+
+
+### Reports
+
+
+
+
+
+
+
+
+### Review
+
+
+
+### Reward
+
+
+
+
+### RMA
+
+
+
+
+### Sales
+
+
+
+### Sales rule
+
+
+
+### Search
+
+
+
+
+### Shipping 
+
+
+
+### Store
+
+
+
+
+
+### Swatches
+
+
+
+
+### TargetRule
+
+
+
+
+
+
+### Tax
+
+
+
+### Testing
+
+
+
+### Theme
+
+
+
+
+
+
+
+
+### UI
+
+
+
+###  URL rewrite
+
+
+
+
+### Visual Merchandiser
+
+
+
+### Web API framework
+
+
+
+### Widget
+
+
+
+### Wishlist
+
+
+### WYSIWG
+
+
+
+## Known issues
+
+
+## Community contributions
+
+This release includes substantial community contributions: over 100 GitHub issues resolved and over 350 pull requests merged. We are grateful to the wider Magento community for this effort and would like to acknowledge their contributions to this release.
+
+
+
+### Individual contributor contributions
+
+The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
+
+
+
+### Partner contributions
+
+The following table highlights contributions made by Partners. This table lists the Partner who contributed the pull request, the external pull request, and the GitHub issue number associated with it (if available). 
+
+
+### System requirements
+Our technology stack is built on PHP and MySQL. For details, see [Technology stack requirements]({{page.baseurl}}/install-gde/system-requirements-tech.html).
+
+
+### Installation and upgrade instructions
+
+See [How to get the Magento software](http://devdocs.magento.com/guides/v2.2/install-gde/bk-install-guide.html) for complete installation and upgrade information.
+
+## Migration toolkits
+The <a href="{{ page.baseurl }}/migration/migration-migrate.html" target="_blank">Data Migration Tool</a> helps transfer existing Magento 1.x store data to Magento 2.x. This command-line interface includes verification, progress tracking, logging, and testing functions. For installation instructions, see  <a href="{{ page.baseurl }}/migration/migration-tool-install.html" target="_blank">Install the Data Migration Tool</a>. Consider exploring or contributing to the <a href="https://github.com/magento/data-migration-tool" target="_blank"> Magento Data Migration repository</a>.
+
+The <a href="https://github.com/magento/code-migration" target="_blank">Code Migration Toolkit</a> helps transfer existing Magento 1.x store extensions and customizations to Magento 2.2.x. The command-line interface includes scripts for converting Magento 1.x modules and layouts.

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -6,7 +6,7 @@ title: Magento Commerce 2.2.9 Release Notes
 
 *Release notes published on June 26, 2019.*
 
-We are pleased to present Magento Commerce 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and 285 community-submitted pull requests.
+We are pleased to present Magento Commerce 2.2.9. This release includes 75 critical enhancements to product security, over 100 core code fixes and enhancements, and over 200 community-submitted pull requests.
 
 ## Highlights
 
@@ -27,7 +27,7 @@ This release contains 150 enhancements to core quality, which improve the qualit
 * **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.
 <!--- MAGETWO-98424-->
 
-* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
+* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98948-->
 
 * **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
@@ -78,6 +78,7 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- MAGETWO-98678 -->
 * You can now add backordered products to the cart when backorders are enabled.
+
 
 ### Bundle products
 
@@ -708,6 +709,8 @@ This release includes substantial community contributions: over 100 GitHub issue
 ### Individual contributor contributions
 
 The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
+
+{% include release-notes/engcomm-2-2-9-issues.md %}
 
 ### Partner contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -547,9 +547,6 @@ See [Configure the lock provider](https://devdocs.magento.com/guides/v2.3/instal
 <!-- MAGETWO-96898 -->
 * Tier pricing for bundle products now works as expected: Magento displays the correct price in the cart, and reminds customers that they can buy a specific quantity of the product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages.
 
-### Quick Order
-
-<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 ### Reports
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -13,9 +13,6 @@ title: Magento Commerce 2.2.9 Release Notes
 
 We are pleased to present Magento Commerce 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and  285 community-submitted pull requests. 
 
-Although this release includes these security enhancements, no confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions, so we recommend that you upgrade your Magento software to the latest version as soon as possible.
-
-See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
 
 
@@ -28,7 +25,7 @@ Look for the following highlights in this release:
 
 This release is focused on substantial security enhancements:
 
-* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
 * **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
 
@@ -43,11 +40,6 @@ This release contains 150 enhancements to core quality, which improve the qualit
 * **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 
-
-## Vertex
-
-
-
 ## Functional fixes
 
 In addition to security enhancements, this release contains the following functional fixes. 
@@ -55,29 +47,15 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale dpeloyment takes more than 400 seconds. Previously, Magento threw this error under these conditions, `2436; Status: 0`.
+<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw this error under these conditions, `2436; Status: 0`.
 
 <!-- MAGETWO-76424 -->* Magento no longer displays an extraneous blank option in the country drop-down menu. 
 
 ### AdminGWS
 
-<!-- MAGETWO-98053 -->* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets that the administrator has privilege for. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to. 
+<!-- MAGETWO-98053 -->* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to. 
 
-<!-- MAGETWO-87222 -->* 
-
-
-The cart rules disappear with error: Item (Magento\SalesRule\Model\Rule\Interceptor) with the same ID "140" already exists
-
-ISSUE:
-Cart Price Rules page grid is missing. The "Search" button, number of records found and pagination buttons are there. But the actual table listing existing price rules are not showing. If you add a new price rule, the number of records will increment, but the table remains missing.
-
-Go to MARKETING > Promotions > Cart Price Rules
-
-EXPECTED RESULTS:
-Cart Price Rules grid shows existing cart price rules
-
-ACTUAL RESULTS:
-Cart Price Rules grid is missing
+<!-- MAGETWO-87222 -->* Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible. 
 
 
 ### Backend
@@ -88,7 +66,7 @@ Cart Price Rules grid is missing
 
 <!-- ENGCOM-4121 -->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
-<!-- ENGCOM-4142 -->* FMagento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+<!-- ENGCOM-4142 -->* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
 <!-- ENGCOM-4229 -->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
@@ -102,16 +80,6 @@ Cart Price Rules grid is missing
 <!-- MAGETWO-99000 -->* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
 
 
-<!-- MAGETWO-95281 -->* copy from 231 96418
-
-B2B quote error if a customer is changed to another company
-
-Two companies and each one has its own custom catalog. A customer assigned to one company generates a quote and then that customer is assigned to a different company. The quote no longer shows in the customers account in the quote section of the frontend. An error similar to this is shown:
-
-Requested quote is not found. Row ID: quoteId = <some Id>
-
-
-
 
 <!-- MAGETWO-98553 -->* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog. 
 
@@ -121,7 +89,7 @@ Requested quote is not found. Row ID: quoteId = <some Id>
 
 ### Bundle products
 
-<!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+<!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
 <!-- ENGCOM-4557 -->* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
@@ -130,29 +98,7 @@ Requested quote is not found. Row ID: quoteId = <some Id>
 
 
 
-<!-- MAGETWO-97226 -->* 
-
-Fixed price set for a product in Shared Catalog does not update. The price on storefront and in Admin remains the same.
-
-STEPS TO REPLICATE:
-
-Go to Catalog > Shared Catalogs > Default catalog (also reproduces with a private catalog)
-Go to Set Pricing and Structure
-Click Configure
-Select a product
-Click Next
-Set some fixed price, e.g. 1$ or 0$
-Click Generate Catalog
-Click Save
-Wait for the queue to be processed
-On storefront go to product display page
-Observe that price does not update to the fixed price
-EXPECTED RESULTS:
-The shared catalog product price is used.
-
-ACTUAL RESULTS:
-The product is shown with the original price.
-
+<!-- MAGETWO-97226 -->*  Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
 
 
 
@@ -160,24 +106,23 @@ The product is shown with the original price.
 ### Catalog
 
 <!-- MAGETWO-94426 -->* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
+<!-- MAGETWO-74081 -->* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
-<!-- MAGETWO-74081 -->* You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+<!-- MAGETWO-98626 -->* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404. 
 
-<!-- MAGETWO-98626 -->* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the broweser returned a 404. 
+<!-- MAGETWO-74455 -->* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values. 
 
-<!-- MAGETWO-74455 -->* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the asme attribute values. 
-
-<!-- MAGETWO-74037 -->* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attibute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+<!-- MAGETWO-74037 -->* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
 <!-- MAGETWO-73157 -->* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
-<!-- MAGETWO-72650 -->* Tax recalculation has been moved out of the transation into the backgound for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
+<!-- MAGETWO-72650 -->* Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
 
 <!-- MAGETWO-97472 -->* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level. 
 
 <!-- MAGETWO-97405 -->* You can now use storeview-level attributes to filter products on the products list.
 
-<!-- MAGETWO-97400 -->* The selected store scope view now affetcs the categories dispalyed on theproduct edit page's category tree. 
+<!-- MAGETWO-97400 -->* The selected store scope view now affects the categories displayed on the product edit page's category tree. 
 
 <!-- MAGETWO-97973 -->* Magento now calculates and displays the correct tier price for bundle products.
 
@@ -185,9 +130,9 @@ The product is shown with the original price.
 
 <!-- MAGETWO-97380 -->* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
-<!-- MAGETWO-97425 -->* Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty. 
+<!-- MAGETWO-97425 -->* Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty. 
 
-<!-- MAGETWO-98470 -->* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty. 
+<!-- MAGETWO-98470 -->* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave  special prices empty. 
 
 <!-- MAGETWO-95020 -->* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories. 
 
@@ -207,9 +152,9 @@ The product is shown with the original price.
 
 <!-- ENGCOM-4327 -->* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
-<!-- ENGCOM-4340 -->*  A  product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously price in tnis metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+<!-- ENGCOM-4340 -->*  A  product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
-<!-- ENGCOM-4429 -->*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator  applyied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+<!-- ENGCOM-4429 -->*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, `MinimalTierPriceCalculator`  applied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
 <!-- ENGCOM-4447 -->* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
@@ -226,22 +171,6 @@ s
 
 
 
-### Catalog rule
-
-<!-- MAGETWO-98679 -->* 
-
-Discounts of products disappear on storefront after drag & drop via Visual Merchandiser in category
-
-he drag & drop product via Visual Merchandiser and after this action on storefront on this category disappear discounts on products.
-
-Expected result:
-Catalog rule rule1 should be applied and all products should have a discount
-
-Actual result:
-Product(s) displayed without discounts
-
-
-
 
 
 
@@ -250,34 +179,10 @@ Product(s) displayed without discounts
 
 ### Cart and checkout
 
-<!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shoppping cart for guest customers when **Persistent Shopping Cart** is enabled.
-
-
-<!-- MAGETWO-96375 -->* 
+<!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
 
 
 
-Checkout Free Shipping Recalculation after Coupon Code Added
-
-STEPS TO REPLICATE:
-1. Create Product with price 90
-2. Enable free shipping for order more than 89$
-3. Create Cart price rule with Code for 10% discount
-4. Login to frontend
-5. Add product to cart
-6. Go to checkout 
-7. Apply discount code
- Check that subtotal less than 89
-8. Go to Checkout Shipping step
-
-EXPECTED RESULTS:
-Free shipping should be unavailable
-
-ACTUAL RESULTS:
-Free shipping options available
-
-Case 2
-Apply discount on Payment step
 
 
 
@@ -305,7 +210,7 @@ Apply discount on Payment step
 
 <!-- ENGCOM-4479 -->* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
-<!-- ENGCOM-4369 -->* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw this JavaScript erro,  `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+<!-- ENGCOM-4369 -->* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw this JavaScript error,  `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
 <!-- ENGCOM-4630 -->* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
@@ -326,7 +231,7 @@ Apply discount on Payment step
 
 <!-- ENGCOM- 4123-->* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
-<!-- ENGCOM-4204 -->* Added missing bottom border to the list of customizable options on the product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+<!-- ENGCOM-4204 -->* Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
 <!-- ENGCOM-4230 -->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
@@ -334,12 +239,12 @@ Apply discount on Payment step
 
 <!-- ENGCOM-4247 -->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
-<!-- ENGCOM- 4535-->* Added missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
+<!-- ENGCOM- 4535-->* Added a missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 
 ### Company
 
-<!-- MAGETWO-98381 -->* Magento no longer throws an error when you tryto export a customer report with a description filter. 
+<!-- MAGETWO-98381 -->* Magento no longer throws an error when you try to export a customer report with a description filter. 
 
 
 
@@ -349,9 +254,9 @@ Apply discount on Payment step
 
 <!-- MAGETWO-97332 -->* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
-<!-- ENGCOM-4308 -->* Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+<!-- ENGCOM-4308 -->* Fixed misalignment of fields on the Configure Product page that is accessed from the wishlist. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
-<!-- ENGCOM-4092 -->* You can now  successfully run `bin/magneto setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed this error, `Attribute with ID "Manufacturer" does not exist`.  *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
+<!-- ENGCOM-4092 -->* You can now  successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed this error, `Attribute with ID "Manufacturer" does not exist`.  *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
 
 <!-- ENGCOM-4470 -->* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
@@ -365,10 +270,7 @@ Apply discount on Payment step
 
 ### CMS
 
-<!-- MAGETWO-99818 -->* 
-
-
-Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
+<!-- MAGETWO-99818 -->* Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
 
 
 
@@ -392,17 +294,16 @@ Additional permissions added for updating "Design" fieldset of categories, produ
 
 <!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless  configued for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
-<!-- MAGETWO-97412 -->* You can now crreate customer segments that exceed 1,500,000 customers. Previously, Magento displayed a 500 error when you tried to create a customer segment that included more than 3312436 customers.
 
 <!-- ENGCOM-4132 -->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
 <!-- ENGCOM-4187 -->* Removed an empty block on the My Account page sidebar. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
-<!-- ENGCOM-4284 -->* The Customer Name Prefix on the customer configuration page no longer displays extraneous shows white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+<!-- ENGCOM-4284 -->* The Customer Name Prefix on the customer configuration page no longer displays extraneous  white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
 <!-- ENGCOM-4367 -->* The customer login block  (defined as `Magento\Customer\Block\Form\Login`)  no longer sets the page title. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
-<!-- ENGCOM-4476 -->* The default sort order for the shopping cart and customer orders page is now by create date in descending order. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+<!-- ENGCOM-4476 -->* The default sort order for the shopping cart and customer orders page now begins with the latest create date and descends. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
 <!-- ENGCOM-4213 -->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
@@ -412,31 +313,7 @@ Additional permissions added for updating "Design" fieldset of categories, produ
 
 
 
-<!-- MAGETWO-98044 -->* copy 98087
-
-
-TEPS
-Admin > Stores > Configuration > Customers > Customer Configuration > Create New Account Options > Default Groups
-Set Default Customer Group = Wholesale for Default Website
-Set Default Customer Group = Retailer for Second Website
-Set Enable Automatic Assignment to Customer Group to Yes
-Start creating an order from Admin for sample data customer Veronica which is already assigned to General group
- EXPECTED RESULT
-Group remains General for customer which was already assigned to some customer group
- ACTUAL RESULT
-The group is switched to Retailer
-Try to switch group back to General
- EXPECTED RESULT
-Customer group can be switched when creating an order
- ACTUAL RESULT
-The group is automatically switched back to Retailer
-
-
-ISSUE
-1. When loading a customer in backend order with a customer group already defined, example USA Dealer 20%, it would revert back to the config default of "General". This should take into account the customer group already set and saved for the customer. 
-2. When trying to choose a customer group on a new order with a new customer, the default selection was working and wasn't reverting back to Store #1 customer group. 
-3. The big issue here is when changing the customer group to a Dealer group (Any customer group that will give cart / catalog discount) that is meant to give discount, the order/invoice comes through with no discount and uses the General group again once placing the order. So for all our B2B customers in the last two days our sales processed orders but resulted in no discount given even when the customer group was selected.
-
+<!-- MAGETWO-98044 -->* When loading an order for a customer already assigned to a customer group, Magento now shows the assigned customer group in the order information.  Additionally, Magento now saves the group assignment if you change it when creating a customer order. Previously, the customer group reverted to the default configured group assignment for customers with an existing group assignment. On new orders, if you changed the customer group during the ordering process, the new assignment was not saved. When you loaded the customer order, the customer group showed the default group instead of the group assignment applied during the ordering process.
 
 
 
@@ -485,36 +362,16 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 ### EAV
 
-<!-- ENGCOM-4632 -->* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization,both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+<!-- ENGCOM-4632 -->* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
-
-
-
-<!-- ENGCOM-4518 -->*
-
-Fixed-Quantity_and_stock_status when visibility set to storefront throwing exception
-
-
-Steps to reproduce 
-To reproduce the issue. Please follow the below steps,
-
-1.Product attribute grid -> select Quantity attribute-> Storefront Properties -> Change Visible on Catalog 2.Pages on Storefront to Yes
-
-Expected result 
-Attribute should visible on frontend
-
-Actual result
-1.Exception whille catalog product view
-
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
+<!-- ENGCOM-4518 -->* Magento no longer throws an exception when the  `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 
 
 
 ### Email
 
-<!-- ENGCOM-4305 -->* Corrected problems with the disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+<!-- ENGCOM-4305 -->* Corrected problems with  disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
 
 
@@ -528,7 +385,7 @@ Actual result
 
 <!-- ENGCOM-4354 -->* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
 
-<!-- ENGCOM-4395 -->* The module ranking in the app/etc/config now reamins consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
+<!-- ENGCOM-4395 -->* The module ranking in  `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
 
 <!-- ENGCOM-4542 -->*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
@@ -541,8 +398,6 @@ Actual result
 
 #### JavaScript framework
 
-
-
 <!-- ENGCOM-4610 -->* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 
@@ -553,59 +408,12 @@ Actual result
 
 ### General
 
-<!-- ENGCOM-2667 -->*
-
-
-Steps to reproduce
-Login to Admin
-go to Stores -> All Stores.
-Sort by any column
-Actual result
-sorting doesn't work
+<!-- ENGCOM-2667 -->* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
 
 
-*Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
-
-<!-- ENGCOM-4516 -->*
-
-
-Allow BEM class via attribute tag
-
-Adding BEM class in XML via attribute tag causes class to be rewritten
-
-Steps to reproduce
-Go to default.xml
-Add attribute tag with a class to the body element i.e. <attribute name="class" value="background-color--white"/>
-Clear cache and reload page
-Expected result
-Class should be rendered as it is added in the XML i.e. background-color--white
-Actual result
-Classes with -- in them are replaced with a single - so result appears as background-color-white
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21804](https://github.com/magento/magento2/pull/21804)*. [GitHub-10645](https://github.com/magento/magento2/issues/10645)
-
-
-
-<!-- ENGCOM-4548 -->*
-
-Product attribute labels are translated
-
-Steps to reproduce 
-Add product attribute into product page.
-Add store specific label
-add same phrase into translation file
-
-Expected result 
-Attribute label is not translated and kept as set in admin (store specific label)
-
-Actual result 
-Attribute label is translated
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
-
-
+<!-- ENGCOM-4548 -->* Product attribute labels are no longer translated but maintain their store-specific valu *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
 <!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
 
@@ -613,41 +421,20 @@ Attribute label is translated
 
 ### Gift card account
 
-<!-- MAGETWO-98000 -->* Gift card accounta are now created as expected when gift card orders are authorized and captured with PayPal Express.
+<!-- MAGETWO-98000 -->* Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
 
 
 
 ### Import/export
 
-<!-- MAGETWO-96895 -->* 
+<!-- MAGETWO-96895 -->* The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
 
-Merchant reports when you choose "Skip error entries" as the validation method for the import, Magento will continue to try to validate data and won't let you process the import. Is this the way this is designed to work? Thank you!
-
-*REPRODUCE*
-
-Go to System > Import
-Try to validate an import.csv where one sku is correct and second is incorrect
-EXPECTED RESULT: 
-Validation process should consider Skip error entries value
-
-ACTUAL RESULT: 
-Validation process doesn't consider Skip error entries value and prevents import
-
-
-
-
-
-<!-- MAGETWO-98694 -->* 
-
-URL key of product doesn't saved correctly if fill it in Arabic.
-
-
-Translated Arabic URL's are returning 404's
+<!-- MAGETWO-98694 -->* Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors. 
 
 
 ### Indexers
 
-<!-- ENGCOM-4555 -->* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin's indexer list,  Magento threw a fatal error.*Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+<!-- ENGCOM-4555 -->* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list,  Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
  
 
 
@@ -655,7 +442,7 @@ Translated Arabic URL's are returning 404's
 
 <!-- ENGCOM-4570 -->* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
-<!-- ENGCOM-4484 -->* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contined logic.  *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
+<!-- ENGCOM-4484 -->* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic.  *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
 
 <!-- ENGCOM-4587 -->* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
@@ -689,44 +476,23 @@ Translated Arabic URL's are returning 404's
 
 <!-- ENGCOM-4593 -->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
 
-### PAge Cache
+### Page Cache
 
-<!-- MAGETWO-90953 -->* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode. 
+<!-- MAGETWO-90953 -->* Page caching is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode. 
 
 
 
 ### Payment methods
 
-<!-- MAGETWO-98991 -->*   Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.  
+<!-- MAGETWO-98991 -->*   Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.  
 
+<!-- MAGETWO-98670 -->* Magento now displays the account owner name that you've specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified. 
 
-
-<!-- MAGETWO-98670 -->* 
-
-
-Enable Braintree through Paypal
-Add a product to the cart
-Go to the cart page and click on the blue Paypal button
-Log in to the Paypal account
-Add a new shipping address for a different person (not the owner of the account)
-When you return to Magento, the account owner's name is listed on the Shipping Address
- EXPECTED RESULTS:
-When using Braintree through Paypal, if you add a Shipping Address on the Paypal with a different name, that specified name should be displayed when redirected to Magento
-
- ACTUAL RESULTS:
-When using Braintree through Paypal, if you add a Shipping Address on the Paypal with a different name, the account owner's name is displayed when redirected to Magento
-
-<!-- MAGETWO-98431 -->*  
-
-
-Paypal securetoken/securetokenId can be compromised	
-
-
-
+<!-- MAGETWO-98431 -->*  The PayPal  `securetoken` and `securetokenid`  are no longer vulnerable to compromise. 
 
 <!-- MAGETWO-96137 -->* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
 
-<!-- ENGCOM-4328 -->* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to supprt accessibility. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+<!-- ENGCOM-4328 -->* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
 <!-- MAGETWO-98111 -->* You can now place an order using Cybersource payment from the Admin. 
 
@@ -738,7 +504,7 @@ Paypal securetoken/securetokenId can be compromised
 
 <!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
 
-<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the product tha.
+<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 <!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
 
@@ -747,7 +513,7 @@ Paypal securetoken/securetokenId can be compromised
 
 ### Quick Order
 
-<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the product tha.
+<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 
 
@@ -773,14 +539,6 @@ Paypal securetoken/securetokenId can be compromised
 <!-- ENGCOM- 4539-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 
-
-
-
-### Reward
-
-
-
-
 ### RMA
 
 <!-- MAGETWO-93976 -->* Product-level RMA disabling now works as expected.
@@ -792,36 +550,12 @@ Paypal securetoken/securetokenId can be compromised
 
 <!-- MAGETWO-97008 -->* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price (specifically, the  price column  contains the custom price excluding tax). Previously, the `sales_order_item` table's price column displayed the custom price including tax. 
 
-
-
-
-
-<!-- MAGETWO-97096 -->* 
-
-Multistore Allowed Countries List Problem
-
-ACTUAL RESULT
-No validation error about missing shipping country.
-On placing the order 'Invalid value of "US" provided for the countryId field.' error is displayed
-
-EXPECTED RESULT
-New customer is created for the 2nd website
-The order is placed without errors
-
-
-
-
-
+<!-- MAGETWO-97096 -->* Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted. 
 
 <!-- ENGCOM-4280 -->*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
 
-<!-- ENGCOM-4361 -->*
 
-*Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
-
-
-Same as 3910
 
 
 <!-- ENGCOM-3968 -->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
@@ -844,47 +578,13 @@ Same as 3910
 <!-- ENGCOM-4485 -->* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
 
 
-<!-- ENGCOM-4540 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21845](https://github.com/magento/magento2/pull/21845)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
-
-
-Unresolved (same as 4406)
-
 
 ### Search
 
 
-<!-- MAGETWO-97914 -->* 
+<!-- MAGETWO-97374 -->* Layered navigation results no longer includes price ranges that contain no products. 
 
-The current problem is that the catalogsearch indexer is taking about 17 hours to complete.
-Merchant has 20k items. Previously we had suggested them to upgrade ES to 5.2. Initially SI mentions that it used to take about a couple of hours to complete, after the upgrade they noticed the time increased to 17 hours.
-Reindexing takes less then 10 minutes with MySQL though
-I've tested DB dumps with clean 2.2.7 code and reindexing still takes too long. 
-The problem occurs only with DB dumps, not on celan instance.
-
-
-
-<!-- MAGETWO-97374 -->* Layered navigation results no longer include price ranges that contain no products. 
-
-
-<!-- ENGCOM-4082 -->*
-
-Quick search by SKU not working properly
-
-Try to search products with end of string like "-" or "-"
-The exception error appear Unexpected $end
-
-Exceptions when search product with sku like "42-" 
-
-
-
-
-*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
-
-
-
-
+<!-- ENGCOM-4082 -->* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
 
 <!-- ENGCOM-4209 -->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
@@ -894,24 +594,6 @@ Exceptions when search product with sku like "42-"
 
 ### Shipping 
 
-<!-- ENGCOM-3602 -->*
-
-Fix DHL Quotes for Domestic Shipments when Content Type is set to Non-Document 
-
-DHL Shipping Quotes fail for Domestic Shipments when Content Mode is "Non Documents"
-
-Steps to reproduce
-Setup DHL module to obtain quotes via XML
-Setup store as ship from address SW1 1AA, GB
-Set DHL Content Type to Non Documents
-Attempt to obtain shipping quote for destination SW1 1AA, GB
-Expected result 
-
-A quote is obtained
-Actual result 
-
-
-*Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19488](https://github.com/magento/magento2/pull/19488)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
 
 
 
@@ -925,21 +607,14 @@ Actual result
 
 <!-- MAGETWO-92495 -->* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed. 
 
-<!-- ENGCOM-4120 -->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+<!-- ENGCOM-4120 -->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
-
-<!-- ENGCOM-4477 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21695](https://github.com/magento/magento2/pull/21695)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
-
-
-Same as 3608
 
 
 
 ### Tax
 
-<!-- ENGCOM-4434 -->*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error.*Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+<!-- ENGCOM-4434 -->*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
 <!-- ENGCOM-4439 -->* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
@@ -965,11 +640,11 @@ Same as 3608
 
 <!-- ENGCOM-4011 -->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
-<!-- ENGCOM-3974 -->* Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+<!-- ENGCOM-3974 -->* Fixed issue where the drop-down toggle arrow did not close as expected on product pages. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
 <!-- ENGCOM-4311 -->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
-<!-- ENGCOM-4317 -->* The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+<!-- ENGCOM-4317 -->* The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
 <!-- ENGCOM-4366 -->* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw this error,  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
@@ -983,31 +658,8 @@ Same as 3608
 
 
 
-<!-- MAGETWO-98208 -->*
 
-The system allows creating a product which will have a system or non-human readable URLs
-
-URLs not using SEO friendly format if you assign to website
-
-ACTUAL RESULTS
-You will see the product has url like catalog/product/view/id/1/s/testproduct-overriden/category/3/
-
-EXPECTED BEHAVIOUR
-Url should have human-readable URL e.g: testingproduct.
-
-
-
-
-<!-- MAGETWO-97898 -->*
-
-Store switcher URL redirects to the same store
-
-Visiting the URL in the format `http://mysite.com/<store_view_b>/stores/store/switch/_store/<store_view_a>/_from_store/<store_view_b>` does not redirect to Store View A - it stays at store view B
-
-
-
-
-<!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button.*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+<!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 
 <!-- ENGCOM-4116 -->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
@@ -1026,36 +678,6 @@ Visiting the URL in the format `http://mysite.com/<store_view_b>/stores/store/sw
 
 
 
-### Web API framework
-
-<!-- MAGETWO-73978 -->*
-
-API call with pageSize and currentPage > items should return error	
-
-In catalogProductRepositoryV1, it's possible to specify searchCriteria[pageSize] and searchCriteria[currentPage].
-
-Example: GET http://<hostname>/index.php/rest/V1/products?searchCriteria[pageSize]=10&searchCriteria[currentPage]=2
-
-Consider the case where there are 1,000 products in the product catalog.
-
-Case 1: Query within number of products available:
-searchCriteria[pageSize]=10&searchCriteria[currentPage]=2
-
-Expected Result:
- API returns 10 results from page 2 (items 11-20 in database)
-
-Actual Result:
- Performs as expected
-
-Case 2: Query beyond number of products available:
-searchCriteria[pageSize]=1000&searchCriteria[currentPage]=50
-
-Expected Result:
- API returns error, because page 50 with size of 1000 would start with item 49,001, which does not make sense because there are only 1,000 products.
-
-Actual Result:
- API "wraps" through results, ignores the specified currentPage value, and returns same results as the highest valid currentPage
-
 
 
 
@@ -1070,13 +692,6 @@ Actual Result:
 
 
 
-
-## Known issues
-
-
-
-
-
 ## Community contributions
 
 This release includes substantial community contributions: over 100 GitHub issues resolved and over 350 pull requests merged. We are grateful to the wider Magento community for this effort and would like to acknowledge their contributions to this release.
@@ -1086,14 +701,12 @@ This release includes substantial community contributions: over 100 GitHub issue
 
 The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
 
-{% include release-notes/engcomm-2-2-8-issues.md %}
 
 
 ### Partner contributions
 
 The following table highlights contributions made by Partners. This table lists the Partner who contributed the pull request, the external pull request, and the GitHub issue number associated with it (if available). 
 
-{% include release-notes/engcomm-2-2-8-partner.md %}
 
 ### System requirements
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -1,0 +1,1265 @@
+---
+group: release-notes
+title: Magento Commerce 2.2.9 Release Notes
+
+---
+
+
+*Release notes published on  2019.*
+
+
+
+
+
+We are pleased to present Magento Commerce 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and  285 community-submitted pull requests. 
+
+Although this release includes these security enhancements, no confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions, so we recommend that you upgrade your Magento software to the latest version as soon as possible.
+
+See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+
+
+
+## Highlights
+
+Look for the following highlights in this release:
+
+### Merchant tool enhancements
+
+
+  
+### Substantial security enhancements
+
+These releases include security enhancements that help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+
+
+### Infrastructure improvements
+
+
+
+### Bundled extension enhancements
+
+This release of Magento includes extensions developed by third-party vendors. 
+
+
+#### dotdigital Engagement Cloud (formerly dotmailer)
+
+
+#### Magento Shipping
+
+
+
+#### Vertex
+
+
+
+## Functional fixes
+
+In addition to security enhancements, this release contains the following functional fixes. 
+
+
+### Installation, setup, and deployment
+
+
+
+
+
+### Backend
+
+<!-- ENGCOM-4517 -->*
+*Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+
+
+Unresolved (same as 4452)
+
+
+
+<!-- ENGCOM-4435 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+
+Same as 4377
+
+
+<!-- ENGCOM-4121 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+
+Copy from 2.3.1 4029
+
+
+
+
+<!-- ENGCOM-4142 -->*
+*Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+
+Copy from 2.3.1 4029
+
+
+
+<!-- ENGCOM-4229 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
+
+Copy from 2.3.1 4113
+
+
+
+
+
+### B2B
+
+
+
+### Bundle products
+
+<!-- ENGCOM-4041 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+
+Copy from 2.3.1 3948
+
+
+
+<!-- ENGCOM-4557 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+
+232 4507
+
+
+<!-- ENGCOM-4143 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
+
+
+Copy from 2.3.1 3871
+
+
+
+
+
+
+
+
+### CAPTCHA
+
+
+
+
+
+### Catalog
+
+<!-- ENGCOM-3697 -->*
+
+*Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+
+backport from 2.3.1 3698
+
+
+
+<!-- ENGCOM-4245 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+
+Copy from 4001
+
+
+
+<!-- ENGCOM-4030 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+
+
+
+<!-- ENGCOM-4254 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+
+
+Copy from 2.3.1 4093
+
+<!-- ENGCOM-4236 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+
+Copy from 2.3.1 4150
+
+
+
+<!-- ENGCOM-4253 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21199](https://github.com/magento/magento2/pull/21199)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
+
+
+<!-- ENGCOM-4292 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+
+
+(2.3.2  4217)
+
+
+
+
+<!-- ENGCOM-4290 -->*
+
+*Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+
+
+Copy from 2.3.1 3184
+
+
+
+
+<!-- ENGCOM-4327 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+
+2.3.2 4207
+
+
+<!-- ENGCOM-4340 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+
+
+Same as 3767
+
+
+<!-- ENGCOM-4429 -->*
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+
+
+Same as 4360
+
+
+
+<!-- ENGCOM-4447 -->*
+
+*Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+
+
+Same as 4065
+
+
+
+
+<!-- ENGCOM-4182 -->*
+
+*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
+
+
+
+
+<!-- ENGCOM-4271 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+
+
+(4202 — 2.3.2) 
+
+
+
+<!-- ENGCOM-4020 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+
+
+
+Copy from 231 3771
+
+
+
+<!-- ENGCOM-4514 -->*
+
+*Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
+
+
+
+Same as 4490
+
+
+
+
+
+### Catalog rule
+
+
+
+### Cart and checkout
+
+
+
+
+<!-- ENGCOM-4013 -->*
+
+*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+
+
+
+<!-- ENGCOM-4283 -->*
+
+*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+
+
+
+
+<!-- ENGCOM-4127 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+
+Copy from 2.3.1 4032
+
+
+
+<!-- ENGCOM-4043 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+	•	
+Copy from 2.3.1 3971
+
+
+<!-- ENGCOM- 4133-->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+
+
+
+
+
+Copy from 2.3.1 3938
+
+
+
+<!-- ENGCOM-4205 -->*
+
+*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+
+
+Copy from 2.3.1 4066
+
+
+<!-- ENGCOM-4390 -->*
+
+*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
+
+
+
+Same as 3477
+
+
+<!-- ENGCOM-4421 -->*
+
+*Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
+
+
+Same as 4355
+
+
+
+
+
+<!-- ENGCOM-4436 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+
+
+Same as 4436
+
+
+<!-- ENGCOM-4479 -->*
+
+*Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
+
+
+Same as 4362
+
+
+
+
+<!-- ENGCOM-4369 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+
+
+
+<!-- ENGCOM-4630 -->*
+
+*Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
+
+
+
+<!-- ENGCOM-4622 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+
+
+### Checkout agreements
+
+<!-- ENGCOM-3989 -->*
+
+*Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
+
+Copy from 2.3.1 3231
+
+
+<!-- ENGCOM- -->*
+
+
+
+
+
+### Clean up and minor refactoring
+
+<!-- ENGCOM-4304 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+
+
+
+Copy from 2.3.1 4036
+
+
+
+<!-- ENGCOM- 4123-->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+
+Copy from 2.3.1 3901
+
+
+
+
+
+<!-- ENGCOM-4204 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+
+
+Copy from 2.3.1 3936
+
+
+
+<!-- ENGCOM-4230 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+
+
+<!-- ENGCOM-4239 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+
+Copy from 2.3.1 4130
+
+
+
+<!-- ENGCOM-4247 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+
+Copy from 2.3.1 4052
+
+<!-- ENGCOM- 4535-->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
+
+(same as 4475)
+
+
+
+
+### Configurable products
+
+<!-- ENGCOM-4308 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+
+
+
+Copy from 2.3.1 4053
+
+
+
+
+<!-- ENGCOM-4092 -->*
+
+*Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
+
+
+
+
+
+
+<!-- ENGCOM-4470 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
+
+
+Same as 3963
+
+
+
+
+
+
+
+
+### CMS
+
+
+<!-- ENGCOM-4200 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+
+
+Copy from 2.3.1 4051
+
+
+
+
+
+
+
+### Customer
+
+<!-- ENGCOM-4132 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+
+
+Copy from 4028
+
+
+
+
+
+<!-- ENGCOM-4187 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+
+
+
+
+Copy from 2.3.1 3981
+
+
+
+<!-- ENGCOM-4284 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+
+(2.3.2 4146)
+
+
+
+<!-- ENGCOM-4367 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
+
+
+Same as 4047
+
+
+<!-- ENGCOM-4476 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+
+
+Same as 4431
+
+
+
+
+<!-- ENGCOM-4213 -->*
+
+*Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
+
+
+
+Copy from 2.3.1 4063
+
+
+
+### Customer custom attributes
+
+
+
+
+
+### Developer
+
+
+
+### Directory
+
+<!-- ENGCOM-4234 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
+
+
+
+
+Copy from 2.3.1 4114
+
+
+
+### Downloadable
+
+<!-- ENGCOM- 4297-->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+
+
+
+(2.3.2 3794)
+
+
+<!-- ENGCOM-4466 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+
+
+Same as 4345
+
+
+
+### EAV
+
+<!-- ENGCOM-4632 -->*
+
+*Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+
+
+
+
+<!-- ENGCOM-4518 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
+
+
+
+
+
+<!-- ENGCOM- -->*
+
+<!-- ENGCOM- -->*
+
+
+### Email
+
+<!-- ENGCOM-4305 -->*
+
+*Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+
+
+
+2.3.2 4101 
+
+
+### Frameworks
+
+<!-- ENGCOM-4068 -->*
+
+*Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+
+
+
+Copy from 2.3.1 3524
+
+<!-- ENGCOM- 4286-->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+
+(2.3.2 3932)
+
+
+
+<!-- ENGCOM-4354 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
+
+
+
+Same as 3543
+
+
+<!-- ENGCOM-4395 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
+
+Same as 4223
+
+
+
+
+
+<!-- ENGCOM-4542 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
+
+
+(Same as 4104)
+
+
+
+
+
+
+<!-- ENGCOM- -->*
+
+
+
+
+#### Cache framework
+
+<!-- ENGCOM-4183 -->*
+*Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+
+
+Copy from 2.3.1 3666
+
+
+#### JavaScript framework
+
+
+
+<!-- ENGCOM-4610 -->*
+
+*Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+
+
+
+
+
+
+
+### General
+
+<!-- ENGCOM-2667 -->*
+
+*Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
+
+
+<!-- ENGCOM-4516 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21804](https://github.com/magento/magento2/pull/21804)*. [GitHub-10645](https://github.com/magento/magento2/issues/10645)
+
+
+
+<!-- ENGCOM-4548 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
+
+
+
+<!-- ENGCOM-4272 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
+
+(4241 — 2.3.2)
+
+
+
+
+### Gift card
+
+
+### Gift registry
+
+
+
+
+### Google Analytics
+
+
+
+
+
+
+### Image
+
+
+
+
+
+
+### Import/export
+
+
+### Indexers
+
+<!-- ENGCOM-4555 -->*
+
+*Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+
+Unresolved (same as 4440)
+
+
+
+### Infrastructure
+
+<!-- ENGCOM-4570 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+
+
+
+<!-- ENGCOM-4484 -->*
+*Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
+
+
+
+<!-- ENGCOM-4587 -->*
+
+*Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+
+<!-- ENGCOM-4626 -->*
+
+*Fix submitted by [Lars Roettig](https://github.com/larsroettig) in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
+
+
+
+### Integration
+
+
+
+### Layered navigation
+
+
+
+
+### Magento Shipping
+
+
+
+
+
+### Newsletter
+
+<!-- ENGCOM-4303 -->*
+
+*Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
+
+
+2.3.2 3992
+
+
+
+
+
+### Offline shipping
+
+### Orders
+
+<!-- ENGCOM-4593 -->*
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+
+
+
+### Payment methods
+
+<!-- ENGCOM-4328 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+
+
+2.3.2 4192
+
+
+
+
+### Pricing
+
+
+
+
+### Quote
+
+
+
+
+### Reports
+
+<!-- ENGCOM-4445 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
+
+Same as 3808
+
+
+
+
+
+
+
+### Review
+
+<!-- ENGCOM- 4006-->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+
+
+Copy from 2.3.1 3835
+
+
+
+<!-- ENGCOM- 4539-->*
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
+
+Copy from 2.3.1 4096
+
+
+
+
+
+
+### Reward
+
+
+
+
+### RMA
+
+
+
+### Sales
+
+<!-- ENGCOM-4280 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+
+
+Same as 4154
+
+
+<!-- ENGCOM-4361 -->*
+
+*Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+
+
+Same as 3910
+
+
+<!-- ENGCOM-3968 -->*
+
+*Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
+
+Copy from 2.3.1 3225
+
+ 
+
+
+
+
+<!-- ENGCOM-4403 -->*
+
+*Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
+
+
+Same as 4321
+
+
+
+<!-- ENGCOM-4272 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+
+
+
+<!-- ENGCOM-4285 -->*
+
+*Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
+
+
+
+(2.3.2 4197) 
+
+
+<!-- ENGCOM-4272 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-21144](https://github.com/magento/magento2/issues/21144)
+
+
+
+
+
+
+### Sales rule
+
+
+<!-- ENGCOM-4485 -->*
+*Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
+
+
+Same as 3679
+
+<!-- ENGCOM-4540 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21845](https://github.com/magento/magento2/pull/21845)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
+
+
+Unresolved (same as 4406)
+
+
+### Search
+
+<!-- ENGCOM-4082 -->*
+*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
+
+
+
+
+
+<!-- ENGCOM-4209 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+
+
+Copy from 2.3.1 3991
+
+
+<!-- ENGCOM-4559 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
+
+
+
+<!-- ENGCOM-4082 -->*
+
+*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-9988](https://github.com/magento/magento2/issues/9988)
+
+
+
+
+### Shipping 
+
+<!-- ENGCOM-3602 -->*
+
+*Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19488](https://github.com/magento/magento2/pull/19488)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
+
+
+
+
+
+
+### Staging
+
+
+
+
+
+### Store
+
+
+
+
+
+### Swatches
+
+<!-- ENGCOM-4120 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+
+Copy from 2.3.1 3920
+
+
+<!-- ENGCOM-4477 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21695](https://github.com/magento/magento2/pull/21695)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
+
+
+Same as 3608
+
+
+
+
+
+### TargetRule
+
+
+
+
+
+
+### Tax
+
+<!-- ENGCOM-4434 -->*
+*Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+
+
+<!-- ENGCOM-4439 -->*
+
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+
+Same as 4359
+
+
+
+### Testing
+
+<!-- ENGCOM-4415 -->*
+*Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
+
+
+(Same as 4300)
+
+
+
+### Theme
+
+
+
+
+
+### UI
+
+<!-- ENGCOM-4427 -->*
+
+*Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+
+
+
+<!-- ENGCOM-4598 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+
+
+
+<!-- ENGCOM-4088 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+
+
+Copy from 2.3.1 4019
+
+
+
+<!-- ENGCOM-4011 -->*
+*Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+
+
+Copy from 2.3.1 3822
+
+
+
+<!-- ENGCOM-3974 -->*
+
+*Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+
+Copy from 2.3.1 3842
+
+
+
+<!-- ENGCOM-4311 -->*
+*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+
+Copy from 2.3.1 3267
+
+
+<!-- ENGCOM-4317 -->*
+
+*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+
+2.3.2 4270
+
+
+
+<!-- ENGCOM-4366 -->*
+
+*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+
+
+
+Same as 4152
+
+
+
+<!-- ENGCOM-4444 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
+
+Same as 4250
+
+
+
+
+###  URL rewrite
+
+
+<!-- ENGCOM-4621 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+
+
+<!-- ENGCOM-4116 -->*
+
+*Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+
+Copy from 2.3.1 3925
+
+
+<!-- ENGCOM-4224 -->*
+
+*Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
+
+
+
+Copy from 2.3.1 4050
+
+
+
+### VAT ID
+
+<!-- ENGCOM-4232 -->*
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+
+
+
+
+### Visual Merchandiser
+
+
+
+### Web API framework
+
+
+
+### Widget
+
+
+
+
+### Wishlist
+
+<!-- ENGCOM-4513 -->*
+
+*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
+
+Same as 4460
+
+
+
+
+
+### WYSIWG
+
+
+
+## Known issues
+
+
+
+
+
+## Community contributions
+
+This release includes substantial community contributions: over 100 GitHub issues resolved and over 350 pull requests merged. We are grateful to the wider Magento community for this effort and would like to acknowledge their contributions to this release.
+
+
+### Individual contributor contributions
+
+The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
+
+{% include release-notes/engcomm-2-2-8-issues.md %}
+
+
+### Partner contributions
+
+The following table highlights contributions made by Partners. This table lists the Partner who contributed the pull request, the external pull request, and the GitHub issue number associated with it (if available). 
+
+{% include release-notes/engcomm-2-2-8-partner.md %}
+
+### System requirements
+
+Our technology stack is built on PHP and MySQL. For details, see [Technology stack requirements]({{page.baseurl}}/install-gde/system-requirements-tech.html).
+
+
+### Installation and upgrade instructions
+
+See [How to get the Magento software](http://devdocs.magento.com/guides/v2.2/install-gde/bk-install-guide.html) for complete installation and upgrade information.
+
+
+## Migration toolkits
+
+The <a href="{{ page.baseurl }}/migration/migration-migrate.html" target="_blank">Data Migration Tool</a> helps transfer existing Magento 1.x store data to Magento 2.x. This command-line interface includes verification, progress tracking, logging, and testing functions. For installation instructions, see  <a href="{{ page.baseurl }}/migration/migration-tool-install.html" target="_blank">Install the Data Migration Tool</a>. Consider exploring or contributing to the <a href="https://github.com/magento/data-migration-tool" target="_blank"> Magento Data Migration repository</a>.
+
+The <a href="https://github.com/magento/code-migration" target="_blank">Code Migration Toolkit</a> helps transfer existing Magento 1.x store extensions and customizations to Magento 2.2.x. The command-line interface includes scripts for converting Magento 1.x modules and layouts.

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -4,22 +4,13 @@ title: Magento Commerce 2.2.9 Release Notes
 
 ---
 
-
 *Release notes published on June 26, 2019.*
 
-
-
-
-
-We are pleased to present Magento Commerce 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and  285 community-submitted pull requests. 
-
-
-
+We are pleased to present Magento Commerce 2.2.9. This release includes over 30 critical enhancements to product security, over 150 core code fixes and enhancements, and 285 community-submitted pull requests.
 
 ## Highlights
 
 Look for the following highlights in this release:
-
 
 ### Substantial security enhancements
 
@@ -27,424 +18,465 @@ This release is focused on substantial security enhancements:
 
 * **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
-* **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
+* **Google reCAPTCHA module for PayPal Payflow checkout**. The new Paypal Recaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form. This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html). <!--- MC-15427-->
 
 ### Infrastructure improvements
 
-This release contains 150 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements: 
+This release contains 150 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`, `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements:
 
-* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.  <!--- MAGETWO-98424-->
+* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.
+<!--- MAGETWO-98424-->
 
-* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**.The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947--> 
+* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
 
 * **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 
 ## Functional fixes
 
-In addition to security enhancements, this release contains the following functional fixes. 
-
+In addition to security enhancements, this release contains the following functional fixes.
 
 ### Installation, setup, and deployment
 
-<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw this error under these conditions, `2436; Status: 0`.
+<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`.
 
-<!-- MAGETWO-76424 -->* Magento no longer displays an extraneous blank option in the country drop-down menu. 
+<!-- MAGETWO-76424 -->* Magento no longer displays an extraneous blank option in the country drop-down menu.
 
 ### AdminGWS
 
-<!-- MAGETWO-98053 -->* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to. 
+<!-- MAGETWO-98053 -->
+* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to.
 
-<!-- MAGETWO-87222 -->* Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible. 
-
+<!-- MAGETWO-87222 -->
+* Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible.
 
 ### Backend
 
-<!-- ENGCOM-4517 -->* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+<!-- ENGCOM-4517 -->
+* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
 
-<!-- ENGCOM-4435 -->*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+<!-- ENGCOM-4435 -->
+* Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
 
-<!-- ENGCOM-4121 -->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+<!-- ENGCOM-4121 -->
+* Fixed the alignment of the time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
-<!-- ENGCOM-4142 -->* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+<!-- ENGCOM-4142 -->
+* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
-<!-- ENGCOM-4229 -->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
-
-
-
-
-
+<!-- ENGCOM-4229 -->
+* Fixed the alignment of the reload CAPTCHA icon on the Admin login page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
 ### B2B
 
-<!-- MAGETWO-99000 -->* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
+<!-- MAGETWO-99000 -->
+* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
+
+<!-- MAGETWO-98553 -->
+* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog.
 
 
-
-<!-- MAGETWO-98553 -->* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog. 
-
-
-<!-- MAGETWO-98678 -->* You can now add backordered products to the cart when backorders are enabled. 
-
+<!-- MAGETWO-98678 -->
+* You can now add backordered products to the cart when backorders are enabled.
 
 ### Bundle products
 
-<!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+<!-- ENGCOM-4041 -->
+* Fixed the alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
-<!-- ENGCOM-4557 -->* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+<!-- ENGCOM-4557 -->
+* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
-<!-- ENGCOM-4143 -->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
+<!-- ENGCOM-4143 -->
+* Fixed the alignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
-
-
-
-<!-- MAGETWO-97226 -->*  Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
-
-
-
+<!-- MAGETWO-97226 -->
+* Magento now displays the correct price on the storefront for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
 
 ### Catalog
 
-<!-- MAGETWO-94426 -->* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
-<!-- MAGETWO-74081 -->* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+<!-- MAGETWO-94426 -->
+* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
 
-<!-- MAGETWO-98626 -->* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404. 
+<!-- MAGETWO-74081 -->
+* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
-<!-- MAGETWO-74455 -->* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values. 
+<!-- MAGETWO-98626 -->
+* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
 
-<!-- MAGETWO-74037 -->* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+<!-- MAGETWO-74455 -->
+* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values.
 
-<!-- MAGETWO-73157 -->* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
+<!-- MAGETWO-74037 -->
+* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
-<!-- MAGETWO-72650 -->* Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
+<!-- MAGETWO-73157 -->
+* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the configurabe options from the newly created product to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
-<!-- MAGETWO-97472 -->* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level. 
+<!-- MAGETWO-72650 -->
+* Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
 
-<!-- MAGETWO-97405 -->* You can now use storeview-level attributes to filter products on the products list.
+<!-- MAGETWO-97472 -->
+* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level. 
 
-<!-- MAGETWO-97400 -->* The selected store scope view now affects the categories displayed on the product edit page's category tree. 
+<!-- MAGETWO-97405 -->
+* You can now use storeview-level attributes to filter products on the products list.
 
-<!-- MAGETWO-97973 -->* Magento now calculates and displays the correct tier price for bundle products.
+<!-- MAGETWO-97400 -->
+* The selected store scope view now affects the categories displayed on the product edit page's category tree.
 
-<!-- MAGETWO-95616 -->* Magento no longer permits you to change an attribute set if the new set does not have equivalent attributes as the original set. Previously, Magento sometimes threw this exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.` 
+<!-- MAGETWO-97973 -->
+* Magento now calculates and displays the correct tier price for bundle products.
 
-<!-- MAGETWO-97380 -->* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
+<!-- MAGETWO-95616 -->
+* Magento no longer permits you to change an attribute set if the new set does not have the same attributes as the original set. Previously, Magento sometimes threw the following exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.`
 
-<!-- MAGETWO-97425 -->* Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty. 
+<!-- MAGETWO-97380 -->
+* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
-<!-- MAGETWO-98470 -->* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave  special prices empty. 
+<!-- MAGETWO-97425 -->
+* Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty.
 
-<!-- MAGETWO-95020 -->* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories. 
+<!-- MAGETWO-98470 -->
+* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave special prices empty. 
 
-<!-- ENGCOM-3697 -->* Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+<!-- MAGETWO-95020 -->
+* Clicking on the root category for a store now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
 
-<!-- ENGCOM-4245 -->* Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+<!-- ENGCOM-3697 -->
+* Magento now displays breadcrumbs in the proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
 
-<!-- ENGCOM-4030 -->* Fixed misalignment of product page tab content in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+<!-- ENGCOM-4245 -->
+* Fixed the alignment of the **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
-<!-- ENGCOM-4254 -->* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+<!-- ENGCOM-4030 -->
+* Fixed the alignment of product page tab content in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
-<!-- ENGCOM-4236 -->* Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+<!-- ENGCOM-4254 -->
+* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
-<!-- ENGCOM-4292 -->*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price  wrong. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+<!-- ENGCOM-4236 -->
+* Corrected the behavior of the dropdown menu on the Option Type field in the New Option section of the Customizable Option page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
-<!-- ENGCOM-4290 -->*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`.  *Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+<!-- ENGCOM-4292 -->
+* Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
 
-<!-- ENGCOM-4327 -->* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+<!-- ENGCOM-4290 -->
+* You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw the following error: `Special price date from" Failed to parse time string`. *Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
 
-<!-- ENGCOM-4340 -->*  A  product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+<!-- ENGCOM-4327 -->
+* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
-<!-- ENGCOM-4429 -->*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, `MinimalTierPriceCalculator`  applied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+<!-- ENGCOM-4340 -->
+* The `product:price:amount` metatag for a product now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
-<!-- ENGCOM-4447 -->* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+<!-- ENGCOM-4429 -->
+* Magento no longer adds tax twice when adding a new product with tier pricing. Previously,the `MinimalTierPriceCalculator` function applied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
-<!-- ENGCOM-4182 -->* Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed this exception: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
+<!-- ENGCOM-4447 -->
+* The `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files now allow modules with names that contain numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
-<!-- ENGCOM-4271 -->* You can now open a product's details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+<!-- ENGCOM-4182 -->
+* Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed the following warning: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
 
-<!-- ENGCOM-4020 -->* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+<!-- ENGCOM-4271 -->
+* You can now open the product details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
 
-<!-- ENGCOM-4514 -->* We've fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
-has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.) *Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
+<!-- ENGCOM-4020 -->
+* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+
+<!-- ENGCOM-4514 -->
+* We have fixed the incorrect proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. Specifically, we replaced the following argument:
+
+`<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
+
+with a new value:
+
+ `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`. *Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
 s
-<!-- MAGETWO-98794 -->* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed this message, `The SKU was not found in the catalog.
-
-
-
-
-
-
-
-
+<!-- MAGETWO-98794 -->
+* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product using this method, Magento displayed the following message: `The SKU was not found in the catalog.
 
 ### Cart and checkout
 
-<!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
+<!-- MAGETWO-98569 -->
+* Magento now persists the shipping quote in the shopping cart for guest customers when the **Persistent Shopping Cart** feature is enabled.
 
+<!-- MAGETWO-98365 -->
+* Magento now applies the correct tier price for a product based on the customer's assigned group when they log in, even if the item was added in a previous session when the customer was logged in as a guest. Previously, Magento did not apply the correct tier price to products added when the customer was still a guest.
 
+<!-- MAGETWO-97950 -->
+* Magento now correctly updates the minicart if a selected product is disabled during the shopping session.
 
+<!-- ENGCOM-4013, 4283 -->
+* Corrected the alignment of the order item details label and subtotal label in mobile view. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
+<!-- ENGCOM-4127 -->
+* The title of the shipping method no longer overlaps with the **Edit** button on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
+<!-- ENGCOM-4043 -->
+* Fixed issue displaying numbers that exceed two digits in the **Qty:** field of the **Proceed to Checkout** pop- up. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
 
+<!-- ENGCOM- 4133-->
+* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
 
+<!-- ENGCOM-4205 -->
+* Fixed the alignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
 
-<!-- MAGETWO-98365 -->* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in. 
+<!-- ENGCOM-4390 -->
+* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null when an account was created after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
 
-<!-- MAGETWO-97950 -->* Magento now correctly updates the minicart if a selected product is disabled during the shopping session. 
+<!-- ENGCOM-4421 -->
+* Magento now displays an error message as expected when a customer clicks on **Add to cart** without selecting at least one product from the recently ordered product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
-<!-- ENGCOM-4013, 4283 -->* Corrected misalignment of the order item details label and subtotal label  in mobile view. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+<!-- ENGCOM-4436 -->
+* The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
-<!-- ENGCOM-4127 -->* The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+<!-- ENGCOM-4479 -->
+* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
-<!-- ENGCOM-4043 -->* Fixed issue displaying numbers that exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
-	
-<!-- ENGCOM- 4133-->* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+<!-- ENGCOM-4369 -->
+* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
-<!-- ENGCOM-4205 -->* Fixed misalignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+<!-- ENGCOM-4630 -->
+* Magento no longer empties the shopping cart when you click **Enter** after changing the product quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
-<!-- ENGCOM-4390 -->* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
-
-<!-- ENGCOM-4421 -->* Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
-
-<!-- ENGCOM-4436 -->* The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
-
-<!-- ENGCOM-4479 -->* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
-
-<!-- ENGCOM-4369 -->* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw this JavaScript error,  `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
-
-<!-- ENGCOM-4630 -->* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
-
-<!-- ENGCOM-4622 -->* Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+<!-- ENGCOM-4622 -->
+* Screen readers can now identify the `label` elements that are linked to `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 
 ### Checkout agreements
 
-<!-- ENGCOM-3989 -->*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
-
-
-
-
+<!-- ENGCOM-3989 -->
+* Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-4304 -->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+<!-- ENGCOM-4304 -->
+* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
 
-<!-- ENGCOM- 4123-->* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+<!-- ENGCOM- 4123-->
+* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
-<!-- ENGCOM-4204 -->* Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+<!-- ENGCOM-4204 -->
+* Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
-<!-- ENGCOM-4230 -->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+<!-- ENGCOM-4230 -->
+* Fixed the alignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
-<!-- ENGCOM-4239 -->* Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+<!-- ENGCOM-4239 -->
+* Fixed the alignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
 
-<!-- ENGCOM-4247 -->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+<!-- ENGCOM-4247 -->
+* The Widget Options left navigation block on the Add New Widget page now displays correctly in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
-<!-- ENGCOM- 4535-->* Added a missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
-
+<!-- ENGCOM- 4535-->
+* Added a missing asterisk adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 ### Company
 
-<!-- MAGETWO-98381 -->* Magento no longer throws an error when you try to export a customer report with a description filter. 
-
-
+<!-- MAGETWO-98381 -->
+* Magento no longer throws an error when you try to export a customer report with a description filter.
 
 ### Configurable products
 
-<!-- MAGETWO-97271 -->* Configurable products can no longer be added as a variation of another configurable product in the Admin.
+<!-- MAGETWO-97271 -->
+* Configurable products can no longer be added as a variation of another configurable product in the Admin.
 
-<!-- MAGETWO-97332 -->* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
+<!-- MAGETWO-97332 -->
+* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
-<!-- ENGCOM-4308 -->* Fixed misalignment of fields on the Configure Product page that is accessed from the wishlist. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+<!-- ENGCOM-4308 -->
+* Fixed the alignment of fields on the Configure Product page that is accessed from the Wish List. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
-<!-- ENGCOM-4092 -->* You can now  successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed this error, `Attribute with ID "Manufacturer" does not exist`.  *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
+<!-- ENGCOM-4092 -->
+* You can now successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed the following error: `Attribute with ID "Manufacturer" does not exist`. *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
 
-<!-- ENGCOM-4470 -->* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
-
-
-
-
-
-
-
-
+<!-- ENGCOM-4470 -->
+* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
 ### CMS
 
-<!-- MAGETWO-99818 -->* Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
+<!-- MAGETWO-99818 -->
+* We have modified the required permissions for updating the `design` fieldset of categories, products, and CMS pages:
 
+  * Existing roles that have **save** permission for these entities can save everything.
 
+  * New roles must be granted permission to edit design manually.
 
+  * If you do not have permission to edit the `design` fieldset or use web API endpoints to update a category, Magento does not save your changes and the design properties remain unchanged.
 
-<!-- MAGETWO-98990 -->* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer  11.x. 
+<!-- MAGETWO-98990 -->
+* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer 11.x.
 
-<!-- ENGCOM-4200 -->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
-
-
-
-
-
-
-
+<!-- ENGCOM-4200 -->
+* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
 
 ### Customer
 
-<!-- MAGETWO-98334 -->* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks. 
+<!-- MAGETWO-98334 -->
+* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks.
 
-<!-- MAGETWO-72961 -->* Magento now uses the value of the  default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
+<!-- MAGETWO-72961 -->
+* Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
-<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless  configued for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
-
-
-<!-- ENGCOM-4132 -->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
-
-<!-- ENGCOM-4187 -->* Removed an empty block on the My Account page sidebar. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
-
-<!-- ENGCOM-4284 -->* The Customer Name Prefix on the customer configuration page no longer displays extraneous  white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
-
-<!-- ENGCOM-4367 -->* The customer login block  (defined as `Magento\Customer\Block\Form\Login`)  no longer sets the page title. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
-
-<!-- ENGCOM-4476 -->* The default sort order for the shopping cart and customer orders page now begins with the latest create date and descends. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
-
-<!-- ENGCOM-4213 -->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
-
-<!-- MAGETWO-97684 -->* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required. 
+<!-- MAGETWO-93521 -->
+* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 
+<!-- ENGCOM-4132 -->
+* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
+<!-- ENGCOM-4187 -->
+* Removed an empty block on the My Account page sidebar. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
+<!-- ENGCOM-4284 -->
+* The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
-<!-- MAGETWO-98044 -->* When loading an order for a customer already assigned to a customer group, Magento now shows the assigned customer group in the order information.  Additionally, Magento now saves the group assignment if you change it when creating a customer order. Previously, the customer group reverted to the default configured group assignment for customers with an existing group assignment. On new orders, if you changed the customer group during the ordering process, the new assignment was not saved. When you loaded the customer order, the customer group showed the default group instead of the group assignment applied during the ordering process.
+<!-- ENGCOM-4367 -->
+* The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
+<!-- ENGCOM-4476 -->
+* The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
+<!-- ENGCOM-4213 -->
+* Magento now respects the number of lines permitted in a street address as set in **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
+<!-- MAGETWO-97684 -->
+* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
 
+<!-- MAGETWO-98044 -->
+* Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
 
-
+* Customer groups can now be reassigned successfully during order creation in the Admin.
 
 ### cron
 
-<!-- MAGETWO-98843 -->* Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We've also added new options to configure locks during installation: 
+<!-- MAGETWO-98843 -->
+* Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We have also added new options to configure locks during installation: 
 
-	* `--lock-provider=LOCK-PROVIDER` Lock provider name 
+  * `--lock-provider=LOCK-PROVIDER`—Lock provider name 
 
-	* `--lock-db-prefix=LOCK-DB-PREFIX` Installation specific lock prefix to avoid lock conflicts 
+  * `--lock-db-prefix=LOCK-DB-PREFIX`—Installation specific lock prefix to avoid lock conflicts 
 
-	* `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`  Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181 
+  * `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`—Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181 
 
-	* `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH` The path where Zookeeper will save locks. The default path is /magento/locks 
+  * `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH`—The path where Zookeeper will save locks. The default path is /magento/locks 
 
-	* `--lock-file-path=LOCK-FILE-PATH` The path where file locks will be saved.
+  * `--lock-file-path=LOCK-FILE-PATH`—The path where file locks will be saved.
 
-See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html
+See [Configure the lock provider](https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html).
 
 
 ### Customer custom attributes
 
-<!-- MAGETWO-97528 -->* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed this message, `Please enter a valid date`.
+<!-- MAGETWO-97528 -->
+* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
 
-<!-- MAGETWO-96265 -->* Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default. 
-
-
-
+<!-- MAGETWO-96265 -->
+* Magento now loads the customer attribute page as expected, and users can edit attributes when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
 
 ### Directory
 
-<!-- ENGCOM-4234 -->* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
+<!-- ENGCOM-4234 -->
+* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
 
 ### Downloadable
 
-<!-- ENGCOM- 4297-->* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw this error, `Something went wrong while getting the requested content`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+<!-- ENGCOM- 4297-->
+* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
 
-<!-- ENGCOM-4466 -->* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+<!-- ENGCOM-4466 -->
+* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
 
 
 
 ### EAV
 
-<!-- ENGCOM-4632 -->* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+<!-- ENGCOM-4632 -->
+* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
-<!-- ENGCOM-4518 -->* Magento no longer throws an exception when the  `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
-
-
-
+<!-- ENGCOM-4518 -->
+* Magento no longer throws an exception when the `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 ### Email
 
-<!-- ENGCOM-4305 -->* Corrected problems with  disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+<!-- ENGCOM-4305 -->
+* Corrected problems with disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
 
 
 ### Frameworks
 
-<!-- MAGETWO-98554 -->* Magento now sorts media directories alphabetically during image upload. 
+<!-- MAGETWO-98554 -->
+* Magento now sorts media directories alphabetically during image upload.
 
-<!-- ENGCOM-4068 -->* Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+<!-- ENGCOM-4068 -->
+* Fixed the alignment of the _import successful_ message icon in the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
-<!-- ENGCOM- 4286-->* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+<!-- ENGCOM- 4286-->
+* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
 
-<!-- ENGCOM-4354 -->* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
+<!-- ENGCOM-4354 -->
+* The use of the `SessionManagerInterface` class has replaced the direct use of `SessionManager`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
 
-<!-- ENGCOM-4395 -->* The module ranking in  `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
+<!-- ENGCOM-4395 -->
+* The module ranking in `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
 
-<!-- ENGCOM-4542 -->*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
-
-
+<!-- ENGCOM-4542 -->
+* Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 #### Cache framework
 
-<!-- ENGCOM-4183 -->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+<!-- ENGCOM-4183 -->
+* We corrected a syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php`. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
 
 
 #### JavaScript framework
 
-<!-- ENGCOM-4610 -->* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
-
-
-
-
-
-
+<!-- ENGCOM-4610 -->
+* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 ### General
 
-<!-- ENGCOM-2667 -->* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
+<!-- ENGCOM-2667 -->
+* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
+<!-- ENGCOM-4548 -->
+* Product attribute labels are no longer translated but maintain their store-specific values. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
-
-
-<!-- ENGCOM-4548 -->* Product attribute labels are no longer translated but maintain their store-specific valu *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
-
-<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
-
-
+<!-- ENGCOM-4272 -->
+* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
 
 ### Gift card account
 
-<!-- MAGETWO-98000 -->* Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
-
-
+<!-- MAGETWO-98000 -->
+* Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
 
 ### Import/export
 
-<!-- MAGETWO-96895 -->* The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
+<!-- MAGETWO-96895 -->
+* The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
 
-<!-- MAGETWO-98694 -->* Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors. 
-
+<!-- MAGETWO-98694 -->
+* Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors. 
 
 ### Indexers
 
-<!-- ENGCOM-4555 -->* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list,  Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
- 
-
+<!-- ENGCOM-4555 -->
+* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list, Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
 
 ### Infrastructure
 
-<!-- ENGCOM-4570 -->* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+<!-- ENGCOM-4570 -->
+* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
-<!-- ENGCOM-4484 -->* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic.  *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
+<!-- ENGCOM-4484 -->
+* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
 
-<!-- ENGCOM-4587 -->* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+<!-- ENGCOM-4587 -->
+* You can now use a period (`.`) for inline CMS content edits. Previously, if you included a period (`.`) in your edits, Magento displayed the following error: `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
 <!-- ENGCOM-4626 -->* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`. *Fix submitted by [Lars Roettig](https://github.com/larsroettig) in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
@@ -459,267 +491,238 @@ See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-
 
 ### MSRP
 
-<!-- MAGETWO-73985 -->*  MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
-
-
-
+<!-- MAGETWO-73985 -->
+* MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed on the configurable product page and the category page display of the configurable product.
 
 ### Newsletter
 
-<!-- ENGCOM-4303 -->* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
+<!-- ENGCOM-4303 -->
+* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
-<!-- MAGETWO-96957 -->* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page
-
-
+<!-- MAGETWO-96957 -->
+* We fixed an issue that caused a long delay when you tried to navigate away from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Now, you can navigate away from this page as expected.
 
 ### Orders
 
-<!-- ENGCOM-4593 -->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+<!-- ENGCOM-4593 -->
+* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
 
 ### Page Cache
 
-<!-- MAGETWO-90953 -->* Page caching is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode. 
-
-
+<!-- MAGETWO-90953 -->
+* Page caching is no longer active when maintenance mode is enabled. Previously, Magento cached pages from all IP addresses during maintenance mode.
 
 ### Payment methods
 
-<!-- MAGETWO-98991 -->*   Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.  
+<!-- MAGETWO-98991 -->
+* Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even if a customer had entered all required credit card information.
 
-<!-- MAGETWO-98670 -->* Magento now displays the account owner name that you've specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified. 
+<!-- MAGETWO-98670 -->
+* Magento now displays the account owner name that you have specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified.
 
-<!-- MAGETWO-98431 -->*  The PayPal  `securetoken` and `securetokenid`  are no longer vulnerable to compromise. 
+<!-- MAGETWO-98431 -->
+* The PayPal `securetoken` and `securetokenid` are no longer vulnerable to compromise.
 
-<!-- MAGETWO-96137 -->* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+<!-- MAGETWO-96137 -->
+* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
 
-<!-- ENGCOM-4328 -->* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+<!-- ENGCOM-4328 -->
+* We improved accessibility by adding Alt attribute text that describes credit card type or stored payment methods during checkout. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
-<!-- MAGETWO-98111 -->* You can now place an order using Cybersource payment from the Admin. 
+<!-- MAGETWO-98111 -->
+* You can now place an order using Cybersource payment from the Admin.
 
-<!-- MAGETWO-97464 -->* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update. 
-
-
+<!-- MAGETWO-97464 -->
+* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
 
 ### Pricing
 
-<!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
+<!-- MAGETWO-99247 -->
+* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**.
 
-<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
+<!-- MAGETWO-96062 -->
+* The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
-<!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
-
-
-
+<!-- MAGETWO-96898 -->
+* Tier pricing for bundle products now works as expected: Magento displays the correct price in the cart, and reminds customers that they can buy a specific quantity of the product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages.
 
 ### Quick Order
 
-<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
-
-
-
-
+<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 ### Reports
 
-<!-- MAGETWO-96883 -->* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites. 
+<!-- MAGETWO-96883 -->
+* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.
 
-<!-- ENGCOM-4445 -->* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
-
-
-
-
-
-
-
+<!-- ENGCOM-4445 -->
+* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
 ### Review
 
-<!-- ENGCOM- 4006-->* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+<!-- ENGCOM- 4006-->
+* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
-<!-- ENGCOM- 4539-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
+<!-- ENGCOM- 4539-->
+* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 
 ### RMA
 
-<!-- MAGETWO-93976 -->* Product-level RMA disabling now works as expected.
-
-
-
+<!-- MAGETWO-93976 -->
+* Product-level RMA disabling now works as expected.
 
 ### Sales
 
-<!-- MAGETWO-97008 -->* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price (specifically, the  price column  contains the custom price excluding tax). Previously, the `sales_order_item` table's price column displayed the custom price including tax. 
+<!-- MAGETWO-97008 -->
+* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
 
-<!-- MAGETWO-97096 -->* Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted. 
+<!-- MAGETWO-97096 -->
+* Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted.
 
-<!-- ENGCOM-4280 -->*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+<!-- ENGCOM-4280 -->
+* Corrected the alignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
+<!-- ENGCOM-3968 -->
+* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
 
+<!-- ENGCOM-4403 -->
+* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
 
-
-
-<!-- ENGCOM-3968 -->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
-
-<!-- ENGCOM-4403 -->* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
-
-<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+<!-- ENGCOM-4272 -->
+* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
 
 <!-- ENGCOM-4285 -->* Fixed display of the Luma theme My Account Order status tabs in mobile view. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
 
-
-
-
-
 ### Sales rule
 
+<!-- MAGETWO-98568 -->
+* Magento now displays the Cart Price Rule code on the order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
-<!-- MAGETWO-98568 -->* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
-
-<!-- ENGCOM-4485 -->* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
-
-
+<!-- ENGCOM-4485 -->
+* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
 
 ### Search
 
 
-<!-- MAGETWO-97374 -->* Layered navigation results no longer includes price ranges that contain no products. 
+<!-- MAGETWO-97374 -->
+* Layered navigation results no longer includes price ranges that contain no products.
 
-<!-- ENGCOM-4082 -->* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
+<!-- ENGCOM-4082 -->
+* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
 
-<!-- ENGCOM-4209 -->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+<!-- ENGCOM-4209 -->* Fixed the alignment of the advanced search page price field in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
-<!-- ENGCOM-4559 -->* Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
-
-
+<!-- ENGCOM-4559 -->
+* Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 ### Shipping 
 
-
-
-
-<!-- MAGETWO-96001 -->* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
-
-
-
-
+<!-- MAGETWO-96001 -->
+* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 ### Swatches
 
-<!-- MAGETWO-92495 -->* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed. 
+<!-- MAGETWO-92495 -->
+* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, the wrong colors were randomly displayed.
 
-<!-- ENGCOM-4120 -->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
-
-
-
+<!-- ENGCOM-4120 -->
+* You can now change an attribute type from swatch to dropdown without losing data. Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
 ### Tax
 
-<!-- ENGCOM-4434 -->*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+<!-- ENGCOM-4434 -->
+* You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw a MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
-<!-- ENGCOM-4439 -->* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+<!-- ENGCOM-4439 -->
+* The value of `product_price_value` in the shopping cart data section now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
-<!-- MAGETWO-96870 -->* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
+<!-- MAGETWO-96870 -->
+* The tax that is applied to a simple child product is now based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
-<!-- MAGETWO-97975 -->* The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent  product. 
-
-
-
+<!-- MAGETWO-97975 -- FIX ME? Duplicate of MAGETWO-96870?-->
+* The tax that is applied to simple child product is now based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
 
 ### Testing
 
-<!-- ENGCOM-4415 -->* The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
+<!-- ENGCOM-4415 -->
+* We added the `Squiz.Operators.ValidLogicalOperators` `phpcs` linter rule to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 
 ### UI
 
-<!-- ENGCOM-4427 -->* Form fields of type multiline now work as expwected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+<!-- ENGCOM-4427 -->
+* Form fields of type multiline now work as expected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
 
-<!-- ENGCOM-4598 -->* The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+<!-- ENGCOM-4598 -->
+* The default design of the **Edit** and **Remove items** buttons on the Wish List page now match. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
-<!-- ENGCOM-4088 -->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+<!-- ENGCOM-4088 -->
+* Magento no longer throws a console error during a guest checkout when the list of allowed countries is modified from the Admin page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
-<!-- ENGCOM-4011 -->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+<!-- ENGCOM-4011 -->
+* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
-<!-- ENGCOM-3974 -->* Fixed issue where the drop-down toggle arrow did not close as expected on product pages. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+<!-- ENGCOM-3974 -->
+* The drop-down toggle arrow on product pages now closes as closing as expected. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
-<!-- ENGCOM-4311 -->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+<!-- ENGCOM-4311 -->* Fixed the alignment of drop-down menus on the Advanced Pricing page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
-<!-- ENGCOM-4317 -->* The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+<!-- ENGCOM-4317 -->
+* The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
-<!-- ENGCOM-4366 -->* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw this error,  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+<!-- ENGCOM-4366 -->* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw the following error: `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
 <!-- ENGCOM-4444 -->* Corrected tabbing issue on the product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
 
+### URL rewrite
+
+<!-- ENGCOM-4621 -->
+* Magento now retains filter terms after you have applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 
+<!-- ENGCOM-4116 -->
+* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key, Magento displayed a 404 page. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
 
-
-###  URL rewrite
-
-
-
-
-<!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
-
-
-<!-- ENGCOM-4116 -->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
-
-<!-- ENGCOM-4224 -->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
-
-
+<!-- ENGCOM-4224 -->
+* The store switcher now works in multistore deployments. Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 ### VAT ID
 
-<!-- ENGCOM-4232 -->* Greek VAT numbers can now be validated. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+<!-- ENGCOM-4232 -->
+* Magento can now validate Greek VAT numbers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 
 
+### Wish List
 
+<!-- MAGETWO-73613 -->
+* The wish list quantity field now has limits on both the type and number of characters that you can enter. Previously, you could enter an extremely large quantity of both number and letters into this field, which resulted in undesirable, inaccurate quantity changes
 
-
-
-
-
-
-
-
-### Wishlist
-
-<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesiraable and inaccurate changes in quantity
-
-<!-- ENGCOM-4513 -->* Customer wishlists now include review summaries for included products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
-
-
-
+<!-- ENGCOM-4513 -->* Customer wish lists now include review summaries for included products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 ## Community contributions
 
 This release includes substantial community contributions: over 100 GitHub issues resolved and over 350 pull requests merged. We are grateful to the wider Magento community for this effort and would like to acknowledge their contributions to this release.
 
-
 ### Individual contributor contributions
 
 The following table identifies contributions from our community members. This table lists the external pull requests, the GitHub issue number associated with it (if available), and the community member who contributed the pull request.
 
-
-
 ### Partner contributions
 
-The following table highlights contributions made by Partners. This table lists the Partner who contributed the pull request, the external pull request, and the GitHub issue number associated with it (if available). 
-
+The following table highlights contributions made by Partners. This table lists the Partner who contributed the pull request, the external pull request, and the GitHub issue number associated with it (if available).
 
 ### System requirements
 
 Our technology stack is built on PHP and MySQL. For details, see [Technology stack requirements]({{page.baseurl}}/install-gde/system-requirements-tech.html).
 
-
 ### Installation and upgrade instructions
 
 See [How to get the Magento software](http://devdocs.magento.com/guides/v2.2/install-gde/bk-install-guide.html) for complete installation and upgrade information.
 
-
 ## Migration toolkits
 
-The <a href="{{ page.baseurl }}/migration/migration-migrate.html" target="_blank">Data Migration Tool</a> helps transfer existing Magento 1.x store data to Magento 2.x. This command-line interface includes verification, progress tracking, logging, and testing functions. For installation instructions, see  <a href="{{ page.baseurl }}/migration/migration-tool-install.html" target="_blank">Install the Data Migration Tool</a>. Consider exploring or contributing to the <a href="https://github.com/magento/data-migration-tool" target="_blank"> Magento Data Migration repository</a>.
+The <a href="{{ page.baseurl }}/migration/migration-migrate.html" target="_blank">Data Migration Tool</a> helps transfer existing Magento 1.x store data to Magento 2.x. This command-line interface includes verification, progress tracking, logging, and testing functions. For installation instructions, see <a href="{{ page.baseurl }}/migration/migration-tool-install.html" target="_blank">Install the Data Migration Tool</a>. Consider exploring or contributing to the <a href="https://github.com/magento/data-migration-tool" target="_blank"> Magento Data Migration repository</a>.
 
 The <a href="https://github.com/magento/code-migration" target="_blank">Code Migration Toolkit</a> helps transfer existing Magento 1.x store extensions and customizations to Magento 2.2.x. The command-line interface includes scripts for converting Magento 1.x modules and layouts.

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -5,7 +5,7 @@ title: Magento Commerce 2.2.9 Release Notes
 ---
 
 
-*Release notes published on  2019.*
+*Release notes published on June 26, 2019.*
 
 
 
@@ -23,32 +23,28 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2
 
 Look for the following highlights in this release:
 
-### Merchant tool enhancements
 
-
-  
 ### Substantial security enhancements
 
-These releases include security enhancements that help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+This release is focused on substantial security enhancements:
 
+* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+
+* **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
 
 ### Infrastructure improvements
 
+This release contains 150 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements: 
 
+* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.  <!--- MAGETWO-98424-->
 
-### Bundled extension enhancements
+* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**.The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947--> 
 
-This release of Magento includes extensions developed by third-party vendors. 
-
-
-#### dotdigital Engagement Cloud (formerly dotmailer)
-
-
-#### Magento Shipping
+* **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 
 
-#### Vertex
+## Vertex
 
 
 
@@ -59,45 +55,43 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
+<!-- MAGETWO-98860 -->* Magento no longer throws an error when executing `setup:static-content:deploy` in parallel mode if theme or locale dpeloyment takes more than 400 seconds. Previously, Magento threw this error under these conditions, `2436; Status: 0`.
+
+<!-- MAGETWO-76424 -->* Magento no longer displays an extraneous blank option in the country drop-down menu. 
+
+### AdminGWS
+
+<!-- MAGETWO-98053 -->* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets that the administrator has privilege for. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to. 
+
+<!-- MAGETWO-87222 -->* 
 
 
+The cart rules disappear with error: Item (Magento\SalesRule\Model\Rule\Interceptor) with the same ID "140" already exists
+
+ISSUE:
+Cart Price Rules page grid is missing. The "Search" button, number of records found and pagination buttons are there. But the actual table listing existing price rules are not showing. If you add a new price rule, the number of records will increment, but the table remains missing.
+
+Go to MARKETING > Promotions > Cart Price Rules
+
+EXPECTED RESULTS:
+Cart Price Rules grid shows existing cart price rules
+
+ACTUAL RESULTS:
+Cart Price Rules grid is missing
 
 
 ### Backend
 
-<!-- ENGCOM-4517 -->*
-*Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+<!-- ENGCOM-4517 -->* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
 
+<!-- ENGCOM-4435 -->*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
 
-Unresolved (same as 4452)
+<!-- ENGCOM-4121 -->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
+<!-- ENGCOM-4142 -->* FMagento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
+<!-- ENGCOM-4229 -->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
-<!-- ENGCOM-4435 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
-
-Same as 4377
-
-
-<!-- ENGCOM-4121 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
-
-Copy from 2.3.1 4029
-
-
-
-
-<!-- ENGCOM-4142 -->*
-*Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
-
-Copy from 2.3.1 4029
-
-
-
-<!-- ENGCOM-4229 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
-
-Copy from 2.3.1 4113
 
 
 
@@ -105,38 +99,59 @@ Copy from 2.3.1 4113
 
 ### B2B
 
+<!-- MAGETWO-99000 -->* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
+
+
+<!-- MAGETWO-95281 -->* copy from 231 96418
+
+B2B quote error if a customer is changed to another company
+
+Two companies and each one has its own custom catalog. A customer assigned to one company generates a quote and then that customer is assigned to a different company. The quote no longer shows in the customers account in the quote section of the frontend. An error similar to this is shown:
+
+Requested quote is not found. Row ID: quoteId = <some Id>
+
+
+
+
+<!-- MAGETWO-98553 -->* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog. 
+
+
+<!-- MAGETWO-98678 -->* You can now add backordered products to the cart when backorders are enabled. 
 
 
 ### Bundle products
 
-<!-- ENGCOM-4041 -->*
+<!-- ENGCOM-4041 -->* Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+<!-- ENGCOM-4557 -->* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
-Copy from 2.3.1 3948
-
-
-
-<!-- ENGCOM-4557 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
-
-232 4507
-
-
-<!-- ENGCOM-4143 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
-
-
-Copy from 2.3.1 3871
+<!-- ENGCOM-4143 -->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
 
 
 
+<!-- MAGETWO-97226 -->* 
 
+Fixed price set for a product in Shared Catalog does not update. The price on storefront and in Admin remains the same.
 
+STEPS TO REPLICATE:
 
+Go to Catalog > Shared Catalogs > Default catalog (also reproduces with a private catalog)
+Go to Set Pricing and Structure
+Click Configure
+Select a product
+Click Next
+Set some fixed price, e.g. 1$ or 0$
+Click Generate Catalog
+Click Save
+Wait for the queue to be processed
+On storefront go to product display page
+Observe that price does not update to the fixed price
+EXPECTED RESULTS:
+The shared catalog product price is used.
 
-### CAPTCHA
+ACTUAL RESULTS:
+The product is shown with the original price.
 
 
 
@@ -144,255 +159,162 @@ Copy from 2.3.1 3871
 
 ### Catalog
 
-<!-- ENGCOM-3697 -->*
+<!-- MAGETWO-94426 -->* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
 
-*Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+<!-- MAGETWO-74081 -->* You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
-backport from 2.3.1 3698
+<!-- MAGETWO-98626 -->* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the broweser returned a 404. 
 
+<!-- MAGETWO-74455 -->* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the asme attribute values. 
 
+<!-- MAGETWO-74037 -->* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attibute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
-<!-- ENGCOM-4245 -->*
+<!-- MAGETWO-73157 -->* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+<!-- MAGETWO-72650 -->* Tax recalculation has been moved out of the transation into the backgound for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
 
-Copy from 4001
+<!-- MAGETWO-97472 -->* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level. 
 
+<!-- MAGETWO-97405 -->* You can now use storeview-level attributes to filter products on the products list.
 
+<!-- MAGETWO-97400 -->* The selected store scope view now affetcs the categories dispalyed on theproduct edit page's category tree. 
 
-<!-- ENGCOM-4030 -->*
+<!-- MAGETWO-97973 -->* Magento now calculates and displays the correct tier price for bundle products.
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+<!-- MAGETWO-95616 -->* Magento no longer permits you to change an attribute set if the new set does not have equivalent attributes as the original set. Previously, Magento sometimes threw this exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.` 
 
+<!-- MAGETWO-97380 -->* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
+<!-- MAGETWO-97425 -->* Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty. 
 
-<!-- ENGCOM-4254 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+<!-- MAGETWO-98470 -->* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty. 
 
+<!-- MAGETWO-95020 -->* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories. 
 
-Copy from 2.3.1 4093
+<!-- ENGCOM-3697 -->* Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by [Brandon Brown](https://github.com/Yamaha32088) in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
 
-<!-- ENGCOM-4236 -->*
+<!-- ENGCOM-4245 -->* Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+<!-- ENGCOM-4030 -->* Fixed misalignment of product page tab content in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
-Copy from 2.3.1 4150
+<!-- ENGCOM-4254 -->* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
+<!-- ENGCOM-4236 -->* Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
+<!-- ENGCOM-4292 -->*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price  wrong. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
 
-<!-- ENGCOM-4253 -->*
+<!-- ENGCOM-4290 -->*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`.  *Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21199](https://github.com/magento/magento2/pull/21199)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
+<!-- ENGCOM-4327 -->* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
+<!-- ENGCOM-4340 -->*  A  product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously price in tnis metatag was always calculated in the base currency. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
-<!-- ENGCOM-4292 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+<!-- ENGCOM-4429 -->*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator  applyied the tax twice when calculating the minimal price. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
+<!-- ENGCOM-4447 -->* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
-(2.3.2  4217)
+<!-- ENGCOM-4182 -->* Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed this exception: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
 
+<!-- ENGCOM-4271 -->* You can now open a product's details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
 
+<!-- ENGCOM-4020 -->* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
 
-
-<!-- ENGCOM-4290 -->*
-
-*Fix submitted by [Milan Osztromok](https://github.com/tufahu) in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
-
-
-Copy from 2.3.1 3184
-
-
-
-
-<!-- ENGCOM-4327 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
-
-2.3.2 4207
-
-
-<!-- ENGCOM-4340 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
-
-
-Same as 3767
-
-
-<!-- ENGCOM-4429 -->*
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
-
-
-Same as 4360
-
-
-
-<!-- ENGCOM-4447 -->*
-
-*Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
-
-
-Same as 4065
-
-
-
-
-<!-- ENGCOM-4182 -->*
-
-*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
-
-
-
-
-<!-- ENGCOM-4271 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
-
-
-(4202 — 2.3.2) 
-
-
-
-<!-- ENGCOM-4020 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
-
-
-
-Copy from 231 3771
-
-
-
-<!-- ENGCOM-4514 -->*
-
-*Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
-
-
-
-Same as 4490
-
-
+<!-- ENGCOM-4514 -->* We've fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
+has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.) *Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
+s
+<!-- MAGETWO-98794 -->* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed this message, `The SKU was not found in the catalog.
 
 
 
 ### Catalog rule
 
+<!-- MAGETWO-98679 -->* 
+
+Discounts of products disappear on storefront after drag & drop via Visual Merchandiser in category
+
+he drag & drop product via Visual Merchandiser and after this action on storefront on this category disappear discounts on products.
+
+Expected result:
+Catalog rule rule1 should be applied and all products should have a discount
+
+Actual result:
+Product(s) displayed without discounts
+
+
+
+
+
+
+
 
 
 ### Cart and checkout
 
+<!-- MAGETWO-98569 -->* Magento now persists the shipping quote in the shoppping cart for guest customers when **Persistent Shopping Cart** is enabled.
 
 
+<!-- MAGETWO-96375 -->* 
 
-<!-- ENGCOM-4013 -->*
 
-*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
+Checkout Free Shipping Recalculation after Coupon Code Added
 
+STEPS TO REPLICATE:
+1. Create Product with price 90
+2. Enable free shipping for order more than 89$
+3. Create Cart price rule with Code for 10% discount
+4. Login to frontend
+5. Add product to cart
+6. Go to checkout 
+7. Apply discount code
+ Check that subtotal less than 89
+8. Go to Checkout Shipping step
 
-<!-- ENGCOM-4283 -->*
+EXPECTED RESULTS:
+Free shipping should be unavailable
 
-*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+ACTUAL RESULTS:
+Free shipping options available
 
+Case 2
+Apply discount on Payment step
 
 
 
-<!-- ENGCOM-4127 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
-Copy from 2.3.1 4032
 
+<!-- MAGETWO-98365 -->* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in. 
 
+<!-- MAGETWO-97950 -->* Magento now correctly updates the minicart if a selected product is disabled during the shopping session. 
 
-<!-- ENGCOM-4043 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
-	•	
-Copy from 2.3.1 3971
+<!-- ENGCOM-4013, 4283 -->* Corrected misalignment of the order item details label and subtotal label  in mobile view. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
+<!-- ENGCOM-4127 -->* The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
-<!-- ENGCOM- 4133-->*
+<!-- ENGCOM-4043 -->* Fixed issue displaying numbers that exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+	
+<!-- ENGCOM- 4133-->* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+<!-- ENGCOM-4205 -->* Fixed misalignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
 
+<!-- ENGCOM-4390 -->* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
 
+<!-- ENGCOM-4421 -->* Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
+<!-- ENGCOM-4436 -->* The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
+<!-- ENGCOM-4479 -->* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
-Copy from 2.3.1 3938
+<!-- ENGCOM-4369 -->* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw this JavaScript erro,  `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
+<!-- ENGCOM-4630 -->* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
-
-<!-- ENGCOM-4205 -->*
-
-*Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
-
-
-Copy from 2.3.1 4066
-
-
-<!-- ENGCOM-4390 -->*
-
-*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
-
-
-
-Same as 3477
-
-
-<!-- ENGCOM-4421 -->*
-
-*Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
-
-
-Same as 4355
-
-
-
-
-
-<!-- ENGCOM-4436 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
-
-
-Same as 4436
-
-
-<!-- ENGCOM-4479 -->*
-
-*Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
-
-
-Same as 4362
-
-
-
-
-<!-- ENGCOM-4369 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
-
-
-
-<!-- ENGCOM-4630 -->*
-
-*Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
-
-
-
-<!-- ENGCOM-4622 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+<!-- ENGCOM-4622 -->* Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 
 ### Checkout agreements
 
-<!-- ENGCOM-3989 -->*
-
-*Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
-
-Copy from 2.3.1 3231
-
-
-<!-- ENGCOM- -->*
+<!-- ENGCOM-3989 -->*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
 
 
 
@@ -400,89 +322,39 @@ Copy from 2.3.1 3231
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-4304 -->*
+<!-- ENGCOM-4304 -->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+<!-- ENGCOM- 4123-->* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
+<!-- ENGCOM-4204 -->* Added missing bottom border to the list of customizable options on the product page when accessed from the Admin. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
+<!-- ENGCOM-4230 -->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
-Copy from 2.3.1 4036
+<!-- ENGCOM-4239 -->* Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
 
+<!-- ENGCOM-4247 -->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
-
-<!-- ENGCOM- 4123-->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
-
-Copy from 2.3.1 3901
+<!-- ENGCOM- 4535-->* Added missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 
+### Company
 
-
-
-<!-- ENGCOM-4204 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
-
-
-Copy from 2.3.1 3936
-
-
-
-<!-- ENGCOM-4230 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
-
-
-<!-- ENGCOM-4239 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
-
-Copy from 2.3.1 4130
-
-
-
-<!-- ENGCOM-4247 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
-
-Copy from 2.3.1 4052
-
-<!-- ENGCOM- 4535-->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
-
-(same as 4475)
-
+<!-- MAGETWO-98381 -->* Magento no longer throws an error when you tryto export a customer report with a description filter. 
 
 
 
 ### Configurable products
 
-<!-- ENGCOM-4308 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+<!-- MAGETWO-97271 -->* Configurable products can no longer be added as a variation of another configurable product in the Admin.
 
+<!-- MAGETWO-97332 -->* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
+<!-- ENGCOM-4308 -->* Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
-Copy from 2.3.1 4053
+<!-- ENGCOM-4092 -->* You can now  successfully run `bin/magneto setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed this error, `Attribute with ID "Manufacturer" does not exist`.  *Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
 
+<!-- ENGCOM-4470 -->* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
-
-
-<!-- ENGCOM-4092 -->*
-
-*Fix submitted by [Suneet K.](https://github.com/suneet64) in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
-
-
-
-
-
-
-<!-- ENGCOM-4470 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
-
-
-Same as 3963
 
 
 
@@ -493,13 +365,18 @@ Same as 3963
 
 ### CMS
 
-
-<!-- ENGCOM-4200 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+<!-- MAGETWO-99818 -->* 
 
 
-Copy from 2.3.1 4051
+Additional permissions added for updating "Design" fieldset of categories, products and CMS pages. Existing roles that have save permissions for said entities will remain to be able to save everything, new roles will have to be granted permissions to edit design manually. In case a user doesn't have permission to edit design and use web API endpoints to update a category, a product or a CMS page the design properties will remain unchanged.
+
+
+
+
+<!-- MAGETWO-98990 -->* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer  11.x. 
+
+<!-- ENGCOM-4200 -->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+
 
 
 
@@ -509,208 +386,164 @@ Copy from 2.3.1 4051
 
 ### Customer
 
-<!-- ENGCOM-4132 -->*
+<!-- MAGETWO-98334 -->* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks. 
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+<!-- MAGETWO-72961 -->* Magento now uses the value of the  default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
+<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless  configued for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
-Copy from 4028
+<!-- MAGETWO-97412 -->* You can now crreate customer segments that exceed 1,500,000 customers. Previously, Magento displayed a 500 error when you tried to create a customer segment that included more than 3312436 customers.
 
+<!-- ENGCOM-4132 -->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
+<!-- ENGCOM-4187 -->* Removed an empty block on the My Account page sidebar. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
+<!-- ENGCOM-4284 -->* The Customer Name Prefix on the customer configuration page no longer displays extraneous shows white space when an extra separator is added. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
+<!-- ENGCOM-4367 -->* The customer login block  (defined as `Magento\Customer\Block\Form\Login`)  no longer sets the page title. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
-<!-- ENGCOM-4187 -->*
+<!-- ENGCOM-4476 -->* The default sort order for the shopping cart and customer orders page is now by create date in descending order. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+<!-- ENGCOM-4213 -->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
-
-
-
-Copy from 2.3.1 3981
-
-
-
-<!-- ENGCOM-4284 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
-
-(2.3.2 4146)
-
-
-
-<!-- ENGCOM-4367 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
-
-
-Same as 4047
-
-
-<!-- ENGCOM-4476 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
-
-
-Same as 4431
+<!-- MAGETWO-97684 -->* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required. 
 
 
 
 
-<!-- ENGCOM-4213 -->*
 
-*Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
-
+<!-- MAGETWO-98044 -->* copy 98087
 
 
-Copy from 2.3.1 4063
+TEPS
+Admin > Stores > Configuration > Customers > Customer Configuration > Create New Account Options > Default Groups
+Set Default Customer Group = Wholesale for Default Website
+Set Default Customer Group = Retailer for Second Website
+Set Enable Automatic Assignment to Customer Group to Yes
+Start creating an order from Admin for sample data customer Veronica which is already assigned to General group
+ EXPECTED RESULT
+Group remains General for customer which was already assigned to some customer group
+ ACTUAL RESULT
+The group is switched to Retailer
+Try to switch group back to General
+ EXPECTED RESULT
+Customer group can be switched when creating an order
+ ACTUAL RESULT
+The group is automatically switched back to Retailer
 
+
+ISSUE
+1. When loading a customer in backend order with a customer group already defined, example USA Dealer 20%, it would revert back to the config default of "General". This should take into account the customer group already set and saved for the customer. 
+2. When trying to choose a customer group on a new order with a new customer, the default selection was working and wasn't reverting back to Store #1 customer group. 
+3. The big issue here is when changing the customer group to a Dealer group (Any customer group that will give cart / catalog discount) that is meant to give discount, the order/invoice comes through with no discount and uses the General group again once placing the order. So for all our B2B customers in the last two days our sales processed orders but resulted in no discount given even when the customer group was selected.
+
+
+
+
+
+
+
+
+### cron
+
+<!-- MAGETWO-98843 -->* Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We've also added new options to configure locks during installation: 
+
+	* `--lock-provider=LOCK-PROVIDER` Lock provider name 
+
+	* `--lock-db-prefix=LOCK-DB-PREFIX` Installation specific lock prefix to avoid lock conflicts 
+
+	* `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`  Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181 
+
+	* `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH` The path where Zookeeper will save locks. The default path is /magento/locks 
+
+	* `--lock-file-path=LOCK-FILE-PATH` The path where file locks will be saved.
+
+See https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/Install-cli-subcommands-lock.html
 
 
 ### Customer custom attributes
 
+<!-- MAGETWO-97528 -->* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed this message, `Please enter a valid date`.
 
+<!-- MAGETWO-96265 -->* Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default. 
 
-
-
-### Developer
 
 
 
 ### Directory
 
-<!-- ENGCOM-4234 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
-
-
-
-
-Copy from 2.3.1 4114
-
+<!-- ENGCOM-4234 -->* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
 
 ### Downloadable
 
-<!-- ENGCOM- 4297-->*
+<!-- ENGCOM- 4297-->* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw this error, `Something went wrong while getting the requested content`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
-
-
-
-(2.3.2 3794)
-
-
-<!-- ENGCOM-4466 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
-
-
-Same as 4345
+<!-- ENGCOM-4466 -->* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
 
 
 
 ### EAV
 
-<!-- ENGCOM-4632 -->*
-
-*Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+<!-- ENGCOM-4632 -->* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization,both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
 
 
 
 <!-- ENGCOM-4518 -->*
+
+Fixed-Quantity_and_stock_status when visibility set to storefront throwing exception
+
+
+Steps to reproduce 
+To reproduce the issue. Please follow the below steps,
+
+1.Product attribute grid -> select Quantity attribute-> Storefront Properties -> Change Visible on Catalog 2.Pages on Storefront to Yes
+
+Expected result 
+Attribute should visible on frontend
+
+Actual result
+1.Exception whille catalog product view
+
+
 *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 
 
 
-
-<!-- ENGCOM- -->*
-
-<!-- ENGCOM- -->*
-
-
 ### Email
 
-<!-- ENGCOM-4305 -->*
+<!-- ENGCOM-4305 -->* Corrected problems with the disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
-*Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
-
-
-
-2.3.2 4101 
 
 
 ### Frameworks
 
-<!-- ENGCOM-4068 -->*
+<!-- MAGETWO-98554 -->* Magento now sorts media directories alphabetically during image upload. 
 
-*Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+<!-- ENGCOM-4068 -->* Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
+<!-- ENGCOM- 4286-->* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
 
+<!-- ENGCOM-4354 -->* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
 
-Copy from 2.3.1 3524
+<!-- ENGCOM-4395 -->* The module ranking in the app/etc/config now reamins consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
 
-<!-- ENGCOM- 4286-->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
-
-(2.3.2 3932)
-
-
-
-<!-- ENGCOM-4354 -->*
-
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
-
-
-
-Same as 3543
-
-
-<!-- ENGCOM-4395 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
-
-Same as 4223
-
-
-
-
-
-<!-- ENGCOM-4542 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
-
-
-(Same as 4104)
-
-
-
-
-
-
-<!-- ENGCOM- -->*
-
+<!-- ENGCOM-4542 -->*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines.  *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 
 
 #### Cache framework
 
-<!-- ENGCOM-4183 -->*
-*Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
-
-
-Copy from 2.3.1 3666
+<!-- ENGCOM-4183 -->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
 
 
 #### JavaScript framework
 
 
 
-<!-- ENGCOM-4610 -->*
-
-*Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+<!-- ENGCOM-4610 -->* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 
 
@@ -722,153 +555,210 @@ Copy from 2.3.1 3666
 
 <!-- ENGCOM-2667 -->*
 
+
+Steps to reproduce
+Login to Admin
+go to Stores -> All Stores.
+Sort by any column
+Actual result
+sorting doesn't work
+
+
+
 *Fix submitted by [afirlejczyk](https://github.com/afirlejczyk) in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
 
 <!-- ENGCOM-4516 -->*
+
+
+Allow BEM class via attribute tag
+
+Adding BEM class in XML via attribute tag causes class to be rewritten
+
+Steps to reproduce
+Go to default.xml
+Add attribute tag with a class to the body element i.e. <attribute name="class" value="background-color--white"/>
+Clear cache and reload page
+Expected result
+Class should be rendered as it is added in the XML i.e. background-color--white
+Actual result
+Classes with -- in them are replaced with a single - so result appears as background-color-white
 
 *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21804](https://github.com/magento/magento2/pull/21804)*. [GitHub-10645](https://github.com/magento/magento2/issues/10645)
 
 
 
 <!-- ENGCOM-4548 -->*
+
+Product attribute labels are translated
+
+Steps to reproduce 
+Add product attribute into product page.
+Add store specific label
+add same phrase into translation file
+
+Expected result 
+Attribute label is not translated and kept as set in admin (store specific label)
+
+Actual result 
+Attribute label is translated
+
 *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
 
 
-<!-- ENGCOM-4272 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
-
-(4241 — 2.3.2)
+<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
 
 
 
+### Gift card account
 
-### Gift card
-
-
-### Gift registry
-
-
-
-
-### Google Analytics
-
-
-
-
-
-
-### Image
-
-
-
+<!-- MAGETWO-98000 -->* Gift card accounta are now created as expected when gift card orders are authorized and captured with PayPal Express.
 
 
 
 ### Import/export
 
+<!-- MAGETWO-96895 -->* 
+
+Merchant reports when you choose "Skip error entries" as the validation method for the import, Magento will continue to try to validate data and won't let you process the import. Is this the way this is designed to work? Thank you!
+
+*REPRODUCE*
+
+Go to System > Import
+Try to validate an import.csv where one sku is correct and second is incorrect
+EXPECTED RESULT: 
+Validation process should consider Skip error entries value
+
+ACTUAL RESULT: 
+Validation process doesn't consider Skip error entries value and prevents import
+
+
+
+
+
+<!-- MAGETWO-98694 -->* 
+
+URL key of product doesn't saved correctly if fill it in Arabic.
+
+
+Translated Arabic URL's are returning 404's
+
 
 ### Indexers
 
-<!-- ENGCOM-4555 -->*
-
-*Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
-
-Unresolved (same as 4440)
-
+<!-- ENGCOM-4555 -->* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin's indexer list,  Magento threw a fatal error.*Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+ 
 
 
 ### Infrastructure
 
-<!-- ENGCOM-4570 -->*
+<!-- ENGCOM-4570 -->* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+<!-- ENGCOM-4484 -->* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contined logic.  *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
 
+<!-- ENGCOM-4587 -->* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
-
-<!-- ENGCOM-4484 -->*
-*Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
-
-
-
-<!-- ENGCOM-4587 -->*
-
-*Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
-
-<!-- ENGCOM-4626 -->*
-
-*Fix submitted by [Lars Roettig](https://github.com/larsroettig) in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
-
-
-
-### Integration
-
-
-
-### Layered navigation
+<!-- ENGCOM-4626 -->* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`. *Fix submitted by [Lars Roettig](https://github.com/larsroettig) in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
 
 
 
-### Magento Shipping
+### Logging
 
+<!-- MAGETWO-97595 -->* Editing a theme now creates an entry in the Admin action log as expected. 
+
+
+
+### MSRP
+
+<!-- MAGETWO-73985 -->*  MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
 
 
 
 
 ### Newsletter
 
-<!-- ENGCOM-4303 -->*
+<!-- ENGCOM-4303 -->* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
-*Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
-
-
-2.3.2 3992
+<!-- MAGETWO-96957 -->* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page
 
 
-
-
-
-### Offline shipping
 
 ### Orders
 
-<!-- ENGCOM-4593 -->*
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+<!-- ENGCOM-4593 -->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+
+### PAge Cache
+
+<!-- MAGETWO-90953 -->* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode. 
 
 
 
 ### Payment methods
 
-<!-- ENGCOM-4328 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+<!-- MAGETWO-98991 -->*   Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.  
 
 
-2.3.2 4192
 
+<!-- MAGETWO-98670 -->* 
+
+
+Enable Braintree through Paypal
+Add a product to the cart
+Go to the cart page and click on the blue Paypal button
+Log in to the Paypal account
+Add a new shipping address for a different person (not the owner of the account)
+When you return to Magento, the account owner's name is listed on the Shipping Address
+ EXPECTED RESULTS:
+When using Braintree through Paypal, if you add a Shipping Address on the Paypal with a different name, that specified name should be displayed when redirected to Magento
+
+ ACTUAL RESULTS:
+When using Braintree through Paypal, if you add a Shipping Address on the Paypal with a different name, the account owner's name is displayed when redirected to Magento
+
+<!-- MAGETWO-98431 -->*  
+
+
+Paypal securetoken/securetokenId can be compromised	
+
+
+
+
+<!-- MAGETWO-96137 -->* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+
+<!-- ENGCOM-4328 -->* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to supprt accessibility. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+
+<!-- MAGETWO-98111 -->* You can now place an order using Cybersource payment from the Admin. 
+
+<!-- MAGETWO-97464 -->* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update. 
 
 
 
 ### Pricing
 
+<!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
+
+<!-- MAGETWO-96062 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the product tha.
+
+<!-- MAGETWO-96898 -->* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages. 
 
 
 
-### Quote
+
+### Quick Order
+
+<!-- MAGETWO-97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the product tha.
+
 
 
 
 
 ### Reports
 
-<!-- ENGCOM-4445 -->*
+<!-- MAGETWO-96883 -->* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites. 
 
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
+<!-- ENGCOM-4445 -->* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
-Same as 3808
 
 
 
@@ -878,19 +768,9 @@ Same as 3808
 
 ### Review
 
-<!-- ENGCOM- 4006-->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+<!-- ENGCOM- 4006-->* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
-
-Copy from 2.3.1 3835
-
-
-
-<!-- ENGCOM- 4539-->*
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
-
-Copy from 2.3.1 4096
-
+<!-- ENGCOM- 4539-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 
 
@@ -903,15 +783,37 @@ Copy from 2.3.1 4096
 
 ### RMA
 
+<!-- MAGETWO-93976 -->* Product-level RMA disabling now works as expected.
+
+
 
 
 ### Sales
 
-<!-- ENGCOM-4280 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+<!-- MAGETWO-97008 -->* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price (specifically, the  price column  contains the custom price excluding tax). Previously, the `sales_order_item` table's price column displayed the custom price including tax. 
 
 
-Same as 4154
+
+
+
+<!-- MAGETWO-97096 -->* 
+
+Multistore Allowed Countries List Problem
+
+ACTUAL RESULT
+No validation error about missing shipping country.
+On placing the order 'Invalid value of "US" provided for the countryId field.' error is displayed
+
+EXPECTED RESULT
+New customer is created for the 2nd website
+The order is placed without errors
+
+
+
+
+
+
+<!-- ENGCOM-4280 -->*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
 
 <!-- ENGCOM-4361 -->*
@@ -922,45 +824,13 @@ Same as 4154
 Same as 3910
 
 
-<!-- ENGCOM-3968 -->*
+<!-- ENGCOM-3968 -->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
 
-*Fix submitted by [gwharton](https://github.com/gwharton) in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
+<!-- ENGCOM-4403 -->* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
 
-Copy from 2.3.1 3225
+<!-- ENGCOM-4272 -->* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
 
- 
-
-
-
-
-<!-- ENGCOM-4403 -->*
-
-*Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
-
-
-Same as 4321
-
-
-
-<!-- ENGCOM-4272 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
-
-
-
-<!-- ENGCOM-4285 -->*
-
-*Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
-
-
-
-(2.3.2 4197) 
-
-
-<!-- ENGCOM-4272 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-21144](https://github.com/magento/magento2/issues/21144)
-
+<!-- ENGCOM-4285 -->* Fixed display of the Luma theme My Account Order status tabs in mobile view. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
 
 
 
@@ -969,11 +839,10 @@ Same as 4321
 ### Sales rule
 
 
-<!-- ENGCOM-4485 -->*
-*Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
+<!-- MAGETWO-98568 -->* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
+<!-- ENGCOM-4485 -->* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
 
-Same as 3679
 
 <!-- ENGCOM-4540 -->*
 
@@ -985,30 +854,41 @@ Unresolved (same as 4406)
 
 ### Search
 
+
+<!-- MAGETWO-97914 -->* 
+
+The current problem is that the catalogsearch indexer is taking about 17 hours to complete.
+Merchant has 20k items. Previously we had suggested them to upgrade ES to 5.2. Initially SI mentions that it used to take about a couple of hours to complete, after the upgrade they noticed the time increased to 17 hours.
+Reindexing takes less then 10 minutes with MySQL though
+I've tested DB dumps with clean 2.2.7 code and reindexing still takes too long. 
+The problem occurs only with DB dumps, not on celan instance.
+
+
+
+<!-- MAGETWO-97374 -->* Layered navigation results no longer include price ranges that contain no products. 
+
+
 <!-- ENGCOM-4082 -->*
+
+Quick search by SKU not working properly
+
+Try to search products with end of string like "-" or "-"
+The exception error appear Unexpected $end
+
+Exceptions when search product with sku like "42-" 
+
+
+
+
 *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
 
 
 
 
 
-<!-- ENGCOM-4209 -->*
+<!-- ENGCOM-4209 -->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
-
-
-Copy from 2.3.1 3991
-
-
-<!-- ENGCOM-4559 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
-
-
-
-<!-- ENGCOM-4082 -->*
-
-*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-9988](https://github.com/magento/magento2/issues/9988)
-
+<!-- ENGCOM-4559 -->* Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 
 
@@ -1016,20 +896,26 @@ Copy from 2.3.1 3991
 
 <!-- ENGCOM-3602 -->*
 
+Fix DHL Quotes for Domestic Shipments when Content Type is set to Non-Document 
+
+DHL Shipping Quotes fail for Domestic Shipments when Content Mode is "Non Documents"
+
+Steps to reproduce
+Setup DHL module to obtain quotes via XML
+Setup store as ship from address SW1 1AA, GB
+Set DHL Content Type to Non Documents
+Attempt to obtain shipping quote for destination SW1 1AA, GB
+Expected result 
+
+A quote is obtained
+Actual result 
+
+
 *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19488](https://github.com/magento/magento2/pull/19488)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
 
 
 
-
-
-
-### Staging
-
-
-
-
-
-### Store
+<!-- MAGETWO-96001 -->* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 
 
@@ -1037,10 +923,9 @@ Copy from 2.3.1 3991
 
 ### Swatches
 
-<!-- ENGCOM-4120 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+<!-- MAGETWO-92495 -->* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed. 
 
-Copy from 2.3.1 3920
+<!-- ENGCOM-4120 -->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
 
 <!-- ENGCOM-4477 -->*
@@ -1052,112 +937,44 @@ Same as 3608
 
 
 
-
-
-### TargetRule
-
-
-
-
-
-
 ### Tax
 
-<!-- ENGCOM-4434 -->*
-*Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+<!-- ENGCOM-4434 -->*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error.*Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
+<!-- ENGCOM-4439 -->* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
-<!-- ENGCOM-4439 -->*
+<!-- MAGETWO-96870 -->* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+<!-- MAGETWO-97975 -->* The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent  product. 
 
-Same as 4359
 
 
 
 ### Testing
 
-<!-- ENGCOM-4415 -->*
-*Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
-
-
-(Same as 4300)
-
-
-
-### Theme
-
-
-
+<!-- ENGCOM-4415 -->* The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 
 ### UI
 
-<!-- ENGCOM-4427 -->*
+<!-- ENGCOM-4427 -->* Form fields of type multiline now work as expwected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
 
-*Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+<!-- ENGCOM-4598 -->* The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
+<!-- ENGCOM-4088 -->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
+<!-- ENGCOM-4011 -->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
-<!-- ENGCOM-4598 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+<!-- ENGCOM-3974 -->* Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
+<!-- ENGCOM-4311 -->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
+<!-- ENGCOM-4317 -->* The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
-<!-- ENGCOM-4088 -->*
+<!-- ENGCOM-4366 -->* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw this error,  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+<!-- ENGCOM-4444 -->* Corrected tabbing issue on the product page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
 
-
-Copy from 2.3.1 4019
-
-
-
-<!-- ENGCOM-4011 -->*
-*Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
-
-
-Copy from 2.3.1 3822
-
-
-
-<!-- ENGCOM-3974 -->*
-
-*Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
-
-Copy from 2.3.1 3842
-
-
-
-<!-- ENGCOM-4311 -->*
-*Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
-
-Copy from 2.3.1 3267
-
-
-<!-- ENGCOM-4317 -->*
-
-*Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
-
-2.3.2 4270
-
-
-
-<!-- ENGCOM-4366 -->*
-
-*Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
-
-
-
-Same as 4152
-
-
-
-<!-- ENGCOM-4444 -->*
-
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
-
-Same as 4250
 
 
 
@@ -1165,62 +982,92 @@ Same as 4250
 ###  URL rewrite
 
 
-<!-- ENGCOM-4621 -->*
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+<!-- MAGETWO-98208 -->*
 
+The system allows creating a product which will have a system or non-human readable URLs
 
-<!-- ENGCOM-4116 -->*
+URLs not using SEO friendly format if you assign to website
 
-*Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+ACTUAL RESULTS
+You will see the product has url like catalog/product/view/id/1/s/testproduct-overriden/category/3/
 
-Copy from 2.3.1 3925
-
-
-<!-- ENGCOM-4224 -->*
-
-*Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
+EXPECTED BEHAVIOUR
+Url should have human-readable URL e.g: testingproduct.
 
 
 
-Copy from 2.3.1 4050
+
+<!-- MAGETWO-97898 -->*
+
+Store switcher URL redirects to the same store
+
+Visiting the URL in the format `http://mysite.com/<store_view_b>/stores/store/switch/_store/<store_view_a>/_from_store/<store_view_b>` does not redirect to Store View A - it stays at store view B
+
+
+
+
+<!-- ENGCOM-4621 -->* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button.*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+
+
+<!-- ENGCOM-4116 -->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+
+<!-- ENGCOM-4224 -->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 
 
 ### VAT ID
 
-<!-- ENGCOM-4232 -->*
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+<!-- ENGCOM-4232 -->* Greek VAT numbers can now be validated. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 
 
 
-### Visual Merchandiser
 
 
 
 ### Web API framework
 
+<!-- MAGETWO-73978 -->*
+
+API call with pageSize and currentPage > items should return error	
+
+In catalogProductRepositoryV1, it's possible to specify searchCriteria[pageSize] and searchCriteria[currentPage].
+
+Example: GET http://<hostname>/index.php/rest/V1/products?searchCriteria[pageSize]=10&searchCriteria[currentPage]=2
+
+Consider the case where there are 1,000 products in the product catalog.
+
+Case 1: Query within number of products available:
+searchCriteria[pageSize]=10&searchCriteria[currentPage]=2
+
+Expected Result:
+ API returns 10 results from page 2 (items 11-20 in database)
+
+Actual Result:
+ Performs as expected
+
+Case 2: Query beyond number of products available:
+searchCriteria[pageSize]=1000&searchCriteria[currentPage]=50
+
+Expected Result:
+ API returns error, because page 50 with size of 1000 would start with item 49,001, which does not make sense because there are only 1,000 products.
+
+Actual Result:
+ API "wraps" through results, ignores the specified currentPage value, and returns same results as the highest valid currentPage
 
 
-### Widget
 
 
 
 
 ### Wishlist
 
-<!-- ENGCOM-4513 -->*
+<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesiraable and inaccurate changes in quantity
 
-*Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
-
-Same as 4460
+<!-- ENGCOM-4513 -->* Customer wishlists now include review summaries for included products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 
-
-
-
-### WYSIWG
 
 
 

--- a/guides/v2.2/release-notes/bk-release-notes.md
+++ b/guides/v2.2/release-notes/bk-release-notes.md
@@ -18,6 +18,9 @@ Quarterly patch releases do not introduce backward-incompatible changes, archite
 
 ## Magento 2.2.x Release Notes
 
+* [{{site.data.var.ce}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9CE.html)
+* [{{site.data.var.ee}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9EE.html)
+
 * [{{site.data.var.ce}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8CE.html)
 * [{{site.data.var.ee}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8EE.html)
 


### PR DESCRIPTION
## Purpose of this pull request

- Add release note updates for v2.2.9

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/release-notes/bk-release-notes.html
- https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.html
-https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.html

whatsnew
Added release note information [Magento Commerce](https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.html) and [Magento Commerce Open Source](https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.html) version 2.2.9.