### PR TITLE
Reference for setPaymentMethodAndPlaceOrder Mutation

### DIFF
--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -151,6 +151,9 @@ pages:
                 - label: setPaymentMethodOnCart mutation
                   url: /graphql/reference/quote-payment-method.html
 
+                - label: setPaymentMethodAndPlaceOrder mutation
+                  url: /graphql/reference/quote-set-payment-place-order.html
+
                 - label: setShippingAddressesOnCart mutation
                   url: /graphql/reference/quote-set-shipping-address.html
 

--- a/_includes/graphql/quote-payment-input.md
+++ b/_includes/graphql/quote-payment-input.md
@@ -1,0 +1,4 @@
+Attribute |  Data Type | Description
+--- | --- | ---
+`code` | String! | The internal name for the payment method
+`purchase_order_number` | String | The purchase order number. Optional for most payment methods

--- a/guides/v2.3/graphql/reference/quote-set-payment-place-order.md
+++ b/guides/v2.3/graphql/reference/quote-set-payment-place-order.md
@@ -1,0 +1,81 @@
+---
+group: graphql
+title: setPaymentMethodAndPlaceOrder mutation
+contributor_name: Something Digital
+contributor_link: https://www.somethingdigital.com/
+---
+
+The `setPaymentMethodAndPlaceOrder` mutation sets the cart payment method and converts the cart into an order. The
+mutation returns the resulting order ID. You cannot manage orders with GraphQL, because orders are part of the backend.
+You can use REST or SOAP calls to manage orders to their completion.
+
+Perform the following actions before using the `setPaymentMethodAndPlaceOrder` mutation:
+
+* Create an empty cart
+* Add one or more products to the cart
+* Set the billing address
+* Set the shipping address (non-virtual carts only)
+* Set the shipping method (non-virtual carts only)
+* For guest customers, assign an email to the cart
+
+## Syntax
+
+`mutation: {setPaymentMethodAndPlaceOrder(input: SetPaymentMethodAndPlaceOrderInput): PlaceOrderOutput}`
+
+## Example usage
+
+**Request**
+
+``` text
+mutation {
+  setPaymentMethodAndPlaceOrder(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
+      payment_method: {
+        code: "checkmo"
+      }
+    }
+  ) {
+    order {
+      order_id
+    }
+  }
+}
+```
+
+**Response**
+
+
+```json
+{
+  "data": {
+    "setPaymentMethodAndPlaceOrder": {
+      "order": {
+        "order_id": "000000006"
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `placeOrderInput` object must contain the following attribute:
+
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer’s cart
+`payment_method` | [PaymentMethodInput!](#PaymentMethodInput) | The payment method data for the cart
+
+### PaymentMethodInput attributes {#PaymentMethodInput}
+
+{% include graphql/quote-payment-input.md %}
+
+## Output attributes
+
+The `placeOrderOutput` object contains the `order` object, which contains the following attribute:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`order_id` | String! | The unique ID that identifies the order


### PR DESCRIPTION
Fixes magento/graphql-ce#769

## Purpose of this pull request

This PR adds reference material for the `setPaymentMethodAndPlaceOrder` mutation.

## Links to Magento source code
https://github.com/magento/magento2/blob/1cf357bf8ac263919c69f3e7709291add01ff5fd/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L21

whatsnew
Added the [setPaymentMethodAndPlaceOrder](https://devdocs.magento.com/guides/v2.3/graphql/quote-set-payment-place-order.html) mutation.