### PR TITLE
Regenerate the magento CLI reference

### DIFF
--- a/_data/codebase/v2_2/open-source/bin-magento.yml
+++ b/_data/codebase/v2_2/open-source/bin-magento.yml
@@ -359,7 +359,7 @@ commands:
         is_required: false
         is_array: true
         description: Space-separated list of config types or omit to dump all [scopes,
-          system, themes, i18n]
+          themes, system, i18n]
         default: []
     options:
       help:
@@ -5293,7 +5293,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database server engine
-        default: innodb
+        default: 
       db-password:
         name: "--db-password"
         shortcut: ''
@@ -5317,7 +5317,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database type
-        default: mysql4
+        default: 
       db-init-statements:
         name: "--db-init-statements"
         shortcut: ''
@@ -5325,7 +5325,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database  initial set of commands
-        default: SET NAMES utf8;
+        default: 
       skip-db-validation:
         name: "--skip-db-validation"
         shortcut: "-s"
@@ -5611,7 +5611,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Lock provider name
-        default: db
+        default: 
       lock-db-prefix:
         name: "--lock-db-prefix"
         shortcut: ''
@@ -6169,7 +6169,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database server engine
-        default: innodb
+        default: 
       db-password:
         name: "--db-password"
         shortcut: ''
@@ -6193,7 +6193,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database type
-        default: mysql4
+        default: 
       db-init-statements:
         name: "--db-init-statements"
         shortcut: ''
@@ -6201,7 +6201,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database  initial set of commands
-        default: SET NAMES utf8;
+        default: 
       skip-db-validation:
         name: "--skip-db-validation"
         shortcut: "-s"
@@ -6487,7 +6487,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Lock provider name
-        default: db
+        default: 
       lock-db-prefix:
         name: "--lock-db-prefix"
         shortcut: ''

--- a/_data/codebase/v2_3/open-source/bin-magento.yml
+++ b/_data/codebase/v2_3/open-source/bin-magento.yml
@@ -5688,7 +5688,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database server engine
-        default: innodb
+        default: 
       db-password:
         name: "--db-password"
         shortcut: ''
@@ -5712,7 +5712,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database type
-        default: mysql4
+        default: 
       db-init-statements:
         name: "--db-init-statements"
         shortcut: ''
@@ -5720,7 +5720,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database  initial set of commands
-        default: SET NAMES utf8;
+        default: 
       skip-db-validation:
         name: "--skip-db-validation"
         shortcut: "-s"
@@ -6064,7 +6064,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Lock provider name
-        default: db
+        default: 
       lock-db-prefix:
         name: "--lock-db-prefix"
         shortcut: ''
@@ -6884,7 +6884,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database server engine
-        default: innodb
+        default: 
       db-password:
         name: "--db-password"
         shortcut: ''
@@ -6908,7 +6908,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database type
-        default: mysql4
+        default: 
       db-init-statements:
         name: "--db-init-statements"
         shortcut: ''
@@ -6916,7 +6916,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Database  initial set of commands
-        default: SET NAMES utf8;
+        default: 
       skip-db-validation:
         name: "--skip-db-validation"
         shortcut: "-s"
@@ -7260,7 +7260,7 @@ commands:
         is_value_required: true
         is_multiple: false
         description: Lock provider name
-        default: db
+        default: 
       lock-db-prefix:
         name: "--lock-db-prefix"
         shortcut: ''


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request updates the magento CLI reference.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/reference/cli/magento.html
- https://devdocs.magento.com/guides/v2.2/reference/cli/magento.html