### PR TITLE
Fix example mutation call

### DIFF
--- a/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
+++ b/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
@@ -35,7 +35,7 @@ For logged-in customers, send the customer's authorization token in the `Authori
 mutation {
   setShippingAddressesOnCart(
     input: {
-      cart_id: "A7jCcOmUjjCh7MxDIzu1SeqdqETqEa5h"
+      cart_id: "{ CART_ID }"
       shipping_addresses: [
         {
           address: {


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

Fix example GraphQL mutation and use `cart_id: "{ CART_ID }"` like other example as well.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.html

## Links to Magento source code

- n/a

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->