### PR TITLE
MAGECLOUD-3897: [Cloud Docker] Clarification to the use of mutagen

### DIFF
--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -190,7 +190,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
     ```
     
     By default, the docker-compose configuration will be adapted to use 'docker-sync' for file synchronization.
-    If you want to use 'mutagen.io', you must run the command with the option `--sync-engine=mutagen`
+    To use 'mutagen.io' for file synchronization, you must run the command with the `--sync-engine=mutagen` option.
     
     For example:
     

--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -179,12 +179,23 @@ Continue launching your Docker environment in the _developer_ mode. The develope
 The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
 
-1.  Install the `docker-sync` tool using the [Installation instructions](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html). If you have it installed, continue to the next step.
+1.  Install the `docker-sync` tool using the [Installation instructions](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html).
+    Or install the `mutagen.io` tool using the [Installation instructions](https://mutagen.io/documentation/installation/).
+    If you have it installed, continue to the next step.
 
 1.  In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version](#service-versions).
 
     ```bash
     ./vendor/bin/ece-tools docker:build --mode="developer"
+    ```
+    
+    By default, the docker-compose configuration will be adapted to use 'docker-sync' for file synchronization.
+    If you want to use 'mutagen.io', you must run the command with the option `--sync-engine=mutagen`
+    
+    For example:
+    
+    ```bash
+    ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=mutagen
     ```
 
 1.  _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
@@ -205,25 +216,30 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
 1.  _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [enable and configure Xdebug]({{ page.baseurl }}/cloud/docker/docker-development-debug.html).
 
-1.  Start the file synchronization.
-
-    For the `docker-sync` tool:
+1.  Start the file synchronization with `docker-sync`.
 
     ```bash
     docker-sync start
     ```
-
-    For the `mutagen` tool:
-
-    ```bash
-    bash ./mutagen.sh 
-    ```
+    If it is the first installation you should wait a few minutes for synchronization files
+    
+    {: .bs-callout .bs-callout-info}
+    If you want to use `mutagen.io` you should skip this step. `Mutagen` should be launched after deploying docker containers
 
 1.  Build files to containers and run in the background.
 
     ```bash
     docker-compose up -d
     ```
+    
+1.  Start the file synchronization with `mutagen.io`.
+    
+        ```bash
+        bash ./mutagen.sh 
+        ```
+       
+    {: .bs-callout .bs-callout-info}
+    If you use `docker-sync` you should skip this step.
 
 1. Install Magento in your Docker environment.
 

--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -189,7 +189,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
     ./vendor/bin/ece-tools docker:build --mode="developer"
     ```
     
-    By default, the docker-compose configuration will be adapted to use 'docker-sync' for file synchronization.
+    By default, the docker-compose configuration uses 'docker-sync' for file synchronization.
     To use 'mutagen.io' for file synchronization, you must run the command with the `--sync-engine=mutagen` option.
     
     For example:

--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -224,7 +224,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
     If it is the first installation you should wait a few minutes for synchronization files
     
     {: .bs-callout .bs-callout-info}
-    If you want to use `mutagen.io` you should skip this step. `Mutagen` should be launched after deploying docker containers
+    If you use `mutagen.io` for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the docker containers.
 
 1.  Build files to containers and run in the background.
 

--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -239,7 +239,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
         ```
        
     {: .bs-callout .bs-callout-info}
-    If you use `docker-sync` you should skip this step.
+    If you use `docker-sync` for file synchronization, skip this step.
 
 1. Install Magento in your Docker environment.
 

--- a/guides/v2.3/cloud/docker/docker-config.md
+++ b/guides/v2.3/cloud/docker/docker-config.md
@@ -180,7 +180,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
 
 1.  Install the `docker-sync` tool using the [Installation instructions](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html).
-    Or install the `mutagen.io` tool using the [Installation instructions](https://mutagen.io/documentation/installation/).
+    Optionally, you can install the `mutagen.io` tool using the [Installation instructions](https://mutagen.io/documentation/installation/).
     If you have it installed, continue to the next step.
 
 1.  In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version](#service-versions).


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-3897

It is necessary to clarify, if the developer uses `mutagen.io`, then he should run the command `./vendor/bin/ece-tools docker:build --mode="developer"` with the `--sync-engine=mutagen` option.
For example:```./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=mutagen```
and run the script `./mutagen.sh` after run the Docker containers