### PR TITLE
GraphQL: Add url_suffix attribute

### DIFF
--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -62,6 +62,7 @@ Attribute | Data type | Description
 `upsell_products` | [ProductInterface] | An array of up-sell products
 `url_key` | String | The part of the URL that identifies the product. This attribute is defined in the `CatalogUrlRewriteGraphQl` module
 `url_path` | String | Deprecated. Use `canonical_url` instead
+`url_suffix` | String | The part of the URL that is appended to the `url_key`, such as `.html`. This attribute is defined in the `CatalogUrlRewriteGraphQl` module
 `url_rewrites` | [[UrlRewrite]](#urlRewriteObject) | A list of URL rewrites
 `websites` | [[Website]](#websiteObject) | An array of websites in which the product is available
 

--- a/guides/v2.3/graphql/queries/category.md
+++ b/guides/v2.3/graphql/queries/category.md
@@ -43,6 +43,7 @@ Attribute | Data type | Description
 `updated_at`| String | Timestamp indicating when the category was updated
 `url_key`| String | The url key assigned to the category
 `url_path`| String | The url path assigned to the category
+`url_suffix` | String | The part of the URL that is appended to the `url_key`, such as `.html`. This attribute is defined in the `CatalogUrlRewriteGraphQl` module
 
 #### CategoryProducts object
 

--- a/guides/v2.3/graphql/queries/cms-page.md
+++ b/guides/v2.3/graphql/queries/cms-page.md
@@ -21,7 +21,7 @@ The following query returns information about the "404 Not Found" CMS page:
 
 ```text
 {
-  cmsPage(identifier: 1) {
+  cmsPage(identifier: "no-route") {
     url_key
     title
     content

--- a/guides/v2.3/graphql/queries/url-resolver.md
+++ b/guides/v2.3/graphql/queries/url-resolver.md
@@ -51,7 +51,7 @@ The `urlResolver` query contains the following attribute.
 
 Attribute | Type | Description
 --- | --- | ---
-`url` | String | The requested URL
+`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For CMS page queries, the `url` value must contain the URL key only.
 
 ## Output attributes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `url_suffix` attribute to the `ProductInterface` and the `CatalogInterface`, per internal ticket MC-18996.

While checking the `cmsPage` topic to see if there was any impact, I noticed the example was out of date, so I updated it.

## Affected DevDocs pages

- guides/v2.3/graphql/product/product-interface.md
- guides/v2.3/graphql/queries/category.md
- guides/v2.3/graphql/queries/cms-page.md