### PR TITLE
add setup_version="1.0.0" to module.xml snippet

### DIFF
--- a/guides/v2.3/howdoi/checkout/checkout-add-custom-carrier.md
+++ b/guides/v2.3/howdoi/checkout/checkout-add-custom-carrier.md
@@ -81,7 +81,7 @@ ComponentRegistrar::register(
 ```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Vendor_CustomShipping" >
+    <module name="Vendor_CustomShipping" setup_version="1.0.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
Otherwise compilation will not work.

<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

Correct code snippet, particularly module.xml in the step by step 'add custom shipping carrier' how-to on the devdocs. Without "setup_module" in the XML the module cannot compile.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout-add-custom-carrier.html
