### PR TITLE
MAGECLOUD-4018:  Adjust Service Version Validation for 2.2.10/2.3.3 Support

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_services.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services.md
@@ -159,7 +159,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `mariadb` | 10.0 to 10.2  | 10.0 to 10.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
-`php`     | 7.1, 7.2      | Magento 2.2.5 and later—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, 7.0.6, 7.1.0
+`php`     | Magento 2.3.3 and later - 7.1, 7.2, 7.3<br>Magento 2.3.0-2.3.2 - 7.1, 7.2 | Magento 2.2.10 and later - 7.1, 7.2<br>Magento 2.2.5-2.2.9 —7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1
 `rabbitmq`| 3.5, 3.7      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
-`varnish` | 4.0, 5.0      | 4.0, 5.0
+`varnish` | Magento 2.3.3 and later - 4.0, 5.0, 6.2<br>Magento 2.3.0-2.3.2 - 4.0, 5.0 | 4.0, 5.0

--- a/guides/v2.2/cloud/project/project-conf-files_services.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services.md
@@ -159,7 +159,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `mariadb` | 10.0 to 10.2  | 10.0 to 10.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
-`php`     | Magento 2.3.3 and later - 7.1, 7.2, 7.3<br>Magento 2.3.0-2.3.2 - 7.1, 7.2 | Magento 2.2.10 and later - 7.1, 7.2<br>Magento 2.2.5-2.2.9 —7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1
+`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1
 `rabbitmq`| 3.5, 3.7      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
-`varnish` | Magento 2.3.3 and later - 4.0, 5.0, 6.2<br>Magento 2.3.0-2.3.2 - 4.0, 5.0 | 4.0, 5.0
+`varnish` | Magento 2.3.3 and later—4.0, 5.0, 6.2<br>Magento 2.3.0 to 2.3.2—4.0, 5.0 | 4.0, 5.0


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This PR will update a service compatibility table according to latest releases 2.3.3 and 2.2.10

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
