### PR TITLE
[site] Rename rake test tasks

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -6,7 +6,7 @@ namespace :test do
   task links: %w[build links_no_build]
 
   desc 'Check the entire _site for broken links and invalid HTML'
-  task :cicd do
+  task :html do
     puts 'Checking links with html-proofer...'.magenta
 
     LinkChecker.check_site
@@ -41,11 +41,14 @@ namespace :test do
   end
 
   desc 'Test Markdown style with mdl'
-  task :style do
+  task :md do
     puts 'Testing Markdown style with mdl ...'.magenta
     output = `bin/mdl --style=_checks/styles/style-rules-prod --ignore-front-matter --git-recurse -- .`
     puts output.yellow
     abort "The Markdown linter has found #{output.lines.count} issues".red unless output.empty?
     puts 'No issues found'.magenta
   end
+
+  task style: %w[md]
+  task cicd: %w[html]
 end


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request:

- Renames rake's test:style to test:md
- Renames rake's test:cicd to test:html
- Adds the corresponding aliases to keep the CICD builds green