### PR TITLE
Fix typo in command example

### DIFF
--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -43,7 +43,7 @@ where
 `--ip=<ip address>` is an IP address to exempt from maintenance mode (for example, developers doing the maintenance). To exempt more than one IP address in the same command, use the option multiple times.
 
 {:.bs-callout .bs-callout-info}
-Using `--ip=&lt;ip address>` with `magento maintenance:disable` means only that you're saving the list of IPs for later use. To clear the list of exempt IPs, you can use `magento maintenance:enable --ip=none` or see [Maintain the list of exempt IP addresses](#instgde-cli-maint-exempt).
+Using `--ip=<ip address>` with `magento maintenance:disable` means only that you're saving the list of IPs for later use. To clear the list of exempt IPs, you can use `magento maintenance:enable --ip=none` or see [Maintain the list of exempt IP addresses](#instgde-cli-maint-exempt).
 
 `magento maintenance:status` displays the current status of maintenance mode.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix typo in command example

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.html
https://devdocs.magento.com/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.html
- ...
