### PR TITLE
Fixed MD040 errors in _includes/install/

### DIFF
--- a/_includes/install/allowoverrides22.md
+++ b/_includes/install/allowoverrides22.md
@@ -17,14 +17,16 @@ Failure to enable these settings typically results in no styles displaying on yo
 
 3.	Change the value of `AllowOverride` to `<value from Apache site>`.
 
-	An example for Ubuntu 12 follows.
+    An example for Ubuntu 12 follows.
 
-		<Directory /var/www/>
-		Options Indexes FollowSymLinks MultiViews
-		AllowOverride <value from Apache site>
-		Order allow,deny
-		Allow from all
-		<Directory>
+    ```conf
+    <Directory /var/www/>
+    Options Indexes FollowSymLinks MultiViews
+    AllowOverride <value from Apache site>
+    Order allow,deny
+    Allow from all
+    <Directory>
+    ```
 
 	{:.bs-callout .bs-callout-info}
 	The preceding values for `Order` might not work in all cases. For more information, see the Apache documentation ([2.2](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order)), [2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_host.html#order)).
@@ -32,8 +34,16 @@ Failure to enable these settings typically results in no styles displaying on yo
 4.	Save the file and exit the text editor.
 5.	*Ubuntu only*. Configure Apache to use the `mod_rewrite` module.
 
-			cd /etc/apache2/mods-enabled
-			ln -s ../mods-available/rewrite.load
+    ```bash
+    cd /etc/apache2/mods-enabled
+    ```
+
+    ```bash
+    ln -s ../mods-available/rewrite.load
+    ```
+
 6.	If you changed Apache settings, restart Apache.
 
-		service apache2 restart
+    ```bash
+    service apache2 restart
+    ```

--- a/_includes/install/composer-clone.md
+++ b/_includes/install/composer-clone.md
@@ -15,7 +15,12 @@ To install Composer:
 
 2.	Enter the following commands:
 
-		curl -sS https://getcomposer.org/installer | php
-		mv composer.phar /usr/local/bin/composer
+    ```bash
+    curl -sS https://getcomposer.org/installer | php
+    ```
+
+    ```bash
+    mv composer.phar /usr/local/bin/composer
+    ```
 
 For additional installation options, see the [Composer installation documentation](https://getcomposer.org/download/).

--- a/_includes/install/file-system-perms-before.md
+++ b/_includes/install/file-system-perms-before.md
@@ -32,4 +32,6 @@ After you've performed the other tasks in this topic, enter one of the following
 
 For example,
 
-	su magento_user
+```bash
+su magento_user
+```

--- a/_includes/install/file-system-perms-twouser_cmds-only.md
+++ b/_includes/install/file-system-perms-twouser_cmds-only.md
@@ -1,7 +1,11 @@
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
 
-	cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
+```bash
+cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
+```
 
 In the event file system permissions are set improperly and can't be changed by the Magento file system owner, you can enter the command as a user with `root` privileges:
 
-	cd /var/www/html/magento2 && sudo find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento
+```bash
+cd /var/www/html/magento2 && sudo find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento
+```

--- a/_includes/install/file-system-perms-twouser_cmds-only_22.md
+++ b/_includes/install/file-system-perms-twouser_cmds-only_22.md
@@ -1,7 +1,11 @@
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
 
-	cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
+```bash
+cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
+```
 
 In the event file system permissions are set improperly and can't be changed by the Magento file system owner, you can enter the command as a user with `root` privileges:
 
-	cd /var/www/html/magento2 && sudo find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento
+```bash
+cd /var/www/html/magento2 && sudo find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && sudo find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && sudo chown -R :apache . && sudo chmod u+x bin/magento
+```

--- a/_includes/install/mysql_max-allowed-packet-centos.md
+++ b/_includes/install/mysql_max-allowed-packet-centos.md
@@ -1,9 +1,11 @@
-	To increase the value, open `/etc/mysql.cnf` in a text editor and add search for `max_allowed_packet`. Set the value to `16M` or larger.
+To increase the value, open `/etc/mysql.cnf` in a text editor and add search for `max_allowed_packet`. Set the value to `16M` or larger.
 
-	If it does not exist, add it before `[mysqld_safe]`.
+If it does not exist, add it before `[mysqld_safe]`.
 
-	Save your changes to `mysql.cnf`, close the text editor, and restart MySQL (`service mysqld restart`).
+Save your changes to `mysql.cnf`, close the text editor, and restart MySQL (`service mysqld restart`).
 
-	To optionally verify the value you set, enter the following command at a `mysql>` prompt:
+To optionally verify the value you set, enter the following command at a `mysql>` prompt:
 
-		 SHOW VARIABLES LIKE 'max_allowed_packet';
+```shell
+SHOW VARIABLES LIKE 'max_allowed_packet';
+```

--- a/_includes/install/mysql_max-allowed-packet-ubuntu.md
+++ b/_includes/install/mysql_max-allowed-packet-ubuntu.md
@@ -1,5 +1,7 @@
-	To increase the value, open `/etc/mysql/mysql.cnf` in a text editor and locate the value for `max_allowed_packet`. Save your changes to `mysql.cnf`, close the text editor, and restart MySQL (`service mysql restart`).
+To increase the value, open `/etc/mysql/mysql.cnf` in a text editor and locate the value for `max_allowed_packet`. Save your changes to `mysql.cnf`, close the text editor, and restart MySQL (`service mysql restart`).
 
-	To optionally verify the value you set, enter the following command at a `mysql>` prompt:
+To optionally verify the value you set, enter the following command at a `mysql>` prompt:
 
-		 SHOW VARIABLES LIKE 'max_allowed_packet';
+```shell
+SHOW VARIABLES LIKE 'max_allowed_packet';
+```

--- a/_includes/install/paypal-tls1-2.md
+++ b/_includes/install/paypal-tls1-2.md
@@ -11,22 +11,26 @@ More information:
 
 According to PayPal, symptoms of the issue include the following messages in your error log:
 
-	*Unknown SSL protocol error* in connection to api-3t.sandbox.paypal.com:-9824
+```text
+*Unknown SSL protocol error* in connection to api-3t.sandbox.paypal.com:-9824
+```
 
 or
 
-	140062736746144:error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number:s3_pkt.c:337:
+```text
+140062736746144:error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number:s3_pkt.c:337:
 
-	... (more messages) ...
+... (more messages) ...
 
-	New, (NONE), Cipher is (NONE)
-	Secure Renegotiation IS NOT supported*
-	Compression: NONE
-	Expansion: NONE
-	SSL-Session:
-	Protocol: SSLv3*
+New, (NONE), Cipher is (NONE)
+Secure Renegotiation IS NOT supported*
+Compression: NONE
+Expansion: NONE
+SSL-Session:
+Protocol: SSLv3*
 
-	... (more messages) ...
+... (more messages) ...
+```
 
 ### Description
 
@@ -34,7 +38,9 @@ The source of the issue is your version of [`libcurl`](https://curl.haxx.se/libc
 
 To determine the version of `libcurl` you're running, enter the following command on the server that processes PayPal transactions:
 
-	curl --version
+```bash
+curl --version
+```
 
 If the version is earlier than 7.34, continue with the next section. If you're already running version 7.34 or later, no action is necessary.
 
@@ -44,7 +50,9 @@ The source of the issue is that the [`libcurl`](https://curl.haxx.se/libcurl/c/C
 
 To determine the version of CentOS your server runs, enter the following command:
 
-	cat /etc/*release*
+```bash
+cat /etc/*release*
+```
 
 If you're already running CentOS 6.8 or later, no action is necessary. According to the [CentOS 6.8 changelog](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.8), "various applications now support TLS 1.2, i.e. OpenLDAP, yum, stunnel, vsftpd, git, postfix and others. Also TLS 1.2 has been enabled by default in various packages".
 

--- a/_includes/install/releasenotes/ce_install_20.md
+++ b/_includes/install/releasenotes/ce_install_20.md
@@ -12,13 +12,17 @@ See one of the following sections:
 
 This software is available from `repo.magento.com`. Before installing the Open Source software using Composer, familiarize yourself with the Composer [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html), then run:
 
-	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
+```bash
+composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=<version> <installation directory name>
+```
 
 where `<version>` matches the version you want (for example, `2.0.10`)
 
 For example, to install {{site.data.var.ce}} 2.0.10 in the `magento2` directory:
 
-	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.0.10 magento2
+```bash
+composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.0.10 magento2
+```
 
 ### Get Magento Open Source using a compressed archive {#get-zip}
 {:.no_toc}

--- a/_includes/install/releasenotes/ee_install_20.md
+++ b/_includes/install/releasenotes/ee_install_20.md
@@ -12,13 +12,17 @@ See one of the following sections:
 
 This software is available from `repo.magento.com`. Before installing the Magento Commerce software using Composer, familiarize yourself with the Composer [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html), then run:
 
-	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
+```bash
+composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=<version> <installation directory name>
+```
 
 where `<version>` matches the version you want (for example, `2.0.10`)
 
 For example, to install 2.0.10 in the `magento2` directory:
 
-	composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.0.10 magento2
+```bash
+composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition=2.0.10 magento2
+```
 
 ### Get Magento Commerce using a compressed archive {#get-zip}
 {:.no_toc}

--- a/_includes/install/sampledata/sample-data-other-cmds.md
+++ b/_includes/install/sampledata/sample-data-other-cmds.md
@@ -15,7 +15,9 @@ This topic discusses how to:
 
 Enter the following command:
 
-	bin/magento sampledata:remove
+```bash
+bin/magento sampledata:remove
+```
 
 The complete list of sample data modules follows:
 
@@ -27,6 +29,8 @@ This command enables you to update sample data before you update the Magento app
 
 To prepare sample data for updating, enter the following command:
 
-	bin/magento sampledata:reset
+```bash
+bin/magento sampledata:reset
+```
 
 After that, [update the Magento application]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall.html#instgde-install-magento-update).

--- a/_includes/install/sampledata/sample-data-rc1-web.md
+++ b/_includes/install/sampledata/sample-data-rc1-web.md
@@ -14,13 +14,18 @@ To upgrade to {{site.data.var.ee}} RC1 or RC2 with sample data using the Setup W
 3.	Open `composer.lock` in a text editor.
 4.	Change the following:
 
-	From:
+    From:
 
-		"type": "magento2-module-customer-balance"
+    ```json
+    "type": "magento2-module-customer-balance"
+    ```
 
-	To:
+    To:
 
-		"type": "magento2-module"
+    ```json
+    "type": "magento2-module"
+    ```
+
 5.	Save your changes to `composer.lock` and exit the text editor.
 
 {% include install/sampledata/file-sys-perms-digest.md %}

--- a/_includes/install/tls-repo.md
+++ b/_includes/install/tls-repo.md
@@ -12,9 +12,11 @@ If you have an earlier version of TLS, you'll see the errors discussed in this s
 
 The following error displays if you attempt to run `composer create-project` to get a Magento metapackage:
 
-	[Composer\Downloader\TransportException]
-	The "https://repo.magento.com/packages.json" file could not be downloaded: Failed to enable crypto
-	failed to open stream: operation failed
+```terminal
+[Composer\Downloader\TransportException]
+The "https://repo.magento.com/packages.json" file could not be downloaded: Failed to enable crypto
+failed to open stream: operation failed
+```
 
 ### Using the Web Setup Wizard
 

--- a/_includes/install/ulimit.md
+++ b/_includes/install/ulimit.md
@@ -14,7 +14,9 @@ Before you continue, if you haven't done so already, switch to the [Magento file
 
 Command:
 
-	ulimit -s 65536
+```bash
+ulimit -s 65536
+```
 
 You can change this to a larger value if needed.
 
@@ -27,7 +29,9 @@ To optionally set the value in the user's Bash shell:
 2.	Open `/home/<username>/.bashrc` in a text editor.
 3.	Add the following line:
 
-		ulimit -s 65536
+    ```bash
+    ulimit -s 65536
+    ```
 
 4.	Save your changes to `.bashrc` and exit the text editor.
 

--- a/_includes/install/web/install-web.md
+++ b/_includes/install/web/install-web.md
@@ -28,11 +28,15 @@ To install the Magento software using the Setup Wizard:
 
 2.	Enter the following URL in the browser's address or location bar:
 
-		http://<Magento host or IP>/<path to Magento root>/setup
+    ```text
+    http://<Magento host or IP>/<path to Magento root>/setup
+    ```
 
-	For example, if the Magento server's IP address is 192.0.2.10 and you installed Magento 2 in the `magento2/` directory relative to the web server's docroot, and you did not configure a Virtual Host, enter:
+    For example, if the Magento server's IP address is 192.0.2.10 and you installed Magento 2 in the `magento2/` directory relative to the web server's docroot, and you did not configure a Virtual Host, enter:
 
-		http://192.0.2.10/magento2/setup
+    ```text
+    http://192.0.2.10/magento2/setup
+    ```
 
 3.	On the initial page, click **Agree and Set Up Magento**.
 

--- a/_includes/php-dev/lang-pack-file-struct.md
+++ b/_includes/php-dev/lang-pack-file-struct.md
@@ -2,7 +2,7 @@
 
 A typical directory structure for three language packages follows:
 
-~~~
+```tree
 ├── de_DE
 │   ├── composer.json
 │   ├── language.xml
@@ -21,7 +21,7 @@ A typical directory structure for three language packages follows:
 │   ├── LICENSE_AFL.txt
 │   ├── LICENSE.txt
 │   └── registration.php
-~~~
+```
 
 The only required directory for a language package is the top-level directory. Although not required, we recommend that the directory name match the [ISO](http://www.iso.org/iso/home/standards/language_codes.htm) code to identify the locale.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the `_includes/install/` directory.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you'll see changes in this PR that replaces indentation with fences.

This is one of many PRs related to #5252.