### PR TITLE
Add schema for cart item prices

### DIFF
--- a/guides/v2.3/graphql/reference/quote.md
+++ b/guides/v2.3/graphql/reference/quote.md
@@ -513,8 +513,19 @@ The `CartItemInterface` object can contain the following attributes.
 Attribute |  Data Type | Description
 --- | --- | ---
 `id` | String | ID of the item
+`prices` | [CartItemPrices](#CartItemPrices) | The prices of this item
 `product` | [ProductInterface]({{ page.baseurl }}/graphql/reference/product-interface-implementations.html) | Contains attributes that are common to all types of products
 `quantity` | Float | The number of items in the cart
+
+#### CartItemPrices object {#CartItemPrices}
+
+The `CartItemPrices` object must contain the following attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`price` | Money! | The unit price of this item
+`row_total` | Money! | The row total of this item
+`row_total_including_tax` | Money! | The row total including tax of this item
 
 #### CartItemQuantity object {#CartItemQuantity}
 


### PR DESCRIPTION
## Purpose of this pull request

This PR updates the graphql cart schema to include cart item prices. Depends on magento/graphql-ce#664

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/reference/quote.html#CartItemInterface

cc @keharper 
