### PR TITLE
Remove caching from future feature list

### DIFF
--- a/guides/v2.3/graphql/index.md
+++ b/guides/v2.3/graphql/index.md
@@ -39,7 +39,6 @@ The current GraphQL codebase also supports the following features:
 In the near future, we'll roll out the following features:
 
 * A more performant data retrieval mechanism
-* Caching
 * Queries for other storefront entities like carts and orders
 * Support mutations to enable payments, checkout, and other operations
 


### PR DESCRIPTION
## Purpose of this pull request

Remove caching from the future feature list because query caching is already implemented since 2.3.2.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/index.html
