### PR TITLE
Removed config.env info

### DIFF
--- a/guides/v2.2/cloud/docker/docker-config.md
+++ b/guides/v2.2/cloud/docker/docker-config.md
@@ -114,23 +114,6 @@ Continue launching your Docker environment in the default _production_ mode.
     ./vendor/bin/ece-tools docker:build
     ```
 
-1.  _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
-
-    ```bash
-    cp .docker/config.php.dist .docker/config.php
-    ```
-
-    Convert custom PHP configuration files to Docker ENV files.
-
-    ```bash
-    ./vendor/bin/ece-tools docker:config:convert
-    ```
-
-    This generates the following Docker ENV files: `.docker/config.env`
-
-    {: .bs-callout-info }
-    The `{{site.data.var.ct}}` version 2002.0.12 package does not support the `docker:config:convert` command.
-
 1.  _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [configure Xdebug]({{ page.baseurl }}/cloud/docker/docker-development-debug.html#configure-xdebug).
 
 1.  Build files to containers and run in the background.
@@ -206,14 +189,6 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
     ```bash
     cp .docker/config.php.dist .docker/config.php
     ```
-
-    Convert custom PHP configuration files to Docker ENV files.
-
-    ```bash
-    ./vendor/bin/ece-tools docker:config:convert
-    ```
-
-    This generates the following Docker ENV files: `.docker/config.env`
 
 1.  _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [enable and configure Xdebug]({{ page.baseurl }}/cloud/docker/docker-development-debug.html).
 

--- a/guides/v2.2/cloud/docker/docker-config.md
+++ b/guides/v2.2/cloud/docker/docker-config.md
@@ -114,6 +114,12 @@ Continue launching your Docker environment in the default _production_ mode.
     ./vendor/bin/ece-tools docker:build
     ```
 
+1.  _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
+
+    ```bash
+    cp .docker/config.php.dist .docker/config.php
+    ```
+
 1.  _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [configure Xdebug]({{ page.baseurl }}/cloud/docker/docker-development-debug.html#configure-xdebug).
 
 1.  Build files to containers and run in the background.
@@ -150,7 +156,8 @@ Continue launching your Docker environment in the default _production_ mode.
     ```bash
     docker-compose run deploy magento-command cache:clean
     ```
-1. _Optional_: Restart services if the static content does not synchronize with all images after generation on build phase.
+
+1.  _Optional_: Restart services if the static content does not synchronize with all images after generation on build phase.
 
     ```bash
     docker-compose restart

--- a/guides/v2.2/cloud/docker/docker-development-debug.md
+++ b/guides/v2.2/cloud/docker/docker-development-debug.md
@@ -45,8 +45,6 @@ runtime:
         - PHP_IDE_CONFIG=serverName=magento_cloud_docker
         - XDEBUG_CONFIG=remote_host=host.docker.internal
         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap sockets sysvmsg sysvsem sysvshm opcache zip redis xsl xdebug'
-      env_file:
-        - ./.docker/config.env
     ```
     {:.no-copy}
 

--- a/guides/v2.2/cloud/docker/docker-development-debug.md
+++ b/guides/v2.2/cloud/docker/docker-development-debug.md
@@ -58,8 +58,8 @@ runtime:
 
 1.  In your PhpStorm project, open the settings panel.
 
-    -  _Mac OS X_—Select **File** > **Preferences**.
-    -  _Windows/Linux_—Select **File** > **Settings**.
+    - _Mac OS X_—Select **File** > **Preferences**.
+    - _Windows/Linux_—Select **File** > **Settings**.
 
 1.  In the _Settings_ panel, expand and locate the **Languages & Frameworks** > **PHP** > **Servers** section.
 
@@ -67,10 +67,10 @@ runtime:
 
 1.  Configure the following settings for the new server configuration:
 
-    -  **Name**—Enter the name used for the `serverName` in `PHP_IDE_CONFIG` option from `docker-compose.yml` file.
-    -  **Host**—Enter `localhost`.
-    -  **Port**—Enter `80`.
-    -  **Debugger**—Select `Xdebug`.
+    - **Name**—Enter the name used for the `serverName` in `PHP_IDE_CONFIG` option from `docker-compose.yml` file.
+    - **Host**—Enter `localhost`.
+    - **Port**—Enter `80`.
+    - **Debugger**—Select `Xdebug`.
 
 1.  Select **Use path mappings**. In the _File/Directory_ pane, the root of the project for the `serverName` displays.
 

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -29,13 +29,13 @@ The release notes include:
 
   - {:.new}<!-- MAGECLOUD-3505-->Added support to apply custom hook configuration specified in `.magento.app.yaml` in the Docker environment. Previously, the Docker environment supported only the default hook configuration.
 
-  - {:.new}<!-- MAGECLOUD-3816-->The Docker ENV file `.docker/config.env` is no long generated during the Docker build. The corresponding data is now stored in the `docker-compose.yml` file.
+  - {:.new}<!-- MAGECLOUD-3816-->The Docker ENV file `.docker/config.env` is no long generated during the Docker build. The corresponding data is now stored in the `docker-compose.yml` file. Additionally, the `docker:config:convert` command used to generate the ENV file from a custom PHP configuration is deprecated.
 
   - {:.new}<!-- MAGECLOUD-3953 -->**Updated PHP image**–Added Node.js to the PHP Docker image to support node, npm, and grunt-cli capabilities.
 
 - {:.new}**New environment variables**–
 
-  - {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider. See the variable description in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) topic.
+  - {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider which prevents the launch of duplicate cron jobs and cron groups. See the variable description in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) topic.
 
   - {:.new}<!-- MAGECLOUD-4071 -->Added the **CONSUMERS_WAIT_FOR_MAX_MESSAGES** environment variable to configure how consumers process messages from the message queue when using the `CRON_CONSUMERS_RUNNER` environment variable to manage cron jobs. See the variable description in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) topic.
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -29,13 +29,13 @@ The release notes include:
 
   - {:.new}<!-- MAGECLOUD-3505-->Added support to apply custom hook configuration specified in `.magento.app.yaml` in the Docker environment. Previously, the Docker environment supported only the default hook configuration.
 
-  - {:.new}<!-- MAGECLOUD-3816-->The Docker ENV file `.docker/config.env` is no long generated during the Docker build. The corresponding data is now stored in the `docker-compose.yml` file.
+  - {:.new}<!-- MAGECLOUD-3816-->The Docker ENV file `.docker/config.env` is no long generated during the Docker build. The corresponding data is now stored in the `docker-compose.yml` file. Additionally, the `docker:config:convert` command used to generate the ENV file from a custom PHP configuration file is deprecated.
 
   - {:.new}<!-- MAGECLOUD-3953 -->**Updated PHP image**–Added Node.js to the PHP Docker image to support node, npm, and grunt-cli capabilities.
 
 - {:.new}**New environment variables**–
 
-  - {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider. See the variable description in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) topic.
+  - {:.new}<!-- MAGECLOUD-4052 -->Added the **LOCK_PROVIDER** deploy variable to configure the lock provider which prevents the launch of duplicate cron jobs and cron groups. See the variable description in the [deploy variables]({{page.baseurl}}/cloud/env/variables-deploy.html#lock_provider) topic.
 
   - {:.new}<!-- MAGECLOUD-4071 -->Added the **CONSUMERS_WAIT_FOR_MAX_MESSAGES** environment variable to configure how consumers process messages from the message queue when using the `CRON_CONSUMERS_RUNNER` environment variable to manage cron jobs. See the variable description in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) topic.
 
@@ -492,7 +492,8 @@ You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/guid
 - {:.fix}**Environment variables**—
 
   - <!-- MAGECLOUD-1507 -->The use of `env:STATIC_CONTENT_THREADS` was deprecated and will be removed in a future release. Use the [SCD_THREADS]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_threads) environment variable instead.
-    - <!-- MAGECLOUD-1640 -->The `STATIC_CONTENT_EXCLUDE_THEMES` environment variable was deprecated. You must use the `SCD_EXCLUDE_THEMES` environment variable instead.
+
+  - <!-- MAGECLOUD-1640 -->The `STATIC_CONTENT_EXCLUDE_THEMES` environment variable was deprecated. You must use the `SCD_EXCLUDE_THEMES` environment variable instead.
 
 - {:.fix}<!-- MAGECLOUD-1674 -->**Logging**—We simplified logging around built-in patching operations.
 

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,10 @@
+[35mTesting Markdown style with mdl ...[0m
+[33m[0m
+[35mNo issues found[0m
+[35mChecking links with html-proofer...[0m
+Running ["LinkChecker::DoubleSlashCheck", "ScriptCheck", "ImageCheck", "LinkCheck", "HtmlCheck"] on ["_site"] on *.html... 
+
+
+Ran on 691 files!
+
+


### PR DESCRIPTION
## Purpose of this pull request

Updated the Magento Cloud Guide to remove references to the .docker/config.env file which has been deprecated.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/docker/docker-development-debug.html
- http://devdocs.magento.com/guides/v2.3/cloud/docker/docker-config.html

