### PR TITLE
GraphQL: update description of deprecated directive

### DIFF
--- a/guides/v2.3/graphql/develop/create-graphqls-file.md
+++ b/guides/v2.3/graphql/develop/create-graphqls-file.md
@@ -99,11 +99,7 @@ url_key: String @doc(description: "The url key assigned to the product")
 product_count: Int @doc(description: "The number of products")
 ```
 
-Use the `@deprecated` directive to mark a query, mutation, or attribute as deprecated:
-
-```text
-@deprecated(reason: "description")
-```
+Use the `@deprecated` directive to deprecate attributes and enum values. The GraphQL specification does not permit deprecating input values or arguments. The `reason` keyword allows you to specify which attribute or enum should be used instead.
 
 For example:
 

--- a/guides/v2.3/graphql/develop/create-graphqls-file.md
+++ b/guides/v2.3/graphql/develop/create-graphqls-file.md
@@ -99,7 +99,7 @@ url_key: String @doc(description: "The url key assigned to the product")
 product_count: Int @doc(description: "The number of products")
 ```
 
-Use the `@deprecated` directive to deprecate attributes and enum values. The GraphQL specification does not permit deprecating input values or arguments. The `reason` keyword allows you to specify which attribute or enum should be used instead.
+Use the `@deprecated` directive to deprecate attributes and enum values. The GraphQL specification does not permit deprecating input values or arguments. The `reason` keyword allows you to specify which attribute/field or enum value should be used instead.
 
 For example:
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) updates the description of the `deprecated` keyword.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/develop/create-graphqls-file.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
