### PR TITLE
information added for how to reinstall triggers

### DIFF
--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -19,7 +19,7 @@ bin/magento indexer:info
 
 The list displays as follows:
 
-```
+```terminal
 design_config_grid                       Design Config Grid
 customer_grid                            Customer Grid
 catalog_category_product                 Category Products
@@ -59,7 +59,7 @@ bin/magento indexer:status
 
 Sample result:
 
-```
+```terminal
 +----------------------+------------------+-----------+---------------------+---------------------+
 | Title                | Status           | Update On | Schedule Status     | Schedule Updated    |
 +----------------------+------------------+-----------+---------------------+---------------------+
@@ -106,7 +106,7 @@ bin/magento indexer:reindex
 
 Sample result:
 
-```
+```terminal
 Design Config Grid index has been rebuilt successfully in <time>
 Customer Grid index has been rebuilt successfully in <time>
 Category Products index has been rebuilt successfully in <time>
@@ -148,8 +148,8 @@ Only use the environment variable in the indexer command. Do not save the variab
 
 Use this command to set the following indexer options:
 
-*  **Update on save (`realtime`):** Indexed data is updated as soon as a change is made in the [Admin](https://glossary.magento.com/admin). (For example, the [category](https://glossary.magento.com/category) products index is reindex after products are added to a category in the Admin.) This is the default.
-* **Update by schedule (`schedule`):** Data is indexed according to the schedule set by your Magento cron job.
+-  **Update on save (`realtime`):** Indexed data is updated as soon as a change is made in the [Admin](https://glossary.magento.com/admin). (For example, the [category](https://glossary.magento.com/category) products index is reindex after products are added to a category in the Admin.) This is the default.
+- **Update by schedule (`schedule`):** Data is indexed according to the schedule set by your Magento cron job.
 
 [Learn more about indexing]({{ page.baseurl }}/extension-dev-guide/indexing.html)
 
@@ -169,7 +169,7 @@ bin/magento indexer:show-mode
 
 Sample result:
 
-```
+```terminal
 Design Config Grid:                                Update on Save
 Customer Grid:                                     Update on Save
 Category Products:                                 Update on Save
@@ -211,12 +211,12 @@ bin/magento indexer:set-mode schedule catalog_category_product catalog_product_c
 
 Sample result:
 
-```
+```terminal
 Index mode for Indexer Category Products was changed from 'Update on Save' to 'Update by Schedule'
 Index mode for Indexer Product Categories was changed from 'Update on Save' to 'Update by Schedule'
 ```
 
-The indexers-related database triggers are being added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`. If the triggers are missing somehow from your database while the indexers are set to `schedule`, then a way to reinstall them is by first changing the indexers to `realtime` and afterward changing them back to `schedule`. That will reinstate them.
+The indexers-related database triggers are added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`. If the triggers are missing from your database while the indexers are set to `schedule`, change the indexers to `realtime` and then change them back to `schedule`. This resets the triggers.
 
 #### Related topics
 

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -120,6 +120,20 @@ Product Price index has been rebuilt successfully in <time>
 Catalog Search index has been rebuilt successfully in <time>
 ```
 
+To reinstall triggers:
+
+Set the indexer mode to `realtime` to remove all the triggers
+
+```bash
+bin/magento indexer:set-mode realtime
+```
+
+Set the indexer mode to `schedule` to add all the triggers
+
+```bash
+bin/magento indexer:set-mode schedule
+```
+
 {:.bs-callout .bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules. <!-- Add to docs in 2.3.1 - MAGEDOC-3020:  To reduce processing time, see the next section for reindexing in parallel mode. -->
 

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -216,7 +216,7 @@ Index mode for Indexer Category Products was changed from 'Update on Save' to 'U
 Index mode for Indexer Product Categories was changed from 'Update on Save' to 'Update by Schedule'
 ```
 
-The indexers-related database triggers are being added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`.
+The indexers-related database triggers are being added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`. If the triggers are missing somehow from your database while the indexers are set to `schedule`, then a way to reinstall them is by first changing the indexers to `realtime` and afterward changing them back to `schedule`. That will reinstate them.
 
 #### Related topics
 

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -120,20 +120,6 @@ Product Price index has been rebuilt successfully in <time>
 Catalog Search index has been rebuilt successfully in <time>
 ```
 
-To reinstall triggers:
-
-Set the indexer mode to `realtime` to remove all the triggers
-
-```bash
-bin/magento indexer:set-mode realtime
-```
-
-Set the indexer mode to `schedule` to add all the triggers
-
-```bash
-bin/magento indexer:set-mode schedule
-```
-
 {:.bs-callout .bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules. <!-- Add to docs in 2.3.1 - MAGEDOC-3020:  To reduce processing time, see the next section for reindexing in parallel mode. -->
 
@@ -229,6 +215,8 @@ Sample result:
 Index mode for Indexer Category Products was changed from 'Update on Save' to 'Update by Schedule'
 Index mode for Indexer Product Categories was changed from 'Update on Save' to 'Update by Schedule'
 ```
+
+The indexers-related database triggers are being added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`.
 
 #### Related topics
 

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -22,7 +22,7 @@ The Magento application requires MySQL 5.6.x. Magento versions 2.1.2 and later a
 
 Magento _strongly_ recommends you observe the following standard when you set up your Magento database:
 
-*	Magento uses [MySQL database triggers](http://dev.mysql.com/doc/refman/5.0/en/triggers.html){:target="_blank"} to improve database access during reindexing. Magento does not support any custom triggers in the Magento database because custom triggers can introduce incompatibilities with future Magento versions.
+*	Magento uses [MySQL database triggers](http://dev.mysql.com/doc/refman/5.0/en/triggers.html){:target="_blank"} to improve database access during reindexing. These get created when the indexer mode is set to [schedule](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-index.html#configure-indexers-1){:target="_blank"}. Magento does not support any custom triggers in the Magento database because custom triggers can introduce incompatibilities with future Magento versions.
 *	Familiarize yourself with [these potential MySQL trigger limitations](http://dev.mysql.com/doc/mysql-reslimits-excerpt/5.1/en/stored-program-restrictions.html){:target="_blank"} before you continue.
 *	If you use MySQL database replication, be aware that Magento does _not_ support MySQL statement-based replication. Make sure you use _only_ [row-based replication](http://dev.mysql.com/doc/refman/5.1/en/replication-formats.html){:target="_blank"}.
 


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) provide information about how can you reinstall triggers in mysql

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-index.html#configure-indexers-1

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
Fixed https://github.com/magento/devdocs/issues/4647