### PR TITLE
Fixed path to log files

### DIFF
--- a/guides/v2.2/cloud/project/log-locations.md
+++ b/guides/v2.2/cloud/project/log-locations.md
@@ -20,7 +20,7 @@ You can [set up log-based Slack and email notifications][slacklog] when configur
 
 There are three ways to view logs: file system, project web UI, or magento-cloud CLI.
 
--  **Log directories**—The `/var/log` directory contains logs for all environments. You must use an SSH connection to access the `/var/log` directory in the remote server environment.
+-  **Log directories**—The `var/log` directory contains logs for all environments. You must use an SSH connection to access the `var/log` directory in the remote server environment.
 -  **Project web UI**—You can see build and post-deploy log information in the environment messages list.
 -  **Magento Cloud CLI**—You can view logs using the `magento-cloud log` command.
 
@@ -84,12 +84,12 @@ The following logs have a common location for all Cloud projects:
 
 Logs from the deploy hook are unique for each environment. The deploy log is in the following directories:
 
--  **Starter and Pro Integration**: `/var/log/deploy.log`
--  **Pro Staging**: `/var/log/platform/<project_id>_stg/deploy.log`
--  **Pro Production**: `/var/log/platform/<project_id>/deploy.log`
+-  **Starter and Pro Integration**: `var/log/deploy.log`
+-  **Pro Staging**: `var/log/platform/<project_id>_stg/deploy.log`
+-  **Pro Production**: `var/log/platform/<project_id>/deploy.log`
 
 The value of `<project_id>` depends on the project ID and whether the environment is Staging or Production. For example, with a project ID of `yw1unoukjcawe`, the Staging environment user is `yw1unoukjcawe_stg` and the Production environment user is `yw1unoukjcawe`.
-Using that example, the deploy log is: `/var/log/platform/yw1unoukjcawe_stg/deploy.log`
+Using that example, the deploy log is: `var/log/platform/yw1unoukjcawe_stg/deploy.log`
 
 The log for each deployment concatenates to the specific `deploy.log` file.
 
@@ -125,23 +125,23 @@ Similar to deploy logs, application logs are unique for each environment. The fo
 
 Log file            | Starter and Pro Integration | Pro Staging                                       | Pro Production
 ------------------- | --------------------------- | ------------------------------------------------- | -------------------------------------------
-**Deploy log**  | `/var/log/deploy.log`       | `/var/log/platform/<project_id>_stg/deploy.log`   | `/var/log/platform/<project_id>/deploy.log`
-**Cron log**        | `/var/log/cron.log`         | `/var/log/platform/<project_id>_stg/cron.log`     | `var/log/platform/<project_id>/cron.log`
-**Nginx access log**| `/var/log/access.log`       | `/var/log/platform/<project_id>_stg/access.log`   | `/var/log/platform/<project_id>/access.log`
-**Nginx error log** | `/var/log/error.log`        | `/var/log/platform/<project_id>_stg/error.log`    | `/var/log/platform/<project_id>/error.log`
-**PHP access log**  | `/var/log/php.access.log`   | `/var/log/platform/<project_id>_stg/php.access.log` | `/var/log/platform/<project_id>/php.access.log`
-**PHP FPM log**     | `/var/log/app.log`          | `/var/log/platform/<project_id>_stg/php5-fpm.log` | `/var/log/platform/<project_id>/php5-fpm.log`
+**Deploy log**  | `var/log/deploy.log`       | `var/log/platform/<project_id>_stg/deploy.log`   | `/var/log/platform/<project_id>/deploy.log`
+**Cron log**        | `var/log/cron.log`         | `var/log/platform/<project_id>_stg/cron.log`     | `var/log/platform/<project_id>/cron.log`
+**Nginx access log**| `var/log/access.log`       | `var/log/platform/<project_id>_stg/access.log`   | `/var/log/platform/<project_id>/access.log`
+**Nginx error log** | `var/log/error.log`        | `var/log/platform/<project_id>_stg/error.log`    | `/var/log/platform/<project_id>/error.log`
+**PHP access log**  | `var/log/php.access.log`   | `var/log/platform/<project_id>_stg/php.access.log` | `/var/log/platform/<project_id>/php.access.log`
+**PHP FPM log**     | `var/log/app.log`          | `var/log/platform/<project_id>_stg/php5-fpm.log` | `var/log/platform/<project_id>/php5-fpm.log`
 
 ## Service logs
 
 Because each service runs in a separate container, the service logs are not available in the Integration environment. {{site.data.var.ece}} provides access to the web server container in the Integration environment only. The following service log locations are for the Pro Staging and Production environments:
 
--  **Redis log**: `/var/log/platform/<project_id>_stg/redis-server-<project_id>_stg.log`
--  **Elasticseach log**: `/var/log/elasticsearch/elasticsearch.log`
--  **Mail log**: `/var/log/mail.log`
--  **MySQL error log**: `/var/log/mysql/mysql-error.log`
--  **MySQL slow log**: `/var/log/mysql/mysql-slow.log`
--  **RabbitMQ log**: `/var/log/rabbitmq/rabbit@host1.log`
+-  **Redis log**: `var/log/platform/<project_id>_stg/redis-server-<project_id>_stg.log`
+-  **Elasticseach log**: `var/log/elasticsearch/elasticsearch.log`
+-  **Mail log**: `var/log/mail.log`
+-  **MySQL error log**: `var/log/mysql/mysql-error.log`
+-  **MySQL slow log**: `var/log/mysql/mysql-slow.log`
+-  **RabbitMQ log**: `var/log/rabbitmq/rabbit@host1.log`
 
 [hook]: {{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
 [configlog]: {{page.baseurl}}/config-guide/cli/logging.html


### PR DESCRIPTION
## Purpose of this pull request

Updated paths to Cloud log files to remove preceding slash `/`.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.2/cloud/project/log-locations.html