### PR TITLE
Adding performance information about the correct area usage

### DIFF
--- a/guides/v2.2/ext-best-practices/extension-coding/security-performance-data-bp.md
+++ b/guides/v2.2/ext-best-practices/extension-coding/security-performance-data-bp.md
@@ -85,3 +85,19 @@ public function getCustomerCart()
     return $this->_cart;
 }
 ```
+
+## Use the appropriate area
+
+Make sure that your observer or plugin is declared only in the appropriate area:
+
+- [`adminhtml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Backend/etc/di.xml){:target="_blank"}
+- [`crontab`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Cron/etc/di.xml){:target="_blank"}
+- [`frontend`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Store/etc/di.xml){:target="_blank"}
+- [`graphql`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/GraphQl/etc/di.xml){:target="_blank"}
+- [`webapi_rest`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Webapi/etc/di.xml){:target="_blank"}
+- [`webapi_soap`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Webapi/etc/di.xml){:target="_blank"}
+ 
+For that, the plugins and observers should be declared in `<module-dir>/etc/<area>/` folder.
+
+{:.bs-callout .bs-callout-info}
+The `global` area should be used only if the plugin/observer should be executed in multiple areas.

--- a/guides/v2.3/ext-best-practices/extension-coding/security-performance-data-bp.md
+++ b/guides/v2.3/ext-best-practices/extension-coding/security-performance-data-bp.md
@@ -85,3 +85,19 @@ public function getCustomerCart()
     return $this->_cart;
 }
 ```
+
+## Use the appropriate area
+
+Make sure that your observer or plugin is declared only in the appropriate area:
+
+- [`adminhtml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Backend/etc/di.xml){:target="_blank"}
+- [`crontab`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Cron/etc/di.xml){:target="_blank"}
+- [`frontend`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Store/etc/di.xml){:target="_blank"}
+- [`graphql`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/GraphQl/etc/di.xml){:target="_blank"}
+- [`webapi_rest`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Webapi/etc/di.xml){:target="_blank"}
+- [`webapi_soap`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Webapi/etc/di.xml){:target="_blank"}
+ 
+For that, the plugins and observers should be declared in `<module-dir>/etc/<area>/` folder.
+
+{:.bs-callout .bs-callout-info}
+The `global` area should be used only if the plugin/observer should be executed in multiple areas.


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) adds an additional performance point, that describes the areas where the plugins and observers should run, instead of `global` area.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/ext-best-practices/extension-coding/security-performance-data-bp.html
- https://devdocs.magento.com/guides/v2.3/ext-best-practices/extension-coding/security-performance-data-bp.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Backend/etc/di.xml#L18
- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Captcha/etc/crontab/di.xml
- https://github.com/magento/magento2/blob/2.2/app/code/Magento/Cms/etc/frontend/events.xml
<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
