### PR TITLE
corrected link syntax

### DIFF
--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -31,7 +31,7 @@ Amazon Sales Channel install is a `.zip` file available from the Magento Marketp
       composer require magento/services-connector:~1.0.3
       ```
 
-    - Enter your [authentication keys](https://devdocs.magento.com/guides/v2.3/install-gde/prereq/connect-auth.html). Your public key is your username; your private key is your password.
+    - Enter your [authentication keys]({{ site.baseurl }}/guides/v{{ site.version }}/install-gde/prereq/connect-auth.html). Your public key is your username; your private key is your password.
     - Wait for Composer to finish updating your project dependencies and make sure there aren’t any errors.
 1. After installing, enter an [API Key](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-verify-api-key.html) to complete configuration.
 

--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -31,9 +31,9 @@ Amazon Sales Channel install is a `.zip` file available from the Magento Marketp
       composer require magento/services-connector:~1.0.3
       ```
 
-    - Enter your [authentication keys]({{https://devdocs.magento.com/guides/v2.3/install-gde/prereq/connect-auth.html}}). Your public key is your username; your private key is your password.
+    - Enter your [authentication keys](https://devdocs.magento.com/guides/v2.3/install-gde/prereq/connect-auth.html). Your public key is your username; your private key is your password.
     - Wait for Composer to finish updating your project dependencies and make sure there aren’t any errors.
-1. After installing, enter an [API Key]({{https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-verify-api-key.html}}) to complete configuration.
+1. After installing, enter an [API Key](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-verify-api-key.html) to complete configuration.
 
 ## Add the Amazon Sales Channel API key
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) is to correct syntax errors for links in extensions/amazon-sales/index.md (i.e., remove curly braces from absolute links)

## Affected DevDocs pages
https://devdocs.magento.com/extensions/amazon-sales/
