### PR TITLE
magento/devdocs#: Add documentation about @magentoConfigFixture annotation

### DIFF
--- a/guides/v2.3/graphql/functional-testing.md
+++ b/guides/v2.3/graphql/functional-testing.md
@@ -198,7 +198,7 @@ $registry->register('isSecureArea', false);
 
 ### Fixture configs
 
-Use `@magentoConfigFixture` annotation to set a custom config value. It supports a `store` scope only.
+Use the `@magentoConfigFixture` annotation to set a custom config value. It supports a `store` scope only.
  
 #### Syntax
 
@@ -230,7 +230,7 @@ The following example sets a store-scoped value `1` for the config key `checkout
     }
 ```
 
-In the background process, `@magentoConfigFixture` performs the following action before test execution:  
+`@magentoConfigFixture` performs the following action as a background process before test execution:  
 
 ```sql
 INSERT INTO `core_config_data` (scope`, `scope_id`, `path`, `value`)
@@ -238,7 +238,7 @@ VALUES
 	('stores', 1, 'checkout/options/enable_agreements', '1');
 ```
 
-and automatically removes `checkout/options/enable_agreements` config key from the database after the test has been completed.
+The fixture automatically removes the `checkout/options/enable_agreements` config key from the database after the test has been completed.
 
 ## Defining expected exceptions
 

--- a/guides/v2.3/graphql/functional-testing.md
+++ b/guides/v2.3/graphql/functional-testing.md
@@ -209,7 +209,7 @@ Use `@magentoConfigFixture` annotation to set a custom config value. It supports
 ```
 
 where
-- `<store_code>` - Code of store. See `store`.`code` table
+- `<store_code>` - Store code. See the `store`.`code` database field value.
 - `<config_key>` - Config key. See `core_config_data`.`path` 
 - `<config_value>` - Config value. See `core_config_data`.`value`
 
@@ -230,7 +230,7 @@ The following example sets a store-scoped value `1` for the config key `checkout
     }
 ```
 
-In the background process, `@magentoConfigFixture` do the next before test execution:  
+In the background process, `@magentoConfigFixture` performs the following action before test execution:  
 
 ```sql
 INSERT INTO `core_config_data` (scope`, `scope_id`, `path`, `value`)
@@ -238,7 +238,7 @@ VALUES
 	('stores', 1, 'checkout/options/enable_agreements', '1');
 ```
 
-and automatically removes `checkout/options/enable_agreements` config key from database when test be completed.
+and automatically removes `checkout/options/enable_agreements` config key from the database after the test has been completed.
 
 ## Defining expected exceptions
 

--- a/guides/v2.3/graphql/functional-testing.md
+++ b/guides/v2.3/graphql/functional-testing.md
@@ -95,7 +95,7 @@ A fixture consists of two files:
 - The fixture file, which defines the test
 - A rollback file, which reverts the system to the state before the test was run
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Each fixture should have a corresponding rollback file.
 
 Magento provides fixtures in the `dev/tests/integration/testsuite/Magento/<ModuleName>/_files` directory. Use these fixtures whenever possible. When you create your own fixture, also create a proper rollback.
@@ -195,6 +195,50 @@ try {
 $registry->unregister('isSecureArea');
 $registry->register('isSecureArea', false);
 ```
+
+### Fixture configs
+
+Use `@magentoConfigFixture` annotation to set a custom config value. It supports a `store` scope only.
+ 
+#### Syntax
+
+```php
+/**
+ * @magentoConfigFixture <store_code>_store <config_key> <config_value>
+ */
+```
+
+where
+- `<store_code>` - Code of store. See `store`.`code` table
+- `<config_key>` - Config key. See `core_config_data`.`path` 
+- `<config_value>` - Config value. See `core_config_data`.`value`
+
+{: .bs-callout-info }
+`@magentoConfigFixture` does not require a roll-back.  
+
+#### Example usage 
+ 
+The following example sets a store-scoped value `1` for the config key `checkout/options/enable_agreements` for the `default` store in the `GetActiveAgreement()` test: 
+
+```php
+    /**
+     * @magentoConfigFixture default_store checkout/options/enable_agreements 1
+     */
+    public function testGetActiveAgreement()
+    {
+        ...
+    }
+```
+
+In the background process, `@magentoConfigFixture` do the next before test execution:  
+
+```sql
+INSERT INTO `core_config_data` (scope`, `scope_id`, `path`, `value`)
+VALUES
+	('stores', 1, 'checkout/options/enable_agreements', '1');
+```
+
+and automatically removes `checkout/options/enable_agreements` config key from database when test be completed.
 
 ## Defining expected exceptions
 


### PR DESCRIPTION

## Purpose of this pull request


This pull request (PR) adds a documentation about `@magentoConfigFixture` annotation to [GraphQL functional testing](https://devdocs.magento.com/guides/v2.3/graphql/functional-testing.html) page.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/functional-testing.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [@magentoConfigFixture](https://github.com/magento/graphql-ce/pull/351)

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

CC: @keharper @VitaliyBoyko 

Thank you!

whatsnew
Added a description of the `@magentoConfigFixture` annotation to the [GraphQL functional testing](https://devdocs.magento.com/guides/v2.3/graphql/functional-testing.html) page.