### PR TITLE
Mae cloud fix hotjar feedback

### DIFF
--- a/guides/v2.2/cloud/architecture/cloud-architecture.md
+++ b/guides/v2.2/cloud/architecture/cloud-architecture.md
@@ -3,6 +3,8 @@ group: cloud-guide
 title: Magento Commerce Cloud architecture
 functional_areas:
   - Cloud
+redirect_from:
+  - /guides/v2.2/cloud/basic-information/cloud-plans.html
 ---
 
 {{site.data.var.ece}} has a Starter and a Pro plan. Each plan has a unique architecture to drive your {{site.data.var.ee}} development and deployment process. Both the Starter plan and the Pro plan architecture deploy databases, web server, and caching servers across multiple environments for end-to-end testing while supporting continuous integration.


### PR DESCRIPTION
## Purpose of this pull request

Hotjar feedback:  404 returned when linking to Cloud plans topic at https://devdocs.magento.com/guides/v2.2/cloud/basic-information/cloud-plans.html

Content describing functionality supported fro Cloud Pro and Starter plans is available in the [architecture](https://devdocs.magento.com/guides/v2.3/cloud/architecture/cloud-architecture.html) topic. Updated the Magento Commerce Cloud Pro architecture topic to add a redirect for the obsolete topic describing Magneto Commerce Cloud plans.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.2/cloud/architecture/cloud-architecture.html
