### PR TITLE
Factory entity is removed from 'codegen-over-why' section

### DIFF
--- a/guides/v2.2/extension-dev-guide/code-generation.md
+++ b/guides/v2.2/extension-dev-guide/code-generation.md
@@ -24,7 +24,7 @@ In particular,
 
 *	A Factory class creates instances of a type. See [Instantiating objects with factories] for more information. Factories are directly referenced within application code.
 
-*	You can designate a Proxy to be generated for a type in order to ensure the type is not instantiated until it is needed. See [Proxies] for more information. Proxies are directly referenced within DI configuration.
+*	You can designate a Proxy to be generated for a type in order to ensure the type is not instantiated until it is needed. See [Proxies] for more information. Proxies are directly referenced within [dependency injection](https://glossary.magento.com/dependency-injection) configuration.
 
 *   Interceptor classes are automatically generated to facilitate Magento's plugin system. An interceptor class extends a type and is returned by the Object Manager to allow multiple plugin classes to inject logic into different methods. Interceptors work behind the scenes and are _not_ directly referenced in application code.
 
@@ -32,7 +32,7 @@ You can also use the [code compiler] to generate code at any time.  In Magento 2
 
 ### Why should you regenerate code? {#codegen-over-why}
 
-Suppose a Factory or Proxy class for a Customer class is generated and the Customer class has new methods added to it. Because a Factory or Proxy exists on the file system, it is not regenerated. However, the Factory or Proxy implementation is now incomplete because it does not have the new methods. In this case, you must regenerate the Factory or Proxy class.
+Suppose a Proxy class for a Customer class is generated and the Customer class has new methods added to it. Because a Proxy exists on the file system, it is not regenerated. However, the Proxy implementation is now incomplete because it does not have the new methods. In this case, you must regenerate the Proxy class.
 
 If the code generator implementation itself is changed, you must regenerate all the classes. This is rare, however.
 
@@ -50,7 +50,7 @@ Code generation is required in Magento 2. Generating code assures you of the fol
 
 When code changes as discussed in the preceding section, the Object Manager compiles it.
 
-The code compiler creates `generated/metadata/global.php`, which is a PHP serialized map of all constructor definitions mixed with object linking configuration defined in di.xml. `di.xml` is the dependency injection configuration. There is a global `app/etc/di.xml` and there can one defined for every [module](https://glossary.magento.com/module).
+The code compiler creates `generated/metadata/global.php`, which is a PHP serialized map of all constructor definitions mixed with object linking configuration defined in di.xml. `di.xml` is the [dependency injection](https://glossary.magento.com/dependency-injection) configuration. There is a global `app/etc/di.xml` and there can one defined for every [module](https://glossary.magento.com/module).
 
 <!-- Link Definitions -->
 [Magento/Customer/Model/Resource/AddressRepository]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) will fix the misleading information regarding factory generation.

Fixes https://github.com/magento/devdocs/issues/4661

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/code-generation.html#codegen-over-why

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
