### PR TITLE
Updated option desc for queue:consumers:start

### DIFF
--- a/_includes/config/message-queue-consumers.md
+++ b/_includes/config/message-queue-consumers.md
@@ -32,7 +32,6 @@ Parameter | Value | Required? | Default Value
 `--batch-size=<value>` | The number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue. | No | 0
 `--pid-file-path=<value>` | This option is deprecated. Use the `single-thread` option instead. | No |
 `--single-thread` | This option prevents running multiple copies of a consumer simultaneously. | No |
-'This option prevents running multiple copies of one consumer simultaneously.'
 `--area-code=<value>` | The area code preferred for consumer process. | No | global
 `<consumer_name>` | The consumer to start. | Yes | |
 

--- a/_includes/config/message-queue-consumers.md
+++ b/_includes/config/message-queue-consumers.md
@@ -21,7 +21,7 @@ async.operations.all
 To start message queue consumers:
 
 ```bash
-bin/magento queue:consumers:start [--max-messages=<value>] [--batch-size=<value>] [--pid-file-path=<value>] [--area-code=<value>] <consumer_name> 
+bin/magento queue:consumers:start [--max-messages=<value>] [--batch-size=<value>] [--single-thread] [--area-code=<value>] <consumer_name>
 ```
 
 The following table explains this command’s options, parameters, and values.
@@ -30,10 +30,11 @@ Parameter | Value | Required? | Default Value
 --- | --- | --- | ---
 `--max-messages=<value>` | The maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously. | No | 0
 `--batch-size=<value>` | The number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue. | No | 0
-`--pid-file-path=<value>` | The file path for saving PID of consumer process. Consumer process such as `/var/someConsumer.pid` | No | 
+`--pid-file-path=<value>` | This option is deprecated. Use the `single-thread` option instead. | No |
+`--single-thread` | This option prevents running multiple copies of a consumer simultaneously. | No |
+'This option prevents running multiple copies of one consumer simultaneously.'
 `--area-code=<value>` | The area code preferred for consumer process. | No | global
 `<consumer_name>` | The consumer to start. | Yes | |
-
 
 After consuming all available messages, the command terminates. You can run the command again manually or with a cron job. You can also run multiple instances of the `magento queue:consumers:start` command to process large message queues. For example, you can append `&` to the command to run it in the background, return to a prompt, and continue running commands:
 


### PR DESCRIPTION
# Purpose of this pull request

This pull request (PR) updates the option descriptions for the `queue:consumers:start`Magento CLI command. 
- the `--pid-file-path` option has been deprecated in 2.3.3 and 2.2.10
- the`--single-thread` option was added.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/mq/manage-message-queues.html
- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.html

## Links to Magento source code

https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/MessageQueue/Console/StartConsumerCommand.php

whatsnew
Updated the  option descriptions for the `queue:consumers:start`Magento CLI command:
- Deprecated the `--pid-file-path` option which caused issues with database deadlock on  some Magento Commerce projects deployed on the Cloud platform.
- Added the `--single-thread` option which prevents running multiple copies of a consumer simultaneously

