### PR TITLE
Add store name to store config query schema

### DIFF
--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -38,6 +38,7 @@ The following call returns all details of a store's configuration.
     secure_base_link_url
     secure_base_static_url
     secure_base_media_url
+    store_name
   }
 }
 ```
@@ -63,7 +64,8 @@ The following call returns all details of a store's configuration.
       "secure_base_url": "http://magento2.vagrant193/",
       "secure_base_link_url": "http://magento2.vagrant193/",
       "secure_base_static_url": "http://magento2.vagrant193/pub/static/version1536249714/",
-      "secure_base_media_url": "http://magento2.vagrant193/pub/media/"
+      "secure_base_media_url": "http://magento2.vagrant193/pub/media/",
+      "store_name": "My Store"
     }
   }
 }
@@ -198,6 +200,7 @@ Attribute |  Data Type | Description | Example
 `secure_base_media_url` | String | The secure fully-qualified URL that specifies the location of user media files | `https://magentohost.example.com/pub/media/`
 `secure_base_static_url` | String | The secure fully-qualified URL that specifies the location of static view files | `https://magentohost.example.com/pub/static/`
 `secure_base_url` | String | The store's fully-qualified secure base URL | `https://magentohost.example.com/`
+`store_name` | String | The store's name | `My Store`
 `timezone` | String | The store's time zone | `America/Chicago`
 `website_id` | Integer | The ID number assigned to the parent website | `1`
 `weight_unit` | String | The weight unit for products | `lbs`, `kgs`, etc


### PR DESCRIPTION
## Purpose of this pull request

Adds `store_name` property to `storeConfig` query.

**Depends magento/graphql-ce#952**

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/reference/store-config.html

whatsnew
Added the `store_name` attribute to the [storeConfig](https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html) query.