### PR TITLE
Add article about Stores in Message Queue

### DIFF
--- a/_data/toc/php-developer-guide.yml
+++ b/_data/toc/php-developer-guide.yml
@@ -207,6 +207,9 @@ pages:
             - label: Message queues overview
               url: /extension-dev-guide/message-queues/message-queues.html
 
+            - label: Message queues and stores
+              url: /extension-dev-guide/message-queues/message-queues-stores.html
+
             - label: Configure message Queues
               url: /extension-dev-guide/message-queues/config-mq.html
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -1,0 +1,139 @@
+---
+group: php-developer-guide
+title: Architecture of Message Queues
+contributor_name: Comwrap GmbH
+contributor_link: https://www.comwrap.com
+functional_areas:
+  - Services
+---
+
+One of the key features of Message Queues - is a possibility of processing all asynchronous requests only for particular stores.
+
+For support of store scopes extension `Magento_AmqpStore` is responsible. 
+
+{: .bs-callout .bs-callout-warning }
+Support of stores and mentioned extension is only available starting from Magento 2.3.3 version. If you are using version 2.3.1 or 2.3.2, then you can use Magento [PATCH]:https://magento.com/tech-resources/download#download2312
+
+### Messages Processing 
+
+First system have to process message that is send to Magento Message Queue Framework and add to this message information about current store.  
+ 
+Implementation if this can be found in plugin:
+
+```php
+app/code/Magento/AmqpStore/Plugin/Framework/Amqp/Bulk/Exchange.php
+```
+
+Plugin executes before `enqueue` method of `Magento\Framework\Amqp\Bulk\Exchange`.
+
+Each AMQP message by default contains list of properties. We are interesting in `application_headers`. Those headers are used for transfer current `store_id` into the RabbiMQ queue.  
+
+```php
+public function beforeEnqueue(SubjectExchange $subject, $topic, array $envelopes)
+{
+    try {
+        $storeId = $this->storeManager->getStore()->getId();
+    } catch (NoSuchEntityException $e) {
+        $errorMessage = sprintf(
+            "Can't get current storeId and inject to amqp message. Error %s.",
+            $e->getMessage()
+        );
+        $this->logger->error($errorMessage);
+        throw new \LogicException($errorMessage);
+    }
+    $updatedEnvelopes = [];
+    foreach ($envelopes as $envelope) {
+        $properties = $envelope->getProperties();
+        if (!isset($properties)) {
+            $properties = [];
+        }
+        if (isset($properties['application_headers'])) {
+            $headers = $properties['application_headers'];
+            if ($headers instanceof AMQPTable) {
+                try {
+                    $headers->set('store_id', $storeId);
+                } catch (AMQPInvalidArgumentException $ea) {
+                    $errorMessage = sprintf("Can't set storeId to amqp message. Error %s.", $ea->getMessage());
+                    $this->logger->error($errorMessage);
+                    throw new AMQPInvalidArgumentException($errorMessage);
+                }
+                $properties['application_headers'] = $headers;
+            }
+        } else {
+            $properties['application_headers'] = new AMQPTable(['store_id' => $storeId]);
+        }
+        $updatedEnvelopes[] = $this->envelopeFactory->create(
+            [
+                'body' => $envelope->getBody(),
+                'properties' => $properties
+            ]
+        );
+    }
+    if (!empty($updatedEnvelopes)) {
+        $envelopes = $updatedEnvelopes;
+    }
+    return [$topic, $envelopes];
+}
+```
+
+From example before you can see that plugin checks `application_headers` and add there `store_id` parameter. If headers are not exist, then plugin will create them. In this way RabbitMQ message will receive information for which store requrest have to be processed.
+
+### Processing by consumer
+
+[Consumers]:https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.html are picking up messages from RabbitMQ queue and processing them. 
+
+So on a step when consumer reads message, extension executes around plugin in: 
+
+```php
+Magento\AmqpStore\Plugin\AsynchronousOperations\MassConsumerEnvelopeCallback::aroundExecute(SubjectMassConsumerEnvelopeCallback $subject, callable $proceed, EnvelopeInterface $message) 
+```
+
+```php
+public function aroundExecute(SubjectMassConsumerEnvelopeCallback $subject, callable $proceed, EnvelopeInterface $message)
+    {
+        $amqpProperties = $message->getProperties();
+        if (isset($amqpProperties['application_headers'])) {
+            $headers = $amqpProperties['application_headers'];
+            if ($headers instanceof AMQPTable) {
+                $headers = $headers->getNativeData();
+            }
+            if (isset($headers['store_id'])) {
+                $storeId = $headers['store_id'];
+                try {
+                    $currentStoreId = $this->storeManager->getStore()->getId();
+                } catch (NoSuchEntityException $e) {
+                    $this->logger->error(
+                        sprintf(
+                            "Can't set currentStoreId during processing queue. Message rejected. Error %s.",
+                            $e->getMessage()
+                        )
+                    );
+                    $subject->getQueue()->reject($message, false, $e->getMessage());
+                    return;
+                }
+                if (isset($storeId) && $storeId !== $currentStoreId) {
+                    $this->storeManager->setCurrentStore($storeId);
+                }
+            }
+        }
+        $proceed($message);
+        if (isset($storeId, $currentStoreId) && $storeId !== $currentStoreId) {
+            $this->storeManager->setCurrentStore($currentStoreId);//restore original store value
+        }
+    }
+```
+
+Plugin will check message headers and will set up current store in `storeManager` to received `store_id` value.
+
+#### Related Topics
+
+* [Message Queues Overview]
+* [Configure message queues]
+* [Install RabbitMQ]
+
+<!-- Link definitions -->
+[RabbitMQ]: http://www.rabbitmq.com
+[Configure message queues]: {{ page.baseurl }}/extension-dev-guide/message-queues/config-mq.html
+[Message Queues Overview]: {{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html
+[Configure message queues]: {{ page.baseurl }}/extension-dev-guide/message-queues/config-mq.html
+[Install RabbitMQ]: {{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -1,6 +1,6 @@
 ---
 group: php-developer-guide
-title: Architecture of Message Queues
+title: Message queues and stores
 contributor_name: Comwrap GmbH
 contributor_link: https://www.comwrap.com
 functional_areas:

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -119,7 +119,7 @@ public function aroundExecute(SubjectMassConsumerEnvelopeCallback $subject, call
     }
 ```
 
-The plugin checks the message headers and set the current store value in `storeManager` to the received `store_id` value.
+The plugin checks the message headers and sets the current store value in `storeManager` to the received `store_id` value.
 
 #### Related Topics
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -12,7 +12,7 @@ The `Magento_AmqpStore` module provides the ability for message queues to proces
 For support of store scopes extension `Magento_AmqpStore` is responsible. 
 
 {: .bs-callout .bs-callout-warning }
-Support of stores and mentioned extension is only available starting from Magento 2.3.3 version. If you are using version 2.3.1 or 2.3.2, then you can use Magento [PATCH]:https://magento.com/tech-resources/download#download2312
+You must install the [Scope parameter for Async/Bulk API patch](https://magento.com/tech-resources/download#download2312) to enable asynchronous requests on specific stores. Without this patch, asynchronous requests apply to the default store only.
 
 ### Messages Processing 
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -20,7 +20,7 @@ Magento processes each message that is sent to the Message Queue Framework, addi
 app/code/Magento/AmqpStore/Plugin/Framework/Amqp/Bulk/Exchange.php
 ```
 
-Plugin executes before `enqueue` method of `Magento\Framework\Amqp\Bulk\Exchange`.
+The plugin executes before the `enqueue` method in `Magento\Framework\Amqp\Bulk\Exchange`.
 
 Each AMQP message by default contains list of properties. We are interesting in `application_headers`. Those headers are used for transfer current `store_id` into the RabbiMQ queue.  
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -7,7 +7,7 @@ functional_areas:
   - Services
 ---
 
-One of the key features of Message Queues - is a possibility of processing all asynchronous requests only for particular stores.
+The `Magento_AmqpStore` module provides the ability for message queues to process asynchronous requests for specific stores.
 
 For support of store scopes extension `Magento_AmqpStore` is responsible. 
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -14,7 +14,7 @@ For support of store scopes extension `Magento_AmqpStore` is responsible.
 {: .bs-callout .bs-callout-warning }
 You must install the [Scope parameter for Async/Bulk API patch](https://magento.com/tech-resources/download#download2312) to enable asynchronous requests on specific stores. Without this patch, asynchronous requests apply to the default store only.
 
-### Messages Processing 
+### Processing messages 
 
 First system have to process message that is send to Magento Message Queue Framework and add to this message information about current store.  
  

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -76,7 +76,7 @@ public function beforeEnqueue(SubjectExchange $subject, $topic, array $envelopes
 }
 ```
 
-From example before you can see that plugin checks `application_headers` and add there `store_id` parameter. If headers are not exist, then plugin will create them. In this way RabbitMQ message will receive information for which store requrest have to be processed.
+In this example, you can see that the plugin checks `application_headers` and adds the `store_id` parameter. If the headers do not exist, then plugin creates them. As a result, each RabbitMQ message receives information about the store that is affected by an asynchronous request.
 
 ### Processing by consumer
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -9,16 +9,12 @@ functional_areas:
 
 The `Magento_AmqpStore` module provides the ability for message queues to process asynchronous requests for specific stores.
 
-For support of store scopes extension `Magento_AmqpStore` is responsible. 
-
 {: .bs-callout .bs-callout-warning }
 You must install the [Scope parameter for Async/Bulk API patch](https://magento.com/tech-resources/download#download2312) to enable asynchronous requests on specific stores. Without this patch, asynchronous requests apply to the default store only.
 
 ### Processing messages 
 
-First system have to process message that is send to Magento Message Queue Framework and add to this message information about current store.  
- 
-Implementation if this can be found in plugin:
+Magento processes each message that is sent to the Message Queue Framework, adding information about the current store. The following plugin implements this behavior:
 
 ```php
 app/code/Magento/AmqpStore/Plugin/Framework/Amqp/Bulk/Exchange.php

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -80,7 +80,7 @@ In this example, you can see that the plugin checks `application_headers` and ad
 
 ### Processing by consumer
 
-[Consumers]:https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.html are picking up messages from RabbitMQ queue and processing them. 
+[Consumers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-queue.html) pick up messages from the RabbitMQ queue and process them. 
 
 So on a step when consumer reads message, extension executes around plugin in: 
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -22,7 +22,7 @@ app/code/Magento/AmqpStore/Plugin/Framework/Amqp/Bulk/Exchange.php
 
 The plugin executes before the `enqueue` method in `Magento\Framework\Amqp\Bulk\Exchange`.
 
-Each AMQP message by default contains list of properties. We are interesting in `application_headers`. Those headers are used for transfer current `store_id` into the RabbiMQ queue.  
+By default, each AMQP message contains a list of properties. One of these properties is `application_headers`, and these headers are used for transfer the current `store_id` into the RabbitMQ queue.  
 
 ```php
 public function beforeEnqueue(SubjectExchange $subject, $topic, array $envelopes)

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -123,7 +123,7 @@ public function aroundExecute(SubjectMassConsumerEnvelopeCallback $subject, call
     }
 ```
 
-Plugin will check message headers and will set up current store in `storeManager` to received `store_id` value.
+The plugin checks the message headers and set the current store value in `storeManager` to the received `store_id` value.
 
 #### Related Topics
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -82,7 +82,7 @@ In this example, you can see that the plugin checks `application_headers` and ad
 
 [Consumers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-queue.html) pick up messages from the RabbitMQ queue and process them. 
 
-So on a step when consumer reads message, extension executes around plugin in: 
+On a step when a consumer reads a message, the extension executes an around plugin, as shown here: 
 
 ```php
 Magento\AmqpStore\Plugin\AsynchronousOperations\MassConsumerEnvelopeCallback::aroundExecute(SubjectMassConsumerEnvelopeCallback $subject, callable $proceed, EnvelopeInterface $message) 


### PR DESCRIPTION
## Purpose of this pull request

Pull request adding info about Patch for Stores support for Message Queues.
Its a follow up of this Blog: 
https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135567

## Affected DevDocs pages

guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md 

whatsnew
Added the topic [Message queues and stores](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.html).
