### PR TITLE
Fix external link

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.md
@@ -1793,7 +1793,7 @@ The following table identifies contributions from our community members. This ta
 <tr>
     <td><a target="_blank" href="https://github.com/magento/magento2/pull/13861">13861</a></td>
     <td><a href="https://github.com/magento/magento2/issues/13006" target="_blank">13006</a></td>
-    <td><a target="_blank" href="https://github.com/hiren-wagento">Hiren Patel</a></td>
+    <td><a target="_blank" href="https://github.com/hiren2615">Hiren Patel</a></td>
   </tr>
 <tr>
     <td><a target="_blank" href="https://github.com/magento/magento2/pull/13930">13930</a></td>


### PR DESCRIPTION
<!-- # IMPORTANT

We are no longer accepting pull requests to update v2.1 devdoc files.

Magento 2.1.18 is the final 2.1.x release. After the [June 2019 end-of-support date](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf), Magento will no longer apply security patches, quality fixes, or documentation updates to v2.1.x. To maintain your site's performance, security, and PCI compliance, [upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html) to the latest version of Magento. -->

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. -->

This pull request fixes external link.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.html