### PR TITLE
Add info about service install or update on Pro

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_services-mysql.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-mysql.md
@@ -8,6 +8,8 @@ functional_areas:
 
 The `mysql` service provides persistent data storage based on [MariaDB](https://mariadb.com/) versions 10.0 and later, supporting the [XtraDB](https://www.percona.com/software/mysql-database/percona-server/xtradb) storage engine and reimplemented features from MySQL 5.6 and 5.7.
 
+{% include cloud/service-config-integration-starter.md %}
+
 #### To access the MariaDB database directly:
 
 Using SSH, log in to the remote server and connect to the database.

--- a/guides/v2.2/cloud/project/project-conf-files_services.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services.md
@@ -8,8 +8,6 @@ functional_areas:
 
 The `services.yaml` file defines the services supported and used by {{site.data.var.ece}}, such as MySQL, Redis, and ElasticSearch. You do not need to subscribe to external service providers. This file is in the `.magento` directory of your project.
 
-{% include cloud/note-pro-using-yaml-support.md %}
-
 The deploy script uses the configuration files in the `.magento` directory to provision the environment with the configured services. A service becomes available to your application if it is included in the `relationships` property of the `.magento.app.yaml` file. The `services.yaml` file contains the service _name_, _type_, and _disk_ values. Changing a service configuration causes a deployment to provision the environment with the updated services.
 
 This affects the following environments:
@@ -18,7 +16,7 @@ This affects the following environments:
 -  Pro Integration environments
 
 {:.bs-callout-tip}
-For Pro, you must enter a [Support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) to install or update services in the Staging and Production environments. Indicate the service changes needed and your updated `.magento.app.yaml` and `services.yaml` files in the ticket.
+For Pro, you must enter a [Support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) to install or update services in the Staging and Production environments. Indicate the service changes needed and include your updated `.magento.app.yaml` and `services.yaml` files in the ticket.
 
 ## Default and supported services
 

--- a/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
+++ b/guides/v2.3/cloud/project/project-conf-files_services-elastic.md
@@ -16,6 +16,8 @@ functional_areas:
 
 {{site.data.var.ee}} supports [Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) version 5.2 and 6.x (supported by Magento version 2.3.1 and later).
 
+{% include cloud/service-config-integration-starter.md %}
+
 #### To enable Elasticsearch:
 
 1.  Add the `elasticsearch` service to the `.magento/services.yaml` file with the Elasticsearch version and allocated disk space in MB.


### PR DESCRIPTION
## Purpose of this pull request

The following instructions are missing note about updating `services.yaml` on Pro Staging and Production environments, which requires a support ticket.

- [Set up Elasticsearch service](https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-elastic.html)

- [Set up MySQL service](https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-mysql.html)

Remove duplicate note on [Services](https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services.html) topic.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-elastic.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-mysql.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services.html



