### PR TITLE
Fix root to be visible on Magento DevDocs website

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
@@ -125,8 +125,10 @@ When you change from production to developer mode, you should clear generated cl
 
 1.  If you're changing from production mode to developer mode, delete the contents of the `generated/code` and `generated/metadata` directories:
 
-    rm -rf &lt;magento_root&gt;/generated/metadata/* &lt;magento_root&gt;/generated/code/*
-
+    ```bash
+    rm -rf <magento_root>/generated/metadata/* <magento_root>/generated/code/*
+    ```
+    
 2.  Set the mode:
 
     ```bash

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
@@ -125,7 +125,7 @@ When you change from production to developer mode, you should clear generated cl
 
 1.  If you're changing from production mode to developer mode, delete the contents of the `generated/code` and `generated/metadata` directories:
 
-    rm -rf <magento_root>/generated/metadata/* <magento_root>/generated/code/*
+    rm -rf &lt;magento_root&gt;/generated/metadata/* &lt;magento_root&gt;/generated/code/*
 
 2.  Set the mode:
 


### PR DESCRIPTION
## Purpose of this pull request
The Magento website (https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.html) renders the <magento_root> tags as html, so they are not visible to the reader.

On the Magento website the command looks like
`rm -rf /generated/metadata/* /generated/code/*`
But it should look like 
`rm -rf <magento_root>/generated/metadata/* <magento_root>/generated/code/*`
Note that GitHub is rendering it as intended.


<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->
- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.html

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
