### PR TITLE
Fixed some small typo's in the 2.2.9CE release notes.

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -231,7 +231,7 @@ s
 
 <!-- MAGETWO-72961 -->* Magento now uses the value of the  default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
-<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless  configued for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 
 <!-- ENGCOM-4132 -->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
@@ -406,7 +406,7 @@ See [Configure the lock provider](https://devdocs.magento.com/guides/v2.3/instal
 
 ### Pricing
 
-<!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prics were  not saved on the stor-view level when Catalog Price Scope was to **Global**. 
+<!-- MAGETWO-99247 -->* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prices were not saved on the store-view level when Catalog Price Scope was set to **Global**.
 
 <!-- MAGETWO-96062, 97523 -->* The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
@@ -540,7 +540,7 @@ See [Configure the lock provider](https://devdocs.magento.com/guides/v2.3/instal
 
 ### Wishlist
 
-<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesiraable and inaccurate changes in quantity
+<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesirable and inaccurate changes in quantity
 
 <!-- ENGCOM-4513 -->* Customer wishlists now include review summaries for included products. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request fixes some small typo's in the 2.2.9CE release notes.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.html (not available yet)

## Questions

Here are some remarks which I'm not sure about, so I'd rather ask it first here before adding it to the PR:

1) Regarding the following line:
> Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.

Since English is not my mother tongue I'm not very sure, but this sounds better as `Previously, a report ran by an administrator` instead of `run`?

2) There are a bunch of lines in the CE document which I think only apply to Magento EE, but I'm not 100% sure:

    - The two lines in the `Customer custom attributes` section
    - The one line in the `Logging` section
    - The line `Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.`
    - The line `Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.`
    - The line `The quick order form now handles the SKUs that you enter  for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.`

So these should probably get removed from the CE release notes?

Feel free to fix the remarks I made here yourself, or let me know if I should handle these in this PR.

BTW: I only briefly went through the 2.2.9CE release notes, nothing else (yet). I'm sure I missed many other small problems, but hopefully not that many :)

## Other remarks

I'm noticing a lot of subtle changes in the release notes between the EE & CE versions. Please tell me you are not manually maintaining both lists by hand because it looks like you are. I've noticed this in the previous release notes as well. Many typo's fixed in the EE version didn't get fixed in the CE version.
It would be a lot better if you guys could figure out a way to maintain these descriptions in a single master file from which you then generate these release notes, so they are consistent between CE & EE & 2.1.18 & 2.2.9 & 2.3.2, ... Would save you a lot of time and keep everything consistent, just saying :)

