### PR TITLE
Release note update for Magento 2.3.2 and 2.3.1 June 26 hot fix

### DIFF
--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
@@ -1672,6 +1672,7 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 3. Tap **Save Config**.
 
+* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 
 
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
@@ -1519,6 +1519,10 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 3. Tap **Save Config**.
 
+* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
+
+
+
 ## Community contributions
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
@@ -1128,7 +1128,7 @@ label, types, and disabled settings, but the actual `file-content` was not repla
 
 ## Known issues
 
-* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. 
+* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 
 * **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions. 
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -1015,7 +1015,8 @@ label, types and disabled, but the actual `file-content` was not replaced with t
 
 # Known issues
 
-* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. 
+* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
+ 
 
 * **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions. 
 


### PR DESCRIPTION
## Purpose of this pull request


This pull request (PR) adds information to the relevant release notes about the June 26, 2019 hot fix for the Async/Bulk API scope issue.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html
https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.html
https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.html
https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...
- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
