### PR TITLE
magento/devdocs#5245: Hard tabs. Folder: guides/payments-integrations

### DIFF
--- a/guides/v2.2/payments-integrations/base-integration/formblocktype.md
+++ b/guides/v2.2/payments-integrations/base-integration/formblocktype.md
@@ -76,7 +76,7 @@ The following example adds the Braintree-specific template [`app/code/Magento/Pa
     <body>
         <referenceBlock name="order_create_billing_form">
             <action method="setMethodFormTemplate">
-				<!-- your method code and template -->
+                <!-- your method code and template -->
                 <argument name="method" xsi:type="string">braintree</argument>
                 <argument name="template" xsi:type="string">Magento_Braintree::form/cc.phtml</argument>
             </action>

--- a/guides/v2.2/payments-integrations/payment-gateway/command-pool.md
+++ b/guides/v2.2/payments-integrations/payment-gateway/command-pool.md
@@ -33,7 +33,7 @@ Following is an example of the command pool configuring for the Braintree paymen
             <item name="authorize" xsi:type="string">BraintreeAuthorizeCommand</item>
             <item name="sale" xsi:type="string">BraintreeSaleCommand</item>
             <item name="capture" xsi:type="string">BraintreeCaptureStrategyCommand</item>
-			...
+            ...
         </argument>
     </arguments>
 </virtualType>


### PR DESCRIPTION
## Purpose of this pull request

This pull request converts HARD TABs to SPACES in the folder: `guides/payments-integrations` (v.2.2 and v.2.3)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!

CC: @jeff-matthews 
