### PR TITLE
MAGECLOUD-4071: Re-work consumers to terminate as soon as there is nothing left to process

### DIFF
--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -111,9 +111,15 @@ Use this variable to configure how consumers process messages from the message q
 
 #### Possible values:
 
-`false`— Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `max_messages` value specified in the `CRON_CONSUMERS_RUNNER` deploy variable.
+`false`—Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `max_messages` value specified in the `CRON_CONSUMERS_RUNNER` deploy variable.
 
-`true`–Consumers continue to process messages from the message queue until reaching the maximum number of messages (`max_messages`) specified in the `CRON_CONSUMERS_RUNNER` deploy variable before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `max_messages` the consumer waits for more messages to arrive. If you use workers to run consumers instead of using a cron job, set this variable to true.
+`true`—Consumers continue to process messages from the message queue until reaching the maximum number of messages (`max_messages`) specified in the `CRON_CONSUMERS_RUNNER` deploy variable before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `max_messages` the consumer waits for more messages to arrive. If you use workers to run consumers instead of using a cron job, set this variable to true.
+
+```yaml
+stage:
+  deploy:
+    CONSUMERS_WAIT_FOR_MAX_MESSAGES: true
+```
 
 ### `CRYPT_KEY`
 


### PR DESCRIPTION
# Purpose of this pull request

Add documentation for the [CONSUMERS_WAIT_FOR_MAX_MESSAGES](https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) environment variable to the Magento `ece-tools` package to configure how consumers process messages from the message queue when using the `CRON_CONSUMERS_RUNNER` environment variable to manage cron jobs.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html

## Links to Magento source code

- https://github.com/magento/ece-tools/pull/594

whatsnew
Added documentation for the [CONSUMERS_WAIT_FOR_MAX_MESSAGES](https://devdocs.magento.com/guides/v2.3/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) environment variable to the Magento ece-tools package to configure how consumers process messages from the message queue when using the CRON_CONSUMERS_RUNNER environment variable to manage cron jobs.

