### PR TITLE
Add new class for Related topics and Next step section

### DIFF
--- a/common/css/devdocs.css
+++ b/common/css/devdocs.css
@@ -29,11 +29,10 @@
 }
 
 /* Paragraph that introduces important information (e.g., Related topics, Next step, Examples), but does not qualify as a proper heading */
-.pseudo-header {
+.ref-header {
   font-weight: bold;
-  font-size: 1.375em;
+  font-size: 1.3em;
   margin: 1.5em 0 0.5em 0;
-  color: #767676;
 }
 
 .message-banner.version-banner {

--- a/common/css/devdocs.css
+++ b/common/css/devdocs.css
@@ -28,7 +28,7 @@
   margin-left: 1.0em;
 }
 
-/* Paragraph that introduces important information (e.g., Related topics, Next step, Examples), but does not qualify as a proper heading */
+/* Paragraph that introduces important reference information (e.g., Related topics, Next step, Previous step), but does not qualify as a proper heading. Mimics the current H3 style */
 .ref-header {
   font-weight: bold;
   font-size: 1.3em;

--- a/common/css/devdocs.css
+++ b/common/css/devdocs.css
@@ -28,6 +28,14 @@
   margin-left: 1.0em;
 }
 
+/* Paragraph that introduces important information (e.g., Related topics, Next step, Examples), but does not qualify as a proper heading */
+.pseudo-header {
+  font-weight: bold;
+  font-size: 1.375em;
+  margin: 1.5em 0 0.5em 0;
+  color: #767676;
+}
+
 .message-banner.version-banner {
   margin-bottom: 15px;
 }

--- a/guides/v2.2/advanced-reporting/data-collection.md
+++ b/guides/v2.2/advanced-reporting/data-collection.md
@@ -196,7 +196,8 @@ It cannot contain any parameters.
 ...
 ```
 
-## Related topics
+{:.ref-header}
+Related topics
 
  [Modules providing advanced reporting][modules]
 

--- a/guides/v2.2/advanced-reporting/overview.md
+++ b/guides/v2.2/advanced-reporting/overview.md
@@ -30,7 +30,8 @@ To avoid system overload during its prime time, you can set the preferable time 
 
 Though the Analytics module provides API, it is used specifically to interchange data with the MBI. We do not recommend to extend the advanced reporting functionality in this version.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Magento modules that implement the functionality][modules]{:target="_blank"}
 

--- a/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
@@ -15,7 +15,8 @@ The following discussion focuses on how these topics apply directly to Magento:
 * Event-driven architecture
 * Security
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
@@ -22,7 +22,8 @@ Layered application design offers many advantages, but users of Magento will app
 
 * Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/arch_diagrams.md
+++ b/guides/v2.2/architecture/archi_perspectives/arch_diagrams.md
@@ -14,6 +14,7 @@ The following diagram illustrates the components and shows the "layers" or tiers
 
 ![Architectural Diagram]({{site.baseurl}}/common/images/archi_diagram_desired-state.png)
 
-## Related topics
+{:.ref-header}
+Related topics
 
 *  [Architecture layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -54,6 +54,7 @@ After the area name, the URI segment specifies the *frontname*. When an HTTP req
 
 Note that only the **execute()** method of any given controller is executed.
 
-## Related topics {#m2arch-module-related}
+{:.ref-header}
+Related topics {#m2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -55,6 +55,6 @@ After the area name, the URI segment specifies the *frontname*. When an HTTP req
 Note that only the **execute()** method of any given controller is executed.
 
 {:.ref-header}
-Related topics {#m2arch-module-related}
+Related topicsm2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -55,6 +55,6 @@ After the area name, the URI segment specifies the *frontname*. When an HTTP req
 Note that only the **execute()** method of any given controller is executed.
 
 {:.ref-header}
-Related topicsm2arch-module-related}
+Related topics
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
@@ -155,6 +155,6 @@ return [
 ```
 
 {:.ref-header}
-Related topicsm2arch-module-related}
+Related topics
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
@@ -155,6 +155,6 @@ return [
 ```
 
 {:.ref-header}
-Related topics {#m2arch-module-related}
+Related topicsm2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
@@ -154,6 +154,7 @@ return [
 ];
 ```
 
-## Related topics {#m2arch-module-related}
+{:.ref-header}
+Related topics {#m2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -58,7 +58,7 @@ See [PHP Developer Guide][] for specific instructions on extending modules.
 See [Frontend Developer Guide][] for information on implementing themes and other components.
 
 {:.ref-header}
-Related topicsarch-modules-related}
+Related topics
 
 [Module dependencies][]
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -57,7 +57,8 @@ See [PHP Developer Guide][] for specific instructions on extending modules.
 
 See [Frontend Developer Guide][] for information on implementing themes and other components.
 
-## Related topics {#arch-modules-related}
+{:.ref-header}
+Related topics {#arch-modules-related}
 
 [Module dependencies][]
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -58,7 +58,7 @@ See [PHP Developer Guide][] for specific instructions on extending modules.
 See [Frontend Developer Guide][] for information on implementing themes and other components.
 
 {:.ref-header}
-Related topics {#arch-modules-related}
+Related topicsarch-modules-related}
 
 [Module dependencies][]
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -47,6 +47,6 @@ If module A replaces module B, it needs to be able to do so in such a way that o
 ![Module relationship scenarios: A replaces B]({{site.baseurl}}/common/images/archi_fourth_relate.png)
 
 {:.ref-header}
-Related topics {#m2arch-module-related}
+Related topicsm2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -47,6 +47,6 @@ If module A replaces module B, it needs to be able to do so in such a way that o
 ![Module relationship scenarios: A replaces B]({{site.baseurl}}/common/images/archi_fourth_relate.png)
 
 {:.ref-header}
-Related topicsm2arch-module-related}
+Related topics
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -46,6 +46,7 @@ If module A replaces module B, it needs to be able to do so in such a way that o
 
 ![Module relationship scenarios: A replaces B]({{site.baseurl}}/common/images/archi_fourth_relate.png)
 
-## Related topics {#m2arch-module-related}
+{:.ref-header}
+Related topics {#m2arch-module-related}
 
 [Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/domain_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/domain_layer.md
@@ -38,7 +38,7 @@ There are three primary ways of accessing a module's domain-layer code:
 Your strategy for calling another module's domain-layer code is highly dependent upon the unique configuration and needs of your system.
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/domain_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/domain_layer.md
@@ -38,7 +38,7 @@ There are three primary ways of accessing a module's domain-layer code:
 Your strategy for calling another module's domain-layer code is highly dependent upon the unique configuration and needs of your system.
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/domain_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/domain_layer.md
@@ -37,7 +37,8 @@ There are three primary ways of accessing a module's domain-layer code:
 
 Your strategy for calling another module's domain-layer code is highly dependent upon the unique configuration and needs of your system.
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -20,7 +20,7 @@ Any model that uses an EAV resource has its attributes spread out over a number 
 The `Customer`, `Catalog` and `Order` resource models use EAV attributes.
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -19,7 +19,8 @@ Any model that uses an EAV resource has its attributes spread out over a number 
 
 The `Customer`, `Catalog` and `Order` resource models use EAV attributes.
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -20,7 +20,7 @@ Any model that uses an EAV resource has its attributes spread out over a number 
 The `Customer`, `Catalog` and `Order` resource models use EAV attributes.
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -55,7 +55,8 @@ The View layer calls code from the Model to get information about the state of t
 Web users interact with components of the presentation layer to select actions that initiate calls to the underlying layers.
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -56,7 +56,7 @@ Web users interact with components of the presentation layer to select actions t
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -56,7 +56,7 @@ Web users interact with components of the presentation layer to select actions t
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -70,7 +70,8 @@ The `di.xml` file specifies which PHP class to use for the interface `Magento\Cu
 Another module can change this interface file by specifying a different class name.
 However, if the client code uses the interface definition only, no class change is necessary.
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -71,7 +71,7 @@ Another module can change this interface file by specifying a different class na
 However, if the client code uses the interface definition only, no class change is necessary.
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -71,7 +71,7 @@ Another module can change this interface file by specifying a different class na
 However, if the client code uses the interface definition only, no class change is necessary.
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -95,7 +95,8 @@ Plug-ins are also called *interceptors*. Applications use the [plug-in](https://
 
 See [Plug-ins][] in [PHP Developer Guide][] for information on declaring and prioritizing plug-ins.
 
-## Related topics {#m2arch-related}
+{:.ref-header}
+Related topics {#m2arch-related}
 
 [Architectural basics]({{page.baseurl}}/architecture/archi_perspectives/ABasics_intro.html)
 

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -96,7 +96,7 @@ Plug-ins are also called *interceptors*. Applications use the [plug-in](https://
 See [Plug-ins][] in [PHP Developer Guide][] for information on declaring and prioritizing plug-ins.
 
 {:.ref-header}
-Related topicsm2arch-related}
+Related topics
 
 [Architectural basics]({{page.baseurl}}/architecture/archi_perspectives/ABasics_intro.html)
 

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -96,7 +96,7 @@ Plug-ins are also called *interceptors*. Applications use the [plug-in](https://
 See [Plug-ins][] in [PHP Developer Guide][] for information on declaring and prioritizing plug-ins.
 
 {:.ref-header}
-Related topics {#m2arch-related}
+Related topicsm2arch-related}
 
 [Architectural basics]({{page.baseurl}}/architecture/archi_perspectives/ABasics_intro.html)
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -82,7 +82,8 @@ Delivering a sharply different shopping experience than the default Magento inst
 {:.bs-callout .bs-callout-tip}
  Any customization of your storefront will work optimally, and provide the easiest path for later upgrades, if you follow the best practice of consistently compartmentalizing code by type. For example, keep all HTML in [PHTML](https://glossary.magento.com/phtml) files; keep all JavaScript in JavaScript files.
 
-## Related topics {#m2arch-related}
+{:.ref-header}
+Related topics {#m2arch-related}
 
 [Extensibility and modularity][]
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -83,7 +83,7 @@ Delivering a sharply different shopping experience than the default Magento inst
  Any customization of your storefront will work optimally, and provide the easiest path for later upgrades, if you follow the best practice of consistently compartmentalizing code by type. For example, keep all HTML in [PHTML](https://glossary.magento.com/phtml) files; keep all JavaScript in JavaScript files.
 
 {:.ref-header}
-Related topicsm2arch-related}
+Related topics
 
 [Extensibility and modularity][]
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -83,7 +83,7 @@ Delivering a sharply different shopping experience than the default Magento inst
  Any customization of your storefront will work optimally, and provide the easiest path for later upgrades, if you follow the best practice of consistently compartmentalizing code by type. For example, keep all HTML in [PHTML](https://glossary.magento.com/phtml) files; keep all JavaScript in JavaScript files.
 
 {:.ref-header}
-Related topics {#m2arch-related}
+Related topicsm2arch-related}
 
 [Extensibility and modularity][]
 

--- a/guides/v2.2/architecture/global_extensibility_features.md
+++ b/guides/v2.2/architecture/global_extensibility_features.md
@@ -95,6 +95,7 @@ Plug-ins are also called *interceptors*. Applications use the [plug-in](https://
 
 See [Plug-ins]({{page.baseurl}}/extension-dev-guide/plugins.html) in [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information on declaring and prioritizing plug-ins.
 
-### Related topic {#m2arch-related}
+{:.ref-header}
+Related topic
 
 [Extensibility and modularity]({{page.baseurl}}/architecture/extensibility.html)

--- a/guides/v2.2/architecture/security_intro.md
+++ b/guides/v2.2/architecture/security_intro.md
@@ -40,7 +40,8 @@ You can change this Admin URI in three ways:
 
 Although the use of a non-default admin URL will not secure the site, its use will help prevent large-scale automated attacks. See [Display or change the Admin URI]({{page.baseurl}}/install-gde/install/cli/install-cli-adminurl.html) in Configuration Guide for more information.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Configuration Guide][]
 

--- a/guides/v2.2/architecture/storefront_customization.md
+++ b/guides/v2.2/architecture/storefront_customization.md
@@ -33,7 +33,8 @@ Delivering a sharply different shopping experience than the default Magento inst
 {:.bs-callout .bs-callout-tip}
  Any customization of your storefront will work optimally, and provide the easiest path for later upgrades, if you follow the best practice of consistently compartmentalizing code by type. For example, keep all HTML in [PHTML](https://glossary.magento.com/phtml) files; keep all JavaScript in JavaScript files.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 [Frontend Developer Guide]({{page.baseurl}}/frontend-dev-guide/bk-frontend-dev-guide.html)
 

--- a/guides/v2.2/architecture/tech-stack.md
+++ b/guides/v2.2/architecture/tech-stack.md
@@ -66,6 +66,7 @@ Magento also provides automated testing suites that include unit, integration, f
 This framework is located in the `dev/tests` directory. The functional testing framework `mtf` can be found in a [separate repository](https://github.com/magento/mtf){:target="_blank"}.
 For more information, see the [Functional Testing Framework]({{ page.baseurl }}/mtf/mtf_introduction.html) guide.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Architectural basics]({{ page.baseurl }}/architecture/archi_perspectives/ABasics_intro.html)

--- a/guides/v2.2/bk-get-started-magento.md
+++ b/guides/v2.2/bk-get-started-magento.md
@@ -34,7 +34,8 @@ For more information, see our [Contributors Guide]({{ page.baseurl }}/extension-
 Feel free to contact the documentation team directly at
 [DL-Magento-Doc-Feedback@magento.com](mailto:DL-Magento-Doc-Feedback@magento.com)
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *   [Release Notes]({{ page.baseurl }}/release-notes/bk-release-notes.html)
 *   [Architecture Guide]({{ page.baseurl }}/architecture/bk-architecture.html)

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -170,5 +170,7 @@ To branch from master:
    magento-cloud snapshot:create -e <environment-ID>
    ```
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Install Magento]({{ page.baseurl }}/cloud/before/before-setup-env-install.html)

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -9,7 +9,9 @@ functional_areas:
   - Setup
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html)
 
 The {{site.data.var.ece}} project is a Git repository of Magento code. Each **active** branch in the Integration environment includes a database and services to fully access the Magento site and store. You can clone the project and create an **active** branch from the Integration environment to develop code and add extensions using your local workstation.

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -10,7 +10,9 @@ functional_areas:
   - Configuration
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)
 
 With your workspace prepared, install Magento on your local to verify custom code, extensions, and more. This section includes the installation prep, options, and post-installation configuration you should complete.

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -210,7 +210,8 @@ With these steps completed, you should have:
 * Your initial code branch
 * Magento authentication keys set up and configured in the project and local
 
-**Next steps:**
+{:.ref-header}
+Next steps
 
 For **Pro projects**, we strongly recommend fully deploying this base Magento template `master` branch without any code or configuration changes to Staging and Production. For instructions, see [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html).
 

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -211,7 +211,7 @@ With these steps completed, you should have:
 * Magento authentication keys set up and configured in the project and local
 
 {:.ref-header}
-Next steps
+Next step
 
 For **Pro projects**, we strongly recommend fully deploying this base Magento template `master` branch without any code or configuration changes to Staging and Production. For instructions, see [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html).
 

--- a/guides/v2.2/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.2/cloud/before/before-workspace-cloud-account.md
@@ -18,5 +18,7 @@ We recommend always starting with the blank site from a template as your initial
 
 {% include cloud/new-project-from-template.md %}
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)

--- a/guides/v2.2/cloud/before/before-workspace-cloud-account.md
+++ b/guides/v2.2/cloud/before/before-workspace-cloud-account.md
@@ -4,7 +4,9 @@ subgroup:
 title: Set up an account and project
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
 To begin working with a project and develop your store, you should have received an e-mail invitation to [create a Magento Enterprise Cloud Edition account](https://accounts.magento.cloud). The account provides access to your project for Magento development and deployment across all supported environments.

--- a/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
+++ b/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
@@ -6,7 +6,9 @@ functional_areas:
   - Setup
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)
 
 **This step is optional if you installed nginx as your web server.** The [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html#magento-file-system-owner) provides root access and permissions, for security reasons on a hosted system. Apache installations require

--- a/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
+++ b/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
@@ -101,5 +101,7 @@ To complete the task, restart the web server:
 *	Ubuntu: `service apache2 restart`
 *	CentOS: `service httpd restart`
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)

--- a/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
@@ -229,5 +229,7 @@ The requirements listed in this topic are specific to {{site.data.var.ece}} envi
 
 You can also install additional [optional software]({{ page.baseurl }}/install-gde/prereq/optional.html). These packages should be installed on the local VM.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)

--- a/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
@@ -10,7 +10,9 @@ functional_areas:
   - Configuration
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
 Install the following software packages and tools on your local to prepare for Magento code development. If you already have these packages installed, check for any recommendations or notes and continue to the next step.

--- a/guides/v2.2/cloud/before/before-workspace-ssh.md
+++ b/guides/v2.2/cloud/before/before-workspace-ssh.md
@@ -8,7 +8,9 @@ functional_areas:
   - Setup
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
 
 The [SSH protocol](https://en.wikipedia.org/wiki/Secure_Shell) is designed to maintain a secure connection between two systems&mdash;in this case, your local working environment and your {{site.data.var.ece}} Git project.

--- a/guides/v2.2/cloud/before/before-workspace-ssh.md
+++ b/guides/v2.2/cloud/before/before-workspace-ssh.md
@@ -20,5 +20,7 @@ When initially setting up your local environment, you need to add the SSH keys t
 
 {% include cloud/enable-ssh.md %}
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html)

--- a/guides/v2.2/cloud/before/before-workspace.md
+++ b/guides/v2.2/cloud/before/before-workspace.md
@@ -58,5 +58,7 @@ You should be ready to go! The following sections provide a link to the previous
 
 For Pro projects, you also should deploy across to Staging and Production as part of your set up.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)

--- a/guides/v2.2/cloud/live/go-live-checklist.md
+++ b/guides/v2.2/cloud/live/go-live-checklist.md
@@ -86,5 +86,7 @@ You can also test using the following 3rd party options:
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks in depth: process, method call, query, load, and so on.
 * [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)

--- a/guides/v2.2/cloud/live/launch-steps.md
+++ b/guides/v2.2/cloud/live/launch-steps.md
@@ -10,7 +10,9 @@ functional_areas:
   - Testing
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Go live checklist]({{ page.baseurl }}/cloud/live/go-live-checklist.html)
 
 After testing and completing your launch checklist, you can start the final steps to launch. These steps include entering tickets, cutting over access, and finally testing your store(s) when live.

--- a/guides/v2.2/cloud/live/live-sanity-check.md
+++ b/guides/v2.2/cloud/live/live-sanity-check.md
@@ -203,5 +203,7 @@ To deploy your site:
 
 Debug errors by [reviewing logs]({{page.baseurl}}/cloud/project/log-locations.html). Open a [support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) for additional assistance.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Prepare to deploy to Staging and Production]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html)

--- a/guides/v2.2/cloud/live/stage-prod-live.md
+++ b/guides/v2.2/cloud/live/stage-prod-live.md
@@ -68,7 +68,8 @@ Always update your code in a branch on your local environment, push to Git, and 
 * Add 3rd party integrations
 * Fix issues and check errors
 
-## Next steps
+{:.ref-header}
+Related topicss
 
 To learn more, check the following:
 

--- a/guides/v2.2/cloud/live/stage-prod-live.md
+++ b/guides/v2.2/cloud/live/stage-prod-live.md
@@ -69,7 +69,7 @@ Always update your code in a branch on your local environment, push to Git, and 
 * Fix issues and check errors
 
 {:.ref-header}
-Related topicss
+Related topics
 
 To learn more, check the following:
 

--- a/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
+++ b/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
@@ -11,7 +11,9 @@ functional_areas:
   - Deploy
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Build and deploy on local]({{ page.baseurl }}/cloud/live/live-sanity-check.html)
 
 When you are ready to deploy your store, you must complete deployment and testing on the Staging environment before deploying to Production. The Staging environment provides a near-production environment that includes a database, web server, and all services including Fastly, New Relic, and Blackfire.

--- a/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
+++ b/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
@@ -113,6 +113,8 @@ To add an SSH key using the Project Web Interface:
 
 You can also add an SSH key using the {{site.data.var.ece}} CLI. See [Add an SSH key using the CLI]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html#add-key-cli).
 
-**Next step:**
+{:.ref-header}
+Next step
+
 
 [Migrate and deploy]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html)

--- a/guides/v2.2/cloud/live/stage-prod-migrate.md
+++ b/guides/v2.2/cloud/live/stage-prod-migrate.md
@@ -259,6 +259,7 @@ Use the database dump file to [migrate the database](#cloud-live-migrate-db).
 {:.bs-callout-info}
 After migrating the database, you can set up your stored procedures or views in Staging or Production the same way you did in your Integration environment.
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Test deployment]({{ page.baseurl }}/cloud/live/stage-prod-test.html)

--- a/guides/v2.2/cloud/live/stage-prod-migrate.md
+++ b/guides/v2.2/cloud/live/stage-prod-migrate.md
@@ -6,7 +6,9 @@ functional_areas:
   - Deploy
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Prepare to deploy to Staging and Production]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html)
 
 To migrate your database and static files to Staging and Production:

--- a/guides/v2.2/cloud/live/stage-prod-test.md
+++ b/guides/v2.2/cloud/live/stage-prod-test.md
@@ -11,7 +11,9 @@ functional_areas:
   - Deploy
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Migrate data and static files]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html)
 
 When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) and [Pro]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls) access information.

--- a/guides/v2.2/cloud/setup/first-time-deploy.md
+++ b/guides/v2.2/cloud/setup/first-time-deploy.md
@@ -9,7 +9,9 @@ functional_areas:
   - Deploy
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Install Magento]({{ page.baseurl }}/cloud/before/before-setup-env-install.html)
 
 {:.bs-callout .bs-callout-info}

--- a/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
@@ -120,5 +120,7 @@ The complete workflow for importing existing code includes the following steps:
 
 1.  After the project deploys, **Success** displays next to the name of your project.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Prepare your existing {{site.data.var.ee}} install]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html)

--- a/guides/v2.2/cloud/setup/first-time-setup-import-prepare.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-prepare.md
@@ -222,5 +222,7 @@ The following example compresses the dump so that it does not significantly inte
 
 To find `<cloud SSH URL>`, see [Find the information you need for your import]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html#db-creds).
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Import {{site.data.var.ee}} into {{site.data.var.ece}}]({{ page.baseurl }}/cloud/setup/first-time-setup-import-import.html)

--- a/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
@@ -45,7 +45,8 @@ For upgrade or update, you must use the same authentication keys you used to ins
 For example, you *cannot* use {{ce}} authentication keys to update or upgrade {{ee}} or vice versa.
 You also *cannot* use another user's authentication keys or [Shared account] authentication keys.
 
-### Next step
+{:.ref-header}
+Related topics
 
 Complete the tasks discussed in [Prerequisites].
 

--- a/guides/v2.2/comp-mgr/extens-man/extensman-backup.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-backup.md
@@ -13,7 +13,8 @@ functional_areas:
 
 {% include comp-man/backup.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 
 After your backup is complete, continue with any of the following:
 

--- a/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
@@ -29,4 +29,5 @@ Before continuing, complete all tasks discussed in [Prerequisites]({{ page.baseu
 
 {:.ref-header}
 Related topics
+
 [Start the Extension Manager]({{ page.baseurl }}/comp-mgr/extens-man/extensman-main-pg.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
@@ -27,5 +27,6 @@ Before continuing, complete all tasks discussed in [Prerequisites]({{ page.baseu
 ## Extension Manager checklist
 {% include comp-man/checklist_2.2.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Start the Extension Manager]({{ page.baseurl }}/comp-mgr/extens-man/extensman-main-pg.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
@@ -70,4 +70,5 @@ In the event of failure, see one of the following sections:
 
 {:.ref-header}
 Related topics
+
 [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
@@ -68,5 +68,6 @@ In the event of failure, see one of the following sections:
 
 {% endcollapsible %}
 
-#### Next step
+{:.ref-header}
+Related topics
 [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-success.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-success.md
@@ -20,5 +20,6 @@ The following figure shows an example of a successful readiness check. If all te
 {: .bs-callout-info }
 If you're updating multiple extensions, see [Readiness check with multiple extension updates]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-multi.html#extensman-readiness-multi-success) for additional options.
 
-### Next step
+{:.ref-header}
+Related topics
 [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-success.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-success.md
@@ -22,4 +22,5 @@ If you're updating multiple extensions, see [Readiness check with multiple exten
 
 {:.ref-header}
 Related topics
+
 [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html)

--- a/guides/v2.2/comp-mgr/module-man/compman-backup.md
+++ b/guides/v2.2/comp-mgr/module-man/compman-backup.md
@@ -17,4 +17,3 @@ functional_areas:
 Related topics
 
 After your backup is complete, continue with [Step 3. Enable/disable modules]({{ page.baseurl }}/comp-mgr/module-man/modman-enable-disable.html)
-

--- a/guides/v2.2/comp-mgr/module-man/compman-backup.md
+++ b/guides/v2.2/comp-mgr/module-man/compman-backup.md
@@ -13,7 +13,8 @@ functional_areas:
 
 {% include comp-man/backup.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 
 After your backup is complete, continue with [Step 3. Enable/disable modules]({{ page.baseurl }}/comp-mgr/module-man/modman-enable-disable.html)
 

--- a/guides/v2.2/comp-mgr/module-man/compman-checklist.md
+++ b/guides/v2.2/comp-mgr/module-man/compman-checklist.md
@@ -22,4 +22,5 @@ Before continuing, complete all tasks discussed in [Prerequisites]({{ page.baseu
 
 {:.ref-header}
 Related topics
+
 [Run the Module Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)

--- a/guides/v2.2/comp-mgr/module-man/compman-checklist.md
+++ b/guides/v2.2/comp-mgr/module-man/compman-checklist.md
@@ -20,5 +20,6 @@ Before continuing, complete all tasks discussed in [Prerequisites]({{ page.baseu
 ## Module Manager checklist
 {% include comp-man/checklist_2.2.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Run the Module Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)

--- a/guides/v2.2/comp-mgr/upgrader/upgrade-backup.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade-backup.md
@@ -11,7 +11,8 @@ functional_areas:
 
 {% include comp-man/backup.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 After your backup is complete, continue with [Step 4. Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade.html).
 

--- a/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
@@ -33,5 +33,6 @@ _System upgrade_ refers to updating the Magento 2.x core components and other in
 ## System Upgrade checklist
 {% include comp-man/checklist_2.2.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Start System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)

--- a/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
@@ -35,4 +35,5 @@ _System upgrade_ refers to updating the Magento 2.x core components and other in
 
 {:.ref-header}
 Related topics
+
 [Start System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)

--- a/guides/v2.2/config-guide/bootstrap/magento-bootstrap.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-bootstrap.md
@@ -103,7 +103,8 @@ When the request is redirected to the entry point, the Magento application parse
 
 `\Magento\Core\App\Media` attempts to find the media file in the configured database storage and write it into the `pub/static` directory, then return its contents. On error, it returns an HTTP 404 (Not Found) status code in the header with no contents.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 This topic discussed the basics of Magento application initialization and bootstrapping. To find out how to set bootstrap environment variables, see one of the following topics:
 

--- a/guides/v2.2/config-guide/bootstrap/magento-how-to-set.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-how-to-set.md
@@ -172,7 +172,8 @@ After setting the mode, restart the web server:
 *	Ubuntu: `service apache2 restart`
 *	CentOS: `service httpd restart`
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[Customize base directory paths (MAGE_DIRS)]({{ page.baseurl }}/config-guide/bootstrap/mage-dirs.html)
 *	[Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html)

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -109,10 +109,9 @@ You can create a [custom maintenance page]({{ page.baseurl }}/comp-mgr/trouble/c
 
 If you are using {{site.data.var.ece}}, the Magento application runs in maintenance mode during the deploy phase. When the deployment completes successfully, Magento returns to running in production mode. See [Deployment hooks]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
-### Next step
+{:.ref-header}
+Related topics
 
-To set a mode, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
+- To set a mode, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
 
-### Related topic
-
-To generate static view files for production mode, see [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html)
+- To generate static view files for production mode, see [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html)

--- a/guides/v2.2/config-guide/cache/cache-types.md
+++ b/guides/v2.2/config-guide/cache/cache-types.md
@@ -71,5 +71,6 @@ where
 *   `<backend_type>` is the low-level backend cache type. Specify the name of a class that is compatible with [Zend_Cache_Backend](http://framework.zend.com/apidoc/1.7/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend.html){:target="_blank"} and that implements [Zend_Cache_Backend_Interface](http://framework.zend.com/apidoc/1.6/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend_Interface.html){:target="_blank"}.
 *   `<backend_option>`, `<backend_option_value>` are the name and value of options the Magento framework passes as an associative array to backend cache upon its creation.
 
-### Next step
+{:.ref-header}
+Related topics
 [Low-level cache options]({{ page.baseurl }}/config-guide/cache/cache-options.html)

--- a/guides/v2.2/config-guide/cache/cache-types.md
+++ b/guides/v2.2/config-guide/cache/cache-types.md
@@ -73,4 +73,5 @@ where
 
 {:.ref-header}
 Related topics
+
 [Low-level cache options]({{ page.baseurl }}/config-guide/cache/cache-options.html)

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-import.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-import.md
@@ -116,7 +116,8 @@ Full example:
 *   _Theme registration_. If a theme data is defined in `config.php` but the theme's source code is  not present in the file system, the theme is ignored (that is, not registered).
 *   _Theme removal_. If a theme is not present in `config.php` but the source code is present on the file system, the theme is not removed.
 
-#### For more information
+{:.ref-header}
+Related topics
 
 *   [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)
 *   [`bin/magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html)

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -265,5 +265,6 @@ Result:
 
 <pre class="no-copy">web/unsecure/base_url - http://example-for-store.com/</pre>
 
-#### Related topic
+{:.ref-header}
+Related topic
 [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)

--- a/guides/v2.2/config-guide/cli/config-cli.md
+++ b/guides/v2.2/config-guide/cli/config-cli.md
@@ -18,6 +18,7 @@ This topic discusses configuring the Magento software using the CLI. For informa
 ## First steps {#config-install-cli-first}
 {% include install/first-steps-cli.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Get started with command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)

--- a/guides/v2.2/config-guide/config/config-create.md
+++ b/guides/v2.2/config-guide/config/config-create.md
@@ -75,7 +75,8 @@ To ensure validation of an XML file by appropriate XSD file, you must add the Un
 
 Your IDE can validate your configuration files at both runtime and during development.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 * [Module configuration files]({{ page.baseurl }}/config-guide/config/config-php.html)
 * [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.2/config-guide/config/config-files.md
+++ b/guides/v2.2/config-guide/config/config-files.md
@@ -119,7 +119,8 @@ That is, the file system, database, other storage merges the configuration files
 *  [Framework\Config\ScopeListInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ScopeListInterface.php), which returns a list of scopes.
 *  [Framework\Config\ValidationStateInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ValidationStateInterface.php), which retrieves the validation state.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
  *  [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
  *  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.2/config-guide/cron/custom-cron-ref.md
+++ b/guides/v2.2/config-guide/cron/custom-cron-ref.md
@@ -109,5 +109,6 @@ where:
 | `history_failure_lifetime` | Time (in minutes) that the record of failed cron jobs are kept in the database.                        |
 | `use_separate_process`     | Run this crongroup's jobs in a separate php process                                             |
 
-#### Related topic
+{:.ref-header}
+Related topic
 [Tutorial&mdash;configure custom cron jobs and cron groups]({{ page.baseurl }}/config-guide/cron/custom-cron-tut.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/build-system.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/build-system.md
@@ -98,7 +98,8 @@ To set up the build system:
 
     See the [`.gitignore` reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html) for more information.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
 *	[Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/development-system.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/development-system.md
@@ -24,5 +24,6 @@ You can have any number of development systems, provided the following is true o
 
 If you use Git, Magento's `.gitignore` provides most of the preceding. See the [`.gitignore` reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html) for more information.
 
-#### Next step
+{:.ref-header}
+Related topics
 [Set up a build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/development-system.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/development-system.md
@@ -26,4 +26,5 @@ If you use Git, Magento's `.gitignore` provides most of the preceding. See the [
 
 {:.ref-header}
 Related topics
+
 [Set up a build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/index.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/index.md
@@ -38,5 +38,6 @@ For a complete list of configuration paths, see the following references:
 
 {% include config/split-deploy/split-deploy-assumptions.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Deployment technical overview (implementation details)]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/index.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/index.md
@@ -40,4 +40,5 @@ For a complete list of configuration paths, see the following references:
 
 {:.ref-header}
 Related topics
+
 [Deployment technical overview (implementation details)]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
@@ -289,13 +289,15 @@ File permissions and ownership must be consistent across development, build, and
     {:.bs-callout .bs-callout-info}
     If you choose this approach, you must set file system permissions and ownership every time you pull code from your build system (if the Magento file system owner or web server user are different on your build system).
 
-### For more information
+{:.ref-header}
+Related topics
 
 *   For a complete list of system-specific and sensitive settings and corresponding configuration paths, see [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
 *   [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html) for detailed information about the shared configuration file
 *   [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html) for detailed information about the system-specific configuration file
 
-### Next steps
+{:.ref-header}
+Related topicss
 
 *	[Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
 *	[Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
@@ -292,15 +292,11 @@ File permissions and ownership must be consistent across development, build, and
 {:.ref-header}
 Related topics
 
-*   For a complete list of system-specific and sensitive settings and corresponding configuration paths, see [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
-*   [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html) for detailed information about the shared configuration file
-*   [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html) for detailed information about the system-specific configuration file
-
-{:.ref-header}
-Related topicss
-
-*	[Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
-*	[Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
-*	[Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
+*  For a complete list of system-specific and sensitive settings and corresponding configuration paths, see [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
+*  [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html) for detailed information about the shared configuration file
+*  [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html) for detailed information about the system-specific configuration file
+*	 [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
+*	 [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
+*	 [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
 
 [config-cli-config-set]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set

--- a/guides/v2.2/config-guide/deployment/single-machine.md
+++ b/guides/v2.2/config-guide/deployment/single-machine.md
@@ -80,7 +80,8 @@ For deployment strategies developed by the Magento community, see the blog posts
 
 In Magento 2.2, a near-zero downtime deployment model will be available for a variety of complex environments, including {{site.data.var.ece}}.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Enable or disable maintenance mode][4]
 * [Command line upgrade][1]

--- a/guides/v2.2/config-guide/elasticsearch/es-config-apache.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-apache.md
@@ -190,6 +190,7 @@ This section discusses how to specify who can access the Apache server.
 
 {% include config/es-verify-proxy.md %}
 
-#### Next
+{:.ref-header}
+Next step
 
 [Configure Elasticsearch stopwords]({{ page.baseurl }}/config-guide/elasticsearch/es-config-stopwords.html)

--- a/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
@@ -227,6 +227,7 @@ This section discusses how to specify who can access the Elasticsearch server.
 
 {% include config/es-verify-proxy.md %}
 
-#### Next
+{:.ref-header}
+Next step
 
 [Configure Elasticsearch stopwords]({{ page.baseurl }}/config-guide/elasticsearch/es-config-stopwords.html)

--- a/guides/v2.2/config-guide/elasticsearch/es-overview.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-overview.md
@@ -134,7 +134,8 @@ Elasticsearch 6.x requires JDK 1.8 or higher. Elasticsearch 2.x requires JDK 1.7
 
 For additional information, see [Elasticsearch documentation][]
 
-### Next
+{:.ref-header}
+Next step
 
 * [Configure nginx and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-nginx.html)
 * [Configure Apache and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-apache.html)

--- a/guides/v2.2/config-guide/log/log-intro.md
+++ b/guides/v2.2/config-guide/log/log-intro.md
@@ -29,5 +29,5 @@ The [PSR-3 standard](https://zendframework.github.io/zend-log/psr3) defines a co
 This provides the ability for the implementation to be replaced easily without worry that such replacement may break the application code. It also guarantees a custom component will work even when the Magento log implementation is changed in a future version of the system.
 
 {:.ref-header}
-Next step
+
 [Magento logging in more detail]({{ page.baseurl }}/config-guide/log/log-magento.html)

--- a/guides/v2.2/config-guide/log/log-intro.md
+++ b/guides/v2.2/config-guide/log/log-intro.md
@@ -28,5 +28,6 @@ The [PSR-3 standard](https://zendframework.github.io/zend-log/psr3) defines a co
 
 This provides the ability for the implementation to be replaced easily without worry that such replacement may break the application code. It also guarantees a custom component will work even when the Magento log implementation is changed in a future version of the system.
 
-#### Next
+{:.ref-header}
+Next step
 [Magento logging in more detail]({{ page.baseurl }}/config-guide/log/log-magento.html)

--- a/guides/v2.2/config-guide/log/log-intro.md
+++ b/guides/v2.2/config-guide/log/log-intro.md
@@ -29,5 +29,6 @@ The [PSR-3 standard](https://zendframework.github.io/zend-log/psr3) defines a co
 This provides the ability for the implementation to be replaced easily without worry that such replacement may break the application code. It also guarantees a custom component will work even when the Magento log implementation is changed in a future version of the system.
 
 {:.ref-header}
+Next step
 
 [Magento logging in more detail]({{ page.baseurl }}/config-guide/log/log-magento.html)

--- a/guides/v2.2/config-guide/log/log-magento.md
+++ b/guides/v2.2/config-guide/log/log-magento.md
@@ -72,4 +72,5 @@ The preceding example shows that `SomeModel` receives a `\Psr\Log\LoggerInterfac
 
 {:.ref-header}
 Next step
+
 [Example&mdash;logging database activity]({{ page.baseurl }}/config-guide/log/log-db.html)

--- a/guides/v2.2/config-guide/log/log-magento.md
+++ b/guides/v2.2/config-guide/log/log-magento.md
@@ -70,5 +70,6 @@ The preceding example shows that `SomeModel` receives a `\Psr\Log\LoggerInterfac
 
 [RFC 5424](https://tools.ietf.org/html/rfc5424) defines eight log levels (debug, info, notice, warning, error, critical, alert, and emergency).
 
-### Next
+{:.ref-header}
+Next step
 [Example&mdash;logging database activity]({{ page.baseurl }}/config-guide/log/log-db.html)

--- a/guides/v2.2/config-guide/memcache/memcache.md
+++ b/guides/v2.2/config-guide/memcache/memcache.md
@@ -16,7 +16,8 @@ Magento uses memcached for session storage but not for page caching. For page ca
 {:.bs-callout .bs-callout-info}
 Refer to [Why Redis is better]({{ page.baseurl }}/config-guide/redis/config-redis.html) for a list of advantages to using Redis.
 
-## Next step
+{:.ref-header}
+Related topics
 
 * [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
 * [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)

--- a/guides/v2.2/config-guide/memcache/memcache_centos.md
+++ b/guides/v2.2/config-guide/memcache/memcache_centos.md
@@ -164,6 +164,7 @@ Flush the memcache storage and quit Telnet:
 
 [Additional information about the Telnet test](http://www.darkcoding.net/software/memcached-list-all-keys/)
 
-## Next step
+{:.ref-header}
+Related topics
 
 [Configure Magento to use memcached]({{ page.baseurl }}/config-guide/memcache/memcache_magento.html)

--- a/guides/v2.2/config-guide/memcache/memcache_ubuntu.md
+++ b/guides/v2.2/config-guide/memcache/memcache_ubuntu.md
@@ -131,6 +131,7 @@ Flush memcached storage and quit Telnet:
 
 [Additional information about the Telnet test](http://www.darkcoding.net/software/memcached-list-all-keys/)
 
-## Next step
+{:.ref-header}
+Related topics
 
 [Configure Magento to use memcached]({{ page.baseurl }}/config-guide/memcache/memcache_magento.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master.md
@@ -88,7 +88,8 @@ In this guide, the three master databases are named:
 
 (You can name your databases anything you wish.)
 
-### Next step
+{:.ref-header}
+Related topics
 
 *	If you have not installed components or put Magento into production: [Automatically configure master databases]({{ page.baseurl }}/config-guide/multi-master/multi-master_masterdb.html)
 *	If Magento is already in production or if you've already installed components: [Manually configure master databases]({{ page.baseurl }}/config-guide/multi-master/multi-master_manual.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master_manual.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_manual.md
@@ -687,6 +687,7 @@ select 'SET foreign_key_checks = 1;';
 Drop all tables that start with `quote_`.
 {% endcollapsible %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Verify split databases]({{ page.baseurl }}/config-guide/multi-master/multi-master_verify.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master_masterdb.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_masterdb.md
@@ -25,6 +25,7 @@ You can enable split databases at any time after you install the {{site.data.var
 
 {% include config/split-db.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Verify split databases]({{ page.baseurl }}/config-guide/multi-master/multi-master_verify.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master_verify.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_verify.md
@@ -38,5 +38,6 @@ To verify your split databases are working properly, perform the following tasks
 {:.bs-callout .bs-callout-warning}
 You must back up the two additional database instances manually. Magento backs up only the main database instance. The [`magento setup:backup --db`]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) command and Magento Admin options do not back up the additional tables.
 
-#### Next step (optional)
+{:.ref-header}
+Related topics (optional)
 [Set up optional database replication]({{ page.baseurl }}/config-guide/multi-master/multi-master_slavedb.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master_verify.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_verify.md
@@ -39,5 +39,6 @@ To verify your split databases are working properly, perform the following tasks
 You must back up the two additional database instances manually. Magento backs up only the main database instance. The [`magento setup:backup --db`]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) command and Magento Admin options do not back up the additional tables.
 
 {:.ref-header}
-Related topics (optional)
+Related topics
+
 [Set up optional database replication]({{ page.baseurl }}/config-guide/multi-master/multi-master_slavedb.html)

--- a/guides/v2.2/config-guide/multi-site/ms_websites.md
+++ b/guides/v2.2/config-guide/multi-site/ms_websites.md
@@ -173,11 +173,13 @@ You must perform this step last because you will lose access to the Magento Admi
 
 {% endcollapsible %}
 
-### Next step
+{:.ref-header}
+Related topics
 
 *	{{site.data.var.ece}}: [Set up multiple {{site.data.var.ece}} websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html)
 
-### Related information
+{:.ref-header}
+Related topics
 
 * [Add content to your websites](http://docs.magento.com/m2/ce/user_guide/cms/content-menu.html)
 *	[Tutorial: Set up multiple websites or stores with NGINX]({{ page.baseurl }}/config-guide/multi-site/ms_nginx.html)

--- a/guides/v2.2/config-guide/multi-site/ms_websites.md
+++ b/guides/v2.2/config-guide/multi-site/ms_websites.md
@@ -177,10 +177,6 @@ You must perform this step last because you will lose access to the Magento Admi
 Related topics
 
 *	{{site.data.var.ece}}: [Set up multiple {{site.data.var.ece}} websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html)
-
-{:.ref-header}
-Related topics
-
 * [Add content to your websites](http://docs.magento.com/m2/ce/user_guide/cms/content-menu.html)
 *	[Tutorial: Set up multiple websites or stores with NGINX]({{ page.baseurl }}/config-guide/multi-site/ms_nginx.html)
 *	[Tutorial: Set up multiple websites with Apache]({{ page.baseurl }}/config-guide/multi-site/ms_apache.html)

--- a/guides/v2.2/config-guide/prod/config-reference-var-name.md
+++ b/guides/v2.2/config-guide/prod/config-reference-var-name.md
@@ -242,7 +242,8 @@ content='
 
 %}
 
-### Related information
+{:.ref-header}
+Related topics
 
 *	[Magento User Guide discussion of scope](http://docs.magento.com/m2/ce/user_guide/configuration/scope.html)
 *	[Magento User Guide scope quick reference](http://docs.magento.com/m2/ce/user_guide/stores/store-scope-reference.html)

--- a/guides/v2.2/config-guide/redis/redis-session.md
+++ b/guides/v2.2/config-guide/redis/redis-session.md
@@ -95,7 +95,8 @@ TTL for session records use the value for Cookie Lifetime, which is configured i
 
 {% include config/redis-verify.md %}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
 * [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.2/config-guide/secy/secy.md
+++ b/guides/v2.2/config-guide/secy/secy.md
@@ -38,7 +38,8 @@ A simple [Magento Admin](https://glossary.magento.com/magento-admin) [URL](https
 *	[Secure cron.php][]
 *	[X-Frame-Options header][]
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Configuration Guide][]
 

--- a/guides/v2.2/config-guide/varnish/config-varnish-configure.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-configure.md
@@ -263,6 +263,7 @@ Via: 1.1 varnish-v4
 X-Magento-Cache-Debug: HIT
 ```
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Configure Magento to use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish-magento.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish-final.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-final.md
@@ -76,7 +76,8 @@ Make sure the `<magento_root>/var/page_cache` directory is empty:
 {:.bs-callout .bs-callout-info}
 If you encounter 503 (Backend Fetch Failed) errors, see [Troubleshooting 503 (Service Unavailable) errors]({{ page.baseurl }}/config-guide/varnish/tshoot-varnish-503.html).
 
-#### Next steps
+{:.ref-header}
+Related topicss
 
 *	[How Magento cache clearing works with Varnish]({{ page.baseurl }}/config-guide/varnish/use-varnish-cache.html)
 *	[How Varnish caching works]({{ page.baseurl }}/config-guide/varnish/use-varnish-cache-how.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish-final.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-final.md
@@ -77,7 +77,7 @@ Make sure the `<magento_root>/var/page_cache` directory is empty:
 If you encounter 503 (Backend Fetch Failed) errors, see [Troubleshooting 503 (Service Unavailable) errors]({{ page.baseurl }}/config-guide/varnish/tshoot-varnish-503.html).
 
 {:.ref-header}
-Related topicss
+Related topics
 
 *	[How Magento cache clearing works with Varnish]({{ page.baseurl }}/config-guide/varnish/use-varnish-cache.html)
 *	[How Varnish caching works]({{ page.baseurl }}/config-guide/varnish/use-varnish-cache-how.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish-install.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-install.md
@@ -36,6 +36,7 @@ Copyright (c) 2006-2014 Varnish Software AS
 
 Make sure the version is 4.x or 5.x before continuing. If you are running version 3.x, you must upgrade to a supported version. Consult the Varnish installation documentation for more information.
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Configure Varnish and your web server]({{ page.baseurl }}/config-guide/varnish/config-varnish-configure.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish-magento.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-magento.md
@@ -116,7 +116,8 @@ Static files should not be cached by default, but if you want to cache them, you
 
 You need to make these changes before you configure Magento to use Varnish.
 
-## Next steps
+{:.ref-header}
+Related topicss
 
 -   [Advanced Varnish configuration]({{ page.baseurl }}/config-guide/varnish/config-varnish-advanced.html) (Optional)
 -   [Final verification]({{ page.baseurl }}/config-guide/varnish/config-varnish-final.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish-magento.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish-magento.md
@@ -117,7 +117,7 @@ Static files should not be cached by default, but if you want to cache them, you
 You need to make these changes before you configure Magento to use Varnish.
 
 {:.ref-header}
-Related topicss
+Related topics
 
 -   [Advanced Varnish configuration]({{ page.baseurl }}/config-guide/varnish/config-varnish-advanced.html) (Optional)
 -   [Final verification]({{ page.baseurl }}/config-guide/varnish/config-varnish-final.html)

--- a/guides/v2.2/config-guide/varnish/config-varnish.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish.md
@@ -98,7 +98,8 @@ We know of the following issues with Varnish:
     }
     ```
 
-### Next step
+{:.ref-header}
+Related topics
 [Install Varnish]
 
 <!-- Link Definitions -->

--- a/guides/v2.2/config-guide/varnish/config-varnish.md
+++ b/guides/v2.2/config-guide/varnish/config-varnish.md
@@ -100,6 +100,7 @@ We know of the following issues with Varnish:
 
 {:.ref-header}
 Related topics
+
 [Install Varnish]
 
 <!-- Link Definitions -->

--- a/guides/v2.2/contributor-guide/templates/tutorial-template-last.md
+++ b/guides/v2.2/contributor-guide/templates/tutorial-template-last.md
@@ -47,7 +47,8 @@ Use a Head2 (`## Heading`) as the highest-level heading in this topic.
 ## Congratulations! You've finished.
 {:.no_toc}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Title of linked topic](http://example.com/index.html)
 * [Link and open new tab](http://example.com/index.html){:target="_blank"}

--- a/guides/v2.2/extension-dev-guide/bk-extension-dev-guide.md
+++ b/guides/v2.2/extension-dev-guide/bk-extension-dev-guide.md
@@ -20,7 +20,8 @@ The Magento application is made up of *Modules*, *Themes*, and *Language Package
 {: .bs-callout-info }
 You must follow a [PSR-4 compliant](http://www.php-fig.org/psr/psr-4/) structure when building a module.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
 *	[Introduction to Composer]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer.html)

--- a/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
+++ b/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
@@ -62,5 +62,6 @@ libxml_set_external_entity_loader(['Magento\Framework\Config\Dom\UrnResolver', '
 {: .bs-callout-info }
 The relative path to other XSDs cannot be used from inside the XSD file, because the [entity](https://glossary.magento.com/entity) loader fails to resolve the relative path.
 
-#### Next
+{:.ref-header}
+Next step
 [Name your component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html)

--- a/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
+++ b/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
@@ -64,4 +64,5 @@ The relative path to other XSDs cannot be used from inside the XSD file, because
 
 {:.ref-header}
 Next step
+
 [Name your component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html)

--- a/guides/v2.2/extension-dev-guide/build/component-registration.md
+++ b/guides/v2.2/extension-dev-guide/build/component-registration.md
@@ -105,4 +105,5 @@ ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminNotificat
 
 {:.ref-header}
 Next step
+
 [URN schema validation]({{ page.baseurl }}/extension-dev-guide/build/XSD-XML-validation.html)

--- a/guides/v2.2/extension-dev-guide/build/component-registration.md
+++ b/guides/v2.2/extension-dev-guide/build/component-registration.md
@@ -103,5 +103,6 @@ use \Magento\Framework\Component\ComponentRegistrar;
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminNotification', __DIR__);
 ```
 
-#### Next
+{:.ref-header}
+Next step
 [URN schema validation]({{ page.baseurl }}/extension-dev-guide/build/XSD-XML-validation.html)

--- a/guides/v2.2/extension-dev-guide/build/create_component.md
+++ b/guides/v2.2/extension-dev-guide/build/create_component.md
@@ -87,6 +87,7 @@ In this example:
 {: .bs-callout-info }
 Magento does not currently support the [`path`](https://getcomposer.org/doc/05-repositories.md#path) repository.
 
-#### Next
+{:.ref-header}
+Next step
 
 [Component load order]({{ page.baseurl }}/extension-dev-guide/build/module-load-order.html)

--- a/guides/v2.2/extension-dev-guide/build/di-xml-file.md
+++ b/guides/v2.2/extension-dev-guide/build/di-xml-file.md
@@ -394,7 +394,8 @@ Plugins for the Preference:
 +-----------------------------------------------------+---------+--------+
 ```
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)
 * [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)

--- a/guides/v2.2/extension-dev-guide/build/required-configuration-files.md
+++ b/guides/v2.2/extension-dev-guide/build/required-configuration-files.md
@@ -59,6 +59,7 @@ If the module is a service that may call an API, or does some other work that is
 
 Keep in mind that you might be able to handle your module's configuration solely with configuration files at the top level of your module's `etc` directory, but the nested directory is a useful way to keep the configuration neatly compartmentalized.
 
-#### Next
+{:.ref-header}
+Next step
 
 [Create your component file structure]({{ page.baseurl }}/extension-dev-guide/build/module-file-structure.html)

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -107,6 +107,7 @@ You can style the output text by using `<error>This is an error message</error>`
 
 To be added at a later time.
 
-### Related topic
+{:.ref-header}
+Related topic
 
 [Command naming guidelines]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-naming-guidelines.html)

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
@@ -174,6 +174,7 @@ To avoid naming your command the same as another command, we recommend:
     dev:myname:theme:delete
     ```
 
-### Related topic
+{:.ref-header}
+Related topic
 
 [How to add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-howto.html)

--- a/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.md
+++ b/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.md
@@ -93,7 +93,8 @@ A message similar to the following is displayed:
 
 To set a configuration setting as both sensitive and system-specific, create two entries with the `name` property for `argument` set to `sensitive` for one entry and `environment` for the other.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 * [Configuration importers][config-importers]
 *	[The di.xml file][di-xml]

--- a/guides/v2.2/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.2/extension-dev-guide/indexer-batch.md
@@ -132,7 +132,6 @@ The indexer table switching mechanism requires additional database storage.
 
 {:.ref-header}
 Related topics
-{:.no_toc}
 
 * [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)
 * [Adding a custom indexer]({{ page.baseurl }}/extension-dev-guide/indexing-custom.html)

--- a/guides/v2.2/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.2/extension-dev-guide/indexer-batch.md
@@ -130,7 +130,8 @@ Make sure that these indexers are in "Update By Schedule" mode. If "Update On Sa
 {: .bs-callout-info }
 The indexer table switching mechanism requires additional database storage.
 
-### Related topics
+{:.ref-header}
+Related topics
 {:.no_toc}
 
 * [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)

--- a/guides/v2.2/extension-dev-guide/intro/intro-composer-gloss.md
+++ b/guides/v2.2/extension-dev-guide/intro/intro-composer-gloss.md
@@ -38,7 +38,8 @@ Merchants do not need to understand that, under the covers, some packages are sh
 {: .bs-callout .bs-callout-warning }
 You can upload to Magento Marketplace as many shared packages as you want but you must specifically give components access to them. Failure to do so means your components won't work properly after they're installed by merchants. For more information, see the [Magento Marketplace User Guide](http://docs.magento.com/marketplace/user_guide/getting-started.html){: target="_blank"}.
 
-#### For more information
+{:.ref-header}
+Related topics
 
 *	<a href="{{ page.baseurl }}/extension-dev-guide/package/package_module.html#package-metapackage">metapackages</a>
 *	<a href="{{ page.baseurl }}/extension-dev-guide/build/composer-integration.html">component types in <code>composer.json</code></a>.

--- a/guides/v2.2/extension-dev-guide/message-queues/queue-migration.md
+++ b/guides/v2.2/extension-dev-guide/message-queues/queue-migration.md
@@ -128,7 +128,8 @@ The first column in the following table lists the all the parameters in the `que
 `<publisher>/<connection>/exchange` | `<publisher>/exchange`
 `<publisher>/<connection>/disabled` | Not present in 2.0. Omit this parameter to accept the default value.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
 *	[Configure message queues]({{ page.baseurl }}/extension-dev-guide/message-queues/config-mq.html)

--- a/guides/v2.2/extension-dev-guide/object-manager.md
+++ b/guides/v2.2/extension-dev-guide/object-manager.md
@@ -71,7 +71,8 @@ $objectManager->configure([
 ]);
 ```
 
-## Related topics
+{:.ref-header}
+Related topics
 
 - [The `di.xml` file][`di.xml`]
 - [Dependency injection][]

--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -344,12 +344,14 @@ Magento uses plugins defined in the global scope when the system is in a specifi
 
 For example, the developer can disable a global plugin in the [backend](https://glossary.magento.com/backend) area by disabling it in the specific `di.xml` file for the backend area.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *  [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
 *  [Events and observers]({{ page.baseurl }}/extension-dev-guide/events-and-observers.html)
 
-### Related information
+{:.ref-header}
+Related topics
 
 * [The Plugin Integration Test Kata](http://vinaikopp.com/2016/03/07/04_the_plugin_integration_test_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}
 * [The Around Interceptor Kata](http://vinaikopp.com/2016/02/22/03_the_around_interceptor_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}

--- a/guides/v2.2/extension-dev-guide/plugins.md
+++ b/guides/v2.2/extension-dev-guide/plugins.md
@@ -349,9 +349,5 @@ Related topics
 
 *  [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
 *  [Events and observers]({{ page.baseurl }}/extension-dev-guide/events-and-observers.html)
-
-{:.ref-header}
-Related topics
-
-* [The Plugin Integration Test Kata](http://vinaikopp.com/2016/03/07/04_the_plugin_integration_test_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}
-* [The Around Interceptor Kata](http://vinaikopp.com/2016/02/22/03_the_around_interceptor_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}
+*  [The Plugin Integration Test Kata](http://vinaikopp.com/2016/03/07/04_the_plugin_integration_test_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}
+*  [The Around Interceptor Kata](http://vinaikopp.com/2016/02/22/03_the_around_interceptor_kata){:target="_blank"} by Magento contributor [Vinai Kopp](http://vinaikopp.com/blog/list){:target="_blank"}

--- a/guides/v2.2/extension-dev-guide/prepare/dev-modtypes.md
+++ b/guides/v2.2/extension-dev-guide/prepare/dev-modtypes.md
@@ -9,7 +9,8 @@ Each component type has a different [directory structure][directory-structure] a
 
 {% include php-dev/composer-types.md %}
 
-#### Next
+{:.ref-header}
+Next step
 [About component file structure][component-file-structure]
 
 [directory-structure]: {{ page.baseurl }}/extension-dev-guide/build/module-file-structure.html

--- a/guides/v2.2/extension-dev-guide/prepare/dev-modtypes.md
+++ b/guides/v2.2/extension-dev-guide/prepare/dev-modtypes.md
@@ -11,6 +11,7 @@ Each component type has a different [directory structure][directory-structure] a
 
 {:.ref-header}
 Next step
+
 [About component file structure][component-file-structure]
 
 [directory-structure]: {{ page.baseurl }}/extension-dev-guide/build/module-file-structure.html

--- a/guides/v2.2/extension-dev-guide/prepare/prepare_file-str.md
+++ b/guides/v2.2/extension-dev-guide/prepare/prepare_file-str.md
@@ -9,6 +9,7 @@ In addition, you can choose the component root directory to start development. T
 
 {% include php-dev/component-root.md %}
 
-#### Related topic
+{:.ref-header}
+Related topic
 
 [Roadmap for developing and packaging components]({{ page.baseurl }}/extension-dev-guide/prepare/dev-summary.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
@@ -145,7 +145,7 @@ Management interfaces provide management functions that are not related to repos
 </table>
 
 {:.ref-header}
-Related topics {#related-topics}
+Related topicsrelated-topics}
 
 - [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)
 - [Configure services as web APIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
@@ -145,7 +145,7 @@ Management interfaces provide management functions that are not related to repos
 </table>
 
 {:.ref-header}
-Related topicsrelated-topics}
+Related topics
 
 - [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)
 - [Configure services as web APIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/design-patterns.md
@@ -144,7 +144,8 @@ Management interfaces provide management functions that are not related to repos
    </tr>
 </table>
 
-### Related topics {#related-topics}
+{:.ref-header}
+Related topics {#related-topics}
 
 - [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)
 - [Configure services as web APIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
@@ -38,7 +38,8 @@ Eventually, you will be able to use different storage technologies for different
 
 Backward compatibility can be indicated by the use of `@api`. For more information, see [Backward compatibility]({{ page.baseurl }}/contributor-guide/backward-compatible-development/).
 
-### Related topics {#related-topics}
+{:.ref-header}
+Related topics {#related-topics}
 
 - [Service contract design patterns]({{ page.baseurl }}/extension-dev-guide/service-contracts/design-patterns.html)
 - [Configure services as webAPIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
@@ -39,7 +39,7 @@ Eventually, you will be able to use different storage technologies for different
 Backward compatibility can be indicated by the use of `@api`. For more information, see [Backward compatibility]({{ page.baseurl }}/contributor-guide/backward-compatible-development/).
 
 {:.ref-header}
-Related topics {#related-topics}
+Related topicsrelated-topics}
 
 - [Service contract design patterns]({{ page.baseurl }}/extension-dev-guide/service-contracts/design-patterns.html)
 - [Configure services as webAPIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
+++ b/guides/v2.2/extension-dev-guide/service-contracts/service-contracts.md
@@ -39,7 +39,7 @@ Eventually, you will be able to use different storage technologies for different
 Backward compatibility can be indicated by the use of `@api`. For more information, see [Backward compatibility]({{ page.baseurl }}/contributor-guide/backward-compatible-development/).
 
 {:.ref-header}
-Related topicsrelated-topics}
+Related topics
 
 - [Service contract design patterns]({{ page.baseurl }}/extension-dev-guide/service-contracts/design-patterns.html)
 - [Configure services as webAPIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/frontend-dev-guide/bk-frontend-dev-guide.md
+++ b/guides/v2.2/frontend-dev-guide/bk-frontend-dev-guide.md
@@ -61,7 +61,7 @@ To use this guide, you must be familiar with:
 *	Responsive Web Design (RWD)
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Themes]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html)
 *	[Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html)

--- a/guides/v2.2/frontend-dev-guide/bk-frontend-dev-guide.md
+++ b/guides/v2.2/frontend-dev-guide/bk-frontend-dev-guide.md
@@ -60,7 +60,8 @@ To use this guide, you must be familiar with:
 *	PHTML, PHP (Basic)
 *	Responsive Web Design (RWD)
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Themes]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html)
 *	[Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html)

--- a/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_overview.md
+++ b/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_overview.md
@@ -36,7 +36,8 @@ But if there is something you want to improve, the only recommended way is creat
 
 Making changes in the Magento out-of-the-box themes is a bad idea, because can result in your changes being overwritten during upgrade.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 - [CSS in Magento themes][css overview]
 - [Simple ways to customize a theme's styles]

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-extend.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-extend.md
@@ -58,7 +58,7 @@ Where a `handle ID` is defined by the name of the corresponding layout file, and
 2. Replaces the base URL placeholders in the result.
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Override a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-override.html){:target="_blank"}
 *	[XML instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html){:target="_blank"}

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-extend.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-extend.md
@@ -57,7 +57,8 @@ Where a `handle ID` is defined by the name of the corresponding layout file, and
 
 2. Replaces the base URL placeholders in the result.
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Override a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-override.html){:target="_blank"}
 *	[XML instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html){:target="_blank"}

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
@@ -94,7 +94,8 @@ Although the layout overriding mechanism provides great customization flexibilit
 *	Changing block name or alias. The name of a block should not be changed, and neither should the alias of a block remaining in the same parent element.
 *	Changing handle inheritance. For example, you should not change the page type parent handle.
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html)
 *	[Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html)

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
@@ -95,7 +95,7 @@ Although the layout overriding mechanism provides great customization flexibilit
 *	Changing handle inheritance. For example, you should not change the page type parent handle.
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html)
 *	[Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html)

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
@@ -108,7 +108,8 @@ Layout validations and error handling depends on the [application mode] in which
 
 - production or default modes: syntax is validated in `.xml` and `.xsd` files. If validation fails, errors are logged to the `var/log` directory without throwing an exception. The validation according to the xsd schema is not performed.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Layout instructions]
 * [Common layout customization tasks]

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -583,7 +583,8 @@ class Product
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
 
-### Related topics
+{:.ref-header}
+Related topics
 
 - [Layout instructions]
 - [Extend a layout]

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_css.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_css.md
@@ -115,7 +115,8 @@ For grouping style rules in certain media queries the `.media-width()` mixin use
 
 You can find more information about the Magento UI library responsive mixin usage in `<your_Magento_instance>/pub/static/frontend/Magento/blank/en_US/css/docs/responsive.html` (view in a browser).
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Create a theme]({{page.baseurl}}/frontend-dev-guide/themes/theme-create.html)
 * [CSS and Less preprocessing]({{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html)

--- a/guides/v2.2/get-started/authentication/gs-authentication-oauth.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication-oauth.md
@@ -453,7 +453,8 @@ class OauthClient extends AbstractService
 ```
 {% endcollapsible %}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Create an integration]( {{ page.baseurl }}/get-started/create-integration.html )
 

--- a/guides/v2.2/get-started/authentication/gs-authentication-token.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication-token.md
@@ -111,7 +111,8 @@ Customers can access only resources with `self` permissions.
 For example, to make a web API call with a customer token:
 `curl -X GET "http://magento.ll/index.php/rest/V1/customers/me" -H "Authorization: Bearer asdf3hjklp5iuytre"`
 
-## Related topics
+{:.ref-header}
+Related topics
 [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html)
 
 [Configure services as web APIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/get-started/authentication/gs-authentication-token.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication-token.md
@@ -113,6 +113,7 @@ For example, to make a web API call with a customer token:
 
 {:.ref-header}
 Related topics
+
 [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html)
 
 [Configure services as web APIs]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-to-web-service.html)

--- a/guides/v2.2/get-started/authentication/gs-authentication.md
+++ b/guides/v2.2/get-started/authentication/gs-authentication.md
@@ -165,7 +165,8 @@ Each type of client has a preferred authentication method. To authenticate, use 
    </tr>
 </table>
 
-## Related topics
+{:.ref-header}
+Related topics
 
 Proceed to the authentication method for your preferred client:
 

--- a/guides/v2.2/get-started/gs-curl.md
+++ b/guides/v2.2/get-started/gs-curl.md
@@ -28,6 +28,7 @@ Option | Description
 `-T` | Transfers the specified local file to the remote URL.
 `-X` | Specifies the request method to use when communicating with the HTTP server. The specified request method is used instead of the default GET method.
 
-## Next step
+{:.ref-header}
+Related topics
 
 [Status codes and responses]({{ page.baseurl }}/get-started/gs-web-api-response.html)

--- a/guides/v2.2/get-started/gs-web-api-request.md
+++ b/guides/v2.2/get-started/gs-web-api-request.md
@@ -273,6 +273,7 @@ This request returns a list of all customers in JSON format, as shown below. You
 }
 ```
 
-## Next step
+{:.ref-header}
+Related topics
 
 Run the web API call through a [cURL command]({{ page.baseurl }}/get-started/gs-curl.html) or a REST client.

--- a/guides/v2.2/get-started/soap/soap-web-api-calls.md
+++ b/guides/v2.2/get-started/soap/soap-web-api-calls.md
@@ -88,7 +88,8 @@ $soapClient = new SoapClient($wsdlUrl, ['version' => SOAP_1_2, 'stream_context' 
 $soapResponse = $soapClient->testModule1AllSoapAndRestV1Item($serviceArgs); ?>
 ```
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 * [OAuth-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-oauth.html)
 * [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)

--- a/guides/v2.2/get-started/soap/soap-web-api-calls.md
+++ b/guides/v2.2/get-started/soap/soap-web-api-calls.md
@@ -89,7 +89,7 @@ $soapResponse = $soapClient->testModule1AllSoapAndRestV1Item($serviceArgs); ?>
 ```
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 * [OAuth-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-oauth.html)
 * [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)

--- a/guides/v2.2/get-started/soap/soap-web-api-calls.md
+++ b/guides/v2.2/get-started/soap/soap-web-api-calls.md
@@ -89,7 +89,7 @@ $soapResponse = $soapClient->testModule1AllSoapAndRestV1Item($serviceArgs); ?>
 ```
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 * [OAuth-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-oauth.html)
 * [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)

--- a/guides/v2.2/howdoi/checkout/checkout_new_field.md
+++ b/guides/v2.2/howdoi/checkout/checkout_new_field.md
@@ -199,6 +199,7 @@ class MyBlock extends Template {
 }
 ```
 
-### Related topics
+{:.ref-header}
+Related topics
 
 - [EAV and extension attributes]({{ page.baseurl }}/extension-dev-guide/attributes.html)

--- a/guides/v2.2/howdoi/customize_product.md
+++ b/guides/v2.2/howdoi/customize_product.md
@@ -26,7 +26,8 @@ This tutorial includes the following customizations:
 * [Customize the form configuration]({{ page.baseurl }}/howdoi/customize-form-configuration.html)
 * [Customize using a modifier class]({{ page.baseurl }}/howdoi/customize-modifier-class.html)
 
-### Recommended reading
+{:.ref-header}
+Related topics
 
 * [Form UI component]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html)
 * [About PHP modifiers in UI components]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html)

--- a/guides/v2.2/install-gde/install/cli/dev_add-update.md
+++ b/guides/v2.2/install-gde/install/cli/dev_add-update.md
@@ -71,7 +71,8 @@ Add a `require` section like the following:
 
 Save your changes to `composer.json`, exit the text editor, and enter `composer update`
 
-### For more information
+{:.ref-header}
+Related topics
 
 If you have issues, see [Composer troubleshooting](https://getcomposer.org/doc/articles/troubleshooting.md){:target="_blank"}.
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-install.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-install.md
@@ -250,7 +250,8 @@ For security, remove write permissions from these directories: '/var/www/html/ma
 [SUCCESS]: Admin Panel URI: /admin_puu71q
 ```
 
-#### Next step
+{:.ref-header}
+Related topics
 
 *	If you have one user account to access the Magento server, see [Optionally set a umask]({{ page.baseurl }}/install-gde/install/post-install-umask.html).
 

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db-status.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-db-status.md
@@ -43,7 +43,8 @@ Exit code  | Description | Suggested action
  1 | Some modules use code versions newer or older than the database | Run [`magento setup:upgrade`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db-upgr.html) to update the database schema and run `composer update` from the Magento root directory to update component dependencies |
  2 | setup:upgrade is required | [`magento setup:upgrade`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db-upgr.html) to update the [database schema](https://glossary.magento.com/database-schema) |
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)
 *	[Remove sample data modules or update sample data]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-other.html)

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -60,7 +60,8 @@ If applicable, continue your Magento software installation:
 *	[Command line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)
 *	[Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)
 *	[Remove sample data modules or update sample data]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-other.html)

--- a/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -84,7 +84,8 @@ where
 
 `--none` clears the list.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)
 *	[Remove sample data modules or update sample data]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-other.html)

--- a/guides/v2.2/install-gde/install/cli/install-cli.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli.md
@@ -32,7 +32,7 @@ If you chose to enable SELinux, see [SELinux and iptables]({{ page.baseurl }}/in
 {% include install/first-steps-cli.md %}
 
 {:.ref-header}
-Related topicss
+Related topics
 
 *	[Get started with the command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands.html)
 *	[Install the Magento software]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)

--- a/guides/v2.2/install-gde/install/cli/install-cli.md
+++ b/guides/v2.2/install-gde/install/cli/install-cli.md
@@ -31,7 +31,8 @@ If you chose to enable SELinux, see [SELinux and iptables]({{ page.baseurl }}/in
 ## First steps {#instgde-install-cli-first}
 {% include install/first-steps-cli.md %}
 
-### Next steps
+{:.ref-header}
+Related topicss
 
 *	[Get started with the command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands.html)
 *	[Install the Magento software]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html)

--- a/guides/v2.2/install-gde/install/get-software.md
+++ b/guides/v2.2/install-gde/install/get-software.md
@@ -15,7 +15,8 @@ functional_areas:
 
 {% include install/get-software_zip.md %}
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 -   [Clone the Magento repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 -   [Get the Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_get-ftp.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_get-ftp.md
@@ -76,6 +76,7 @@ To extract the archive:
 
 	![]({{ site.baseurl }}/common/images/install-merch_file-manager-after.png){:width="750px"}
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Install the Magento software]({{ page.baseurl }}/install-gde/install/hosted/hosted_install.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_install_1_readiness.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_install_1_readiness.md
@@ -13,7 +13,8 @@ functional_areas:
 
 {% include install/web/install-web_1-readiness.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Step 2. Add a database]({{ page.baseurl }}/install-gde/install/hosted/hosted_install_2_db.html)
 

--- a/guides/v2.2/install-gde/install/hosted/hosted_install_2_db.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_install_2_db.md
@@ -13,6 +13,7 @@ functional_areas:
 
 {% include install/web/install-web_2-db.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Step 3. Web configuration]({{ page.baseurl }}/install-gde/install/hosted/hosted_install_3_web-conf.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_install_3_web-conf.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_install_3_web-conf.md
@@ -13,6 +13,7 @@ functional_areas:
 
 {% include install/web/install-web_3-web-conf.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Step 4. Customize your store]({{ page.baseurl }}/install-gde/install/hosted/hosted_install_4_customize-store.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_install_4_customize-store.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_install_4_customize-store.md
@@ -13,6 +13,7 @@ functional_areas:
 
 {% include install/web/install-web_4-customize-store.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Step 5. Create Admin account]({{ page.baseurl }}/install-gde/install/hosted/hosted_install_5_create-admin.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_install_5_create-admin.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_install_5_create-admin.md
@@ -13,6 +13,7 @@ functional_areas:
 
 {% include install/web/install-web_5-create-admin.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Step 6. Install]({{ page.baseurl }}/install-gde/install/hosted/hosted_install_6_install.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_start.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_start.md
@@ -30,6 +30,7 @@ We recommend you contact your shared hosting provider's technical support to ver
 
 For complete details, see [System requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Configure a database and a database user]({{ page.baseurl }}/install-gde/install/hosted/hosted_start_db.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_start_db.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_start_db.md
@@ -38,6 +38,7 @@ To configure a MySQL database and database user:
 
     ![Give the database user all privileges to the database]({{ site.baseurl }}/common/images/install-merch_db-user-privs.png){:width="750px"}
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Configure PHP]({{ page.baseurl }}/install-gde/install/hosted/hosted_start_php.html)

--- a/guides/v2.2/install-gde/install/hosted/hosted_start_php.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_start_php.md
@@ -34,6 +34,7 @@ To configure PHP:
 
 5.	Click **Save**.
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Transfer the Magento software to your hosted system]({{ page.baseurl }}/install-gde/install/hosted/hosted_get-ftp.html)

--- a/guides/v2.2/install-gde/install/prepare-install.md
+++ b/guides/v2.2/install-gde/install/prepare-install.md
@@ -55,7 +55,8 @@ If so, create [`auth.json`]({{ page.baseurl }}/install-gde/prereq/dev_install.ht
 
 {% include install/file-system-perms-before_22.md %}
 
-### Next step {#next-step-section}
+{:.ref-header}
+Related topics {#next-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.2/install-gde/install/prepare-install.md
+++ b/guides/v2.2/install-gde/install/prepare-install.md
@@ -56,7 +56,7 @@ If so, create [`auth.json`]({{ page.baseurl }}/install-gde/prereq/dev_install.ht
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topics {#next-step-section}
+Related topicsnext-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.2/install-gde/install/prepare-install.md
+++ b/guides/v2.2/install-gde/install/prepare-install.md
@@ -56,7 +56,7 @@ If so, create [`auth.json`]({{ page.baseurl }}/install-gde/prereq/dev_install.ht
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topicsnext-step-section}
+Related topics
 
 Install the Magento software:
 

--- a/guides/v2.2/install-gde/install/web/install-web.md
+++ b/guides/v2.2/install-gde/install/web/install-web.md
@@ -19,5 +19,6 @@ If you chose to enable SELinux, see [SELinux and iptables]({{ page.baseurl }}/in
 
 {% include install/web/install-web.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 [Step 1: Readiness Check]({{ page.baseurl }}/install-gde/install/web/install-web_1-readiness.html)

--- a/guides/v2.2/install-gde/install/web/install-web.md
+++ b/guides/v2.2/install-gde/install/web/install-web.md
@@ -21,4 +21,5 @@ If you chose to enable SELinux, see [SELinux and iptables]({{ page.baseurl }}/in
 
 {:.ref-header}
 Related topics
+
 [Step 1: Readiness Check]({{ page.baseurl }}/install-gde/install/web/install-web_1-readiness.html)

--- a/guides/v2.2/install-gde/install/web/install-web_1-readiness.md
+++ b/guides/v2.2/install-gde/install/web/install-web_1-readiness.md
@@ -18,5 +18,6 @@ functional_areas:
 
 {:.ref-header}
 Related topics
+
 [Step 2. Add a database]({{ page.baseurl }}/install-gde/install/web/install-web_2-db.html)
 

--- a/guides/v2.2/install-gde/install/web/install-web_1-readiness.md
+++ b/guides/v2.2/install-gde/install/web/install-web_1-readiness.md
@@ -16,6 +16,7 @@ functional_areas:
 
 {% include install/web/install-web_1-readiness.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Step 2. Add a database]({{ page.baseurl }}/install-gde/install/web/install-web_2-db.html)
 

--- a/guides/v2.2/install-gde/install/web/install-web_2-db.md
+++ b/guides/v2.2/install-gde/install/web/install-web_2-db.md
@@ -18,4 +18,5 @@ functional_areas:
 
 {:.ref-header}
 Related topics
+
 [Step 3. Web configuration]({{ page.baseurl }}/install-gde/install/web/install-web_3-web-conf.html)

--- a/guides/v2.2/install-gde/install/web/install-web_2-db.md
+++ b/guides/v2.2/install-gde/install/web/install-web_2-db.md
@@ -16,5 +16,6 @@ functional_areas:
 
 {% include install/web/install-web_2-db.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Step 3. Web configuration]({{ page.baseurl }}/install-gde/install/web/install-web_3-web-conf.html)

--- a/guides/v2.2/install-gde/install/web/install-web_3-web-conf.md
+++ b/guides/v2.2/install-gde/install/web/install-web_3-web-conf.md
@@ -16,5 +16,6 @@ functional_areas:
 
 {% include install/web/install-web_3-web-conf.md %}
 
-### Next step
+{:.ref-header}
+Related topics
 [Step 4. Customize your store]({{ page.baseurl }}/install-gde/install/web/install-web_4-customize-store.html)

--- a/guides/v2.2/install-gde/install/web/install-web_3-web-conf.md
+++ b/guides/v2.2/install-gde/install/web/install-web_3-web-conf.md
@@ -18,4 +18,5 @@ functional_areas:
 
 {:.ref-header}
 Related topics
+
 [Step 4. Customize your store]({{ page.baseurl }}/install-gde/install/web/install-web_4-customize-store.html)

--- a/guides/v2.2/install-gde/install/web/install-web_4-customize-store.md
+++ b/guides/v2.2/install-gde/install/web/install-web_4-customize-store.md
@@ -13,5 +13,6 @@ functional_areas:
 
 {% include install/web/install-web_4-customize-store.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 [Step 5. Create Admin account]({{ page.baseurl }}/install-gde/install/web/install-web_5-create-admin.html)

--- a/guides/v2.2/install-gde/install/web/install-web_4-customize-store.md
+++ b/guides/v2.2/install-gde/install/web/install-web_4-customize-store.md
@@ -15,4 +15,5 @@ functional_areas:
 
 {:.ref-header}
 Related topics
+
 [Step 5. Create Admin account]({{ page.baseurl }}/install-gde/install/web/install-web_5-create-admin.html)

--- a/guides/v2.2/install-gde/install/web/install-web_5-create-admin.md
+++ b/guides/v2.2/install-gde/install/web/install-web_5-create-admin.md
@@ -15,4 +15,5 @@ functional_areas:
 
 {:.ref-header}
 Related topics
+
 [Step 6. Install]({{ page.baseurl }}/install-gde/install/web/install-web_6-install.html)

--- a/guides/v2.2/install-gde/install/web/install-web_5-create-admin.md
+++ b/guides/v2.2/install-gde/install/web/install-web_5-create-admin.md
@@ -13,5 +13,6 @@ functional_areas:
 
 {% include install/web/install-web_5-create-admin.md %}
 
-#### Next step
+{:.ref-header}
+Related topics
 [Step 6. Install]({{ page.baseurl }}/install-gde/install/web/install-web_6-install.html)

--- a/guides/v2.2/install-gde/prereq/apache.md
+++ b/guides/v2.2/install-gde/prereq/apache.md
@@ -98,7 +98,8 @@ To install the default version of Apache (Ubuntu 14, 16&mdash;Apache 2.4, Ubuntu
 ### Enable rewrites and .htaccess for Apache 2.2
 {% include install/allowoverrides22.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html))
@@ -155,7 +156,8 @@ To upgrade to Apache 2.4:
 ### Enable rewrites and .htaccess for Apache 2.4 {#enable-rewr-apache24-upgr-ubuntu12}
 {% include install/allowoverrides24.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html))
@@ -199,7 +201,8 @@ Installing and configuring Apache is basically a three-step process: install the
 ### Enable rewrites and .htaccess for Apache 2.2 (including CentOS 7)
 {% include install/allowoverrides22.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html))

--- a/guides/v2.2/install-gde/prereq/apache.md
+++ b/guides/v2.2/install-gde/prereq/apache.md
@@ -252,7 +252,8 @@ For example:
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order){:target="_blank"}.
 {% endcollapsible %}
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
 *	[PHP 5.5, 5.6, or 7.0&mdash;CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)

--- a/guides/v2.2/install-gde/prereq/connect-auth.md
+++ b/guides/v2.2/install-gde/prereq/connect-auth.md
@@ -13,7 +13,8 @@ functional_areas:
 
 {% include install/auth-tokens-get.md %}
 
-#### Related topics:
+{:.ref-header}
+Related topics:
 
 *	Use your authentication keys to:
 

--- a/guides/v2.2/install-gde/prereq/connect-auth.md
+++ b/guides/v2.2/install-gde/prereq/connect-auth.md
@@ -14,7 +14,7 @@ functional_areas:
 {% include install/auth-tokens-get.md %}
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	Use your authentication keys to:
 

--- a/guides/v2.2/install-gde/prereq/dev_install.md
+++ b/guides/v2.2/install-gde/prereq/dev_install.md
@@ -57,7 +57,8 @@ To authenticate, you will need to generate [Magento authentication keys][] and a
 
 {% include install/auth-json.md %}
 
-## Next step
+{:.ref-header}
+Related topics
 
 After completing the tasks discussed on this page, see [Update installation dependencies][].
 

--- a/guides/v2.2/install-gde/prereq/install-rabbitmq.md
+++ b/guides/v2.2/install-gde/prereq/install-rabbitmq.md
@@ -131,7 +131,8 @@ To configure support for SSL, edit the `ssl` and `ssl_options` parameters in the
 
 After you have connected {{site.data.var.ee}} and RabbitMQ, you must start the message queue consumers. See [Configure message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html) for details.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.2/install-gde/prereq/mysql.md
+++ b/guides/v2.2/install-gde/prereq/mysql.md
@@ -410,7 +410,8 @@ To configure a MySQL database instance:
 {:.bs-callout .bs-callout-info}
 We recommend you configure your database instance as appropriate for your business. When configuring your database, remember that indexers require higher `tmp_table_size` and `max_heap_table_size` values, for example, 64M. If you configure the `batch_size` parameter, you can adjust that value along with the table size settings to improve indexer performance. Refer to  [Performance Best Practices]({{ page.baseurl }}/performance-best-practices/index.html) for more information. sure all MySQL and Magento index tables can be kept in memory, for example, configure `innodb_buffer_pool_size`.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Set up a remote MySQL database connection]({{ page.baseurl }}/install-gde/prereq/mysql_remote.html)
 *	[Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)

--- a/guides/v2.2/install-gde/prereq/mysql_remote.md
+++ b/guides/v2.2/install-gde/prereq/mysql_remote.md
@@ -142,7 +142,8 @@ When you install the Magento software using either the command line or Setup Wiz
 *	Database password is the local web node user's password
 *	Database name is the name of the database on the remote server
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.2/install-gde/prereq/nginx.md
+++ b/guides/v2.2/install-gde/prereq/nginx.md
@@ -586,7 +586,7 @@ To configure SELinux and firewalld:
 Open a web browser and navigate to your site's base URL to [verify the installation.]({{ page.baseurl }}/install-gde/install/verify.html)
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
 *	[PHP 5.5, 5.6, or 7.0&mdash;CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)

--- a/guides/v2.2/install-gde/prereq/nginx.md
+++ b/guides/v2.2/install-gde/prereq/nginx.md
@@ -585,7 +585,8 @@ To configure SELinux and firewalld:
 
 Open a web browser and navigate to your site's base URL to [verify the installation.]({{ page.baseurl }}/install-gde/install/verify.html)
 
-#### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
 *	[PHP 5.5, 5.6, or 7.0&mdash;CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)

--- a/guides/v2.2/install-gde/prereq/optional.md
+++ b/guides/v2.2/install-gde/prereq/optional.md
@@ -236,7 +236,7 @@ To install phpmyadmin on CentOS:
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)

--- a/guides/v2.2/install-gde/prereq/optional.md
+++ b/guides/v2.2/install-gde/prereq/optional.md
@@ -235,7 +235,8 @@ To install phpmyadmin on CentOS:
 
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 5.5, 5.6, or 7.0&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)

--- a/guides/v2.2/install-gde/prereq/php-centos.md
+++ b/guides/v2.2/install-gde/prereq/php-centos.md
@@ -336,6 +336,7 @@ There is more than one way to install PHP 7.1 on CentOS; the following is a sugg
 
 {:.ref-header}
 Next step
+
 [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
 
 {:.ref-header}

--- a/guides/v2.2/install-gde/prereq/php-centos.md
+++ b/guides/v2.2/install-gde/prereq/php-centos.md
@@ -334,10 +334,12 @@ There is more than one way to install PHP 7.1 on CentOS; the following is a sugg
 
 {% endcollapsible %}
 
-### Next
+{:.ref-header}
+Next step
 [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.2/install-gde/prereq/php-ubuntu.md
+++ b/guides/v2.2/install-gde/prereq/php-ubuntu.md
@@ -258,10 +258,12 @@ If PHP is *not* installed, see one of the following sections:
 
 {% endcollapsible %}
 
-### Next
+{:.ref-header}
+Next step
 [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.2/install-gde/prereq/php-ubuntu.md
+++ b/guides/v2.2/install-gde/prereq/php-ubuntu.md
@@ -260,6 +260,7 @@ If PHP is *not* installed, see one of the following sections:
 
 {:.ref-header}
 Next step
+
 [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
 
 {:.ref-header}

--- a/guides/v2.2/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.2/install-gde/prereq/prereq-overview.md
@@ -120,10 +120,12 @@ Enter `exit` at the `mysql>` prompt to exit.
 
 To install or upgrade MySQL, see [MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html).
 
-#### Next step
+{:.ref-header}
+Related topics
 [Choose how to install the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.2/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.2/install-gde/prereq/prereq-overview.md
@@ -122,14 +122,11 @@ To install or upgrade MySQL, see [MySQL]({{ page.baseurl }}/install-gde/prereq/m
 
 {:.ref-header}
 Related topics
-[Choose how to install the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
 
-{:.ref-header}
-Related topics
-
-*	[MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
-*	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
-*	[PHP 7.0 or 7.1&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
-*	[PHP 7.0 or 7.1&mdash;CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)
-*	[Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)
-*	[How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
+*  [Choose how to install the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
+*  [MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
+*  [Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
+*  [PHP 7.0 or 7.1&mdash;Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)
+*  [PHP 7.0 or 7.1&mdash;CentOS]({{ page.baseurl }}/install-gde/prereq/php-centos.html)
+*  [Installing optional software]({{ page.baseurl }}/install-gde/prereq/optional.html)
+*  [How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)

--- a/guides/v2.2/install-gde/prereq/security.md
+++ b/guides/v2.2/install-gde/prereq/security.md
@@ -68,7 +68,8 @@ Depending on your security requirements, you might find it necessary to open por
 *	Ubuntu: [Ubuntu documentation page](https://help.ubuntu.com/community/IptablesHowTo){:target="_blank"}.
 *	CentOS: [CentOS how-to](http://wiki.centos.org/HowTos/Network/IPTables){:target="_blank"}.
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 5.5, 5.6, or 7.0—Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)

--- a/guides/v2.2/install-gde/prereq/security.md
+++ b/guides/v2.2/install-gde/prereq/security.md
@@ -69,7 +69,7 @@ Depending on your security requirements, you might find it necessary to open por
 *	CentOS: [CentOS how-to](http://wiki.centos.org/HowTos/Network/IPTables){:target="_blank"}.
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 5.5, 5.6, or 7.0—Ubuntu]({{ page.baseurl }}/install-gde/prereq/php-ubuntu.html)

--- a/guides/v2.2/install-gde/prereq/zip_install.md
+++ b/guides/v2.2/install-gde/prereq/zip_install.md
@@ -86,7 +86,8 @@ The Magento software extracts to the directory you created. After the file has e
 
 {% include install/file-system-perms-before_22.md %}
 
-### Next step {#next-step-section}
+{:.ref-header}
+Related topics {#next-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.2/install-gde/prereq/zip_install.md
+++ b/guides/v2.2/install-gde/prereq/zip_install.md
@@ -87,7 +87,7 @@ The Magento software extracts to the directory you created. After the file has e
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topicsnext-step-section}
+Related topics
 
 Install the Magento software:
 

--- a/guides/v2.2/install-gde/prereq/zip_install.md
+++ b/guides/v2.2/install-gde/prereq/zip_install.md
@@ -87,7 +87,7 @@ The Magento software extracts to the directory you created. After the file has e
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topics {#next-step-section}
+Related topicsnext-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
@@ -156,7 +156,8 @@ If you need to enable the loading of default Magento JS components and widget in
 $(mage.apply);
 ```
 
-### Related topic
+{:.ref-header}
+Related topic
 
 - [JavaScript resources in Magento]({{ page.baseurl }}/javascript-dev-guide/javascript/js-resources.html)
 - [About AMD modules and RequireJS]({{ page.baseurl }}/javascript-dev-guide/javascript/js-resources.html)

--- a/guides/v2.2/migration/migration-manually.md
+++ b/guides/v2.2/migration/migration-manually.md
@@ -64,6 +64,7 @@ You must manually re-create all:
 {: .bs-callout-info }
 You may adjust the time zone for a database entity using the `\Migration\Handler\Timezone` handler. See the [Follow-up]({{ page.baseurl }}/migration/migration-migrate-follow-up.html) section for more details.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * <a href="{{ page.baseurl }}/migration/migration-migrate-after.html">After migration</a>

--- a/guides/v2.2/migration/migration-migrate-delta.md
+++ b/guides/v2.2/migration/migration-migrate-delta.md
@@ -55,7 +55,8 @@ If an [extension](https://glossary.magento.com/extension) has its own tables, an
 
 3. Add the name of the newly created class to the delta mode section of `config.xml`
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Data that needs to be migrated manually]({{ page.baseurl }}/migration/migration-manually.html)
 

--- a/guides/v2.2/migration/migration-tool-configure.md
+++ b/guides/v2.2/migration/migration-tool-configure.md
@@ -239,6 +239,7 @@ Even though you will be working with `map.xml.dist` file most of the time, the f
 
 You can refer to [ Data Migration Tool Technical Specification]({{ page.baseurl }}/migration/migration-tool-internal-spec.html) for more details.
 
-## Next step
+{:.ref-header}
+Related topics
 
 [Migrate using data migration tool]({{ page.baseurl }}/migration/migration-migrate-settings.html)

--- a/guides/v2.2/migration/migration-tool-install.md
+++ b/guides/v2.2/migration/migration-tool-install.md
@@ -121,7 +121,8 @@ If you've cloned Magento 2 from the GitHub repository, follow the steps below to
 
 3. The `version` entry in that file is the version of the Data Migration Tool.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * <a href="{{ page.baseurl }}/migration/migration-tool-configure.html">Configure migration</a>
 * <a href="{{ page.baseurl }}/migration/migration-tool-preconditions.html">Preconditions</a>

--- a/guides/v2.2/migration/migration-tool-preconditions.md
+++ b/guides/v2.2/migration/migration-tool-preconditions.md
@@ -45,6 +45,7 @@ To find the latest extensions versions, visit [Magento Marketplace](https://mark
 
 You can also use the Magento [Code Migration Tool](https://github.com/magento/code-migration/blob/develop/README.md){:target="_blank"}.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Install the Data Migration Tool]({{ page.baseurl }}/migration/migration-tool-install.html)

--- a/guides/v2.2/migration/migration-tool-upgrade.md
+++ b/guides/v2.2/migration/migration-tool-upgrade.md
@@ -67,7 +67,8 @@ See the [Install Data Migration Tool]({{ page.baseurl }}/migration/migration-too
 	`composer require magento/data-migration-tool:2.1.2`
 4.	Wait while the command completes.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Configure migration]({{ page.baseurl }}/migration/migration-tool-configure.html)
 * [Preconditions]({{ page.baseurl }}/migration/migration-tool-preconditions.html)

--- a/guides/v2.2/mrg/intro.md
+++ b/guides/v2.2/mrg/intro.md
@@ -14,7 +14,8 @@ The information includes:
 
 Information is being published gradually, until we complete work on automation of the process.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
 * [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)

--- a/guides/v2.2/mtf/create_test.md
+++ b/guides/v2.2/mtf/create_test.md
@@ -8,7 +8,8 @@ The Magento testing framework (FTF) works with functional tests only. Functional
 Tests usually cover functionality of a business [entity](https://glossary.magento.com/entity). A goal is to find discrepancies between expected and real behavior of the product.
 Magento provides functional tests in the `<magento2_root_dir>/dev/tests/functional/` directory. In this guide, we call them [out-of-the-box tests][out-of-the-box test]. You can use them to test the default Magento functionality. Also, you can create a test [extending from the out-of-the-box test][], or [create your own functional tests][].
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Out-of-the-box test][out-of-the-box test]
 

--- a/guides/v2.2/mtf/mtf_installation.md
+++ b/guides/v2.2/mtf/mtf_installation.md
@@ -79,7 +79,8 @@ ls
 Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`.
 The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
-## Next steps {#mtf_install_next}
+{:.ref-header}
+Related topicss {#mtf_install_next}
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.2/mtf/mtf_installation.md
+++ b/guides/v2.2/mtf/mtf_installation.md
@@ -80,7 +80,7 @@ Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`.
 The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
 {:.ref-header}
-Related topicss {#mtf_install_next}
+Related topicss
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.2/mtf/mtf_installation.md
+++ b/guides/v2.2/mtf/mtf_installation.md
@@ -80,7 +80,7 @@ Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`.
 The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
 {:.ref-header}
-Related topicss
+Related topics
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.2/payments-integrations/base-integration/payment-action.md
+++ b/guides/v2.2/payments-integrations/base-integration/payment-action.md
@@ -73,6 +73,7 @@ The most important builder in this pool is `Magento\Braintree\Gateway\Request\Pa
 
 Please see the [Get payment information from frontend to backend]({{ page.baseurl }}/payments-integrations/base-integration/get-payment-info.html) for details about how payment information can be handled.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 - [Add a custom payment method to checkout]({{ page.baseurl }}/howdoi/checkout/checkout_payment.html): how to add a custom payment integration to [checkout](https://glossary.magento.com/checkout) page.

--- a/guides/v2.2/rest/generate-local.md
+++ b/guides/v2.2/rest/generate-local.md
@@ -53,7 +53,8 @@ You must specify an authorization token for an [admin](https://glossary.magento.
 
 To return the complete JSON schema, specify the `?services=all` parameter in the URL. The default `store_code` is `all`, but you can also specify `default` or a store code defined on the system. For example: `http://<magento_host>/rest/default/schema?services=all`
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Token-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-token.html)
 

--- a/guides/v2.2/rest/notes.md
+++ b/guides/v2.2/rest/notes.md
@@ -18,5 +18,6 @@ The REST URL to update a customer is `<route url="/V1/customers/:id" method="PUT
 
 This applies to all REST APIs where a parameter is passed in the URL. Anything specified in the request body with the same parameter name as the URL will be ignored.
 
-## Related topics
+{:.ref-header}
+Related topics
 [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.2/rest/notes.md
+++ b/guides/v2.2/rest/notes.md
@@ -20,4 +20,5 @@ This applies to all REST APIs where a parameter is passed in the URL. Anything s
 
 {:.ref-header}
 Related topics
+
 [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.2/rest/retrieve-filtered-responses.md
+++ b/guides/v2.2/rest/retrieve-filtered-responses.md
@@ -190,6 +190,5 @@ The following query returns only the `sku` and `name` parameters for product ite
 
 {:.ref-header}
 Related topics
-{:.no_toc}
 
 * [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.2/rest/retrieve-filtered-responses.md
+++ b/guides/v2.2/rest/retrieve-filtered-responses.md
@@ -188,7 +188,8 @@ The following query returns only the `sku` and `name` parameters for product ite
 }
 ```
 
-## Related topics
+{:.ref-header}
+Related topics
 {:.no_toc}
 
 * [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
@@ -72,7 +72,7 @@ The `product_sku` is the `sku` of the configurable product. The `sku` specified 
   ## Congratulations! You've finished.
   {:.no_toc}
 
-  {:.ref-header}
+{:.ref-header}
 Related topics
 
   * [Order Processing with REST APIs Tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html)

--- a/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
@@ -72,6 +72,7 @@ The `product_sku` is the `sku` of the configurable product. The `sku` specified 
   ## Congratulations! You've finished.
   {:.no_toc}
 
-  ## Related topics
+  {:.ref-header}
+Related topics
 
   * [Order Processing with REST APIs Tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html)

--- a/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
@@ -78,7 +78,8 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 ## Congratulations! You've finished.
 {:.no_toc}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
 * [Create a configurable product Tutorial]({{ site.baseurl }}/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.html)

--- a/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
@@ -76,7 +76,7 @@ A [credit memo](https://glossary.magento.com/credit-memo) id, such as `3`.
 Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credit Memos**. The credit memo is displayed in the grid.
 
 ## Congratulations! You've finished.
-{:.no_toc}
+
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
@@ -77,7 +77,6 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 
 ## Congratulations! You've finished.
 
-
 {:.ref-header}
 Related topics
 

--- a/guides/v2.3/architecture/archi_perspectives/arch_diagrams.md
+++ b/guides/v2.3/architecture/archi_perspectives/arch_diagrams.md
@@ -14,7 +14,8 @@ The following diagram illustrates the components and shows the "layers" or tiers
 
 ![Architectural Diagram]({{site.baseurl}}/common/images/archi_diagram_desired-state.png)
 
-## Related topics
+{:.ref-header}
+Related topics
 
 -  [Architecture layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)
 -  [Service Isolation](https://github.com/magento/architecture/blob/master/design-documents/service-isolation.md)

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -28,7 +28,8 @@ These files allow you to skip the progressive upgrade scripts and jump right to 
 
 Read more about writing [declarative XML schemas][].
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -29,7 +29,7 @@ These files allow you to skip the progressive upgrade scripts and jump right to 
 Read more about writing [declarative XML schemas][].
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -29,7 +29,7 @@ These files allow you to skip the progressive upgrade scripts and jump right to 
 Read more about writing [declarative XML schemas][].
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -72,7 +72,7 @@ Web users interact with components of the presentation layer to select actions t
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
 {:.ref-header}
-Related topics {#related}
+Related topicsrelated}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -72,7 +72,7 @@ Web users interact with components of the presentation layer to select actions t
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
 {:.ref-header}
-Related topicsrelated}
+Related topics
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -71,7 +71,8 @@ The View layer calls code from the Model to get information about the state of t
 Web users interact with components of the presentation layer to select actions that initiate calls to the underlying layers.
 Presentation layer components make calls to the service layer, which in turn sends requests to the [domain](https://glossary.magento.com/domain) layer.
 
-## Related topics {#related}
+{:.ref-header}
+Related topics {#related}
 
 [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 

--- a/guides/v2.3/architecture/global_extensibility_features.md
+++ b/guides/v2.3/architecture/global_extensibility_features.md
@@ -88,6 +88,7 @@ See [Plug-ins]({{page.baseurl}}/extension-dev-guide/plugins.html) in [PHP Develo
 
 [Declarative schema]({{page.baseurl}}/extension-dev-guide/declarative-schema/index.html) allows developers to declare the final desired state of the database as it pertains to their modules. The system adjusts to database changes automatically without performing redundant operations. Developers are no longer forced to write installation and upgrade scripts for each new version. In addition, declarative schema allows data be deleted when a module is uninstalled.
 
-### Related topic {#m2arch-related}
+{:.ref-header}
+Related topic
 
 [Extensibility and modularity]({{page.baseurl}}/architecture/extensibility.html)

--- a/guides/v2.3/architecture/security_intro.md
+++ b/guides/v2.3/architecture/security_intro.md
@@ -32,6 +32,7 @@ Magento safeguards your store from clickjacking attacks by using an X-Frame-Opti
 
 A simple [Magento Admin](https://glossary.magento.com/magento-admin) [URL](https://glossary.magento.com/url) (like `admin` or `backend`) makes it easy to target attacks on specific locations using automated password guessing. To prevent against this type of attack, Magento by default creates a random Admin URI when you install the product. The CLI command `php bin/magento info:adminuri` is provided so that you can  see the URI if you forget it. You can also use the CLI to change this URI.  Although the use of a non-default admin URL will not secure the site, its use will help prevent large-scale automated attacks. See [Display or change the Admin URI]({{page.baseurl}}/install-gde/install/cli/install-cli-adminurl.html) in Configuration Guide for more information.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Configuration Guide]({{page.baseurl}}/config-guide/bk-config-guide.html)

--- a/guides/v2.3/architecture/tech-stack.md
+++ b/guides/v2.3/architecture/tech-stack.md
@@ -66,6 +66,7 @@ Magento also provides automated testing suites that include unit, integration, f
 This framework is located in the `dev/tests` directory. The functional testing framework `mtf` can be found in a [separate repository](https://github.com/magento/mtf){:target="_blank"}.
 For more information, see the [Functional Testing Framework]({{page.baseurl}}/mtf/mtf_introduction.html) guide.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Architectural basics]({{page.baseurl}}/architecture/archi_perspectives/ABasics_intro.html)

--- a/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
@@ -225,5 +225,7 @@ The requirements listed in this topic are specific to {{site.data.var.ece}} envi
 
 You can also install additional [optional software]({{ page.baseurl }}/install-gde/prereq/optional.html). These packages should be installed on the local VM.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)

--- a/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.3/cloud/before/before-workspace-magento-prereqs.md
@@ -10,7 +10,9 @@ functional_areas:
   - Configuration
 ---
 
-**Previous step:**
+{:.ref-header}
+Previous step
+
 [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
 
 Install the following software packages and tools on your local to prepare for Magento code development. If you already have these packages installed, check for any recommendations or notes and continue to the next step.

--- a/guides/v2.3/cloud/live/go-live-checklist.md
+++ b/guides/v2.3/cloud/live/go-live-checklist.md
@@ -84,5 +84,7 @@ You can also test using the following 3rd party options:
 * [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks in depth: process, method call, query, load, and so on.
 * [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)

--- a/guides/v2.3/cloud/live/live-sanity-check.md
+++ b/guides/v2.3/cloud/live/live-sanity-check.md
@@ -203,5 +203,7 @@ To deploy your site:
 
 Debug errors by [reviewing logs]({{page.baseurl}}/cloud/project/log-locations.html). Open a [support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) for additional assistance.
 
-**Next step:**
+{:.ref-header}
+Next step
+
 [Prepare to deploy to Staging and Production]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html)

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -267,5 +267,6 @@ Result:
 
 <pre class="no-copy">web/unsecure/base_url - http://example-for-store.com/</pre>
 
-#### Related topic
+{:.ref-header}
+Related topic
 [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -269,4 +269,5 @@ Result:
 
 {:.ref-header}
 Related topic
+
 [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -197,7 +197,8 @@ Index mode for Indexer Product Categories was changed from 'Update on Save' to '
 
 The indexers-related database triggers are added when the indexer mode is set to `schedule` and removed when the indexer mode is set to `realtime`. If the triggers are missing from your database while the indexers are set to `schedule`, change the indexers to `realtime` and then change them back to `schedule`. This resets the triggers.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 * [Manage the cache]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html)
 * [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-queue.md
@@ -13,7 +13,8 @@ You must start a message queue consumer to enable asynchronous operations such a
 
 {% include config/message-queue-consumers.md %}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Message queues overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
 * [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)

--- a/guides/v2.3/config-guide/config/config-files.md
+++ b/guides/v2.3/config-guide/config/config-files.md
@@ -127,7 +127,8 @@ That is, the file system, database, other storage merges the configuration files
 *  [Framework\Config\ScopeListInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ScopeListInterface.php), which returns a list of scopes.
 *  [Framework\Config\ValidationStateInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ValidationStateInterface.php), which retrieves the validation state.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
  *  [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
  *  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.3/config-guide/deployment/pipeline/build-system.md
+++ b/guides/v2.3/config-guide/deployment/pipeline/build-system.md
@@ -95,7 +95,8 @@ To set up the build system:
 
     See the [`.gitignore` reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html) for more information.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
 *	[Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)

--- a/guides/v2.3/config-guide/memcache/memcache.md
+++ b/guides/v2.3/config-guide/memcache/memcache.md
@@ -16,7 +16,8 @@ Magento uses memcached for session storage but not for page caching. For page ca
 {:.bs-callout .bs-callout-info}
 Refer to [Why Redis is better]({{ page.baseurl }}/config-guide/redis/config-redis.html) for a list of advantages to using Redis.
 
-## Next step
+{:.ref-header}
+Related topics
 
 * [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
 * [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)

--- a/guides/v2.3/config-guide/memcache/memcache_centos.md
+++ b/guides/v2.3/config-guide/memcache/memcache_centos.md
@@ -164,6 +164,7 @@ Flush the memcache storage and quit Telnet:
 
 [Additional information about the Telnet test](http://www.darkcoding.net/software/memcached-list-all-keys/)
 
-## Next step
+{:.ref-header}
+Related topics
 
 [Configure Magento to use memcached]({{ page.baseurl }}/config-guide/memcache/memcache_magento.html)

--- a/guides/v2.3/config-guide/redis/redis-session.md
+++ b/guides/v2.3/config-guide/redis/redis-session.md
@@ -99,7 +99,8 @@ TTL for session records use the value for Cookie Lifetime, which is configured i
 
 {% include config/redis-verify.md %}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
 * [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.3/extension-dev-guide/bk-extension-dev-guide.md
+++ b/guides/v2.3/extension-dev-guide/bk-extension-dev-guide.md
@@ -18,7 +18,8 @@ The Magento application is made up of *Modules*, *Themes*, and *Language Package
 {: .bs-callout-info }
 You must follow a [PSR-4 compliant](http://www.php-fig.org/psr/psr-4/) structure when building a module.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
 *	[Introduction to Composer]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer.html)

--- a/guides/v2.3/extension-dev-guide/depend-inj.md
+++ b/guides/v2.3/extension-dev-guide/depend-inj.md
@@ -105,7 +105,8 @@ Since you cannot specify this data in the constructor signature, Magento cannot 
 
 To get around this limitation, injectable objects can depend on [factories] that produce newable objects.
 
-**Related topics**
+{:.ref-header}
+Related topics
 
 *	[The `di.xml` file]({{ page.baseurl }}/extension-dev-guide/build/di-xml-file.html)
 *	[ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)

--- a/guides/v2.3/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.3/extension-dev-guide/indexer-batch.md
@@ -140,7 +140,8 @@ To determine whether any 3rd-party extensions are using the Product EAV indexer,
 
 To disable the Product EAV indexer in the Admin, go to **Stores** > Settings > **Configuration** > **Catalog** > **Catalog** > **Catalog Search** and make sure the **Search Engine** field has a value other than MySQL.  Then set the value of **Enable EAV Indexer** to No.
 
-### Related topics
+{:.ref-header}
+Related topics
 {:.no_toc}
 
 * [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)

--- a/guides/v2.3/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.3/extension-dev-guide/indexer-batch.md
@@ -142,7 +142,6 @@ To disable the Product EAV indexer in the Admin, go to **Stores** > Settings > *
 
 {:.ref-header}
 Related topics
-{:.no_toc}
 
 * [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)
 * [Adding a custom indexer]({{ page.baseurl }}/extension-dev-guide/indexing-custom.html)

--- a/guides/v2.3/extension-dev-guide/message-queues/queue-migration.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/queue-migration.md
@@ -123,7 +123,8 @@ The first column in the following table lists the all the parameters in the `que
 `<publisher>/<connection>/exchange` | `<publisher>/exchange`
 `<publisher>/<connection>/disabled` | Not present in 2.0. Omit this parameter to accept the default value.
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 *	[Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
 *	[Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html)

--- a/guides/v2.3/extension-dev-guide/prepare/prepare_file-str.md
+++ b/guides/v2.3/extension-dev-guide/prepare/prepare_file-str.md
@@ -10,6 +10,7 @@ In addition, you can choose the component root directory to start development. T
 
 {% include php-dev/component-root-2.3.md %}
 
-#### Related topic
+{:.ref-header}
+Related topic
 
 [Roadmap for developing and packaging components]({{ page.baseurl }}/extension-dev-guide/prepare/dev-summary.html)

--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -586,7 +586,8 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
 
-### Related topics
+{:.ref-header}
+Related topics
 
 - [Layout instructions]
 - [Extend a layout]

--- a/guides/v2.3/install-gde/install/get-software.md
+++ b/guides/v2.3/install-gde/install/get-software.md
@@ -13,7 +13,8 @@ functional_areas:
 
 {% include install/get-software_zip.md %}
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 -   [Clone the Magento repository]({{page.baseurl }}/install-gde/prereq/dev_install.html)
 -   [Get the Composer metapackage]({{page.baseurl }}/install-gde/composer.html)

--- a/guides/v2.3/install-gde/install/hosted/hosted_get-ftp.md
+++ b/guides/v2.3/install-gde/install/hosted/hosted_get-ftp.md
@@ -78,6 +78,7 @@ To extract the archive:
 
     ![]({{ site.baseurl }}/common/images/install-merch_file-manager-after.png){:width="750px"}
 
-### Next step
+{:.ref-header}
+Related topics
 
 [Install the Magento software]({{page.baseurl }}/install-gde/install/hosted/hosted_install.html)

--- a/guides/v2.3/install-gde/prereq/apache.md
+++ b/guides/v2.3/install-gde/prereq/apache.md
@@ -249,7 +249,8 @@ For example:
 The preceding values for `Order` might not work in all cases. For more information, see the [Apache documentation](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order){:target="_blank"}.
 {% endcollapsible %}
 
-#### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[PHP&mdash;Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)
 *	[PHP&mdash;CentOS]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-centos)

--- a/guides/v2.3/install-gde/prereq/apache.md
+++ b/guides/v2.3/install-gde/prereq/apache.md
@@ -95,7 +95,8 @@ To install the default version of Apache (Ubuntu 14, 16&mdash;Apache 2.4, Ubuntu
 ### Enable rewrites and .htaccess for Apache 2.2
 {% include install/allowoverrides22.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu))
@@ -152,7 +153,8 @@ To upgrade to Apache 2.4:
 ### Enable rewrites and .htaccess for Apache 2.4 {#enable-rewr-apache24-upgr-ubuntu12}
 {% include install/allowoverrides24.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu))
@@ -196,7 +198,8 @@ Installing and configuring Apache is basically a three-step process: install the
 ### Enable rewrites and .htaccess for Apache 2.2 (including CentOS 7)
 {% include install/allowoverrides22.md %}
 
-__Next steps:__
+{:.ref-header}
+Next steps
 
 *	[Solving 403 (Forbidden) errors](#apache-error)
 *	Continue with the next prerequisite ([PHP Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu))

--- a/guides/v2.3/install-gde/prereq/apache.md
+++ b/guides/v2.3/install-gde/prereq/apache.md
@@ -250,7 +250,7 @@ The preceding values for `Order` might not work in all cases. For more informati
 {% endcollapsible %}
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[PHP&mdash;Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)
 *	[PHP&mdash;CentOS]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-centos)

--- a/guides/v2.3/install-gde/prereq/install-rabbitmq.md
+++ b/guides/v2.3/install-gde/prereq/install-rabbitmq.md
@@ -130,7 +130,8 @@ To configure support for SSL, edit the `ssl` and `ssl_options` parameters in the
 
 After you have connected Magento and RabbitMQ, you must start the message queue consumers. See [Configure message queues]({{page.baseurl}}/config-guide/mq/manage-mysql.html) for details.
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing optional software]({{page.baseurl}}/install-gde/prereq/optional.html)
 *	[Apache]({{page.baseurl}}/install-gde/prereq/apache.html)

--- a/guides/v2.3/install-gde/prereq/mysql.md
+++ b/guides/v2.3/install-gde/prereq/mysql.md
@@ -398,7 +398,8 @@ To configure a MySQL database instance:
 
     -   For optimal performance, make sure all MySQL and Magento index tables can be kept in memory (e.g., configure `innodb_buffer_pool_size`).
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html)
 *	[Installing optional software]({{page.baseurl }}/install-gde/prereq/optional.html)

--- a/guides/v2.3/install-gde/prereq/mysql_remote.md
+++ b/guides/v2.3/install-gde/prereq/mysql_remote.md
@@ -140,7 +140,8 @@ When you install the Magento software using either the command line or Setup Wiz
 *	Database password is the local web node user's password
 *	Database name is the name of the database on the remote server
 
-### Related topics
+{:.ref-header}
+Related topics
 
 *	[Installing optional software]({{page.baseurl }}/install-gde/prereq/optional.html)
 *	[Apache]({{page.baseurl }}/install-gde/prereq/apache.html)

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -555,7 +555,8 @@ To configure SELinux and firewalld:
 
 Open a web browser and navigate to your site's base URL to [verify the installation.]({{page.baseurl }}/install-gde/install/verify.html)
 
-#### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[PHP](php-centos-ubuntu.html)
 *	[MySQL]({{page.baseurl }}/install-gde/prereq/mysql.html)

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -556,7 +556,7 @@ To configure SELinux and firewalld:
 Open a web browser and navigate to your site's base URL to [verify the installation.]({{page.baseurl }}/install-gde/install/verify.html)
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[PHP](php-centos-ubuntu.html)
 *	[MySQL]({{page.baseurl }}/install-gde/prereq/mysql.html)

--- a/guides/v2.3/install-gde/prereq/optional.md
+++ b/guides/v2.3/install-gde/prereq/optional.md
@@ -235,7 +235,8 @@ To install phpmyadmin on CentOS:
 
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Apache]({{page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP&mdash;Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)

--- a/guides/v2.3/install-gde/prereq/optional.md
+++ b/guides/v2.3/install-gde/prereq/optional.md
@@ -236,7 +236,7 @@ To install phpmyadmin on CentOS:
 8.	When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Apache]({{page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP&mdash;Ubuntu]({{page.baseurl }}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)

--- a/guides/v2.3/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.3/install-gde/prereq/prereq-overview.md
@@ -116,11 +116,13 @@ Enter `exit` at the `mysql>` prompt to exit.
 
 To install or upgrade MySQL, see [MySQL]({{page.baseurl}}/install-gde/prereq/mysql.html).
 
-#### Next step
+{:.ref-header}
+Related topics
 
 [Choose how to install the Magento software]({{page.baseurl}}/install-gde/bk-install-guide.html)
 
-#### Related topics
+{:.ref-header}
+Related topics
 
 * [MySQL]({{page.baseurl}}/install-gde/prereq/mysql.html)
 * [Apache]({{page.baseurl}}/install-gde/prereq/apache.html)

--- a/guides/v2.3/install-gde/prereq/prereq-overview.md
+++ b/guides/v2.3/install-gde/prereq/prereq-overview.md
@@ -119,14 +119,10 @@ To install or upgrade MySQL, see [MySQL]({{page.baseurl}}/install-gde/prereq/mys
 {:.ref-header}
 Related topics
 
-[Choose how to install the Magento software]({{page.baseurl}}/install-gde/bk-install-guide.html)
-
-{:.ref-header}
-Related topics
-
-* [MySQL]({{page.baseurl}}/install-gde/prereq/mysql.html)
-* [Apache]({{page.baseurl}}/install-gde/prereq/apache.html)
-* [PHP&mdash;Ubuntu]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)
-* [PHP&mdash;CentOS]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html#php-for-centos)
-* [Installing optional software]({{page.baseurl}}/install-gde/prereq/optional.html)
-* [How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
+*  [Choose how to install the Magento software]({{page.baseurl}}/install-gde/bk-install-guide.html)
+*  [MySQL]({{page.baseurl}}/install-gde/prereq/mysql.html)
+*  [Apache]({{page.baseurl}}/install-gde/prereq/apache.html)
+*  [PHP&mdash;Ubuntu]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html#php-for-ubuntu)
+*  [PHP&mdash;CentOS]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html#php-for-centos)
+*  [Installing optional software]({{page.baseurl}}/install-gde/prereq/optional.html)
+*  [How to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)

--- a/guides/v2.3/install-gde/prereq/security.md
+++ b/guides/v2.3/install-gde/prereq/security.md
@@ -68,7 +68,8 @@ Depending on your security requirements, you might find it necessary to open por
 *	Ubuntu: [Ubuntu documentation page](https://help.ubuntu.com/community/IptablesHowTo)
 *	CentOS: [CentOS how-to](http://wiki.centos.org/HowTos/Network/IPTables).
 
-### Related topics:
+{:.ref-header}
+Related topics:
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 7.1 or 7.2]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html)

--- a/guides/v2.3/install-gde/prereq/security.md
+++ b/guides/v2.3/install-gde/prereq/security.md
@@ -69,7 +69,7 @@ Depending on your security requirements, you might find it necessary to open por
 *	CentOS: [CentOS how-to](http://wiki.centos.org/HowTos/Network/IPTables).
 
 {:.ref-header}
-Related topics:
+Related topics
 
 *	[Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
 *	[PHP 7.1 or 7.2]({{page.baseurl}}/install-gde/prereq/php-centos-ubuntu.html)

--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -93,7 +93,7 @@ The Magento software extracts to the directory you created. After the file has e
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topicsnext-step-section}
+Related topics
 
 Install the Magento software:
 

--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -93,7 +93,7 @@ The Magento software extracts to the directory you created. After the file has e
 {% include install/file-system-perms-before_22.md %}
 
 {:.ref-header}
-Related topics {#next-step-section}
+Related topicsnext-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -92,7 +92,8 @@ The Magento software extracts to the directory you created. After the file has e
 
 {% include install/file-system-perms-before_22.md %}
 
-## Next step {#next-step-section}
+{:.ref-header}
+Related topics {#next-step-section}
 
 Install the Magento software:
 

--- a/guides/v2.3/mrg/intro.md
+++ b/guides/v2.3/mrg/intro.md
@@ -4,7 +4,8 @@ title: Introduction to the Module Reference Guide
 
 The [Module](https://glossary.magento.com/module) Reference Guide contains brief descriptions for the modules specific to {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.b2b}}. The topics are generated from the corresponding READMEs that were pulled in from the Magento codebase.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 - [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
 - [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)

--- a/guides/v2.3/mtf/mtf_installation.md
+++ b/guides/v2.3/mtf/mtf_installation.md
@@ -77,7 +77,7 @@ Find the `mtf` directory.
 Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`. The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
 {:.ref-header}
-Related topicss {#mtf_install_next}
+Related topicss
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.3/mtf/mtf_installation.md
+++ b/guides/v2.3/mtf/mtf_installation.md
@@ -77,7 +77,7 @@ Find the `mtf` directory.
 Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`. The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
 {:.ref-header}
-Related topicss
+Related topics
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.3/mtf/mtf_installation.md
+++ b/guides/v2.3/mtf/mtf_installation.md
@@ -76,7 +76,8 @@ Find the `mtf` directory.
 
 Open `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md`. The latest version in `CHANGELOG.md` is version of the FTF you installed.
 
-## Next steps {#mtf_install_next}
+{:.ref-header}
+Related topicss {#mtf_install_next}
 
 [Adjust the FTF configuration ]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
 

--- a/guides/v2.3/rest/generate-local.md
+++ b/guides/v2.3/rest/generate-local.md
@@ -63,7 +63,8 @@ To return the complete JSON schema, specify the `?services=all` parameter in the
 
 The base URL for returning the asynchronous schema is `http://<magento_host>/rest/<store_code>/async/schema`.
 
-## Related topics
+{:.ref-header}
+Related topics
 
 [Token-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-token.html)
 

--- a/guides/v2.3/rest/retrieve-filtered-responses.md
+++ b/guides/v2.3/rest/retrieve-filtered-responses.md
@@ -190,6 +190,5 @@ The following query returns only the `sku` and `name` parameters for product ite
 
 {:.ref-header}
 Related topics
-{:.no_toc}
 
 * [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.3/rest/retrieve-filtered-responses.md
+++ b/guides/v2.3/rest/retrieve-filtered-responses.md
@@ -188,7 +188,8 @@ The following query returns only the `sku` and `name` parameters for product ite
 }
 ```
 
-## Related topics
+{:.ref-header}
+Related topics
 {:.no_toc}
 
 * [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.3/rest/tutorials/bulk-configurable-product/create-personalization-option.md
+++ b/guides/v2.3/rest/tutorials/bulk-configurable-product/create-personalization-option.md
@@ -72,6 +72,7 @@ contributor_link: http://comwrap.com/
 ## Congratulations! You've finished.
   {:.no_toc}
 
-## Related topics
+{:.ref-header}
+Related topics
 
    * [Order Processing with REST APIs Tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html)

--- a/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
@@ -78,7 +78,8 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 ## Congratulations! You've finished.
 {:.no_toc}
 
-## Related topics
+{:.ref-header}
+Related topics
 
 * [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
 * [Create a configurable product Tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html)


### PR DESCRIPTION
This PR introduces a new `ref-header` class for DevDocs. The class is designed specifically as a title for introducing **Related topics** and **Next step** sections at the bottom of topics.

Although this isn't technically required to enable rule MD001, it's preferable because changing H4s to H3s to resolve errors will force these headings into the **On this page** TOC.

Using the `{:.no_toc}` class is not an ideal solution because it requires the class be added to the line immediate above or below the header, which will break linting rule [MD022 - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines).

Related to #5240 