### PR TITLE
KB migration: Enable Elasticsearch on Cloud

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-elastic.md
@@ -43,6 +43,18 @@ functional_areas:
 
 1. [Verify the relationships]({{page.baseurl}}/cloud/project/project-conf-files_services.html#service-relationships) and configure Elasticsearch in the Admin UI.
 
+1. Reindex the Catalog Search index.
+
+    ```bash
+    bin/magento indexer:reindex catalogsearch_fulltext
+    ```
+
+1. Clean the cache.
+
+    ```bash
+    bin/magento cache:clean
+    ```
+
 ### Add Elasticsearch plugins
 
 Optionally, you can add plugins with the `.magento/services.yaml` file. For example, to enable the ICU analysis plugin and Python script support plugin, add the `configuration:plugins` section with the listed plugin codes:

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -43,6 +43,18 @@ functional_areas:
 
 1.  [Verify the relationships]({{page.baseurl}}/cloud/project/project-conf-files_services.html#service-relationships) and configure Elasticsearch in the Admin UI.
 
+1. Reindex the Catalog Search index.
+
+    ```bash
+    bin/magento indexer:reindex catalogsearch_fulltext
+    ```
+
+1. Clean the cache.
+
+    ```bash
+    bin/magento cache:clean
+    ```
+
 ## Elasticsearch plugins
 
 Optionally, you can add plugins with the `.magento/services.yaml` file. For example, to enable the ICU analysis plugin and Python script support plugin, add the `configuration:plugins` section with the listed plugin codes:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to consolidate the [KB article](https://support.magento.com/hc/en-us/articles/115004905874-Enable-Elasticsearch-on-Cloud) and existing devdocs topic. It adds required steps for enabling Elasticsearch on cloud. You must reindex the Catalog Search index.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/cloud/project/project-conf-files_services-elastic.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-elastic.html