### PR TITLE
Changed note style to warning

### DIFF
--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -33,7 +33,7 @@ The release notes include:
 
     -   {:.fix}<!-- MAGECLOUD-3832 -->Updated the Sodium library from version 1.0.11 to version 1.0.18, and updated the Sodium PHP extension.
 
-        {:.bs-callout-info}
+        {:.bs-callout-warning}
         {{site.data.var.ece}} customers must submit a support ticket to upgrade the libsodium package on Pro Production and Staging environments prior to upgrading to {{site.data.var.ee}} 2.3.2. Currently, you cannot upgrade Starter environments to {{site.data.var.ee}} 2.3.2.
 
     -   {:.fix}<!-- MAGECLOUD-3446 -->Added the `analysis-icu` and the `analysis-phonetic` Elasticsearch plugins to all Docker images.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes the note style from `info` to `warning` to match the style in [version 2.2](https://devdocs.magento.com/guides/v2.2/cloud/release-notes/cloud-tools.html#v2002020) and [release notes](https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.html#known-issues).

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/release-notes/cloud-tools.html#v2002020