### PR TITLE
Added missing Highlights information to 2.3.2 Open Source release notes

### DIFF
--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
@@ -81,7 +81,6 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 GraphQL enhancements include:
 
-* **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 
 * **Improvements to GraphQL coverage**.  Improved coverage for cart and checkout operations include mutations that provide support for the following actions:
 
@@ -92,6 +91,8 @@ GraphQL enhancements include:
   * Set shipping methods
   * Set the payment method (offline methods only)
   * Place an order
+
+* **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 
 * **GraphQL performance test scenario coverage**. We have added PWA GraphQL test scenarios for critical checkout and catalog browsing to the performance builds. GraphQL community developers can use the new scenarios to measure storefront performance. <!--- MC-15826, 15922-->
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
@@ -79,7 +79,7 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 ### GraphQL
 
-GraphQL performance improvements include these enhancements:
+GraphQL enhancements include:
 
 * **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -3,7 +3,7 @@ group: release-notes
 title: Magento Open Source 2.3.2 Release Notes
 ---
 
-*Release notes published June 26, 2019.*
+*Release notes published June 25, 2019.*
 
 We are pleased to present Magento Open Source 2.3.2.  This release includes over 200 functional fixes to the core product, over 350 pull requests contributed by the community, and  over 75 security enhancements. It includes significant contributions from our community members. 
 
@@ -58,6 +58,46 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 * Data export. Previously, connection timeouts occurred during export of large data sets (for example, the export of 200,000 products). See [Export](https://docs.magento.com/m2/b2b/user_guide/system/data-export.html) for more information. 
  <!--- MC-5953-->
+### Inventory Management enhancements
+
+* **New commands** allow merchants to check for reservation inconsistencies and resolve any that occur. See [Inventory CLI reference](https://devdocs.magento.com/guides/v2.3/inventory/inventory-cli-reference.html).
+
+* Improved user interface for assigning sources to products. This redesigned interface includes:
+
+  * Support for decimal order quantity
+  * New test scenarios created to cover Credit Memo use cases
+  * New InventoryGraphQl module provides attributes that return correct information about product quantities
+  * Single product save (using asynchronous synchronization with legacy catalog inventory)
+  * Multiple product save
+  * Bulk inventory transfer
+
+* **New endpoint** for Bulk Partial Stock Transfer to bulk transfer a custom product quantity between sources. See [Inventory Bulk Actions](https://devdocs.magento.com/guides/v2.3/rest/modules/inventory/bulk-inventory.html).
+
+* Fixes to multiple  bugs. See [Inventory Management release notes](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html).
+
+### GraphQL
+
+GraphQL performance improvements include these enhancements:
+
+* **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
+
+* **Improvements to GraphQL coverage**.  Improved coverage for cart and checkout operations include mutations that provide support for the following actions:
+
+  * Support for simple and virtual products
+  * Add, update, and delete cart items
+  * Set shipping addresses (with address book support)
+  * Set the billing address (with address book support)
+  * Set shipping methods
+  * Set the payment method (offline methods only)
+  * Place an order
+
+* **GraphQL performance test scenario coverage**. We have added PWA GraphQL test scenarios for critical checkout and catalog browsing to the performance builds. GraphQL community developers can use the new scenarios to measure storefront performance. <!--- MC-15826, 15922-->
+
+See [Release notes](https://devdocs.magento.com/guides/v2.3/graphql/release-notes.html) for a more detailed discussion of recent GraphQL bug fixes.
+
+### Progressive Web Apps (PWA)
+
+* **Improved modular component library**. PWA Studio continues to build out the concept for functional and data components through the Peregrine library. Components can now be reused and scaled for frontend needs. Magento has planned a phased rollout for Peregrine functional and data components, starting with the Search component which is launching with this release.
 
 ### Vendor-developed extension enhancements
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -7,6 +7,9 @@ title: Magento Open Source 2.3.2 Release Notes
 
 We are pleased to present Magento Open Source 2.3.2.  This release includes over 200 functional fixes to the core product, over 350 pull requests contributed by the community, and  over 75 security enhancements. It includes significant contributions from our community members. 
 
+## Other release information
+
+Although code for these features is bundled with quarterly releases of the Magento core code, several of these projects (for example, Page Builder, Inventory Management, and Progressive Web Applications (PWA) Studio) are also released independently. Bug fixes for these projects are documented in separate, project-specific release information which is available in the documentation for each project.
 
 ## Highlights
 
@@ -58,6 +61,7 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 * Data export. Previously, connection timeouts occurred during export of large data sets (for example, the export of 200,000 products). See [Export](https://docs.magento.com/m2/b2b/user_guide/system/data-export.html) for more information. 
  <!--- MC-5953-->
+
 ### Inventory Management enhancements
 
 * **New commands** allow merchants to check for reservation inconsistencies and resolve any that occur. See [Inventory CLI reference](https://devdocs.magento.com/guides/v2.3/inventory/inventory-cli-reference.html).
@@ -77,7 +81,7 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 ### GraphQL
 
-GraphQL performance improvements include these enhancements:
+Graph enhancements include:
 
 * **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -83,7 +83,6 @@ Magento now performs the following tasks as **asynchronous background processes*
 
 Graph enhancements include:
 
-* **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 
 * **Improvements to GraphQL coverage**.  Improved coverage for cart and checkout operations include mutations that provide support for the following actions:
 
@@ -94,6 +93,8 @@ Graph enhancements include:
   * Set shipping methods
   * Set the payment method (offline methods only)
   * Place an order
+
+* **GraphQL caching**. GraphQL can now cache the `category`, `cmsBlocks`, `cmsPage`, `products`, and `urlResolver` queries, which improves response times.  To enable this feature, send these queries using HTTP GET. You can send all other queries with HTTP GET, but they are not cached.
 
 * **GraphQL performance test scenario coverage**. We have added PWA GraphQL test scenarios for critical checkout and catalog browsing to the performance builds. GraphQL community developers can use the new scenarios to measure storefront performance. <!--- MC-15826, 15922-->
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR)  will add the merchant tools-related Highlights information to the Magento Open Source 2.3.2 Release Notes

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html

- ...
- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...
- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
