### PR TITLE
Moved environment variable changes to correct section

### DIFF
--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -39,6 +39,10 @@ The release notes include:
 
   - {:.new}<!-- MAGECLOUD-4071 -->Added the **CONSUMERS_WAIT_FOR_MAX_MESSAGES** environment variable to configure how consumers process messages from the message queue when using the `CRON_CONSUMERS_RUNNER` environment variable to manage cron jobs. See the variable description in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) topic.
 
+  - {:.fix}<!-- MAGECLOUD-3913 -->Fixed an issue that can cause database deadlock errors when the `consumers_runner` cron job starts multiple instances of the same consumer on different nodes. Now, if you have enabled the [**CRON_CONSUMERS_RUNNER**]({{ page.baseurl }}/cloud/env/variables-deploy.html#cron_consumers_runner) deploy variable in your environment, the `consumers_runner` job uses the `single-thread` option to start one instance of each consumer on only one node.
+
+  - {:.fix}<!-- MAGECLOUD-3866 -->Fixed an issue affecting [**WARM_UP_PAGES**]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages) functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.
+
 - {:.new}<!-- MAGECLOUD-2514 -->Updated the logging information returned by the `module:refresh` command. Now, you can see a detailed list of enabled modules in the `cloud.log` file.
 
 - {:.new}<!-- MAGECLOUD-3535 -->Improved version compatibility validation and warning notifications for compatibility issues between Magento version and installed services, such as Elasticsearch, RabbitMq, Redis, and DB.
@@ -49,11 +53,7 @@ The release notes include:
 
 - {:.fix}<!-- MAGECLOUD-3806 -->Fixed an issue when running the `setup:upgrade` command that did not interrupt the deployment process when a failure occurred during the `app:config:import` task.
 
-- {:.fix}<!-- MAGECLOUD-3866 -->Fixed an issue affecting WARM_UP_PAGES functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.
-
 - {:.new}<!-- MAGECLOUD-3871 -->Changed the default log level for the file handler to `debug` to reduce the amount of detail in the log displayed in the Project Web Interface, while still providing detailed information for debugging.
-
-- {:.fix}<!-- MAGECLOUD-3913 -->Fixed an issue that can cause database deadlock errors when the `consumers_runner` cron job starts multiple instances of the same consumer on different nodes. Now, if you have enabled the [CRON_CONSUMERS_RUNNER]({{ page.baseurl }}/cloud/env/variables-deploy.html#cron_consumers_runner) deploy variable in your environment, the `consumers_runner` job uses the `single-thread` option to start one instance of each consumer on only one node.
 
 - {:.fix}<!-- MAGECLOUD-3957 -->Fixed an issue that caused an error with static content deployment during build. After a Magento installation and `{{site.data.var.ct}}` config dump, an error occurred if there was no locale specified for the admin user in the `config.php` file. Now, there is a default locale for the admin user in the `config.php` file.
 

--- a/guides/v2.3/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.3/cloud/release-notes/cloud-tools.md
@@ -46,6 +46,10 @@ The release notes include:
 
   - {:.new}<!-- MAGECLOUD-4071 -->Added the **CONSUMERS_WAIT_FOR_MAX_MESSAGES** environment variable to configure how consumers process messages from the message queue when using the `CRON_CONSUMERS_RUNNER` environment variable to manage cron jobs. See the variable description in the [deploy variables]({{ page.baseurl }}/cloud/env/variables-deploy.html#consumers_wait_for_max_messages) topic.
 
+  - {:.fix}<!-- MAGECLOUD-3913 -->Fixed an issue that can cause database deadlock errors when the `consumers_runner` cron job starts multiple instances of the same consumer on different nodes. Now, if you have enabled the [**CRON_CONSUMERS_RUNNER**]({{ page.baseurl }}/cloud/env/variables-deploy.html#cron_consumers_runner) deploy variable in your environment, the `consumers_runner` job uses the `single-thread` option to start one instance of each consumer on only one node.
+
+  - {:.fix}<!-- MAGECLOUD-3866 -->Fixed an issue affecting [**WARM_UP_PAGES**]({{ page.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages) functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.
+
 - {:.new}<!-- MAGECLOUD-2514 -->Updated the logging information returned by the `module:refresh` command. Now, you can see a detailed list of enabled modules in the `cloud.log` file.
 
 - {:.new}<!-- MAGECLOUD-3535 -->Improved version compatibility validation and warning notifications for compatibility issues between Magento version and installed services, such as Elasticsearch, RabbitMq, Redis, and DB.
@@ -56,11 +60,7 @@ The release notes include:
 
 - {:.fix}<!-- MAGECLOUD-3806 -->Fixed an issue when running the `setup:upgrade` command that did not interrupt the deployment process when a failure occurred during the `app:config:import` task.
 
-- {:.fix}<!-- MAGECLOUD-3866 -->Fixed an issue affecting WARM_UP_PAGES functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.
-
 - {:.new}<!-- MAGECLOUD-3871 -->Changed the default log level for the file handler to `debug` to reduce the amount of detail in the log displayed in the Project Web Interface, while still providing detailed information for debugging.
-
-- {:.fix}<!-- MAGECLOUD-3913 -->Fixed an issue that can cause database deadlock errors when the `consumers_runner` cron job starts multiple instances of the same consumer on different nodes. Now, if you have enabled the [CRON_CONSUMERS_RUNNER]({{ page.baseurl }}/cloud/env/variables-deploy.html#cron_consumers_runner) deploy variable in your environment, the `consumers_runner` job uses the `single-thread` option to start one instance of each consumer on only one node.
 
 - {:.fix}<!-- MAGECLOUD-3957 -->Fixed an issue that caused an error with static content deployment during build. After a Magento installation and `{{site.data.var.ct}}` config dump, an error occurred if there was no locale specified for the admin user in the `config.php` file. Now, there is a default locale for the admin user in the `config.php` file.
 


### PR DESCRIPTION
## Purpose of this pull request

Moved changes to the environment variables for v2002.0.21 to the _Environment variable updates_ section in the Cloud release notes.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/cloud/release-notes/cloud-tools.html
- https://devdocs.magento.com/guides/v2.3/cloud/release-notes/cloud-tools.html
