### PR TITLE
Updated Magento binding syntax for template binding #5233

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -62,7 +62,7 @@ The table below shows examples of how the Knockout bindings map to their Magento
 |html           |`<div data-bind="html: '<span/>'"> </div>`                                     | `<div html="'<span/>'"> </div>`                                       |
 |click          |`<div data-bind="click: onClick"> </div>`                                      | `<div click="onClick"> </div>`                                        |
 |event          |`<div data-bind="event: {mouseover: showEl}"> </div>`                          | `<div event="mouseover: showEl"> </div>`                              |
-|template       |`<div data-bind="template: templateUrl"> </div>`                               | `<div template="templateUrl"> </div>`                                 |
+|template       |`<div data-bind="template: {name: 'templateUrl', data: {}}"> </div>`                               | `<div template=" {name: 'templateUrl', data: {}}" ></div>`                                 |
 |submit         |`<form data-bind="submit: onSubmit"> </form>`                                  | `<form submit="onSubmit"> </form>`                                    |
 |options        |`<select data-bind="options: optionsList"> </select>`                          | `<select options="optionsList"> </select>`                            |
 |selectedOptions|`<select data-bind="options: optionsList, selectedOptions: value"> </select>`  | `<select options="optionsList" selectedOptions="value"> </select>`    |


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request 

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR):
Topic Link : https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/magento-bindings.html
Issue Reference : magento/magento2#24087 and fixes #5233
Here Knockout Syntax and Magento Syntax for template binding is wrong. It's not working.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/magento-bindings.html

