### PR TITLE
Remove wrong path for placing JS files in theme in "Use custom JavaScript" documentation

### DIFF
--- a/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
@@ -29,7 +29,7 @@ To use a custom implementation of an existing Magento JS component:
 Place the custom component source file in one of the following
 locations:
 
-- Your theme JS files: `/web/js` or `/_/web/js`
+- Your theme JS files: `/web/js`
 - Your module view JS files: `<module_dir>/view/frontend/web/js`
 
 Create a RequireJS configuration file `requirejs-config.js`, having


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates **Use custom JavaScript** documentation in order to remove wrong reference for placing JS files in the theme scope - `<theme-dir>/_/web/js/`.

This practice was not found in the *Blank* theme nor *Luma* theme and it doesn't work in custom theme either:

![Not possible to grab files under /_/web/js/ during theme compilation](https://user-images.githubusercontent.com/13456702/64670855-2d6bab00-d46f-11e9-9afd-26053712c33b.png)


## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/custom_js.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/custom_js.html

