### PR TITLE
Minor grammar issue

### DIFF
--- a/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
@@ -12,7 +12,7 @@ functional_areas:
 
 In general, *stopwords* are a language's most common words that search engines filter out after processing text. Originally, when disk space and memory were extremely limited, every kilobyte saved meant a significant improvement in performance. Therefore, search engines achieved performance gains by ignoring certain words and keeping the index small.
 
-Although we have more storage today, performance is still important. Elasticsearch, like other search engines, still use stopwords to improve performance.
+Although we have more storage today, performance is still important. Elasticsearch, like other search engines, still uses stopwords to improve performance.
 
 You must manage your Elasticsearch stopwords using `.csv` files located in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory or the `<magento_root>/app/code/Magento/Elasticsearch/etc/stopwords/` directory, depending on how you installed the Magento software.
 


### PR DESCRIPTION
## Purpose of this pull request

This PR is a minor grammar update. Since `Elasticsearch` is a singular noun, the verb following it should be the singular `uses` instead of the plural `use`.

## Affected DevDocs pages

es-config-stopwords.html

**Note**
This is my first PR in this project. I have read the contributing guidelines and code of conduct and have signed the Magento Contributor Agreement. Please let me know if I missed anything along the way.
