### PR TITLE
 MAGECLOUD-4052 lock provider variable

### DIFF
--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -253,7 +253,7 @@ stage:
 ### `LOCK_PROVIDER`
 
 -  **Default**—`file`
--  **Version**—Magento 2.1.5 and later
+-  **Version**—Magento 2.2.5 and later
 
 The lock provider prevents the launch of duplicate cron jobs and cron groups. You must use the `file` lock provider in the Production environment. Starter environments and the Pro Integration environment do not use the [MAGENTO_CLOUD_LOCKS_DIR]({{page.baseurl}}/cloud/env/variables-cloud.html) variable, so `{{site.data.var.ct}}` applies the `db` lock provider automatically.
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -58,8 +58,8 @@ stage:
 
 Enables or disables cleaning [static content files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) generated during the build or deploy phase. We recommend the default value _true_ in development.
 
--   **`true`**—Removes all existing static content before deploying the updated static content.
--   **`false`**—The deployment only overwrites existing static content files if the generated content contains a newer version.
+-  **`true`**—Removes all existing static content before deploying the updated static content.
+-  **`false`**—The deployment only overwrites existing static content files if the generated content contains a newer version.
 
 If you make modifications to static content through a separate process, set the value to _false_.
 
@@ -79,9 +79,9 @@ deploy updates to existing files without removing the previous versions. Because
 
 Use this environment variable to confirm message queues are running after a deployment.
 
--   `cron_run`—A boolean value that enables or disables the `consumers_runner` cron job (default = `false`).
--   `max_messages`—A number specifying the maximum number of messages each consumer must process before terminating (default = `1000`). Although we do not recommend it, you can use `0` to prevent the consumer from terminating.
--   `consumers`—An array of strings specifying which consumer(s) to run. An empty array runs _all_ consumers.
+-  `cron_run`—A boolean value that enables or disables the `consumers_runner` cron job (default = `false`).
+-  `max_messages`—A number specifying the maximum number of messages each consumer must process before terminating (default = `1000`). Although we do not recommend it, you can use `0` to prevent the consumer from terminating.
+-  `consumers`—An array of strings specifying which consumer(s) to run. An empty array runs _all_ consumers.
 
 ```yaml
 stage:
@@ -101,6 +101,7 @@ By default, the deployment process overwrites all settings in the `env.php` file
 ```bash
 ./bin/magento queue:consumers:list
 ```
+
 ### `CRYPT_KEY`
 
 -  **Default**—_Not set_
@@ -134,7 +135,7 @@ stage:
       _merge: true
 ```
 
-Also, you can configure a table prefix. 
+Also, you can configure a table prefix.
 
 {: .bs-callout .bs-callout-warning}
 If you do not use the merge option with the table prefix, you must provide default connection settings or the deploy fails validation.
@@ -147,7 +148,7 @@ stage:
     DATABASE_CONFIGURATION:
       connection:
         default:
-          username: user 
+          username: user
           host: host
           dbname: magento
           password: password
@@ -171,10 +172,9 @@ MariaDB [main]> SHOW TABLES;
 | ece_cache                           |
 | ece_cache_tag                       |
 | ece_captcha_log                     |
-.....
+...
 ```
 {: .no-copy}
-
 
 ### `ELASTICSUITE_CONFIGURATION`
 
@@ -210,8 +210,8 @@ stage:
 
 **Known limitations**—
 
--   Changing the search engine to any type other than `elasticsuite` causes a deploy failure accompanied by an appropriate validation error
--   Removing the ElasticSearch service causes a deploy failure accompanied by an appropriate validation error
+-  Changing the search engine to any type other than `elasticsuite` causes a deploy failure accompanied by an appropriate validation error
+-  Removing the ElasticSearch service causes a deploy failure accompanied by an appropriate validation error
 
 {:.bs-callout .bs-callout-info}
 Magento does not support the ElasticSuite third-party plugin.
@@ -223,15 +223,15 @@ Magento does not support the ElasticSuite third-party plugin.
 
 Enables and disables Google Analytics when deploying to Staging and Integration environments. By default, Google Analytics is true only for the Production environment. Set this value to `true` to enable Google Analytics in the Staging and Integration environments.
 
--   **`true`**—Enables Google Analytics on Staging and Integration environments.
--   **`false`**—Disables Google Analytics on Staging and Integration environments.
+-  **`true`**—Enables Google Analytics on Staging and Integration environments.
+-  **`false`**—Disables Google Analytics on Staging and Integration environments.
 
 Add the `ENABLE_GOOGLE_ANALYTICS` environment variable to the `deploy` stage in the `.magento.env.yaml` file:
 
 ```yaml
 stage:
   deploy:
-    ENABLE_GOOGLE_ANALYTICS: true 
+    ENABLE_GOOGLE_ANALYTICS: true
 ```
 
 {:.bs-callout .bs-callout-info}
@@ -242,13 +242,28 @@ The {{ site.data.var.ece }} deploy process always enables Google Analytics on Pr
 -  **Default**—`true`
 -  **Version**—Magento 2.1.4 and later
 
-On deployment to Pro or Starter Staging and Production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) deploy variable which is ignored when deploying to Staging or Production environments. 
+On deployment to Pro or Starter Staging and Production environments, this variable replaces Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. Use this setting to override the default behavior of the [UPDATE_URLS](#update_urls) deploy variable which is ignored when deploying to Staging or Production environments.
 
 ```yaml
 stage:
   deploy:
     FORCE_UPDATE_URLS: true
 ```
+
+### `LOCK_PROVIDER`
+
+-  **Default**—`file`
+-  **Version**—Magento 2.1.5 and later
+
+The lock provider prevents the launch of duplicate cron jobs and cron groups. You must use the `file` lock provider in the Production environment. Starter environments and the Pro Integration environment do not use the [MAGENTO_CLOUD_LOCKS_DIR]({{page.baseurl}}/cloud/env/variables-cloud.html) variable, so `{{site.data.var.ct}}` applies the `db` lock provider automatically.
+
+```yaml
+stage:
+  deploy:
+    LOCK_PROVIDER: "db"
+```
+
+See [Configure the lock]({{page.baseurl}}/install-gde/install/cli/install-cli-subcommands-lock.html?itm_source=devdocs&itm_medium=quick_search&itm_campaign=federated_search&itm_term=lock%20provide#instgde-cli-lockconfig) in the _Install guide_.
 
 ### `MYSQL_USE_SLAVE_CONNECTION`
 
@@ -338,8 +353,8 @@ The following example merges new values to an existing configuration:
 ```yaml
 stage:
   deploy:
-    RESOURCE_CONFIGURATION: 
-      _merge: false 
+    RESOURCE_CONFIGURATION:
+      _merge: false
       default_setup:
         connection: default
 ```
@@ -415,14 +430,15 @@ stage:
       "Magento/backend": [ ]
 ```
 
-### `SCD_MAX_EXECUTION_TIME` 
+### `SCD_MAX_EXECUTION_TIME`
 
 -  **Default**—_Not set_
 -  **Version**—Magento 2.2.0 and later
 
-Allows you to increase the maximum expected execution time for static content deployment. 
+Allows you to increase the maximum expected execution time for static content deployment.
 
-By default, Magento Commerce sets the maximum expected execution to 400 seconds, but in some scenarios you might need more time to complete the static content deployment for a Cloud project.                                                                                
+By default, Magento Commerce sets the maximum expected execution to 400 seconds, but in some scenarios you might need more time to complete the static content deployment for a Cloud project.
+
 ```yaml
 stage:
   deploy:
@@ -570,7 +586,7 @@ stage:
 
 On deployment, replace Magento base URLs in the database with the project URLs specified by the [`MAGENTO_CLOUD_ROUTES`]({{page.baseurl}}/cloud/env/variables-cloud.html) variable. This configuration is useful for local development, where base URLs are set up for your local environment. When you deploy to a Cloud environment, we change the URLs so you can access your storefront and Magento Admin using project URLs.
 
-If you need to update URLs when deploying to Pro or Starter Staging and Production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable. 
+If you need to update URLs when deploying to Pro or Starter Staging and Production environments,  use the [`FORCE_UPDATE_URLS`](#force_update_urls) variable.
 
 ```yaml
 stage:

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -19,6 +19,8 @@ The release notes include:
 
 ## v2002.0.21
 
+-  {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider. See the definition in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) content.
+
 -  {:.new}<!-- MAGECLOUD-3535 -->Added version compatibility validation between Magento version and installed services, such as RabbitMq, Redis, and DB. Displays a warning message if the service version is not compatible.
 
 -  {:.fix}<!-- MAGECLOUD-3806 -->Fixed an issue when running the `setup:upgrade` command that did not interrupt the deployment process when a failure occured during the `app:config:import` task.

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -19,6 +19,8 @@ The release notes include:
 
 ## v2002.0.21
 
+-  {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider. See the definition in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) content.
+
 -  {:.new}<!-- MAGECLOUD-3535 -->Added version compatibility validation between Magento version and installed services, such as RabbitMq, Redis, and DB. Displays a warning message if the service version is not compatible.
 
 -  {:.fix}<!-- MAGECLOUD-3806 -->Fixed an issue when running the `setup:upgrade` command that did not interrupt the deployment process when a failure occured during the `app:config:import` task.


### PR DESCRIPTION
This PR adds the LOCK_PROVIDER variable to the deploy variables topic. Also, added a release note, which can be reorganized later if there are more updates to environment variables.