### PR TITLE
magento/devdocs#5245: Hard tabs. Folders in the root

### DIFF
--- a/_layouts/m1x.html
+++ b/_layouts/m1x.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
+    <meta charset="utf-8">
 
-	<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
-	<link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
-	<link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
-	<link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
+    <link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
 
-	<title>{{ page.title }}</title>
+    <title>{{ page.title }}</title>
 </head>
 <body>
-	<a name="top"></a>
-	<img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
-	{% include m1x/eol_message.html %}
-	<h1>{{ page.title }}</h1>
-	<div id="content">
-		{{ content }}
-	</div>
+    <a name="top"></a>
+    <img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
+    {% include m1x/eol_message.html %}
+    <h1>{{ page.title }}</h1>
+    <div id="content">
+        {{ content }}
+    </div>
 </body>
 </html>

--- a/_layouts/m1x_rest.html
+++ b/_layouts/m1x_rest.html
@@ -1,132 +1,132 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
+    <meta charset="utf-8">
 
-	<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
-	<link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
-	<link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
-	<link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function(){
-			var currentUrl = window.location.href;
-			$.each($('.soap-api-menu a'), function(index, element) {
-				if (currentUrl.indexOf($(element).attr('href')) > -1) {
-					$(element).addClass('active');
-					$(element).parents('ul').show();
-					$(element).parents('li.parent').addClass('open');
-					$(element).nextAll('ul').show();
-				}
-			});
-			$.each($('.soap-api-menu li.parent .arr'), function(index, element) {
-				$(element).on('click', function(e){
-					$(this).parent('li.parent').toggleClass('open');
-					$(this).next('ul').slideToggle();
-				})
-			});
-		});
-	</script>
-	<title>{{ page.title }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
+    <link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            var currentUrl = window.location.href;
+            $.each($('.soap-api-menu a'), function(index, element) {
+                if (currentUrl.indexOf($(element).attr('href')) > -1) {
+                    $(element).addClass('active');
+                    $(element).parents('ul').show();
+                    $(element).parents('li.parent').addClass('open');
+                    $(element).nextAll('ul').show();
+                }
+            });
+            $.each($('.soap-api-menu li.parent .arr'), function(index, element) {
+                $(element).on('click', function(e){
+                    $(this).parent('li.parent').toggleClass('open');
+                    $(this).next('ul').slideToggle();
+                })
+            });
+        });
+    </script>
+    <title>{{ page.title }}</title>
 </head>
 <body>
-	<a name="top"></a>
-	<img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
-	{% include m1x/eol_message.html %}
-	<h1>{{ page.title }}</h1>
-	<div id="content">
-		<p><a href="{{ site.m1xgithuburl }}/{{ page.github_path }}" target="_blank">Edit this page on GitHub <img src="{{ site.baseurl }}/common/images/github_icon.png" height="15px"></a></p>
-		<div class="soap-api-menu">
-			<ul>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/introduction.html">Introduction</a>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/rest/authentication/oauth_authentication.html">Authentication</a>
-					<span class="arr"></span>
-					<ul>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/authentication/oauth_configuration.html">OAuth Configuration</a>
-						</li>
-					</ul>
-				</li>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/common_http_status_codes.html">Common HTTP Status Codes</a>
-				</li>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/http_methods.html">HTTP Methods</a>
-				</li>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/get_filters.html">GET Filters</a>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/permission_settings.html">Permission Settings</a>
-					<span class="arr"></span>
-					<ul>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/roles_configuration.html">Roles Configuration</a>
-						</li>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/attributes_configuration.html">Attributes Configuration</a>
-						</li>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/attributes_description.html">Attributes Description</a>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/rest/Resources/resources.html">Resources</a>
-					<span class="arr"></span>
-					<ul>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/Resources/inventory.html">Inventory</a>
-						</li>
-						<li class="parent"><a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/sales_orders.html">Orders</a>
-							<span class="arr"></span>
-							<ul>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_addresses.html">Order Addresses</a></li>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_comments.html">Order Comments</a>
-								</li>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_items.html">Order Items</a>
-								</li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/products.html">Products</a>
-							<span class="arr"></span>
-							<ul>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_categories.html">Product Categories</a></li>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_images.html">Product Images</a>
-								</li>
-								<li>
-									<a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_websites.html">Product Websites</a>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/Resources/resource_customer_addresses.html">Customer Addresses</a>
-						</li>
-						<li>
-							<a href="{{ site.m1xgdeurl }}/api/rest/Resources/resource_customers.html">Customers</a>
-						</li>
-					</ul>
-				</li>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/response_formats.html">Response Formats</a>
-				</li>
-				<li>
-					<a href="{{ site.m1xgdeurl }}/api/rest/testing_rest_resources.html">Testing REST Resources</a>
-				</li>
-			</ul>
-		</div>
-		<div class="soap-api-content">
-		{{ content }}
-		</div>
-	</div>
+    <a name="top"></a>
+    <img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
+    {% include m1x/eol_message.html %}
+    <h1>{{ page.title }}</h1>
+    <div id="content">
+        <p><a href="{{ site.m1xgithuburl }}/{{ page.github_path }}" target="_blank">Edit this page on GitHub <img src="{{ site.baseurl }}/common/images/github_icon.png" height="15px"></a></p>
+        <div class="soap-api-menu">
+            <ul>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/introduction.html">Introduction</a>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/rest/authentication/oauth_authentication.html">Authentication</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/authentication/oauth_configuration.html">OAuth Configuration</a>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/common_http_status_codes.html">Common HTTP Status Codes</a>
+                </li>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/http_methods.html">HTTP Methods</a>
+                </li>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/get_filters.html">GET Filters</a>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/permission_settings.html">Permission Settings</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/roles_configuration.html">Roles Configuration</a>
+                        </li>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/attributes_configuration.html">Attributes Configuration</a>
+                        </li>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/permission_settings/attributes_description.html">Attributes Description</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/resources.html">Resources</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/Resources/inventory.html">Inventory</a>
+                        </li>
+                        <li class="parent"><a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/sales_orders.html">Orders</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_addresses.html">Order Addresses</a></li>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_comments.html">Order Comments</a>
+                                </li>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Orders/order_items.html">Order Items</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/products.html">Products</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_categories.html">Product Categories</a></li>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_images.html">Product Images</a>
+                                </li>
+                                <li>
+                                    <a href="{{ site.m1xgdeurl }}/api/rest/Resources/Products/product_websites.html">Product Websites</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/Resources/resource_customer_addresses.html">Customer Addresses</a>
+                        </li>
+                        <li>
+                            <a href="{{ site.m1xgdeurl }}/api/rest/Resources/resource_customers.html">Customers</a>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/response_formats.html">Response Formats</a>
+                </li>
+                <li>
+                    <a href="{{ site.m1xgdeurl }}/api/rest/testing_rest_resources.html">Testing REST Resources</a>
+                </li>
+            </ul>
+        </div>
+        <div class="soap-api-content">
+        {{ content }}
+        </div>
+    </div>
 </body>
 </html>

--- a/_layouts/m1x_soap.html
+++ b/_layouts/m1x_soap.html
@@ -1,440 +1,440 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
+    <meta charset="utf-8">
 
-	<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
-	<link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
-	<link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
-	<link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function(){
-			var currentUrl = window.location.href;
-			$.each($('.soap-api-menu a'), function(index, element) {
-				if (currentUrl.indexOf($(element).attr('href')) > -1) {
-					$(element).addClass('active');
-					$(element).parents('ul').show();
-					$(element).parents('li.parent').addClass('open');
-					$(element).nextAll('ul').show();
-				}
-			});
-			$.each($('.soap-api-menu li.parent .arr'), function(index, element) {
-				$(element).on('click', function(e){
-					$(this).parent('li.parent').toggleClass('open');
-					$(this).next('ul').slideToggle();
-				})
-			});
-		});
-	</script>
-	<title>{{ page.title }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/common/css/stylesheet.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/common/css/stylesheet-fonts.css" type="text/css">
+    <link rel="icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ site.baseurl }}/common/css/favicon.ico" type="image/x-icon">
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            var currentUrl = window.location.href;
+            $.each($('.soap-api-menu a'), function(index, element) {
+                if (currentUrl.indexOf($(element).attr('href')) > -1) {
+                    $(element).addClass('active');
+                    $(element).parents('ul').show();
+                    $(element).parents('li.parent').addClass('open');
+                    $(element).nextAll('ul').show();
+                }
+            });
+            $.each($('.soap-api-menu li.parent .arr'), function(index, element) {
+                $(element).on('click', function(e){
+                    $(this).parent('li.parent').toggleClass('open');
+                    $(this).next('ul').slideToggle();
+                })
+            });
+        });
+    </script>
+    <title>{{ page.title }}</title>
 </head>
 <body>
-	<a name="top"></a>
-	<img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
-	{% include m1x/eol_message.html %}
-	<h1>{{ page.title }}</h1>
-	<div id="content">
-		<p><a href="{{ site.m1xgithuburl }}/{{ page.github_path }}" target="_blank">Edit this page on GitHub <img src="{{ site.baseurl }}/common/images/github_icon.png" height="15px"></a></p>
-		<div class="soap-api-menu">
-			<ul>
-				<li> <a href="{{ site.m1xgdeurl }}/api/soap/introduction.html" title="Introduction">Introduction</a> </li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalog.html" title="Catalog">Catalog</a>
-					<span class="arr"></span>
-					<ul>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalogCategory.html" title="Catalog Category">Catalog Category</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="catalog_category.assignedProducts" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html">catalog_category.assignedProducts</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html" title="catalog_category.assignProduct">catalog_category.assignProduct</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.create.html" title="catalog_category.create">catalog_category.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.currentStore.html" title="catalog_category.currentStore">catalog_category.currentStore</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.delete.html" title="catalog_category.delete">catalog_category.delete</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.info.html" title="catalog_category.info">catalog_category.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.level.html" title="catalog_category.level">catalog_category.level</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.move.html" title="catalog_category.move">catalog_category.move</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html" title="catalog_category.removeProduct">catalog_category.removeProduct</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.tree.html" title="catalog_category.tree">catalog_category.tree</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.update.html" title="catalog_category.update">catalog_category.update</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html" title="catalog_category.updateProduct">catalog_category.updateProduct</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html" title="Catalog Category Attributes">Catalog Category Attributes</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="catalog_category_attribute.currentStore" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html">catalog_category_attribute.currentStore</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html" title="catalog_category_attribute.list">catalog_category_attribute.list</a> </li>
-								<li><a title="catalog_category_attribute.options" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html">catalog_category_attribute.options</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalogProduct.html" title="Catalog Product">Catalog Product</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.create.html" title="catalog_product.create">catalog_product.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.currentStore.html" title="catalog_product.currentStore">catalog_product.currentStore</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.delete.html" title="catalog_product.delete">catalog_product.delete</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html" title="catalog_product.getSpecialPrice">catalog_product.getSpecialPrice</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.info.html" title="catalog_product.info">catalog_product.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.list.html" title="catalog_product.list">catalog_product.list</a> </li>
-								<li><a title="catalog_product.listOfAdditionalAttributes" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html">catalog_product.listOfAdditionalAttributes</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html" title="catalog_product.setSpecialPrice">catalog_product.setSpecialPrice</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.update.html" title="catalog_product.update">catalog_product.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/catalogProductAttribute.html" title="Catalog Product Attribute">Catalog Product Attribute</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.addOption.html" title="product_attribute.addOption">product_attribute.addOption</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.create.html" title="product_attribute.create">product_attribute.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.currentStore.html" title="product_attribute.currentStore">product_attribute.currentStore</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.info.html" title="product_attribute.info">product_attribute.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.list.html" title="product_attribute.list">product_attribute.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.options.html" title="product_attribute.options">product_attribute.options</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html" title="product_attribute.remove">product_attribute.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.removeOption.html" title="product_attribute.removeOption">product_attribute.removeOption</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.types.html" title="product_attribute.types">product_attribute.types</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.update.html" title="product_attribute.update">product_attribute.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/productImages.html" title="Catalog Product Attribute Media">Catalog Product Attribute<br>Media</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="catalog_product_attribute_media.create" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html">catalog_product_attribute_media.create</a> </li>
-								<li><a title="catalog_product_attribute_media.currentStore" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.currentStore.html">catalog_product_attribute_media.currentStore</a> </li>
-								<li><a title="catalog_product_attribute_media.info" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html">catalog_product_attribute_media.info</a> </li>
-								<li><a title="catalog_product_attribute_media.list" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html">catalog_product_attribute_media.list</a> </li>
-								<li><a title="catalog_product_attribute_media.remove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html">catalog_product_attribute_media.remove</a> </li>
-								<li><a title="catalog_product_attribute_media.types" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html">catalog_product_attribute_media.types</a> </li>
-								<li><a title="catalog_product_attribute_media.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html">catalog_product_attribute_media.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/productAttributeSet.html" title="Catalog Product Attribute Set">Catalog Product Attribute Set</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="product_attribute_set.attributeAdd" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html">product_attribute_set.attributeAdd</a> </li>
-								<li><a title="product_attribute_set.attributeRemove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html">product_attribute_set.attributeRemove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html" title="product_attribute_set.create">product_attribute_set.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html" title="product_attribute_set.groupAdd">product_attribute_set.groupAdd</a> </li>
-								<li><a title="product_attribute_set.groupRemove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html">product_attribute_set.groupRemove</a> </li>
-								<li><a title="product_attribute_set.groupRename" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html">product_attribute_set.groupRename</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html" title="product_attribute_set.list">product_attribute_set.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html" title="product_attribute_set.remove">product_attribute_set.remove</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/catalogProductCustomOption.html" title="Catalog Product Custom Option">Catalog Product Custom<br>Option</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html" title="product_custom_option.add">product_custom_option.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html" title="product_custom_option.info">product_custom_option.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html" title="product_custom_option.list">product_custom_option.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html" title="product_custom_option.remove">product_custom_option.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html" title="product_custom_option.types">product_custom_option.types</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html" title="product_custom_option.update">product_custom_option.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/catalogProductCustomOptionValue.html" title="Catalog Product Custom Option Value">Catalog Product Custom Option Value</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html" title="product_custom_option_value.add">product_custom_option_value.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html" title="product_custom_option_value.info">product_custom_option_value.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html" title="product_custom_option_value.list">product_custom_option_value.list</a> </li>
-								<li><a title="product_custom_option_value.remove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html">product_custom_option_value.remove</a> </li>
-								<li><a title="product_custom_option_value.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html">product_custom_option_value.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/catalogProductDownloadableLink.html" title="Catalog Product Downloadable Link">Catalog Product Downloadable Link</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html" title="product_downloadable_link.add">product_downloadable_link.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html" title="product_downloadable_link.list">product_downloadable_link.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html" title="product_downloadable_link.remove">product_downloadable_link.remove</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalogProductLink.html" title="Catalog Product Link">Catalog Product Link</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html" title="catalog_product_link.assign">catalog_product_link.assign</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html" title="catalog_product_link.attributes">catalog_product_link.attributes</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.list.html" title="catalog_product_link.list">catalog_product_link.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html" title="catalog_product_link.remove">catalog_product_link.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.types.html" title="catalog_product_link.types">catalog_product_link.types</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.update.html" title="catalog_product_link.update">catalog_product_link.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/catalogProductTag.html" title="Catalog Product Tag">Catalog Product Tag</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.add.html" title="product_tag.add">product_tag.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.info.html" title="product_tag.info">product_tag.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.list.html" title="product_tag.list">product_tag.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.remove.html" title="product_tag.remove">product_tag.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.update.html" title="product_tag.update">product_tag.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalogProductTierPrice.html" title="Catalog Product Tier Price">Catalog Product Tier Price</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="catalog_product_attribute_tier_price.info" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html">catalog_product_attribute_tier_price.info</a> </li>
-								<li><a title="catalog_product_attribute_tier_price.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html">catalog_product_attribute_tier_price.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/productTypes.html" title="Catalog Product Types">Catalog Product Types</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html" title="catalog_product_type.list">catalog_product_type.list</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/Inventory.html" title="Catalog Inventory">Catalog Inventory</a>
-					<span class="arr"></span>
-					<ul>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.list.html" title="cataloginventory_stock_item.list">cataloginventory_stock_item.list</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.update.html" title="cataloginventory_stock_item.update">cataloginventory_stock_item.update</a> </li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/checkout/checkout.html" title="Checkout">Checkout</a>
-					<span class="arr"></span>
-					<ul>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.html" title="Cart">Cart</a>
-							<span class="arr"></span>
-							<ul>
-								<li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.create.html" title="cart.create">cart.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.info.html" title="cart.info">cart.info</a> </li>
-								<li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.license.html" title="cart.license">cart.license</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.order.html" title="cart.order">cart.order</a> </li>
-								<li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.totals.html" title="cart.totals">cart.totals</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cartCoupon.html" title="Cart Coupon">Cart Coupon</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.add.html" title="cart_coupon.add">cart_coupon.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.remove.html" title="cart_coupon.remove">cart_coupon.remove</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cartCustomer.html" title="Cart Customer">Cart Customer</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.addresses.html" title="cart_customer.addresses">cart_customer.addresses</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.set.html" title="cart_customer.set">cart_customer.set</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cartPayment.html" title="Cart Payment">Cart Payment</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.list.html" title="cart_payment.list">cart_payment.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.method.html" title="cart_payment.method">cart_payment.method</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cartProduct.html" title="Cart Product">Cart Product</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.add.html" title="cart_product.add">cart_product.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.list.html" title="cart_product.list">cart_product.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.moveToCustomerQuote.html" title="cart_product.moveToCustomerQuote">cart_product.moveToCustomerQuote</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.remove.html" title="cart_product.remove">cart_product.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.update.html" title="cart_product.update">cart_product.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cartShipping.html" title="Cart Shipping">Cart Shipping</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.list.html" title="cart_shipping.list">cart_shipping.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.method.html" title="cart_shipping.method">cart_shipping.method</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/create_your_own_api.html" title="Create Your Own API">Create Your Own API</a> </li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.html" title="Customer">Customer</a>
-					<span class="arr"></span>
-					<ul>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer_group.html" title="customer_group">customer_group</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.create.html" title="customer.create">customer.create</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.delete.html" title="customer.delete">customer.delete</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.info.html" title="customer.info">customer.info</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.list.html" title="customer.list">customer.list</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.update.html" title="customer.update">customer.update</a> </li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customerAddress.html" title="Customer Address">Customer Address</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.create.html" title="customer_address.create">customer_address.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.delete.html" title="customer_address.delete">customer_address.delete</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.info.html" title="customer_address.info">customer_address.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.list.html" title="customer_address.list">customer_address.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.update.html" title="customer_address.update">customer_address.update</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/directory/directory.html" title="Directory">Directory</a>
-					<span class="arr"></span>
-					<ul>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_country.list.html" title="directory_country.list">directory_country.list</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_region.list.html" title="directory_region.list">directory_region.list</a> </li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/sales/sales.html" title="Sales">Sales</a>
-					<span class="arr"></span>
-					<ul>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/salesOrder.html" title="Sales Order">Sales Order</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.addComment.html" title="sales_order.addComment">sales_order.addComment</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.cancel.html" title="sales_order.cancel">sales_order.cancel</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.hold.html" title="sales_order.hold">sales_order.hold</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.info.html" title="sales_order.info">sales_order.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.list.html" title="sales_order.list">sales_order.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.unhold.html" title="sales_order.unhold">sales_order.unhold</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html" title="Sales Order Credit Memo">Sales Order Credit Memo</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a title="sales_order_creditmemo.addComment" href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html">sales_order_creditmemo.addComment</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.cancel.html" title="sales_order_creditmemo.cancel">sales_order_creditmemo.cancel</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html" title="sales_order_creditmemo.create">sales_order_creditmemo.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html" title="sales_order_creditmemo.info">sales_order_creditmemo.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html" title="sales_order_creditmemo.list">sales_order_creditmemo.list</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/salesOrderInvoice.html" title="Sales Order Invoice">Sales Order Invoice</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html" title="sales_order_invoice.addComment">sales_order_invoice.addComment</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.cancel.html" title="sales_order_invoice.cancel">sales_order_invoice.cancel</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html" title="sales_order_invoice.capture">sales_order_invoice.capture</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html" title="sales_order_invoice.create">sales_order_invoice.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html" title="sales_order_invoice.info">sales_order_invoice.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html" title="sales_order_invoice.list">sales_order_invoice.list</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/salesOrderShipment.html" title="Sales Order Shipment">Sales Order Shipment</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html" title="sales_order_shipment.addComment">sales_order_shipment.addComment</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html" title="sales_order_shipment.addTrack">sales_order_shipment.addTrack</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html" title="sales_order_shipment.create">sales_order_shipment.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html" title="sales_order_shipment.getCarriers">sales_order_shipment.getCarriers</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html" title="sales_order_shipment.info">sales_order_shipment.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html" title="sales_order_shipment.list">sales_order_shipment.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html" title="sales_order_shipment.removeTrack">sales_order_shipment.removeTrack</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/enterprise_customerbalance.html" title="Enterprise Customer Balance">Enterprise Customer Balance</a>
-					<span class="arr"></span>
-					<ul>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.html" title="Customer Balance">Customer Balance</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html" title="storecredit.balance">storecredit.balance</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html" title="storecredit.history">storecredit.history</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.html" title="Shopping Cart Customer Balance">Shopping Cart Customer Balance</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html" title="storecredit_quote.removeAmount">storecredit_quote.removeAmount</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html" title="storecredit_quote.setAmount">storecredit_quote.setAmount</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/enterprise_giftCard.html" title="Enterprise Gift Card">Enterprise Gift Card</a>
-					<span class="arr"></span>
-					<ul>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cartGiftCard.html" title="Cart Gift Card">Cart Gift Card</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html" title="cart_giftcard.add">cart_giftcard.add</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html" title="cart_giftcard.list">cart_giftcard.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html" title="cart_giftcard.remove">cart_giftcard.remove</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftCardAccount.html" title="Gift Card Account">Gift Card Account</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html" title="giftcard_account.create">giftcard_account.create</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html" title="giftcard_account.info">giftcard_account.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html" title="giftcard_account.list">giftcard_account.list</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html" title="giftcard_account.remove">giftcard_account.remove</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html" title="giftcard_account.update">giftcard_account.update</a> </li>
-							</ul>
-						</li>
-						<li class="parent">
-							<a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftCardCustomer.html" title="Gift Card Customer">Gift Card Customer</a>
-							<span class="arr"></span>
-							<ul>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html" title="giftcard_customer.info">giftcard_customer.info</a> </li>
-								<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html" title="giftcard_customer.redeem">giftcard_customer.redeem</a> </li>
-							</ul>
-						</li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftMessage.html" title="Enterprise Gift Message">Enterprise Gift Message</a>
-					<span class="arr"></span>
-					<ul>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html" title="giftmessage.setForQuote">giftmessage.setForQuote</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html" title="giftmessage.setForQuoteItem">giftmessage.setForQuoteItem</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html" title="giftmessage.setForQuoteProduct">giftmessage.setForQuoteProduct</a> </li>
-					</ul>
-				</li>
-				<li class="parent">
-					<a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/miscellaneous.html" title="Miscellaneous">Miscellaneous</a>
-					<span class="arr"></span>
-					<ul>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/magento.info.html" title="magento.info">magento.info</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.info.html" title="store.info">store.info</a> </li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.list.html" title="store.list">store.list</a> </li>
-					</ul>
-				</li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/wsi_compliance.html" title="WS-I Compliance">WS-I Compliance</a>
-				</li>
-			</ul>
-		</div>
-		<div class="soap-api-content">
-		{{ content }}
-		</div>
-	</div>
+    <a name="top"></a>
+    <img src="{{ site.baseurl }}/guides/m1x/images/m1xheader.png" width="1024" alt="header" />
+    {% include m1x/eol_message.html %}
+    <h1>{{ page.title }}</h1>
+    <div id="content">
+        <p><a href="{{ site.m1xgithuburl }}/{{ page.github_path }}" target="_blank">Edit this page on GitHub <img src="{{ site.baseurl }}/common/images/github_icon.png" height="15px"></a></p>
+        <div class="soap-api-menu">
+            <ul>
+                <li> <a href="{{ site.m1xgdeurl }}/api/soap/introduction.html" title="Introduction">Introduction</a> </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalog.html" title="Catalog">Catalog</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalogCategory.html" title="Catalog Category">Catalog Category</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="catalog_category.assignedProducts" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html">catalog_category.assignedProducts</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html" title="catalog_category.assignProduct">catalog_category.assignProduct</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.create.html" title="catalog_category.create">catalog_category.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.currentStore.html" title="catalog_category.currentStore">catalog_category.currentStore</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.delete.html" title="catalog_category.delete">catalog_category.delete</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.info.html" title="catalog_category.info">catalog_category.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.level.html" title="catalog_category.level">catalog_category.level</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.move.html" title="catalog_category.move">catalog_category.move</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html" title="catalog_category.removeProduct">catalog_category.removeProduct</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.tree.html" title="catalog_category.tree">catalog_category.tree</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.update.html" title="catalog_category.update">catalog_category.update</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html" title="catalog_category.updateProduct">catalog_category.updateProduct</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html" title="Catalog Category Attributes">Catalog Category Attributes</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="catalog_category_attribute.currentStore" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html">catalog_category_attribute.currentStore</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html" title="catalog_category_attribute.list">catalog_category_attribute.list</a> </li>
+                                <li><a title="catalog_category_attribute.options" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html">catalog_category_attribute.options</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalogProduct.html" title="Catalog Product">Catalog Product</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.create.html" title="catalog_product.create">catalog_product.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.currentStore.html" title="catalog_product.currentStore">catalog_product.currentStore</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.delete.html" title="catalog_product.delete">catalog_product.delete</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html" title="catalog_product.getSpecialPrice">catalog_product.getSpecialPrice</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.info.html" title="catalog_product.info">catalog_product.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.list.html" title="catalog_product.list">catalog_product.list</a> </li>
+                                <li><a title="catalog_product.listOfAdditionalAttributes" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html">catalog_product.listOfAdditionalAttributes</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html" title="catalog_product.setSpecialPrice">catalog_product.setSpecialPrice</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.update.html" title="catalog_product.update">catalog_product.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/catalogProductAttribute.html" title="Catalog Product Attribute">Catalog Product Attribute</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.addOption.html" title="product_attribute.addOption">product_attribute.addOption</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.create.html" title="product_attribute.create">product_attribute.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.currentStore.html" title="product_attribute.currentStore">product_attribute.currentStore</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.info.html" title="product_attribute.info">product_attribute.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.list.html" title="product_attribute.list">product_attribute.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.options.html" title="product_attribute.options">product_attribute.options</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html" title="product_attribute.remove">product_attribute.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.removeOption.html" title="product_attribute.removeOption">product_attribute.removeOption</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.types.html" title="product_attribute.types">product_attribute.types</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.update.html" title="product_attribute.update">product_attribute.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/productImages.html" title="Catalog Product Attribute Media">Catalog Product Attribute<br>Media</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="catalog_product_attribute_media.create" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html">catalog_product_attribute_media.create</a> </li>
+                                <li><a title="catalog_product_attribute_media.currentStore" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.currentStore.html">catalog_product_attribute_media.currentStore</a> </li>
+                                <li><a title="catalog_product_attribute_media.info" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html">catalog_product_attribute_media.info</a> </li>
+                                <li><a title="catalog_product_attribute_media.list" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html">catalog_product_attribute_media.list</a> </li>
+                                <li><a title="catalog_product_attribute_media.remove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html">catalog_product_attribute_media.remove</a> </li>
+                                <li><a title="catalog_product_attribute_media.types" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html">catalog_product_attribute_media.types</a> </li>
+                                <li><a title="catalog_product_attribute_media.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html">catalog_product_attribute_media.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/productAttributeSet.html" title="Catalog Product Attribute Set">Catalog Product Attribute Set</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="product_attribute_set.attributeAdd" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html">product_attribute_set.attributeAdd</a> </li>
+                                <li><a title="product_attribute_set.attributeRemove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html">product_attribute_set.attributeRemove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html" title="product_attribute_set.create">product_attribute_set.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html" title="product_attribute_set.groupAdd">product_attribute_set.groupAdd</a> </li>
+                                <li><a title="product_attribute_set.groupRemove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html">product_attribute_set.groupRemove</a> </li>
+                                <li><a title="product_attribute_set.groupRename" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html">product_attribute_set.groupRename</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html" title="product_attribute_set.list">product_attribute_set.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html" title="product_attribute_set.remove">product_attribute_set.remove</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/catalogProductCustomOption.html" title="Catalog Product Custom Option">Catalog Product Custom<br>Option</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html" title="product_custom_option.add">product_custom_option.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html" title="product_custom_option.info">product_custom_option.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html" title="product_custom_option.list">product_custom_option.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html" title="product_custom_option.remove">product_custom_option.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html" title="product_custom_option.types">product_custom_option.types</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html" title="product_custom_option.update">product_custom_option.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/catalogProductCustomOptionValue.html" title="Catalog Product Custom Option Value">Catalog Product Custom Option Value</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html" title="product_custom_option_value.add">product_custom_option_value.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html" title="product_custom_option_value.info">product_custom_option_value.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html" title="product_custom_option_value.list">product_custom_option_value.list</a> </li>
+                                <li><a title="product_custom_option_value.remove" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html">product_custom_option_value.remove</a> </li>
+                                <li><a title="product_custom_option_value.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html">product_custom_option_value.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/catalogProductDownloadableLink.html" title="Catalog Product Downloadable Link">Catalog Product Downloadable Link</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html" title="product_downloadable_link.add">product_downloadable_link.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html" title="product_downloadable_link.list">product_downloadable_link.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html" title="product_downloadable_link.remove">product_downloadable_link.remove</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalogProductLink.html" title="Catalog Product Link">Catalog Product Link</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html" title="catalog_product_link.assign">catalog_product_link.assign</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html" title="catalog_product_link.attributes">catalog_product_link.attributes</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.list.html" title="catalog_product_link.list">catalog_product_link.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html" title="catalog_product_link.remove">catalog_product_link.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.types.html" title="catalog_product_link.types">catalog_product_link.types</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.update.html" title="catalog_product_link.update">catalog_product_link.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/catalogProductTag.html" title="Catalog Product Tag">Catalog Product Tag</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.add.html" title="product_tag.add">product_tag.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.info.html" title="product_tag.info">product_tag.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.list.html" title="product_tag.list">product_tag.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.remove.html" title="product_tag.remove">product_tag.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.update.html" title="product_tag.update">product_tag.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalogProductTierPrice.html" title="Catalog Product Tier Price">Catalog Product Tier Price</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="catalog_product_attribute_tier_price.info" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html">catalog_product_attribute_tier_price.info</a> </li>
+                                <li><a title="catalog_product_attribute_tier_price.update" href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html">catalog_product_attribute_tier_price.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/productTypes.html" title="Catalog Product Types">Catalog Product Types</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html" title="catalog_product_type.list">catalog_product_type.list</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/Inventory.html" title="Catalog Inventory">Catalog Inventory</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.list.html" title="cataloginventory_stock_item.list">cataloginventory_stock_item.list</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.update.html" title="cataloginventory_stock_item.update">cataloginventory_stock_item.update</a> </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/checkout/checkout.html" title="Checkout">Checkout</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.html" title="Cart">Cart</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.create.html" title="cart.create">cart.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.info.html" title="cart.info">cart.info</a> </li>
+                                <li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.license.html" title="cart.license">cart.license</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.order.html" title="cart.order">cart.order</a> </li>
+                                <li> <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.totals.html" title="cart.totals">cart.totals</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cartCoupon.html" title="Cart Coupon">Cart Coupon</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.add.html" title="cart_coupon.add">cart_coupon.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.remove.html" title="cart_coupon.remove">cart_coupon.remove</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cartCustomer.html" title="Cart Customer">Cart Customer</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.addresses.html" title="cart_customer.addresses">cart_customer.addresses</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.set.html" title="cart_customer.set">cart_customer.set</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cartPayment.html" title="Cart Payment">Cart Payment</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.list.html" title="cart_payment.list">cart_payment.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.method.html" title="cart_payment.method">cart_payment.method</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cartProduct.html" title="Cart Product">Cart Product</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.add.html" title="cart_product.add">cart_product.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.list.html" title="cart_product.list">cart_product.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.moveToCustomerQuote.html" title="cart_product.moveToCustomerQuote">cart_product.moveToCustomerQuote</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.remove.html" title="cart_product.remove">cart_product.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.update.html" title="cart_product.update">cart_product.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cartShipping.html" title="Cart Shipping">Cart Shipping</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.list.html" title="cart_shipping.list">cart_shipping.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.method.html" title="cart_shipping.method">cart_shipping.method</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li><a href="{{ site.m1xgdeurl }}/api/soap/create_your_own_api.html" title="Create Your Own API">Create Your Own API</a> </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.html" title="Customer">Customer</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer_group.html" title="customer_group">customer_group</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.create.html" title="customer.create">customer.create</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.delete.html" title="customer.delete">customer.delete</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.info.html" title="customer.info">customer.info</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.list.html" title="customer.list">customer.list</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.update.html" title="customer.update">customer.update</a> </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customerAddress.html" title="Customer Address">Customer Address</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.create.html" title="customer_address.create">customer_address.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.delete.html" title="customer_address.delete">customer_address.delete</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.info.html" title="customer_address.info">customer_address.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.list.html" title="customer_address.list">customer_address.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.update.html" title="customer_address.update">customer_address.update</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/directory/directory.html" title="Directory">Directory</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_country.list.html" title="directory_country.list">directory_country.list</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_region.list.html" title="directory_region.list">directory_region.list</a> </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/sales/sales.html" title="Sales">Sales</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/salesOrder.html" title="Sales Order">Sales Order</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.addComment.html" title="sales_order.addComment">sales_order.addComment</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.cancel.html" title="sales_order.cancel">sales_order.cancel</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.hold.html" title="sales_order.hold">sales_order.hold</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.info.html" title="sales_order.info">sales_order.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.list.html" title="sales_order.list">sales_order.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.unhold.html" title="sales_order.unhold">sales_order.unhold</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html" title="Sales Order Credit Memo">Sales Order Credit Memo</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a title="sales_order_creditmemo.addComment" href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html">sales_order_creditmemo.addComment</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.cancel.html" title="sales_order_creditmemo.cancel">sales_order_creditmemo.cancel</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html" title="sales_order_creditmemo.create">sales_order_creditmemo.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html" title="sales_order_creditmemo.info">sales_order_creditmemo.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html" title="sales_order_creditmemo.list">sales_order_creditmemo.list</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/salesOrderInvoice.html" title="Sales Order Invoice">Sales Order Invoice</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html" title="sales_order_invoice.addComment">sales_order_invoice.addComment</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.cancel.html" title="sales_order_invoice.cancel">sales_order_invoice.cancel</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html" title="sales_order_invoice.capture">sales_order_invoice.capture</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html" title="sales_order_invoice.create">sales_order_invoice.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html" title="sales_order_invoice.info">sales_order_invoice.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html" title="sales_order_invoice.list">sales_order_invoice.list</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/salesOrderShipment.html" title="Sales Order Shipment">Sales Order Shipment</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html" title="sales_order_shipment.addComment">sales_order_shipment.addComment</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html" title="sales_order_shipment.addTrack">sales_order_shipment.addTrack</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html" title="sales_order_shipment.create">sales_order_shipment.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html" title="sales_order_shipment.getCarriers">sales_order_shipment.getCarriers</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html" title="sales_order_shipment.info">sales_order_shipment.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html" title="sales_order_shipment.list">sales_order_shipment.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html" title="sales_order_shipment.removeTrack">sales_order_shipment.removeTrack</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/enterprise_customerbalance.html" title="Enterprise Customer Balance">Enterprise Customer Balance</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.html" title="Customer Balance">Customer Balance</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html" title="storecredit.balance">storecredit.balance</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html" title="storecredit.history">storecredit.history</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.html" title="Shopping Cart Customer Balance">Shopping Cart Customer Balance</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html" title="storecredit_quote.removeAmount">storecredit_quote.removeAmount</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html" title="storecredit_quote.setAmount">storecredit_quote.setAmount</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/enterprise_giftCard.html" title="Enterprise Gift Card">Enterprise Gift Card</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cartGiftCard.html" title="Cart Gift Card">Cart Gift Card</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html" title="cart_giftcard.add">cart_giftcard.add</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html" title="cart_giftcard.list">cart_giftcard.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html" title="cart_giftcard.remove">cart_giftcard.remove</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftCardAccount.html" title="Gift Card Account">Gift Card Account</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html" title="giftcard_account.create">giftcard_account.create</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html" title="giftcard_account.info">giftcard_account.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html" title="giftcard_account.list">giftcard_account.list</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html" title="giftcard_account.remove">giftcard_account.remove</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html" title="giftcard_account.update">giftcard_account.update</a> </li>
+                            </ul>
+                        </li>
+                        <li class="parent">
+                            <a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftCardCustomer.html" title="Gift Card Customer">Gift Card Customer</a>
+                            <span class="arr"></span>
+                            <ul>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html" title="giftcard_customer.info">giftcard_customer.info</a> </li>
+                                <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html" title="giftcard_customer.redeem">giftcard_customer.redeem</a> </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftMessage.html" title="Enterprise Gift Message">Enterprise Gift Message</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html" title="giftmessage.setForQuote">giftmessage.setForQuote</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html" title="giftmessage.setForQuoteItem">giftmessage.setForQuoteItem</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html" title="giftmessage.setForQuoteProduct">giftmessage.setForQuoteProduct</a> </li>
+                    </ul>
+                </li>
+                <li class="parent">
+                    <a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/miscellaneous.html" title="Miscellaneous">Miscellaneous</a>
+                    <span class="arr"></span>
+                    <ul>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/magento.info.html" title="magento.info">magento.info</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.info.html" title="store.info">store.info</a> </li>
+                        <li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.list.html" title="store.list">store.list</a> </li>
+                    </ul>
+                </li>
+                <li><a href="{{ site.m1xgdeurl }}/api/soap/wsi_compliance.html" title="WS-I Compliance">WS-I Compliance</a>
+                </li>
+            </ul>
+        </div>
+        <div class="soap-api-content">
+        {{ content }}
+        </div>
+    </div>
 </body>
 </html>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -3,8 +3,8 @@
 <div class="content-container">
 
   <aside class="sidebar">
-  	<button class="toc-toggler">Table of Contents</button>
-  	<div class="sidebar-wrapper">
+    <button class="toc-toggler">Table of Contents</button>
+    <div class="sidebar-wrapper">
 
 
       {% assign steps = site.pages | where: "guide_version", page.guide_version | where: "level3_subgroup", page.level3_subgroup | sort: "menu_order" %}
@@ -26,10 +26,10 @@
   </aside>
   <!-- /.sidebar -->
 
-	<section class="content">
-		<div class="content-wrap">
-			{% include layout/page-header.html %}
-			{{ content }}
+  <section class="content">
+    <div class="content-wrap">
+      {% include layout/page-header.html %}
+      {{ content }}
 
       <div class="horisontal-nav">
         {% assign steps_size = steps | size %}
@@ -48,13 +48,13 @@
       </div>
       <!-- /.horisontal-nav -->
 
-		</div>
-		<!-- /.content-wrap -->
+    </div>
+    <!-- /.content-wrap -->
 
-		{% include layout/page-info.html %}
+    {% include layout/page-info.html %}
 
-	</section>
-	<!-- /.content -->
+  </section>
+  <!-- /.content -->
 
 </div> <!-- /.content-container -->
 

--- a/codelinks/attributes.md
+++ b/codelinks/attributes.md
@@ -15,7 +15,7 @@ This document lists the PHP, REST, and SOAP calls that indicate they return deta
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `CustomerRepositoryInterface::getList($searchCriteria)` | `CustomerRepositoryInterface::getById($customerId)`
-REST | `/V1/customers/search` |	`/V1/customers/{id}`
+REST | `/V1/customers/search` | `/V1/customers/{id}`
 SOAP | `customerCustomerRepositoryV1GetList` | `customerCustomerRepositoryV1GetById`
 
 ### Magento\Customer\Api\GroupRepositoryInterface {#GroupRepositoryInterface}
@@ -23,7 +23,7 @@ SOAP | `customerCustomerRepositoryV1GetList` | `customerCustomerRepositoryV1GetB
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `GroupRepositoryInterface::getList($searchCriteria)` | `GroupRepositoryInterface::getById($id)`
-REST | `/V1/customerGroups/search` |	`/V1/customerGroups/{id}`
+REST | `/V1/customerGroups/search` | `/V1/customerGroups/{id}`
 SOAP | `customerGroupRepositoryV1GetList` | `customerGroupRepositoryV1GetById`
 
 ## EAV module {#EAV}
@@ -33,7 +33,7 @@ SOAP | `customerGroupRepositoryV1GetList` | `customerGroupRepositoryV1GetById`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP |  `AttributeSetRepositoryInterface::getList($entityTypeCode, $searchCriteria)` | `AttributeSetRepositoryInterface::get($attributeSetId)`
-REST | `/V1/eav/attribute-sets/list` |	`/V1/eav/attribute-sets/{attributeSetId}`
+REST | `/V1/eav/attribute-sets/list` | `/V1/eav/attribute-sets/{attributeSetId}`
 SOAP | `eavAttributeSetRepositoryV1GetList` | `eavAttributeSetRepositoryV1Get`
 
 ## GiftWrapping module (Enterprise Edition) {#GiftWrapping}
@@ -42,8 +42,8 @@ SOAP | `eavAttributeSetRepositoryV1GetList` | `eavAttributeSetRepositoryV1Get`
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `WrappingRepositoryInterface::getList($searchCriteria)`	| `WrappingRepositoryInterface::get($ruleId)`
-REST | `/V1/gift-wrappings`	| `/V1/gift-wrappings/:id`
+PHP | `WrappingRepositoryInterface::getList($searchCriteria)` | `WrappingRepositoryInterface::get($ruleId)`
+REST | `/V1/gift-wrappings` | `/V1/gift-wrappings/:id`
 SOAP | `giftWrappingWrappingRepositoryV1GetList` | `giftWrappingWrappingRepositoryV1Get`
 
 ## Quote module {#Quote}
@@ -53,7 +53,7 @@ SOAP | `giftWrappingWrappingRepositoryV1GetList` | `giftWrappingWrappingReposito
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `CartRepositoryInterface::getList($searchCriteria)` | `CartRepositoryInterface::get($cartId)`
-REST | `/V1/carts/search`	| `/V1/carts/{cartId}`
+REST | `/V1/carts/search` | `/V1/carts/{cartId}`
 SOAP | `quoteCartRepositoryV1GetList` | `quoteCartRepositoryV1Get`
 
 ### Magento\Quote\Api\GuestPaymentMethodManagementInterface {#GuestPaymentMethodManagementInterface}
@@ -61,7 +61,7 @@ SOAP | `quoteCartRepositoryV1GetList` | `quoteCartRepositoryV1Get`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `GuestPaymentMethodManagementInterface::getList($cartId)` | `GuestPaymentMethodManagementInterface::get($cartId)`
-REST | `/V1/guest-carts/:cartId/payment-methods`	| `/V1/guest-carts/:cartId/selected-payment-method`
+REST | `/V1/guest-carts/:cartId/payment-methods` | `/V1/guest-carts/:cartId/selected-payment-method`
 SOAP | `quoteGuestPaymentMethodManagementV1GetList` | `quoteGuestPaymentMethodManagementV1Get`
 
 ### Magento\Quote\Api\PaymentMethodManagementInterface {#PaymentMethodManagementInterface}
@@ -69,13 +69,13 @@ SOAP | `quoteGuestPaymentMethodManagementV1GetList` | `quoteGuestPaymentMethodMa
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `PaymentMethodManagementInterface::getList($cartId)` | `PaymentMethodManagementInterface::get($cartId)`
-REST |`/V1/carts/:cartId/payment-methods` |	`/V1/carts/:cartId/selected-payment-method`
+REST |`/V1/carts/:cartId/payment-methods` | `/V1/carts/:cartId/selected-payment-method`
 SOAP | `quotePaymentMethodManagementV1GetList` | `quotePaymentMethodManagementV1Get`
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `PaymentMethodManagementInterface::getList($cartId)` | `PaymentMethodManagementInterface::get($cartId)`
-REST | `/V1/carts/mine/payment-methods` |	`/V1/carts/mine/selected-payment-method`
+REST | `/V1/carts/mine/payment-methods` | `/V1/carts/mine/selected-payment-method`
 SOAP | `quotePaymentMethodManagementV1GetList` | `quotePaymentMethodManagementV1Get`
 
 ## Sales module {#Sales}
@@ -85,7 +85,7 @@ SOAP | `quotePaymentMethodManagementV1GetList` | `quotePaymentMethodManagementV1
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `CreditmemoRepositoryInterface::getList($searchCriteria)` | `CreditmemoRepositoryInterface::get($id)`
-REST | `/V1/creditmemos`	| `/V1/creditmemo/{id}`
+REST | `/V1/creditmemos` | `/V1/creditmemo/{id}`
 SOAP | `salesCreditmemoRepositoryV1GetList` | `salesCreditmemoRepositoryV1Get`
 
 ### Magento\Sales\Api\InvoiceRepositoryInterface {#InvoiceRepositoryInterface}
@@ -93,7 +93,7 @@ SOAP | `salesCreditmemoRepositoryV1GetList` | `salesCreditmemoRepositoryV1Get`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `InvoiceRepositoryInterface::getList($searchCriteria)` | `InvoiceRepositoryInterface::get($id)`
-REST | `/V1/invoices`	| `/V1/invoices/{id}`
+REST | `/V1/invoices` | `/V1/invoices/{id}`
 SOAP | `salesInvoiceRepositoryV1GetList` | `salesInvoiceRepositoryV1Get`
 
 ### Magento\Sales\Api\OrderItemRepositoryInterface {#OrderItemRepositoryInterface}
@@ -101,7 +101,7 @@ SOAP | `salesInvoiceRepositoryV1GetList` | `salesInvoiceRepositoryV1Get`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `OrderItemRepositoryInterface::getList($searchCriteria)` | `OrderItemRepositoryInterface::get($id)`
-REST | `/V1/orders/items`	| `/V1/orders/items/{id}`
+REST | `/V1/orders/items` | `/V1/orders/items/{id}`
 SOAP | `salesOrderItemRepositoryV1GetList` | `salesOrderItemRepositoryV1Get`
 
 ### Magento\Sales\Api\OrderRepositoryInterface {#OrderRepositoryInterface}
@@ -109,7 +109,7 @@ SOAP | `salesOrderItemRepositoryV1GetList` | `salesOrderItemRepositoryV1Get`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `OrderRepositoryInterface::getList($searchCriteria)` | `OrderRepositoryInterface::get($id)`
-REST | `/V1/orders`	| `/V1/orders/{id}`
+REST | `/V1/orders` | `/V1/orders/{id}`
 SOAP | `salesOrderRepositoryV1GetList` | `salesOrderRepositoryV1GetList`
 
 ### Magento\Sales\Api\ShipmentRepositoryInterface {#ShipmentRepositoryInterface}
@@ -117,7 +117,7 @@ SOAP | `salesOrderRepositoryV1GetList` | `salesOrderRepositoryV1GetList`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `ShipmentRepositoryInterface::getList($searchCriteria)` | `ShipmentRepositoryInterface::get($id)`
-REST | `/V1/shipments`	| `/V1/shipment/{id}`
+REST | `/V1/shipments` | `/V1/shipment/{id}`
 SOAP | `salesShipmentRepositoryV1GetList` | `salesShipmentRepositoryV1Get`
 
 ### Magento\SalesRule\Api\TransactionRepositoryInterface {#TransactionRepositoryInterface}
@@ -125,7 +125,7 @@ SOAP | `salesShipmentRepositoryV1GetList` | `salesShipmentRepositoryV1Get`
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
 PHP | `TransactionRepositoryInterface::getList($searchCriteria)` | `TransactionRepositoryInterface:get($id)`
-REST | `/V1/transactions`	| `/V1/transactions/{id}`
+REST | `/V1/transactions` | `/V1/transactions/{id}`
 SOAP | `salesTransactionRepositoryV1GetList` | `salesTransactionRepositoryV1Get`
 
 ## SalesRule module {#SalesRule}
@@ -134,16 +134,16 @@ SOAP | `salesTransactionRepositoryV1GetList` | `salesTransactionRepositoryV1Get`
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `CouponRepositoryInterface::getList($searchCriteria)`	| `CouponRepositoryInterface::getById($couponId)`
-REST | 	`/V1/coupons/search`	| `/V1/coupons/{couponId}`
+PHP | `CouponRepositoryInterface::getList($searchCriteria)` | `CouponRepositoryInterface::getById($couponId)`
+REST |  `/V1/coupons/search` | `/V1/coupons/{couponId}`
 SOAP | `salesRuleCouponRepositoryV1GetList` | `salesRuleCouponRepositoryV1GetById`
 
 ### Magento\SalesRule\Api\RuleRepositoryInterface {#RuleRepositoryInterface}
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `RuleRepositoryInterface::getList($searchCriteria)`	| `RuleRepositoryInterface::getById($ruleId)`
-REST | 	`/V1/salesRules/search`	| `/V1/salesRules/{ruleId}`
+PHP | `RuleRepositoryInterface::getList($searchCriteria)` | `RuleRepositoryInterface::getById($ruleId)`
+REST |  `/V1/salesRules/search` | `/V1/salesRules/{ruleId}`
 SOAP | `salesRuleRuleRepositoryV1GetListRequest` | `salesRuleRuleRepositoryV1GetById`
 
 ## Tax module {#Tax}
@@ -152,22 +152,22 @@ SOAP | `salesRuleRuleRepositoryV1GetListRequest` | `salesRuleRuleRepositoryV1Get
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `TaxClassRepositoryInterface::getList($searchCriteria)`	| `TaxClassRepositoryInterface::get($taxClassId)`
-REST | `/V1/taxClasses/search`	| `/V1/taxClass/{rateId}`
+PHP | `TaxClassRepositoryInterface::getList($searchCriteria)` | `TaxClassRepositoryInterface::get($taxClassId)`
+REST | `/V1/taxClasses/search` | `/V1/taxClass/{rateId}`
 SOAP | `taxTaxClassRepositoryV1GetList` | `taxTaxClassRepositoryV1Get`
 
 ### Magento\Tax\Api\TaxRateRepositoryInterface {#TaxRateRepositoryInterface}
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `TaxRateRepositoryInterface::getList($searchCriteria)`	| `TaxRateRepositoryInterface::get($rateId)`
-REST | `/V1/taxRates/search`	| `/V1/taxRates/{rateId}`
+PHP | `TaxRateRepositoryInterface::getList($searchCriteria)` | `TaxRateRepositoryInterface::get($rateId)`
+REST | `/V1/taxRates/search` | `/V1/taxRates/{rateId}`
 SOAP | `taxTaxRateRepositoryV1GetList` | `taxTaxRateRepositoryV1Get`
 
 ### Magento\Tax\Api\TaxRuleRepositoryInterface {#TaxRuleRepositoryInterface}
 
 Language | Does not return detailed attributes | Returns detailed attributes
 --- | --- | ---
-PHP | `TaxRuleRepositoryInterface::getList($searchCriteria)`	| `TaxRuleRepositoryInterface::get($ruleId)`
-REST | `/V1/taxRules/search`	| `/V1/taxRules/{ruleId}`
+PHP | `TaxRuleRepositoryInterface::getList($searchCriteria)` | `TaxRuleRepositoryInterface::get($ruleId)`
+REST | `/V1/taxRules/search` | `/V1/taxRules/{ruleId}`
 SOAP | `taxTaxRuleRepositoryV1GetList` | `taxTaxRuleRepositoryV1Get`

--- a/common/css/stylesheet.css
+++ b/common/css/stylesheet.css
@@ -2,8 +2,8 @@
 /* CSS Document */
 
 body {
-	 background-color: #ffffff;  margin: 0 auto; font-size:15px; font: 15px/22px Helvetica, Arial, sans-serif; color:#5A5A5A; font-weight:normal; width:1024px;
-	}
+     background-color: #ffffff;  margin: 0 auto; font-size:15px; font: 15px/22px Helvetica, Arial, sans-serif; color:#5A5A5A; font-weight:normal; width:1024px;
+    }
 
 /* containers */
 #container { width:940px; margin:0; }
@@ -11,18 +11,18 @@ body {
 
 /* left nav style */
 .show {
-	display:block;  position: relative;
+    display:block;  position: relative;
     top: -15px;
 }
 .hide{
-	display:none; position: relative;
+    display:none; position: relative;
     top: -15px;
 }
 #container-2 { width:940px; margin:10px 0 0 45px; }
 #left-nav { float:left; width:220px; margin-right:20px; display:block; }
 #left-nav  ul { margin:10px 0 8px; }
 #left-nav li { border-bottom:2px dotted #dddddd; list-style: none;
-	padding: 10px 5px; margin: 10px 0; }
+    padding: 10px 5px; margin: 10px 0; }
 #content-2 { float:right; width:700px; }
 #left-nav h4 { color:#666666; border-bottom:2px dotted #dddddd; padding:5px; }
 #left-nav li.highlight a:link, #left-nav li.highlight a:visited {
@@ -30,12 +30,12 @@ body {
     text-decoration: none;
 }
 #left-nav ul.related-documents li {
-	font-size:13px; border:0; padding: 5px; margin: 5px 0 5px 5px;
-	background-image: url(".bullet-round-orange.png");
-	background-repeat: no-repeat;
-	background-position: 0 9px;
-	padding-left: 16px;
-	}
+    font-size:13px; border:0; padding: 5px; margin: 5px 0 5px 5px;
+    background-image: url(".bullet-round-orange.png");
+    background-repeat: no-repeat;
+    background-position: 0 9px;
+    padding-left: 16px;
+    }
 
 /* end left nav styles */
 
@@ -76,19 +76,19 @@ a:active{ color:#0090c0; }
 
 .msg-box, .sm-note-box {
     margin:2px 0 15px 0;
-	width:85%;
-	border-radius: 8px 0 8px 0;
-	font-size:14px;
-	color:#777777;
+    width:85%;
+    border-radius: 8px 0 8px 0;
+    font-size:14px;
+    color:#777777;
     padding: 8px 12px 8px 0;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-	min-height:35px; }
+    min-height:35px; }
 
 .sm-note-box {
-	min-height:15px;
+    min-height:15px;
     background-color: rgba(0, 0, 0, 0.025);
-	border:1px solid #888888;
-	border-left: 3px solid #888888; }
+    border:1px solid #888888;
+    border-left: 3px solid #888888; }
 
 .sm-note-box span { padding: 0 10px 0 10px; }
 
@@ -97,22 +97,22 @@ a:active{ color:#0090c0; }
 .caution {
     background-color: rgba(240, 171, 0, .05);
     border: 1px solid #f7941d;
-	border-left: 5px solid #f7941d; }
+    border-left: 5px solid #f7941d; }
 
 .important {
     background-color: rgba(229, 122, 63, 0.04);
-	border:1px solid #EE6933;
-	border-left: 5px solid #EE6933; }
+    border:1px solid #EE6933;
+    border-left: 5px solid #EE6933; }
 
 .note {
     background-color: rgba(0, 0, 0, 0.025);
-	border:1px solid #888888;
-	border-left: 5px solid #888888; }
+    border:1px solid #888888;
+    border-left: 5px solid #888888; }
 
 .tip {
     background-color: rgba(246, 220, 27, .05);
-	border:1px solid #fbe841;
-	border-left: 5px solid #fbe841; }
+    border:1px solid #fbe841;
+    border-left: 5px solid #fbe841; }
 
 .msg-box span { position:relative; left:10px; padding-right:5px; }
 .msg-box img { position:relative; top:-3px; left:5px; }
@@ -121,7 +121,7 @@ a:active{ color:#0090c0; }
 pre { font-size:14px; line-height:20px; overflow: auto; }
 pre strong{ color:#333333; }
 pre, .link-callout { padding:10px; margin:0 0 20px;
-	background-color: #F3F6F9; border:1px solid #ebeff2; border-radius: 4px; }
+    background-color: #F3F6F9; border:1px solid #ebeff2; border-radius: 4px; }
 
 .link-callout {  width:450px; color:#666666;  }
 
@@ -129,41 +129,41 @@ pre, .link-callout { padding:10px; margin:0 0 20px;
 /* LISTS */
 ul, ol ul li, ul ol li, ol li ol li ul.level1 li
 {
-	list-style-type: none;
-	padding: 0;
-	margin: 0;
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
 }
 
 ul li li, ul li li li, ol li li {
-	margin-left: 5px;
+    margin-left: 5px;
 }
  ul li li li {
-	margin-left: 10px;
+    margin-left: 10px;
 }
 
 ul.level1 li, ul li.level1, ol li ol li ul.level1 li
 {
-	background-image: url("bullet-round-orange.png");
-	background-repeat: no-repeat;
-	background-position: 0 7px;
-	padding-left: 16px;
-	margin-bottom:6px;
+    background-image: url("bullet-round-orange.png");
+    background-repeat: no-repeat;
+    background-position: 0 7px;
+    padding-left: 16px;
+    margin-bottom:6px;
 }
 ul.level2 li, ul li.level2, ol li ol li ul.level2 li
 {
-	background-image: url("bullet-round-gold.png");
-	background-repeat: no-repeat;
-	background-position: 0 6px;
-	padding-left: 16px;
-	margin-bottom:6px;
+    background-image: url("bullet-round-gold.png");
+    background-repeat: no-repeat;
+    background-position: 0 6px;
+    padding-left: 16px;
+    margin-bottom:6px;
 }
 ul.level3 li, ul li.level3, ol li ol li ul.level3 li
 {
-	background-image: url("bullet-round-gray.png");
-	background-repeat: no-repeat;
-	background-position: 0 6px;
-	padding-left: 16px;
-	margin-bottom:6px;
+    background-image: url("bullet-round-gray.png");
+    background-repeat: no-repeat;
+    background-position: 0 6px;
+    padding-left: 16px;
+    margin-bottom:6px;
 }
 ol li, ul ol li { list-style: decimal outside none; background-image:none; }
 ol li { margin-bottom:8px; }
@@ -247,14 +247,14 @@ ul:nth-child(3) li {
 /* NUMBERED CODE */
 
 pre.lineCount { background: #F3F6F9 url("gutter.png") 2.1em 0 repeat-y;
-	border:1px solid #ebeff2; line-height:0; margin:0; padding:0; }
+    border:1px solid #ebeff2; line-height:0; margin:0; padding:0; }
 
 ol.listLineCount {
-	overflow:auto;
-	margin:0;
-	padding-left: 32px;
-	color:#ffffff;
-	line-height:5px;
+    overflow:auto;
+    margin:0;
+    padding-left: 32px;
+    color:#ffffff;
+    line-height:5px;
 }
 
 .lineCount ol li { color:#333333; font-weight:400; }
@@ -272,10 +272,10 @@ table {
     border-collapse: collapse;
     text-align: left;
     width: 100%;
-	color:#555555;
+    color:#555555;
 }
 table td, table th, table tr, table tr th {
-	padding:8px;}
+    padding:8px;}
 
 table tr:nth-child(odd) { /*(odd) or (2n 1)*/
     background-color: #F3F6F9;
@@ -304,16 +304,16 @@ table th {
     font-weight: 600;
     padding: 5px;
     vertical-align: top;
-	font-size:13px;
+    font-size:13px;
 }
 /*table .table-headings th {
-	background-color: rgba(220, 229, 237, .50);
+    background-color: rgba(220, 229, 237, .50);
     border:1px solid #dce5ed;
-	color: #555555;
+    color: #555555;
     font-weight: bold;
     padding: 10px;
     vertical-align: top;
-	font-size:14px;
+    font-size:14px;
 }*/
 /*table tr {
     border-color: transparent #ffffff;
@@ -335,7 +335,7 @@ td {
     border:1px solid #dce5ed;
     color: #555555;
     padding: 10px;
-	font-size:13px;
+    font-size:13px;
 }
 
 /* Back to Top */
@@ -343,8 +343,8 @@ td {
 p.btt a:link, p.btt a:active, p.btt a:visited {
     background: url("btt.png") no-repeat scroll 0 2px transparent;
     float: right;
-	position:relative;
-	top:-35px;
+    position:relative;
+    top:-35px;
     font-size: 12px;
     padding: 0 0 0 15px;
     text-decoration: none;
@@ -354,20 +354,20 @@ p.btt.last {position:relative;top:40px;}
 /* paging */
 p.paging {
     float: right;
-	position:relative;
-	top:-42px;
+    position:relative;
+    top:-42px;
     font-size: 12px;
-	font-weight:600;
-	color:#777777;
+    font-weight:600;
+    color:#777777;
     padding: 0 0 0 15px;
     text-decoration: none;
 }
 p.paging span { padding:5px; }
 p.paging a {
-	font-weight:100; padding:5px; }
+    font-weight:100; padding:5px; }
 p.paging.bottom {
-	position:relative;
-	top:42px; }
+    position:relative;
+    top:42px; }
 
 /* Rules */
 .dotted-rule { border-top: 2px dotted #dddddd; margin: 15px 0 15px 0; }
@@ -680,16 +680,16 @@ a.image:hover {
 }
 
 .message-banner {
-	background: #FBEDD9;
-	border: 1px solid #C27500;
-	padding: 20px;
-	border-radius: 2px;
-	margin: 10px 0;
+    background: #FBEDD9;
+    border: 1px solid #C27500;
+    padding: 20px;
+    border-radius: 2px;
+    margin: 10px 0;
 }
 
 .message-banner h4 {
-	margin-top: 0;
+    margin-top: 0;
 }
 .message-banner p:last-child {
-	margin-bottom: 0;
+    margin-bottom: 0;
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request converts HARD TABs to SPACES in the folders: `/_layouts`, `/codelinks`, `/common`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!

CC: @jeff-matthews 