### PR TITLE
Add missing location for RequireJS configuration file

### DIFF
--- a/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
@@ -20,7 +20,8 @@ To add a custom JS component (module), take the following steps:
 
 2. Optionally, in the corresponding [module](https://glossary.magento.com/module) or theme, create a `requirejs-config.js` configuration file, if it does not yet exist there and set path for your resource. The RequireJS configuration file can be placed in one of the following locations:
 
-- Your theme: `<theme_dir>/<module_dir>`
+- Your theme: `<theme_dir>`
+- Module within your theme: `<theme_dir>/<module_dir>`
 - Your module (depending on the needed area - **base**, **frontend**, **adminhtml**): `<module_dir>/view/<area>`
 
 ## Replace a default JS component {#js_replace}


### PR DESCRIPTION
# Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) updates the **Use custom JavaScript** documentation with the aim to add a missing place to define the RequireJS configuration.

The current documentation doesn't inform that the `requirejs-config.js` file can be placed under `<theme-dir>` as well.

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/custom_js.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/custom_js.html