### PR TITLE
MAGEDOC-4099: Added more info about pre-release packages

### DIFF
--- a/_includes/install/pre-release.md
+++ b/_includes/install/pre-release.md
@@ -1,2 +1,2 @@
 {:.bs-callout-info}
-{{site.data.var.ee}} customers can access 2.3.x and 2.2.x patches two weeks before the General Availability (GA) date. Pre-release packages are available through Composer only. You cannot find them on the Magento Portal or GitHub until GA. If you cannot find these packages in Composer, contact Magento Support.
+{{site.data.var.ee}} customers can access 2.3.x and 2.2.x patches two weeks before the General Availability (GA) date. Pre-release packages are available through Composer only. You cannot access pre-releases on the Magento Portal or GitHub until GA. If you cannot find these packages in Composer, contact Magento Support.

--- a/_includes/install/pre-release.md
+++ b/_includes/install/pre-release.md
@@ -1,0 +1,2 @@
+{:.bs-callout-info}
+{{site.data.var.ee}} customers can access 2.3.x and 2.2.x patches two weeks before the General Availability (GA) date. Pre-release packages are available through Composer only. You cannot find them on the Magento Portal or GitHub until GA. If you cannot find these packages in Composer, contact Magento Support.

--- a/guides/v2.2/release-notes/release-notes-2-2-10-commerce.md
+++ b/guides/v2.2/release-notes/release-notes-2-2-10-commerce.md
@@ -8,6 +8,8 @@ title: Magento Commerce 2.2.10 Release Notes
 
 Magento Commerce 2.2.10 offers significant platform upgrades, substantial security changes, and PSD2-compliant core payment methods. This release includes over 147 functional fixes and enhancements to the core product and 75 security enhancements. It includes 56 community-fixed GitHub issues.
 
+{% include install/pre-release.md %}
+
 ## Highlights
 
 Look for the following highlights in this release:

--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -41,7 +41,7 @@ Using the more manual process of upgrading via the command line allows you to tr
 ## Manage packages
 
 {:.bs-callout-info}
-See the examples at the end of this section for help specifying different release levels. For example, minor release, quality patch, and security patch. {{site.data.var.ee}} customers can access 2.3.x patches two weeks before the General Availability (GA) date.
+See the examples at the end of this section for help specifying different release levels. For example, minor release, quality patch, and security patch. {{site.data.var.ee}} customers can access 2.3.x patches two weeks before the General Availability (GA) date. Pre-release packages are available through Composer only. You cannot find them on the Magento Portal or GitHub until GA. If you cannot find these packages in Composer, contact Magento Support.
 
 1. Backup the `composer.json` file.
 

--- a/guides/v2.3/install-gde/composer.md
+++ b/guides/v2.3/install-gde/composer.md
@@ -51,8 +51,7 @@ To get the Magento metapackage:
 
     See [troubleshooting][] for help with more errors.
 
-    {:.bs-callout-info}
-    {{site.data.var.ee}} customers can access 2.3.x patches two weeks before the General Availability (GA) date.
+    {% include install/pre-release.md %}
 
 ### Example - Minor release
 

--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -9,6 +9,8 @@ Magento Commerce 2.3.3 offers significant platform upgrades, substantial securit
 
 This release includes over 170 functional fixes to the core product and  over 75 security enhancements. It includes over 200 contributions from our community members. These contributions range from minor clean-up of core code to significant enhancements to Inventory Management and GraphQL.
 
+{% include install/pre-release.md %}
+
 ## Other release information
 
 Although code for these features is bundled with quarterly releases of the Magento core code, several of these projects (for example, Page Builder, Inventory Management, and Progressive Web Applications (PWA) Studio) are also released independently. Bug fixes for these projects are documented in separate, project-specific release information which is available in the documentation for each project.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies where pre-release Composer packages are located.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/install-gde/composer.html
- https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html
- https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html
- https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-10-commerce.html

See MAGEDOC-4099 for links to staging.