### PR TITLE
Fix the outdated "Compile LESS using Grunt" documentation

### DIFF
--- a/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
@@ -16,7 +16,7 @@ The topic describes how to install, configure, and use [Grunt JavaScript task ru
 
 To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/local-themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
 
-1. Install [node.js](https://nodejs.org/en/download/package-manager/) to any location on your machine.
+1. Install [node.js] to any location on your machine.
 
 2. Install the Grunt CLI globally. To do this, run the following command in a command prompt:
     ```bash

--- a/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
@@ -23,7 +23,7 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
     ```bash
     npm install -g grunt-cli
     ```
-    
+
 1. From the `<Magento_root>` directory, copy and paste the contents of the following files:
 
     - `package.json.sample` to `package.json`
@@ -37,7 +37,7 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
     npm install
     npm update
     ```
-    
+
 1. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/local-themes.js` file, add your theme to `module.exports` like following:
 
     ```javascript
@@ -54,7 +54,7 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
     ```
 
     Where the following notation is used:
-    
+
     - `<Vendor>`: vendor name.
     - `<theme>`: your theme code, conventionally should correspond to the theme directory name.
     - `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.

--- a/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
@@ -14,17 +14,18 @@ The topic describes how to install, configure, and use [Grunt JavaScript task ru
 
 ## Adding themes to Grunt configuration {#add_theme}
 
-To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
+To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/local-themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
 
-1. Install [node.js] to any location on your machine.
+1. Install [node.js](https://nodejs.org/en/download/package-manager/) to any location on your machine.
 
-2. Install the Grunt CLI globally:
+2. Install the Grunt CLI globally. To do this, run the following command in a command prompt:
     ```bash
     npm install -g grunt-cli
     ```
-3. Rename the following files in your Magento root directory:
-    -   `package.json.sample` to `package.json`
-    -   `Gruntfile.js.sample` to `Gruntfile.js`
+3. From the `<Magento_root>` directory, copy and paste the contents of the following files:
+    - `package.json.sample` to `package.json`
+    - `Gruntfile.js.sample` to `Gruntfile.js`
+    - `grunt-config.json.sample` into `grunt-config.json`
 
 4. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
     ```
@@ -32,12 +33,10 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
     npm install
     npm update
     ```
-5. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/themes.js` file, add your theme to `module.exports` like following:
+5. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/local-themes.js` file, add your theme to `module.exports` like following:
     ```javascript
-    module.exports = {
-
         <theme>: {
-            area: 'frontend',
+            area: '<area>',
             name: '<Vendor>/<theme>',
             locale: '<language>',
             files: [
@@ -45,12 +44,14 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
                 '<path_to_file2>'
             ],
             dsl: 'less'
-        },
+        }
     ```
 
     Where the following notation is used:
+    - `<Vendor>`: vendor name.
     - `<theme>`: your theme code, conventionally should correspond to the theme directory name.
-    - `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`
+    - `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.
+    - `<area>`: area code, can be either `frontend` or `adminhtml`.
     - `<path_to_file>`: path to the root source file, relative to the `app/design/frontend/<Vendor>/<theme>/web` directory. You need to specify all [root source files of the theme]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms). If your theme [inherits] from a certain theme, and does not contain its own root source files, specify the root source files of the parent theme.
 
 6. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension] in your browser.
@@ -109,4 +110,4 @@ To change or override any of these variables, simply create a file in `<theme-di
 
 [inherits]: {{page.baseurl}}/frontend-dev-guide/themes/theme-inherit.html
 [LiveReload extension]: http://livereload.com/extensions/
-[node.js]: https://github.com/nodejs/node/wiki
+[node.js]: https://nodejs.org/en/download/package-manager/

--- a/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
@@ -18,43 +18,50 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
 
 1. Install [node.js] to any location on your machine.
 
-2. Install the Grunt CLI globally. To do this, run the following command in a command prompt:
+1. Install the Grunt CLI globally. To do this, run the following command in a command prompt:
+
     ```bash
     npm install -g grunt-cli
     ```
-3. From the `<Magento_root>` directory, copy and paste the contents of the following files:
+    
+1. From the `<Magento_root>` directory, copy and paste the contents of the following files:
+
     - `package.json.sample` to `package.json`
     - `Gruntfile.js.sample` to `Gruntfile.js`
     - `grunt-config.json.sample` into `grunt-config.json`
 
-4. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
-    ```
+1. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
+
+    ```bash
     cd <your_Magento_instance_directory>
     npm install
     npm update
     ```
-5. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/local-themes.js` file, add your theme to `module.exports` like following:
+    
+1. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/local-themes.js` file, add your theme to `module.exports` like following:
+
     ```javascript
-        <theme>: {
-            area: '<area>',
-            name: '<Vendor>/<theme>',
-            locale: '<language>',
-            files: [
-                '<path_to_file1>', //path to root source file
-                '<path_to_file2>'
-            ],
-            dsl: 'less'
-        }
+    <theme>: {
+        area: '<area>',
+        name: '<Vendor>/<theme>',
+        locale: '<language>',
+        files: [
+            '<path_to_file1>', //path to root source file
+            '<path_to_file2>'
+        ],
+        dsl: 'less'
+    }
     ```
 
     Where the following notation is used:
+    
     - `<Vendor>`: vendor name.
     - `<theme>`: your theme code, conventionally should correspond to the theme directory name.
     - `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.
     - `<area>`: area code, can be either `frontend` or `adminhtml`.
     - `<path_to_file>`: path to the root source file, relative to the `app/design/frontend/<Vendor>/<theme>/web` directory. You need to specify all [root source files of the theme]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms). If your theme [inherits] from a certain theme, and does not contain its own root source files, specify the root source files of the parent theme.
 
-6. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension] in your browser.
+1. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension] in your browser.
 
 ## Grunt commands {#grunt_commands}
 
@@ -70,16 +77,17 @@ grunt watch | Tracks the changes in the source files, recompiles `.css` files, a
 ## Use cases of tracking changes using Grunt {#use_cases}
 
 The following shows which Grunt tasks to use for debugging:
--   After you switch the compilation mode from client-side to server-side, run the `exec` command.
--   After you customize the content of any `.less` file, except the root source files, run the `less` task and reload the page.
--   After you [customize the root source files or move the files included to the root files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception), run the `exec` command and reload the page.
--   After you run `php bin/magento setup:upgrade`, run `exec` command.
--   After you run the `exec` command, run the `clear` command to `clear` the Magento cache, then run the `watch` command. Running the commands in this order will ensure that any custom jQuery attributes like product sliders, banners, etc are loaded correctly.
+
+-  After you switch the compilation mode from client-side to server-side, run the `exec` command.
+-  After you customize the content of any `.less` file, except the root source files, run the `less` task and reload the page.
+-  After you [customize the root source files or move the files included to the root files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception), run the `exec` command and reload the page.
+-  After you run `php bin/magento setup:upgrade`, run `exec` command.
+-  After you run the `exec` command, run the `clear` command to `clear` the Magento cache, then run the `watch` command. Running the commands in this order will ensure that any custom jQuery attributes like product sliders, banners, etc are loaded correctly.
 
 If you have LiveReload installed, run the `grunt watch` command, and the flow is even simpler:
 
--   After you customize the content of any `.less` file, changes are applied and the page reloads automatically. No additional changes
--   After you [customize the root source files or move the files included to the root files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception), run the `clean` and `exec` commands, which reloads the page in the browser.
+-  After you customize the content of any `.less` file, changes are applied and the page reloads automatically. No additional changes
+-  After you [customize the root source files or move the files included to the root files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception), run the `clean` and `exec` commands, which reloads the page in the browser.
 
 ## CSS source maps {#source_maps}
 
@@ -103,7 +111,7 @@ To change or override any of these variables, simply create a file in `<theme-di
 
 ![node declaration autocomplete]({{ site.baseurl }}/common/images/fdg/lib-map.png){:width="610px"}
 
-```
+```css
 @navigation__background: @secondary__color__light;
 @font-family__sans-serif: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 ```

--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -22,22 +22,27 @@ Magento has built-in Grunt tasks configured, but there are still several steps y
 
 1. Install [node.js](https://nodejs.org/en/download/package-manager/) to any location on your machine.
 
-2. Install Grunt CLI tool globally. To do this, run the following command in a command prompt:
+1. Install Grunt CLI tool globally. To do this, run the following command in a command prompt:
+
     ```bash
     npm install -g grunt-cli
     ```
-3. From the `<Magento_root>` directory, copy and paste the contents of the following files:
-	- `package.json.sample` into `package.json`
-	- `Gruntfile.js.sample` into `Gruntfile.js`
-	- `grunt-config.json.sample` into `grunt-config.json`
+    
+1. From the `<Magento_root>` directory, copy and paste the contents of the following files:
 
-4. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
+   -  `package.json.sample` into `package.json`
+   -  `Gruntfile.js.sample` into `Gruntfile.js`
+   -  `grunt-config.json.sample` into `grunt-config.json`
+
+1. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
+
     ```bash
     cd your_Magento_instance_directory
     npm install
     npm update
     ```
-5. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension](http://livereload.com/extensions/) in your browser.
+    
+1. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension](http://livereload.com/extensions/) in your browser.
 
 ## Grunt configuration file {#grunt_config}
 
@@ -46,24 +51,25 @@ Copy the contents of `themes.js` into `local-themes.js` in the `dev/tools/grunt/
 If installed as described above, Grunt will use the default configuration files located in the `dev/tools/grunt/configs/` directory. You can define your theme in the `local-themes.js` file. The following shows an example of how you can define your theme.
 
 ```javascript
-    <theme>: {
-        area: '<area>',
-        name: '<Vendor>/<theme>,
-        locale: '<language>',
-        files: [
-            '<path_to_file1>', //path to root source file
-            '<path_to_file2>'
-        ],
-        dsl: 'less'
-    }
+<theme>: {
+  area: '<area>',
+  name: '<Vendor>/<theme>,
+  locale: '<language>',
+  files: [
+    '<path_to_file1>', //path to root source file
+    '<path_to_file2>'
+  ],
+dsl: 'less'
+}
 ```
 
 Where the following notation is used:
-- `<Vendor>`: vendor name.
-- `<theme>`: your theme code, conventionally should correspond to the theme directory name.
-- `<area>`: area code, can be either `frontend` or `adminhtml`.
-- `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.
-- `<path_to_file>`: path to the root source file, relative to the `app/design/frontend/<Vendor>/<theme>/web` directory. You need to specify all [root source files of the theme]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms). If your theme [inherits] from a certain theme, and does not contain its own root source files, specify the root source files of the parent theme.
+
+-  `<Vendor>`: vendor name.
+-  `<theme>`: your theme code, conventionally should correspond to the theme directory name.
+-  `<area>`: area code, can be either `frontend` or `adminhtml`.
+-  `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.
+-  `<path_to_file>`: path to the root source file, relative to the `app/design/frontend/<Vendor>/<theme>/web` directory. You need to specify all [root source files of the theme]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms). If your theme [inherits] from a certain theme, and does not contain its own root source files, specify the root source files of the parent theme.
 
 ## Using custom Grunt configuration files
 
@@ -74,18 +80,21 @@ There are several ways to declare a custom configuration file.
 To use a custom file for Grunt configuration:
 
 1. Copy the default configuration file to the preferred location in the Magento instance directory. Do not change the file name
-2. Open the `grunt-config.json` file in the Magento root and set configurations object as follows
-	* key: file alias
-	* value: path to your custom file
+1. Open the `grunt-config.json` file in the Magento root and set configurations object as follows.
+
+   -  key: file alias
+   -  value: path to your custom file
 
    Example:
    If your custom configuration file `local-themes.js` is located in the `<magento_root>/dev/tools/grunt/configs` directory, the following is already set in your `grunt-config.json`:
 
-       {
-           "themes": "dev/tools/grunt/configs/local-themes"
-       }
+   ```config
+   {
+    "themes": "dev/tools/grunt/configs/local-themes"
+   }
+   ```
 
-This path is also added to your .gitignore by default
+This path is also added to your .gitignore by default.
 
 ### How to declare custom configuration file: Option 2
 
@@ -93,11 +102,13 @@ You can also use the other way to declare a custom config file:
 
 1. In your Grunt related scripts, in the file router set the alias and path to the default configuration file. For example, for the `themes.js` configuration file this would look like following:
 
-       filesRouter.set('themes', 'dev/tools/grunt/configs/themes');
+   ```config
+   filesRouter.set('themes', 'dev/tools/grunt/configs/themes');
+   ```
 
-   It must be added earlier, than the `get()` method with  this alias is called.
+   It must be added earlier, than the `get()` method with this alias is called.
 
-2. In the `dev/tools/grunt/configs/` directory, create a copy of the default configuration file. Change its name by adding the ".loc" suffix. For example, your copy of `themes.js` will be `themes.loc.js`.
+1. In the `dev/tools/grunt/configs/` directory, create a copy of the default configuration file. Change its name by adding the ".loc" suffix. For example, your copy of `themes.js` will be `themes.loc.js`.
 
 ### How to use custom configuration file
 
@@ -105,10 +116,10 @@ To tell Grunt to use a custom configuration file, instead of the default one, ad
 
 1. Require file-router:
 
-       var fileRouter = require('/files-router');
+   ```config
+   var fileRouter = require('/files-router');
+   ```
 
-2. Call the `get(%file_alias%)` method to get the configuration file.
+1. Call the `get(%file_alias%)` method to get the configuration file.
 
-   Example:
-
-       var themes = fileRouter.get('themes');
+   `var themes = fileRouter.get('themes');`

--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -27,7 +27,7 @@ Magento has built-in Grunt tasks configured, but there are still several steps y
     ```bash
     npm install -g grunt-cli
     ```
-    
+
 1. From the `<Magento_root>` directory, copy and paste the contents of the following files:
 
    -  `package.json.sample` into `package.json`
@@ -41,7 +41,7 @@ Magento has built-in Grunt tasks configured, but there are still several steps y
     npm install
     npm update
     ```
-    
+
 1. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension](http://livereload.com/extensions/) in your browser.
 
 ## Grunt configuration file {#grunt_config}

--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -20,23 +20,23 @@ Make sure that you [set]({{ page.baseurl }}/config-guide/cli/config-cli-subcomma
 
 Magento has built-in Grunt tasks configured, but there are still several steps you need to take to be able to use it:
 
-1. Install [node.js](https://github.com/joyent/node/wiki/installing-node.js-via-package-manager) to any location on your machine.
+1. Install [node.js](https://nodejs.org/en/download/package-manager/) to any location on your machine.
 
 2. Install Grunt CLI tool globally. To do this, run the following command in a command prompt:
-
-       npm install -g grunt-cli
-
+    ```bash
+    npm install -g grunt-cli
+    ```
 3. From the `<Magento_root>` directory, copy and paste the contents of the following files:
 	- `package.json.sample` into `package.json`
 	- `Gruntfile.js.sample` into `Gruntfile.js`
 	- `grunt-config.json.sample` into `grunt-config.json`
 
 4. Install (or refresh) the `node.js` project dependency, including Grunt, for your Magento instance. To do this, run the following commands in a command prompt:
-
-       cd your_Magento_instance_directory
-       npm install
-       npm update
-
+    ```bash
+    cd your_Magento_instance_directory
+    npm install
+    npm update
+    ```
 5. (Optional) If you want to use Grunt for "watching" changes automatically, without reloading pages in a browser each time, install the [LiveReload extension](http://livereload.com/extensions/) in your browser.
 
 ## Grunt configuration file {#grunt_config}
@@ -46,17 +46,24 @@ Copy the contents of `themes.js` into `local-themes.js` in the `dev/tools/grunt/
 If installed as described above, Grunt will use the default configuration files located in the `dev/tools/grunt/configs/` directory. You can define your theme in the `local-themes.js` file. The following shows an example of how you can define your theme.
 
 ```javascript
-    Theme_Name: {
-        area: 'frontend',
-        name: 'Vendor_Name/Theme_Name',
-        locale: 'en_US',
+    <theme>: {
+        area: '<area>',
+        name: '<Vendor>/<theme>,
+        locale: '<language>',
         files: [
-            'css/styles-m',
-            'css/styles-l'
+            '<path_to_file1>', //path to root source file
+            '<path_to_file2>'
         ],
         dsl: 'less'
     }
 ```
+
+Where the following notation is used:
+- `<Vendor>`: vendor name.
+- `<theme>`: your theme code, conventionally should correspond to the theme directory name.
+- `<area>`: area code, can be either `frontend` or `adminhtml`.
+- `<language>`: specified in the `code_subtag` format, for example `en_US`. Only one locale can be specified here. To debug the theme with another locale, create one more theme declaration, having specified another value for `language`.
+- `<path_to_file>`: path to the root source file, relative to the `app/design/frontend/<Vendor>/<theme>/web` directory. You need to specify all [root source files of the theme]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms). If your theme [inherits] from a certain theme, and does not contain its own root source files, specify the root source files of the parent theme.
 
 ## Using custom Grunt configuration files
 


### PR DESCRIPTION
## Purpose of this pull request

The custom theme must not be defined in the core `dev/tools/grunt/configs/themes.js` themes configuration file directly anymore. The separate configuration file should be created since the `grunt-config.json.sample` is available.
The related implementation can be found in the following commit: https://github.com/magento/magento2/commit/5c76ada4a409f2a9948b3ac3efd9899cff36c1b6

This pull request fixes the outdated instructions for LESS compilation using Grunt and also adds content improvements.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/css-topics/css_debug.html
- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/tools/using_grunt.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html

## Links to Magento source code

- `/grunt-config.json.sample`
- `/dev/tools/grunt/configs/themes.js`

whatsnew
Updated information about using LESS with Grunt in [Compile LESS using Grunt](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html) and [Using Grunt for Magento tasks](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html])