### PR TITLE
fix formatting in GraphQL release notes

### DIFF
--- a/guides/v2.3/graphql/release-notes.md
+++ b/guides/v2.3/graphql/release-notes.md
@@ -29,7 +29,7 @@ These release notes can include:
   - [Assign an email]({{page.baseurl}}/graphql/reference/quote-set-guest-email.html) to a guest cart.
   - [Place an order]({{page.baseurl}}/graphql/reference/quote-place-order.html).
 
-- {:.new} ** Added support for payment methods that implement [Magento Vault]({{page.baseurl}}/graphql/reference/vault.html)
+- {:.new} **Added support for payment methods that implement [Magento Vault]({{page.baseurl}}/graphql/reference/vault.html)**
 - 
 - {:.new} **Added new queries and extended the functionality of others.**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the formatting of a bulleted item in the GraphQL release notes.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/release-notes.html
