### PR TITLE
Deprecate setPaymentAndPlaceOrder mutation

### DIFF
--- a/guides/v2.3/graphql/mutations/set-payment-place-order.md
+++ b/guides/v2.3/graphql/mutations/set-payment-place-order.md
@@ -7,6 +7,9 @@ redirect from:
   - /guides/v2.3/graphql/reference/quote-set-payment-place-order.html
 ---
 
+{:.bs-callout-warning}
+The `setPaymentMethodAndPlaceOrder` mutation has been deprecated. Use the [setPaymentMethodOnCart]({{page.baseurl}}/graphql/mutations/set-payment-method.html) and [placeOrder]({{page.baseurl}}/graphql/mutations/place-order.html) mutations instead. You can run the two methods in the same call if your use case allows it.
+
 The `setPaymentMethodAndPlaceOrder` mutation sets the cart payment method and converts the cart into an order. The
 mutation returns the resulting order ID. You cannot manage orders with GraphQL, because orders are part of the backend.
 You can use REST or SOAP calls to manage orders to their completion.
@@ -28,7 +31,7 @@ Perform the following actions before using the `setPaymentMethodAndPlaceOrder` m
 
 **Request**
 
-``` text
+```graphql
 mutation {
   setPaymentMethodAndPlaceOrder(
     input: {

--- a/guides/v2.3/graphql/tutorials/checkout/checkout-payment-method.md
+++ b/guides/v2.3/graphql/tutorials/checkout/checkout-payment-method.md
@@ -14,7 +14,7 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-{:.bs-callout .bs-callout-tip}
+{:.bs-callout-tip}
 You must always set a payment method.
 
 Use the following `cart` query to determine which payment methods which are available for your order.
@@ -23,7 +23,7 @@ Use the following `cart` query to determine which payment methods which are avai
 
 **Request**
 
-{:.bs-callout .bs-callout-info}
+{:.bs-callout-info}
 For logged-in customers, send the customer's authorization token in the `Authorization` parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more information.
 
 ```text
@@ -58,8 +58,8 @@ There are two mutation queries in GraphQl which can be use to set the payment me
 
 |Mutation|Description|
 |--- |--- |
-|`setPaymentMethodOnCart`|Sets the payment method for your order|
-|`setPaymentMethodAndPlaceOrder`|Sets the payment method and then immediately places your order. In this case ["Step 10. Place the order"]({{ page.baseurl }}/graphql/tutorials/checkout/checkout-place-order.html) can be skipped|
+|`setPaymentMethodOnCart`|Sets the payment method for your order.|
+|`setPaymentMethodAndPlaceOrder`| **Deprecated** Sets the payment method and then immediately places your order. In this case ["Step 10. Place the order"]({{ page.baseurl }}/graphql/tutorials/checkout/checkout-place-order.html) can be skipped.|
 
 ### Set payment method on cart {#setPaymentMethodOnCart}
 
@@ -67,10 +67,10 @@ Use the `setPaymentMethodOnCart` mutation to set the payment method for your ord
 
 **Request**
 
-{:.bs-callout .bs-callout-info}
+{:.bs-callout-info}
 For logged-in customers, send the customer's authorization token in the `Authorization` parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more information.
 
-```text
+```graphql
 mutation {
   setPaymentMethodOnCart(input: {
       cart_id: "{ CART_ID }"
@@ -109,9 +109,12 @@ If the operation is successful, the response contains the code of the selected p
 
 Use the `setPaymentMethodAndPlaceOrder` mutation to set the payment method and place the order.
 
+{:.bs-callout-warning}
+The `setPaymentMethodAndPlaceOrder` mutation has been deprecated.
+
 **Request**
 
-```text
+```graphql
 mutation {
   setPaymentMethodAndPlaceOrder(input: {
       cart_id: "{ CART_ID }"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the documentation in response to [GraphQL PR-916[(https://github.com/magento/graphql-ce/pull/916)

## Affected DevDocs pages

- guides/v2.3/graphql/mutations/set-payment-place-order.md

whatsnew
Deprecated the [setPaymentMethodAndPlaceOrder mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-payment-place-order.html).
