### PR TITLE
Notice should read development system has things not ready for prod

### DIFF
--- a/_includes/config/split-deploy/example_save-shared-config.md
+++ b/_includes/config/split-deploy/example_save-shared-config.md
@@ -31,7 +31,7 @@
     ```
 
     {:.bs-callout .bs-callout-warning}
-    Do _not_ submit changes to the `generated`, `pub/media`, or `pub/static` directories to source control. You'll generate those files on your build system. The production system likely has code, themes, and so on that aren't ready to use on production.
+    Do _not_ submit changes to the `generated`, `pub/media`, or `pub/static` directories to source control. You'll generate those files on your build system. The development system likely has code, themes, and so on that aren't ready to use on the production system.
 
 1.  Check in your changes to `app/etc/config.php` only to source control.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the wording in a notice on the pipeline deployment CLI example which incorrectly states that the production system may have things not ready for production which may cause confusion. It should read: "The development system likely has code, themes, and so on that aren’t ready to use on the production system."

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/deployment/pipeline/example/cli.html
