### PR TITLE
Fix typo in credentials section

### DIFF
--- a/guides/v2.2/get-started/authentication/gs-authentication-token.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication-token.md
@@ -59,7 +59,7 @@ Component | Specifies
 --- | ---
 Endpoint |  A combination of the _server_ that fulfills the request, the web service, and the `resource` against which the request is being made.<br/><br/>For example, in the `POST <host>/rest/<store_code>/V1/integration/customer/token` endpoint:<br/>The server is `magento.host/index.php/`,<br/> the web service is `rest`.<br/> and the resource is `/V1/integration/customer/token`.
 Content type | The content type of the request body. Set this value to either `"Content-Type:application/json"` or `"Content-Type:application/xml"`.
-Credentials | The username and password for a Magento account.<br/><br/>To specify these credentials in a JSON request body, include code similar to the following in the call: <br/><br/>`{"username":"<USER-NAME>;", "password":"<PASSWORD>"}`<br/><br/>To specify these credentials in XML, include code similar to the following in the call:<br/><br/>`<login><username>customer1@example.com</username><password>customer1pw</password></login>`
+Credentials | The username and password for a Magento account.<br/><br/>To specify these credentials in a JSON request body, include code similar to the following in the call: <br/><br/>`{"username":"<USER-NAME>", "password":"<PASSWORD>"}`<br/><br/>To specify these credentials in XML, include code similar to the following in the call:<br/><br/>`<login><username>customer1@example.com</username><password>customer1pw</password></login>`
 
 
 #### Examples {#token-example}


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) removes not needed semicolon from credentials example

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/get-started/authentication/gs-authentication-token.html
- https://devdocs.magento.com/guides/v2.2/get-started/authentication/gs-authentication-token.html

## Links to Magento source code

- ...

