### PR TITLE
Fixed MD040 errors in Install Guide

### DIFF
--- a/guides/v2.2/install-gde/basics/basics_magento-installed.md
+++ b/guides/v2.2/install-gde/basics/basics_magento-installed.md
@@ -19,9 +19,11 @@ To determine if the Magento software is installed already, you can access the [M
 
 Then open a web browser and go to the URL you were provided. Some examples follow:
 
-	http://www.example.com/magento2/admin
-	https://www.example.com/admin
-	http://www.example.com
+```http
+http://www.example.com/magento2/admin
+https://www.example.com/admin
+http://www.example.com
+```
 
 If a 404 (Not Found) error displays, Magento probably isn't installed. You should confirm that with your system administrator or hosting provider.
 

--- a/guides/v2.2/install-gde/basics/basics_os-version.md
+++ b/guides/v2.2/install-gde/basics/basics_os-version.md
@@ -23,27 +23,34 @@ If you already know you're running Ubuntu or CentOS but don't know the version, 
 
 To find the CentOS version, enter the following command in Terminal:
 
-	cat /etc/*release*
+```bash
+cat /etc/*release*
+```
 
 The following sample output shows you're running CentOS 6.5 (you can ignore most of the output):
 
-	CentOS release 6.5 (Final)
-	LSB_VERSION=base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch
-	cat: /etc/lsb-release.d: Is a directory
-	CentOS release 6.5 (Final)
-	CentOS release 6.5 (Final)
+```terminal
+CentOS release 6.5 (Final)
+LSB_VERSION=base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch
+cat: /etc/lsb-release.d: Is a directory
+CentOS release 6.5 (Final)
+CentOS release 6.5 (Final)
+```
 
 ### Ubuntu
 
 To find the Ubuntu version, enter the following command in Terminal:
 
-	lsb_release -a
+```bash
+lsb_release -a
+```
 
 The following sample output shows you're running Ubuntu 14:
 
-	No LSB modules are available.
-	Distributor ID: Ubuntu
-	Description:    Ubuntu 14.04.1 LTS
-	Release:        14.04
-	Codename:       trusty
-
+```terminal
+No LSB modules are available.
+Distributor ID: Ubuntu
+Description:    Ubuntu 14.04.1 LTS
+Release:        14.04
+Codename:       trusty
+```

--- a/guides/v2.2/install-gde/install/cli/dev_downgrade.md
+++ b/guides/v2.2/install-gde/install/cli/dev_downgrade.md
@@ -33,18 +33,28 @@ To change versions after cloning:
 1.	Log in to your Magento server as, or switch to, [the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 2.	Use the following command to uninstall the Magento software:
 
-		php <your Magento clone dir>/bin/magento setup:uninstall
+    ```bash
+    php <your Magento clone dir>/bin/magento setup:uninstall
+    ```
+
 3.	Either remove your old Magento clone directory or [update the Magento software]({{ page.baseurl }}/install-gde/install/cli/dev_update-magento.html).
 4.	If you haven't already done so, clone the Magento 2 GitHub repository as follows:
 
-		git clone git@github.com:magento/magento2.git
+    ```bash
+    git clone git@github.com:magento/magento2.git
+    ```
+
 5.	Change to [release tag](https://github.com/magento/magento2/tags) as follows:
 
-		git checkout tags/<tag name>  [-b <branch name>]
+    ```bash
+    git checkout tags/<tag name>  [-b <branch name>]
+    ```
 
-	For example, to check out the 2.2.0 release tag in a new branch named `2.2.0`, enter
+    For example, to check out the 2.2.0 release tag in a new branch named `2.2.0`, enter
 
-		git checkout tags/2.2.0 -b 2.2.0
+    ```bash
+    git checkout tags/2.2.0 -b 2.2.0
+    ```
 
 5.	Install the Magento software using the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html) or [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html).
 
@@ -56,18 +66,28 @@ To change versions after cloning:
 2.	Create a [new database instance]({{ page.baseurl }}/install-gde/prereq/mysql.html#instgde-prereq-mysql-config) for your installation.
 2.	[Back up]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html#instgde-cli-uninst-back) the Magento file system, database, and media files:
 
-		php <magento_root>/bin/magento setup:backup --code --media --db
+    ```bash
+    php <magento_root>/bin/magento setup:backup --code --media --db
+    ```
+
 3.	Change to [release tag](https://github.com/magento/magento2/tags) as follows:
 
-		git checkout tags/<tag name>  [-b <branch name>]
+    ```bash
+    git checkout tags/<tag name>  [-b <branch name>]
+    ```
 
-	For example, to check out the 2.2.0 release tag in a new branch named `2.2.0`, enter
+    For example, to check out the 2.2.0 release tag in a new branch named `2.2.0`, enter
 
-		git checkout tags/2.2.0 -b 2.2.0
+    ```bash
+    git checkout tags/2.2.0 -b 2.2.0
+    ```
 
 4.	Manually clear Magento `var` directories:
 
-		rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/code/*
+    ```bash
+    rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/code/*
+    ```
+
 5.	Install the Magento software in your new database instance.
 
-	You can install using either the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html) or [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html).
+    You can install using either the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html) or [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html).

--- a/guides/v2.2/install-gde/install/cli/dev_reinstall.md
+++ b/guides/v2.2/install-gde/install/cli/dev_reinstall.md
@@ -18,28 +18,37 @@ To reinstall the Magento software as a contributing developer:
 2.	Log in to your Magento server as a user with permissions to modify files in the Magento file system (for example, the [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 3.	Make a backup copy of `composer.json` in your Magento installation directory:
 
-		cd <magento_root>
-		cp composer.json composer.json.bak
+    ```bash
+    cd <magento_root>
+    ```
+
+    ```bash
+    cp composer.json composer.json.bak
+    ```
 
 4.	Open `composer.json` in a text editor.
 5.	Locate the following line:
 
-		 "require": {
-        	"magento/product-community-edition": "<version>"
-    	},
+    ```json
+    "require": {
+          "magento/product-community-edition": "<version>"
+      },
+    ```
 
 5.	Replace `<version>` with the version to which you want to upgrade, where `<version>` is the product version to use.
 
-	(The product version is in the format `2.0.x`)
+    (The product version is in the format `2.0.x`)
 
 <!-- is the `magento/product-community-edition` version from -->.
 
 5.	Save your changes to `composer.json` and exit the text editor.
 6.	Enter the following command:
 
-		composer update
+    ```bash
+    composer update
+    ```
 
-	Wait for dependencies to update.
+    Wait for dependencies to update.
 
 4. [Install the Magento software]({{ page.baseurl }}/install-gde/install/cli/install-cli.html).
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-adminurl.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-adminurl.md
@@ -20,11 +20,15 @@ This section discusses how to use the command line to display the [Admin](https:
 
 Command options:
 
-	magento info:adminuri
+```bash
+magento info:adminuri
+```
 
 A sample result follows:
 
-	Admin Panel URI: /admin_1wgrah
+```terminal
+Admin Panel URI: /admin_1wgrah
+```
 
 You can also view the Admin URI in `<magento_root>/app/etc/env.php`. A snippet follows:
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-install.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-install.md
@@ -62,7 +62,7 @@ If an error displays when you run these commands, verify that you updated instal
 
 The install command uses the following format:
 
-```
+```bash
 magento setup:install --<option>=<value> ... --<option>=<value>
 ```
 
@@ -160,25 +160,29 @@ The following example installs Magento with the following options:
 *	Default currency is U.S. dollars
 *	Default time zone is U.S. Central (America/Chicago)
 
-		magento setup:install --base-url=http://127.0.0.1/magento2/ \
-		--db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
-		--admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
-		--admin-user=admin --admin-password=admin123 --language=en_US \
-		--currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```bash
+    magento setup:install --base-url=http://127.0.0.1/magento2/ \
+    --db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
+    --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
+    --admin-user=admin --admin-password=admin123 --language=en_US \
+    --currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```
 
 Messages similar to the following display to indicate a successful installation:
 
-	Post installation file permissions check...
-	For security, remove write permissions from these directories: '/var/www/html/magento2/app/etc'
-	[Progress: 274 / 274]
-	[SUCCESS]: Magento installation complete.
-	[SUCCESS]: Admin Panel URI: /admin_puu71q
+```terminal
+Post installation file permissions check...
+For security, remove write permissions from these directories: '/var/www/html/magento2/app/etc'
+[Progress: 274 / 274]
+[SUCCESS]: Magento installation complete.
+[SUCCESS]: Admin Panel URI: /admin_puu71q
+```
 
 #### Example 2— Basic install without admin user account
 
 In {{ site.data.var.ee }} version 2.2.8 and later, you have the option to install Magento without creating the Magento administrator user as shown in the following example.
 
-```
+```bash
 magento setup:install --base-url=http://127.0.0.1/magento2/ \
 --db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
 --language=en_US --currency=USD --timezone=America/Chicago --use-rewrites=1
@@ -186,7 +190,7 @@ magento setup:install --base-url=http://127.0.0.1/magento2/ \
 
 Messages like the following display if the installation is successful:
 
-```
+```terminal
 Post installation file permissions check...
 For security, remove write permissions from these directories: '/var/www/html/magento2/app/etc'
 [Progress: 274 / 274]
@@ -223,7 +227,7 @@ The following example installs Magento with the following options:
 *	Session data is saved in the database
 *	Uses server rewrites
 
-    ```
+    ```bash
     magento setup:install --base-url=http://127.0.0.1/magento2/ \
     --db-host=localhost --db-name=magento \
     --db-user=magento --db-password=magento \
@@ -238,11 +242,13 @@ You must enter the command either on a single line or, as in the preceding examp
 
 Messages like the following display if the installation is successful:
 
-	Post installation file permissions check...
-	For security, remove write permissions from these directories: '/var/www/html/magento2/app/etc'
-	[Progress: 274 / 274]
-	[SUCCESS]: Magento installation complete.
-	[SUCCESS]: Admin Panel URI: /admin_puu71q
+```terminal
+Post installation file permissions check...
+For security, remove write permissions from these directories: '/var/www/html/magento2/app/etc'
+[Progress: 274 / 274]
+[SUCCESS]: Magento installation complete.
+[SUCCESS]: Admin Panel URI: /admin_puu71q
+```
 
 #### Next step
 
@@ -250,4 +256,3 @@ Messages like the following display if the installation is successful:
 
 	This type of setup is typical for shared hosting.
 *	[Verify the installation]({{ page.baseurl }}/install-gde/install/verify.html).
-

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db-status.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db-status.md
@@ -23,13 +23,17 @@ Before you run this command, you must [Create or update the deployment configura
 
 To check the status of the Magento database, enter
 
-	magento setup:db:status
+```bash
+magento setup:db:status
+```
 
 This command has no arguments or options.
 
 Sample output follows:
 
-	All modules are up to date.
+```terminal
+All modules are up to date.
+```
 
 The command returns one of the following exit codes:
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db.md
@@ -25,10 +25,6 @@ Command usage:
 magento setup:db-schema:upgrade
 ```
 
-```bash
-	magento setup:db-data:upgrade
-  ```
-
 To see the status of the database, enter
 
 ```bash

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db.md
@@ -21,9 +21,16 @@ Before you run this command, you must [Create or update the deployment configura
 
 Command usage:
 
-	magento setup:db-schema:upgrade
+```bash
+magento setup:db-schema:upgrade
+```
+
+```bash
 	magento setup:db-data:upgrade
+  ```
 
 To see the status of the database, enter
 
-	magento setup:db:status
+```bash
+magento setup:db:status
+```

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -34,7 +34,9 @@ You can use this command if:
 
 Command options:
 
-	magento setup:config:set [--<parameter>=<value>, ...]
+```bash
+magento setup:config:set [--<parameter>=<value>, ...]
+```
 
 The following table discusses the meanings of installation parameters and values.
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-enable.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-enable.md
@@ -19,8 +19,13 @@ This command has no prerequisites.
 
 To enable or disable available modules, use the following command:
 
-	magento module:enable [-c|--clear-static-content] [-f|--force] [--all] <module-list>
-	magento module:disable [-c|--clear-static-content] [-f|--force] [--all] <module-list>
+```bash
+magento module:enable [-c|--clear-static-content] [-f|--force] [--all] <module-list>
+```
+
+```bash
+magento module:disable [-c|--clear-static-content] [-f|--force] [--all] <module-list>
+```
 
 where
 
@@ -35,11 +40,15 @@ where
 
 Use the following command to list enabled and disabled modules:
 
-	magento module:status
+```bash
+magento module:status
+```
 
 For example, to disable the Weee module, enter:
 
-	magento module:disable Magento_Weee
+```bash
+magento module:disable Magento_Weee
+```
 
 For important information about enabling and disabling modules, see [About enabling and disabling modules](#instgde-cli-subcommands-enable-modules).
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -34,9 +34,17 @@ Use the `magento maintenance` CLI command to enable or disable Magento maintenan
 
 Command usage:
 
-	magento maintenance:enable [--ip=<ip address> ... --ip=<ip address>] | [ip=none]
-	magento maintenance:disable [--ip=<ip address> ... --ip=<ip address>] | [ip=none]
-	magento maintenance:status
+```bash
+magento maintenance:enable [--ip=<ip address> ... --ip=<ip address>] | [ip=none]
+```
+
+```bash
+magento maintenance:disable [--ip=<ip address> ... --ip=<ip address>] | [ip=none]
+```
+
+```bash
+magento maintenance:status
+```
 
 where
 
@@ -49,11 +57,15 @@ Using `--ip=<ip address>` with `magento maintenance:disable` means only that you
 
 For example, to enable maintenance mode with no IP address exemptions:
 
-	magento maintenance:enable
+```bash
+magento maintenance:enable
+```
 
 To enable maintenance mode for all clients except 192.0.2.10 and 192.0.2.11:
 
-	magento maintenance:enable --ip=192.0.2.10 --ip=192.0.2.11
+```bash
+magento maintenance:enable --ip=192.0.2.10 --ip=192.0.2.11
+```
 
 {: .bs-callout-info }
   After you place Magento in maintenance mode, you must stop all message queue consumer processes. One way to find these processes is to run the `ps -ef | grep queue:consumer:start` command. Then run the `kill <process_id>` command for each consumer. In a multiple node environment, be sure to repeat this task on each node.
@@ -62,7 +74,9 @@ To enable maintenance mode for all clients except 192.0.2.10 and 192.0.2.11:
 
 To maintain the list of exempt IP addresses, you can either use the `[--ip=<ip list>]` option in the preceding commands or you can use the following:
 
-	magento maintenance:allow-ips <ip address> .. <ip address> [--none]
+```bash
+magento maintenance:allow-ips <ip address> .. <ip address> [--none]
+```
 
 where
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-store.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-store.md
@@ -24,7 +24,9 @@ Before you run this command, you must do all of the following *or* you must [ins
 
 Command usage:
 
-	magento setup:store-config:set [--<parameter_name>=<value>, ...]
+```bash
+magento setup:store-config:set [--<parameter_name>=<value>, ...]
+```
 
 where the following table defines parameters and values.
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-theme-uninstall.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-theme-uninstall.md
@@ -34,7 +34,9 @@ In addition to the command arguments discussed here, see [Common arguments]({{ p
 
 Command usage:
 
-	magento theme:uninstall [--backup-code] [-c|--clear-static-content] {theme path} ... {theme path}
+```bash
+magento theme:uninstall [--backup-code] [-c|--clear-static-content] {theme path} ... {theme path}
+```
 
 where
 
@@ -66,32 +68,38 @@ The command performs the following tasks:
 
 For example, if you attempt to uninstall a theme that another theme depends on, the following message displays:
 
-	Cannot uninstall frontend/ExampleCorp/SampleModuleTheme because the following package(s) depend on it:
+```terminal
+Cannot uninstall frontend/ExampleCorp/SampleModuleTheme because the following package(s) depend on it:
         ExampleCorp/sample-module-theme-depend
+```
 
 One alternative is to uninstall both themes at the same time as follows after backing up the Magento codebase:
 
-	magento theme:uninstall frontend/ExampleCorp/SampleModuleTheme frontend/ExampleCorp/SampleModuleThemeDepend --backup-code
+```bash
+magento theme:uninstall frontend/ExampleCorp/SampleModuleTheme frontend/ExampleCorp/SampleModuleThemeDepend --backup-code
+```
 
 Messages similar to the following display:
 
-	Code backup is starting...
-	Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
-	Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
-	[SUCCESS]: Code backup completed successfully.Removing frontend/ExampleCorp/SampleModuleTheme, frontend/ExampleCorp/SampleModuleThemeDepend from database
-	Loading composer repositories with package information
-	Updating dependencies (including require-dev)
-	Removing frontend/ExampleCorp/SampleModuleTheme, frontend/ExampleCorp/SampleModuleThemeDepend from Magento codebase
-	  - Removing ExampleCorp/sample-module-theme-depend (dev-master)
-	Removing ExampleCorp/SampleThemeDepend
-	  - Removing ExampleCorp/sample-module-theme (dev-master)
-	Removing ExampleCorp/SampleTheme
-	Writing lock file
-	Generating autoload files
-	Cache cleared successfully.
-	Alert: Generated static view files were not cleared. You can clear them using the --clear-static-content option.
-	Failure to clear static view files might cause display issues in the Admin and storefront.
-	Disabling maintenance mode
+```terminal
+Code backup is starting...
+Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
+Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
+[SUCCESS]: Code backup completed successfully.Removing frontend/ExampleCorp/SampleModuleTheme, frontend/ExampleCorp/SampleModuleThemeDepend from database
+Loading composer repositories with package information
+Updating dependencies (including require-dev)
+Removing frontend/ExampleCorp/SampleModuleTheme, frontend/ExampleCorp/SampleModuleThemeDepend from Magento codebase
+  - Removing ExampleCorp/sample-module-theme-depend (dev-master)
+Removing ExampleCorp/SampleThemeDepend
+  - Removing ExampleCorp/sample-module-theme (dev-master)
+Removing ExampleCorp/SampleTheme
+Writing lock file
+Generating autoload files
+Cache cleared successfully.
+Alert: Generated static view files were not cleared. You can clear them using the --clear-static-content option.
+Failure to clear static view files might cause display issues in the Admin and storefront.
+Disabling maintenance mode
+```
 
 {: .bs-callout-info }
 To uninstall a Magento [Admin](https://glossary.magento.com/admin) theme, you must also remove it from your component's [dependency injection](https://glossary.magento.com/dependency-injection) configuration, `<component root directory>/etc/di.xml`.

--- a/guides/v2.2/install-gde/install/cli/install-cli-uninstall-langpk.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-uninstall-langpk.md
@@ -23,7 +23,9 @@ In addition to the command arguments discussed here, see [Common arguments]({{ p
 
 Command usage:
 
-	magento i18n:uninstall [-b|--backup-code] {language package name} ... {language package name}
+```bash
+magento i18n:uninstall [-b|--backup-code] {language package name} ... {language package name}
+```
 
 The language package uninstall command performs the following tasks:
 
@@ -36,24 +38,30 @@ The language package uninstall command performs the following tasks:
 
 For example, if you attempt to uninstall a language package that another language package depends on, the following message displays:
 
-	Cannot uninstall vendorname/language-en_us because the following package(s) depend on it:
-        vendorname/language-en_gb
+```terminal
+Cannot uninstall vendorname/language-en_us because the following package(s) depend on it:
+      vendorname/language-en_gb
+```
 
 One alternative is to uninstall both language packages after backing up the Magento codebase:
 
-	magento i18n:uninstall vendorname/language-en_us vendorname/language-en_gb --backup-code
+```bash
+magento i18n:uninstall vendorname/language-en_us vendorname/language-en_gb --backup-code
+```
 
 Messages similar to the following display:
 
-	Code backup is starting...
-	Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
-	Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
-	[SUCCESS]: Code backup completed successfully.
-	Loading composer repositories with package information
-	Updating dependencies (including require-dev)
-	  - Removing vendorname/language-en_us (dev-master)
-	Removing Magento/LanguageEn_us
-	  - Removing vendorname/language-en_br (dev-master)
-		Removing vendorname/language-en_br (dev-master)
-	Writing lock file
-	Generating autoload files
+```terminal
+Code backup is starting...
+Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
+Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
+[SUCCESS]: Code backup completed successfully.
+Loading composer repositories with package information
+Updating dependencies (including require-dev)
+  - Removing vendorname/language-en_us (dev-master)
+Removing Magento/LanguageEn_us
+  - Removing vendorname/language-en_br (dev-master)
+  - Removing vendorname/language-en_br (dev-master)
+Writing lock file
+Generating autoload files
+```

--- a/guides/v2.2/install-gde/install/cli/install-cli-uninstall-mods.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-uninstall-mods.md
@@ -28,8 +28,10 @@ In addition to the command arguments discussed here, see [Common arguments]({{ p
 
 Command usage:
 
-	magento module:uninstall [--backup-code] [--backup-media] [--backup-db] [-r|--remove-data] [-c|--clear-static-content] \
-	{ModuleName} ... {ModuleName}
+```bash
+magento module:uninstall [--backup-code] [--backup-media] [--backup-db] [-r|--remove-data] [-c|--clear-static-content] \
+  {ModuleName} ... {ModuleName}
+```
 
 where `{ModuleName}` specifies the module name in `<VendorName>_<ModuleName>` format. For example, the Magento Customer module name is `Magento_Customer`. To get a list of module names, enter `magento module:status`
 
@@ -70,46 +72,52 @@ The module uninstall command performs the following tasks:
 
 For example, if you attempt to uninstall a module that another module depends on, the following message displays:
 
-	magento module:uninstall Magento_SampleMinimal
-		Cannot uninstall module 'Magento_SampleMinimal' because the following module(s) depend on it:
+```terminal
+magento module:uninstall Magento_SampleMinimal
+    Cannot uninstall module 'Magento_SampleMinimal' because the following module(s) depend on it:
         Magento_SampleModifyContent
+```
 
 One alternative is to uninstall both modules after backing up the Magento module file system, `pub/media` files, and database tables but *not* removing the module's [database schema](https://glossary.magento.com/database-schema) or data:
 
-	magento module:uninstall Magento_SampleMinimal Magento_SampleModifyContent --backup-code --backup-media --backup-db
+```bash
+magento module:uninstall Magento_SampleMinimal Magento_SampleModifyContent --backup-code --backup-media --backup-db
+```
 
 Messages similar to the following display:
 
-	You are about to remove code and/or database tables. Are you sure?[y/N]y
-	Enabling maintenance mode
-	Code backup is starting...
-	Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
-	Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
-	[SUCCESS]: Code backup completed successfully.
-	Media backup is starting...
-	Media backup filename: 1435261098_filesystem_media.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
-	Media backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_media.tgz
-	[SUCCESS]: Media backup completed successfully.
-	DB backup is starting...
-	DB backup filename: 1435261098_db.gz (The archive can be uncompressed with 7-Zip on Windows systems)
-	DB backup path: /var/www/html/magento2/var/backups/1435261098_db.gz
-	[SUCCESS]: DB backup completed successfully.
-	You are about to remove a module(s) that might have database data. Remove the database data manually after uninstalling, if desired.
-	Removing Magento_SampleMinimal, Magento_SampleModifyContent from module registry in database
-	Removing Magento_SampleMinimal, Magento_SampleModifyContent from module list in deployment configuration
-	Removing code from Magento codebase:
-	Loading composer repositories with package information
-	Updating dependencies (including require-dev)
-	  - Removing magento/sample-module-modifycontent (1.0.0)
-	Removing Magento/SampleModifycontent
-	  - Removing magento/sample-module-minimal (1.0.0)
-	Removing Magento/SampleMinimal
-	Writing lock file
-	Generating autoload files
-	Cache cleared successfully.
-	Generated classes cleared successfully.
-	Alert: Generated static view files were not cleared. You can clear them using the --clear-static-content option. Failure to clear static view files might cause display issues in the Admin and storefront.
-	Disabling maintenance mode
+```terminal
+You are about to remove code and/or database tables. Are you sure?[y/N]y
+Enabling maintenance mode
+Code backup is starting...
+Code backup filename: 1435261098_filesystem_code.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
+Code backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_code.tgz
+[SUCCESS]: Code backup completed successfully.
+Media backup is starting...
+Media backup filename: 1435261098_filesystem_media.tgz (The archive can be uncompressed with 7-Zip on Windows systems)
+Media backup path: /var/www/html/magento2/var/backups/1435261098_filesystem_media.tgz
+[SUCCESS]: Media backup completed successfully.
+DB backup is starting...
+DB backup filename: 1435261098_db.gz (The archive can be uncompressed with 7-Zip on Windows systems)
+DB backup path: /var/www/html/magento2/var/backups/1435261098_db.gz
+[SUCCESS]: DB backup completed successfully.
+You are about to remove a module(s) that might have database data. Remove the database data manually after uninstalling, if desired.
+Removing Magento_SampleMinimal, Magento_SampleModifyContent from module registry in database
+Removing Magento_SampleMinimal, Magento_SampleModifyContent from module list in deployment configuration
+Removing code from Magento codebase:
+Loading composer repositories with package information
+Updating dependencies (including require-dev)
+  - Removing magento/sample-module-modifycontent (1.0.0)
+Removing Magento/SampleModifycontent
+  - Removing magento/sample-module-minimal (1.0.0)
+Removing Magento/SampleMinimal
+Writing lock file
+Generating autoload files
+Cache cleared successfully.
+Generated classes cleared successfully.
+Alert: Generated static view files were not cleared. You can clear them using the --clear-static-content option. Failure to clear static view files might cause display issues in the Admin and storefront.
+Disabling maintenance mode
+```
 
 {:.bs-callout .bs-callout-info}
 Errors display if you attempt to uninstall a module with a dependency on another module. In that case, you cannot uninstall one module; you must uninstall both.
@@ -118,7 +126,9 @@ Errors display if you attempt to uninstall a module with a dependency on another
 
 To restore the Magento codebase to the state at which you backed it up, use the following command:
 
-	magento setup:rollback [-c|--code-file="<filename>"] [-m|--media-file="<filename>"] [-d|--db-file="<filename>"]
+```bash
+magento setup:rollback [-c|--code-file="<filename>"] [-m|--media-file="<filename>"] [-d|--db-file="<filename>"]
+```
 
 where `<filename>` is the name of the backup file located in `<magento_root>/var/backups`. To display a list of backup files, enter `magento info:backups:list`
 
@@ -158,20 +168,26 @@ For example, to restore a code (that is, file system) backup, enter the followin
 
 *	Display a list of backups:
 
-		magento info:backups:list
+    ```bash
+    magento info:backups:list
+    ```
 
 *	Restore a file backup named `1433876616_filesystem.tgz`:
 
-		magento setup:rollback --code-file="1433876616_filesystem.tgz"
+    ```bash
+    magento setup:rollback --code-file="1433876616_filesystem.tgz"
+    ```
 
-	Messages similar to the following display:
+    Messages similar to the following display:
 
-		Enabling maintenance mode
-		Code rollback is starting ...
-		Code rollback filename: 1433876616_filesystem.tgz
-		Code rollback file path: /var/www/html/magento2/var/backups/1433876616_filesystem.tgz
-		[SUCCESS]: Code rollback has completed successfully.
-		Disabling maintenance mode
+    ```terminal
+    Enabling maintenance mode
+    Code rollback is starting ...
+    Code rollback filename: 1433876616_filesystem.tgz
+    Code rollback file path: /var/www/html/magento2/var/backups/1433876616_filesystem.tgz
+    [SUCCESS]: Code rollback has completed successfully.
+    Disabling maintenance mode
+    ```
 
 {:.bs-callout .bs-callout-info}
 To run the `magento` command again without changing directories, you might need to enter `cd pwd`.

--- a/guides/v2.2/install-gde/install/legacy-file-system-perms.md
+++ b/guides/v2.2/install-gde/install/legacy-file-system-perms.md
@@ -36,9 +36,11 @@ In developer mode, Magento sets permissions as follows:
 
 Changing modes affects permissions and ownership the following subdirectories in your Magento installation:
 
-	var/view_preprocessed
-	var/generation
-	var/di
+```text
+var/view_preprocessed
+var/generation
+var/di
+```
 
 When you change to production mode, we set the following permissions on these directories and subdirectories:
 
@@ -56,28 +58,36 @@ Use the following steps:
 1.	If you haven't already done so, log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 2.	Change to the Magento installation directory:
 
-		cd <web server docroot>/<magento2 base dir>
+    ```bash
+    cd <web server docroot>/<magento2 base dir>
+    ```
 
-	The base directory is typically a subdirectory named `magento2` under your web server's docroot. Need help locating the docroot? Click [here]({{ page.baseurl }}/install-gde/basics/basics_docroot.html).<br>
+    The base directory is typically a subdirectory named `magento2` under your web server's docroot. Need help locating the docroot? Click [here]({{ page.baseurl }}/install-gde/basics/basics_docroot.html).<br>
 
-	Examples:
+    Examples:
 
-	*	Ubuntu: `/var/www/magento2`
-	*	CentOS: `/var/www/html/magento2`
+    *	Ubuntu: `/var/www/magento2`
+    *	CentOS: `/var/www/html/magento2`
 
 2.	Set ownership:
 
-		chown -R :<your web server group name> .
+    ```bash
+    chown -R :<your web server group name> .
+    ```
 
-	Typical examples:
+    Typical examples:
 
-	*	CentOS: `chown -R :apache .`
-	*	Ubuntu: `chown -R :www-data .`
+    *	CentOS: `chown -R :apache .`
+    *	Ubuntu: `chown -R :www-data .`
 
 3.	Set permissions:
 
-		find . -type d -exec chmod 770 {} + && find . -type f -exec chmod 660 {} + && chmod u+x bin/magento
+    ```bash
+    find . -type d -exec chmod 770 {} + && find . -type f -exec chmod 660 {} + && chmod u+x bin/magento
+    ```
 
-	If you must enter the commands as `sudo`, use:
+    If you must enter the commands as `sudo`, use:
 
-		sudo find . -type d -exec chmod 770 {} + && sudo find . -type f -exec chmod 660 {} + && sudo chmod u+x bin/magento
+    ```bash
+    sudo find . -type d -exec chmod 770 {} + && sudo find . -type f -exec chmod 660 {} + && sudo chmod u+x bin/magento
+    ```

--- a/guides/v2.2/install-gde/prereq/apache.md
+++ b/guides/v2.2/install-gde/prereq/apache.md
@@ -44,12 +44,16 @@ Failure to enable these settings typically results in no styles displaying on yo
 
 To verify the Apache version you're currently running, enter:
 
-	apache2 -v
+```bash
+apache2 -v
+```
 
 The result displays similar to the following:
 
-	Server version: Apache/2.2.22 (Ubuntu)
-	Server built: Jul 22 2014 14:35:32
+```terminal
+Server version: Apache/2.2.22 (Ubuntu)
+Server built: Jul 22 2014 14:35:32
+```
 
 *	If Apache is *not* installed, see:
 	*	[Installing or upgrading Apache on Ubuntu](#install-prereq-apache-ubuntu)
@@ -69,16 +73,22 @@ To install the default version of Apache (Ubuntu 14, 16&mdash;Apache 2.4, Ubuntu
 
 1.	Install Apache
 
-		apt-get -y install apache2
+    ```bash
+    apt-get -y install apache2
+    ```
 
 2.	Verify the installation.
 
-		apache2 -v
+    ```bash
+    apache2 -v
+    ```
 
-	The result displays similar to the following:
+    The result displays similar to the following:
 
-		Server version: Apache/2.4.18 (Ubuntu)
-		Server built: 2016-04-15T18:00:57
+    ```terminal
+    Server version: Apache/2.4.18 (Ubuntu)
+    Server built: 2016-04-15T18:00:57
+    ```
 
 3.	Enable rewrites and `.htaccess` as discussed in the following sections.
 
@@ -106,25 +116,39 @@ To upgrade to Apache 2.4:
 
 1.	Add the `ppa:ondrej` repository, which has Apache 2.4:
 
-		apt-get -y update
-		apt-add-repository ppa:ondrej/apache2
-		apt-get -y update
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-add-repository ppa:ondrej/apache2
+    ```
+
+    ```bash
+    apt-get -y update
+    ```
 
 2.	Install Apache 2.4:
 
-		apt-get install -y apache2
+    ```bash
+    apt-get install -y apache2
+    ```
 
-{:.bs-callout .bs-callout-info}
-If the `apt-get install` command fails because of unmet dependencies, consult a resource like [http://askubuntu.com](http://askubuntu.com/questions/140246/how-do-i-resolve-unmet-dependencies-after-adding-a-ppa){:target="_blank"}.
+    {:.bs-callout .bs-callout-info}
+    If the `apt-get install` command fails because of unmet dependencies, consult a resource like [http://askubuntu.com](http://askubuntu.com/questions/140246/how-do-i-resolve-unmet-dependencies-after-adding-a-ppa){:target="_blank"}.
 
 3.	Verify the installation.
 
-		apache2 -v
+    ```bash
+    apache2 -v
+    ```
 
-	Messages similar to the following should display:
+    Messages similar to the following should display:
 
-		Server version: Apache/2.4.10 (Ubuntu)
-		Server built: Jul 22 2014 22:46:25
+    ```terminal
+    Server version: Apache/2.4.10 (Ubuntu)
+    Server built: Jul 22 2014 22:46:25
+    ```
 
 4.	Continue with the next section.
 
@@ -150,21 +174,27 @@ Installing and configuring Apache is basically a three-step process: install the
 
 1.	Install Apache 2 if you haven't already done so.
 
-		yum -y install httpd
+    ```bash
+    yum -y install httpd
+    ```
 
 2.	Verify the installation:
 
-		httpd -v
+    ```bash
+    httpd -v
+    ```
 
-	Messages similar to the following display to confirm the installation was successful:
+    Messages similar to the following display to confirm the installation was successful:
 
-		Server version: Apache/2.2.15 (Unix)
-		Server built: Oct 16 2014 14:48:21
+    ```terminal
+    Server version: Apache/2.2.15 (Unix)
+    Server built: Oct 16 2014 14:48:21
+    ```
 
 3.	Continue with the next section.
 
-{:.bs-callout .bs-callout-info}
-Even though Apache 2.4 is provided by default with CentOS 7, you configure it like Apache 2.2. See the following section.
+    {:.bs-callout .bs-callout-info}
+    Even though Apache 2.4 is provided by default with CentOS 7, you configure it like Apache 2.2. See the following section.
 
 ### Enable rewrites and .htaccess for Apache 2.2 (including CentOS 7)
 {% include install/allowoverrides22.md %}
@@ -191,12 +221,14 @@ To enable website visitors to access your site, use one of the [Require directiv
 
 For example:
 
-	<Directory /var/www/>
-		Options Indexes FollowSymLinks MultiViews
-		AllowOverride <value from Apache site>
-		Order allow,deny
-		Require all granted
-	</Directory>
+```conf
+<Directory /var/www/>
+  Options Indexes FollowSymLinks MultiViews
+  AllowOverride <value from Apache site>
+  Order allow,deny
+  Require all granted
+</Directory>
+```
 
 {:.bs-callout .bs-callout-info}
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order){:target="_blank"}.
@@ -207,12 +239,14 @@ To enable website visitors to access your site, use the [Allow directive](http:/
 
 For example:
 
-	<Directory /var/www/>
-		Options Indexes FollowSymLinks MultiViews
-		AllowOverride <value from Apache site>
-		Order allow,deny
-		Allow from all
-	</Directory>
+```conf
+<Directory /var/www/>
+  Options Indexes FollowSymLinks MultiViews
+  AllowOverride <value from Apache site>
+  Order allow,deny
+  Allow from all
+</Directory>
+```
 
 {:.bs-callout .bs-callout-info}
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order){:target="_blank"}.

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -51,35 +51,45 @@ To install MySQL 5.7 on Ubuntu 16:
 
 1.	Enter this command:
 
-		sudo apt install -y mysql-server mysql-client
+    ```bash
+    sudo apt install -y mysql-server mysql-client
+    ```
 
 2. Start MySQL:
 
-        sudo service mysql start
+    ```bash
+    sudo service mysql start
+    ```
 
 3.	Secure the installation:
 
-		sudo mysql_secure_installation
+    ```bash
+    sudo mysql_secure_installation
+    ```
 
 4.	Test the installation by entering the following command:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Sample output:
+    Sample output:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 45
-		Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 45
+    Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its
+    affiliates. Other names may be trademarks of their respective
+    owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -93,35 +103,45 @@ To install MySQL 5.6 on Ubuntu 14:
 
 1.	Enter this command:
 
-		apt-get -y install mysql-server-5.6 mysql-client-5.6
+    ```bash
+    apt-get -y install mysql-server-5.6 mysql-client-5.6
+    ```
 
 2. Start MySQL:
 
-        sudo service mysql start
+    ```bash
+    sudo service mysql start
+    ```
 
 3.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Test the installation by entering the following command:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Sample output:
+    Sample output:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 45
-		Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 45
+    Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its
+    affiliates. Other names may be trademarks of their respective
+    owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -135,38 +155,57 @@ To install MySQL 5.6 on Ubuntu 12, use the following instructions from [askubunt
 
 1.	Enter the following commands in the order shown:
 
-		apt-get -y update
-		apt-add-repository ppa:ondrej/mysql-5.6
-		apt-get -y update
-		apt-get -y install mysql-server
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-add-repository ppa:ondrej/mysql-5.6
+    ```
+
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-get -y install mysql-server
+    ```
 
 2. Start MySQL:
 
-        sudo service mysql start
+    ```bash
+    sudo service mysql start
+    ```
 
 3.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Test the installation by entering the following command:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Messages similar to the following display:
+    Messages similar to the following display:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 43
-		Server version: 5.6.21-1+deb.sury.org~precise+1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 43
+    Server version: 5.6.21-1+deb.sury.org~precise+1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its
+    affiliates. Other names may be trademarks of their respective
+    owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -187,8 +226,13 @@ The following procedure is based on [How to Install Latest MySQL 5.7.9 on RHEL/C
 
 As a user with `root` privileges, enter the following commands in the order shown:
 
-	wget http://dev.mysql.com/get/mysql57-community-release-el7-7.noarch.rpm
-	yum -y localinstall mysql57-community-release-el7-7.noarch.rpm
+```bash
+wget http://dev.mysql.com/get/mysql57-community-release-el7-7.noarch.rpm
+```
+
+```bash
+yum -y localinstall mysql57-community-release-el7-7.noarch.rpm
+```
 
 Continue with [Install and configure MySQL 5.7 on CentOS 6 or 7](#mysql57-centos-config).
 
@@ -198,8 +242,13 @@ The following procedure is based on [How to Install Latest MySQL 5.7.9 on RHEL/C
 
 As a user with `root` privileges, enter the following commands in the order shown:
 
-	wget http://dev.mysql.com/get/mysql57-community-release-el6-7.noarch.rpm
-	yum -y localinstall mysql57-community-release-el6-7.noarch.rpm
+```bash
+wget http://dev.mysql.com/get/mysql57-community-release-el6-7.noarch.rpm
+```
+
+```bash
+yum -y localinstall mysql57-community-release-el6-7.noarch.rpm
+```
 
 Continue with the next section.
 
@@ -207,25 +256,40 @@ Continue with the next section.
 
 1.	Enter the following commands in the order shown:
 
-		yum -y install mysql-community-server
-		service mysqld start
+    ```bash
+    yum -y install mysql-community-server
+    ```
+
+    ```bash
+    service mysqld start
+    ```
 
 2.	Verify the version:
 
-		mysql --version
+    ```bash
+    mysql --version
+    ```
 
-	Sample output follows:
+    Sample output follows:
 
-		mysql  Ver 14.14 Distrib 5.7.12, for Linux (x86_64) using  EditLine wrapper
+    ```terminal
+    mysql  Ver 14.14 Distrib 5.7.12, for Linux (x86_64) using  EditLine wrapper
+    ```
 
 3.	Get the temporary database `root` user password:
 
-		grep 'temporary password' /var/log/mysqld.log
+    ```bash
+    grep 'temporary password' /var/log/mysqld.log
+    ```
+
 4.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
-	Follow the prompts on your screen to set a new password and configure other options.
+    Follow the prompts on your screen to set a new password and configure other options.
+
 5.	Configure MySQL 5.7 as discussed in [Configuring the Magento database instance](#instgde-prereq-mysql-config).
 
 ## Installing and configuring MySQL 5.6 on CentOS {#instgde-prereq-mysql-centos}
@@ -234,41 +298,65 @@ The following procedure is based on [Install MySQL Server 5.6 in CentOS 6.x and 
 
 1.	*CentOS 6* Install the MySQL database:
 
-		yum -y update
-		sudo wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el6-5.noarch.rpm
-		sudo yum -y install mysql-server
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    sudo wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el6-5.noarch.rpm
+    ```
+
+    ```bash
+    sudo yum -y install mysql-server
+    ```
 
 2.	*CentOS 7* Install the MySQL database:
 
-		yum -y update
-		sudo wget http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el7-5.noarch.rpm
-		sudo yum -y install mysql-server
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    sudo wget http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el7-5.noarch.rpm
+    ```
+
+    ```bash
+    sudo yum -y install mysql-server
+    ```
 
 2.	Start MySQL:
 
-		service mysqld start
+    ```bash
+    service mysqld start
+    ```
 
 3.	Set a password for the <tt>root</tt> user and set other security-related options. Enter the following command and follow the prompts on your screen to complete the configuration:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Verify the MySQL server version:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Messages similar to the following display:
+    Messages similar to the following display:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 15
-		Server version: 5.6.23 MySQL Community Server (GPL)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 15
+    Server version: 5.6.23 MySQL Community Server (GPL)
 
-		Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its
+    affiliates. Other names may be trademarks of their respective
+    owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can configure MySQL to use the [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} parameter. We recommend a value of at least 16MB.
 
@@ -285,21 +373,36 @@ To configure a MySQL database instance:
 1.	Log in to your database server as any user.
 2.	Get to a MySQL command prompt:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
 3.	Enter the MySQL `root` user's password when prompted.
 4.	Enter the following commands in the order shown to create a database instance named `magento` with username `magento`:
 
-		create database magento;
-		create user magento IDENTIFIED BY 'magento';
-		GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';
-		flush privileges;
+    ```shell
+    create database magento;
+    ```
+
+    ```shell
+    create user magento IDENTIFIED BY 'magento';
+    ```
+
+    ```shell
+    GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';
+    ```
+
+    ```shell
+    flush privileges;
+    ```
 
 5.	Enter `exit` to quit the command prompt.
 
 6.	Verify the database:
 
-		mysql -u magento -p
+    ```bash
+    mysql -u magento -p
+    ```
 
 	If the MySQL monitor displays, you created the database properly. If an error displays, repeat the preceding commands.
 

--- a/guides/v2.2/install-gde/prereq/mysql_remote.md
+++ b/guides/v2.2/install-gde/prereq/mysql_remote.md
@@ -44,37 +44,42 @@ To create a remote connection:
 
 1.	On your database server, as a user with `root` privileges, open your MySQL configuration file.
 
-	To locate it, enter the following command:
+    To locate it, enter the following command:
 
-		mysql --help
+    ```bash
+    mysql --help
+    ```
 
-	The location displays similar to the following:
+    The location displays similar to the following:
 
-		Default options are read from the following files in the given order:
-		/etc/my.cnf /etc/mysql/my.cnf /usr/etc/my.cnf ~/.my.cnf
+    ```terminal
+    Default options are read from the following files in the given order:
+    /etc/my.cnf /etc/mysql/my.cnf /usr/etc/my.cnf ~/.my.cnf
+    ```
 
-	{:.bs-callout .bs-callout-info}
-  		On Ubuntu 16, the path is typically `/etc/mysql/mysql.conf.d/mysqld.cnf`.
+    {:.bs-callout .bs-callout-info}
+    On Ubuntu 16, the path is typically `/etc/mysql/mysql.conf.d/mysqld.cnf`.
 
 3.	Search the configuration file for `bind-address`.
 
-	If it exists, change the value as follows.
+    If it exists, change the value as follows.
 
-	If it doesn't exist, add it anywhere except the `[mysqld]` section.
+    If it doesn't exist, add it anywhere except the `[mysqld]` section.
 
-		bind-address = <ip address of your Magento web node>
+    ```conf
+    bind-address = <ip address of your Magento web node>
+    ```
 
-	See [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html), especially if you have a clustered web server.
+    See [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html), especially if you have a clustered web server.
 
 3.	Save your changes to the configuration file and exit the text editor.
 4.	Restart the MySQL service:
 
-	CentOS: `service mysqld restart`
+    * CentOS: `service mysqld restart`
+    * Ubuntu: `service mysql restart`
 
-	Ubuntu: `service mysql restart`
-
-{:.bs-callout .bs-callout-info}
-  	If MySQL fails to start, look in syslog for the source of the issue. Resolve the issue using [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_bind-address) or another authoritative source.
+    {:.bs-callout .bs-callout-info}
+    If MySQL fails to start, look in syslog for the source of the issue. Resolve the issue using [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_bind-address) or another authoritative source.
 
 ## Grant access to a database user {#instgde-prereq-mysql-remote-access}
 
@@ -88,34 +93,42 @@ To grant access to a database user:
 2.	Connect to the MySQL database as the `root` user.
 3.	Enter the following command:
 
-		GRANT ALL ON <local database name>.* TO <remote web node username>@<remote web node server ip address> IDENTIFIED BY '<database user password>';
+    ```shell
+    GRANT ALL ON <local database name>.* TO <remote web node username>@<remote web node server ip address> IDENTIFIED BY '<database user password>';
+    ```
 
-	For example,
+    For example,
 
-		GRANT ALL ON magento_remote.* TO dbuser@192.0.2.50 IDENTIFIED BY 'dbuserpassword';
+    ```shell
+    GRANT ALL ON magento_remote.* TO dbuser@192.0.2.50 IDENTIFIED BY 'dbuserpassword';
+    ```
 
-{:.bs-callout .bs-callout-info}
-  If your web server is clustered, enter the same command on every web server. You must use the same username for every web server.
+    {:.bs-callout .bs-callout-info}
+    If your web server is clustered, enter the same command on every web server. You must use the same username for every web server.
 
 ## Verify database access {#instgde-prereq-mysql-remote-verify}
 
 On your web node host, enter the following command to verify the connection works:
 
-	mysql -u <local database username> -h <database server ip address> -p
+```bash
+mysql -u <local database username> -h <database server ip address> -p
+```
 
 If the MySQL monitor displays as follows, the database is ready for the Magento software:
 
-	Welcome to the MySQL monitor.  Commands end with ; or \g.
-	Your MySQL connection id is 213
-	Server version: 5.6.26 MySQL Community Server (GPL)
+```terminal
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 213
+Server version: 5.6.26 MySQL Community Server (GPL)
 
-	Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
 
-	Oracle is a registered trademark of Oracle Corporation and/or its
-	affiliates. Other names may be trademarks of their respective
-	owners.
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
 
-	Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+```
 
 If your web server is clustered, enter the command on each web server host.
 

--- a/guides/v2.2/install-gde/prereq/nginx.md
+++ b/guides/v2.2/install-gde/prereq/nginx.md
@@ -32,7 +32,9 @@ The following section describes how to install Magento 2.x on Ubuntu 16 using ng
 
 ### Install nginx
 
-	apt-get -y install nginx
+```bash
+apt-get -y install nginx
+```
 
 After completing the following sections and [installing Magento]({{ page.baseurl }}/install-gde/prereq/nginx.html#install-magento2-ubuntu), we'll use a sample configuration file to [configure nginx]({{ page.baseurl }}/install-gde/prereq/nginx.html#configure-nginx-ubuntu).
 
@@ -44,21 +46,30 @@ To install and configure `php-fpm`:
 
 1. Install `php-fpm` and `php-cli`:
 
-		apt-get -y install php7.0-fpm php7.0-cli
+    ```bash
+    apt-get -y install php7.0-fpm php7.0-cli
+    ```
 
-   {:.bs-callout .bs-callout-info}
-   This command installs the latest available version of PHP 7.0.X. See [Magento 2.2.x technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for supported PHP versions.
+    {:.bs-callout .bs-callout-info}
+    This command installs the latest available version of PHP 7.0.X. See [Magento 2.2.x technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for supported PHP versions.
 
 2. Open the `php.ini` files in an editor:
 
-		vim /etc/php/7.0/fpm/php.ini
-		vim /etc/php/7.0/cli/php.ini
+    ```bash
+    vim /etc/php/7.0/fpm/php.ini
+    ```
+
+    ```bash
+    vim /etc/php/7.0/cli/php.ini
+    ```
 
 3. Edit both files to match the following lines:
 
-		memory_limit = 2G
-		max_execution_time = 1800
-		zlib.output_compression = On
+    ```conf
+    memory_limit = 2G
+    max_execution_time = 1800
+    zlib.output_compression = On
+    ```
 
     {:.bs-callout .bs-callout-info}
     We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
@@ -67,7 +78,9 @@ To install and configure `php-fpm`:
 
 5. Restart the `php-fpm` service:
 
-		systemctl restart php7.0-fpm
+    ```bash
+    systemctl restart php7.0-fpm
+    ```
 
 ### Install and configure MySQL
 
@@ -92,20 +105,26 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1.  Change to the web server docroot directory or a directory that you have configured as a virtual host docroot. For this example, we're using the Ubuntu default `/var/www/html`.
 
-		cd /var/www/html
+    ```bash
+    cd /var/www/html
+    ```
 
 1.  Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-		curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```bash
+    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```
 
 1. Create a new Composer project using the {{site.data.var.ce}} or {{site.data.var.ee}} metapackage.
 
     **{{site.data.var.ce}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
     ```
 
     **{{site.data.var.ee}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
     ```
@@ -114,11 +133,23 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Set read-write permissions for the web server group before you install the Magento software. This is necessary so that the Setup Wizard and command line can write files to the Magento file system.
 
-    ```terminal
+    ```bash
     cd /var/www/html/<magento install directory>
+    ```
+
+    ```bash
     find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    ```
+
+    ```bash
     find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+    ```
+
+    ```bash
     chown -R :www-data . # Ubuntu
+    ```
+
+    ```bsah
     chmod u+x bin/magento
     ```
 
@@ -145,8 +176,13 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Switch to developer mode:
 
-		cd /var/www/html/magento2/bin
+    ```bash
+    cd /var/www/html/magento2/bin
+    ```
+
+    ```bash
     ./magento deploy:mode:set developer
+    ```
 
 ### Configure nginx {#configure-nginx-ubuntu}
 
@@ -156,21 +192,25 @@ These instructions assume you're using the Ubuntu default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-		vim /etc/nginx/sites-available/magento
+    ```bash
+    vim /etc/nginx/sites-available/magento
+    ```
 
 2. Add the following configuration:
 
-		upstream fastcgi_backend {
-			server unix:/run/php/php7.0-fpm.sock;
-		}
+    ```conf
+    upstream fastcgi_backend {
+      server unix:/run/php/php7.0-fpm.sock;
+    }
 
-		server {
+    server {
 
-			listen 80;
-			server_name www.magento-dev.com;
-			set $MAGE_ROOT /var/www/html/magento2;
-			include /var/www/html/magento2/nginx.conf.sample;
-		}
+      listen 80;
+      server_name www.magento-dev.com;
+      set $MAGE_ROOT /var/www/html/magento2;
+      include /var/www/html/magento2/nginx.conf.sample;
+    }
+    ```
 
     {:.bs-callout .bs-callout-info}
     The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -181,15 +221,21 @@ These instructions assume you're using the Ubuntu default location for the nginx
 
 5. Activate the newly created virtual host by creating a symlink to it in the `/etc/nginx/sites-enabled` directory:
 
-		ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
+    ```bash
+    ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
+    ```
 
 6. Verify that the syntax is correct:
 
-		nginx -t
+    ```bash
+    nginx -t
+    ```
 
 7. Restart nginx:
 
-		systemctl restart nginx
+    ```bash
+    systemctl restart nginx
+    ```
 
 ### Verify the installation
 
@@ -201,13 +247,23 @@ The following section describes how to install Magento 2.x on CentOS 7 using ngi
 
 ### Install nginx
 
-	yum -y install epel-release
-	yum -y install nginx
+```bash
+yum -y install epel-release
+```
+
+```bash
+yum -y install nginx
+```
 
 After installation is complete, start nginx and configure it to start at boot time:
 
-	systemctl start nginx
-	systemctl enable nginx
+```bash
+systemctl start nginx
+```
+
+```bash
+systemctl enable nginx
+```
 
 After completing the following sections and [installing Magento]({{ page.baseurl }}/install-gde/prereq/nginx.html#install-magento2-centos), we'll use a sample configuration file to [configure nginx]({{ page.baseurl }}/install-gde/prereq/nginx.html#configure-nginx-centos).
 
@@ -217,7 +273,9 @@ Magento requires several [PHP extensions]({{ page.baseurl }}/install-gde/prereq/
 
 1. Install `php-fpm`:
 
-		yum -y install php70w-fpm
+    ```bash
+    yum -y install php70w-fpm
+    ```
 
 2. Open the `/etc/php.ini` file in an editor.
 
@@ -225,16 +283,20 @@ Magento requires several [PHP extensions]({{ page.baseurl }}/install-gde/prereq/
 
 4. Edit the file to match the following lines:
 
-		memory_limit = 2G
-		max_execution_time = 1800
-		zlib.output_compression = On
+    ```conf
+    memory_limit = 2G
+    max_execution_time = 1800
+    zlib.output_compression = On
+    ```
 
     {:.bs-callout .bs-callout-info}
     We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
 
 5. Uncomment the session path directory and set the path:
 
-		session.save_path = "/var/lib/php/session"
+    ```conf
+    session.save_path = "/var/lib/php/session"
+    ```
 
 6. Save and exit the editor.
 
@@ -242,41 +304,62 @@ Magento requires several [PHP extensions]({{ page.baseurl }}/install-gde/prereq/
 
 8. Edit the file to match the following lines:
 
-		user = nginx
-		group = nginx
-		listen = /run/php-fpm/php-fpm.sock
-		listen.owner = nginx
-		listen.group = nginx
-		listen.mode = 0660
+    ```conf
+    user = nginx
+    group = nginx
+    listen = /run/php-fpm/php-fpm.sock
+    listen.owner = nginx
+    listen.group = nginx
+    listen.mode = 0660
+    ```
 
 9. Uncomment the environment lines:
 
-		env[HOSTNAME] = $HOSTNAME
-		env[PATH] = /usr/local/bin:/usr/bin:/bin
-		env[TMP] = /tmp
-		env[TMPDIR] = /tmp
-		env[TEMP] = /tmp
+    ```conf
+    env[HOSTNAME] = $HOSTNAME
+    env[PATH] = /usr/local/bin:/usr/bin:/bin
+    env[TMP] = /tmp
+    env[TMPDIR] = /tmp
+    env[TEMP] = /tmp
+    ```
 
 10. Save and exit the editor.
 
 11. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-		mkdir -p /var/lib/php/session/
-		chown -R apache:apache /var/lib/php/
+    ```bash
+    mkdir -p /var/lib/php/session/
+    ```
+
+    ```bash
+    chown -R apache:apache /var/lib/php/
+    ```
 
 12. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-		mkdir -p /run/php-fpm/
-		chown -R apache:apache /run/php-fpm/
+    ```bash
+    mkdir -p /run/php-fpm/
+    ```
+
+    ```bash
+    chown -R apache:apache /run/php-fpm/
+    ```
 
 13. Start the `php-fpm` service and configure it to start at boot time:
 
-		systemctl start php-fpm
-		systemctl enable php-fpm
+    ```bash
+    systemctl start php-fpm
+    ```
+
+    ```bash
+    systemctl enable php-fpm
+    ```
 
 14. Verify that the `php-fpm` service is running:
 
-		netstat -pl | grep php-fpm.sock
+    ```bash
+    netstat -pl | grep php-fpm.sock
+    ```
 
 ### Install and configure MySQL
 
@@ -296,41 +379,76 @@ For this example, we'll download and extract an archive.
 
 1. Change to the web server docroot directory, or to a directory you’ve configured as a virtual host docroot. For this example, we're using the CentoOS default `/usr/share/nginx/html`.
 
-		cd /usr/share/nginx/html
+    ```bash
+    cd /usr/share/nginx/html
+    ```
 
 2. Download the Magento archive, extract it, and rename the folder `magento2/`:
 
-		wget https://github.com/magento/magento2/archive/2.2.tar.gz
-		tar -xzvf 2.2.tar.gz
-		mv magento2-2.2/ magento2/
+    ```bash
+    wget https://github.com/magento/magento2/archive/2.2.tar.gz
+    ```
+
+    ```bash
+    tar -xzvf 2.2.tar.gz
+    ```
+
+    ```bash
+    mv magento2-2.2/ magento2/
+    ```
 
 3. [Set directory ownership and file permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 
-		cd /usr/share/nginx/html/magento2
-		find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
-		find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
-		chown -R :apache .
-		chmod u+x bin/magento
+    ```bash
+    cd /usr/share/nginx/html/magento2
+    ```
+
+    ```bash
+    find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+    ```
+
+    ```bashfind var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+    ```
+
+    ```bash
+    chown -R :apache .
+    ```
+
+    ```bash
+    chmod u+x bin/magento
+    ```
 
 4. Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-		curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```bash
+    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```
 
 5. Update Magento dependencies:
 
-		cd /usr/share/nginx/html/magento2
-		composer install
+    ```bash
+    cd /usr/share/nginx/html/magento2
+    ```
+
+    ```bash
+    composer install
+    ```
 
 6. If prompted, enter your [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html).
 
 7. Install Magento from the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html).
 
-		cd /usr/share/nginx/html/magento2/bin
-		./magento setup:install --base-url=http://www.magento-dev.com/ \
-		--db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
-		--admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
-		--admin-user=admin --admin-password=admin123 --language=en_US \
-		--currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```bash
+    cd /usr/share/nginx/html/magento2/bin
+    ```
+
+    ```bash
+    ./magento setup:install --base-url=http://www.magento-dev.com/ \
+    --db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
+    --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
+    --admin-user=admin --admin-password=admin123 --language=en_US \
+    --currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```
 
     Replace `http://www.magento-dev.com` with your domain name.
 
@@ -339,8 +457,13 @@ For this example, we'll download and extract an archive.
 
 8. Switch Magento to developer mode:
 
-		cd /usr/share/nginx/html/magento2/bin
-		./magento deploy:mode:set developer
+    ```bash
+    cd /usr/share/nginx/html/magento2/bin
+    ```
+
+    ```bash
+    ./magento deploy:mode:set developer
+    ```
 
 ### Configure nginx {#configure-nginx-centos}
 
@@ -350,21 +473,25 @@ These instructions assume you're using the CentOS default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-		vim /etc/nginx/conf.d/magento.conf
+    ```bash
+    vim /etc/nginx/conf.d/magento.conf
+    ```
 
 2. Add the following configuration:
 
-		upstream fastcgi_backend {
-			server unix:/run/php-fpm/php-fpm.sock;
-		}
+    ```conf
+    upstream fastcgi_backend {
+      server unix:/run/php-fpm/php-fpm.sock;
+    }
 
-		server {
+    server {
 
-			listen 80;
-			server_name www.magento-dev.com;
-			set $MAGE_ROOT /usr/share/nginx/html/magento2;
-			include /usr/share/nginx/html/magento2/nginx.conf.sample;
-		}
+      listen 80;
+      server_name www.magento-dev.com;
+      set $MAGE_ROOT /usr/share/nginx/html/magento2;
+      include /usr/share/nginx/html/magento2/nginx.conf.sample;
+    }
+    ```
 
     {:.bs-callout .bs-callout-info}
     The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -375,46 +502,83 @@ These instructions assume you're using the CentOS default location for the nginx
 
 5. Verify that the syntax is correct:
 
-		nginx -t
+    ```bash
+    nginx -t
+    ```
 
 6. Restart nginx:
 
-		systemctl restart nginx
+    ```bash
+    systemctl restart nginx
+    ```
 
 ### Configure SELinux and Firewalld
 
 SELinux is enabled by default on CentOS 7. Use the following command to see if it's running:
 
-	sestatus
+```bash
+sestatus
+```
 
 To configure SELinux and firewalld:
 
 1. Install SELinux management tools:
 
-		yum -y install policycoreutils-python
+    ```bash
+    yum -y install policycoreutils-python
+    ```
 
 2. Run the following commands to change the security context for the Magento installation directory:
 
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
+    ```
+
+    ```bash
 		restorecon -Rv '/usr/share/nginx/html/magento2/'
+    ```
 
 3. Install the firewalld package:
 
-		yum -y install firewalld
+    ```bash
+    yum -y install firewalld
+    ```
 
 4. Start the firewall service and configure it to start at boot time:
 
-		systemctl start firewalld
-		systemctl enable firewalld
+    ```bash
+    systemctl start firewalld
+    ```
+
+    ```bash
+    systemctl enable firewalld
+    ```
 
 5. Run the following commands to open ports for HTTP and HTTPS so you can access the Magento base URL from a web browser:
 
-		firewall-cmd --permanent --add-service=http
-		firewall-cmd --permanent --add-service=https
-		firewall-cmd --reload
+    ```bash
+    firewall-cmd --permanent --add-service=http
+    ```
+
+    ```bash
+    firewall-cmd --permanent --add-service=https
+    ```
+
+    ```bash
+    firewall-cmd --reload
+    ```
 
 ### Verify the installation
 

--- a/guides/v2.2/install-gde/prereq/nginx.md
+++ b/guides/v2.2/install-gde/prereq/nginx.md
@@ -407,7 +407,8 @@ For this example, we'll download and extract an archive.
     find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
     ```
 
-    ```bashfind var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+    ```bash
+    find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
     ```
 
     ```bash

--- a/guides/v2.2/install-gde/prereq/optional.md
+++ b/guides/v2.2/install-gde/prereq/optional.md
@@ -31,7 +31,9 @@ See one of the following sections:
 
 Enter the following command to install NTP:
 
-	apt-get install ntp
+```bash
+apt-get install ntp
+```
 
 Continue with [Use NTP pool servers](#install-optional-ntp-servers)
 
@@ -41,17 +43,23 @@ To install and configure NTP:
 
 1.	Enter the following command to find the appropriate NTP software:
 
-		yum search ntp
+    ```bash
+    yum search ntp
+    ```
 
 2.	Select a package to install. For example, `ntp.x86_64`.
 
 2.	Install the package.
 
-		yum -y install ntp.x86_64
+    ```bash
+    yum -y install ntp.x86_64
+    ```
 
 3.	Enter the following command so that NTP starts when the server starts.
 
-		chkconfig ntpd on
+    ```bash
+    chkconfig ntpd on
+    ```
 
 3.	Continue with the next section.
 
@@ -63,33 +71,37 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
 
 2.	Look for lines similar to the following:
 
-		server 0.centos.pool.ntp.org
-		server 1.centos.pool.ntp.org
-		server 2.centos.pool.ntp.org
+    ```conf
+    server 0.centos.pool.ntp.org
+    server 1.centos.pool.ntp.org
+    server 2.centos.pool.ntp.org
+    ```
 
 3.	Replace those lines or add additional lines that specify your NTP pool server or other NTP servers. It's a good idea to specify more than one.
 
 4.	An example of using three United States-based NTP servers follows:
 
-		server 0.us.pool.ntp.org
-		server 1.us.pool.ntp.org
-		server 2.us.pool.ntp.org
+    ```conf
+    server 0.us.pool.ntp.org
+    server 1.us.pool.ntp.org
+    server 2.us.pool.ntp.org
+    ```
 
 5.	Save your changes to `/etc/ntp.conf` and exit the text editor.
 
 4.	Restart the service.
 
-	Ubuntu: `service ntp restart`
+    * Ubuntu: `service ntp restart`
 
-	CentOS: `service ntpd restart`
+    * CentOS: `service ntpd restart`
 
 4.	Enter `date` to check the server's date.
 
-	If the date is incorrect, make sure the NTP client port (typically, UDP 123) is open in your firewall.
+    If the date is incorrect, make sure the NTP client port (typically, UDP 123) is open in your firewall.
 
-	Try the `ntpdate _[pool server hostname]_` command. If it fails, search for the error it returns.
+    Try the `ntpdate _[pool server hostname]_` command. If it fails, search for the error it returns.
 
-	If all else fails, try rebooting the server.
+    If all else fails, try rebooting the server.
 
 ## Create phpinfo.php {#install-optional-phpinfo}
 [`phpinfo.php`](http://php.net/manual/en/function.phpinfo.php){:target="_blank"} displays a large amount of information about [PHP](https://glossary.magento.com/php) and its extensions.
@@ -99,15 +111,19 @@ Use `phpinfo.php` in a development system _only_. It can be a security issue in 
 
 Add the following code anywhere in your web server's docroot:
 
-	<?php
-	// Show all information, defaults to INFO_ALL
-	phpinfo();
+```php
+<?php
+// Show all information, defaults to INFO_ALL
+phpinfo();
+```
 
 For more information, see the [phpinfo manual page](http://php.net/manual/en/function.phpinfo.php){:target="_blank"}.
 
 To view the results, enter the following [URL](https://glossary.magento.com/url) in your browser's location or address field:
 
-	http://<web server host or IP>/phpinfo.php
+```http
+http://<web server host or IP>/phpinfo.php
+```
 
 If a 404 (Not Found) error displays, check the following:
 
@@ -134,13 +150,17 @@ To install phpmyadmin on Ubuntu:
 
 1.	Use the following command:
 
-		apt-get install phpmyadmin
+    ```bash
+    apt-get install phpmyadmin
+    ```
 
 2.	Follow the prompts on your screen to complete the installation.
 
 3.	To use phpmyadmin, enter the following URL in your browser's address or location field:
 
-		http://<web server host or IP>/phpmyadmin
+    ```http
+    http://<web server host or IP>/phpmyadmin
+    ```
 
 4.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
@@ -150,45 +170,69 @@ To install phpmyadmin on CentOS:
 
 1.	Download the epel RPM for the version of CentOS you're using. A sample follows.
 
-		cd /tmp
-		wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
-		rpm -ivh epel-release-6-8.noarch.rpm
+    ```bash
+    cd /tmp
+    ```
+
+    ```bash
+    wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+    ```
+
+    ```bash
+    rpm -ivh epel-release-6-8.noarch.rpm
+    ```
 
 2.	Install `phpmyadmin` as follows:
 
-		yum -y install phpmyadmin
+    ```bash
+    yum -y install phpmyadmin
+    ```
 
 3.	Authorize access to phpmyadmin from your machine's IP address.
 
-	Open the following file for editing:
+    Open the following file for editing:
 
-		vim /etc/httpd/conf.d/phpMyAdmin.conf
+    ```bash
+    vim /etc/httpd/conf.d/phpMyAdmin.conf
+    ```
 
 3.	Replace the following IP address with your IP address
 
-		Require ip localhost
+    ```conf
+    Require ip localhost
+    ```
 
-	For example,
+    For example,
 
-		Require ip 192.51.100.101
+    ```conf
+    Require ip 192.51.100.101
+    ```
 
 4.	Replace the following IP with your IP address:
 
-		Allow from localhost
+    ```conf
+    Allow from localhost
+    ```
 
-	For example,
+    For example,
 
-		Allow from 192.51.100.101
+    ```conf
+    Allow from 192.51.100.101
+    ```
 
 5.	Save your changes to `/etc/httpd/conf.d/phpMyAdmin.conf` and exit the text editor.
 
 6.	Restart Apache.
 
-		service httpd Restart
+    ```bash
+    service httpd Restart
+    ```
 
 7.	To use phpmyadmin, enter the following command in your browser's address or location field:
 
-		http://<web server host or IP>/phpmyadmin
+    ```http
+    http://<web server host or IP>/phpmyadmin
+    ```
 
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 

--- a/guides/v2.2/install-gde/prereq/php-centos.md
+++ b/guides/v2.2/install-gde/prereq/php-centos.md
@@ -74,44 +74,77 @@ There is more than one way to install PHP 7.0 on CentOS; the following is a sugg
 
 1.	*CentOS 6*. Enter the following commands in the order shown:
 
-		yum -y update
-		yum -y install epel-release
-		wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-		wget https://centos6.iuscommunity.org/ius-release.rpm
-		rpm -Uvh ius-release*.rpm
-		yum -y update
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    yum -y install epel-release
+    ```
+
+    ```bash
+    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+    ```
+
+    ```bash
+    wget https://centos6.iuscommunity.org/ius-release.rpm
+    ```
+
+    ```bash
+    rpm -Uvh ius-release*.rpm
+    ```
+
+    ```bash
+    yum -y update
+    ```
+
 2.	*CentOS 7*. Enter the following commands:
 
-		yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm
-		yum -y update
+    ```bash
+    yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm
+    ```
+
+    ```bash
+    yum -y update
+    ```
+
 3.	Install all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions):
 
-		yum -y install php70u php70u-pdo php70u-mysqlnd php70u-opcache php70u-xml php70u-mcrypt php70u-gd php70u-devel php70u-mysql php70u-intl php70u-mbstring php70u-bcmath php70u-json php70u-iconv php70u-soap
+    ```bash
+    yum -y install php70u php70u-pdo php70u-mysqlnd php70u-opcache php70u-xml php70u-mcrypt php70u-gd php70u-devel php70u-mysql php70u-intl php70u-mbstring php70u-bcmath php70u-json php70u-iconv php70u-soap
+    ```
 
-	{:.bs-callout .bs-callout-info}
-  	The `bcmath` extension is required for {{site.data.var.ee}} only.
+    {:.bs-callout .bs-callout-info}
+    The `bcmath` extension is required for {{site.data.var.ee}} only.
 
 4.	Restart Apache: `service httpd restart`
 
 5.	Verify that PHP 7.0 is installed properly:
 
-		php -v
+    ```bash
+    php -v
+    ```
 
     The following response indicates that PHP 7.0.3 is installed:
 
-		PHP 7.0.3 (cli) (built: Feb 4 2016 08:51:10) ( NTS )
-		Copyright (c) 1997-2016 The PHP Group
-		Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
+    ```terminal
+    PHP 7.0.3 (cli) (built: Feb 4 2016 08:51:10) ( NTS )
+    Copyright (c) 1997-2016 The PHP Group
+    Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
+    ```
 
     {:.bs-callout .bs-callout-info}
     The preceding message confirms that the `Zend OPcache` is installed. We strongly recommend using the OPcache for performance reasons. If your PHP distribution does not come with the OPcache, see the [PHP OPcache documentation](http://php.net/manual/en/opcache.setup.php){:target="_blank"}.
 
 6.	Verify that all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions) were installed:
 
-		php -me
+    ```bash
+    php -me
+    ```
 
     You should see output similar to the following:
-    ```
+
+    ```terminal
     [PHP Modules]
     bcmath
     calendar
@@ -175,44 +208,77 @@ There is more than one way to install PHP 7.1 on CentOS; the following is a sugg
 
 1.	*CentOS 6*. Enter the following commands in the order shown:
 
-		yum -y update
-		yum -y install epel-release
-		wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-		wget https://centos6.iuscommunity.org/ius-release.rpm
-		rpm -Uvh ius-release*.rpm
-		yum -y update
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    yum -y install epel-release
+    ```
+
+    ```bash
+    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+    ```
+
+    ```bash
+    wget https://centos6.iuscommunity.org/ius-release.rpm
+    ```
+
+    ```bash
+    rpm -Uvh ius-release*.rpm
+    ```
+
+    ```bash
+    yum -y update
+    ```
+
 2.	*CentOS 7*. Enter the following commands:
 
-		yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm
-		yum -y update
+    ```bash
+    yum install -y http://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm
+    ```
+
+    ```bash
+    yum -y update
+    ```
+
 3.	Install all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions):
 
-		yum -y install php71u php71u-pdo php71u-mysqlnd php71u-opcache php71u-xml php71u-mcrypt php71u-gd php71u-devel php71u-mysql php71u-intl php71u-mbstring php71u-bcmath php71u-json php71u-iconv php71u-soap
+    ```bash
+    yum -y install php71u php71u-pdo php71u-mysqlnd php71u-opcache php71u-xml php71u-mcrypt php71u-gd php71u-devel php71u-mysql php71u-intl php71u-mbstring php71u-bcmath php71u-json php71u-iconv php71u-soap
+    ```
 
-	{:.bs-callout .bs-callout-info}
-  	The `bcmath` extension is required for {{site.data.var.ee}} only.
+    {:.bs-callout .bs-callout-info}
+    The `bcmath` extension is required for {{site.data.var.ee}} only.
 
 4.	Restart Apache: `service httpd restart`
 
 5.	Verify that PHP 7.1 is installed properly:
 
-		php -v
+    ```bash
+    php -v
+    ```
 
     The following response indicates that PHP 7.1.6 is installed:
 
-		PHP 7.1.6 (cli) (built: Jan 9 2017 09:23:16) ( NTS )
-		Copyright (c) 1997-2017 The PHP Group
-		Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies with Zend OPcache v7.1.6, Copyright (c) 1999-2017, by Zend Technologies
+    ```terminal
+    PHP 7.1.6 (cli) (built: Jan 9 2017 09:23:16) ( NTS )
+    Copyright (c) 1997-2017 The PHP Group
+    Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies with Zend OPcache v7.1.6, Copyright (c) 1999-2017, by Zend Technologies
+    ```
 
     {:.bs-callout .bs-callout-info}
     The preceding message confirms that the `Zend OPcache` is installed. We strongly recommend using the OPcache for performance reasons. If your PHP distribution does not come with the OPcache, see the [PHP OPcache documentation](http://php.net/manual/en/opcache.setup.php){:target="_blank"}.
 
 6.	Verify that all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions) were installed:
 
-		php -me
+    ```bash
+    php -me
+    ```
 
     You should see output similar to the following:
-    ```
+
+    ```terminal
     [PHP Modules]
     bcmath
     calendar

--- a/guides/v2.2/install-gde/prereq/php-settings.md
+++ b/guides/v2.2/install-gde/prereq/php-settings.md
@@ -18,7 +18,10 @@ This topic discusses how to set required [PHP](https://glossary.magento.com/php)
 
 *	Set the system time zone for PHP; otherwise, errors like the following display during the installation and time-related operations like cron might not work:
 
-		PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more messages follow]
+    ```terminal
+    PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more messages follow]
+    ```
+
 *	Set [`always_populate_raw_post_data = -1`](http://php.net/manual/en/ini.core.php#ini.always-populate-raw-post-data){:target="_blank"}
 
 	`always_populate_raw_post_data` is deprecated in PHP 5.6 and is dropped in PHP 7.0.x. This setting causes PHP to always populate `$HTTP_RAW_POST_DATA` with raw POST data. Failure to set this properly in PHP 5.5 or 5.6 results in errors when connecting to the database.
@@ -56,7 +59,9 @@ To find the web server configuration, run a [`phpinfo.php` file]({{ page.baseurl
 
 To locate the PHP command-line configuration, enter
 
-	php --ini
+```bash
+php --ini
+```
 
 Use the value of Loaded Configuration file.
 
@@ -73,13 +78,15 @@ Use the following guidelines to find it:
 
 *	Apache web server:
 
-	For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
+    For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
 
-	For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
+    For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
 
-	If not, use the following command to locate it:
+    If not, use the following command to locate it:
 
-		sudo find / -name 'opcache.ini'
+    ```bash
+    sudo find / -name 'opcache.ini'
+    ```
 
 *	nginx web server with PHP-FPM: `/etc/php5/fpm/php.ini`
 
@@ -95,19 +102,31 @@ If you have more than one `opcache.ini`, modify all of them.
 3.	Locate your server's time zone in the available [time zone settings](http://php.net/manual/en/timezones.php){:target="_blank"}
 4.	Locate the following setting and uncomment it if necessary:
 
-		date.timezone =
+    ```conf
+    date.timezone =
+    ```
+
 5.	Add the time zone setting you found in step 2.
 6.	Change the value of `memory_limit` to one of the values at the beginning of this section.
 
-	For example,
+    For example,
 
-		memory_limit=2G
+    ```conf
+    memory_limit=2G
+    ```
+
 7.	_Required for PHP 5.6, recommended for PHP 5.5_. Locate `always_populate_raw_post_data`, uncomment it if necessary, and set it as follows:
 
-		always_populate_raw_post_data = -1
+    ```conf
+    always_populate_raw_post_data = -1
+    ```
+
 8.	Locate the following setting:
 
-		asp_tags =
+    ```conf
+    asp_tags =
+    ```
+
 9.	Make sure its value is set to `Off`.
 10.	Save your changes and exit the text editor.
 11.	Open the other `php.ini` (if they are different) and make the same changes in it.

--- a/guides/v2.2/install-gde/prereq/php-ubuntu.md
+++ b/guides/v2.2/install-gde/prereq/php-ubuntu.md
@@ -53,33 +53,51 @@ If PHP is *not* installed, see one of the following sections:
 
 1.	Enter the following commands in the order shown:
 
-		sudo apt-get -y update
-		sudo add-apt-repository ppa:ondrej/php
-		sudo apt-get -y update
-		sudo apt-get install -y php7.0 libapache2-mod-php7.0 php7.0-common php7.0-gd php7.0-mysql php7.0-mcrypt php7.0-curl php7.0-intl php7.0-xsl php7.0-mbstring php7.0-zip php7.0-bcmath php7.0-iconv php7.0-soap
+    ```bash
+    sudo apt-get -y update
+    ```
+
+    ```bash
+    sudo add-apt-repository ppa:ondrej/php
+    ```
+
+    ```bash
+    sudo apt-get -y update
+    ```
+
+    ```bash
+    sudo apt-get install -y php7.0 libapache2-mod-php7.0 php7.0-common php7.0-gd php7.0-mysql php7.0-mcrypt php7.0-curl php7.0-intl php7.0-xsl php7.0-mbstring php7.0-zip php7.0-bcmath php7.0-iconv php7.0-soap
+    ```
 
     {:.bs-callout .bs-callout-info}
     The last command installs all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions). The `bcmath` extension is required for {{site.data.var.ee}} only.
 
 2.	Verify that PHP 7.0 is installed properly:
 
-		php -v
+    ```bash
+    php -v
+    ```
 
     The following response indicates that PHP 7.0.21 is installed:
 
-		PHP 7.0.21-1~ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jul  6 2017 09:07:54) ( NTS )
-		Copyright (c) 1997-2017 The PHP Group
-		Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies with Zend OPcache v7.0.21-1~ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2016, by Zend Technologies
+    ```terminal
+    PHP 7.0.21-1~ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jul  6 2017 09:07:54) ( NTS )
+    Copyright (c) 1997-2017 The PHP Group
+    Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies with Zend OPcache v7.0.21-1~ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2016, by Zend Technologies
+    ```
 
     {:.bs-callout .bs-callout-info}
     The preceding message confirms that the `Zend OPcache` is installed. We strongly recommend using the OPcache for performance reasons. If your PHP distribution does not come with the OPcache, see the [PHP OPcache documentation](http://php.net/manual/en/opcache.setup.php){:target="_blank"}.
 
 3.	Verify that all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions) were installed:
 
-		php -me
+    ```bash
+    php -me
+    ```
 
     You should see output similar to the following:
-    ```
+
+    ```terminal
     [PHP Modules]
     bcmath
     calendar
@@ -140,33 +158,51 @@ If PHP is *not* installed, see one of the following sections:
 
 1.	Enter the following commands in the order shown:
 
-		sudo apt-get -y update
-		sudo add-apt-repository ppa:ondrej/php
-		sudo apt-get -y update
-		sudo apt-get install -y php7.1 libapache2-mod-php7.1 php7.1-common php7.1-gd php7.1-mysql php7.1-mcrypt php7.1-curl php7.1-intl php7.1-xsl php7.1-mbstring php7.1-zip php7.1-bcmath php7.1-iconv php7.1-soap
+    ```bash
+    sudo apt-get -y update
+    ```
+
+    ```bash
+    sudo add-apt-repository ppa:ondrej/php
+    ```
+
+    ```bash
+    sudo apt-get -y update
+    ```
+
+    ```bash
+    sudo apt-get install -y php7.1 libapache2-mod-php7.1 php7.1-common php7.1-gd php7.1-mysql php7.1-mcrypt php7.1-curl php7.1-intl php7.1-xsl php7.1-mbstring php7.1-zip php7.1-bcmath php7.1-iconv php7.1-soap
+    ```
 
     {:.bs-callout .bs-callout-info}
     The last command installs all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions). The `bcmath` extension is required for {{site.data.var.ee}} only.
 
 2.	Verify that PHP 7.1 is installed properly:
 
-		php -v
+    ```bash
+    php -v
+    ```
 
     The following response indicates that PHP 7.1.7 is installed:
 
-		PHP 7.1.7-1~ubuntu14.04.1+deb.sury.org+1 (cli) (built: Jul  6 2017 09:07:54) ( NTS )
-		Copyright (c) 1997-2017 The PHP Group
-		Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies with Zend OPcache v7.1.7-1~ubuntu14.04.1+deb.sury.org+1, Copyright (c) 1999-2017, by Zend Technologies
+    ```terminal
+    PHP 7.1.7-1~ubuntu14.04.1+deb.sury.org+1 (cli) (built: Jul  6 2017 09:07:54) ( NTS )
+    Copyright (c) 1997-2017 The PHP Group
+    Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies with Zend OPcache v7.1.7-1~ubuntu14.04.1+deb.sury.org+1, Copyright (c) 1999-2017, by Zend Technologies
+    ```
 
     {:.bs-callout .bs-callout-info}
     The preceding message confirms that the `Zend OPcache` is installed. We strongly recommend using the OPcache for performance reasons. If your PHP distribution does not come with the OPcache, see the [PHP OPcache documentation](http://php.net/manual/en/opcache.setup.php){:target="_blank"}.
 
 3.	Verify that all [required PHP extensions]({{ page.baseurl }}/install-gde/system-requirements-tech.html#required-php-extensions) were installed:
 
-		php -me
+    ```bash
+    php -me
+    ```
 
     You should see output similar to the following:
-    ```
+
+    ```terminal
     [PHP Modules]
     bcmath
     calendar

--- a/guides/v2.2/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.2/install-gde/prereq/prereq-overview.md
@@ -61,8 +61,10 @@ Ubuntu: `apache2 -v`
 
 You must run Apache version 2.2 or 2.4 as the following result indicates:
 
-	Server version: Apache/2.2.15 (Unix)
-	Server built: Jul 23 2014 14:17:29
+```terminal
+Server version: Apache/2.2.15 (Unix)
+Server built: Jul 23 2014 14:17:29
+```
 
 To install or upgrade Apache, see [Apache]({{ page.baseurl }}/install-gde/prereq/apache.html).
 
@@ -78,7 +80,7 @@ You must run [PHP](https://glossary.magento.com/php) version 7.0.x or 7.1.x as t
 PHP 7.0.8-2+deb.sury.org~trusty+1 (cli) ( NTS )
 Copyright (c) 1997-2016 The PHP Group
 Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
-		with Zend OPcache v7.0.8-2+deb.sury.org~trusty+1, Copyright (c) 1999-2016, by Zend Technologies
+    with Zend OPcache v7.0.8-2+deb.sury.org~trusty+1, Copyright (c) 1999-2016, by Zend Technologies
 ```
 
 To install PHP, see:
@@ -94,21 +96,25 @@ mysql -u <database root user or database owner name> -p
 
 For example:
 
-	mysql -u magento -p
+```bash
+mysql -u magento -p
+```
 
 You must run MySQL version 5.6 or later as the following result indicates:
 
-		Welcome to the MySQL monitor. Commands end with ; or \g.
-		Your MySQL connection id is 871
-		Server version: 5.6.21 MySQL Community Server (GPL)
+```terminal
+Welcome to the MySQL monitor. Commands end with ; or \g.
+Your MySQL connection id is 871
+Server version: 5.6.21 MySQL Community Server (GPL)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+```
 
 Enter `exit` at the `mysql>` prompt to exit.
 

--- a/guides/v2.2/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.2/install-gde/prereq/prereq-overview.md
@@ -31,13 +31,23 @@ Enter the following commands as a user with `root` privileges:
 
 *	Ubuntu
 
-		apt-get update
-		apt-get upgrade
+    ```bash
+    apt-get update
+    ```
+
+    ```bash
+    apt-get upgrade
+    ```
 
 *	CentOS
 
-		yum -y update
-		yum -y upgrade
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    yum -y upgrade
+    ```
 
 ## Prerequisite check {#instgde-prereq-check}
 
@@ -58,14 +68,18 @@ To install or upgrade Apache, see [Apache]({{ page.baseurl }}/install-gde/prereq
 
 ### PHP
 
-	php -v
+```bash
+php -v
+```
 
 You must run [PHP](https://glossary.magento.com/php) version 7.0.x or 7.1.x as the following result indicates:
 
-	PHP 7.0.8-2+deb.sury.org~trusty+1 (cli) ( NTS )
-	Copyright (c) 1997-2016 The PHP Group
-	Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
-      with Zend OPcache v7.0.8-2+deb.sury.org~trusty+1, Copyright (c) 1999-2016, by Zend Technologies
+```terminal
+PHP 7.0.8-2+deb.sury.org~trusty+1 (cli) ( NTS )
+Copyright (c) 1997-2016 The PHP Group
+Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
+		with Zend OPcache v7.0.8-2+deb.sury.org~trusty+1, Copyright (c) 1999-2016, by Zend Technologies
+```
 
 To install PHP, see:
 
@@ -74,7 +88,9 @@ To install PHP, see:
 
 ### MySQL
 
-	mysql -u <database root user or database owner name> -p
+```bash
+mysql -u <database root user or database owner name> -p
+```
 
 For example:
 

--- a/guides/v2.2/install-gde/prereq/security.md
+++ b/guides/v2.2/install-gde/prereq/security.md
@@ -20,10 +20,21 @@ functional_areas:
 
 If you choose to enable SELinux, you might have issues running the installer unless you change the *security context* of some directories as follows:
 
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/app/etc
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/var
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/media
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/static
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/app/etc
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/var
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/media
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/static
+```
 
 The preceding commands work only with the Apache web server. Because of the variety of configurations and security requirements, we don't guarantee these commands work in all situations. For more information, see:
 
@@ -38,15 +49,17 @@ To enable Apache to initiate a connection to another host with SELinux enabled:
 
 1.	To determine if SELinux is enabled, use the following command:
 
-		getenforce
+    ```bash
+    getenforce
+    ```
 
-	`Enforcing` displays to confirm that SELinux is running.
+    `Enforcing` displays to confirm that SELinux is running.
 
 2.	Enter one of the following commands:
 
-	CentOS: `setsebool -P httpd_can_network_connect=1`
+    * CentOS: `setsebool -P httpd_can_network_connect=1`
 
-	Ubuntu: `setsebool -P apache2_can_network_connect=1`
+    * Ubuntu: `setsebool -P apache2_can_network_connect=1`
 
 ## Opening Ports In Your Firewall {#install-iptables}
 

--- a/guides/v2.2/install-gde/trouble/git/tshoot_clone.md
+++ b/guides/v2.2/install-gde/trouble/git/tshoot_clone.md
@@ -15,7 +15,7 @@ functional_areas:
 
 Error is similar to the following:
 
-```
+```terminal
 Cloning into 'magento2'...
 Permission denied (publickey).
 fatal: The remote end hung up unexpectedly

--- a/guides/v2.2/install-gde/trouble/git/tshoot_git-pull-origin.md
+++ b/guides/v2.2/install-gde/trouble/git/tshoot_git-pull-origin.md
@@ -15,16 +15,22 @@ functional_areas:
 
 One of the steps to updating the Magento 2 software is to update your local repository by running:
 
-	git pull origin develop
+```bash
+git pull origin develop
+```
 
 The following error might display:
 
-	error: Your local changes to the following files would be overwritten by merge:
-	<list of files>
+```terminal
+error: Your local changes to the following files would be overwritten by merge:
+<list of files>
+``
 
 To find which files are subject to being overwritten, either read the message or enter:
 
-	git status
+```bash
+git status
+```
 
 The next section discusses suggested solutions.
 
@@ -42,21 +48,27 @@ Try any of the following:
 
 *	If you're certain you didn't modify any files and you don't mind removing or overwriting the changes in the Magento file system, enter:
 
-		git reset --hard HEAD && git pull origin develop
+    ```bash
+    git reset --hard HEAD && git pull origin develop
+    ```
 
-	After that, continue where you left off with your Magento 2 update.
+    After that, continue where you left off with your Magento 2 update.
 
 *	It's possible that a GitHub configuration setting can prevent these errors in the future. By default, GitHub stores content using the operating system-default line ending characters. If you're using Linux but another collaborator committed a change using Windows, GitHub converts the Windows line endings to Linux when you clone or pull. This gives the appearance of a change to files when in fact, no change was made.
 
-	To configure GitHub to ignore line endings, enter the following command in your Git client:
+    To configure GitHub to ignore line endings, enter the following command in your Git client:
 
-		git config --system core.autocrlf false
+    ```bash
+    git config --system core.autocrlf false
+    ```
 
-	If you use Windows, enter:
+    If you use Windows, enter:
 
-		git config --system core.eol LF
+    ```bash
+    git config --system core.eol LF
+    ```
 
-	{:.bs-callout .bs-callout-info}
-  Magento does <em>not</em> recommend or endorse any particular GitHub configuration settings. The preceding are suggestions only. For more information, consult the [GitHub help](https://help.github.com/).
+    {:.bs-callout .bs-callout-info}
+    Magento does <em>not</em> recommend or endorse any particular GitHub configuration settings. The preceding are suggestions only. For more information, consult the [GitHub help](https://help.github.com/).
 
-	Continue where you left off with your Magento 2 update.
+    Continue where you left off with your Magento 2 update.

--- a/guides/v2.2/install-gde/trouble/php/tshoot_70pct.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_70pct.md
@@ -40,11 +40,13 @@ Set all of the following as appropriate.
 
 If you use nginx, use our included `nginx.conf.sample` or add a timeout settings in the nginx host configuration file to the `location ~ ^/setup/index.php` section as follows:
 
-	location ~ ^/setup/index.php {
-		.....................
-		fastcgi_read_timeout 600s;
-       	fastcgi_connect_timeout 600s;
-	}
+```conf
+location ~ ^/setup/index.php {
+  .....................
+  fastcgi_read_timeout 600s;
+      fastcgi_connect_timeout 600s;
+}
+```
 
 Restart nginx: `service nginx restart`
 
@@ -52,11 +54,15 @@ Restart nginx: `service nginx restart`
 
 If you use Varnish, edit `default.vcl` and add a timeout limit value to the `backend` stanza as follows:
 
-	backend default {
-    .....................
-	      .first_byte_timeout = 600s;
-	}
+```conf
+backend default {
+  .....................
+      .first_byte_timeout = 600s;
+}
+```
 
 Restart Varnish.
 
-		service varnish restart
+```bash
+service varnish restart
+```

--- a/guides/v2.2/install-gde/trouble/php/tshoot_mcrypt.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_mcrypt.md
@@ -47,14 +47,14 @@ Determine if the mcrypt extension is loaded in any of the following ways:
 *	Set up a [phpinfo.php](http://kb.mediatemple.net/questions/764/How+can+I+create+a+phpinfo.php+page%3F#gs){:target="_blank"} file in the web server's root directory and examine the output in a web browser.
 *	Run the following command:
 
-  ```bash
-  php -r "phpinfo();" | grep mcrypt
-  ```
+    ```bash
+    php -r "phpinfo();" | grep mcrypt
+    ```
 
-	If mycrypt is *not* installed, messages similar to the following display:
+    If mycrypt is *not* installed, messages similar to the following display:
 
-  ```terminal
-  PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20121212/mcrypt.so' - /usr/lib/php5/20121212/mcrypt.so: cannot open shared object file: No such file or directory in Unknown on line 0
-  ```
+    ```terminal
+    PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20121212/mcrypt.so' - /usr/lib/php5/20121212/mcrypt.so: cannot open shared object file: No such file or directory in Unknown on line 0
+    ```
 
 In some cases, you might need to install the Magento software from the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html) and specify the full path to the LAMP stack that has mcrypt installed.

--- a/guides/v2.2/install-gde/trouble/php/tshoot_mod_access_compat.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_mod_access_compat.md
@@ -19,7 +19,9 @@ When you try to access your [Magento Admin](https://glossary.magento.com/magento
 
 To confirm this issue is not related to [maintenance mode]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html), look in your Apache `error.log` for messages that include:
 
-	"Invalid command 'Order', perhaps misspelled or defined by a module not included in the server configuration".
+```text
+"Invalid command 'Order', perhaps misspelled or defined by a module not included in the server configuration".
+```
 
 #### Details
 
@@ -31,8 +33,13 @@ Not all Apache 2.4 distributions have this issue because in some cases, a compat
 
 As a user with 'root' privileges, enter the following commands:
 
-	a2enmod access_compat
-	service <name> restart
+```bash
+a2enmod access_compat
+```
+
+```bash
+service <name> restart
+```
 
 On CentOS, `<name>` is `httpd`. On Ubuntu, `<name>` is `apache2`.
 

--- a/guides/v2.2/install-gde/trouble/php/tshoot_nginx-port.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_nginx-port.md
@@ -17,9 +17,11 @@ If you use the [nginx](https://glossary.magento.com/nginx) web server and you at
 
 You can confirm the issue by the following error in the `var/report` directory:
 
-	NOTE: You cannot install Magento using the Setup Wizard because the Magento setup directory cannot be accessed.
-	You can install Magento using either the command line or you must restore access to the following directory: /var/www/html/setup
-	If you are using the sample nginx configuration, please go to http://ce.mtf03.bcn.magento.com/setup/";i:1;s:641:"#0 /var/www/html/lib/internal/Magento/Framework/App/Http.php(213): Magento\Framework\App\Http->redirectToSetup(Object(Magento\Framework\App\Bootstrap), Object(Exception))
+```text
+NOTE: You cannot install Magento using the Setup Wizard because the Magento setup directory cannot be accessed.
+You can install Magento using either the command line or you must restore access to the following directory: /var/www/html/setup
+If you are using the sample nginx configuration, please go to http://ce.mtf03.bcn.magento.com/setup/";i:1;s:641:"#0 /var/www/html/lib/internal/Magento/Framework/App/Http.php(213): Magento\Framework\App\Http->redirectToSetup(Object(Magento\Framework\App\Bootstrap), Object(Exception))
+```
 
 ### Workaround
 

--- a/guides/v2.2/install-gde/trouble/php/tshoot_opcache.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_opcache.md
@@ -13,9 +13,11 @@ functional_areas:
 
 In Magento 2.1 or later, when creating a new product in the Magento Admin, the following error might display:
 
-	Warning: Illegal string offset 'is_in_stock' in [...]/vendor/
-	magento/module-catalog-inventory/Ui/DataProvider/Product/Form/
-	Modifier/AdvancedInventory.php on line 87
+```text
+Warning: Illegal string offset 'is_in_stock' in [...]/vendor/
+magento/module-catalog-inventory/Ui/DataProvider/Product/Form/
+Modifier/AdvancedInventory.php on line 87
+```
 
 ### Detail
 
@@ -36,13 +38,15 @@ Use the following guidelines to find it:
 
 *	Apache web server:
 
-	For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
+    For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
 
-	For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
+    For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
 
-	If not, use the following command to locate it:
+    If not, use the following command to locate it:
 
-		sudo find / -name 'opcache.ini'
+    ```bash
+    sudo find / -name 'opcache.ini'
+    ```
 
 *	nginx web server with PHP-FPM: `/etc/php5/fpm/php.ini`
 
@@ -64,4 +68,6 @@ If you have more than one `opcache.ini`, modify all of them.
 
 6.	Regenerate DI configuration and all missing classes that can be auto-generated:
 
-	*	`bin/magento setup:di:compile`
+    ```bash
+    bin/magento setup:di:compile`
+    ```

--- a/guides/v2.2/install-gde/trouble/php/tshoot_pdo.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_pdo.md
@@ -13,9 +13,10 @@ functional_areas:
 
 ### Details
 
-	PHP Fatal error:  Class 'PDO' not found in /var/www/html/magento2/setup/module/Magento/Setup/src/Module/Setup/ConnectionFactory.php on line 44
+```text
+PHP Fatal error:  Class 'PDO' not found in /var/www/html/magento2/setup/module/Magento/Setup/src/Module/Setup/ConnectionFactory.php on line 44
+```
 
 ### Solution:
 
 Make sure you installed all required PHP extensions ([Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-centos.html) [CentOS]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)).
-

--- a/guides/v2.2/install-gde/trouble/php/tshoot_php-date.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_php-date.md
@@ -15,9 +15,10 @@ functional_areas:
 
 During the installation, the following message displays:
 
-	PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more]
+```text
+PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more]
+```
 
 ### Solution
 
 Set the [PHP timezone]({{ page.baseurl }}/install-gde/prereq/php-settings.html) properly.
-

--- a/guides/v2.2/install-gde/trouble/php/tshoot_php-set.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_php-set.md
@@ -20,18 +20,22 @@ To increase your PHP memory limit:
 1.	Log in to your Magento server.
 2.	Locate your `php.ini` file using the following command:
 
-		php --ini
+    ```bash
+    php --ini
+    ```
+
 3.	As a user with `root` privileges, use a text editor to open the `php.ini` specified by `Loaded Configuration File`.
 4.	Locate `memory_limit`.
 5.	Change it to a value of `2GB` for normal use and debugging.
 6.	Save your changes to `php.ini` and exit the text editor.
 7.	Restart your web server.
 
-	Examples follow:
+    Examples follow:
 
-	*	CentOS: `service httpd restart`
-	*	Ubuntu: `service apache2 restart`
-	*	nginx (both CentOS and Ubuntu): `service nginx restart`
+    *	CentOS: `service httpd restart`
+    *	Ubuntu: `service apache2 restart`
+    *	nginx (both CentOS and Ubuntu): `service nginx restart`
+
 8.	Try the installation again.
 
 ## max-input-vars error due to large forms
@@ -43,7 +47,8 @@ When this occurs, a warning appears in the PHP log:
 ```bash
 PHP message: PHP Warning: Unknown: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini.
 ```
- There is no 'proper' value for `max-input-vars`; it depends on the size and complexity of your configuration. Modify the value in the `php.ini` file as needed. See [Required PHP settings][].
+
+There is no 'proper' value for `max-input-vars`; it depends on the size and complexity of your configuration. Modify the value in the `php.ini` file as needed. See [Required PHP settings][].
 
 ## xdebug maximum function nesting level error {#trouble-php-xdebug}
 
@@ -53,7 +58,9 @@ See [During installation, xdebug maximum function nesting level error]({{ page.b
 
 Error text is typically:
 
-    Parse error: syntax error, unexpected 'data' (T_STRING)
+```text
+Parse error: syntax error, unexpected 'data' (T_STRING)
+```
 
 ### Solution: Set <code>asp_tags = off</code> in <code>php.ini</code>
 Multiple templates have syntax for support abstract level on templates (use different templates engines like Twig) wrapped in `<% %>` tags, like this [template][]{:target="_blank"} for displaying a product image:

--- a/guides/v2.2/install-gde/trouble/php/tshoot_php-set.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_php-set.md
@@ -44,7 +44,7 @@ Configurations with a high number of storeviews, products, attributes, or option
 If the number of values sent surpasses the `max-input-vars` limit set within `php.ini` (default is 1000), the remaining data is not transferred and those database values do not get updated.
 When this occurs, a warning appears in the PHP log:
 
-```bash
+```terminal
 PHP message: PHP Warning: Unknown: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini.
 ```
 
@@ -58,7 +58,7 @@ See [During installation, xdebug maximum function nesting level error]({{ page.b
 
 Error text is typically:
 
-```text
+```terminal
 Parse error: syntax error, unexpected 'data' (T_STRING)
 ```
 

--- a/guides/v2.2/install-gde/trouble/php/tshoot_phpini.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_phpini.md
@@ -15,8 +15,10 @@ functional_areas:
 
 During or after installation, a  message similar to the following displays:
 
-	Exception' with message 'PHP Fatal error: Uncaught exception 'PDOException' with message
-	'SQLSTATE[HY000] [2002] No such file or directory
+```text
+Exception' with message 'PHP Fatal error: Uncaught exception 'PDOException' with message
+  'SQLSTATE[HY000] [2002] No such file or directory
+```
 
 ### Solution
 
@@ -27,7 +29,9 @@ To determine whether or not you're using one instance of PHP:
 1.	Log in to your Magento server.
 2.	Enter the following command:
 
-		php -i | grep 'php.ini'
+    ```bash
+    php -i | grep 'php.ini'
+    ```
 
 	This determines the settings used by the PHP command-line interface (CLI). Note where `php.ini` is located.
 

--- a/guides/v2.2/install-gde/trouble/php/tshoot_session.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_session.md
@@ -35,7 +35,9 @@ Solutions:
 
 Locate `php.ini` by entering the following command:
 
-	php -i | grep "Loaded Configuration File"
+```bash
+php -i | grep "Loaded Configuration File"
+```
 
 Typical locations follow:
 
@@ -48,10 +50,14 @@ Typical locations follow:
 2.	Locate `session.save_handler`
 3.	Set it in any of the following ways:
 
-	*	To comment it out:
+    *	To comment it out:
 
-			;session.save_path = <path>
+        ```conf
+        ;session.save_path = <path>
+        ```
 
-	*	To set it to a file system path:
+    *	To set it to a file system path:
 
-			session.save_handler = files
+        ```conf
+        session.save_handler = files
+        ```

--- a/guides/v2.2/install-gde/trouble/php/tshoot_xdebug.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_xdebug.md
@@ -15,7 +15,9 @@ functional_areas:
 
 During the installation, a  message similar to the following displays:
 
-	PHP Fatal error: Maximum function nesting level of '100' reached, aborting! in <path>/ClassLoader.php
+```text
+PHP Fatal error: Maximum function nesting level of '100' reached, aborting! in <path>/ClassLoader.php
+```
 
 ### Solution
 

--- a/guides/v2.2/install-gde/trouble/tshoot_access-browser.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_access-browser.md
@@ -13,8 +13,10 @@ functional_areas:
 
 ### Symptom: The following message displays when you try to access the Magento storefront or Admin:
 
-	Whoops, it looks like you have an invalid PHP version.
-	Magento supports PHP 5.5 or newer.
+```text
+Whoops, it looks like you have an invalid PHP version.
+Magento supports PHP 5.5 or newer.
+```
 
 #### Solution
 

--- a/guides/v2.2/install-gde/trouble/tshoot_bundlesampledata.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_bundlesampledata.md
@@ -15,7 +15,9 @@ functional_areas:
 
 During the installation, a  message similar to the following displays:
 
-	[ERROR] exception 'LogicException' with message 'Unknown module in the requested list: 'Magento_BundleSampleData''
+```text
+[ERROR] exception 'LogicException' with message 'Unknown module in the requested list: 'Magento_BundleSampleData''
+```
 
 ### Solution
 

--- a/guides/v2.2/install-gde/trouble/tshoot_composer-fail.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_composer-fail.md
@@ -15,8 +15,10 @@ functional_areas:
 
 During download, the following error displays:
 
-	[ErrorException]
-  	file_get_contents(app/etc/NonComposerComponentRegistration.php): failed to open stream: No such file or directory
+```text
+[ErrorException]
+    file_get_contents(app/etc/NonComposerComponentRegistration.php): failed to open stream: No such file or directory
+```
 
 ### Description
 
@@ -26,11 +28,15 @@ The workaround is to downgrade Composer to an earlier version and try your Magen
 
 Any version of Composer dated between November 21 and November 26, 2015 has this issue. To confirm this issue is related to the Composer version, enter the following command:
 
-	composer -v
+```bash
+composer -v
+```
 
 The version displays similar to the following:
 
-	Composer version 1.0-dev (2b14f0a047dd4f3545ec82381f65c36ea93a4c81) 2015-11-25 17:13:09
+```terminal
+Composer version 1.0-dev (2b14f0a047dd4f3545ec82381f65c36ea93a4c81) 2015-11-25 17:13:09
+```
 
 Note the date is 2015-11-25, which indicates Composer has this issue.
 
@@ -38,16 +44,22 @@ To work around it:
 
 1.	Change your version of Composer to enable you to download the Magento software by doing any of the following:
 
-	*	Downgrade Composer using the following command:
+    *	Downgrade Composer using the following command:
 
-			composer self-update 1.0.0-alpha11
+        ```bash
+        composer self-update 1.0.0-alpha11
+        ```
 
-	*	Upgrade Composer to a version later than November 26, 2015:
+    *	Upgrade Composer to a version later than November 26, 2015:
 
-			composer self-update
+        ```bash
+        composer self-update
+        ```
 
 2.	Delete your Magento 2 directory and subdirectories.
 3.	Try the download again using either [`composer create-project`]({{ page.baseurl }}/install-gde/composer.html) or [`git clone`]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
 4.	After successfully downloading the Magento software, update Composer:
 
-		composer self-update
+    ```bash
+    composer self-update
+    ```

--- a/guides/v2.2/install-gde/trouble/tshoot_exceptions.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_exceptions.md
@@ -13,25 +13,29 @@ functional_areas:
 
 ### Symptom: Exceptions display during installation. Users have reported a variety of exceptions, including the following:
 
-	Module 'Magento_Indexer':
-	Running recurring..
-	[ERROR] exception 'Exception' with message 'Recoverable Error: Argument 1 passed to Magento\Indexer\Model\Config\Data::__construct() must be an instance of Magento\Framework\Indexer\Config\Reader, instance of Magento\Indexer\Model\Config\Reader given, called in /home/magento2_dev/
-	public_html/generated/code/Magento/Indexer/Model/Config/Data/Interceptor.php on line 14 and defined in /home/magento2_dev/public_html/
-	app/code/Magento/Indexer/Model/Config/Data.php on line 22' in /home/magento2_dev/public_html/lib/internal/Magento/Framework/App/ErrorHandler.php:67
-	Stack trace:
-	#0 /home/magento2_dev/public_html/app/code/Magento/Indexer/Model/Config/Data.php(22): Magento\Framework\App\ErrorHandler->handler(4096,
-	'Argument 1 pass...', '/home/magento2...', 22, Array)
-	#1 /home/magento2_dev/public_html/generated/code/Magento/Indexer/Model/Config/Data/Interceptor.php(14): Magento\Indexer\Model\Config\Data->
-	__construct(Object(Magento\Indexer\Model\Config\Reader), Object(Magento\Framework\App\Cache\Type\Config), Object(Magento\Indexer\Model\Resource\Indexer\State\Collection), 'indexer_config')
-	#2 /home/magento2_dev/public_html/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php(103): Magento\Indexer\Model\Config\Data\Interceptor->__construct(Object(Magento\Indexer\Model\Config\Reader), Object(Magento\Framework\App\Cache\Type\Config),
-	Object(Magento\Indexer\Model\Resource\Indexer\State\Collection), 'indexer_config')
+```text
+Module 'Magento_Indexer':
+Running recurring..
+[ERROR] exception 'Exception' with message 'Recoverable Error: Argument 1 passed to Magento\Indexer\Model\Config\Data::__construct() must be an instance of Magento\Framework\Indexer\Config\Reader, instance of Magento\Indexer\Model\Config\Reader given, called in /home/magento2_dev/
+public_html/generated/code/Magento/Indexer/Model/Config/Data/Interceptor.php on line 14 and defined in /home/magento2_dev/public_html/
+app/code/Magento/Indexer/Model/Config/Data.php on line 22' in /home/magento2_dev/public_html/lib/internal/Magento/Framework/App/ErrorHandler.php:67
+Stack trace:
+#0 /home/magento2_dev/public_html/app/code/Magento/Indexer/Model/Config/Data.php(22): Magento\Framework\App\ErrorHandler->handler(4096,
+'Argument 1 pass...', '/home/magento2...', 22, Array)
+#1 /home/magento2_dev/public_html/generated/code/Magento/Indexer/Model/Config/Data/Interceptor.php(14): Magento\Indexer\Model\Config\Data->
+__construct(Object(Magento\Indexer\Model\Config\Reader), Object(Magento\Framework\App\Cache\Type\Config), Object(Magento\Indexer\Model\Resource\Indexer\State\Collection), 'indexer_config')
+#2 /home/magento2_dev/public_html/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php(103): Magento\Indexer\Model\Config\Data\Interceptor->__construct(Object(Magento\Indexer\Model\Config\Reader), Object(Magento\Framework\App\Cache\Type\Config),
+Object(Magento\Indexer\Model\Resource\Indexer\State\Collection), 'indexer_config')
 
-	... more ...
+... more ...
+```
 
 #### Solution
 
 Clear the `<magento_root>/generated/code` and other directories under `var` and `generated` as follows:
 
-	rm -rf <magento_root>/generated/code/* <magento_root>/generated/metadata/* <magento_root>/var/cache/*
+```bash
+rm -rf <magento_root>/generated/code/* <magento_root>/generated/metadata/* <magento_root>/var/cache/*
+```
 
 After clearing the directories, try the installation again.

--- a/guides/v2.2/install-gde/trouble/tshoot_install_depend.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_install_depend.md
@@ -28,7 +28,7 @@ Magento\Framework\Exception
 [Exception](https://glossary.magento.com/exception)
  [PHP](https://glossary.magento.com/php) Fatal error:  Class 'Magento\Framework\Stdlib\DateTime\TimezoneInterface' not found in /var/www/magento2/app/bootstrap.php on line 56</pre>
 
-```
+```text
 Dependencies not installed. Please run 'composer install' under /setup directory.
 ```
 

--- a/guides/v2.2/install-gde/trouble/tshoot_mysql_table-open-cache.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_mysql_table-open-cache.md
@@ -15,7 +15,9 @@ functional_areas:
 
 During installation, the following message displays:
 
-	MySQL server has gone away
+```text
+MySQL server has gone away
+```
 
 ### Solution
 
@@ -33,7 +35,9 @@ Set the value of [table_open_cache](https://dev.mysql.com/doc/refman/5.6/en/tabl
 
 3.	Set the value to at least 250:
 
-		table_open_cache=250
+    ```conf
+    table_open_cache=250
+    ```
 
 4.	Save your changes to `my.cnf` and exit the text editor.
 

--- a/guides/v2.2/install-gde/trouble/tshoot_sample-data.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_sample-data.md
@@ -17,14 +17,16 @@ This topic discusses solutions to errors you might encounter installing optional
 
 Error in the console log during sample data installation using the Setup Wizard:
 
-	Module 'Magento_CatalogRuleSampleData':
-	[ERROR] exception 'Magento\Framework\Exception\LocalizedException' with message 'Can't create directory /var/www/html/magento2/generated/code/Magento/CatalogRule/Model/.' in /var/www/html/magento2/lib/internal/Magento/Framework/Code/Generator.php:103
+```text
+Module 'Magento_CatalogRuleSampleData':
+[ERROR] exception 'Magento\Framework\Exception\LocalizedException' with message 'Can't create directory /var/www/html/magento2/generated/code/Magento/CatalogRule/Model/.' in /var/www/html/magento2/lib/internal/Magento/Framework/Code/Generator.php:103
 
-	(more)
+(more)
 
-	Next exception 'ReflectionException' with message 'Class Magento\CatalogRule\Model\RuleFactory does not exist' in /var/www/html/magento2/lib/internal/Magento/Framework/Code/Reader/ClassReader.php:29
+Next exception 'ReflectionException' with message 'Class Magento\CatalogRule\Model\RuleFactory does not exist' in /var/www/html/magento2/lib/internal/Magento/Framework/Code/Reader/ClassReader.php:29
 
-	(more)
+(more)
+```
 
 These exceptions result from file system permissions settings.
 
@@ -35,7 +37,9 @@ These exceptions result from file system permissions settings.
 
 If you're currently set for [production mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode), sample data installation fails if you use the [`magento sampledata:deploy`]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-composer.html) command:
 
-	PHP Fatal error: Uncaught TypeError: Argument 1 passed to Symfony\Component\Console\Input\ArrayInput::__construct() must be of the type array, object given, called in /<path>/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php on line 97 and defined in /<path>/vendor/symfony/console/Symfony/Component/Console/Input/ArrayInput.php:37
+```text
+PHP Fatal error: Uncaught TypeError: Argument 1 passed to Symfony\Component\Console\Input\ArrayInput::__construct() must be of the type array, object given, called in /<path>/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php on line 97 and defined in /<path>/vendor/symfony/console/Symfony/Component/Console/Input/ArrayInput.php:37
+```
 
 #### Solution
 
@@ -43,16 +47,29 @@ Don't install sample data in production mode. Switch to developer mode and clear
 
 Enter the following commands in the order shown as the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html):
 
-	cd <magento_root>
-	bin/magento deploy:mode:set developer
-	rm -rf generated/code/* generated/metadata/*
-	bin/magento sampledata:deploy
+```bash
+cd <magento_root>
+```
+
+```bash
+bin/magento deploy:mode:set developer
+```
+
+```bash
+rm -rf generated/code/* generated/metadata/*
+```
+
+```bash
+bin/magento sampledata:deploy
+```
 
 ### Symptom (security) {#trouble-samp-secy}
 
 During installation of optional sample data, a  message similar to the following displays:
 
-	PHP Fatal error: Call to undefined method Magento\Catalog\Model\Resource\Product\Interceptor::getWriteConnection() in /var/www/magento2/app/code/Magento/SampleData/Module/Catalog/Setup/Product/Gallery.php on line 144
+```text
+PHP Fatal error: Call to undefined method Magento\Catalog\Model\Resource\Product\Interceptor::getWriteConnection() in /var/www/magento2/app/code/Magento/SampleData/Module/Catalog/Setup/Product/Gallery.php on line 144
+```
 
 #### Solution
 
@@ -65,24 +82,36 @@ During sample data installation, disable SELinux using a resource such as:
 
 Other errors display, such as:
 
-	[Magento\Setup\SampleDataException] Error during sample data installation: Class Magento\Sales\Model\Service\OrderFactory does not exist
+```text
+[Magento\Setup\SampleDataException] Error during sample data installation: Class Magento\Sales\Model\Service\OrderFactory does not exist
+```
 
 #### Solution
 
 There are known issues with using sample data with the Magento 2 develop branch. Use the master branch instead. You can switch to the master branch as follows:
 
-	cd <magento_root>
-	git checkout master
-	git pull origin master
+```bash
+cd <magento_root>
+```
+
+```bash
+git checkout master
+```
+
+```bash
+git pull origin master
+```
 
 ### Symptom (max_execution_time) {#trouble-samp-max}
 
 The installation stops before the sample data installation finishes. An example follows:
 
-	(more)
+```text
+(more)
 
-	Module 'Magento_CustomerSampleData':
-	Installing data...
+Module 'Magento_CustomerSampleData':
+Installing data...
+```
 
 Sample data installation does not finish.
 
@@ -94,6 +123,8 @@ As a user with `root` privileges, modify `php.ini` to increase the value of `max
 
 If you're not sure where `php.ini` is located, enter the following command:
 
-	php --ini
+```bash
+php --ini
+```
 
 The value of `Loaded Configuration File` is the `php.ini` you must modify.

--- a/guides/v2.2/install-gde/trouble/tshoot_segfault.md
+++ b/guides/v2.2/install-gde/trouble/tshoot_segfault.md
@@ -15,7 +15,9 @@ functional_areas:
 
 When you attempt to roll back using the command line, the following error displays:
 
-	Segmentation fault
+```terminal
+Segmentation fault
+```
 
 As a result, the rollback does not complete.
 
@@ -32,7 +34,9 @@ If you haven't done so already, switch to the [Magento file system owner]({{ pag
 
 Command:
 
-	ulimit -s 65536
+```bash
+ulimit -s 65536
+```
 
 You can change this to a larger value if needed.
 
@@ -45,7 +49,9 @@ To optionally set the value in the user's Bash shell:
 2.	Open `/home/<username>/.bashrc` in a text editor.
 3.	Add the following line:
 
-		ulimit -s 65536
+    ```bash
+    ulimit -s 65536
+    ```
 
 4.	Save your changes to `.bashrc` and exit the text editor.
 

--- a/guides/v2.3/install-gde/install-quick-ref.md
+++ b/guides/v2.3/install-gde/install-quick-ref.md
@@ -53,8 +53,13 @@ If not, see the [Installation overview]({{page.baseurl }}/install-gde/bk-install
 
 When all prerequisites have been met, get the Magento software using [Composer](https://glossary.magento.com/composer) as follows:
 
-	cd <web server docroot directory>
-	composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
+```bash
+cd <web server docroot directory>
+```
+
+```bash
+composer create-project --repository=https://repo.magento.com/ magento/project-community-edition magento2
+```
 
 You're required to authenticate; see [Get your authentication keys]({{page.baseurl }}/install-gde/prereq/connect-auth.html) for details. This downloads Magento code only; it doesn't install the software for you.
 
@@ -91,16 +96,23 @@ The following example shows how to install using the command line with the follo
 *	Default currency is U.S. dollars
 *	Default time zone is U.S. Central (America/Chicago)
 
-		php /var/www/html/magento2/bin/magento setup:install --base-url=http://192.0.2.5/magento2/ \
-		--db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
-		--admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
-		--admin-user=admin --admin-password=admin123 --language=en_US \
-		--currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```bash
+    php /var/www/html/magento2/bin/magento setup:install --base-url=http://192.0.2.5/magento2/ \
+    --db-host=localhost --db-name=magento --db-user=magento --db-password=magento \
+    --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
+    --admin-user=admin --admin-password=admin123 --language=en_US \
+    --currency=USD --timezone=America/Chicago --use-rewrites=1
+    ```
 
 Optionally switch to [developer mode]({{page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
 
-	cd <magento_root>/bin
-	php magento deploy:mode:set developer
+```bash
+cd <magento_root>/bin
+```
+
+```bash
+php magento deploy:mode:set developer
+```
 
 {% endcollapsible %}
 
@@ -129,7 +141,10 @@ To run the Web Setup Wizard:
 
 1.	Enter the following URL in your browser's address or location field:
 
-		http://192.0.2.5/magento2/setup
+    ```http
+    http://192.0.2.5/magento2/setup
+    ```
+
 2.	At the welcome page, click **Agree and Setup Magento**.
 
 	![You must accept the license agreement to install the Magento software]({{ site.baseurl }}/common/images/install_qr_wizard-welcome.png){:width="200px"}

--- a/guides/v2.3/install-gde/prereq/apache.md
+++ b/guides/v2.3/install-gde/prereq/apache.md
@@ -41,12 +41,16 @@ Failure to enable these settings typically results in no styles displaying on yo
 
 To verify the Apache version you're currently running, enter:
 
-	apache2 -v
+```bash
+apache2 -v
+```
 
 The result displays similar to the following:
 
-	Server version: Apache/2.2.22 (Ubuntu)
-	Server built: Jul 22 2014 14:35:32
+```terminal
+Server version: Apache/2.2.22 (Ubuntu)
+Server built: Jul 22 2014 14:35:32
+```
 
 *	If Apache is *not* installed, see:
 	*	[Installing or upgrading Apache on Ubuntu](#install-prereq-apache-ubuntu)
@@ -66,16 +70,22 @@ To install the default version of Apache (Ubuntu 14, 16&mdash;Apache 2.4, Ubuntu
 
 1.	Install Apache
 
-		apt-get -y install apache2
+    ```bash
+    apt-get -y install apache2
+    ```
 
 2.	Verify the installation.
 
-		apache2 -v
+    ```bash
+    apache2 -v
+    ```
 
-	The result displays similar to the following:
+    The result displays similar to the following:
 
-		Server version: Apache/2.4.18 (Ubuntu)
-		Server built: 2016-04-15T18:00:57
+    ```terminal
+    Server version: Apache/2.4.18 (Ubuntu)
+    Server built: 2016-04-15T18:00:57
+    ```
 
 3.	Enable rewrites and `.htaccess` as discussed in the following sections.
 
@@ -103,25 +113,39 @@ To upgrade to Apache 2.4:
 
 1.	Add the `ppa:ondrej` repository, which has Apache 2.4:
 
-		apt-get -y update
-		apt-add-repository ppa:ondrej/apache2
-		apt-get -y update
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-add-repository ppa:ondrej/apache2
+    ```
+
+    ```bash
+    apt-get -y update
+    ```
 
 2.	Install Apache 2.4:
 
-		apt-get install -y apache2
+    ```bash
+    apt-get install -y apache2
+    ```
 
-{:.bs-callout .bs-callout-info}
-If the 'apt-get install' command fails because of unmet dependencies, consult a resource like [http://askubuntu.com](http://askubuntu.com/questions/140246/how-do-i-resolve-unmet-dependencies-after-adding-a-ppa){:target="_blank"}.
+    {:.bs-callout .bs-callout-info}
+    If the 'apt-get install' command fails because of unmet dependencies, consult a resource like [http://askubuntu.com](http://askubuntu.com/questions/140246/how-do-i-resolve-unmet-dependencies-after-adding-a-ppa){:target="_blank"}.
 
 3.	Verify the installation.
 
-		apache2 -v
+    ```bash
+    apache2 -v
+    ```
 
-	Messages similar to the following should display:
+    Messages similar to the following should display:
 
-		Server version: Apache/2.4.10 (Ubuntu)
-		Server built: Jul 22 2014 22:46:25
+    ```terminal
+    Server version: Apache/2.4.10 (Ubuntu)
+    Server built: Jul 22 2014 22:46:25
+    ```
 
 4.	Continue with the next section.
 
@@ -147,21 +171,27 @@ Installing and configuring Apache is basically a three-step process: install the
 
 1.	Install Apache 2 if you haven't already done so.
 
-		yum -y install httpd
+    ```bash
+    yum -y install httpd
+    ```
 
 2.	Verify the installation:
 
-		httpd -v
+    ```bash
+    httpd -v
+    ```
 
-	Messages similar to the following display to confirm the installation was successful:
+    Messages similar to the following display to confirm the installation was successful:
 
-		Server version: Apache/2.2.15 (Unix)
-		Server built: Oct 16 2014 14:48:21
+    ```terminal
+    Server version: Apache/2.2.15 (Unix)
+    Server built: Oct 16 2014 14:48:21
+    ```
 
 3.	Continue with the next section.
 
-{:.bs-callout .bs-callout-info}
-Even though Apache 2.4 is provided by default with CentOS 7, you configure it like Apache 2.2. See the following section.
+    {:.bs-callout .bs-callout-info}
+    Even though Apache 2.4 is provided by default with CentOS 7, you configure it like Apache 2.2. See the following section.
 
 ### Enable rewrites and .htaccess for Apache 2.2 (including CentOS 7)
 {% include install/allowoverrides22.md %}
@@ -188,12 +218,14 @@ To enable website visitors to access your site, use one of the [Require directiv
 
 For example:
 
-	<Directory /var/www/>
-		Options Indexes FollowSymLinks MultiViews
-		AllowOverride <value from Apache site>
-		Order allow,deny
-		Require all granted
-	</Directory>
+```conf
+<Directory /var/www/>
+  Options Indexes FollowSymLinks MultiViews
+  AllowOverride <value from Apache site>
+  Order allow,deny
+  Require all granted
+</Directory>
+```
 
 {:.bs-callout .bs-callout-info}
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order){:target="_blank"}.
@@ -204,12 +236,14 @@ To enable website visitors to access your site, use the [Allow directive](http:/
 
 For example:
 
-	<Directory /var/www/>
-		Options Indexes FollowSymLinks MultiViews
-		AllowOverride <value from Apache site>
-		Order allow,deny
-		Allow from all
-	</Directory>
+```conf
+<Directory /var/www/>
+  Options Indexes FollowSymLinks MultiViews
+  AllowOverride <value from Apache site>
+  Order allow,deny
+  Allow from all
+</Directory>
+```
 
 {:.bs-callout .bs-callout-info}
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order){:target="_blank"}.

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -51,35 +51,42 @@ To install MySQL 5.7 on Ubuntu 16:
 
 1.	Enter this command:
 
-		sudo apt install -y mysql-server mysql-client
+    ```bash
+    sudo apt install -y mysql-server mysql-client
+    ```
 
 2. Start MySQL:
 
-        sudo service mysql start
+    ```bash
+    sudo service mysql start
+    ```
 
 3.	Secure the installation:
 
-		sudo mysql_secure_installation
+    ```bash
+    sudo mysql_secure_installation
+    ```
 
 4.	Test the installation:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Sample output:
+    Sample output:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 45
-		Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 45 Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -93,35 +100,42 @@ To install MySQL 5.6 on Ubuntu 14:
 
 1.	Enter this command:
 
-		apt-get -y install mysql-server-5.6 mysql-client-5.6
+    ```bash
+    apt-get -y install mysql-server-5.6 mysql-client-5.6
+    ```
 
 2. Start MySQL:
 
-        sudo service mysql start
+    ```bash
+    sudo service mysql start
+    ```
 
 3.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Test the installation by entering the following command:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Sample output:
+    Sample output:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 45
-		Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 45 Server version: 5.6.19-0ubuntu0.14.04.1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -135,10 +149,21 @@ To install MySQL 5.6 on Ubuntu 12, use the following instructions from [askubunt
 
 1.	Enter the following commands in the order shown:
 
-		apt-get -y update
-		apt-add-repository ppa:ondrej/mysql-5.6
-		apt-get -y update
-		apt-get -y install mysql-server
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-add-repository ppa:ondrej/mysql-5.6
+    ```
+
+    ```bash
+    apt-get -y update
+    ```
+
+    ```bash
+    apt-get -y install mysql-server
+    ```
 
 2. Start MySQL:
 
@@ -146,27 +171,30 @@ To install MySQL 5.6 on Ubuntu 12, use the following instructions from [askubunt
 
 3.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Test the installation:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Messages similar to the following display:
+    Messages similar to the following display:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 43
-		Server version: 5.6.21-1+deb.sury.org~precise+1 (Ubuntu)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 43 Server version: 5.6.21-1+deb.sury.org~precise+1 (Ubuntu)
 
-		Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-		mysql>
+    mysql>
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can increase the value for [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} that is larger than the default, 16MB.
 
@@ -187,8 +215,13 @@ The following procedure is based on [How to Install Latest MySQL 5.7.9 on RHEL/C
 
 As a user with `root` privileges, enter the following commands in the order shown:
 
-	wget http://dev.mysql.com/get/mysql57-community-release-el7-7.noarch.rpm
-	yum -y localinstall mysql57-community-release-el7-7.noarch.rpm
+```bash
+wget http://dev.mysql.com/get/mysql57-community-release-el7-7.noarch.rpm
+```
+
+```bash
+yum -y localinstall mysql57-community-release-el7-7.noarch.rpm
+```
 
 Continue with [Install and configure MySQL 5.7 on CentOS 6 or 7](#mysql57-centos-config).
 
@@ -198,8 +231,13 @@ The following procedure is based on [How to Install Latest MySQL 5.7.9 on RHEL/C
 
 As a user with `root` privileges, enter the following commands in the order shown:
 
-	wget http://dev.mysql.com/get/mysql57-community-release-el6-7.noarch.rpm
-	yum -y localinstall mysql57-community-release-el6-7.noarch.rpm
+```bash
+wget http://dev.mysql.com/get/mysql57-community-release-el6-7.noarch.rpm
+```
+
+```bash
+yum -y localinstall mysql57-community-release-el6-7.noarch.rpm
+```
 
 Continue with the next section.
 
@@ -207,23 +245,37 @@ Continue with the next section.
 
 1.	Enter the following commands in the order shown:
 
-		yum -y install mysql-community-server
-		service mysqld start
+    ```bash
+    yum -y install mysql-community-server
+    ```
+
+    ```bash
+    service mysqld start
+    ```
 
 2.	Verify the version:
 
-		mysql --version
+    ```bash
+    mysql --version
+    ```
 
-	Sample output follows:
+    Sample output follows:
 
-		mysql  Ver 14.14 Distrib 5.7.12, for Linux (x86_64) using  EditLine wrapper
+    ```bash
+    mysql  Ver 14.14 Distrib 5.7.12, for Linux (x86_64) using  EditLine wrapper
+    ```
 
 3.	Get the temporary database `root` user password:
 
-		grep 'temporary password' /var/log/mysqld.log
+    ```bash
+    grep 'temporary password' /var/log/mysqld.log
+    ```
+
 4.	Secure the installation:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 	Follow the prompts on your screen to set a new password and configure other options.
 5.	Configure MySQL 5.7 as discussed in [Configuring the Magento database instance](#instgde-prereq-mysql-config).
@@ -234,41 +286,62 @@ The following procedure is based on [Install MySQL Server 5.6 in CentOS 6.x and 
 
 1.	*CentOS 6* Install the MySQL database:
 
-		yum -y update
-		sudo wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el6-5.noarch.rpm
-		sudo yum -y install mysql-server
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    sudo wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el6-5.noarch.rpm
+    ```
+
+    ```bash
+    sudo yum -y install mysql-server
+    ```
 
 2.	*CentOS 7* Install the MySQL database:
 
-		yum -y update
-		sudo wget http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el7-5.noarch.rpm
-		sudo yum -y install mysql-server
+    ```bash
+    yum -y update
+    ```
+
+    ```bash
+    sudo wget http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm && sudo rpm -ivh mysql-community-release-el7-5.noarch.rpm
+    ```
+
+    ```bash
+    sudo yum -y install mysql-server
+    ```
 
 2.	Start MySQL:
 
-		service mysqld start
+    ```bash
+    service mysqld start
+    ```
 
 3.	Set a password for the <tt>root</tt> user and set other security-related options. Enter the following command and follow the prompts on your screen to complete the configuration:
 
-		mysql_secure_installation
+    ```bash
+    mysql_secure_installation
+    ```
 
 4.	Verify the MySQL server version:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
-	Messages similar to the following display:
+    Messages similar to the following display:
 
-		Welcome to the MySQL monitor.  Commands end with ; or \g.
-		Your MySQL connection id is 15
-		Server version: 5.6.23 MySQL Community Server (GPL)
+    ```terminal
+    Welcome to the MySQL monitor.  Commands end with ; or \g.
+    Your MySQL connection id is 15 Server version: 5.6.23 MySQL Community Server (GPL)
 
-		Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
 
-		Oracle is a registered trademark of Oracle Corporation and/or its
-		affiliates. Other names may be trademarks of their respective
-		owners.
+    Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.
 
-		Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    ```
 
 5.	If you expect to import large numbers of products into Magento, you can configure MySQL to use the [`max_allowed_packet`](http://dev.mysql.com/doc/refman/5.6/en/program-variables.html){:target="_blank"} parameter. We recommend a value of at least 16MB.
 
@@ -285,23 +358,38 @@ To configure a MySQL database instance:
 1.	Log in to your database server as any user.
 2.	Get to a MySQL command prompt:
 
-		mysql -u root -p
+    ```bash
+    mysql -u root -p
+    ```
 
 3.	Enter the MySQL `root` user's password when prompted.
 4.	Enter the following commands in the order shown to create a database instance named `magento` with username `magento`:
 
-		create database magento;
-		create user magento IDENTIFIED BY 'magento';
-		GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';
-		flush privileges;
+    ```shell
+    create database magento;
+    ```
+
+    ```shell
+    create user magento IDENTIFIED BY 'magento';
+    ```
+
+    ```shell
+    GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';
+    ```
+
+    ```shell
+    flush privileges;
+    ```
 
 5.	Enter `exit` to quit the command prompt.
 
 6.	Verify the database:
 
-		mysql -u magento -p
+    ```bash
+    mysql -u magento -p
+    ```
 
-	If the MySQL monitor displays, you created the database properly. If an error displays, repeat the preceding commands.
+    If the MySQL monitor displays, you created the database properly. If an error displays, repeat the preceding commands.
 
 7.	If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html).
 

--- a/guides/v2.3/install-gde/prereq/mysql_remote.md
+++ b/guides/v2.3/install-gde/prereq/mysql_remote.md
@@ -44,37 +44,43 @@ To create a remote connection:
 
 1.	On your database server, as a user with `root` privileges, open your MySQL configuration file.
 
-	To locate it, enter the following command:
+    To locate it, enter the following command:
 
-		mysql --help
+    ```bash
+    mysql --help
+    ```
 
-	The location displays similar to the following:
+    The location displays similar to the following:
 
-		Default options are read from the following files in the given order:
-		/etc/my.cnf /etc/mysql/my.cnf /usr/etc/my.cnf ~/.my.cnf
+    ```terminal
+    Default options are read from the following files in the given order:
+    /etc/my.cnf /etc/mysql/my.cnf /usr/etc/my.cnf ~/.my.cnf
+    ```
 
     {:.bs-callout .bs-callout-info}
     On Ubuntu 16, the path is typically `/etc/mysql/mysql.conf.d/mysqld.cnf`.
 
 3.	Search the configuration file for `bind-address`.
 
-	If it exists, change the value as follows.
+    If it exists, change the value as follows.
 
-	If it doesn't exist, add it anywhere except the `[mysqld]` section.
+    If it doesn't exist, add it anywhere except the `[mysqld]` section.
 
-		bind-address = <ip address of your Magento web node>
+    ```conf
+    bind-address = <ip address of your Magento web node>
+    ```
 
-	See [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html), especially if you have a clustered web server.
+    See [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html), especially if you have a clustered web server.
 
 3.	Save your changes to the configuration file and exit the text editor.
 4.	Restart the MySQL service:
 
-	CentOS: `service mysqld restart`
+    * CentOS: `service mysqld restart`
 
-	Ubuntu: `service mysql restart`
+    * Ubuntu: `service mysql restart`
 
-{:.bs-callout .bs-callout-info}
-If MySQL fails to start, look in syslog for the source of the issue. Resolve the issue using [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_bind-address) or another authoritative source.
+    {:.bs-callout .bs-callout-info}
+    If MySQL fails to start, look in syslog for the source of the issue. Resolve the issue using [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_bind-address) or another authoritative source.
 
 ## Grant access to a database user {#instgde-prereq-mysql-remote-access}
 
@@ -88,34 +94,39 @@ To grant access to a database user:
 2.	Connect to the MySQL database as the `root` user.
 3.	Enter the following command:
 
-		GRANT ALL ON <local database name>.* TO <remote web node username>@<remote web node server ip address> IDENTIFIED BY '<database user password>';
+    ```shell
+    GRANT ALL ON <local database name>.* TO <remote web node username>@<remote web node server ip address> IDENTIFIED BY '<database user password>';
+    ```
 
-	For example,
+    For example,
 
-		GRANT ALL ON magento_remote.* TO dbuser@192.0.2.50 IDENTIFIED BY 'dbuserpassword';
+    ```shell
+    GRANT ALL ON magento_remote.* TO dbuser@192.0.2.50 IDENTIFIED BY 'dbuserpassword';
+    ```
 
-{:.bs-callout .bs-callout-info}
-If your web server is clustered, enter the same command on every web server. You must use the same username for every web server.
+    {:.bs-callout .bs-callout-info}
+    If your web server is clustered, enter the same command on every web server. You must use the same username for every web server.
 
 ## Verify database access {#instgde-prereq-mysql-remote-verify}
 
 On your web node host, enter the following command to verify the connection works:
 
-	mysql -u <local database username> -h <database server ip address> -p
+```bash
+mysql -u <local database username> -h <database server ip address> -p
+```
 
 If the MySQL monitor displays as follows, the database is ready for the Magento software:
 
-	Welcome to the MySQL monitor.  Commands end with ; or \g.
-	Your MySQL connection id is 213
-	Server version: 5.6.26 MySQL Community Server (GPL)
+```terminal
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 213 Server version: 5.6.26 MySQL Community Server (GPL)
 
-	Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
 
-	Oracle is a registered trademark of Oracle Corporation and/or its
-	affiliates. Other names may be trademarks of their respective
-	owners.
+Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.
 
-	Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+```
 
 If your web server is clustered, enter the command on each web server host.
 

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -29,7 +29,9 @@ The following section describes how to install Magento 2.x on Ubuntu 16 using ng
 
 ### Install nginx
 
-	apt-get -y install nginx
+```bash
+apt-get -y install nginx
+```
 
 After completing the following sections and [installing Magento]({{page.baseurl }}/install-gde/prereq/nginx.html#install-magento2-ubuntu), we'll use a sample configuration file to [configure nginx]({{page.baseurl }}/install-gde/prereq/nginx.html#configure-nginx-ubuntu).
 
@@ -41,30 +43,41 @@ To install and configure `php-fpm`:
 
 1. Install `php-fpm` and `php-cli`:
 
-		apt-get -y install php7.2-fpm php7.2-cli
+    ```bash
+    apt-get -y install php7.2-fpm php7.2-cli
+    ```
 
     {:.bs-callout .bs-callout-info}
     This command installs the latest available version of PHP 7.2.X. See [Magento 2.3.x technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for supported PHP versions.
 
 2. Open the `php.ini` files in an editor:
 
-		vim /etc/php/7.2/fpm/php.ini
-		vim /etc/php/7.2/cli/php.ini
+    ```bash
+    vim /etc/php/7.2/fpm/php.ini
+    ```
+
+    ```bash
+    vim /etc/php/7.2/cli/php.ini
+    ```
 
 3. Edit both files to match the following lines:
 
-		memory_limit = 2G
-		max_execution_time = 1800
-		zlib.output_compression = On
+    ```conf
+    memory_limit = 2G
+    max_execution_time = 1800
+    zlib.output_compression = On
+    ```
 
-{:.bs-callout .bs-callout-info}
-We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
+    {:.bs-callout .bs-callout-info}
+    We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
 
 4. Save and exit the editor.
 
 5. Restart the `php-fpm` service:
 
-		systemctl restart php7.2-fpm
+    ```bash
+    systemctl restart php7.2-fpm
+    ```
 
 ### Install and configure MySQL
 
@@ -89,20 +102,26 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1.  Change to the web server docroot directory or a directory that you have configured as a virtual host docroot. For this example, we're using the Ubuntu default `/var/www/html`.
 
-		cd /var/www/html
+    ```bash
+    cd /var/www/html
+    ```
 
 1.  Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-		curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```bash
+    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```
 
 1. Create a new Composer project using the {{site.data.var.ce}} or {{site.data.var.ee}} metapackage.
 
     **{{site.data.var.ce}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
     ```
 
     **{{site.data.var.ee}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
     ```
@@ -142,8 +161,13 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Switch to developer mode:
 
-		cd /var/www/html/magento2/bin
+    ```bash
+    cd /var/www/html/magento2/bin
+    ```
+
+    ```bash
     ./magento deploy:mode:set developer
+    ```
 
 ### Configure nginx {#configure-nginx-ubuntu}
 
@@ -153,21 +177,25 @@ These instructions assume you're using the Ubuntu default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-		vim /etc/nginx/sites-available/magento
+    ```bash
+    vim /etc/nginx/sites-available/magento
+    ```
 
 2. Add the following configuration:
 
-		upstream fastcgi_backend {
-			server  unix:/run/php/php7.2-fpm.sock;
-		}
+    ```conf
+    upstream fastcgi_backend {
+      server  unix:/run/php/php7.2-fpm.sock;
+    }
 
-		server {
+    server {
 
-			listen 80;
-			server_name www.magento-dev.com;
-			set $MAGE_ROOT /var/www/html/magento2;
-			include /var/www/html/magento2/nginx.conf.sample;
-		}
+      listen 80;
+      server_name www.magento-dev.com;
+      set $MAGE_ROOT /var/www/html/magento2;
+      include /var/www/html/magento2/nginx.conf.sample;
+    }
+    ```
 
 {:.bs-callout .bs-callout-info}
 The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -178,15 +206,21 @@ The `include` directive must point to the sample nginx configuration file in you
 
 5. Activate the newly created virtual host by creating a symlink to it in the `/etc/nginx/sites-enabled` directory:
 
-		ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
+    ```bash
+    ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
+    ```
 
 6. Verify that the syntax is correct:
 
-		nginx -t
+    ```bash
+    nginx -t
+    ```
 
 7. Restart nginx:
 
-		systemctl restart nginx
+    ```bash
+    systemctl restart nginx
+    ```
 
 ### Verify the installation
 
@@ -198,13 +232,23 @@ The following section describes how to install Magento 2.x on CentOS 7 using ngi
 
 ### Install nginx
 
-	yum -y install epel-release
-	yum -y install nginx
+```bash
+yum -y install epel-release
+```
+
+```bash
+yum -y install nginx
+```
 
 After installation is complete, start nginx and configure it to start at boot time:
 
-	systemctl start nginx
-	systemctl enable nginx
+```bash
+systemctl start nginx
+```
+
+```bash
+systemctl enable nginx
+```
 
 After completing the following sections and [installing Magento]({{page.baseurl }}/install-gde/prereq/nginx.html#install-magento2-centos), we'll use a sample configuration file to [configure nginx]({{page.baseurl }}/install-gde/prereq/nginx.html#configure-nginx-centos).
 
@@ -214,7 +258,9 @@ Magento requires several [PHP extensions](php-centos-ubuntu.html) to function pr
 
 1. Install `php-fpm`:
 
-		yum -y install php70w-fpm
+    ```bash
+    yum -y install php70w-fpm
+    ```
 
 2. Open the `/etc/php.ini` file in an editor.
 
@@ -222,16 +268,20 @@ Magento requires several [PHP extensions](php-centos-ubuntu.html) to function pr
 
 4. Edit the file to match the following lines:
 
-		memory_limit = 2G
-		max_execution_time = 1800
-		zlib.output_compression = On
+    ```conf
+    memory_limit = 2G
+    max_execution_time = 1800
+    zlib.output_compression = On
+    ```
 
 {:.bs-callout .bs-callout-info}
 We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
 
 5. Uncomment the session path directory and set the path:
 
-		session.save_path = "/var/lib/php/session"
+    ```conf
+    session.save_path = "/var/lib/php/session"
+    ```
 
 6. Save and exit the editor.
 
@@ -239,41 +289,62 @@ We recommend setting the memory limit to 2G when testing Magento. Refer to [Requ
 
 8. Edit the file to match the following lines:
 
-		user = nginx
-		group = nginx
-		listen = /run/php-fpm/php-fpm.sock
-		listen.owner = nginx
-		listen.group = nginx
-		listen.mode = 0660
+    ```conf
+    user = nginx
+    group = nginx
+    listen = /run/php-fpm/php-fpm.sock
+    listen.owner = nginx
+    listen.group = nginx
+    listen.mode = 0660
+    ```
 
 9. Uncomment the environment lines:
 
-		env[HOSTNAME] = $HOSTNAME
-		env[PATH] = /usr/local/bin:/usr/bin:/bin
-		env[TMP] = /tmp
-		env[TMPDIR] = /tmp
-		env[TEMP] = /tmp
+    ```cond
+    env[HOSTNAME] = $HOSTNAME
+    env[PATH] = /usr/local/bin:/usr/bin:/bin
+    env[TMP] = /tmp
+    env[TMPDIR] = /tmp
+    env[TEMP] = /tmp
+    ```
 
 10. Save and exit the editor.
 
 11. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-		mkdir -p /var/lib/php/session/
-		chown -R apache:apache /var/lib/php/
+    ```bash
+    mkdir -p /var/lib/php/session/
+    ```
+
+    ```bash
+    chown -R apache:apache /var/lib/php/
+    ```
 
 12. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-		mkdir -p /run/php-fpm/
-		chown -R apache:apache /run/php-fpm/
+    ```bash
+    mkdir -p /run/php-fpm/
+    ```
+
+    ```bash
+    chown -R apache:apache /run/php-fpm/
+    ```
 
 13. Start the `php-fpm` service and configure it to start at boot time:
 
-		systemctl start php-fpm
-		systemctl enable php-fpm
+    ```bash
+    systemctl start php-fpm
+    ```
+
+    ```bash
+    systemctl enable php-fpm
+    ```
 
 14. Verify that the `php-fpm` service is running:
 
-		netstat -pl | grep php-fpm.sock
+    ```bash
+    netstat -pl | grep php-fpm.sock
+    ```
 
 ### Install and configure MySQL
 
@@ -298,20 +369,26 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1.  Change to the web server docroot directory or a directory that you have configured as a virtual host docroot. For this example, we're using the Ubuntu default `/var/www/html`.
 
-		cd /var/www/html
+    ```bash
+    cd /var/www/html
+    ```
 
 1.  Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-		curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```bash
+    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+    ```
 
 1. Create a new Composer project using the {{site.data.var.ce}} or {{site.data.var.ee}} metapackage.
 
     **{{site.data.var.ce}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
     ```
 
     **{{site.data.var.ee}}**
+
     ```bash
     composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
     ```
@@ -351,8 +428,13 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Switch to developer mode:
 
-		cd /var/www/html/magento2/bin
+    ```bash
+    cd /var/www/html/magento2/bin
+    ```
+
+    ```bash
     ./magento deploy:mode:set developer
+    ```
 
 ### Configure nginx {#configure-nginx-centos}
 
@@ -362,21 +444,25 @@ These instructions assume you're using the CentOS default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-		vim /etc/nginx/conf.d/magento.conf
+    ```bash
+    vim /etc/nginx/conf.d/magento.conf
+    ```
 
 2. Add the following configuration:
 
-		upstream fastcgi_backend {
-			server  unix:/run/php-fpm/php-fpm.sock;
-		}
+    ```conf
+    upstream fastcgi_backend {
+      server  unix:/run/php-fpm/php-fpm.sock;
+    }
 
-		server {
+    server {
 
-			listen 80;
-			server_name www.magento-dev.com;
-			set $MAGE_ROOT /usr/share/nginx/html/magento2;
-			include /usr/share/nginx/html/magento2/nginx.conf.sample;
-		}
+      listen 80;
+      server_name www.magento-dev.com;
+      set $MAGE_ROOT /usr/share/nginx/html/magento2;
+      include /usr/share/nginx/html/magento2/nginx.conf.sample;
+    }
+    ```
 
 {:.bs-callout .bs-callout-info}
 The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -387,46 +473,83 @@ The `include` directive must point to the sample nginx configuration file in you
 
 5. Verify that the syntax is correct:
 
-		nginx -t
+    ```bash
+    nginx -t
+    ```
 
 6. Restart nginx:
 
-		systemctl restart nginx
+    ```bash
+    systemctl restart nginx
+    ```
 
 ### Configure SELinux and Firewalld
 
 SELinux is enabled by default on CentOS 7. Use the following command to see if it's running:
 
-	sestatus
+```bash
+sestatus
+```
 
 To configure SELinux and firewalld:
 
 1. Install SELinux management tools:
 
-		yum -y install policycoreutils-python
+    ```bash
+    yum -y install policycoreutils-python
+    ```
 
 2. Run the following commands to change the security context for the Magento installation directory:
 
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
-		semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
-		restorecon -Rv '/usr/share/nginx/html/magento2/'
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
+    ```
+
+    ```bash
+    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
+    ```
+
+    ```bash
+    restorecon -Rv '/usr/share/nginx/html/magento2/'
+    ```
 
 3. Install the firewalld package:
 
-		yum -y install firewalld
+    ```bash
+    yum -y install firewalld
+    ```
 
 4. Start the firewall service and configure it to start at boot time:
 
-		systemctl start firewalld
-		systemctl enable firewalld
+    ```bash
+    systemctl start firewalld
+    ```
+
+    ```bash
+    systemctl enable firewalld
+    ```
 
 5. Run the following commands to open ports for HTTP and HTTPS so you can access the Magento base URL from a web browser:
 
-		firewall-cmd --permanent --add-service=http
-		firewall-cmd --permanent --add-service=https
-		firewall-cmd --reload
+    ```bash
+    firewall-cmd --permanent --add-service=http
+    ```
+
+    ```bash
+    firewall-cmd --permanent --add-service=https
+    ```
+
+    ```bash
+    firewall-cmd --reload
+    ```
 
 ### Verify the installation
 

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -300,7 +300,7 @@ We recommend setting the memory limit to 2G when testing Magento. Refer to [Requ
 
 9. Uncomment the environment lines:
 
-    ```cond
+    ```conf
     env[HOSTNAME] = $HOSTNAME
     env[PATH] = /usr/local/bin:/usr/bin:/bin
     env[TMP] = /tmp

--- a/guides/v2.3/install-gde/prereq/optional.md
+++ b/guides/v2.3/install-gde/prereq/optional.md
@@ -31,7 +31,7 @@ See one of the following sections:
 
 Enter the following command to install NTP:
 
-```bsh
+```bash
 apt-get install ntp
 ```
 

--- a/guides/v2.3/install-gde/prereq/optional.md
+++ b/guides/v2.3/install-gde/prereq/optional.md
@@ -31,7 +31,9 @@ See one of the following sections:
 
 Enter the following command to install NTP:
 
-	apt-get install ntp
+```bsh
+apt-get install ntp
+```
 
 Continue with [Use NTP pool servers](#install-optional-ntp-servers).
 
@@ -41,17 +43,23 @@ To install and configure NTP:
 
 1.	Enter the following command to find the appropriate NTP software:
 
-		yum search ntp
+    ```bash
+    yum search ntp
+    ```
 
 2.	Select a package to install. For example, `ntp.x86_64`.
 
 2.	Install the package.
 
-		yum -y install ntp.x86_64
+    ```bash
+    yum -y install ntp.x86_64
+    ```
 
 3.	Enter the following command so that NTP starts when the server starts.
 
-		chkconfig ntpd on
+    ```bash
+    chkconfig ntpd on
+    ```
 
 3.	Continue with the next section.
 
@@ -63,33 +71,37 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
 
 2.	Look for lines similar to the following:
 
-		server 0.centos.pool.ntp.org
-		server 1.centos.pool.ntp.org
-		server 2.centos.pool.ntp.org
+    ```conf
+    server 0.centos.pool.ntp.org
+    server 1.centos.pool.ntp.org
+    server 2.centos.pool.ntp.org
+    ```
 
 3.	Replace those lines or add additional lines that specify your NTP pool server or other NTP servers. It's a good idea to specify more than one.
 
 4.	An example of using three United States-based NTP servers follows:
 
-		server 0.us.pool.ntp.org
-		server 1.us.pool.ntp.org
-		server 2.us.pool.ntp.org
+    ```conf
+    server 0.us.pool.ntp.org
+    server 1.us.pool.ntp.org
+    server 2.us.pool.ntp.org
+    ```
 
 5.	Save your changes to `/etc/ntp.conf` and exit the text editor.
 
 4.	Restart the service.
 
-	Ubuntu: `service ntp restart`
+    * Ubuntu: `service ntp restart`
 
-	CentOS: `service ntpd restart`
+    * CentOS: `service ntpd restart`
 
 4.	Enter `date` to check the server's date.
 
-	If the date is incorrect, make sure the NTP client port (typically, UDP 123) is open in your firewall.
+    If the date is incorrect, make sure the NTP client port (typically, UDP 123) is open in your firewall.
 
-	Try the `ntpdate _[pool server hostname]_` command. If it fails, search for the error it returns.
+    Try the `ntpdate _[pool server hostname]_` command. If it fails, search for the error it returns.
 
-	If all else fails, try rebooting the server.
+    If all else fails, try rebooting the server.
 
 ## Create phpinfo.php {#install-optional-phpinfo}
 [`phpinfo.php`](http://php.net/manual/en/function.phpinfo.php){:target="_blank"} displays a large amount of information about [PHP](https://glossary.magento.com/php) and its extensions.
@@ -99,15 +111,19 @@ Use `phpinfo.php` in a development system _only_. It can be a security issue in 
 
 Add the following code anywhere in your web server's docroot:
 
-	<?php
-	// Show all information, defaults to INFO_ALL
-	phpinfo();
+```php
+<?php
+// Show all information, defaults to INFO_ALL
+phpinfo();
+```
 
 For more information, see the [phpinfo manual page](http://php.net/manual/en/function.phpinfo.php){:target="_blank"}.
 
 To view the results, enter the following [URL](https://glossary.magento.com/url) in your browser's location or address field:
 
-	http://<web server host or IP>/phpinfo.php
+```http
+http://<web server host or IP>/phpinfo.php
+```
 
 If a 404 (Not Found) error displays, check the following:
 
@@ -134,13 +150,17 @@ To install phpmyadmin on Ubuntu:
 
 1.	Use the following command:
 
-		apt-get install phpmyadmin
+    ```bash
+    apt-get install phpmyadmin
+    ```
 
 2.	Follow the prompts on your screen to complete the installation.
 
 3.	To use phpmyadmin, enter the following URL in your browser's address or location field:
 
-		http://<web server host or IP>/phpmyadmin
+    ```http
+    http://<web server host or IP>/phpmyadmin
+    ```
 
 4.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
@@ -150,45 +170,69 @@ To install phpmyadmin on CentOS:
 
 1.	Download the epel RPM for the version of CentOS you're using. A sample follows.
 
-		cd /tmp
-		wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
-		rpm -ivh epel-release-6-8.noarch.rpm
+    ```bash
+    cd /tmp
+    ```
+
+    ```bash
+    wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+    ```
+
+    ```bash
+    rpm -ivh epel-release-6-8.noarch.rpm
+    ```
 
 2.	Install `phpmyadmin` as follows:
 
-		yum -y install phpmyadmin
+    ```bash
+    yum -y install phpmyadmin
+    ```
 
 3.	Authorize access to phpmyadmin from your machine's IP address.
 
-	Open the following file for editing:
+    Open the following file for editing:
 
-		vim /etc/httpd/conf.d/phpMyAdmin.conf
+    ```bash
+    vim /etc/httpd/conf.d/phpMyAdmin.conf
+    ```
 
 3.	Replace the following IP address with your IP address
 
-		Require ip localhost
+    ```conf
+    Require ip localhost
+    ```
 
-	For example,
+    For example,
 
-		Require ip 192.51.100.101
+    ```conf
+    Require ip 192.51.100.101
+    ```
 
 4.	Replace the following IP with your IP address:
 
-		Allow from localhost
+    ```conf
+    Allow from localhost
+    ```
 
-	For example,
+    For example,
 
-		Allow from 192.51.100.101
+    ```conf
+    Allow from 192.51.100.101
+    ```
 
 5.	Save your changes to `/etc/httpd/conf.d/phpMyAdmin.conf` and exit the text editor.
 
 6.	Restart Apache.
 
-		service httpd Restart
+    ```bash
+    service httpd Restart
+    ```
 
 7.	To use phpmyadmin, enter the following command in your browser's address or location field:
 
-		http://<web server host or IP>/phpmyadmin
+    ```http
+    http://<web server host or IP>/phpmyadmin
+    ```
 
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 

--- a/guides/v2.3/install-gde/prereq/php-settings.md
+++ b/guides/v2.3/install-gde/prereq/php-settings.md
@@ -13,7 +13,9 @@ This topic discusses how to set required [PHP](https://glossary.magento.com/php)
 
 *	Set the system time zone for PHP; otherwise, errors like the following display during the installation and time-related operations like cron might not work:
 
-		PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more messages follow]
+    ```terminal
+    PHP Warning:  date(): It is not safe to rely on the system's timezone settings. [more messages follow]
+    ```
 
 *	Set the PHP memory limit.
 
@@ -48,7 +50,9 @@ To find the web server configuration, run a [`phpinfo.php` file]({{page.baseurl}
 
 To locate the PHP command-line configuration, enter
 
-	php --ini
+```bash
+php --ini
+```
 
 Use the value of Loaded Configuration file.
 
@@ -63,13 +67,15 @@ Use the following guidelines to find it:
 
 *	Apache web server:
 
-	For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
+    For Ubuntu with Apache, OPcache settings are typically located in `php.ini`.
 
-	For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
+    For CentOS with Apache or nginx, OPcache settings are typically located in `/etc/php.d/opcache.ini`
 
-	If not, use the following command to locate it:
+    If not, use the following command to locate it:
 
-		sudo find / -name 'opcache.ini'
+    ```bash
+    sudo find / -name 'opcache.ini'
+    ```
 
 *	nginx web server with PHP-FPM: `/etc/php5/fpm/php.ini`
 
@@ -83,17 +89,25 @@ To set PHP options:
 3.	Locate your server's time zone in the available [time zone settings](http://php.net/manual/en/timezones.php){:target="_blank"}
 4.	Locate the following setting and uncomment it if necessary:
 
-		date.timezone =
+    ```conf
+    date.timezone =
+    ```
+
 5.	Add the time zone setting you found in step 2.
 6.	Change the value of `memory_limit` to one of the values at the beginning of this section.
 
-	For example,
+    For example,
 
-		memory_limit=2G
+    ```conf
+    memory_limit=2G
+    ```
 
 8.	Locate the following setting:
 
-		asp_tags =
+    ```conf
+    asp_tags =
+    ```
+
 9.	Make sure its value is set to `Off`.
 10.	Save your changes and exit the text editor.
 11.	Open the other `php.ini` (if they are different) and make the same changes in it.

--- a/guides/v2.3/install-gde/prereq/security.md
+++ b/guides/v2.3/install-gde/prereq/security.md
@@ -20,10 +20,21 @@ Magento has no recommendation about using SELinux; you can use it for enhanced s
 
 If you choose to enable SELinux, you might have issues running the installer unless you change the *security context* of some directories as follows:
 
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/app/etc
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/var
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/media
-	chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/static
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/app/etc
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/var
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/media
+```
+
+```bash
+chcon -R --type httpd_sys_rw_content_t <magento_root>/pub/static
+```
 
 The preceding commands work only with the Apache web server. Because of the variety of configurations and security requirements, we don't guarantee these commands work in all situations. For more information, see:
 
@@ -38,15 +49,17 @@ To enable Apache to initiate a connection to another host with SELinux enabled:
 
 1.	To determine if SELinux is enabled, use the following command:
 
-		getenforce
+    ```bash
+    getenforce
+    ```
 
-	`Enforcing` displays to confirm that SELinux is running.
+    `Enforcing` displays to confirm that SELinux is running.
 
 2.	Enter one of the following commands:
 
-	CentOS: `setsebool -P httpd_can_network_connect=1`
+    * CentOS: `setsebool -P httpd_can_network_connect=1`
 
-	Ubuntu: `setsebool -P apache2_can_network_connect=1`
+    * Ubuntu: `setsebool -P apache2_can_network_connect=1`
 
 ## Opening Ports In Your Firewall {#install-iptables}
 

--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -50,22 +50,31 @@ To transfer the Magento software archive to your server:
 7.	Change to the web server docroot or the virtual host directory.
 7.	Create a subdirectory for the Magento software.
 
-	If you set up a virtual host, the subdirectory name must match the name in your virtual host.
+    If you set up a virtual host, the subdirectory name must match the name in your virtual host.
 
-	For example,
+    For example,
 
-		mkdir magento2ce
-		mkdir magento2ee
+    ```bash
+    mkdir magento2ce
+    ```
 
-	You can also use a generic directory name
+    ```bash
+    mkdir magento2ee
+    ```
 
-		mkdir magento2
+    You can also use a generic directory name
+
+    ```bash
+    mkdir magento2
+    ```
 
 7.	Copy the Magento archive to that directory.
 
-	For example,
+    For example,
 
-		cp /var/www/Magento-CE-2.0.0+Samples.tar.bz2 magento2
+    ```bash
+    cp /var/www/Magento-CE-2.0.0+Samples.tar.bz2 magento2
+    ```
 
 8.	Continue with the next section.
 

--- a/guides/v2.3/install-gde/trouble/php/tshoot_pdo.md
+++ b/guides/v2.3/install-gde/trouble/php/tshoot_pdo.md
@@ -13,9 +13,10 @@ functional_areas:
 
 ### Details
 
-	PHP Fatal error:  Class 'PDO' not found in /var/www/html/magento2/setup/module/Magento/Setup/src/Module/Setup/ConnectionFactory.php on line 44
+```terminal
+PHP Fatal error:  Class 'PDO' not found in /var/www/html/magento2/setup/module/Magento/Setup/src/Module/Setup/ConnectionFactory.php on line 44
+```
 
 ### Solution
 
 Make sure you installed all [required PHP extensions](../../prereq/php-centos-ubuntu.html).
-


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD040 errors in the Installation Guide

The MD040 rule requires that a language be specified for fenced code blocks. However, it also identifies indented code blocks, so you may see changes in this PR that replace indentation with fences.

This is one of many PRs related to #5252.

My apologies... I got carried away fixing errors and lost track of how many files I was touching. This is a large review effort, but I'm quite confident it can be scanned. I know I'm prone to typos when specifiying lexers, so maybe focus your efforts there. I've done enough of these by now that I think the indentation is spot on. Just trust me ;)