### PR TITLE
Added link to web configuration for multisite

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -138,6 +138,9 @@ web:
 
 ```
 
+{:.bs-callout-info}
+This example shows the default web configuration for a Cloud project configured to support a single domain. For a project that requires support for multiple websites or stores, the `web` configuration must be set up to support shared domains. See [Configure locations for shared domains]{{ page.baseurl }}cloud/project-multi-sites.html#locations}.
+
 ### `disk`
 
 Defines the persistent disk size of the application in MB.
@@ -146,7 +149,7 @@ Defines the persistent disk size of the application in MB.
 disk: 2048
 ```
 
-{:.bs-callout .bs-callout-info}
+{:.bs-callout-info}
 The minimal recommended disk size is 256MB. If you see the error `UserError: Error building the project: Disk size may not be smaller than 128MB`, increase the size to 256MB.
 
 ### `mounts`

--- a/guides/v2.2/cloud/project/project-conf-files_magento-app.md
+++ b/guides/v2.2/cloud/project/project-conf-files_magento-app.md
@@ -139,7 +139,7 @@ web:
 ```
 
 {:.bs-callout-info}
-This example shows the default web configuration for a Cloud project configured to support a single domain. For a project that requires support for multiple websites or stores, the `web` configuration must be set up to support shared domains. See [Configure locations for shared domains]{{ page.baseurl }}cloud/project-multi-sites.html#locations}.
+This example shows the default web configuration for a Cloud project configured to support a single domain. For a project that requires support for multiple websites or stores, the `web` configuration must be set up to support shared domains. See [Configure locations for shared domains]{{ page.baseurl }}/cloud/project-multi-sites.html#locations).
 
 ### `disk`
 


### PR DESCRIPTION
## Purpose of this pull request

Updated the `web` property description in the [.magento.app.yaml refeference](https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_magento-app.html) topic to add a link to the custom configuration instructions for Cloud projects that support multiple websites or stores.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_magento-app.html


