### PR TITLE
MAGECLOUD-3860 clarify functional testing for ece-tools

### DIFF
--- a/guides/v2.1/cloud/docker/docker-development-testing.md
+++ b/guides/v2.1/cloud/docker/docker-development-testing.md
@@ -7,7 +7,9 @@ functional_areas:
   - Configuration
 ---
 
-You can use the `{{site.data.var.ct}}` package to run functional tests in the Docker environment. Functional tests are in the `src/Test/Functional/Acceptance` folder. See an example in the [ece-tools repository](https://github.com/magento/ece-tools/tree/develop/src/Test/Functional/Acceptance).
+You can use the `{{site.data.var.ct}}` package to run functional tests in the Docker environment, which is helpful when testing code intended for `{{site.data.var.ct}}` contribution. Functional tests are in the `src/Test/Functional/Acceptance` folder. See an example in the [ece-tools repository](https://github.com/magento/ece-tools/tree/develop/src/Test/Functional/Acceptance).
+
+For testing the Magento application, see the [Magento Functional Testing Framework (MFTF)]({{site.baseurl}}/mftf/docs/commands/mftf.html).
 
 ## Prerequisites
 

--- a/guides/v2.2/cloud/docker/docker-development-testing.md
+++ b/guides/v2.2/cloud/docker/docker-development-testing.md
@@ -7,7 +7,9 @@ functional_areas:
   - Configuration
 ---
 
-You can use the `{{site.data.var.ct}}` package to run functional tests in the Docker environment. Functional tests are in the `src/Test/Functional/Acceptance` folder. See an example in the [ece-tools repository](https://github.com/magento/ece-tools/tree/develop/src/Test/Functional/Acceptance).
+You can use the `{{site.data.var.ct}}` package to run functional tests in the Docker environment, which is helpful when testing code intended for `{{site.data.var.ct}}` contribution. Functional tests are in the `src/Test/Functional/Acceptance` folder. See an example in the [ece-tools repository](https://github.com/magento/ece-tools/tree/develop/src/Test/Functional/Acceptance).
+
+For testing the Magento application, see the [Magento Functional Testing Framework (MFTF)]({{site.baseurl}}/mftf/docs/commands/mftf.html).
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR is a bug fix that corrects the Cloud Docker functional testing topic to clarify that it is specific to ece-tools. Added a link to MFTF for testing the Magento application.

This applies to the topic: https://devdocs.magento.com/guides/v2.3/cloud/docker/docker-development-testing.html

whatsnew
Clarified the Functional testing for Docker is for ece-tools and not for the Magento application.