### PR TITLE
Fixed code block style (MD040) in the Extension Developer Guide

### DIFF
--- a/guides/v2.2/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.2/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -36,6 +36,7 @@ In the module's root directory, create the file `composer.json`. This file gives
 For more information see: [`composer.json`]({{ page.baseurl }}/extension-dev-guide/build/composer-integration.html).
 
 {% collapsible File content for composer.json %}
+
  ```json
     {
       "name": "mycompany/sample-module-minimal",
@@ -57,6 +58,7 @@ For more information see: [`composer.json`]({{ page.baseurl }}/extension-dev-gui
       }
     }
  ```
+
 {% endcollapsible %}
 
 #### `registration.php`
@@ -66,6 +68,7 @@ In the module's root directory, create the file `registration.php`. This file re
 For more information see: [registering your component]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html).
 
 {% collapsible File content for registration.php %}
+
   ```php
     <?php
     \Magento\Framework\Component\ComponentRegistrar::register(
@@ -74,6 +77,7 @@ For more information see: [registering your component]({{ page.baseurl }}/extens
         __DIR__
     );
  ```
+
 {% endcollapsible %}
 
 #### `etc/module.xml`
@@ -83,6 +87,7 @@ In the module's root directory, create a new directory called `etc`. Under that 
 For more information see: [naming your component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html).
 
 {% collapsible File content for module.xml %}
+
  ```xml
     <?xml version="1.0"?>
     <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
@@ -90,6 +95,7 @@ For more information see: [naming your component]({{ page.baseurl }}/extension-d
       </module>
     </config>
  ```
+
 {% endcollapsible %}
 
 ### Routing and navigation
@@ -117,6 +123,7 @@ The following parts make up the generated page request link to the **Hello World
 
 [//]: # (Stop list rendering before collapsible, see: https://github.com/magento/devdocs/issues/2655)
 {% collapsible File content for menu.xml %}
+
  ```xml
     <?xml version="1.0"?>
     <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
@@ -126,6 +133,7 @@ The following parts make up the generated page request link to the **Hello World
         </menu>
     </config>
  ```
+
 {% endcollapsible %}
 
 #### `etc/adminhtml/routes.xml`
@@ -133,6 +141,7 @@ The following parts make up the generated page request link to the **Hello World
 Under `etc/adminhtml` create the file `routes.xml`. The contents of this  XML file tells Magento to route requests that use the `frontName` `exampleadminnewpage` to this module.
 
 {% collapsible File content for routes.xml %}
+
  ```xml
   <?xml version="1.0"?>
   <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
@@ -143,6 +152,7 @@ Under `etc/adminhtml` create the file `routes.xml`. The contents of this  XML fi
       </router>
   </config>
  ```
+
 {% endcollapsible %}
 
 ### Page controller
@@ -159,6 +169,7 @@ mkdir -p Controller/Adminhtml/HelloWorld
 
 Inside `Controller/Adminhtml/HelloWorld` directory, create the file `Index.php`. This file is the class assigned to the default Index action for the `HelloWorld` controller. Since the admin area serves this page, the file belongs in the `Adminhtml` directory, and the class itself extends [`\Magento\Backend\App\Action`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Backend/App/Action.php){:target="_blank"}.
 {% collapsible File content for Index.php %}
+
  ```php
     <?php
       namespace MyCompany\ExampleAdminNewPage\Controller\Adminhtml\HelloWorld;
@@ -196,6 +207,7 @@ Inside `Controller/Adminhtml/HelloWorld` directory, create the file `Index.php`.
       }
     ?>
  ```
+
 {% endcollapsible %}
 
 ### Page view
@@ -219,6 +231,7 @@ This file defines the [layout](https://glossary.magento.com/layout) and structur
 The name of this file uses the following pattern: *routeId*\_*controller*\_*action*.xml
 
 {% collapsible File content for exampleadminnewpage_helloworld_index.xml %}
+
  ```xml
     <?xml version="1.0"?>
     <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
@@ -234,6 +247,7 @@ The name of this file uses the following pattern: *routeId*\_*controller*\_*acti
         </body>
     </page>
  ```
+
 {% endcollapsible %}
 
 #### `view/adminhtml/templates/helloworld.phtml`
@@ -242,9 +256,11 @@ The name of this file uses the following pattern: *routeId*\_*controller*\_*acti
 This template file contains the actual page content for the **Hello World** page.
 
 {% collapsible File content for helloworld.phtml %}
+
 ```html
     <p>Hello World!</p>
- ```
+```
+
 {% endcollapsible %}
 
 ### Full module directory structure

--- a/guides/v2.2/extension-dev-guide/build/module-file-structure.md
+++ b/guides/v2.2/extension-dev-guide/build/module-file-structure.md
@@ -45,7 +45,7 @@ Additional folders can be added for configuration and other ancillary functions 
 
 A typical [theme](https://glossary.magento.com/theme) file structure can look like the following:
 
-~~~
+```tree
 ├── composer.json
 ├── etc
 │   └── view.xml
@@ -81,7 +81,7 @@ A typical [theme](https://glossary.magento.com/theme) file structure can look li
         ├── navigation-menu.js
         ├── responsive.js
         └── theme.js
-~~~
+```
 
 #### Common directories
 {:.no_toc}

--- a/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.md
+++ b/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.md
@@ -117,7 +117,7 @@ For another example of a context class, see [Magento/Framework/App/Http/Context]
 
 Use the `X-Magento-Vary` cookie to transfer context on the HTTP layer. HTTP proxies can be configured to calculate a unique identifier for cache based on the cookie and URL. For example, [our sample Varnish 4 configuration]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/PageCache/etc/varnish4.vcl#L63-L68){:target="_blank"} uses the following:
 
-```
+```conf
 sub vcl_hash {
     if (req.http.cookie ~ "X-Magento-Vary=") {
         hash_data(regsub(req.http.cookie, "^.*?X-Magento-Vary=([^;]+);*.*$", "\1"));

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -36,12 +36,18 @@ To modify `di.xml`:
 1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `di.xml`:
 
-		cd <magento_root>/app/etc
-		cp di.xml di.xml.bak
+    ```bash
+    cd <magento_root>/app/etc
+    ```
+
+    ```bash
+    cp di.xml di.xml.bak
+    ```
 
 3.	Open `di.xml` in a text editor and locate the following block:
 
-		<type name="Magento\Framework\App\Cache\Frontend\Pool">
+    ```xml
+    <type name="Magento\Framework\App\Cache\Frontend\Pool">
            <arguments>
               <argument name="frontendSettings" xsi:type="array">
                   <item name="page_cache" xsi:type="array">
@@ -59,6 +65,7 @@ To modify `di.xml`:
               </argument>
            </arguments>
         </type>
+    ```
 
 	The `<type name="Magento\Framework\App\Cache\Frontend\Pool">` node configures options for the in-memory pool of all frontend cache instances.
 
@@ -67,26 +74,26 @@ To modify `di.xml`:
 4.	Replace the entire block with the following:
 
     ```xml
-		<type name="Magento\Framework\App\Cache\Frontend\Pool">
-        	<arguments>
-            	<argument name="frontendSettings" xsi:type="array">
-            	    <item name="page_cache" xsi:type="array">
+    <type name="Magento\Framework\App\Cache\Frontend\Pool">
+          <arguments>
+              <argument name="frontendSettings" xsi:type="array">
+                  <item name="page_cache" xsi:type="array">
                         <item name="backend" xsi:type="string">database</item>
                     </item>
                     <item name="<your cache id>" xsi:type="array">
                         <item name="backend" xsi:type="string">database</item>
                     </item>
-           		</argument>
-        	</arguments>
-    	</type>
-    	<type name="Magento\Framework\App\Cache\Type\FrontendPool">
-        	<arguments>
-         	   <argument name="typeFrontendMap" xsi:type="array">
-         	       <item name="backend" xsi:type="string">database</item>
-         	   </argument>
-        	</arguments>
-    	</type>
-      ```
+              </argument>
+          </arguments>
+    </type>
+    <type name="Magento\Framework\App\Cache\Type\FrontendPool">
+          <arguments>
+              <argument name="typeFrontendMap" xsi:type="array">
+                 <item name="backend" xsi:type="string">database</item>
+              </argument>
+          </arguments>
+    </type>
+    ```
 
     where `<your cache id>` is your unique cache identifier.
 
@@ -106,30 +113,37 @@ To enable database caching using a custom cache frontend, you must modify `<mage
 1.	Log in to the Magento server as, or switch to, the [Magento file system owner].
 2.	Enter the following commands to make a copy of `env.php`:
 
-		cd <magento_root>/app/etc
-		cp env.php env.php.bak
+    ```bash
+    cd <magento_root>/app/etc
+    ```
+
+    ```bash
+    cp env.php env.php.bak
+    ```
 
 3.	Open `env.php` in a text editor and add the following anywhere, such as before `'cache_types' =>`:
 
-		'cache' => [
-		    'frontend' => [
-		        '<unique frontend id>' => [
-		             <cache options>
-		        ],
-		    ],
-		    'type' => [
-		         <cache type 1> => [
-		             'frontend' => '<unique frontend id>'
-		        ],
-		    ],
-		    'type' => [
-		         <cache type 2> => [
-		             'frontend' => '<unique frontend id>'
-		        ],
-		    ],
-		],
+    ```php
+    'cache' => [
+        'frontend' => [
+            '<unique frontend id>' => [
+                 <cache options>
+            ],
+        ],
+        'type' => [
+             <cache type 1> => [
+                 'frontend' => '<unique frontend id>'
+            ],
+        ],
+        'type' => [
+             <cache type 2> => [
+                 'frontend' => '<unique frontend id>'
+            ],
+        ],
+    ],
+    ```
 
-	An example is shown in [Configuration examples].
+    An example is shown in [Configuration examples].
 
 4.	Save your changes to `env.php` and exit the text editor.
 5.	Continue with the next section.
@@ -144,7 +158,7 @@ Use the following steps:
 2.	Clear the current cache directories:
 
     ```bash
-		rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/metadata/* <magento_root>/generated/code/*
+    rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/metadata/* <magento_root>/generated/code/*
     ```
 
 3.	In a web browser, go to any cacheable page (such as the [storefront](https://glossary.magento.com/storefront) front door page).
@@ -152,8 +166,13 @@ Use the following steps:
 	If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must [enable developer mode].)
 4.	Enter the following commands:
 
-		ls <magento_root>/var/cache/*
-		ls <magento_root>/var/page_cache/*
+    ```bash
+    ls <magento_root>/var/cache/*
+    ```
+
+    ```bash
+    ls <magento_root>/var/page_cache/*
+    ```
 
     {:.bs-callout .bs-callout-info }
     Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -95,8 +95,13 @@ You can style the output text by using `<error>This is an error message</error>`
 
 3.	Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
 
-		cd <magento_root>/var
-		rm -rf cache/* page_cache/* di/* generation/*
+    ```bash
+    cd <magento_root>/var
+    ```
+
+    ```bash
+    rm -rf cache/* page_cache/* di/* generation/*
+    ```
 
 ## Add CLI commands using the Composer autoloader {#cli-autoload}
 
@@ -105,4 +110,3 @@ To be added at a later time.
 #### Related topic
 
 [Command naming guidelines]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-naming-guidelines.html)
-

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
@@ -44,15 +44,18 @@ bin/magento list
 `action` is an action the command does.
 
 ### Examples
-	// general commands: just a group and an action
-	magento setup:install
-	magento module:status
 
-	// set of commands with a subject
-	magento setup:config:set
-	magento setup:config:delete
-	magento setup:db-schema:upgrade
-	magento setup:db-data:upgrade
+```terminal
+// general commands: just a group and an action
+magento setup:install
+magento module:status
+
+// set of commands with a subject
+magento setup:config:set
+magento setup:config:delete
+magento setup:db-schema:upgrade
+magento setup:db-data:upgrade
+```
 
 {: .bs-callout-info }
 `db-schema` and `db-data` are examples of compound words.
@@ -141,14 +144,16 @@ Use options for:
 
 Example:
 
-	// correct
-	magento dev:theme:create --extend-from=Magento/luma frontend Foo bar
-	magento module:disable --force Magento_Catalog
-	magento module:disable -f Magento_Catalog
+```terminal
+// correct
+magento dev:theme:create --extend-from=Magento/luma frontend Foo bar
+magento module:disable --force Magento_Catalog
+magento module:disable -f Magento_Catalog
 
-	//incorrect
-	magento module:disable --force=1 Magento_Catalog
-	magento module:disable -f=yes Magento_Catalog
+//incorrect
+magento module:disable --force=1 Magento_Catalog
+magento module:disable -f=yes Magento_Catalog
+```
 
 ## Recommendations to avoid naming collisions {#cli-collision}
 
@@ -158,14 +163,16 @@ To avoid naming your command the same as another command, we recommend:
 
 *	Restricting command names to start with a unique name, such as a vendor name. The [usability](https://glossary.magento.com/usability) of the command depends on what you choose for a vendor name.
 
-	For example, `myname:dev:theme:create` is not obvious and is hard to remember.
+    For example, `myname:dev:theme:create` is not obvious and is hard to remember.
 
-	The vendor name doesn't have to start the command name; it could be in the middle. This way, related commands are grouped together.
+    The vendor name doesn't have to start the command name; it could be in the middle. This way, related commands are grouped together.
 
-	Examples:
+    Examples:
 
-		dev:myname:theme:create
-		dev:myname:theme:delete
+    ```terminal
+    dev:myname:theme:create
+    dev:myname:theme:delete
+    ```
 
 #### Related topic
 

--- a/guides/v2.2/extension-dev-guide/code-generation.md
+++ b/guides/v2.2/extension-dev-guide/code-generation.md
@@ -7,10 +7,12 @@ title: Code generation
 
 The Magento application generates code to create non-existent classes. As an example, look at the [Magento/Customer/Model/Resource/AddressRepository] constructor. A snippet follows:
 
-	...
-	    public function __construct(
-	        \Magento\Customer\Model\AddressFactory $addressFactory,
-	...
+```php?start_inline=1
+...
+		public function __construct(
+				\Magento\Customer\Model\AddressFactory $addressFactory,
+...
+```
 
 The first constructor parameter has a type of `Magento\Customer\Model\AddressFactory`. However, this class does not exist in `\Magento\Customer\Model` in the Magento 2 codebase. The Magento application *generates* this class because its name uses a recognized convention (in this case, because the name ends with `Factory`).
 

--- a/guides/v2.2/extension-dev-guide/code-generation.md
+++ b/guides/v2.2/extension-dev-guide/code-generation.md
@@ -7,10 +7,10 @@ title: Code generation
 
 The Magento application generates code to create non-existent classes. As an example, look at the [Magento/Customer/Model/Resource/AddressRepository] constructor. A snippet follows:
 
-```php?start_inline=1
+```php
 ...
-		public function __construct(
-				\Magento\Customer\Model\AddressFactory $addressFactory,
+public function __construct(
+    \Magento\Customer\Model\AddressFactory $addressFactory,
 ...
 ```
 

--- a/guides/v2.2/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/guides/v2.2/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -152,6 +152,7 @@ Now we need to bind our plugin to `ProductInterface`:
 ## Extension Attributes Configuration:
 
 For scalar attributes we can use next configuration:
+
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
@@ -162,6 +163,7 @@ For scalar attributes we can use next configuration:
 ```
 
 For non-scalar attributes:
+
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">

--- a/guides/v2.2/extension-dev-guide/framework/serializer.md
+++ b/guides/v2.2/extension-dev-guide/framework/serializer.md
@@ -55,11 +55,11 @@ private $serializer;
 public function __construct(SerializerInterface $serializer) {
   $this->serializer = $serializer;
 }
-
 ```
 
 \\
 The following example shows how to use a serializer's `serialize()` and `unserialize()` functions to store and retrieve array data from a cache:
+
 ```php
 
 ...
@@ -97,9 +97,7 @@ public function loadDataFromCache()
   }
   return $data;
 }
-
 ...
-
 ```
 
 ## Backward Compatibility Note

--- a/guides/v2.2/extension-dev-guide/message-queues/implement-bulk.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/implement-bulk.md
@@ -24,6 +24,7 @@ A publisher's duties include scheduling a bulk operation. It must generate a `bu
 The following code sample shows how these duties can be completed.
 
 {% collapsible Code sample: %}
+
 ```php
 
 <?php
@@ -151,6 +152,7 @@ class ScheduleBulk
     }
 }
 ```
+
 {% endcollapsible %}
 
 ### Create a consumer {#createconsumer}
@@ -158,6 +160,7 @@ class ScheduleBulk
 A consumer class receives messages from the message queue and changes the status after it is processed. The following example defines a consumer that handles price update bulk operations.
 
 {% collapsible Code sample: %}
+
 ```php
 
 <?php
@@ -277,6 +280,7 @@ class Consumer
 }
 
 ```
+
 {% endcollapsible %}
 
 ### Configure message queues {#configmq}

--- a/guides/v2.2/extension-dev-guide/routing.md
+++ b/guides/v2.2/extension-dev-guide/routing.md
@@ -42,7 +42,7 @@ The following tables show the core routers that come with Magento:
 
 A Magento [URL](https://glossary.magento.com/url) that uses the standard router has the following format:
 
-```
+```text
 <store-url>/<store-code>/<front-name>/<controller-name>/<action-name>
 ```
 
@@ -188,6 +188,7 @@ Declaring a new route:
 ```
 
 Declaring the layout handler for our new route:
+
 ```xml
 <?xml version="1.0"?>
 

--- a/guides/v2.2/extension-dev-guide/searching-with-repositories.md
+++ b/guides/v2.2/extension-dev-guide/searching-with-repositories.md
@@ -100,6 +100,7 @@ $searchCriteria->setSortOrders([$sortOrder]);
 #### Pagination
 
 The `setPageSize` function paginates the Search Criteria by limiting the amount of entities it retrieves:
+
 ```php
 $searchCriteria->setPageSize(20); //retrieve 20 or less entities
 
@@ -136,6 +137,7 @@ Below is the code that applies filters to a collection.
 The method applies custom filters for some fields, otherwise it applies `$collection->addFieldToFilter($fields, $conditions)`.
 
 {% collapsible Show Code for addFilterGroupToCollection %}
+
 ```php
     /**
      * Add FilterGroup to the collection
@@ -168,6 +170,7 @@ The method applies custom filters for some fields, otherwise it applies `$collec
         }
     }
 ```
+
 {% endcollapsible %}
 
 You can configure this class to use a specific custom field mapping and custom filter in the `di.xml` file.
@@ -189,6 +192,7 @@ The example below uses [dependency injection](https://glossary.magento.com/depen
 ```
 
 {% collapsible Show code for ProductCategoryFilter %}
+
 ```php
 namespace Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor;
 
@@ -225,6 +229,7 @@ class ProductCategoryFilter implements CustomFilterInterface
 }
 
 ```
+
 {% endcollapsible %}
 
 | Argument | Description |

--- a/guides/v2.2/extension-dev-guide/validate/test-module.md
+++ b/guides/v2.2/extension-dev-guide/validate/test-module.md
@@ -35,9 +35,11 @@ Before you publish your component, test installing it using the [Magento Compone
 1.	[Package your component] in a GitHub repository that is accessible by the machine on which you run the [Magento Admin](https://glossary.magento.com/magento-admin).
 1.	On that machine, create a static route from `https://repo.magento.com` to your GitHub repository.
 
-	To create a static route, add a line similar to the following to your `hosts` file:
+    To create a static route, add a line similar to the following to your `hosts` file:
 
-		<IP or hostname of your GitHub repository> https://repo.magento.com
+    ```conf
+    <IP or hostname of your GitHub repository> https://repo.magento.com
+    ```
 
 1.	[Install your component], like a merchant.
 1.	Verify it installed correctly.

--- a/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -85,13 +85,15 @@ In the module's root directory, create a new directory called `etc`. Under that 
 For more information see: [naming your component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html).
 
 {% collapsible File content for module.xml %}
- ```xml
+
+```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
   <module name="MyCompany_ExampleAdminNewPage">
   </module>
 </config>
- ```
+```
+
 {% endcollapsible %}
 
 If your module does not implement [Declarative Schema]({{ page.baseurl }}/extension-dev-guide/declarative-schema/index.html), define the `setup_version` attribute in the module element.
@@ -125,15 +127,17 @@ The following parts make up the generated page request link to the **Hello World
 
 [//]: # (Stop list rendering before collapsible, see: https://github.com/magento/devdocs/issues/2655)
 {% collapsible File content for menu.xml %}
- ```xml
-  <?xml version="1.0"?>
-  <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
-      <menu>
-        <add id="MyCompany_ExampleAdminNewPage::greetings" title="Greetings" translate="title" module="MyCompany_ExampleAdminNewPage" parent="Magento_Backend::content" sortOrder="50" dependsOnModule="MyCompany_ExampleAdminNewPage" resource="MyCompany_ExampleAdminNewPage::greetings"/>
-        <add id="MyCompany_ExampleAdminNewPage::greetings_helloworld" title="Hello World" translate="title" module="MyCompany_ExampleAdminNewPage" parent="MyCompany_ExampleAdminNewPage::greetings" sortOrder="10" dependsOnModule="MyCompany_ExampleAdminNewPage" action="exampleadminnewpage/helloworld" resource="MyCompany_ExampleAdminNewPage::greetings"/>
-      </menu>
-  </config>
- ```
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+      <add id="MyCompany_ExampleAdminNewPage::greetings" title="Greetings" translate="title" module="MyCompany_ExampleAdminNewPage" parent="Magento_Backend::content" sortOrder="50" dependsOnModule="MyCompany_ExampleAdminNewPage" resource="MyCompany_ExampleAdminNewPage::greetings"/>
+      <add id="MyCompany_ExampleAdminNewPage::greetings_helloworld" title="Hello World" translate="title" module="MyCompany_ExampleAdminNewPage" parent="MyCompany_ExampleAdminNewPage::greetings" sortOrder="10" dependsOnModule="MyCompany_ExampleAdminNewPage" action="exampleadminnewpage/helloworld" resource="MyCompany_ExampleAdminNewPage::greetings"/>
+    </menu>
+</config>
+```
+
 {% endcollapsible %}
 
 ### `etc/adminhtml/routes.xml`
@@ -141,16 +145,18 @@ The following parts make up the generated page request link to the **Hello World
 Under `etc/adminhtml` create the file `routes.xml`. The contents of this  XML file tells Magento to route requests that use the `frontName` `exampleadminnewpage` to this module.
 
 {% collapsible File content for routes.xml %}
- ```xml
-  <?xml version="1.0"?>
-  <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
-      <router id="admin">
-          <route id="exampleadminnewpage" frontName="exampleadminnewpage">
-              <module name="MyCompany_ExampleAdminNewPage"/>
-          </route>
-      </router>
-  </config>
- ```
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="exampleadminnewpage" frontName="exampleadminnewpage">
+            <module name="MyCompany_ExampleAdminNewPage"/>
+        </route>
+    </router>
+</config>
+```
+
 {% endcollapsible %}
 
 ## Page controller
@@ -228,7 +234,8 @@ This file defines the [layout](https://glossary.magento.com/layout) and structur
 The name of this file uses the following pattern: *routeId*\_*controller*\_*action*.xml
 
 {% collapsible File content for exampleadminnewpage_helloworld_index.xml %}
- ```xml
+
+```xml
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
@@ -242,7 +249,8 @@ The name of this file uses the following pattern: *routeId*\_*controller*\_*acti
         </referenceContainer>
     </body>
 </page>
- ```
+```
+
 {% endcollapsible %}
 
 ### `view/adminhtml/templates/helloworld.phtml`

--- a/guides/v2.3/extension-dev-guide/build/module-file-structure.md
+++ b/guides/v2.3/extension-dev-guide/build/module-file-structure.md
@@ -43,7 +43,7 @@ Additional folders can be added for configuration and other ancillary functions 
 
 A typical [theme](https://glossary.magento.com/theme) file structure can look like the following:
 
-~~~
+```tree
 ├── composer.json
 ├── etc
 │   └── view.xml
@@ -79,7 +79,7 @@ A typical [theme](https://glossary.magento.com/theme) file structure can look li
         ├── navigation-menu.js
         ├── responsive.js
         └── theme.js
-~~~
+```
 
 #### Common directories
 {:.no_toc}

--- a/guides/v2.3/extension-dev-guide/message-queues/implement-bulk.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/implement-bulk.md
@@ -18,8 +18,8 @@ A publisher's duties include scheduling a bulk operation. It must generate a `bu
 The following code sample shows how these duties can be completed.
 
 {% collapsible Code sample: %}
-```php
 
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
@@ -145,6 +145,7 @@ class ScheduleBulk
     }
 }
 ```
+
 {% endcollapsible %}
 
 ### Create a consumer {#createconsumer}
@@ -152,8 +153,8 @@ class ScheduleBulk
 A consumer class receives messages from the message queue and changes the status after it is processed. The following example defines a consumer that handles price update bulk operations.
 
 {% collapsible Code sample: %}
-```php
 
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
@@ -269,8 +270,8 @@ class Consumer
         );
     }
 }
-
 ```
+
 {% endcollapsible %}
 
 ### Configure message queues {#configmq}

--- a/guides/v2.3/extension-dev-guide/routing.md
+++ b/guides/v2.3/extension-dev-guide/routing.md
@@ -43,7 +43,7 @@ The following tables show the core routers that come with Magento:
 
 A Magento [URL](https://glossary.magento.com/url) that uses the standard router has the following format:
 
-```
+```text
 <store-url>/<store-code>/<front-name>/<controller-name>/<action-name>
 ```
 
@@ -193,6 +193,7 @@ Declaring a new route:
 ```
 
 Declaring the layout handler for our new route:
+
 ```xml
 <?xml version="1.0"?>
 

--- a/guides/v2.3/extension-dev-guide/searching-with-repositories.md
+++ b/guides/v2.3/extension-dev-guide/searching-with-repositories.md
@@ -86,6 +86,7 @@ The field is the name of the field to sort.
 The direction is the method of sorting whose value can be `ASC` or `DESC`.
 
 The example below defines a Sort Order object that will sort the customer email in ascending order:
+
 ```php
 $sortOrder
     ->setField("email")
@@ -97,9 +98,9 @@ $searchCriteria->setSortOrders([$sortOrder]);
 #### Pagination
 
 The `setPageSize` function paginates the Search Criteria by limiting the amount of entities it retrieves:
+
 ```php
 $searchCriteria->setPageSize(20); //retrieve 20 or less entities
-
 ```
 
 The `setCurrentPage` function sets the current page:
@@ -108,7 +109,6 @@ The `setCurrentPage` function sets the current page:
 $searchCriteria
     ->setPageSize(20)
     ->setCurrentPage(2); //show the 21st to 40th entity
-
 ```
 
 ### Search Result
@@ -135,6 +135,7 @@ Below is the code that applies filters to a collection.
 The method applies custom filters for some fields, otherwise it applies `$collection->addFieldToFilter($fields, $conditions)`.
 
 {% collapsible Show Code for addFilterGroupToCollection %}
+
 ```php
     /**
      * Add FilterGroup to the collection
@@ -167,6 +168,7 @@ The method applies custom filters for some fields, otherwise it applies `$collec
         }
     }
 ```
+
 {% endcollapsible %}
 
 You can configure this class to use a specific custom field mapping and custom filter in the `di.xml` file.
@@ -188,6 +190,7 @@ The example below uses [dependency injection](https://glossary.magento.com/depen
 ```
 
 {% collapsible Show code for ProductCategoryFilter %}
+
 ```php
 namespace Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor;
 
@@ -224,6 +227,7 @@ class ProductCategoryFilter implements CustomFilterInterface
 }
 
 ```
+
 {% endcollapsible %}
 
 | Argument | Description |

--- a/guides/v2.3/extension-dev-guide/validate/test-module.md
+++ b/guides/v2.3/extension-dev-guide/validate/test-module.md
@@ -33,9 +33,11 @@ Before you publish your component, test installing it using the [Magento Compone
 1.	[Package your component] in a GitHub repository that is accessible by the machine on which you run the [Magento Admin](https://glossary.magento.com/magento-admin).
 1.	On that machine, create a static route from `https://repo.magento.com` to your GitHub repository.
 
-	To create a static route, add a line similar to the following to your `hosts` file:
+    To create a static route, add a line similar to the following to your `hosts` file:
 
-		<IP or hostname of your GitHub repository> https://repo.magento.com
+    ```conf
+    <IP or hostname of your GitHub repository> https://repo.magento.com
+    ```
 
 1.	[Install your component], like a merchant.
 1.	Verify it installed correctly.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the Extension Developer Guide.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.