### PR TITLE
magento-coding-standard requires squizlabs/php_codesniffer:~3.3.0

### DIFF
--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -92,7 +92,7 @@ composer show magento/product-enterprise-edition {{ page.guide_version }}.* --al
 #### Specify additional packages
 
 ```bash
-composer require --dev allure-framework/allure-phpunit:~1.2.0 friendsofphp/php-cs-fixer:~2.13.0 lusitanian/oauth:~0.8.10 magento/magento-coding-standard:~1.0.0 magento/magento2-functional-testing-framework:~2.3.14 pdepend/pdepend:2.5.2 phpunit/phpunit:~6.5.0 sebastian/phpcpd:~3.0.0 squizlabs/php_codesniffer:3.2.2 --sort-packages --no-update
+composer require --dev allure-framework/allure-phpunit:~1.2.0 friendsofphp/php-cs-fixer:~2.13.0 lusitanian/oauth:~0.8.10 magento/magento-coding-standard:~1.0.0 magento/magento2-functional-testing-framework:~2.3.14 pdepend/pdepend:2.5.2 phpunit/phpunit:~6.5.0 sebastian/phpcpd:~3.0.0 squizlabs/php_codesniffer:~3.3.0 --sort-packages --no-update
 ```
 
 #### Remove unused packages


### PR DESCRIPTION
magento/magento-coding-standard version ~1.0.0 requires "squizlabs/php_codesniffer" version ~3.3.0 but current documentation requires "squizlabs/php_codesniffer" version 3.2.2 which is too old. Change the documentation to include the right version.

Doc page [https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html)

`composer update` throws the error below:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - magento/magento-coding-standard 1.0.2 requires squizlabs/php_codesniffer ~3.3.0 -> satisfiable by squizlabs/php_codesniffer[3.3.0, 3.3.1, 3.3.2] but these conflict with your requirements or minimum-stability.
    - magento/magento-coding-standard 1.0.1 requires squizlabs/php_codesniffer ~3.3.0 -> satisfiable by squizlabs/php_codesniffer[3.3.0, 3.3.1, 3.3.2] but these conflict with your requirements or minimum-stability.
    - magento/magento-coding-standard 1.0.0 requires squizlabs/php_codesniffer ~3.3.0 -> satisfiable by squizlabs/php_codesniffer[3.3.0, 3.3.1, 3.3.2] but these conflict with your requirements or minimum-stability.
    - Installation request for magento/magento-coding-standard ~1.0.0 -> satisfiable by magento/magento-coding-standard[1.0.0, 1.0.1, 1.0.2].
```