### PR TITLE
Fixed code block style (MD040) in the Inventory guide

### DIFF
--- a/guides/v2.2/get-started/authentication/gs-authentication-token.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication-token.md
@@ -68,7 +68,7 @@ The following image shows a token request for the [admin](https://glossary.magen
 
 The following example uses the `curl` command to request a token for a customer account:
 
-```
+```bash
 curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token" \
      -H "Content-Type:application/json" \
      -d "{"username":"customer1", "password":"customer1pw"}"
@@ -76,7 +76,7 @@ curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token"
 
 The following example makes the same request with [XML](https://glossary.magento.com/xml) for a customer account token:
 
-```
+```bash
 curl -X POST "http://magento.vg/index.php/rest/V1/integration/customer/token" \
      -H "Content-Type:application/xml"  \
      -d "<login><username>customer1</username><password>customer1pw</password></login>"

--- a/guides/v2.3/inventory/reservations.md
+++ b/guides/v2.3/inventory/reservations.md
@@ -62,17 +62,17 @@ The following example shows the sequence of reservations generated for a simple 
 
 1. The customer makes a purchase order for 25 units of product `SKU-1`. The reservation contains the following information:
 
-   ```
-   reservation_id = 1
-   stock_id = 1
-   sku = SKU-1
-   quantity = -25
-   event_type = order_placed
-   ```
+    ```text
+    reservation_id = 1
+    stock_id = 1
+    sku = SKU-1
+    quantity = -25
+    event_type = order_placed
+    ```
 
 2. The customer sends an invoice for 20 items, essentially canceling 5 of the units ordered.
 
-   ```
+   ```text
    reservation_id = 2
    stock_id = 1
    sku = SKU-1
@@ -82,7 +82,7 @@ The following example shows the sequence of reservations generated for a simple 
 
 3. The merchant ships the purchased 20 units.
 
-   ```
+   ```text
    reservation_id = 3
    stock_id = 1
    sku = `SKU-1`

--- a/guides/v2.3/inventory/reservations.md
+++ b/guides/v2.3/inventory/reservations.md
@@ -62,12 +62,12 @@ The following example shows the sequence of reservations generated for a simple 
 
 1. The customer makes a purchase order for 25 units of product `SKU-1`. The reservation contains the following information:
 
-    ```text
-    reservation_id = 1
-    stock_id = 1
-    sku = SKU-1
-    quantity = -25
-    event_type = order_placed
+   ```text
+   reservation_id = 1
+   stock_id = 1
+   sku = SKU-1
+   quantity = -25
+   event_type = order_placed
     ```
 
 2. The customer sends an invoice for 20 items, essentially canceling 5 of the units ordered.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the Inventory Guide.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.