### PR TITLE
Fixing the developer mode sentence

### DIFF
--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -33,7 +33,7 @@ You can run Magento in any of the following *modes*:
 				<li>Enables enhanced debugging</li>
 				<li>Shows custom <code>X-Magento-*</code> HTTP request and response headers</li>
 				<li>Results in the slowest performance</li>
-				<li>Does not show errors on the frontend</li></ul>
+				<li>Show errors on the frontend</li></ul>
     </td>
 	</tr>
 	<tr>


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) fixes the `developer` mode sentence, that says that in developer mode the errors aren't showing - which is wrong.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/config-guide/bootstrap/magento-modes.html
- https://devdocs.magento.com/guides/v2.3/config-guide/bootstrap/magento-modes.html


Fixes #5201