### PR TITLE
Fixed MD040 errors in _includes/config/

### DIFF
--- a/_includes/config/install-java.md
+++ b/_includes/config/install-java.md
@@ -2,7 +2,9 @@
 
 To determine if Java is already installed, enter the following command:
 
-	java -version
+```bash
+java -version
+```
 
 If the message `java: command not found` displays, you must install the Java SDK as discussed in the next section.
 
@@ -17,7 +19,9 @@ See [this article on digitalocean](https://www.digitalocean.com/community/tutori
 
 Be sure to install the JDK and *not* the JRE.
 
-	yum -y install java-1.7.0-openjdk
+```bash
+yum -y install java-1.7.0-openjdk
+```
 
 {:.bs-callout .bs-callout-info}
 Java version 7 might not be available for all operating systems. For example, you can [search the list of available packages for Ubuntu](http://packages.ubuntu.com/).
@@ -26,8 +30,16 @@ Java version 7 might not be available for all operating systems. For example, yo
 
 To install JDK 1.8 on Ubuntu, enter the following commands as a user with `root` privileges:
 
-	add-apt-repository -y ppa:webupd8team/java
-	apt-get -y update
-	apt-get install -y oracle-java8-installer
+```bash
+add-apt-repository -y ppa:webupd8team/java
+```
+
+```bash
+apt-get -y update
+```
+
+```bash
+apt-get install -y oracle-java8-installer
+```
 
 For other options, see [Oracle documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html).

--- a/_includes/config/install-java8.md
+++ b/_includes/config/install-java8.md
@@ -2,7 +2,9 @@
 
 To determine if Java is already installed, enter the following command:
 
-	java -version
+```bash
+java -version
+```
 
 If the message `java: command not found` displays, you must install the Java SDK as discussed in the next section.
 
@@ -17,7 +19,9 @@ See [this article on digitalocean](https://www.digitalocean.com/community/tutori
 
 Be sure to install the JDK and *not* the JRE.
 
-	yum -y install java-1.8.0-openjdk
+```bash
+yum -y install java-1.8.0-openjdk
+```
 
 {:.bs-callout .bs-callout-info}
 Java version 8 might not be available for all operating systems. For example, you can [search the list of available packages for Ubuntu](http://packages.ubuntu.com/).
@@ -26,8 +30,16 @@ Java version 8 might not be available for all operating systems. For example, yo
 
 To install JDK 1.8 on Ubuntu, enter the following commands as a user with `root` privileges:
 
-	add-apt-repository -y ppa:webupd8team/java
-	apt-get -y update
-	apt-get install -y oracle-java8-installer
+```bash
+add-apt-repository -y ppa:webupd8team/java
+```
+
+```bash
+apt-get -y update
+```
+
+```bash
+apt-get install -y oracle-java8-installer
+```
 
 For other options, see [Oracle documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html).

--- a/_includes/config/redis-verify.md
+++ b/_includes/config/redis-verify.md
@@ -4,7 +4,9 @@ To verify that Redis and Magento are working together, use the following command
 
 In a command prompt on the server on which Redis is running, enter:
 
-	redis-cli monitor
+```bash
+redis-cli monitor
+```
 
 Refresh your storefront page and you'll see output similar to the following.
 
@@ -52,7 +54,9 @@ If you use Redis for page caching, you'll see output similar to the following:
 
 Enter the following command:
 
-	redis-cli ping
+```bash
+redis-cli ping
+```
 
 `PONG` should be the response.
 

--- a/_includes/config/secure-ws-apache_step1.md
+++ b/_includes/config/secure-ws-apache_step1.md
@@ -6,9 +6,12 @@ First, see if you have the Apache `htpasswd` utility is installed as follows:
 
 1.	Enter the following command to determine if `htpasswd` is already installed:
 
-		which htpasswd
+    ```bash
+    which htpasswd
+    ```
 
-	If a path displays, it is installed; if the command returns no output, `htpasswd` is not installed.
+    If a path displays, it is installed; if the command returns no output, `htpasswd` is not installed.
+
 2.	If necessary, install `htpasswd`:
 
 	*	Ubuntu: `apt-get -y install apache2-utils`
@@ -18,8 +21,10 @@ First, see if you have the Apache `htpasswd` utility is installed as follows:
 
 Enter the following commands as a user with `root` privileges:
 
-	mkdir -p /usr/local/apache/password
-	htpasswd -c /usr/local/apache/password/.<password file name> <username>
+```bash
+mkdir -p /usr/local/apache/password
+htpasswd -c /usr/local/apache/password/.<password file name> <username>
+```
 
 where
 
@@ -39,17 +44,29 @@ Follow the prompts on your screen to create a password for the user.
 **Example 1: cron**
 You must set up authentication for only one user for cron; in this example, we use the web server user. To create a password file for the web server user, enter the following commands:
 
-	mkdir -p /usr/local/apache/password
-	htpasswd -c /usr/local/apache/password/.htpasswd apache
+```bash
+mkdir -p /usr/local/apache/password
+```
+
+```bash
+htpasswd -c /usr/local/apache/password/.htpasswd apache
+```
 
 **Example 2: Elasticsearch**
 You must set up authentication for two users: one with access to nginx and one with access to Elasticsearch. To create password files for these users, enter the following commands:
 
-	mkdir -p /usr/local/apache/password
-	htpasswd -c /usr/local/apache/password/.htpasswd_elasticsearch magento_elasticsearch
+```bash
+mkdir -p /usr/local/apache/password
+```
+
+```bash
+htpasswd -c /usr/local/apache/password/.htpasswd_elasticsearch magento_elasticsearch
+```
 
 #### Add additional users
 
 To add another user to your password file, enter the following command as a user with `root` privileges:
 
-	htpasswd /usr/local/apache/password/.htpasswd <username>
+```bash
+htpasswd /usr/local/apache/password/.htpasswd <username>
+```

--- a/_includes/config/secure-ws-apache_step1.md
+++ b/_includes/config/secure-ws-apache_step1.md
@@ -23,6 +23,9 @@ Enter the following commands as a user with `root` privileges:
 
 ```bash
 mkdir -p /usr/local/apache/password
+```
+
+```bash
 htpasswd -c /usr/local/apache/password/.<password file name> <username>
 ```
 

--- a/_includes/config/secure-ws-apache_step2.md
+++ b/_includes/config/secure-ws-apache_step2.md
@@ -2,12 +2,18 @@ You can optionally enable more than one user to securely communicate by adding t
 
 To add another user to your password file, enter the following command as a user with `root` privileges:
 
-	htpasswd /usr/local/apache/password/<password file name> <username>
+```bash
+htpasswd /usr/local/apache/password/<password file name> <username>
+```
 
 To create an authorized group, create a group file anywhere outside the web server docroot. The group file specifies the name of the group and the users in the group. In this example, the group name is `MagentoGroup`.
 
-	vim /usr/local/apache/password/.group
+```bash
+vim /usr/local/apache/password/.group
+```
 
 Contents of the file:
 
-	MagentoGroup: <username1> ... <usernameN>
+```text
+MagentoGroup: <username1> ... <usernameN>
+```

--- a/_includes/config/setup-cron.md
+++ b/_includes/config/setup-cron.md
@@ -19,21 +19,29 @@ Magento uses cron for two sets of tasks, and for each, cron can run with a diffe
 
 To display the path to your PHP binary, enter
 
-	which php
+```bash
+which php
+```
 
 A sample result follows:
 
-	/usr/bin/php
+```bash
+/usr/bin/php
+```
 
 #### Create the cron job
 
 To create a cron job for the Magento file system owner, enter the following command as a user with `root` privileges:
 
-	crontab -u <Magento file system owner username> -e
+```bash
+crontab -u <Magento file system owner username> -e
+```
 
 For example,
 
-	crontab -u magento_user -e
+```bash
+crontab -u magento_user -e
+```
 
 A text editor displays. (You might need to choose a text editor first.)
 

--- a/_includes/config/setup-cron_2.2.md
+++ b/_includes/config/setup-cron_2.2.md
@@ -19,21 +19,27 @@ Starting with version 2.2, Magento creates a crontab for you. We add the Magento
 
 To create the Magento crontab, use the following command:
 
-	php bin/magento cron:install [--force]
+```bash
+php bin/magento cron:install [--force]
+```
 
 Use `--force` to rewrite an existing Magento crontab. (Any existing crontab is not affected.)
 
 To view the crontab, switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) and enter the following command:
 
-	crontab -l
+```bash
+crontab -l
+```
 
 A sample follows:
 
-	#~ MAGENTO START
-	* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run 2>&1 | grep -v Ran jobs by schedule >> /var/www/html/magento2/var/log/magento.cron.log
-	* * * * * /usr/bin/php /var/www/html/magento2/update/cron.php >> /var/www/html/magento2/var/log/update.cron.log
-	* * * * * /usr/bin/php /var/www/html/magento2/bin/magento setup:cron:run >> /var/www/html/magento2/var/log/setup.cron.log
-	#~ MAGENTO END
+```terminal
+#~ MAGENTO START
+* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run 2>&1 | grep -v Ran jobs by schedule >> /var/www/html/magento2/var/log/magento.cron.log
+* * * * * /usr/bin/php /var/www/html/magento2/update/cron.php >> /var/www/html/magento2/var/log/update.cron.log
+* * * * * /usr/bin/php /var/www/html/magento2/bin/magento setup:cron:run >> /var/www/html/magento2/var/log/setup.cron.log
+#~ MAGENTO END
+```
 
 #### Related topic
 

--- a/_includes/config/setup-cron_2.2_how-to.md
+++ b/_includes/config/setup-cron_2.2_how-to.md
@@ -10,7 +10,9 @@ To create the Magento crontab:
 2.	Change to your Magento installation directory.
 3.	Enter the following command:
 
-		php bin/magento cron:install [--force]
+    ```bash
+    php bin/magento cron:install [--force]
+    ```
 
 Use `--force` to rewrite an existing Magento crontab.
 
@@ -21,12 +23,16 @@ Use `--force` to rewrite an existing Magento crontab.
 
 To view the crontab, enter the following command as the Magento file system owner:
 
-	crontab -l
+```bash
+crontab -l
+```
 
 A sample follows:
 
-	#~ MAGENTO START
-	* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run | grep -v Ran jobs by schedule >> /var/www/html/magento2/var/log/magento.cron.log
-	* * * * * /usr/bin/php /var/www/html/magento2/update/cron.php >> /var/www/html/magento2/var/log/update.cron.log
-	* * * * * /usr/bin/php /var/www/html/magento2/bin/magento setup:cron:run >> /var/www/html/magento2/var/log/setup.cron.log
-	#~ MAGENTO END
+```terminal
+#~ MAGENTO START
+* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run | grep -v Ran jobs by schedule >> /var/www/html/magento2/var/log/magento.cron.log
+* * * * * /usr/bin/php /var/www/html/magento2/update/cron.php >> /var/www/html/magento2/var/log/update.cron.log
+* * * * * /usr/bin/php /var/www/html/magento2/bin/magento setup:cron:run >> /var/www/html/magento2/var/log/setup.cron.log
+#~ MAGENTO END
+```

--- a/_includes/config/split-db.md
+++ b/_includes/config/split-db.md
@@ -5,32 +5,46 @@ Create checkout and OMS master databases as follows:
 1.	Log in to your database server as any user.
 2.	Enter the following command to get to a MySQL command prompt:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
 3.	Enter the MySQL `root` user's password when prompted.
 4.	Enter the following commands in the order shown to create database instances named `magento_quote` and `magento_sales` with the same usernames and passwords:
 
-		create database magento_quote;
-		GRANT ALL ON magento_quote.* TO magento_quote@localhost IDENTIFIED BY 'magento_quote';
+    ```shell
+    create database magento_quote;
+    GRANT ALL ON magento_quote.* TO magento_quote@localhost IDENTIFIED BY 'magento_quote';
 
-		create database magento_sales;
-		GRANT ALL ON magento_sales.* TO magento_sales@localhost IDENTIFIED BY 'magento_sales';
+    create database magento_sales;
+    GRANT ALL ON magento_sales.* TO magento_sales@localhost IDENTIFIED BY 'magento_sales';
+    ```
 
 5.	Enter `exit` to quit the command prompt.
 
 6.	Verify the databases, one at a time:
 
-	Checkout database:
+    Checkout database:
 
-		mysql -u magento_quote -p
-		exit
+    ```bash
+    mysql -u magento_quote -p
+    ```
 
-	Order management database:
+    ```shell
+    exit
+    ```
 
-		mysql -u magento_sales -p
-		exit
+    Order management database:
 
-	If the MySQL monitor displays, you created the database properly. If an error displays, repeat the preceding commands.
+    ```bash
+    mysql -u magento_sales -p
+    ```
+
+    ```shell
+    exit
+    ```
+
+    If the MySQL monitor displays, you created the database properly. If an error displays, repeat the preceding commands.
 
 ## Configure {{site.data.var.ee}} to use the master databases {#config-ee-multidb-master-cli}
 
@@ -44,26 +58,38 @@ After setting up a total of three master databases, use the Magento command line
 
 Command syntax:
 
-	magento setup:db-schema:split-quote --host="<checkout db host or ip>" --dbname="<name>" --username="<checkout db username>" --password="<password>"
+```bash
+magento setup:db-schema:split-quote --host="<checkout db host or ip>" --dbname="<name>" --username="<checkout db username>" --password="<password>"
+```
 
 For example,
 
-	magento setup:db-schema:split-quote --host="localhost" --dbname="magento_quote" --username="magento_quote" --password="magento_quote"
+```bash
+magento setup:db-schema:split-quote --host="localhost" --dbname="magento_quote" --username="magento_quote" --password="magento_quote"
+```
 
 The following message displays to confirm a successful setup:
 
-	Migration has been finished successfully!
+```terminal
+Migration has been finished successfully!
+```
 
 ### Configure the OMS database   {#config-ee-multidb-master-cli-oms}
 
 Command syntax:
 
-	magento setup:db-schema:split-sales --host="<checkout db host or ip>" --dbname="<name>" --username="<checkout db username>" --password="<password>"
+```bash
+magento setup:db-schema:split-sales --host="<checkout db host or ip>" --dbname="<name>" --username="<checkout db username>" --password="<password>"
+```
 
 For example,
 
-	magento setup:db-schema:split-sales --host="localhost" --dbname="magento_sales" --username="magento_sales" --password="magento_sales"
+```bash
+magento setup:db-schema:split-sales --host="localhost" --dbname="magento_sales" --username="magento_sales" --password="magento_sales"
+```
 
 The following message displays to confirm a successful setup:
 
-	Migration has been finished successfully!
+```terminal
+Migration has been finished successfully!
+```

--- a/_includes/config/split-deploy/example_build-sync.md
+++ b/_includes/config/split-deploy/example_build-sync.md
@@ -4,17 +4,28 @@ To update your build system:
 2.	Change to the build system's Magento root directory.
 3.	Pull the changes to `app/etc/config.php` from source control.
 
-	The Git command follows:
+    The Git command follows:
 
-		git pull mconfig m2.2_deploy
+    ```bash
+    git pull mconfig m2.2_deploy
+    ```
+
 4.	Compile code:
 
-		php bin/magento setup:di:compile
+    ```bash
+    php bin/magento setup:di:compile
+    ```
+
 5.	After code has been compiled, generate static view files:
 
-		php bin/magento setup:static-content:deploy -f
+    ```bash
+    php bin/magento setup:static-content:deploy -f
+    ```
+
 6.	Check the changes into source control.
 
-	The Git command follows:
+    The Git command follows:
 
-		git add -A && git commit -m "Updated files on build system" && git push mconfig m2.2_deploy
+    ```bash
+    git add -A && git commit -m "Updated files on build system" && git push mconfig m2.2_deploy
+    ```

--- a/_includes/config/split-deploy/example_update-prod.md
+++ b/_includes/config/split-deploy/example_update-prod.md
@@ -3,22 +3,39 @@ To update the production system:
 1.	Log in to your production system as, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
 2.	Start maintenance mode:
 
-		cd <Magento root dir>
-		php bin/magento maintenance:enable
+    ```bash
+    cd <Magento root dir>
+    ```
 
-	For additional options, such as the ability to set an IP address whitelist, see [`magento maintenance:enable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html).
+    ```bash
+    php bin/magento maintenance:enable
+    ```
+
+    For additional options, such as the ability to set an IP address whitelist, see [`magento maintenance:enable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html).
+
 3.	If you use {{site.data.var.ee}}, stop queue workers. TBD
 3.	Pull code from source control.
 
-	The Git command follows:
+    The Git command follows:
 
-		git pull mconfig m2.2_deploy
+    ```bash
+    git pull mconfig m2.2_deploy
+    ```
+
 4.	Update the configuration:
 
-		php bin/magento app:config:import
+    ```bash
+    php bin/magento app:config:import
+    ```
+
 5.	Clean the cache:
 
-		php bin/magento cache:clean
+    ```bash
+    php bin/magento cache:clean
+    ```
+
 4.	End maintenance mode:
 
-		php bin/magento maintenance:disable
+    ```bash
+    php bin/magento maintenance:disable
+    ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the `_includes/config/` directory.

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.