### PR TITLE
Fix procedures in Cloud includes and references

### DIFF
--- a/_includes/cloud/backup-db.md
+++ b/_includes/cloud/backup-db.md
@@ -1,6 +1,7 @@
 We recommend creating a backup of your project before an upgrade. Use the following steps to back up your Integration, Staging, and Production environments.
 
-#### To back up your Integration environment database and code:
+{:.procedure}
+To back up your Integration environment database and code:
 
 1.  Create a local backup of the remote database.
 
@@ -16,7 +17,8 @@ We recommend creating a backup of your project before an upgrade. Use the follow
 
     Optionally, you can omit `[--media]` if you have a large number of static files that are already in source control.
 
-#### To back up your Staging or Production environment database before deploying:
+{:.procedure}
+To back up your Staging or Production environment database before deploying:
 
 1.  Use SSH to log in to the remote server.
 

--- a/_includes/cloud/composer-name.md
+++ b/_includes/cloud/composer-name.md
@@ -1,6 +1,7 @@
 This section discusses how to get a module's Composer name and its version from Magento Marketplace. Alternatively, you can find the name and version of *any* module (whether or not you purchased it on Marketplace) in the module's `composer.json` file. Open `composer.json` in a text editor and write down the values of `"name"` and `"version"`.
 
-#### To get the module's Composer name from Magento Marketplace:
+{:.procedure}
+To get the module's Composer name from Magento Marketplace:
 
 1.	Log in to [Magento Marketplace](https://marketplace.magento.com) with the username and password you used to purchase the component.
 2.	In the upper right corner, click **&lt;your username>** > **My Account** as the following figure shows.

--- a/_includes/cloud/enable-ssh.md
+++ b/_includes/cloud/enable-ssh.md
@@ -36,7 +36,8 @@ If you already have SSH keys, continue to:
 
 Use the `ssh-keygen` command to create an SSH key pair. `ssh-keygen` is typically installed on Linux systems.
 
-#### To create an SSH key pair:
+{:.procedure}
+To create an SSH key pair:
 
 1.  The command syntax follows, entering the email used for your GitHub account:
 

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -1,4 +1,5 @@
-#### To create and transfer `config.local.php`:
+{:.procedure}
+To create and transfer `config.local.php`:
 
 1.  On your local workstation, find the integration server SSH URL.
 

--- a/_includes/config/cli-inventory.md
+++ b/_includes/config/cli-inventory.md
@@ -1,4 +1,4 @@
-#### To import geocodes for offline calculation
+**To import geocodes for offline calculation**:
 
 Enter the following command with a space-separated list of [ISO-3166 alpha2 country codes](https://www.geonames.org/countries/):
 

--- a/_includes/config/cli-inventory.md
+++ b/_includes/config/cli-inventory.md
@@ -1,4 +1,4 @@
-**To import geocodes for offline calculation**:
+#### To import geocodes for offline calculation:
 
 Enter the following command with a space-separated list of [ISO-3166 alpha2 country codes](https://www.geonames.org/countries/):
 

--- a/_includes/config/cli-inventory.md
+++ b/_includes/config/cli-inventory.md
@@ -1,4 +1,4 @@
-#### To import geocodes for offline calculation:
+#### To import geocodes for offline calculation
 
 Enter the following command with a space-separated list of [ISO-3166 alpha2 country codes](https://www.geonames.org/countries/):
 

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -9,7 +9,7 @@ functional_areas:
   - Setup
 ---
 
-#### Previous step:
+**Previous step:**
 [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html)
 
 The {{site.data.var.ece}} project is a Git repository of Magento code. Each **active** branch in the Integration environment includes a database and services to fully access the Magento site and store. You can clone the project and create an **active** branch from the Integration environment to develop code and add extensions using your local workstation.
@@ -18,57 +18,58 @@ The {{site.data.var.ece}} project is a Git repository of Magento code. Each **ac
 
 The following instructions use a combination of Magento Cloud CLI commands and Git commands to clone a `master` environment from your project to your local workstation. To see a full list of Magento Cloud CLI commands, use the `magento-cloud list` command.
 
-{: .bs-callout-info }
+{:.bs-callout-info }
 Some Git commands cannot complete an action in your {{site.data.var.ece}} project. For example, you can create a new branch using a Git command, but you cannot create and activate a new environment using the `git checkout -b <branch-name>` command. You must create an environment using the `magento-cloud environment:branch <branch-name>` command for the environment to become _active_. Alternatively, you can use the Project Web UI to create active environments. See [Magento CLI reference]({{page.baseurl}}/cloud/reference/cli-ref-topic.html).
 
-#### To clone a project master environment:
+{:.procedure}
+To clone a project master environment:
 
-1.  Log in to your local workstation with a [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html) account.
+1. Log in to your local workstation with a [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html) account.
 
-1.  Change to the web server or virtual host _docroot_ directory.
+1. Change to the web server or virtual host _docroot_ directory.
 
-1.  Log in to the Magento Cloud CLI.
+1. Log in to the Magento Cloud CLI.
 
-    ```bash
-    magento-cloud login
-    ```
+   ```bash
+   magento-cloud login
+   ```
 
-1.  List your projects.
+1. List your projects.
 
-    ```bash
-    magento-cloud project:list
-    ```
+   ```bash
+   magento-cloud project:list
+   ```
 
-1.  Clone a project.
+1. Clone a project.
 
-    ```bash
-    magento-cloud project:get <project-ID>
-    ```
+   ```bash
+   magento-cloud project:get <project-ID>
+   ```
 
-    When prompted for a directory name, enter `magento2`.
+   When prompted for a directory name, enter `magento2`.
 
-1.  Change to the `magento2` directory.
+1. Change to the `magento2` directory.
 
-1.  List available environments for the project.
+1. List available environments for the project.
 
-    ```bash
-    magento-cloud environment:list
-    ```
+   ```bash
+   magento-cloud environment:list
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    The `magento-cloud environment:list` command displays environment hierarchies, whereas the `git branch` command does not.
+   {:.bs-callout-info}
+   The `magento-cloud environment:list` command displays environment hierarchies, whereas the `git branch` command does not.
 
-1.  Fetch the remote branches.
+1. Fetch the remote branches.
 
-    ```bash
-    git fetch magento
-    ```
+   ```bash
+   git fetch magento
+   ```
 
-1.  Pull updated code.
+1. Pull updated code.
 
-    ```bash
-    git pull magento <environment-ID>
-    ```
+   ```bash
+   git pull magento <environment-ID>
+   ```
 
 ## Change the Magento ADMIN variables
 
@@ -82,102 +83,96 @@ We recommend changing the environment-level variables for the Magento Admin URL 
 {:.bs-callout .bs-callout-info}
 Make note of any updated values so that you can use them to install Magento from the command line and to verify the installation. The values for the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` variables are used only for installation.
 
-#### To view existing variables: {#variablelist}
+{:.procedure}
+To view existing variables:
 
-If you are not sure that the `master` branch has all Magento Admin variables and settings configured, you can view a list of existing variables:
+-  If you are not sure that the `master` branch has all Magento Admin variables and settings configured, you can view a list of existing variables:
 
-```bash
-magento-cloud variables
-```
+   ```bash
+   magento-cloud variables
+   ```
 
-```terminal
-Variables on the project Project-Name (<project-id>), environment <environment-name>:
-+----------------------------+-------------+-------------------------------------+
-| Name                       | Level       | Value                               |
-+----------------------------+-------------+-------------------------------------+
-| php:blackfire.agent_socket | project     | tcp://blackfire.magento.cloud:8307  |
-| env:COMPOSER_AUTH          | project     | {                                   |
-|                            |             |    "http-basic": {                  |
-|                            |             |       "repo.magento.com": {         |
-|                            |             |       "username":                   |
-|                            |             | "<public-key>",                     |
-|                            |             |       "password":                   |
-|                            |             | "<private-key>"                     |
-|                            |             |     }                               |
-|                            |             |   }                                 |
-|                            |             | }                                   |
-| ADMIN_EMAIL                | project     | admin@123.com                       |
-| ADMIN_EMAIL                | environment | admin@123.com                       |
-| ADMIN_PASSWORD             | environment | password                            |
-| ADMIN_URL                  | environment | admin123                            |
-| ADMIN_USERNAME             | environment | admin                               |
-+----------------------------+-------------+-------------------------------------+
-```
-{: .no-copy}
+   ```terminal
+   Variables on the project Project-Name (<project-id>), environment <environment-name>:
+   +----------------------------+-------------+-------------------------------------+
+   | Name                       | Level       | Value                               |
+   +----------------------------+-------------+-------------------------------------+
+   | php:blackfire.agent_socket | project     | tcp://blackfire.magento.cloud:8307  |
+   | env:COMPOSER_AUTH          | project     | {                                   |
+   |                            |             |    "http-basic": {                  |
+   |                            |             |       "repo.magento.com": {         |
+   |                            |             |       "username":                   |
+   |                            |             | "<public-key>",                     |
+   |                            |             |       "password":                   |
+   |                            |             | "<private-key>"                     |
+   |                            |             |     }                               |
+   |                            |             |   }                                 |
+   |                            |             | }                                   |
+   | ADMIN_EMAIL                | project     | admin@123.com                       |
+   | ADMIN_EMAIL                | environment | admin@123.com                       |
+   | ADMIN_PASSWORD             | environment | password                            |
+   | ADMIN_URL                  | environment | admin123                            |
+   | ADMIN_USERNAME             | environment | admin                               |
+   +----------------------------+-------------+-------------------------------------+
+   ```
+   {: .no-copy}
 
-#### To set a variable:
+{:.procedure}
+To set a variable using the CLI:
 
 ```bash
 magento-cloud vset <variable-name> <variable-value>
 ```
 
-{: .bs-callout .bs-callout-warning}
+{:.bs-callout-warning}
 Every time you add or modify a variable using the web interface or the CLI, the branch automatically redeploys.
 
-#### To add variables using the Project Web Interface:
+{:.procedure}
+To add variables using the Project Web Interface:
 
-Alternatively, you can add or update variables in the Project Web Interface.
+1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 
-1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
+1. Click the **Configure environment** gear icon ![Configure your environment]({{ site.baseurl }}/common/images/cloud_edit-project.png) next to the Project name.
 
-1.  Click the **Configure environment** gear icon ![Configure your environment]({{ site.baseurl }}/common/images/cloud_edit-project.png) next to the Project name.
+   ![Project without code]({{ site.baseurl }}/common/images/cloud_project_empty.png)
 
-	![Project without code]({{ site.baseurl }}/common/images/cloud_project_empty.png)
+1. Select the **Variables** tab.
 
-1.  Select the **Variables** tab.
+1. Click **Add Variable**.
 
-1.  Click **Add Variable**.
+1. Enter the **Name** and **Value** for the variable. For example, enter `ADMIN_EMAIL` and your License Owner email address or another accessible email for resetting the password for the default admin account.
 
-1.  Enter the **Name** and **Value** for the variable. For example, enter `ADMIN_EMAIL` and your License Owner email address or another accessible email for resetting the password for the default admin account.
+   ![Project variable]({{ site.baseurl }}/common/images/cloud_project_variable.png)
 
-	![Project variable]({{ site.baseurl }}/common/images/cloud_project_variable.png)
-
-1.  Click **Add variable**. After you add the variable, wait until deployment completes.
+1. Click **Add variable**. After you add the variable, wait until deployment completes.
 
 ## Create a branch for development {#branch}
 
 After cloning your project and updating the Magento administrator account configuration, you can branch for development. As stated earlier, you must create an environment using the `magento-cloud environment:branch <branch-name>` command or the Project Web Interface for the environment to become _active_.
 
-- For [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html#clone-branch), consider creating a branch for `staging`, then create a development branch based on the `staging` branch.
-* For [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html), create development branches based on the Integration environment.
+-  For [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html#clone-branch), consider creating a branch for `staging`, then create a development branch based on the `staging` branch.
+-  For [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html), create development branches based on the Integration environment.
 
-#### To branch from master:
+{:.procedure}
+To branch from master:
 
-1.  Do one of the following from the CLI.
+1. Create a new environment from the master branch.
 
-    -  To create a new environment:
+   ```bash
+   magento-cloud branch <new-environment-name> master
+   ```
 
-        ```bash
-        magento-cloud branch <environment-name> <parent-environment-ID>
-        ```
+1. Update dependencies.
 
-    -   To check out an existing environment:
+   ```bash
+   composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
+   ```
 
-        ```bash
-        magento-cloud checkout <environment-name>
-        ```
+1. Create a [snapshot]({{ page.baseurl }}/cloud/project/project-webint-snap.html) of the environment.
 
-1.  Update dependencies.
+   ```bash
+   magento-cloud snapshot:create -e <environment-ID>
+   ```
 
-    ```bash
-    composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
-    ```
-
-1.  Create a [snapshot]({{ page.baseurl }}/cloud/project/project-webint-snap.html) of the environment.
-
-    ```bash
-    magento-cloud snapshot:create -e <environment-ID>
-    ```
-
-#### Next step:
+**Next step:**
 [Install Magento]({{ page.baseurl }}/cloud/before/before-setup-env-install.html)

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -83,42 +83,38 @@ We recommend changing the environment-level variables for the Magento Admin URL 
 {:.bs-callout .bs-callout-info}
 Make note of any updated values so that you can use them to install Magento from the command line and to verify the installation. The values for the `ADMIN_EMAIL`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` variables are used only for installation.
 
-{:.procedure}
-To view existing variables:
+If you are not sure that the `master` branch has all Magento Admin variables and settings configured, you can view a list of existing variables:
 
--  If you are not sure that the `master` branch has all Magento Admin variables and settings configured, you can view a list of existing variables:
+```bash
+magento-cloud variables
+```
 
-   ```bash
-   magento-cloud variables
-   ```
+```terminal
+Variables on the project Project-Name (<project-id>), environment <environment-name>:
++----------------------------+-------------+-------------------------------------+
+| Name                       | Level       | Value                               |
++----------------------------+-------------+-------------------------------------+
+| php:blackfire.agent_socket | project     | tcp://blackfire.magento.cloud:8307  |
+| env:COMPOSER_AUTH          | project     | {                                   |
+|                            |             |    "http-basic": {                  |
+|                            |             |       "repo.magento.com": {         |
+|                            |             |       "username":                   |
+|                            |             | "<public-key>",                     |
+|                            |             |       "password":                   |
+|                            |             | "<private-key>"                     |
+|                            |             |     }                               |
+|                            |             |   }                                 |
+|                            |             | }                                   |
+| ADMIN_EMAIL                | project     | admin@123.com                       |
+| ADMIN_EMAIL                | environment | admin@123.com                       |
+| ADMIN_PASSWORD             | environment | password                            |
+| ADMIN_URL                  | environment | admin123                            |
+| ADMIN_USERNAME             | environment | admin                               |
++----------------------------+-------------+-------------------------------------+
+```
+{: .no-copy}
 
-   ```terminal
-   Variables on the project Project-Name (<project-id>), environment <environment-name>:
-   +----------------------------+-------------+-------------------------------------+
-   | Name                       | Level       | Value                               |
-   +----------------------------+-------------+-------------------------------------+
-   | php:blackfire.agent_socket | project     | tcp://blackfire.magento.cloud:8307  |
-   | env:COMPOSER_AUTH          | project     | {                                   |
-   |                            |             |    "http-basic": {                  |
-   |                            |             |       "repo.magento.com": {         |
-   |                            |             |       "username":                   |
-   |                            |             | "<public-key>",                     |
-   |                            |             |       "password":                   |
-   |                            |             | "<private-key>"                     |
-   |                            |             |     }                               |
-   |                            |             |   }                                 |
-   |                            |             | }                                   |
-   | ADMIN_EMAIL                | project     | admin@123.com                       |
-   | ADMIN_EMAIL                | environment | admin@123.com                       |
-   | ADMIN_PASSWORD             | environment | password                            |
-   | ADMIN_URL                  | environment | admin123                            |
-   | ADMIN_USERNAME             | environment | admin                               |
-   +----------------------------+-------------+-------------------------------------+
-   ```
-   {: .no-copy}
-
-{:.procedure}
-To set a variable using the CLI:
+You can use the `mmagento-cloud` CLI to set a variable:
 
 ```bash
 magento-cloud vset <variable-name> <variable-value>

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -114,7 +114,7 @@ Variables on the project Project-Name (<project-id>), environment <environment-n
 ```
 {: .no-copy}
 
-You can use the `mmagento-cloud` CLI to set a variable:
+You can use the `magento-cloud` CLI to set a variable:
 
 ```bash
 magento-cloud vset <variable-name> <variable-value>

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -10,8 +10,7 @@ functional_areas:
   - Configuration
 ---
 
-#### Previous step
-
+**Previous step**
 [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)
 
 With your workspace prepared, install Magento on your local to verify custom code, extensions, and more. This section includes the installation prep, options, and post-installation configuration you should complete.
@@ -48,7 +47,8 @@ magento-cloud variable:get -e <environment-ID>
 
 You need Magento authentication keys to install Magento in your local development environment. These are different than the authentication keys included in the code repository `auth.json` file. See [Add Magento authentication keys]({{page.baseurl}}/cloud/access-acct/first-time-setup_import-prepare.html).
 
-#### To create authentication keys through the Magento Marketplace
+{:.procedure}
+To create authentication keys through the Magento Marketplace:
 
 1. Log in to the [Magento Marketplace](https://marketplace.magento.com). If you do not have an account, click **Register**.
 
@@ -106,7 +106,8 @@ Be ready to install Magento using one of the following options:
 * [Install the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
 * [Install the Magento software using the Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
-### To install Magento using the command line
+{:.procedure}
+To install Magento using the command line:
 
 1. Switch to the user.
 
@@ -209,7 +210,7 @@ With these steps completed, you should have:
 * Your initial code branch
 * Magento authentication keys set up and configured in the project and local
 
-## Next steps
+**Next steps**
 
 For **Pro projects**, we strongly recommend fully deploying this base Magento template `master` branch without any code or configuration changes to Staging and Production. For instructions, see [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html).
 

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -10,7 +10,7 @@ functional_areas:
   - Configuration
 ---
 
-**Previous step**
+**Previous step:**
 [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)
 
 With your workspace prepared, install Magento on your local to verify custom code, extensions, and more. This section includes the installation prep, options, and post-installation configuration you should complete.

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -210,7 +210,7 @@ With these steps completed, you should have:
 * Your initial code branch
 * Magento authentication keys set up and configured in the project and local
 
-**Next steps**
+**Next steps:**
 
 For **Pro projects**, we strongly recommend fully deploying this base Magento template `master` branch without any code or configuration changes to Staging and Production. For instructions, see [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html).
 

--- a/guides/v2.2/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.2/cloud/before/before-workspace-cloud-account.md
@@ -2,12 +2,9 @@
 group:
 subgroup:
 title: Set up an account and project
-menu_title: Set up an account and project
-menu_order:
-menu_node:
 ---
 
-#### Previous step:
+**Previous step:**
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
 To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Enterprise Cloud Edition account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.
@@ -21,5 +18,5 @@ We recommend always starting with the blank site from a template as your initial
 
 {% include cloud/new-project-from-template.md %}
 
-#### Next step
+**Next step**
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)

--- a/guides/v2.2/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.2/cloud/before/before-workspace-cloud-account.md
@@ -18,5 +18,5 @@ We recommend always starting with the blank site from a template as your initial
 
 {% include cloud/new-project-from-template.md %}
 
-**Next step**
+**Next step:**
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)

--- a/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
+++ b/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
@@ -1,15 +1,12 @@
 ---
 group: cloud-guide
-subgroup: 080_setup
 title: Set up the Magento file system owner
-menu_title: Set up the Magento file system owner
-menu_order: 25
-menu_node:
 functional_areas:
   - Cloud
   - Setup
 ---
-#### Previous step: {#mage-owner-about-group}
+
+**Previous step:**
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)
 
 **This step is optional if you installed nginx as your web server.** The [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html#magento-file-system-owner) provides root access and permissions, for security reasons on a hosted system. Apache installations require
@@ -87,5 +84,5 @@ To complete the task, restart the web server:
 *	Ubuntu: `service apache2 restart`
 *	CentOS: `service httpd restart`
 
-#### Next step:
+**Next step:**
 [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)

--- a/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
@@ -10,7 +10,7 @@ functional_areas:
   - Configuration
 ---
 
-#### Previous step:
+**Previous step:**
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
 Install the following software packages and tools on your local to prepare for Magento code development. If you already have these packages installed, check for any recommendations or notes and continue to the next step.
@@ -193,5 +193,5 @@ The requirements listed in this topic are specific to {{site.data.var.ece}} envi
 
 You can also install additional [optional software]({{ page.baseurl }}/install-gde/prereq/optional.html). These packages should be installed on the local VM.
 
-#### Next step:
+**Next step:**
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)

--- a/guides/v2.2/cloud/before/before-workspace-ssh.md
+++ b/guides/v2.2/cloud/before/before-workspace-ssh.md
@@ -8,7 +8,7 @@ functional_areas:
   - Setup
 ---
 
-#### Previous step:
+**Previous step:**
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
 
 The [SSH protocol](https://en.wikipedia.org/wiki/Secure_Shell) is designed to maintain a secure connection between two systems&mdash;in this case, your local working environment and your {{site.data.var.ece}} Git project.
@@ -20,5 +20,5 @@ When initially setting up your local environment, you need to add the SSH keys t
 
 {% include cloud/enable-ssh.md %}
 
-#### Next step:
+**Next step:**
 [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html)

--- a/guides/v2.2/cloud/before/before-workspace.md
+++ b/guides/v2.2/cloud/before/before-workspace.md
@@ -58,5 +58,5 @@ You should be ready to go! The following sections provide a link to the previous
 
 For Pro projects, you also should deploy across to Staging and Production as part of your set up.
 
-#### Next step:
+**Next step:**
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)

--- a/guides/v2.2/cloud/configure/import-url-rewrites.md
+++ b/guides/v2.2/cloud/configure/import-url-rewrites.md
@@ -7,12 +7,13 @@ functional_areas:
   - Configuration
 ---
 
-You can easily migrate to the {{site.data.var.ece}} platform without losing SEO rankings and traffic.  Use the `magento/url-rewrite-import-export` module to redirect traffic from your old, indexed URLs to new URLs.
+You can easily migrate to the {{site.data.var.ece}} platform without losing SEO rankings and traffic. Use the `magento/url-rewrite-import-export` module to redirect traffic from your old, indexed URLs to new URLs.
 
 {: .bs-callout-info }
 This module is available for Magento version 2.2.x only.
 
-#### To install the URL rewrite module:
+{:.procedure}
+To install the URL rewrite module:
 
 1.  Add the module to the `composer.json` file.
 
@@ -70,7 +71,8 @@ Column | Description
 
 You use the Magento Admin panel to import the URL Rewrites file.
 
-#### To import URL Rewrites:
+{:.procedure}
+To import URL Rewrites:
 
 1.  On the _Marketing_ menu, click **URL Rewrites** in the _SEO & Search_ section.
 
@@ -97,7 +99,8 @@ If the import is **not** successful, you receive an error message reporting the 
 
 ![Failed URL rewrite]({{site.baseurl}}/common/images/cloud-urlrewrite-failed.png)
 
-#### To research the URL rewrite error:
+{:.procedure}
+To research the URL rewrite error:
 
 1.  Click **View Details** to see detailed information about the failure.
 

--- a/guides/v2.2/cloud/configure/setup-cron-jobs.md
+++ b/guides/v2.2/cloud/configure/setup-cron-jobs.md
@@ -27,7 +27,8 @@ crons:
 {:.bs-callout-info}
 We use only one cron for {{site.data.var.ece}} projects because of the nature of read-only environments. This configuration is different from {{site.data.var.ee}}, which has three default cron jobs. See [Configure and run crons]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html) in the {{site.data.var.ee}} documentation.
 
-## Verify cron configuration on Starter projects
+{:.procedure}
+To verify cron configuration on Starter projects:
 
 1. Log in to the {{site.data.var.ece}} project environment using [SSH]({{ page.baseurl }}/cloud/env/environments-ssh.html#ssh).
 
@@ -40,7 +41,8 @@ Magento added an auto-crons configuration option to all Pro plan projects to sup
 {:.bs-callout-info}
 Although you can use crontab to review configuration on Pro plan projects, Magento does not use crontab to run cron jobs for {{ site.data.var.ee }} sites deployed on the Cloud platform.
 
-#### To review cron configuration on Pro plan environments:
+{:.procedure}
+To review cron configuration on Pro plan environments:
 
 1. Log in to the Staging or Production environment using [SSH]({{ page.baseurl }}/cloud/env/environments-ssh.html#ssh).
 
@@ -120,7 +122,8 @@ The default cron interval for all environments provisioned in the US-3, EU-3, an
 
 On {{ site.data.var.ee }} Pro projects, the [auto-crons feature](#verify-cron-configuration-on-pro-projects) must be enabled on your {{site.data.var.ece}} project before you can add custom cron jobs to Staging and Production environments using `.magento.app.yaml`. If this feature is not enabled,contact your Magento account manager or CSM.
 
-#### To add custom crons
+{:.procedure}
+To add custom crons:
 
 1. In your local development environment, edit the `.magento.app.yaml` file in the Magento `/app` directory.
 

--- a/guides/v2.2/cloud/deploy/static-content-deployment.md
+++ b/guides/v2.2/cloud/deploy/static-content-deployment.md
@@ -31,7 +31,8 @@ By default, the [STATIC_CONTENT_SYMLINK environment variable]({{page.baseurl}}/c
 
 Generating static content requires access to themes and locales. Magento stores themes in the file system, which is accessible during the build phase; however, Magento stores locales in the database. The database is _not_ available during the build phase. In order to generate the static content during the build phase, you must use the `config:dump` command in the {{site.data.var.ct}} package to move locales to the file system. It reads the locales and saves them in the `app/etc/config.php` file.
 
-#### To configure your project to generate SCD on build:
+{:.procedure}
+To configure your project to generate SCD on build:
 
 1.  Log in to your Cloud environment using SSH and move locales to the file system, then update the [`config.php` file]({{site.baseurl}}/guides/v2.2/cloud/project/project-upgrade.html#create-a-new-configphp-file).
 

--- a/guides/v2.2/cloud/reference/cli-ref-topic.md
+++ b/guides/v2.2/cloud/reference/cli-ref-topic.md
@@ -12,7 +12,9 @@ You can install the Magento Cloud CLI when setting up your local environment for
 * [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
 * [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)
 
-#### To list all available commands:
+## Common commands
+
+The following lists all available commands:
 
 ```bash
 magento-cloud list
@@ -20,45 +22,10 @@ magento-cloud list
 
 Magento designed these commands to manage Cloud Integration environments. It is a best practice to run the Magento Cloud CLI from a project directory, because you can omit the `-p <project ID>` parameter.
 
-#### To log in to a project:
-
-```bash
-magento-cloud login
-```
-
-#### To clone a project to a directory:
-
-```bash
-magento-cloud project:get <PROJECT_ID> <DIRECTORY> -e <ENVIRONMENT_ID>
-```
-
-If you want to clone the `master` environment, omit the `-e <ENVIRONMENT_ID>` parameter.
-
-#### To list the environments in the current project:
-
-```bash
-magento-cloud environment:list
-```
-
-The `magento-cloud environment:list` command displays environment hierarchies, whereas `git branch` does not. If you have any nested environments, use the `magento-cloud environment:list` command.
-
-## Git commands
-
-You may notice that some of these commands are similar to Git commands. The `magento-cloud` Git commands directly connect to the Magento Git-based Cloud project with additional features. For example, when you push a Git branch, it is not activated until you access GitHub. The Magento CLI command includes activation.
-
-#### To push an empty commit and force a redeployment:
-
-```bash
-git commit --allow-empty -m "redeploy" && git push <BRANCH_NAME>
-```
-
-Some actions, such as adding a user, do not result in deployment.
-
-#### To create a new branch:
-
-```bash
-magento-cloud environment:branch <NAME> <PARENT_BRANCH>
-```
+Action | Command
+------ | --------
+To log in to a project: | `magento-cloud login`
+To clone a project to a directory: | `magento-cloud project:get <PROJECT_ID> <DIRECTORY> -e <ENVIRONMENT_ID>`<br>**Note**: If you want to clone the `master` environment, omit the `-e <ENVIRONMENT_ID>` parameter.
 
 ## Environment commands
 
@@ -66,13 +33,23 @@ The environment _name_ is different from the environment _ID_ only if you use sp
 
 An environment name _cannot_ include characters reserved for your Linux shell or for regular expressions. Forbidden characters include curly braces (`{ }`), parentheses, asterisk (`*`), angle brackets (`< >`), ampersand (`&`), percent (`%`), and other characters.
 
-#### To check out an existing environment:
+The `magento-cloud environment:list` command displays environment hierarchies, whereas `git branch` does not. If you have any nested environments, use the following:
 
 ```bash
-magento-cloud environment:checkout <ENVIRONMENT_ID>
+magento-cloud environment:list
 ```
 
-#### To redeploy the environment:
+### Common environment commands
+
+Action | Command
+------ | --------
+Checkout environment | `magento-cloud environment:checkout <ENVIRONMENT_ID>`
+Merge change to parent environment | `magento-cloud environment:merge -p <PROJECT_ID> -e <ENVIRONMENT_ID>`
+Synchronize with parent environment | `magento-cloud environment:synchronize -p <PROJECT_ID> -e <ENVIRONMENT_ID> {code|data}`
+List environment variables | `magento-cloud variable:list`
+Set a variable value | `magento-cloud variable:set <VARIABLE_NAME> <VARIABLE_VALUE>`
+
+### Redeploy the environment
 
 Trigger a redeployment without using a push. You must verify and confirm the environment to redeploy. Do not use redeploy if there is a build in a pending state.
 
@@ -81,50 +58,23 @@ magento-cloud environment:redeploy
 Are you sure you want to redeploy the environment <environment_name>? [Y/n]
 ```
 
-#### To merge changes from environment to parent:
+## Git commands
+
+You may notice that some of these commands are similar to Git commands. The `magento-cloud` commands directly connect to the Magento Git-based Cloud project with additional features. For example, when you push a Git branch, it is not activated until you access GitHub. The Magento CLI command includes activation.
+
+To create a new branch, use the magento-cloud command so the branch is activated.
 
 ```bash
-magento-cloud environment:merge -p <PROJECT_ID> -e <ENVIRONMENT_ID>
+magento-cloud environment:branch <NAME> <PARENT_BRANCH>
 ```
 
-#### To synchronize with parent:
+Pushing an empty commit forces a redeployment. For example:
 
 ```bash
-magento-cloud environment:synchronize -p <PROJECT_ID> -e <ENVIRONMENT_ID> {code|data}
+git commit --allow-empty -m "redeploy" && git push <BRANCH_NAME>
 ```
 
-#### To list variables for this environment:
-
-```bash
-magento-cloud variable:list
-```
-
-#### To set a value for an environment variable:
-
-```bash
-magento-cloud variable:set <VARIABLE_NAME> <VARIABLE_VALUE>
-```
-
-## Common commands
-
-The listed commands are for Magento Cloud CLI version 1.11.1 and later.
-
-Command | Description
--------------- | ---------------
-`clear-cache` | Clear the cache for the CLI.
-`clean` | Remove old project builds. When using `local:build` in a separate location from your code, use _clean_ to clear those builds. By default, your latest five builds are not deleted.
-`docs` | Provides a link for documentation.
-`help` | Display help information for the command.
-`list` | List all available commands in the Magento Cloud CLI.
-`multi` | Executes a command on multiple projects. Use the `-p` option to provide a list of project IDs.
-`redeploy` | Redeploys the application.
-`web` | Opens a web UI based on the parameters you enter.
-
-#### To see a comprehensive list of commands with descriptions:
-
-```bash
-magento-cloud list
-```
+Some actions, such as adding a user, do not result in deployment.
 
 ## Command help
 

--- a/guides/v2.2/cloud/reference/cli-ref-topic.md
+++ b/guides/v2.2/cloud/reference/cli-ref-topic.md
@@ -14,7 +14,7 @@ You can install the Magento Cloud CLI when setting up your local environment for
 
 ## Common commands
 
-The following lists all available commands:
+The following lists the available `magento-cloud` CLI commands:
 
 ```bash
 magento-cloud list

--- a/guides/v2.2/cloud/reference/ece-tools-reference.md
+++ b/guides/v2.2/cloud/reference/ece-tools-reference.md
@@ -11,7 +11,7 @@ The `{{site.data.var.ct}}` package is a set of scripts and tools designed to man
 
 The `{{site.data.var.ct}}` package is compatible with {{site.data.var.ee}}—starting with version 2.1.4—and contains scripts and {{site.data.var.ece}} commands designed to help manage your code and automatically build and deploy your projects.
 
-#### To list the available `{{site.data.var.ct}}` commands:
+To list the available `{{site.data.var.ct}}` commands:
 
 ```bash
 php ./vendor/bin/ece-tools list
@@ -89,9 +89,7 @@ Magento Cloud Services:
 
 ## Verify environment configuration
 
-There is a set of verification commands available to help evaluate the configuration of your project. See [Smart wizards][wizard] in the _Optimize deployment_ section for a detailed description of each wizard command. The `wizard:ideal-state` command runs automatically during the build phase.
-
-#### To verify the ideal state of your project:
+There is a set of verification commands available to help evaluate the configuration of your project. See [Smart wizards][wizard] in the _Optimize deployment_ section for a detailed description of each wizard command. The `wizard:ideal-state` command runs automatically during the build phase. To verify the ideal state of your project:
 
 ```bash
 php ./vendor/bin/ece-tools wizard:ideal-state

--- a/guides/v2.2/cloud/reference/ece-tools-reference.md
+++ b/guides/v2.2/cloud/reference/ece-tools-reference.md
@@ -11,7 +11,7 @@ The `{{site.data.var.ct}}` package is a set of scripts and tools designed to man
 
 The `{{site.data.var.ct}}` package is compatible with {{site.data.var.ee}}—starting with version 2.1.4—and contains scripts and {{site.data.var.ece}} commands designed to help manage your code and automatically build and deploy your projects.
 
-To list the available `{{site.data.var.ct}}` commands:
+The following lists the available `{{site.data.var.ct}}` commands:
 
 ```bash
 php ./vendor/bin/ece-tools list

--- a/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
@@ -38,7 +38,8 @@ You must enter all {{site.data.var.ece}} commands on the machine on which your C
 
 You need your {{site.data.var.ece}} database name and credentials so that you can import your {{site.data.var.ee}} data. You can find the name and credentials for your {{site.data.var.ece}} database in the `$MAGENTO_CLOUD_RELATIONSHIPS` environment variable.
 
-#### To find {{site.data.var.ece}} database access information:
+{:.procedure}
+To find {{site.data.var.ece}} database access information:
 
 1.  Log in to your remote repository using [SSH]({{ page.baseurl }}/cloud/env/environments-ssh.html#ssh).
 
@@ -119,5 +120,5 @@ The complete workflow for importing existing code includes the following steps:
 
 1.  After the project deploys, **Success** displays next to the name of your project.
 
-#### Next step
+**Next step**
 [Prepare your existing {{site.data.var.ee}} install]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html)

--- a/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
@@ -120,5 +120,5 @@ The complete workflow for importing existing code includes the following steps:
 
 1.  After the project deploys, **Success** displays next to the name of your project.
 
-**Next step**
+**Next step:**
 [Prepare your existing {{site.data.var.ee}} install]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html)

--- a/guides/v2.2/cloud/trouble/robots-sitemap.md
+++ b/guides/v2.2/cloud/trouble/robots-sitemap.md
@@ -17,7 +17,8 @@ You do not have to generate a `robots.txt` file because it generates the `robots
 
 This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.app.yaml` file. See an example of these rules in the [magento-cloud repository](https://github.com/magento/magento-cloud/blob/master/.magento.app.yaml#L43-L49).
 
-#### To generate a `sitemap.xml` file in version 2.2 and later
+{:.procedure}
+To generate a `sitemap.xml` file in version 2.2 and later:
 
 1. Access the Magento Admin panel.
 1. On the _Marketing_ menu, click **Site Map** in the _SEO & Search_ section.
@@ -30,7 +31,8 @@ This requires ECE-Tools version 2002.0.12 and later with an updated `.magento.ap
 1. Click **Save & Generate**. The new site map becomes available in the _Site Map_ grid.
 1. Click the path in the _Link for Google_ column.
 
-#### To add content to `robots.txt` file
+{:.procedure}
+To add content to `robots.txt` file:
 
 1. Access the Magento Admin panel.
 1. On the _Content_ menu, click **Configuration** in the _Design_ section.
@@ -47,7 +49,7 @@ If the `<domain.your.project>/robots.txt` file generates a `404 error`, [submit 
 
  If you have different domains and you need separate site maps, you can create a VCL to route to the proper sitemap. Generate the `sitemap.xml` file in the Magento Admin panel as described above, then create a custom Fastly VCL snippet to manage the redirect. See [Custom Fastly VCL snippets]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html).
 
-### To use a Fastly VCL snippet for redirect
+### Use a Fastly VCL snippet for redirect
 
 Create a custom VCL snippet to rewrite the path for `sitemap.xml` to `/media/sitemap.xml` using the `type` and `content` key-value pairs.
 
@@ -73,7 +75,8 @@ The following example demonstrates how to rewrite the path for `robots.txt` and 
 }
 ```
 
-#### To use a Fastly VCL snippet for particular domain redirect:
+{:.procedure}
+To use a Fastly VCL snippet for particular domain redirect:
 
 Create a `pub/media/domain_robots.txt` file, where the domain is `domain.com` and use the next VCL snippet:
 

--- a/guides/v2.2/cloud/trouble/robots-sitemap.md
+++ b/guides/v2.2/cloud/trouble/robots-sitemap.md
@@ -32,7 +32,7 @@ To generate a `sitemap.xml` file in version 2.2 and later:
 1. Click the path in the _Link for Google_ column.
 
 {:.procedure}
-To add content to `robots.txt` file:
+To add content to the `robots.txt` file:
 
 1. Access the Magento Admin panel.
 1. On the _Content_ menu, click **Configuration** in the _Design_ section.

--- a/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
@@ -193,5 +193,5 @@ The requirements listed in this topic are specific to {{site.data.var.ece}} envi
 
 You can also install additional [optional software]({{ page.baseurl }}/install-gde/prereq/optional.html). These packages should be installed on the local VM.
 
-#### Next step:
+**Next step:**
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)


### PR DESCRIPTION
This replaces level 4 headers used for procedures with the new procedure class. The procedure class shifts the title to the right to align with the step numbering.

This PR addresses the directories: includes, before, config, reference, setup, trouble

- some topics have previous and next steps that used the H4. I changed them to Bold type in anticipation of the header level rule
- two topics had severe formatting issues that affected the use of the procedure class. One solution was to move commands to a table.