### PR TITLE
Add GTM tag in order to verify site in GSC

### DIFF
--- a/_includes/layout/site-nav.html
+++ b/_includes/layout/site-nav.html
@@ -1,3 +1,10 @@
+{% if site.environment == "public" %}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google.gtm }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{% endif %}
+
 <nav class="site-nav">
 
   <div class="menu-btn">


### PR DESCRIPTION
Putting this in the highest place after the opening `<body>` tag per GTM requirements.

<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) will add `<noscript>` gtm tag in order to verify site in Google Search Console.

## Affected DevDocs pages

- all