### PR TITLE
magento/devdocs#: Cloud. `magento-cloud db:dump` command

### DIFF
--- a/_includes/cloud/backup-db.md
+++ b/_includes/cloud/backup-db.md
@@ -8,6 +8,9 @@ We recommend creating a backup of your project before an upgrade. Use the follow
     magento-cloud db:dump
     ```
 
+    {: .bs-callout-info }
+    The `magento-cloud db:dump` command runs the [mysqldump](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html) command with the `--single-transaction` flag, which allows you to back up your database without locking the tables. 
+
 1.  Back up code and media.
 
     ```bash


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) answers on the question does `magento-cloud db:dump` command lock the tables?

<img width="551" alt="5453" src="https://user-images.githubusercontent.com/13585327/65423057-c8219d80-de10-11e9-9035-ac361c5985d3.png">


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/cloud/project/project-upgrade.html
- https://devdocs.magento.com/guides/v2.3/cloud/project/project-upgrade.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [--single-transaction](https://github.com/magento/ece-tools/blob/develop/src/DB/Dump.php#L52)
- [MySqlDump](https://www.eversql.com/how-to-backup-mysql-database-using-mysqldump-without-locking/)

<img width="644" alt="5453-2" src="https://user-images.githubusercontent.com/13585327/65423105-ed161080-de10-11e9-85c4-c836e91fd3e2.png">


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!