### PR TITLE
Add missing curly brace in the nginx configuration

### DIFF
--- a/guides/v2.2/comp-mgr/trouble/cman/maint-mode.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/maint-mode.md
@@ -139,6 +139,7 @@ To redirect traffic to a custom maintenance page:
         location @maintenance {
         root $MAGE_ROOT;
         rewrite ^(.*)$ /maintenance.html break;
+	}
 
         include /var/www/html/magento2/nginx.conf;
     }


### PR DESCRIPTION
## Purpose of this pull request

Adds a missing closing curly brace to a snippet of nginx configuration.  People who don't notice it's missing will get nginx errors without it.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/comp-mgr/trouble/cman/maint-mode.html

## Links to Magento source code

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
