### PR TITLE
Updated the devdocs gems bunlde

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: 450a470aa4b937400190d009131fa91cf27d7a9d
+  revision: 5ce6bf94dbf827682b1f83d5e3c4fbc4c4f69478
   specs:
-    devdocs (0.0.1)
+    devdocs (2)
       jekyll (>= 3.3)
 
 GEM
@@ -33,10 +33,10 @@ GEM
     exifr (1.3.6)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
+    ffi (1.11.1)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
-    fspath (3.1.0)
+    fspath (3.1.1)
     html-proofer (3.9.3)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
@@ -50,18 +50,18 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    image_optim (0.26.3)
+    image_optim (0.26.4)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
       image_size (>= 1.5, < 3)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
-    image_optim_pack (0.5.2.20190428)
+    image_optim_pack (0.5.3)
       fspath (>= 2.1, < 4)
       image_optim (~> 0.19)
     image_size (2.0.1)
-    in_threads (1.5.1)
-    jekyll (3.8.5)
+    in_threads (1.5.2)
+    jekyll (3.8.6)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -118,16 +118,16 @@ GEM
     parallel (1.17.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    progress (3.5.0)
-    progressbar (1.10.0)
-    public_suffix (3.0.3)
+    progress (3.5.1)
+    progressbar (1.10.1)
+    public_suffix (3.1.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rouge (3.3.0)
+    rouge (3.5.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -147,7 +147,7 @@ GEM
       netrc (~> 0.10)
       octokit (~> 4.14)
       thor (~> 0.20)
-    yell (2.1.0)
+    yell (2.2.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request updates the bundled dependencies due to the [jekyll 3.8.6](https://github.com/jekyll/jekyll/releases/tag/v3.8.6) release.

## Upgrading guidelines

- Checkout to a new branch from the up-to-date `master`.
- Run `bundle update`.
- Run `rake preview:all`.
- Do manual sanity check by opening random pages (versioned and versionless).
- Commit the updated Gemfile.lock
- Build the branch on Staging.
- Do manual sanity check by opening random pages (versioned and versionless).
- Proceed with a regular PR workflow.