### PR TITLE
Remove unnecessary visible backticks

### DIFF
--- a/guides/v2.2/frontend-dev-guide/css-topics/css-critical-path.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css-critical-path.md
@@ -16,9 +16,9 @@ CSS critical path configuration is located in **Stores** > Settings > **Configur
 
 Enable CSS critical path:
 
-    ```bash
-    bin/magento config:set dev/css/use_css_critical_path 1
-    ```
+```bash
+bin/magento config:set dev/css/use_css_critical_path 1
+```
 
 Make sure that there is a `critical.css` file for your theme. Other non-critical CSS files will be loaded asynchronously.
 


### PR DESCRIPTION
## Purpose of this pull request

This PR tidies up a code block that contains visible back ticks that should not be there.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/css-topics/css-critical-path.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-critical-path.html
