### PR TITLE
Removed Magento 1 code reference

### DIFF
--- a/guides/v2.3/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.3/coding-standards/code-standard-demarcation.md
@@ -398,8 +398,8 @@ jQuery('#{$htmlId}-suggest').treeSuggest({$selectorOptions});
 ```php
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'class'    => 'parent category',
 ));
@@ -411,8 +411,8 @@ $fieldset->addField('new_category_parent', 'text', array(
 ```php
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'style'    => 'border: 1px solid #ccc;',
 ));
@@ -491,7 +491,7 @@ public function getAttributeId($element)
    <input type="checkbox"
       <?php echo ($this->getAttributeName($element)) ? ' name="' . $this->getAttributeName($element) . '"' : NULL; ?>
       data-mage-init="{customToggleWidget: [elementSelector: "input[name='someCustomName']"]}" />
-   <?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+   <?php echo __('Change'); ?>
 </label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->
@@ -515,7 +515,7 @@ public function getCheckbox($elementName){
 <span class="attribute-change-checkbox">
 	<label>
 		<?php echo $this->getCheckbox($element)?>
-		<?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+		<?php echo __('Change'); ?>
 	</label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) is removing Magento 1 code reference.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- guides/v2.3/coding-standards/code-standard-demarcation.md 



<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
