### PR TITLE
Updating the checking cron module section

### DIFF
--- a/guides/v2.2/config-guide/cron/custom-cron-tut.md
+++ b/guides/v2.2/config-guide/cron/custom-cron-tut.md
@@ -84,6 +84,8 @@ Before you continue, make sure the sample module is registered and enabled.
 
 2. Make sure that the module's name is displaying under `List of enabled modules:`.
 
+If the module does not display, review [step 1](#cron-tut-get) carefully. Make sure your code is in the correct directory. Spelling and case are important; if anything is different, the module won't load. Also, don't forget to run `magento setup:upgrade`.
+
 ## Step 3: Create a class to run cron {#cron-tut-class}
 
 This step shows a simple class to create a cron job. The class only writes a row to the `cron_schedule` table that confirms it's set up successfully.

--- a/guides/v2.2/config-guide/cron/custom-cron-tut.md
+++ b/guides/v2.2/config-guide/cron/custom-cron-tut.md
@@ -76,17 +76,13 @@ If you already have a sample module, you can use it; skip this step and the next
 
 Before you continue, make sure the sample module is registered and enabled.
 
-{% collapsible To verify the sample module: %}
+1. Run the following command:
 
-1.  Log in to the Magento Admin as an administrator.
-2.  Click **Stores** > **Settings** > **Configuration** > ADVANCED > **Advanced**.
-3.  In the right pane, under Disable Modules Output, look for **Magento_SampleMinimal** as the following figure shows.
+    ```bash
+    bin/magento module:status
+    ```
 
-    ![Verify your sample module]({{ site.baseurl }}/common/images/config_module-enabled.png){:width="900px"}
-
-If the module doesn't display, review [step 1](#cron-tut-get) carefully. Make sure your code is in the correct directory. Spelling and case are important; if anything is different, the module won't load. Also, don't forget to run `magento setup:upgrade`.
-
-{% endcollapsible %}
+2. Make sure that the module's name is displaying under `List of enabled modules:`.
 
 ## Step 3: Create a class to run cron {#cron-tut-class}
 
@@ -102,7 +98,8 @@ This step shows a simple class to create a cron job. The class only writes a row
 ```php
 <?php
 namespace Magento\SampleMinimal\Cron;
-use \Psr\Log\LoggerInterface;
+
+use Psr\Log\LoggerInterface;
 
 class Test {
     protected $logger;
@@ -111,20 +108,16 @@ class Test {
         $this->logger = $logger;
     }
 
-/**
-   * Write to system.log
-   *
-   * @return void
-   */
-
+   /**
+    * Write to system.log
+    * 
+    * @return void
+    */
     public function execute() {
         $this->logger->info('Cron Works');
     }
-
 }
 ```
-
-<!-- ?> -->
 
 {% endcollapsible %}
 

--- a/guides/v2.2/config-guide/cron/custom-cron-tut.md
+++ b/guides/v2.2/config-guide/cron/custom-cron-tut.md
@@ -83,6 +83,16 @@ Before you continue, make sure the sample module is registered and enabled.
     ```
 
 2. Make sure that the module's name is displaying under `List of enabled modules:`.
+    
+    ```text
+    List of enabled modules:
+    ...
+    Magento_SampleMinimal
+    ...
+
+    List of disabled modules:
+    None
+    ```
 
 If the module does not display, review [step 1](#cron-tut-get) carefully. Make sure your code is in the correct directory. Spelling and case are important; if anything is different, the module won't load. Also, don't forget to run `magento setup:upgrade`.
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) updates the outdated section Stores > Settings > Configuration > ADVANCED > **Advanced**, that could be used for disabling module output.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/config-guide/cron/custom-cron-tut.html
- https://devdocs.magento.com/guides/v2.2/config-guide/cron/custom-cron-tut.html

## Links to Magento source code

- ...

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
Fixes #5203