### PR TITLE
Make <error> and <info> tags visible in callout

### DIFF
--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -75,7 +75,7 @@ Following is a summary of the process:
 ```
     
 {: .bs-callout-info }
-You can style the output text by using ```<error>This is an error message</error>``` or ```<info>This is a success message</info>```.
+You can style the output text by using `<error>This is an error message</error>` or `<info>This is a success message</info>`.
 
 2.	Declare your Command class in `Magento\Framework\Console\CommandListInterface` using dependency injection (`<your component root dir>/etc/di.xml`):
 

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -75,7 +75,7 @@ Following is a summary of the process:
 ```
     
 {: .bs-callout-info }
-You can style the output text by using <error>This is an error message</error> or <info>This is a success message</info>.
+You can style the output text by using ```<error>This is an error message</error>``` or ```<info>This is a success message</info>```.
 
 2.	Declare your Command class in `Magento\Framework\Console\CommandListInterface` using dependency injection (`<your component root dir>/etc/di.xml`):
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) attemtps to make the callout text in the cli-howto guide clearer by making sure the HTML-like tags get rendered.

I stumbled across this while reading the devdocs and it took me a minute to parse the meaning of the callout text because the <error> and <info> tags weren't being shown. I figured I'd propose a quick fix.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.html
- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.html

I haven't checked to see if this kind of behaviour occurs in other guides
