### PR TITLE
magento/devdocs#: Editorial. ColorPicker component.

### DIFF
--- a/guides/v2.3/ui_comp_guide/components/ui-colorpicker.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-colorpicker.md
@@ -7,33 +7,11 @@ The ColorPicker component uses the [Spectrum](https://bgrins.github.io/spectrum/
 The ColorPicker component must be a child of the [Listing]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html) or [Form]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html) components.
 
 ## Configuration options
-
-<table>
-  <tr>
-    <th>Option</th>
-    <th>Description</th>
-    <th>Type</th>
-    <th>Default Value</th>
-  </tr>
-  <tr>
-    <td><code>colorFormat</code></td>
-    <td>Defines the color format displayed in the selection tool and input field. Valid formats: <code>hex</code>, <code>rgb</code>, <code>hsl</code>, <code>hsv</code>, <code>name</code>, <code>none</code></td>
-    <td><code>string</code></td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td><code>colorPickerMode</code></td>
-    <td>Defines the mode that affects the available color picker functionality. Valid modes: <code>simple</code>, <code>full</code>, <code>noalpha</code>, <code>palette</code></td>
-    <td><code>string</code></td>
-    <td><code>-</code></td>
-  </tr>
-  <tr>
-    <td><code>elementTmpl</code></td>
-    <td>The path to the <code>.html</code> template of the particular field type (color-picker).</td>
-    <td><code>String</code></td>
-    <td><code>ui/form/element/email</code></td>
-  </tr>
-</table>
+|Option|Description|Type|Default Value|
+|--- |--- |--- |--- |
+|`colorFormat`|Defines the color format displayed in the selection tool and input field. Valid formats: `hex`, `rgb`, `hsl`, `hsv`, `name`, `none`|`string`|`-`|
+|`colorPickerMode`|Defines the mode that affects the available color picker functionality. Valid modes: `simple`, `full`, `noalpha`, `palette`|`string`|`-`|
+|`elementTmpl`|The path to the `.html` template of the particular field type (color-picker).|`string`|`ui/form/element/email`|
 
 ## Sources files
 
@@ -61,4 +39,3 @@ The ColorPicker component must be a child of the [Listing]({{ page.baseurl }}/ui
     ...
     </form>
 ```
-


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) formats table content of "**ColorPicker component**" page regarding to [DevDocs Contributor](https://devdocs.magento.com/guides/v2.3/contributor-guide/templates/basic_template.html#tables).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-colorpicker.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!