### PR TITLE
Added information about missed UI Columns options and added the Source files section

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-columns.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-columns.md
@@ -7,192 +7,29 @@ The Columns component is a collection of columns. It renders the `<table>` eleme
 
 ## Configuration options
 
-<table>
-  <tr>
-    <th>
-      Option
-    </th>
-    <th>
-      Description
-    </th>
-    <th>
-      Type
-    </th>
-    <th>
-      Default
-    </th>
-  </tr>
-  <tr>
-    <td>
-      <code>displayMode</code>
-    </td>
-    <td>
-      Initial display mode.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      <code>'grid'</code>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>displayModes</code>
-    </td>
-    <td>
-      List of available display modes.
-    </td>
-    <td>
-      {<br />
-      [name: string]: <a href="#displaymode">DisplayMode</a><br />
-      }
-    </td>
-    <td>
-      <code>{<br />
-      value: 'grid',<br />
-      label: 'Grid',<br />
-      template: 'ui/grid/listing'<br />
-      }</code>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>dndConfig</code>
-    </td>
-    <td>
-      Configuration of the <a href="{{ page.baseurl }}/ui_comp_guide/components/ui-draganddrop.html">DragAndDrop
-      component</a>.
-    </td>
-    <td>
-      Object
-    </td>
-    <td>
-      Specified in the <a href="{{ page.baseurl }}/ui_comp_guide/components/ui-draganddrop.html">
-      DragAndDrop component configuration</a>.
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>stickyTmpl</code>
-    </td>
-    <td>
-      Path to the <code>.html</code> template used for the <a href="{{ page.baseurl }}/ui_comp_guide/components/ui-toolbar.html">
-      Toolbar component</a> when it receives a fixed position.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      <code>ui/grid/sticky/listing</code>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>template</code>
-    </td>
-    <td>
-      Path to the component’s <code>.html</code> template.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      <code>ui/grid/listing</code>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>editorConfig</code>
-    </td>
-    <td>
-      Configuration of the InlineEditing
-      component.
-    </td>
-    <td>
-      Object
-    </td>
-    <td>
-      Specified in the <a href="{{ page.baseurl }}/ui_comp_guide/components/ui-insertlisting.html">
-      InlineEditing component configuration</a>.
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>viewSwitcherTmpl</code>
-    </td>
-    <td>
-      Path to the .html template for rendering the list of
-      available display modes. By default this list is not
-      displayed.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      <code>ui/grid/view-switcher</code>
-    </td>
-  </tr>
-</table>
+| Option | Description | Type | Default |
+| --- | --- | --- | --- |
+| `component` | The path to the component’s `.js` file. | String | `Magento_Ui/js/grid/listing` |
+| `displayMode` | Initial display mode. | String | `'grid'` |
+| `displayModes` | List of available display modes. | {<br />[name: string]: [DisplayMode](#displaymode)<br />} |  `{grid: {value: 'grid',label: 'Grid',template: '${ $.template }'},list: {value: 'list',label: 'List',template: '${ $.listTemplate }'}}` |
+| `dndConfig` | Configuration of the [DragAndDrop component]({{ page.baseurl }}/ui_comp_guide/components/ui-draganddrop.html). | Object | Specified in the [DragAndDrop component configuration]({{ page.baseurl }}/ui_comp_guide/components/ui-draganddrop.html). |
+| `stickyTmpl` | Path to the `.html` template used for the [Toolbar component]({{ page.baseurl }}/ui_comp_guide/components/ui-toolbar.html) when it receives a fixed position. | String | `ui/grid/sticky/listing` |
+| `template` | Path to the component’s `.html` template. | String | `ui/grid/listing` |
+| `editorConfig` | Configuration of the InlineEditing component. | Object | Specified in the [InlineEditing component configuration]({{ page.baseurl }}/ui_comp_guide/components/ui-insertlisting.html). |
+| `viewSwitcherTmpl` | Path to the .html template for rendering the list of available display modes. By default this list is not displayed. | String | `ui/grid/view-switcher` |
+| `componentType` | The type of component. | String | `columns` |
+| `resizeConfig` | Configurations of [`Resize`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/resize.js) component. | Object | `{name: '${ $.name }_resize',columnsProvider: '${ $.name }',component: 'Magento_Ui/js/grid/resize',enabled: false}` |
 
 ### DisplayMode interface {#displaymode}
 
-<table>
-  <tr>
-    <th>
-      Option
-    </th>
-    <th>
-      Description
-    </th>
-    <th>
-      Type
-    </th>
-    <th>
-      Required
-    </th>
-  </tr>
-  <tr>
-    <td>
-      <code>label</code>
-    </td>
-    <td>
-      Label for the list of available modes.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      Optional
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>template</code>
-    </td>
-    <td>
-      Path to the <code>.html</code> template used to render
-      listing in the selected mode.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      Optional
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>value</code>
-    </td>
-    <td>
-      Mode's identifier.
-    </td>
-    <td>
-      String
-    </td>
-    <td>
-      Optional
-    </td>
-  </tr>
-</table>
+| Option | Description | Type | Required |
+| --- | --- | --- | --- |
+| `label` | Label for the list of available modes. | String | Optional |
+| `template` | Path to the `.html` template used to render listing in the selected mode. | String | Optional |
+| `value` | Mode's identifier. | String | Optional |
+
+## Source files
+
+Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
+
+- [`Magento/Ui/view/base/web/js/grid/listing.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/listing.js)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about missed options of the UI Columns component and adds the `Source files` section.
Also, the tables markdown was adjusted.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-columns.html
- https://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-columns.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/view/base/web/js/grid/listing.js#L20
- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Ui/view/base/web/js/grid/listing.js#L20

