### PR TITLE
Enrich Calendar Widget Code example section

### DIFF
--- a/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
@@ -79,8 +79,13 @@ This example shows how to initialize the calendar widget, including custom param
 
 The result is a calendar and a icon(_Click Here_) that opens the calendar.
 
+#### Calendar field initial state
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-initial.png)
+
+#### Calendar field opened state
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-open.png)
+
+#### Calendar field date chosen
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-result.png)
 
 [Datepicker Widget]: http://api.jQueryui.com/datepicker/

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
@@ -6,11 +6,11 @@ title: Calendar widget
 
 The Calendar widget is a customized jQuery [Datepicker Widget] that enables selecting a data using a pop-up or an in-line calendar. Calendar is also responsible for:
 
--	 Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
--	 Taking into account server time zone offset.
--	 Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
--	 Making the calendar initialization easier.
--	 The Calendar widget source is [lib/web/mage/calendar.js].
+-  Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
+-  Taking into account server time zone offset.
+-  Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
+-  Making the calendar initialization easier.
+-  The Calendar widget source is [lib/web/mage/calendar.js].
 
 ## Initialize the calendar widget {#fedg_calendar_init}
 
@@ -20,11 +20,11 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 The calendar widget's *global configuration* is a set of default options that are applied when each calendar instance is initialized. It includes the following:
 
--	 Translations for days, months, and control buttons
--	 Date and time format
--	 Animation settings
--	 Calendar pop-up mode
--	 Server time zone offset
+-  Translations for days, months, and control buttons
+-  Date and time format
+-  Animation settings
+-  Calendar pop-up mode
+-  Server time zone offset
 
 Global configuration for calendar is stored in a jQuery object as a hash of properties. Having global configuration set enables specifying all translations and default options at once, and use it for all instances of calendar, and it enables usage of inline translation for the calendar. During initialization, the calendar widget merges the hash of options from the global configuration, and the options which are transferred from PHP, and then passes the merged options to datepicker.
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
@@ -60,9 +60,17 @@ This example shows how to initialize the calendar widget, including custom param
 <script>
   require([
     'jquery',
+    'mage/translate',
     'mage/calendar'
-    ], function ($) {
-      $('#example-date').calendar();
+    ], function ($, $t) {
+      $('#example-date').calendar({
+        changeMonth: true,
+        changeYear: true,
+        showButtonPanel: true,
+        currentText: $t('Go Today'),
+        closeText: $t('Close'),
+        showWeek: true
+      });
     })
 </script>
 ```

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.md
@@ -4,15 +4,13 @@ subgroup: 3_Widgets
 title: Calendar widget
 ---
 
-## Overview {#fedg_jquery-widget_calendar-overview}
-
 The Calendar widget is a customized jQuery [Datepicker Widget] that enables selecting a data using a pop-up or an in-line calendar. Calendar is also responsible for:
 
-*	Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
-*	Taking into account server time zone offset.
-*	Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
-*	Making the calendar initialization easier.
-*	The Calendar widget source is [lib/web/mage/calendar.js].
+-	 Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
+-	 Taking into account server time zone offset.
+-	 Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
+-	 Making the calendar initialization easier.
+-	 The Calendar widget source is [lib/web/mage/calendar.js].
 
 ## Initialize the calendar widget {#fedg_calendar_init}
 
@@ -22,11 +20,11 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 The calendar widget's *global configuration* is a set of default options that are applied when each calendar instance is initialized. It includes the following:
 
-*	Translations for days, months, and control buttons
-*	Date and time format
-*	Animation settings
-*	Calendar pop-up mode
-*	Server time zone offset
+-	 Translations for days, months, and control buttons
+-	 Date and time format
+-	 Animation settings
+-	 Calendar pop-up mode
+-	 Server time zone offset
 
 Global configuration for calendar is stored in a jQuery object as a hash of properties. Having global configuration set enables specifying all translations and default options at once, and use it for all instances of calendar, and it enables usage of inline translation for the calendar. During initialization, the calendar widget merges the hash of options from the global configuration, and the options which are transferred from PHP, and then passes the merged options to datepicker.
 
@@ -80,12 +78,15 @@ This example shows how to initialize the calendar widget, including custom param
 The result is a calendar and a icon(_Click Here_) that opens the calendar.
 
 #### Calendar field initial state
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-initial.png)
 
 #### Calendar field opened state
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-open.png)
 
 #### Calendar field date chosen
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-result.png)
 
 [Datepicker Widget]: http://api.jQueryui.com/datepicker/

--- a/guides/v2.3/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.3/javascript-dev-guide/widgets/widget_calendar.md
@@ -47,6 +47,47 @@ require([
 
 Most options, methods, and events for the calendar widget correspond to the jQuery [Datepicker Widget] options.
 
+## Code sample
+
+This example shows how to initialize the calendar widget, including custom parameters.
+
+```html
+<div class="field">
+    <label>Date : </label>
+    <input type="text" class="input-text" id="example-date" style="width: auto" name="example-date" />
+</div>
+
+<script>
+  require([
+    'jquery',
+    'mage/translate',
+    'mage/calendar'
+    ], function ($, $t) {
+      $('#example-date').calendar({
+        changeMonth: true,
+        changeYear: true,
+        showButtonPanel: true,
+        currentText: $t('Go Today'),
+        closeText: $t('Close'),
+        showWeek: true
+      });
+    })
+</script>
+```
+
+### Result
+
+The result is a calendar and a icon(_Click Here_) that opens the calendar.
+
+#### Calendar field initial state
+![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-initial.png)
+
+#### Calendar field opened state
+![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-open.png)
+
+#### Calendar field date chosen
+![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-result.png)
+
 [Datepicker Widget]: http://api.jQueryui.com/datepicker/
 [global configuration]: #fedg_calendar_config
 [lib/web/mage/calendar.js]: {{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/mage/calendar.js

--- a/guides/v2.3/javascript-dev-guide/widgets/widget_calendar.md
+++ b/guides/v2.3/javascript-dev-guide/widgets/widget_calendar.md
@@ -4,15 +4,13 @@ subgroup: 3_Widgets
 title: Calendar widget
 ---
 
-## Overview {#fedg_jquery-widget_calendar-overview}
-
 The Calendar widget is a customized jQuery [Datepicker Widget] that enables selecting a data using a pop-up or an in-line calendar. Calendar is also responsible for:
 
-*	Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
-*	Taking into account server time zone offset.
-*	Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
-*	Making the calendar initialization easier.
-*	The Calendar widget source is [lib/web/mage/calendar.js].
+-  Merging the [global configuration] with the options that are passed from PHP when Calendar is initialized.
+-  Taking into account server time zone offset.
+-  Converting date and time formats to avoid inconsistency in Zend Date format and Datepicker format.
+-  Making the calendar initialization easier.
+-  The Calendar widget source is [lib/web/mage/calendar.js].
 
 ## Initialize the calendar widget {#fedg_calendar_init}
 
@@ -22,11 +20,11 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 The calendar widget's *global configuration* is a set of default options that are applied when each calendar instance is initialized. It includes the following:
 
-*	Translations for days, months, and control buttons
-*	Date and time format
-*	Animation settings
-*	Calendar pop-up mode
-*	Server time zone offset
+-  Translations for days, months, and control buttons
+-  Date and time format
+-  Animation settings
+-  Calendar pop-up mode
+-  Server time zone offset
 
 Global configuration for calendar is stored in a jQuery object as a hash of properties. Having global configuration set enables specifying all translations and default options at once, and use it for all instances of calendar, and it enables usage of inline translation for the calendar. During initialization, the calendar widget merges the hash of options from the global configuration, and the options which are transferred from PHP, and then passes the merged options to datepicker.
 
@@ -80,12 +78,15 @@ This example shows how to initialize the calendar widget, including custom param
 The result is a calendar and a icon(_Click Here_) that opens the calendar.
 
 #### Calendar field initial state
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-initial.png)
 
 #### Calendar field opened state
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-open.png)
 
 #### Calendar field date chosen
+
 ![Calendar Widget]({{ site.baseurl }}/common/images/widget/calendar-widget-result.png)
 
 [Datepicker Widget]: http://api.jQueryui.com/datepicker/


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request (PR) updates documentation for **Calendar Widget**, specifically the code example section, where passed parameters for widget initialization doesn't match with shown final result below.

Below is the illustration of a calendar initialized with parameters from the Code Example section:
![magento-calendar-widget-no-options-result](https://user-images.githubusercontent.com/13456702/64709820-8f540100-d4bf-11e9-9b4b-ee382b0a1a2c.jpg)

Whereas, the documentation says it have to look like below. Also, the Result section looks unformatted.
![docs-widget-result](https://user-images.githubusercontent.com/13456702/64709986-dcd06e00-d4bf-11e9-961f-ff329b64f953.png)

The *Result* section was updated as well to look better
![image](https://user-images.githubusercontent.com/13456702/64712585-28851680-d4c4-11e9-9dfa-2a5110377213.png)


## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/widgets/widget_calendar.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_calendar.html

