### PR TITLE
Debug logging options should match sentence context

### DIFF
--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -15,7 +15,7 @@ functional_areas:
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or developer mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
-As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
+As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for current mode.
 
 ### To enable debug logging
 

--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -15,7 +15,7 @@ functional_areas:
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or developer mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
-As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for current mode.
+As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for the current mode.
 
 ### To enable debug logging
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -15,7 +15,7 @@ functional_areas:
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
-As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for current mode.
+As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for the current mode.
 
 ### To enable debug logging
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -15,7 +15,7 @@ functional_areas:
 By default, Magento writes to the debug log (`<install_directory>/var/log/debug.log`) when it is in default or develop mode, but not when it is in production mode. Use the `bin/magento setup:config:set --enable-debug-logging=true | false` command to change the default value.
 
 {:.bs-callout .bs-callout-info}
-As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 0 | 1` command to enable or disable debug logging for current mode.
+As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug/debug_logging 1 | 0` command to enable or disable debug logging for current mode.
 
 ### To enable debug logging
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) swaps the `1` and `0` options to match the order in which "enable" and "disable" appear in the rest of the sentence.

This issue was reported by Magento Support.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html
- https://devdocs.magento.com/guides/v2.2/config-guide/cli/logging.html
