### PR TITLE
Fix Cloud procedures for Docker and integrations

### DIFF
--- a/guides/v2.2/cloud/docker/docker-config.md
+++ b/guides/v2.2/cloud/docker/docker-config.md
@@ -78,7 +78,7 @@ For example, the following command starts the Docker configuration generator for
     ```
 
     {: .bs-callout-tip }
-To change the `magento2.docker` hostname for your project, you must update the host in three files: `.docker/config.php`, `docker-compose.yml`, and `/etc/hosts`
+    To change the `magento2.docker` hostname for your project, you must update the host in three files: `.docker/config.php`, `docker-compose.yml`, and `/etc/hosts`
 
 1.  Stop the default Apache instance on Mac OS.
 
@@ -272,19 +272,14 @@ Start containers from a suspended state | `docker-compose start`
 Stop the synchronization daemon | `docker-sync stop`
 Start the synchronization daemon | `docker-sync start`
 
-#### To stop and remove the Docker configuration:
+{:.procedure}
+To stop and remove the Docker configuration:
 
-Remove all components of your local Docker instance including containers, networks, volumes, and images.
+-  Remove all components of your local Docker instance including containers, networks, volumes, and images.
 
-```bash
-docker-compose down -v
-```
-
-#### To stop `docker-sync` daemon:
-
-```bash
-docker-sync stop
-```
+   ```bash
+   docker-compose down -v
+   ```
 
 ## Advanced usage
 

--- a/guides/v2.2/cloud/docker/docker-config.md
+++ b/guides/v2.2/cloud/docker/docker-config.md
@@ -272,14 +272,14 @@ Start containers from a suspended state | `docker-compose start`
 Stop the synchronization daemon | `docker-sync stop`
 Start the synchronization daemon | `docker-sync start`
 
-{:.procedure}
-To stop and remove the Docker configuration:
-
--  Remove all components of your local Docker instance including containers, networks, volumes, and images.
+Use the following command to stop and remove the Docker configuration:
 
    ```bash
    docker-compose down -v
    ```
+
+{: .bs-callout-warning}
+This removes all components of your local Docker instance including containers, networks, volumes, and images.
 
 ## Advanced usage
 

--- a/guides/v2.2/cloud/docker/docker-database.md
+++ b/guides/v2.2/cloud/docker/docker-database.md
@@ -26,7 +26,8 @@ return [
 ```
 {: .no-copy}
 
-#### To connect to the database using Docker commands:
+{:.procedure}
+To connect to the database using Docker commands:
 
 1.  Connect to the CLI container.
 
@@ -52,7 +53,8 @@ return [
     ```
     {: .no-copy}
 
-#### To connect to the database:
+{:.procedure}
+To connect to the database:
 
 1.  Find the port used by the database. The port may change each time you restart Docker.
 

--- a/guides/v2.2/cloud/docker/docker-development-debug.md
+++ b/guides/v2.2/cloud/docker/docker-development-debug.md
@@ -54,7 +54,8 @@ runtime:
     XDEBUG_CONFIG='remote_host=host.docker.internal remote_port=9002'
     ```
 
-#### To configure PhpStorm to work with Xdebug:
+{:.procedure}
+To configure PhpStorm to work with Xdebug:
 
 1.  In your PhpStorm project, open the settings panel.
 
@@ -84,7 +85,8 @@ runtime:
 
 The following steps describe debugging web requests and CLI commands.
 
-#### To debug web requests:
+{:.procedure}
+To debug web requests:
 
 1.  In your PhpStorm project, click ![Start listening for connections]({{ site.baseurl }}/common/images/install_docker_php-storm_xdebug-start-listening.png){:width="25px"} (**Start listening**) in the top navigation bar.
 
@@ -96,9 +98,10 @@ The following steps describe debugging web requests and CLI commands.
 
 1.  When PhpStorm recognizes the Xdebug connection, you can begin debugging web requests.
 
-#### To debug CLI commands:
-
 You can debug any Magento command or PHP script using the following steps.
+
+{:.procedure}
+To debug CLI commands:
 
 1.  In your PhpStorm project, open the **Build, Extension, Deployment** > **Docker** panel, and then click `+` to add a new Docker server and update the following settings:
 
@@ -133,7 +136,8 @@ You can debug any Magento command or PHP script using the following steps.
 
 You can install and use the Xdebug Helper Chrome extension to debug your PhP code from the browser.
 
-#### To use Xdebug Helper with Chrome:
+{:.procedure}
+To use Xdebug Helper with Chrome:
 
 1.  Install the [Xdebug Helper extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en) from the Chrome store.
 

--- a/guides/v2.2/cloud/docker/docker-development.md
+++ b/guides/v2.2/cloud/docker/docker-development.md
@@ -20,9 +20,7 @@ The database container is based on the [mariadb](https://hub.docker.com/_/mariad
     - `/var/lib/mysql`
     - `./docker/mysql`
 
-#### To import a database dump:
-
-Place the SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
+To import a database dump, place the SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
 
 The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command.
 
@@ -39,26 +37,30 @@ The following CLI containers, which are based on a [PHP-CLI version 7 image](htt
     -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environment
     -  Cron only works with the CLI container to run the `./bin/magento cron:run` command
 
-#### To run the `{{site.data.var.ct}}` ideal-state command:
+{:.procedure}
+To check the state of the your project:
 
-```bash
-docker-compose run deploy ece-command wizard:ideal-state
-```
+-  Run the `{{site.data.var.ct}}` ideal-state command.
 
-Sample response:
+   ```bash
+   docker-compose run deploy ece-command wizard:ideal-state
+   ```
 
-```terminal
-...
- - Your application does not have the "post_deploy" hook enabled.
-The configured state is not ideal
-```
-{: .no-copy}
+-  Sample response:
+
+   ```terminal
+   ...
+    - Your application does not have the "post_deploy" hook enabled.
+   The configured state is not ideal
+   ```
+   {: .no-copy}
 
 ### Cron container
 
 The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`crons` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
 
-#### To view the cron log:
+{:.procedure}
+To view the cron log:
 
 ```bash
 docker-compose run deploy bash -c "cat /app/var/cron.log"

--- a/guides/v2.2/cloud/docker/docker-development.md
+++ b/guides/v2.2/cloud/docker/docker-development.md
@@ -37,30 +37,26 @@ The following CLI containers, which are based on a [PHP-CLI version 7 image](htt
     -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environment
     -  Cron only works with the CLI container to run the `./bin/magento cron:run` command
 
-{:.procedure}
-To check the state of the your project:
+For example, you can check the state of the your project using the _ideal-state_ wizard:
 
--  Run the `{{site.data.var.ct}}` ideal-state command.
+Run the `{{site.data.var.ct}}` ideal-state command.
 
-   ```bash
-   docker-compose run deploy ece-command wizard:ideal-state
-   ```
+```bash
+docker-compose run deploy ece-command wizard:ideal-state
+```
 
--  Sample response:
+Sample response:
 
-   ```terminal
-   ...
-    - Your application does not have the "post_deploy" hook enabled.
-   The configured state is not ideal
-   ```
-   {: .no-copy}
+```terminal
+...
+ - Your application does not have the "post_deploy" hook enabled.
+The configured state is not ideal
+```
+{: .no-copy}
 
 ### Cron container
 
-The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`crons` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons).
-
-{:.procedure}
-To view the cron log:
+The Cron container is based on PHP-CLI images, and executes operations in the background immediately after the Docker environment start. It uses the cron configuration defined in the [`crons` property of the `.magento.app.yaml` file]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#crons). To view the cron log:
 
 ```bash
 docker-compose run deploy bash -c "cat /app/var/cron.log"

--- a/guides/v2.2/cloud/integrations/bitbucket-integration.md
+++ b/guides/v2.2/cloud/integrations/bitbucket-integration.md
@@ -80,7 +80,8 @@ You must clone your {{site.data.var.ece}} project from an existing environment a
 
 The Bitbucket integration requires an [OAuth consumer](https://confluence.atlassian.com/x/pwIwDg). You need the OAuth `key` and `secret` from this consumer to complete the next section.
 
-#### To create an OAuth consumer in Bitbucket:
+{:.procedure}
+To create an OAuth consumer in Bitbucket:
 
 1. Log in to your [Bitbucket](https://bitbucket.org/account/signin/) account.
 
@@ -199,7 +200,8 @@ After configuring the Bitbucket integration, test it by pushing a simple change 
 
 The Bitbucket integration cannot activate new environments in your {{site.data.var.ece}} project. If you create an environment with Bitbucket, you must activate the environment manually. To avoid this extra step, it is best practice to create environments using the `magento-cloud` CLI tool or the Project Web UI.
 
-#### To activate a branch created with Bitbucket:
+{:.procedure}
+To activate a branch created with Bitbucket:
 
 1. Use the magento-cloud CLI to push the branch.
 
@@ -239,7 +241,8 @@ After you create a new environment, you can push the corresponding branch to you
 
 You can safely remove the Bitbucket integration from your project without affecting your code.
 
-#### To remove the Bitbucket integration:
+{:.procedure}
+To remove the Bitbucket integration:
 
 1. From the terminal, log in to your {{site.data.var.ece}} project.
 

--- a/guides/v2.2/cloud/integrations/cloud-integrations.md
+++ b/guides/v2.2/cloud/integrations/cloud-integrations.md
@@ -17,7 +17,7 @@ Integrations are useful for leveraging the functionality of external services—
    -  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html)
    <!-- -  [GitLab]({{ page.baseurl }}/cloud/integrations/gitlab-integration.html) -->
 
-#### To list the configured integrations:
+Use the `magento-cloud` CLI to list the integrations configured for your project:
 
 ```bash
 magento-cloud integration:list

--- a/guides/v2.2/cloud/integrations/github-integration.md
+++ b/guides/v2.2/cloud/integrations/github-integration.md
@@ -87,7 +87,8 @@ The following enables the GitHub integration and provides a Payload URL to use w
 {: .bs-callout .bs-callout-warning}
 The following command overwrites _all_ code in your {{site.data.var.ece}} project with code from your GitHub repository. This includes all branches, including the Production branch. This action happens instantly and cannot be undone. As a best practice, it is very important to clone all of your branches from your {{site.data.var.ece}} project and push them to your GitHub repository **before** adding the GitHub integration.
 
-#### To enable the GitHub integration:
+{:.procedure}
+To enable the GitHub integration:
 
 1.  Enable the integration.
 

--- a/guides/v2.2/cloud/integrations/health-notifications.md
+++ b/guides/v2.2/cloud/integrations/health-notifications.md
@@ -16,7 +16,8 @@ functional_areas:
 
 The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipients` address. The following example registers a health email integration with two recipients.
 
-#### To register health notifications for email:
+{:.procedure}
+To register health notifications for email:
 
 ```bash
 magento-cloud integration:add --type health.email --from-address you@example.com --recipients them@example.com --recipients others@example.com
@@ -26,7 +27,8 @@ magento-cloud integration:add --type health.email --from-address you@example.com
 
 Slack is an external service that uses interactive apps called bots to post messages in a chat room. Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot user for your channel, or channels, save the [bot token](https://api.slack.com/docs/token-types#bot) provided by Slack to register your integration.
 
-#### To register health notifications in a Slack channel:
+{:.procedure}
+To register health notifications in a Slack channel:
 
 ```bash
 magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --channel '#slack-channel-name'
@@ -36,7 +38,8 @@ magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --chan
 
 PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key, or _routing key_, to register your integration.
 
-#### To register health notifications for PagerDuty:
+{:.procedure}
+To register health notifications for PagerDuty:
 
 ```bash
 magento-cloud integration:add --type health.pagerduty --routing-key PAGERDUTY_ROUTING_KEY

--- a/guides/v2.2/cloud/integrations/health-notifications.md
+++ b/guides/v2.2/cloud/integrations/health-notifications.md
@@ -14,10 +14,7 @@ functional_areas:
 
 ## Email notifications
 
-The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipients` address. The following example registers a health email integration with two recipients.
-
-{:.procedure}
-To register health notifications for email:
+The health email integration requires an origination address and at least one recipient address. You can use the same email address for the `from-address` and the `recipients` address. The following example registers a health email integration with two recipients:
 
 ```bash
 magento-cloud integration:add --type health.email --from-address you@example.com --recipients them@example.com --recipients others@example.com
@@ -25,10 +22,7 @@ magento-cloud integration:add --type health.email --from-address you@example.com
 
 ## Slack channel notifications
 
-Slack is an external service that uses interactive apps called bots to post messages in a chat room. Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot user for your channel, or channels, save the [bot token](https://api.slack.com/docs/token-types#bot) provided by Slack to register your integration.
-
-{:.procedure}
-To register health notifications in a Slack channel:
+Slack is an external service that uses interactive apps called bots to post messages in a chat room. Before you can receive health notifications in Slack, you must create a new, custom [bot user](https://api.slack.com/bot-users) for your Slack group. After you configure the bot user for your channel, or channels, save the [bot token](https://api.slack.com/docs/token-types#bot) provided by Slack to register your integration. The following example registers health notifications in a Slack channel:
 
 ```bash
 magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --channel '#slack-channel-name'
@@ -36,10 +30,7 @@ magento-cloud integration:add --type health.slack --token SLACK_BOT_TOKEN --chan
 
 ## PagerDuty notifications
 
-PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key, or _routing key_, to register your integration.
-
-{:.procedure}
-To register health notifications for PagerDuty:
+PagerDuty is an external service that can notify on-call team members of important issues. Before you can receive health notifications in PagerDuty, you must create a [PagerDuty integration](https://v2.developer.pagerduty.com/v2/docs/integrating) that uses the Events API version 2. Use the Integration Key, or _routing key_, to register your integration. The following example registers notifications for PagerDuty using a routing key:
 
 ```bash
 magento-cloud integration:add --type health.pagerduty --routing-key PAGERDUTY_ROUTING_KEY


### PR DESCRIPTION
This replaces level 4 headers used for procedures with the new procedure class. The procedure class shifts the title to the right to align with the step numbering.

Some procedures have a single step, or a single step with response. I need feedback on how to handle these cases. You can find a sample of single step items in Health Notifications: /guides/v2.2/integrations/health-notifications.html

Also, line 41 in guides/v2.2/cloud/docker/docker-development.md would also be a single step, but I used an unordered list so that I could indent the items.