### PR TITLE
[site] Upgrade RubyGems instead of Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ $ ruby -v
 
 See the [Ruby site](https://www.ruby-lang.org/en/documentation/installation) for instructions.
 
-### Install Bundler
+### Upgrade RubyGems
 
-Install the [Bundler](https://bundler.io/) gem, which helps with Ruby dependencies:
+Upgrade [RubyGems](https://github.com/rubygems/rubygems), which helps with dependencies (gems):
 
 ```
-$ gem install bundler
+$ gem update --system
 ```
 
 Once you have completed preparing your environment, you can build locally and review the site in your browser.


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request changes installation guidelines in README to upgrade RubyGems instead of installing the latest Bundler. The latest RubyGems sets up the default version of Bundler that matches the version that builds the Gemfile.lock.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- none