### PR TITLE
Added information about missed option of UI LinkColumn component and added the Source files section

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-linkcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-linkcolumn.md
@@ -11,17 +11,12 @@ Constructor: [app/code/Magento/Ui/view/base/web/js/grid/columns/link.js]({{ site
 
 ## LinkColumn configuration
 
-<table>
-  <tr>
-    <th>Option</th>
-    <th>Description</th>
-    <th>Type</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><code>link</code></td>
-    <td>The key in a field's record object that contains the link value.</td>
-    <td>String</td>
-    <td><code>link</code></td>
-  </tr>
-</table>
+| Option | Description | Type | Default |
+| --- | --- | --- | --- |
+| `link` | The key in a field's record object that contains the link value. | String | `link` |
+| `bodyTmpl` | Path to the template that is used to render a column's field in the table's body. | String | `ui/grid/cells/link` |
+
+## Source files
+
+Extends [Column component]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html)
+- [`app/code/Magento/Ui/view/base/web/js/grid/columns/link.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/link.js)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about the missed `bodyTmpl ` option of  UI LinkColumn component and adds the `Source files` section.
Also, the tables markdown was adjusted.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-linkcolumn.html
- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-linkcolumn.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/view/base/web/js/grid/columns/link.js#L16
- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Ui/view/base/web/js/grid/columns/link.js#L16
