### PR TITLE
Fixing the Markdown syntax in checkout_new_field

### DIFF
--- a/guides/v2.2/howdoi/checkout/checkout_new_field.md
+++ b/guides/v2.2/howdoi/checkout/checkout_new_field.md
@@ -154,7 +154,7 @@ Clear the `generated/code` directory when you run the `setup:di:compile` command
 
 If you completed all the steps described in the previous sections, Magento will generate the interface that includes your custom attribute and you can access your field value.
 
-You can set/get these attributes values by creating an instance of the  `Magento/Quote/Api/Data/AddressInterface.php interface`.
+You can set/get these attributes values by creating an instance of the  `Magento/Quote/Api/Data/AddressInterface.php`  interface.
 
 ```php
 <?php

--- a/guides/v2.2/howdoi/checkout/checkout_new_field.md
+++ b/guides/v2.2/howdoi/checkout/checkout_new_field.md
@@ -154,7 +154,7 @@ Clear the `generated/code` directory when you run the `setup:di:compile` command
 
 If you completed all the steps described in the previous sections, Magento will generate the interface that includes your custom attribute and you can access your field value.
 
-You can set/get these attributes values by creating an instance of the  `Magento/Quote/Api/Data/AddressInterface.php`  interface.
+You can set/get these attributes values by creating an instance of the  `Magento/Quote/Api/Data/AddressInterface.php` interface.
 
 ```php
 <?php


### PR DESCRIPTION
## Purpose of this pull request

Fix the Markdown syntax in the checkout new field page, as you can see below.

<img width="1280" alt="Screen Shot 2019-09-16 at 1 25 17 PM" src="https://user-images.githubusercontent.com/610598/64975456-7499d780-d885-11e9-95b8-30a9f8a83d8f.png">

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_new_field.html