### PR TITLE
Separate indexing configuration into `_config.index.yml`

### DIFF
--- a/_config.index.yml
+++ b/_config.index.yml
@@ -1,0 +1,24 @@
+# Jekyll Algolia settings for indexing https://community.algolia.com/jekyll-algolia/options.html
+algolia:
+  files_to_exclude:
+    - guides/m1x/**/*.html
+    - guides/m1x/**/*.md
+    - swagger
+    - redoc
+  # Index HTML elements, especially code samples.
+  nodes_to_index: 'p,li,td,code'
+  # Override 10KB default and use our allowed max of 20KB
+  max_record_size: 20000
+  settings:
+    attributesForFaceting:
+      - searchable(functional_areas)
+      - searchable(guide_version)
+      - searchable(versionless)  
+
+# Disable the code blocks line numbers at indexing stage
+kramdown:
+  syntax_highlighter_opts:
+    span:
+      line_numbers: false
+    block:
+      line_numbers: false

--- a/_config.yml
+++ b/_config.yml
@@ -178,20 +178,6 @@ algolia:
   application_id: E642SEDTHL
   index_name: devdocs
   api_key: d2d0f33ab73e291ef8d88d8b565e754c
-  files_to_exclude:
-    - guides/m1x/**/*.html
-    - guides/m1x/**/*.md
-    - swagger
-    - redoc
-  # Index HTML elements, especially code samples.
-  nodes_to_index: 'p,li,td,code'
-  # Override 10KB default and use our allowed max of 20KB
-  max_record_size: 20000
-  settings:
-    attributesForFaceting:
-      - searchable(functional_areas)
-      - searchable(guide_version)
-      - searchable(versionless)  
 
 google:
   analytics: UA-66243208-1


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

- This pull request (PR) prevents the code blocks line numbers from being indexed by Jekyll Algolia.
- Separates indexing config from public search config (should be left at `_config.yml`)

We have to change the Jenkins indexing job in order for this to work:
```
ALGOLIA_API_KEY='$var' bundle exec jekyll algolia --config _config.yml,_config.index.yml
```

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

none

