### PR TITLE
Fixed code block style (MD040) in the Frontend and JS Developer Guides

### DIFF
--- a/guides/v2.2/frontend-dev-guide/layouts/layout-practice.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-practice.md
@@ -221,7 +221,7 @@ To add quick basic styling and visual behavior to the "dropdown" menu, OrangeCo 
 
 `app/design/frontend/OrangeCo/orange/web/css/source/_extend.less`
 
-```
+```css
 //
 //  Common
 //  _____________________________________________

--- a/guides/v2.2/frontend-dev-guide/templates/template-email.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-email.md
@@ -388,7 +388,7 @@ The sales emails are configured to display all of the above values, if they're c
 
 In order to support the translation of content, all strings in emails are output using the `trans` directive. Example:
 
-```
+```html
 {% raw %}{{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}{% endraw %}
 {% raw %}{{trans "Once your package ships we will send you a tracking number."}}{% endraw %}
 ```
@@ -397,7 +397,7 @@ The `trans` directive will translate strings into whatever locale is configured 
 
 The directive supports multiple named parameters, separated by spaces. For example:
 
-```
+```html
 {% raw %}
 {{trans "Dear %first_name %last_name," first_name=$first_name last_name=$last_name}}
 {% endraw %}
@@ -407,7 +407,7 @@ Please note, that variable assignment must not contain spaces.
 
 Correct:
 
-```
+```html
 {% raw %}
 {{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}
 {% endraw %}
@@ -415,7 +415,7 @@ Correct:
 
 Incorrect:
 
-```
+```html
 {% raw %}
 {{trans "Thank you for your order from %store_name." store_name = $store.getFrontendName()}}
 {% endraw %}

--- a/guides/v2.2/frontend-dev-guide/templates/template-override.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-override.md
@@ -18,7 +18,7 @@ The template is specified in the `template` attribute of the `<block>` layout in
 
 Take this example from [`app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml`]:
 
-```
+```xml
 <block class="Magento\Catalog\Block\Category\View" name="category.image" template="Magento_Catalog::category/image.phtml">
 ```
 
@@ -70,10 +70,13 @@ See [Layout instructions]
 The `echo` command in PHP can be written using the short tag in Magento templates.
 
 For example:
+
 ```phtml
 <?= $block->getAdjustmentsHtml() ?>
 ```
+
 is the same as writing
+
 ```phtml
 <?php echo $block->getAdjustmentsHtml() ?>
 ```

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_loader.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_loader.md
@@ -57,6 +57,7 @@ The URL to the loader image. This image is displayed when the widget is active; 
 HTML wrapper for the output, or a DOM element selector.
 
 **Default value**:
+
 ```html
 <div class="loading-mask" data-role="loader">
     <div class="loader">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the Frontend and JS Developer guides.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.