### PR TITLE
Fixed code block style (MD040) in the UI components Guide

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
@@ -72,6 +72,7 @@ It also instantiates all bindings defined for the rendered elements in the scope
 **Aliases**: `[bindHtml]`
 
 **Usage example**:
+
 ```html
 <div bindHtml="
     <div data-bind='text: \'String from the text binding\''></div>
@@ -209,6 +210,7 @@ The `i18n` binding is used to translate a string according to the currently enab
 **Aliases**: `[translate]`, `<translate>`
 
 **Usage example**:
+
 ```html
 <div data-bind="i18n: 'Translate as a standard knockout binding'"></div>
 
@@ -223,13 +225,14 @@ The keyboard binding allows setting up listeners for the `keypress` event of a s
 
 **Source**: `<Magento_Ui_module_dir>/view/base/web/js/lib/knockout/bindings/keyboard.js`. [See on GitHub]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/keyboard.js).
 
-**Value type**:` [name: number]: (e: KeyboardEvent) => void`
+**Value type**:`[name: number]: (e: KeyboardEvent) => void`
 
 A collection in which keys represent keyboard keys codes and values are callback functions invoked when the associated key is pressed.
 
 **Aliases**: `[keyboard]`
 
 **Usage example**:
+
 ```html
 <input type="text" keyboard="{
     13: function (e) {
@@ -249,6 +252,7 @@ The `mageInit` binding is an adapter for the `[data-mage-init]` attribute that i
 **Aliases**: -
 
 **Usage example**: creating modal window
+
 ```html
 <div mageInit="{
     'Magento_Ui/js/modal/modal': {
@@ -271,6 +275,7 @@ The `optgroup` binding is a decorator for the standard Knockout's options bindin
 **Aliases**: -
 
 **Usage example**:
+
 ```html
 <select data-bind="
     optionsValue: 'value',
@@ -306,6 +311,7 @@ Callback that is invoked when user clicks outside of the element.
 **Aliases**: `[outerClick]`
 
 **Usage example**:
+
 ```html
 <div id="target" outerClick="function () {
     console.log('Clicked outside of the "target" node.');
@@ -326,6 +332,7 @@ Configuration that is passed to the Slider widget.
 **Aliases**: `[range]`
 
 **Usage example**:
+
 ```html
 <div
     class="data-slider"
@@ -356,6 +363,7 @@ Configuration for the Resizable widget.
 ```
 
 ### `scope`
+
 A binding that allows evaluating descendant nodes in the scope of an object found in the UiRegistry by provided string.
 
 **Source**: `<Magento_Ui_module_dir>/view/base/web/js/lib/knockout/bindings/scope.js`. [See on Github]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/scope.js).
@@ -367,6 +375,7 @@ Component's name by which to perform a lookup in the registry.
 **Aliases**: `[ko-scope]`, `<scope>`
 
 **Usage example**:
+
 ```html
 <!-- as an attribute -->
 <div ko-scope="'name.of.component'"></div>
@@ -405,6 +414,7 @@ Configuration for the `template` binding. If the provided value is a string, it 
 **Aliases:** `[render]`, `<render>`
 
 **Usage example**:
+
 ```html
 <div data-bind="template: 'path/to/the/template'"></div>
 ```

--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -9,6 +9,7 @@ title: Magento binding syntax
 Within HTML templates, Magento gives you the option of using a binding syntax that is simpler and easier to read and write than the standard Knockout binding syntax. The following code snippets help make the comparison.
 
 ### Knockout syntax
+
 ```html
 <!-- ko if: isVisible-->
     <div class="someClass">
@@ -17,7 +18,9 @@ Within HTML templates, Magento gives you the option of using a binding syntax th
     </div>
 <!-- /ko -->
 ```
+
 ### Magento syntax
+
 ```html
 <if args="isVisible">
     <div class="someClass">
@@ -26,7 +29,9 @@ Within HTML templates, Magento gives you the option of using a binding syntax th
     </div>
 </if>
 ```
+
 or
+
 ```html
 <div class="someClass" if="isVisible">
     <span translate="'Some translatable message!'"></span>
@@ -76,4 +81,3 @@ The table below shows examples of how the Knockout bindings map to their Magento
 |checked        |`<input type="checkbox" data-bind="checked: isChecked"/>`                      | `<input type="checkbox" ko-checked="isChecked"/>`                     |
 |                |`<input type="radio" data-bind="value: value,checked: isSelected" />`                      | `<input type="radio" ko-checked="element.isSelected" ko-value="value" />`                     |
 |checkedValue   |`<input type="checkbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="checkbox" checkedValue="$data" checked="isChecked"/>`   |
-

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_data_source.md
@@ -83,7 +83,7 @@ The properties Magento will parse are:
 
 The `links` property is the same as duplicating a value in both `imports` and `exports`. Each of those properties expect an object that contains key/value pairs to bind the expression to. In the example above, it would appear in the `defaults` property like this:
 
-```
+```js
 imports: {
     totalRecords: '${ $.provider }:data.totalRecords'
 }
@@ -91,7 +91,7 @@ imports: {
 
 When the Element class initializes, it will process the link that was declared in `imports`. Remember that one of the first things Magento does is process string literals, though, so it is actually working with something that looks more like the following (where `example` is the UI Component Name for clarity):
 
-```
+```js
 imports: {
     totalRecords: 'example.example_data_source:data.totalRecords'
 }

--- a/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
@@ -141,7 +141,7 @@ The urlInput component implements the `<urlInput>` form field.
 
 By default, you can use `Magento\Ui\Model\UrlInput\LinksConfigProvider`, which provides text input for URLs. `LinksConfigProvider` is composite and you can add new options to the `di.xml` file.
 
-```
+```xml
 <type name="Magento\Ui\Model\UrlInput\LinksConfigProvider">
     <arguments>
         <argument name="linksConfiguration" xsi:type="array">
@@ -153,7 +153,7 @@ By default, you can use `Magento\Ui\Model\UrlInput\LinksConfigProvider`, which p
 
 The option `class` implements `\Magento\Ui\Model\UrlInput\ConfigInterface` and provides the child component configuration:
 
-```
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.

--- a/guides/v2.3/ui_comp_guide/howto/update-url-type.md
+++ b/guides/v2.3/ui_comp_guide/howto/update-url-type.md
@@ -21,7 +21,7 @@ To update a page URL type, you must:
 
 Create a `.php` file implementing the new link class in the module directory containing the applicable UI component, such as `<your-module>/Ui/Component/UrlInput/`.
 
-```
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
@@ -82,7 +82,7 @@ class Page implements \Magento\Ui\Model\UrlInput\ConfigInterface
 
 Add the link class you just created to the `di.xml` file.
 
-```
+```xml
 <type name="Magento\Ui\Model\UrlInput\LinksConfigProvider">
     <arguments>
         <argument name="linksConfiguration" xsi:type="array">
@@ -98,7 +98,7 @@ Create the JavaScript implementation for the applicable UI component in your mod
 
 `<area>` would be `adminhtml`, `frontend`, or `base` depending on where you are applying the component implementation.
 
-```
+```js
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -198,7 +198,7 @@ define([
 
 Create a controller to search the page using a search key.
 
-```
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
@@ -277,7 +277,7 @@ class Search extends \Magento\Backend\App\Action
 
 Create a controller to return the page, or empty array if the option doesn't exist, by the `cmsPageId`.
 
-```
+```php
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the UI components Guide.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.