### PR TITLE
magento/devdocs#: Cloud. Upgrade Magento version

### DIFF
--- a/guides/v2.2/cloud/project/project-upgrade.md
+++ b/guides/v2.2/cloud/project/project-upgrade.md
@@ -155,7 +155,10 @@ For an upgrade, you delete the `config.php` file. Once this file is added to you
 
 ## Verify and upgrade your extensions {#extensions}
 
-If you need to upgrade any third-party extensions and modules that support version 2.2, we recommend working in a new Integration branch with your extensions disabled. Review your third-party extension and module pages in Marketplace or other company sites to verify support for {{site.data.var.ee}} and {{site.data.var.ece}} version 2.2.
+{: .bs-callout-info }
+Review your third-party extension and module pages in Marketplace or other company sites to verify support for {{site.data.var.ee}} and {{site.data.var.ece}} version 2.2.
+
+If you need to upgrade any third-party extensions and modules that support version 2.2, we recommend working in a new Integration branch with your extensions disabled.
 
 1.  Create a new branch on your local workstation.
 1.  Disable your extensions as needed.

--- a/guides/v2.3/cloud/project/project-upgrade.md
+++ b/guides/v2.3/cloud/project/project-upgrade.md
@@ -57,7 +57,10 @@ If you use PHP version 7.2, you must remove the `mcrypt` extension from the [`ex
 
 ## Verify and upgrade your extensions {#extensions}
 
-If you need to upgrade any third-party extensions and modules that support version 2.3, we recommend working in a new Integration branch with your extensions disabled. Review your third-party extension and module pages in Marketplace or other company sites to verify support for {{site.data.var.ee}} 2.3.
+{: .bs-callout-info }
+Review your third-party extension and module pages in Marketplace or other company sites to verify support for {{site.data.var.ee}} 2.3.
+
+If you need to upgrade any third-party extensions and modules that support version 2.3, we recommend working in a new Integration branch with your extensions disabled.
 
 1.  Create a new branch on your local workstation.
 1.  Disable your extensions as needed.


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) highlight info that customer should check 3rd party extension to work with new Magento version.

This information already exists in DevDocs but it's hidden for readers in the text. 

The last request in the #cloud channel prove that. 



I've contacted to Diego Cabrejas and asked about the reason. He answered, that `The issue was that a 3rd party package was requiring an old version of Magento in its composer.json file.`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/cloud/project/project-upgrade.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-upgrade.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
