### PR TITLE
Async/Bulk API patch- Add sections about stores

### DIFF
--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -81,8 +81,6 @@ Magento generates a `bulk_uuid` for each asynchronous request. Use the `bulk_uui
 
 You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
-Store Code have to be defined before `async` prefix:
-
 ```
 POST /<store_code>/async/V1/products
 PUT /<store_code>/async/V1/products/:sku

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -99,7 +99,7 @@ PUT /all/async/V1/products/:sku
 
 ### Fallback and creating/updating objects when setting store scopes 
 
-Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
+The following rules apply when you create or update an object, such as a product.
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -77,3 +77,31 @@ Magento generates a `bulk_uuid` for each asynchronous request. Use the `bulk_uui
 }
 ```
 
+## Store Scopes
+
+Asynchronous API also can be used to work with particular store. Way of work is exactly the same as for usual synchronous REST API.
+
+Store Code have to be defined before `async` prefix:
+
+```
+POST /<store_code>/async/V1/products
+PUT /<store_code>/async/V1/products/:sku
+```
+
+This will lead to behaviour that only values for respective store will be updated.
+
+In addition can be used `all` prefix which will update values for all existed stores:
+
+```
+POST /all/async/V1/products
+PUT /all/async/V1/products/:sku
+```
+
+### Store Scopes fallback and object creation / update
+
+Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
+
+* If no store code is set while creating new product - new object will be created with all values set globally for each scope
+* If no store code is set while updating product - then by fallback Magento will update values only for default store 
+* If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
+* If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -77,7 +77,7 @@ Magento generates a `bulk_uuid` for each asynchronous request. Use the `bulk_uui
 }
 ```
 
-## Store Scopes
+## Store scopes
 
 You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -79,7 +79,7 @@ Magento generates a `bulk_uuid` for each asynchronous request. Use the `bulk_uui
 
 ## Store Scopes
 
-Asynchronous API also can be used to work with particular store. Way of work is exactly the same as for usual synchronous REST API.
+You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
 Store Code have to be defined before `async` prefix:
 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -88,7 +88,7 @@ POST /<store_code>/async/V1/products
 PUT /<store_code>/async/V1/products/:sku
 ```
 
-This will lead to behaviour that only values for respective store will be updated.
+As a result, the asynchronous calls update the products on the specific store, instead of the default store.
 
 In addition can be used `all` prefix which will update values for all existed stores:
 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -97,7 +97,7 @@ POST /all/async/V1/products
 PUT /all/async/V1/products/:sku
 ```
 
-### Store Scopes fallback and object creation / update
+### Fallback and creating/updating objects when setting store scopes 
 
 Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -102,6 +102,6 @@ PUT /all/async/V1/products/:sku
 Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
-* If no store code is set while updating product - then by fallback Magento will update values only for default store 
+* If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
 * If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -90,7 +90,7 @@ PUT /<store_code>/async/V1/products/:sku
 
 As a result, the asynchronous calls update the products on the specific store, instead of the default store.
 
-In addition can be used `all` prefix which will update values for all existed stores:
+You can specify the `all` store code to perform operations on all existing stores:
 
 ```
 POST /all/async/V1/products

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -102,4 +102,4 @@ The following rules apply when you create or update an object, such as a product
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
 * If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
-* If `<store_code>` parameter is set, then values for only defined store will be updated 
+* If `<store_code>` parameter is set, then values for only defined store will be updated.

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -103,5 +103,5 @@ Stores usage has a next fallback in case if it's used for creating or updating n
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
-* If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
+* If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -101,7 +101,7 @@ PUT /all/async/V1/products/:sku
 
 Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
 
-* If no store code is set while creating new product - new object will be created with all values set globally for each scope
+* If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If no store code is set while updating product - then by fallback Magento will update values only for default store 
 * If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -121,7 +121,7 @@ POST /<store_code>/async/bulk/V1/products
 PUT /<store_code>/async/bulk/V1/products/:sku
 ```
 
-This will lead to behaviour that only values for respective store will be updated.
+As a result, the asynchronous calls update the products on the specific store, instead of the default store.
 
 You can specify the `all` store code to perform operations on all existing stores:
 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -114,8 +114,6 @@ The response contains an array that indicates whether the call successfully adde
 
 You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
-Store Code have to be defined before `async` prefix:
-
 ```
 POST /<store_code>/async/bulk/V1/products
 PUT /<store_code>/async/bulk/V1/products/:sku

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -135,4 +135,4 @@ The following rules apply when you create or update an object, such as a product
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
 * If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
-* If `<store_code>` parameter is set, then values for only defined store will be updated 
+* If `<store_code>` parameter is set, then values for only defined store will be updated.

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -135,6 +135,6 @@ PUT /all/async/bulk/V1/products/:sku
 The following rules apply when you create or update an object, such as a product.
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
-* If no store code is set while updating product - then by fallback Magento will update values only for default store 
+* If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
 * If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -130,7 +130,7 @@ POST /all/async/bulk/V1/products
 PUT /all/async/bulk/V1/products/:sku
 ```
 
-### Store Scopes fallback and object creation / update
+### Fallback and creating/updating objects when setting store scopes
 
 The following rules apply when you create or update an object, such as a product.
 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -109,3 +109,32 @@ The response contains an array that indicates whether the call successfully adde
     "errors": false
 }
 ```
+
+## Store Scopes
+
+Asynchronous API also can be used to work with particular store. Way of work is exactly the same as for usual synchronous REST API.
+
+Store Code have to be defined before `async` prefix:
+
+```
+POST /<store_code>/async/bulk/V1/products
+PUT /<store_code>/async/bulk/V1/products/:sku
+```
+
+This will lead to behaviour that only values for respective store will be updated.
+
+In addition can be used `all` prefix which will update values for all existed stores:
+
+```
+POST /all/async/bulk/V1/products
+PUT /all/async/bulk/V1/products/:sku
+```
+
+### Store Scopes fallback and object creation / update
+
+Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
+
+* If no store code is set while creating new product - new object will be created with all values set globally for each scope
+* If no store code is set while updating product - then by fallback Magento will update values only for default store 
+* If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
+* If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -132,7 +132,7 @@ PUT /all/async/bulk/V1/products/:sku
 
 ### Store Scopes fallback and object creation / update
 
-Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
+The following rules apply when you create or update an object, such as a product.
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If no store code is set while updating product - then by fallback Magento will update values only for default store 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -123,7 +123,7 @@ PUT /<store_code>/async/bulk/V1/products/:sku
 
 This will lead to behaviour that only values for respective store will be updated.
 
-In addition can be used `all` prefix which will update values for all existed stores:
+You can specify the `all` store code to perform operations on all existing stores:
 
 ```
 POST /all/async/bulk/V1/products

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -134,7 +134,7 @@ PUT /all/async/bulk/V1/products/:sku
 
 Stores usage has a next fallback in case if it's used for creating or updating new objects. For example products.
 
-* If no store code is set while creating new product - new object will be created with all values set globally for each scope
+* If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If no store code is set while updating product - then by fallback Magento will update values only for default store 
 * If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -136,5 +136,5 @@ The following rules apply when you create or update an object, such as a product
 
 * If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
 * If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
-* If `all` parameter is transferred, then values for all store scopes will be updated (in case if particular store don't have yet own value set)
+* If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
 * If `<store_code>` parameter is set, then values for only defined store will be updated 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -112,7 +112,7 @@ The response contains an array that indicates whether the call successfully adde
 
 ## Store Scopes
 
-Asynchronous API also can be used to work with particular store. Way of work is exactly the same as for usual synchronous REST API.
+You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
 Store Code have to be defined before `async` prefix:
 

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -110,7 +110,7 @@ The response contains an array that indicates whether the call successfully adde
 }
 ```
 
-## Store Scopes
+## Store scopes
 
 You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adding sections about stores usage in Async and Bulk API

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/rest/asynchronous-web-endpoints.html
https://devdocs.magento.com/guides/v2.3/rest/bulk-endpoints.html

## Notes
Be aware that this feature is available from 2.3.3 officially. And also it will be releases as a patch for 2.3.2.

Patch is available here: https://magento.com/tech-resources/download#download2312
I dont know how this can be highlighter in Docs

whatsnew
Added information about applying store codes to [asynchronous](https://devdocs.magento.com/guides/v2.3/rest/asynchronous-web-endpoints.html) and [bulk](https://devdocs.magento.com/guides/v2.3/rest/bulk-endpoints.html) REST endpoints.