### PR TITLE
Fix discrepancy regarding plurality within link

### DIFF
--- a/guides/v2.2/extension-dev-guide/searching-with-repositories.md
+++ b/guides/v2.2/extension-dev-guide/searching-with-repositories.md
@@ -117,7 +117,7 @@ $searchCriteria
 ### Search Result
 
 The `getList(SearchCriteria $searchCriteria)` method defined in your repository should return a Search Result object.
-This object is an instance of a class that implements the interface [`SearchResultInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SearchResultsInterface.php){:target="_blank"}.
+This object is an instance of a class that implements the interface [`SearchResultsInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SearchResultsInterface.php){:target="_blank"}.
 
 Search Result objects hold the Search Criteria object and the retrieved entities along with information about the total count of found entities regardless of any limitations set in the criteria.
 


### PR DESCRIPTION
## Purpose of this pull request

Under "Search Result" section, link stated SearchResultInterface but goes to SearchResultsInterface...updated link to correctly display interface name.

## Affected DevDocs pages

https://github.com/magento/devdocs/blob/master/guides/v2.2/extension-dev-guide/searching-with-repositories.md