### PR TITLE
Fixed list styles (MD004) in the UI Components Guide

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-columnscontrols.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-columnscontrols.md
@@ -5,8 +5,8 @@ title: ColumnsControls component
 
 The ColumnsControls component is a collection of columns. It provides an interface for showing and hiding columns. The interface contains:
 
-* The total number of all available columns in a grid.
-* The number of columns currently active/displayed.
+*  The total number of all available columns in a grid.
+*  The number of columns currently active/displayed.
 
 ## Configuration options
 
@@ -41,4 +41,4 @@ The ColumnsControls component is a collection of columns. It provides an interfa
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [`app/code/Magento/Ui/view/base/web/js/grid/controls/columns.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/controls/columns.js)
+*  [`app/code/Magento/Ui/view/base/web/js/grid/controls/columns.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/controls/columns.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-exportbutton.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-exportbutton.md
@@ -60,13 +60,12 @@ By default Magento allows [CSV](https://glossary.magento.com/csv) and Excel [XML
 
 To add new export format:
 
-* Add configuration data to ExportButton definition [`Magento/Ui/view/base/ui_component/etc/definition.xml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml)
-* Add controller for new format processing `\Magento\Ui\Controller\Adminhtml\Export\GridToFoo`
-* Add converter `\Magento\Ui\Model\Export\ConvertToFoo`
+*  Add configuration data to ExportButton definition [`Magento/Ui/view/base/ui_component/etc/definition.xml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml)
+*  Add controller for new format processing `\Magento\Ui\Controller\Adminhtml\Export\GridToFoo`
+*  Add converter `\Magento\Ui\Model\Export\ConvertToFoo`
 
 ## Source files
 
 Extends [`UiElement`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html):
 
-- [`app/code/Magento/Ui/view/base/web/js/grid/export.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/export.js)
-
+*  [`app/code/Magento/Ui/view/base/web/js/grid/export.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/export.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-form.md
@@ -13,21 +13,21 @@ Form is a [basic component]({{ page.baseurl }}/ui_comp_guide/bk-ui_comps.html#ge
 
 The following components can be used in the scope of the Form component:
 
-* ActionDelete
-* Checkbox
-* Checkboxset
-* DataSource
-* FieldSet
-* FileUploader
-* Hidden
-* Input
-* Multiline
-* Multiselect
-* Radioset
-* Select
-* Text
-* Textarea
-* [Wysiwyg](https://glossary.magento.com/wysiwyg)
+*  ActionDelete
+*  Checkbox
+*  Checkboxset
+*  DataSource
+*  FieldSet
+*  FileUploader
+*  Hidden
+*  Input
+*  Multiline
+*  Multiselect
+*  Radioset
+*  Select
+*  Text
+*  Textarea
+*  [Wysiwyg](https://glossary.magento.com/wysiwyg)
 
 ## Configuration options
 
@@ -232,8 +232,8 @@ To create an instance of the Form component, you need to do the following:
 
 Component could be configured in two ways:
 
-* globally: using any module's `view/ui_component/etc/definition.xml` file. All settings declared in     this file will be applied to all component's instances
-* locally: using concrete component instance configuration, such as `<your module root dir>view/base/ui_component/customer_form`
+*  globally: using any module's `view/ui_component/etc/definition.xml` file. All settings declared in     this file will be applied to all component's instances
+*  locally: using concrete component instance configuration, such as `<your module root dir>view/base/ui_component/customer_form`
 
 Create configuration file: `<your module root dir>view/base/ui_component/customer_form.xml`
 
@@ -270,11 +270,11 @@ Create configuration file: `<your module root dir>view/base/ui_component/custome
 
 Nodes are optional and contain parameters required for component:
 
-* settings -> deps - sets the dependency on component initialization
+*  settings -> deps - sets the dependency on component initialization
 
-* js_config -> provider - specifies the name of the component data
+*  js_config -> provider - specifies the name of the component data
 
-* settings -> layout - configuration class meets the visualization component. Names for deps and provider are specified with a complete path from the root component with the separator "."
+*  settings -> layout - configuration class meets the visualization component. Names for deps and provider are specified with a complete path from the root component with the separator "."
 
 Add a description of the fields in the form using components and Field Fieldset:
 
@@ -355,9 +355,9 @@ An example of the configuration of the DataSource object:
 
 Component configuration:
 
-* argument `"dataProvider"` - contains configuration, class name, and arguments
+*  argument `"dataProvider"` - contains configuration, class name, and arguments
 
-* `"js_config"` -> `"component"` -> JavaScript indication of a responsible component
+*  `"js_config"` -> `"component"` -> JavaScript indication of a responsible component
 
 Data provided by data source is shared and available for all components in the Assembly (in this case for all child components of UI Form).
 
@@ -404,4 +404,4 @@ To replace one instance of a UI Form Component redefine link to a constructor in
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/form/form.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/form.js)
+*  [app/code/Magento/Ui/view/base/web/js/form/form.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/form.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-massactions.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-massactions.md
@@ -11,9 +11,9 @@ See the [Admin Design Pattern Library (MassActions)]({{ page.baseurl }}/pattern-
 
 The MassActions component has dependencies on the following components:
 
-* Collapsible: `app\code\Magento\Ui\view\base\web\js\lib\collapsible.js`
-* Modal window with confirmation: `app\code\Magento\Ui\view\base\web\js\modal\confirm.js`
-* Modal window with alert: `app\code\Magento\Ui\view\base\web\js\modal\alert.js`
+*  Collapsible: `app\code\Magento\Ui\view\base\web\js\lib\collapsible.js`
+*  Modal window with confirmation: `app\code\Magento\Ui\view\base\web\js\modal\confirm.js`
+*  Modal window with alert: `app\code\Magento\Ui\view\base\web\js\modal\alert.js`
 
 ## Configuration options
 
@@ -170,14 +170,14 @@ Redefine link to constructor:
 
 Extends `Collapsible`:
 
-- [app\code\Magento\Ui\view\base\web\js\grid\massactions.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/massactions.js)
-- [app\code\Magento\Ui\view\base\web\templates\grid\actions.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/actions.html)
+*  [app\code\Magento\Ui\view\base\web\js\grid\massactions.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/massactions.js)
+*  [app\code\Magento\Ui\view\base\web\templates\grid\actions.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/actions.html)
 
 ### Methods and events
 
 The following [API](https://glossary.magento.com/api) methods are available:
 
-* `getAction` - returns the action instance found by the provided identifier
-* `addAction` - adds a new action to the actions
-* `applyAction` - applies the specified action as identifier action
-* `getSelections` - returns the object with current selections
+*  `getAction` - returns the action instance found by the provided identifier
+*  `addAction` - adds a new action to the actions
+*  `applyAction` - applies the specified action as identifier action
+*  `getSelections` - returns the object with current selections

--- a/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-multiselectcolumn.md
@@ -84,7 +84,7 @@ Current implementation:
 
 Example configuration modifications:
 
-* Redefining the link to the template
+*  Redefining the link to the template
 
 ```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
@@ -97,7 +97,7 @@ Example configuration modifications:
 </column>
 ```
 
-* Redefining the name of the property which represents record identifier
+*  Redefining the name of the property which represents record identifier
 
 ```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
@@ -110,7 +110,7 @@ Example configuration modifications:
 </column>
 ```
 
-* Redefining a property data source
+*  Redefining a property data source
 
 ```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
@@ -129,7 +129,7 @@ Example configuration modifications:
 
 Instance Replacement: One Instance of a Component
 
-* Redefine the link to constructor:
+*  Redefine the link to constructor:
 
 ```xml
 <column name="ids" class="Magento\Ui\Component\MassAction\Columns\Column">
@@ -145,9 +145,9 @@ Instance Replacement: One Instance of a Component
 
 Extends [`Column`]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html):
 
-- [app\code\Magento\Ui\view\base\web\js\grid\columns\multiselect.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/multiselect.js)
-- [app\code\Magento\Ui\view\base\web\templates\grid\cells\multiselect.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/multiselect.html) - defines each field in the grid; provides the Multiselect component with the checkbox interface for selecting item(s) in the grid and performing actions over them.
-- [app\code\Magento\Ui\view\base\web\templates\grid\columns\multiselect.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/columns/multiselect.html) - defines the grid header with dropdown lists and Select All, Deselect All, and other options.
+*  [app\code\Magento\Ui\view\base\web\js\grid\columns\multiselect.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/multiselect.js)
+*  [app\code\Magento\Ui\view\base\web\templates\grid\cells\multiselect.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/multiselect.html) - defines each field in the grid; provides the Multiselect component with the checkbox interface for selecting item(s) in the grid and performing actions over them.
+*  [app\code\Magento\Ui\view\base\web\templates\grid\columns\multiselect.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/columns/multiselect.html) - defines the grid header with dropdown lists and Select All, Deselect All, and other options.
 
 ### Methods and Events
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.md
@@ -115,9 +115,9 @@ In this example we showed only a small part of the possible configuration.
 
 The default configuration of a UI component is declared in one of the following ways:
 
-- inside the UI component itself, in the `.js` file
-- in the [`definition.xml` file]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml)
-- in both places, in which case the configurations merge (the UI component `.js` file has priority).
+*  inside the UI component itself, in the `.js` file
+*  in the [`definition.xml` file]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml)
+*  in both places, in which case the configurations merge (the UI component `.js` file has priority).
 
 In the above example, the Fieldset UI component uses a merged configuration from both the `definition.xml` file and from the UI component's `.js` file.
 

--- a/guides/v2.3/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-form.md
@@ -13,21 +13,21 @@ Form is a [basic component]({{ page.baseurl }}/ui_comp_guide/bk-ui_comps.html#ge
 
 The following components can be used in the scope of the Form component:
 
-* ActionDelete
-* Checkbox
-* Checkboxset
-* DataSource
-* FieldSet
-* FileUploader
-* Hidden
-* Input
-* Multiline
-* Multiselect
-* Radioset
-* Select
-* Text
-* Textarea
-* [Wysiwyg](https://glossary.magento.com/wysiwyg)
+*  ActionDelete
+*  Checkbox
+*  Checkboxset
+*  DataSource
+*  FieldSet
+*  FileUploader
+*  Hidden
+*  Input
+*  Multiline
+*  Multiselect
+*  Radioset
+*  Select
+*  Text
+*  Textarea
+*  [Wysiwyg](https://glossary.magento.com/wysiwyg)
 
 ## Configuration options
 
@@ -215,7 +215,8 @@ To create an instance of the Form component, you need to do the following:
 1. In your custom module, add a configuration file for the instance, for example: `customer_form.xml`.
 2. Add a set of fields (the Fieldset component with the component of the Field) for [entity](https://glossary.magento.com/entity) or     to implement the upload of meta info in the DataProvider.
 3. Create the DataProvider class for the entity that implements DataProviderInterface
-* Add a component in Magento [layout](https://glossary.magento.com/layout) as a node: `<uiComponent name="customer_form"/>`
+
+   *  Add a component in Magento [layout](https://glossary.magento.com/layout) as a node: `<uiComponent name="customer_form"/>`
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
@@ -232,8 +233,8 @@ To create an instance of the Form component, you need to do the following:
 
 Component could be configured in two ways:
 
-* globally: using any module's `view/ui_component/etc/definition.xml` file. All settings declared in     this file will be applied to all component's instances
-* locally: using concrete component instance configuration, such as `<your module root dir>view/base/ui_component/customer_form`
+*  globally: using any module's `view/ui_component/etc/definition.xml` file. All settings declared in     this file will be applied to all component's instances
+*  locally: using concrete component instance configuration, such as `<your module root dir>view/base/ui_component/customer_form`
 
 Create configuration file: `<your module root dir>view/base/ui_component/customer_form.xml`
 
@@ -270,11 +271,11 @@ Create configuration file: `<your module root dir>view/base/ui_component/custome
 
 Nodes are optional and contain parameters required for component:
 
-* settings -> deps - sets the dependency on component initialization
+*  settings -> deps - sets the dependency on component initialization
 
-* js_config -> provider - specifies the name of the component data
+*  js_config -> provider - specifies the name of the component data
 
-* settings -> layout - configuration class meets the visualization component. Names for deps and provider are specified with a complete path from the root component with the separator "."
+*  settings -> layout - configuration class meets the visualization component. Names for deps and provider are specified with a complete path from the root component with the separator "."
 
 Add a description of the fields in the form using components and Field Fieldset:
 
@@ -355,9 +356,9 @@ An example of the configuration of the DataSource object:
 
 Component configuration:
 
-* argument `"dataProvider"` - contains configuration, class name, and arguments
+*  argument `"dataProvider"` - contains configuration, class name, and arguments
 
-* `"js_config"` -> `"component"` -> JavaScript indication of a responsible component
+*  `"js_config"` -> `"component"` -> JavaScript indication of a responsible component
 
 Data provided by data source is shared and available for all components in the Assembly (in this case for all child components of UI Form).
 
@@ -404,4 +405,4 @@ To replace one instance of a UI Form Component redefine link to a constructor in
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/form/form.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/form.js)
+*  [app/code/Magento/Ui/view/base/web/js/form/form.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/form.js)

--- a/guides/v2.3/ui_comp_guide/components/ui-secondary-uiselect.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-secondary-uiselect.md
@@ -8,8 +8,8 @@ menu_node:
 
 The UI-select component is a single select/multiple select component that enables the selection of a collection of items. It extends all `abstract` configuration and can be configured in two modes:
 
-* Single - checkbox isn't displayed
-* Multiple - checkboxes are displayed
+*  Single - checkbox isn't displayed
+*  Multiple - checkboxes are displayed
 
 ## Configuration options
 
@@ -97,11 +97,11 @@ actions: [
 
 The following configuration can be passed in as arguments:
 
-* Link to any of the UI component templates
-* Link to the constructor
-* Label to ui-select
-* Default caption
-* Caption if more than one element is selected
+*  Link to any of the UI component templates
+*  Link to the constructor
+*  Label to ui-select
+*  Default caption
+*  Caption if more than one element is selected
 
 ## Modes
 
@@ -109,22 +109,22 @@ The following configuration can be passed in as arguments:
 
 `simple` mode sets the following values to `false`:
 
-* `showCheckbox`
-* `chipsEnabled`
-* `closeBtn`
+*  `showCheckbox`
+*  `chipsEnabled`
+*  `closeBtn`
 
 ### **`optgroup` mode**
 
 `optgroup` mode sets the following values to `false`:
 
-* `showCheckbox`
-* `openLevelsAction`
+*  `showCheckbox`
+*  `openLevelsAction`
 
 `optgroup` sets the following values to `true`:
 
-* `lastSelectable`
-* `optgroupLabels`
-* `labelsDecoration`
+*  `lastSelectable`
+*  `optgroupLabels`
+*  `labelsDecoration`
 
 ## Examples
 
@@ -162,14 +162,14 @@ The UI-select component supports keyboard navigation.
 
 Navigation keys:
 
-* **`Enter`**: if focus is on the caption a list of options opens; if focus is on the same option it will select or deselect the current option
-* **`Space`**: copies the `Enter` key functionality
-* **`Escape`**: closes the list of options
-* **`PageUp`**: sets focus to the previous option
-* **`PageDown`**: sets focus to the next option
+*  **`Enter`**: if focus is on the caption a list of options opens; if focus is on the same option it will select or deselect the current option
+*  **`Space`**: copies the `Enter` key functionality
+*  **`Escape`**: closes the list of options
+*  **`PageUp`**: sets focus to the previous option
+*  **`PageDown`**: sets focus to the next option
 
 ## Source files
 
-- [app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js)
-- [Magento/Ui/view/base/web/js/form/element/abstract.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js)
-- [app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html)
+*  [app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js)
+*  [Magento/Ui/view/base/web/js/form/element/abstract.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js)
+*  [app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD004 errors in the UI Components Guide.

The MD004 rule requires consistent use of unordered list styles. The scope of #5241 also permits—but does not require—resolving errors related to the following rules:

- MD005: List indentation
- MD006: Start bulleted lists at the beginning of a line
- MD007: List indentation
- MD030: Spaces after list markers

This is one of many PRs related to #5241.