### PR TITLE
Fix issue with escaping of JSON in context of html/attribute

### DIFF
--- a/guides/v2.3/frontend-dev-guide/templates/template-security.md
+++ b/guides/v2.3/frontend-dev-guide/templates/template-security.md
@@ -36,15 +36,25 @@ The following code sample illustrates the XSS-safe output in templates:
 
 For the following output cases, use the specified function to generate XSS-safe output.
 
-**Case:** JSON output\\
+**Case:** JSON output in script context\\
 **Function:** No function needed for JSON output.
 
 
 ```html
   <!-- In this example $postData is a JSON string -->
-  <button class="action" data-post='<?php /* @noEscape */ echo $postData ?>' />
+  <script>
+    var postData = <?php /* @noEscape */ echo $postData ?>;
+  </script>
+  
 ```
+**Case:** JSON output in html/attribute context\\
+**Function:** `escapeHtml`
 
+
+```html
+  <!-- In this example $postData is a JSON string -->
+  <button class="action" data-post="<?php echo $block->escapeHtml($postData) ?>" />
+```
 
 **Case:** String output that should not contain HTML\\
 **Function:** `escapeHtml` 


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) fix improper example with escaping of JSON in context of html/attribute.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-security.html




<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
