### PR TITLE
Fix compatibility table

### DIFF
--- a/_data/compatibility.yml
+++ b/_data/compatibility.yml
@@ -21,7 +21,7 @@ extension:
           2.2.4+: general availability
           2.3.0: general availability
           2.3.1: general availability
-    
+      - 
         name: 1.1.1
         support:
           2.2.4+: general availability


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes YAML so Google Ads 1.1.2 renders properly in the compatibility table.

## Affected DevDocs pages

- https://devdocs.magento.com/release