### PR TITLE
Update PayPal URL descriptions

### DIFF
--- a/_includes/graphql/payment-methods/payflow-link-attributes.md
+++ b/_includes/graphql/payment-methods/payflow-link-attributes.md
@@ -1,5 +1,5 @@
 Attribute |  Data Type | Description
 --- | --- | ---
-`cancel_url` |  String! | The URL that PayPal redirects to upon payment cancellation
-`error_url` | String! | The URL that PayPal redirects to upon payment error
-`return_url` | String! | The URL that PayPal redirects to upon payment success
+`cancel_url` | String! | The relative URL of the page that PayPal will redirect to when the buyer cancels the transaction in order to choose a different payment method. If the full URL to this page is `https://www.example.com/paypal/action/cancel.html`, the relative URL is `paypal/action/cancel.html`
+`error_url` | String! | The relative URL of the transaction error page that PayPal will redirect to upon payment error. If the full URL to this page is `https://www.example.com/paypal/action/error.html`, the relative URL is `paypal/action/error.html`
+`return_url` | String! | The relative URL of the final confirmation page that PayPal will redirect to upon payment success. If the full URL to this page is `https://www.example.com/paypal/action/return.html`, the relative URL is `paypal/action/return.html`

--- a/guides/v2.3/graphql/payment-methods/payflow-link.md
+++ b/guides/v2.3/graphql/payment-methods/payflow-link.md
@@ -34,9 +34,9 @@ mutation {
             code: "payflow_link"
             additional_data: {
                 payflow_link: {
-                  return_url: "https://www.example.com/payflow/test/return"
-                  error_url: "https://www.example.com/payflow/test/error"
-                  cancel_url: "https://www.example.com/payflow/test/cancel"
+                  return_url: "paypal/action/return.html"
+                  error_url: "paypal/action/error.html"
+                  cancel_url: "paypal/action/cancel.html"
                 }
             }
         }

--- a/guides/v2.3/graphql/payment-methods/payments-advanced.md
+++ b/guides/v2.3/graphql/payment-methods/payments-advanced.md
@@ -34,9 +34,9 @@ mutation {
             code: "payflow_advanced"
             additional_data: {
                 payflow_link: {
-                  return_url: "https://www.example.com/payflow/test/return"
-                  error_url: "https://www.example.com/payflow/test/error"
-                  cancel_url: "https://www.example.com/payflow/test/cancel"
+                  return_url: "paypal/action/return.html"
+                  error_url: "paypal/action/error.html"
+                  cancel_url: "paypal/action/cancel.html"
                 }
             }
         }

--- a/guides/v2.3/graphql/reference/paypal-create-payflow-pro-token.md
+++ b/guides/v2.3/graphql/reference/paypal-create-payflow-pro-token.md
@@ -69,7 +69,7 @@ Attribute |  Data Type | Description
 
 ### PayflowProUrlInput object
 
-The `PayflowProUrlInput` object contains a set of relative URLs that PayPal will use in response to various actions during the authorization process. Magento prepends the base URL to this value to create a full URL. For example, if the full URL is https://www.example.com/path/to/page.html, the relative URL is path/to/page.html. 
+The `PayflowProUrlInput` object contains a set of relative URLs that PayPal will use in response to various actions during the authorization process. Magento prepends the base URL to this value to create a full URL. For example, if the full URL is `https://www.example.com/path/to/page.html`, the relative URL is `path/to/page.html`. 
 
 Use this input for Payflow Pro and Payment Pro payment methods.
 

--- a/guides/v2.3/graphql/reference/paypal-create-payflow-pro-token.md
+++ b/guides/v2.3/graphql/reference/paypal-create-payflow-pro-token.md
@@ -23,9 +23,9 @@ mutation {
     input: {
       cart_id: "Po1WkfK7d3vZE0qga610NwJIbxgqllpt"
       urls: {
-        return_url: "http://localhost/paypal/return"
-        cancel_url: "http://localhost/paypal/cancel"
-        error_url: "http://localhost/paypal/error"
+        return_url: "paypal/action/return.html"
+        cancel_url: "paypal/action/cancel.html"
+        error_url: "paypal/action/error.html"
       }
     }
   ) {
@@ -69,13 +69,17 @@ Attribute |  Data Type | Description
 
 ### PayflowProUrlInput object
 
+The `PayflowProUrlInput` object contains a set of relative URLs that PayPal will use in response to various actions during the authorization process. Magento prepends the base URL to this value to create a full URL. For example, if the full URL is https://www.example.com/path/to/page.html, the relative URL is path/to/page.html. 
+
+Use this input for Payflow Pro and Payment Pro payment methods.
+
 The `PayflowProUrlInput` object must contain the following attributes:
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cancel_url` | String! | The URL of the original page on your website where the buyer initially chose PayPal as  a payment type
-`error_url` | String! | The URL of the page on your website where any error in the transaction is handled
-`return_url` | String! | The URL of the final review page on your website where the buyer confirms the order and payment
+`cancel_url` | String! | The relative URL of the page that PayPal will redirect to when the buyer cancels the transaction in order to choose a different payment method. If the full URL to this page is `https://www.example.com/paypal/action/cancel.html`, the relative URL is `paypal/action/cancel.html`
+`error_url` | String! | The relative URL of the transaction error page that PayPal will redirect to upon payment error. If the full URL to this page is `https://www.example.com/paypal/action/error.html`, the relative URL is `paypal/action/error.html`
+`return_url` | String! | The relative URL of the final confirmation page that PayPal will redirect to upon payment success. If the full URL to this page is `https://www.example.com/paypal/action/return.html`, the relative URL is `paypal/action/return.html`
 
 ## Output attributes
 


### PR DESCRIPTION
#5017  Purpose of this pull request

This pull request (PR) updates the descriptions of URL attributes for payment methods.

## Affected DevDocs pages

- guides/v2.3/graphql/payment-methods/payments-advanced.html
- guides/v2.3/graphql/payment-methods/payflow-link.html

The changes to the PayPal Express Checkout payment methods are part of another PR.
