### PR TITLE
Added TTFB_TESTED_PAGES

### DIFF
--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -15,14 +15,39 @@ stage:
 
 {% include cloud/customize-build-deploy.md %}
 
+### `TTFB_TESTED_PAGES`
+
+- **Default**— `[]` (an empty array)
+- **Version**—Magento 2.1.4 and later
+
+Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to test, specify the path or the HTTP or HTTPS URL.
+
+```yaml
+stage:
+  post-deploy:
+    TTFB_TESTED_PAGES:
+       - "index.php"
+       - "index.php/customer/account/create"
+       - "https://example.com/catalog/some-category"
+```
+
+After you specify the pages to test and commit your changes, the _Time To First Byte_ test runs during the post-deploy phase and posts results for each path to the cloud log:
+
+```terminal
+[2019-06-20 20:42:22] INFO: TTFB test result: 0.313s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/customer/account/create","status":200}
+[2019-06-20 20:42:22] INFO: TTFB test result: 0.408s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/checkout/cart","status":200}
+```
+
+For redirected paths, the log reports the path of the redirect target instead of the one configured in the environment variable. If you specify an invalid path, the log displays a warning message.
+
 ### `WARM_UP_PAGES`
 
--  **Default**— `index.php`
--  **Version**—Magento 2.1.4 and later
+- **Default**— `index.php`
+- **Version**—Magento 2.1.4 and later
 
 Customize the list of pages used to preload the cache in the `post_deploy` stage. You must configure the post-deploy hook. See the [hooks section][] of the `.magento.app.yaml` file.
 
--   **single pages**—Specify a single page to add to the cache. You do not have to indicate the default base URL. The following example caches the `BASE_URL/index.php` page:
+- **single pages**—Specify a single page to add to the cache. You do not have to indicate the default base URL. The following example caches the `BASE_URL/index.php` page:
 
     ```yaml
     stage:
@@ -31,7 +56,7 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
           - "index.php"
     ```
 
--   **multiple domains**—List multiple URLs. The following example caches pages from two domains:
+- **multiple domains**—List multiple URLs. The following example caches pages from two domains:
 
     ```yaml
     stage:
@@ -47,11 +72,12 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
     <entity_type>:<pattern|url>:<store_id|store_code>
     ```
 
-    -  `entity_type`: Choose `category` or `cms-page`
-    -  `pattern|url`: Use a `regexp` pattern or an exact match `url` to filter the URLs, or use an asterisk (\*) for all pages 
-    -  `store_id|store_code`: Use the ID or Code of the store or an asterisk (\*) for all stores
+    - `entity_type`: Choose `category` or `cms-page`
+    - `pattern|url`: Use a `regexp` pattern or an exact match `url` to filter the URLs, or use an asterisk (\*) for all pages 
+    - `store_id|store_code`: Use the ID or Code of the store or an asterisk (\*) for all stores
 
-    The following example caches: 
+    The following example caches these items:
+
     - all category pages for store with ID 1
     - category page `cars` for store with code `store_en`
     - cms page `contact` for all stores 

--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -20,7 +20,7 @@ stage:
 - **Default**— `[]` (an empty array)
 - **Version**—Magento 2.1.4 and later
 
-Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to test, specify the path or the HTTP or HTTPS URL.
+Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to page to test, specify the absolute path reference or an absolute URL with protocol and host.
 
 ```yaml
 stage:

--- a/guides/v2.1/cloud/env/variables-post-deploy.md
+++ b/guides/v2.1/cloud/env/variables-post-deploy.md
@@ -20,7 +20,7 @@ stage:
 - **Default**— `[]` (an empty array)
 - **Version**—Magento 2.1.4 and later
 
-Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to page to test, specify the absolute path reference or an absolute URL with protocol and host.
+Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. Specify an absolute path reference, or URL with protocol and host, for each page that requires the test.
 
 ```yaml
 stage:
@@ -37,7 +37,7 @@ After you specify the pages to test and commit your changes, the _Time To First 
 [2019-06-20 20:42:22] INFO: TTFB test result: 0.313s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/customer/account/create","status":200}
 [2019-06-20 20:42:22] INFO: TTFB test result: 0.408s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/checkout/cart","status":200}
 ```
-
+{: .no-copy}
 For redirected paths, the log reports the path of the redirect target instead of the one configured in the environment variable. If you specify an invalid path, the log displays a warning message.
 
 ### `WARM_UP_PAGES`

--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -212,7 +212,7 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 For best results, we recommend the following tools:
 
-* [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy#ttfb_tested_pages)—Test Magento application performance by configuring the TTFB_TESTED_PAGES envrionment variable to test site response time.
+* [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the TTFB_TESTED_PAGES envrionment variable to test site response time.
 * [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
 * [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 * New Relic (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.

--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -215,9 +215,9 @@ For best results, we recommend the following tools:
 * [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
 * [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
 * [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
-* New Relic (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
-* [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided)x— Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/)— Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* New Relic (provided)—Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
+* [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided)— Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/)—Real-time analysis of your site pages load time with different origin locations. Pingdom may require a fee. WebPageTest is a free tool.
 
 ## Set up Magento Security Scan Tool {#security-scan}
 

--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -212,7 +212,7 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 For best results, we recommend the following tools:
 
-* [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the TTFB_TESTED_PAGES envrionment variable to test site response time.
+* [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
 * [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
 * [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 * New Relic (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.

--- a/guides/v2.1/cloud/live/stage-prod-test.md
+++ b/guides/v2.1/cloud/live/stage-prod-test.md
@@ -12,6 +12,7 @@ functional_areas:
 ---
 
 #### Previous step:
+
 [Migrate data and static files]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html)
 
 When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) and [Pro]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls) access information.
@@ -49,7 +50,9 @@ The following examples use Pro URLs. You can use any URL with the `dig` command.
 
 Next, use a `curl` command to verify X-Magento-Tags exist and additional header information. The format for the command is:
 
-	curl http[s]://<full site URL> -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1
+```bash
+curl http[s]://<full site URL> -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1
+```
 
 For Starter, enter the full site URL from your environment [Access info]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) in the command to view the headers.
 
@@ -58,20 +61,20 @@ For Pro Staging and Production, the command differs per server:
 * Staging: `curl http[s]://staging.<your domain>.c.<instanceid>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
 * Production:
 
-	* The load balancer: `curl http[s]://<your domain>.c.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
-	* A direct Origin node: `curl http[s]://<your domain>.{1|2|3}.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
+  * The load balancer: `curl http[s]://<your domain>.c.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
+  * A direct Origin node: `curl http[s]://<your domain>.{1|2|3}.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
 
 After you are live, you can also check your live site: `curl https://<your domain> -k -vo /dev/null -HFastly-Debug:1`. You can also add `--resolve` if your live URL is not set up with DNS.
 
 Check the returned response headers and values:
 
-*	`Fastly-Magento-VCL-Uploaded` should be present
-*	`X-Magento-Tags` should be returned
-*	`Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
-*	`X-Cache` should be either `HIT` or `HIT, HIT`
-*	`x-cache-hits` should be 1,1
-*	[`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
-*	[`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
+* `Fastly-Magento-VCL-Uploaded` should be present
+* `X-Magento-Tags` should be returned
+* `Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
+* `X-Cache` should be either `HIT` or `HIT, HIT`
+* `x-cache-hits` should be 1,1
+* [`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
+* [`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
 
 To verify Fastly is enabled in Staging and Production, check the configuration in the Magento Admin for each environment:
 
@@ -209,11 +212,12 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 For best results, we recommend the following tools:
 
-* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+* [Magento application performance test]({{ page.baseurl }}/cloud/env/variables-post-deploy#ttfb_tested_pages)—Test Magento application performance by configuring the TTFB_TESTED_PAGES envrionment variable to test site response time.
+* [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+* [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 * New Relic (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
-* [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+* [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided)x— Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks indepth: process, method call, query, load, and so on.
+* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/)— Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 ## Set up Magento Security Scan Tool {#security-scan}
 

--- a/guides/v2.1/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.1/cloud/release-notes/cloud-tools.md
@@ -26,6 +26,8 @@ The release notes include:
     -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#force_update_urls) content.
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
+    
+    -  {:.new}<!-- MAGECLOUD-3643-->Added the **TTFB_TESTED_PAGES** post-deploy variable to configure _Time to First Byte_  page tests to check Magento Commerce application performance for sites deployed to Cloud infrastructure. See the variable description in [post-deploy variables]({{ page.baseurl }}/cloud/env/variables-post-deploy.html).
 
 -   {:.fix}<!-- MAGECLOUD-3545/Github#455 -->Added the `pub/static/.htaccess` file to the exclude list. [Fix submitted by Björn Kraus of PHOENIX MEDIA GmbH](https://github.com/magento/ece-tools/pull/455).
 

--- a/guides/v2.2/cloud/env/variables-post-deploy.md
+++ b/guides/v2.2/cloud/env/variables-post-deploy.md
@@ -1,1 +1,99 @@
-../../../v2.1/cloud/env/variables-post-deploy.md
+---
+group: cloud-guide
+title: Post-deploy variables
+functional_areas:
+  - Cloud
+  - Configuration
+---
+The following _post\_deploy_ variables control actions in the post-deploy phase and can inherit and override values from the [Global variables]({{ page.baseurl }}/cloud/env/variables-global.html). Insert these variables in the `post-deploy` stage of the `.magento.env.yaml` file:
+
+```yaml
+stage:
+  post-deploy:
+    POST-DEPLOY_VARIABLE_NAME: value
+```
+
+{% include cloud/customize-build-deploy.md %}
+
+### `TTFB_TESTED_PAGES`
+
+- **Default**— `[]` (an empty array)
+- **Version**—Magento 2.1.4 and later
+
+Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to test, specify the path or the HTTP or HTTPS URL.
+
+```yaml
+stage:
+  post-deploy:
+    TTFB_TESTED_PAGES:
+       - "index.php"
+       - "index.php/customer/account/create"
+       - "https://example.com/catalog/some-category"
+```
+
+After you specify the pages to test and commit your changes, the _Time To First Byte_ test runs during the post-deploy phase and posts results for each path to the cloud log:
+
+```terminal
+[2019-06-20 20:42:22] INFO: TTFB test result: 0.313s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/customer/account/create","status":200}
+[2019-06-20 20:42:22] INFO: TTFB test result: 0.408s {"url":"https://staging-tkyicst-xkmwgjkwmwfuk.us-4.magentosite.cloud/checkout/cart","status":200}
+```
+
+For redirected paths, the log reports the path of the redirect target instead of the one configured in the environment variable. If you specify an invalid path, the log displays a warning message.
+
+### `WARM_UP_PAGES`
+
+- **Default**— `index.php`
+- **Version**—Magento 2.1.4 and later
+
+Customize the list of pages used to preload the cache in the `post_deploy` stage. You must configure the post-deploy hook. See the [hooks section][] of the `.magento.app.yaml` file.
+
+- **single pages**—Specify a single page to add to the cache. You do not have to indicate the default base URL. The following example caches the `BASE_URL/index.php` page:
+
+    ```yaml
+    stage:
+      post-deploy: 
+        WARM_UP_PAGES:
+          - "index.php"
+    ```
+
+- **multiple domains**—List multiple URLs. The following example caches pages from two domains:
+
+    ```yaml
+    stage:
+      post-deploy:
+        WARM_UP_PAGES:
+          - 'http://example1.com/test'
+          - 'http://example2.com/test'
+    ```
+
+-   **multiple pages**—Use the following format to cache multiple pages according to a specific regular expression pattern:
+
+    ```terminal
+    <entity_type>:<pattern|url>:<store_id|store_code>
+    ```
+
+    - `entity_type`: Choose `category` or `cms-page`
+    - `pattern|url`: Use a `regexp` pattern or an exact match `url` to filter the URLs, or use an asterisk (\*) for all pages 
+    - `store_id|store_code`: Use the ID or Code of the store or an asterisk (\*) for all stores
+
+    The following example caches: 
+    - all category pages for store with ID 1
+    - category page `cars` for store with code `store_en`
+    - cms page `contact` for all stores 
+    - any category page that contains `car_` and ends with `html` for store with ID 2
+    - any category page that contains `tires_` for store with code `store_gb`
+
+    ```yaml
+    stage:
+      post-deploy: 
+        WARM_UP_PAGES:
+          - "category:*:1"
+          - "category:cars:store_en"
+          - "cms-page:contact:*
+          - "category:|car_.*?\\.html$|:2"
+          - "category:|tires_.*|:store_gb"
+    ```
+
+[hooks section]: {{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
+[CMS]: https://glossary.magento.com/cms/
+[Content elements]: https://docs.magento.com/m2/ce/user_guide/cms/content-elements.html

--- a/guides/v2.2/cloud/env/variables-post-deploy.md
+++ b/guides/v2.2/cloud/env/variables-post-deploy.md
@@ -20,7 +20,7 @@ stage:
 - **Default**— `[]` (an empty array)
 - **Version**—Magento 2.1.4 and later
 
-Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to test, specify the path or the HTTP or HTTPS URL.
+Configure _Time To First Byte_ (TTFB) testing for specified pages to test your {{ site.data.var.ece }} site performance. For each page to page to test, specify the absolute path reference or an absolute URL with protocol and host.
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -27,6 +27,8 @@ The release notes include:
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
 
+    -  {:.new}<!-- MAGECLOUD-3643-->Added the **TTFB_TESTED_PAGES** post-deploy variable to configure _Time to First Byte_  page tests to check Magento Commerce application performance on sites deployed to Cloud infrastructure. See the variable description in [post-deploy variables]({{ page.baseurl }}/cloud/env/variables-post-deploy.html).
+
 -   {:.fix}<!-- MAGECLOUD-3545/Github#455 -->Added the `pub/static/.htaccess` file to the exclude list. [Fix submitted by Björn Kraus of PHOENIX MEDIA GmbH](https://github.com/magento/ece-tools/pull/455).
 
 -   {:.fix}<!-- MAGECLOUD-3178 -->Fixed an error when all validation messages were showing as `Critical` if at least one critical level validator returned an error.

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -26,6 +26,8 @@ The release notes include:
     -   {:.new}<!-- MAGECLOUD-3602-->Added the **FORCE_UPDATE_URLS** deploy variable to update Magento base URLs when deploying to Pro and Starter production and staging environments. See the definition in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#force_update_urls) content.
 
     -   {:.new}<!-- MAGECLOUD-2901 -->Added support for database table prefixes using the [DATABASE_CONFIGURATION environment variable]({{page.baseurl}}/cloud/env/variables-deploy.html#database_configuration).
+    
+    -  {:.new}<!-- MAGECLOUD-3643-->Added the **TTFB_TESTED_PAGES** post-deploy variable to configure _Time to First Byte_  page tests to check Magento Commerce application performance on sites deployed to Cloud infrastructure. See the variable description in [post-deploy variables]({{ page.baseurl }}/cloud/env/variables-post-deploy.html).
 
 -   {:.fix}<!-- MAGECLOUD-3545/Github#455 -->Added the `pub/static/.htaccess` file to the exclude list. [Fix submitted by Björn Kraus of PHOENIX MEDIA GmbH](https://github.com/magento/ece-tools/pull/455).
 


### PR DESCRIPTION
## Purpose of this pull request

Added documentation for the`TTFB_TESTED_PAGES` environment variable used to configure _Time to First Byte_  page tests to check Magento application performance for sites deployed on Cloud infrastructure.

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-post-deploy.html
- https://devdocs.magento.com/guides/v2.3/cloud/live/stage-prod-test.html

## Links to Magento source code

[Magento ECE tools pull request 537](https://github.com/magento/ece-tools/pull/537)
