### PR TITLE
update version constraint Magento Cloud

### DIFF
--- a/guides/v2.3/cloud/project/project-upgrade.md
+++ b/guides/v2.3/cloud/project/project-upgrade.md
@@ -25,7 +25,7 @@ If you use PHP version 7.2, you must remove the `mcrypt` extension from the [`ex
 1.  Change to your Magento root directory and set the upgrade version using the [version constraint syntax]({{page.baseurl}}/cloud/project/ece-tools-upgrade-project.html#metapackage).
 
     ```bash
-    composer require "magento/magento-cloud-metapackage":">=2.3.1 <2.3.2" --no-update
+    composer require "magento/magento-cloud-metapackage":">=2.3.2 <2.3.3" --no-update
     ```
 
     {: .bs-callout-info }


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) update the version constraint to the latest version of the magento-cloud-metapackage.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/cloud/project/project-upgrade.html
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
