### PR TITLE
Fixed list styles (MD004) in the Release Notes

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
@@ -59,631 +59,924 @@ This release contains hundreds of fixes and enhancements.
 
 ### Installation, upgrade, deployment
 
-<!--- 55357/53777-->* You can now run `magento setup:upgrade --keep-generated` in production mode. Previously, Magento would throw an error when you ran `setup:upgrade` after compiling dependency injection. (This significantly curtailed your ability to deploy continuous integration.) [GitHub-4795](https://github.com/magento/magento2/issues/4795)
+<!--- 55357/53777 -->
+*  You can now run `magento setup:upgrade --keep-generated` in production mode. Previously, Magento would throw an error when you ran `setup:upgrade` after compiling dependency injection. (This significantly curtailed your ability to deploy continuous integration.) [GitHub-4795](https://github.com/magento/magento2/issues/4795)
 
-<!---56397, 58064-->* You can now upgrade your Magento installation when using multiple master databases for checkout, order management, and product data.
+<!---56397, 58064 -->
+*  You can now upgrade your Magento installation when using multiple master databases for checkout, order management, and product data.
 
-<!---56977, 54716-->* We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
+<!---56977, 54716 -->
+*  We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
 
-<!---57343-->*  You can now deploy build processes on a different staging machine than the one you're running your production environment on.
+<!---57343 -->
+*   You can now deploy build processes on a different staging machine than the one you're running your production environment on.
 
-<!---57943-->* Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
+<!---57943 -->
+*  Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
 
-<!--- 62400-->* Third-party command line tools no longer fail when you run `setup:di:compile`.
+<!--- 62400 -->
+*  Third-party command line tools no longer fail when you run `setup:di:compile`.
 
-<!--- 62648-->* Magento now correctly applies [website](https://glossary.magento.com/website) configuration parameters to the corresponding [store view](https://glossary.magento.com/store-view). [GitHub-7943](https://github.com/magento/magento2/issues/7943)
+<!--- 62648 -->
+*  Magento now correctly applies [website](https://glossary.magento.com/website) configuration parameters to the corresponding [store view](https://glossary.magento.com/store-view). [GitHub-7943](https://github.com/magento/magento2/issues/7943)
 
-<!--- 64085-->* Fixed HTML inline style used when sending emails when implementing the upgraded `emorgifier` library. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
+<!--- 64085 -->
+*  Fixed HTML inline style used when sending emails when implementing the upgraded `emorgifier` library. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
 
-<!--- 60835-->* We’ve changed how Magento displays status updates during a product upgrade. Previously, potentially vulnerable information such as full paths and module names were displayed in the product GUI, potentially exposing this information to a malicious user. Magento now restricts this potentially vulnerable information to logs that are available to administrators only.
+<!--- 60835 -->
+*  We’ve changed how Magento displays status updates during a product upgrade. Previously, potentially vulnerable information such as full paths and module names were displayed in the product GUI, potentially exposing this information to a malicious user. Magento now restricts this potentially vulnerable information to logs that are available to administrators only.
 
-<!--- 70314-->* The `cron:install` command now works as expected in Magento 2.2.0. Previously, the configuration for `crontab` commands contained double quotes that were not escaped, which caused invalid commands to be written to the `crontab` file. [GitHub-10040](https://github.com/magento/magento2/issues/10040)
+<!--- 70314 -->
+*  The `cron:install` command now works as expected in Magento 2.2.0. Previously, the configuration for `crontab` commands contained double quotes that were not escaped, which caused invalid commands to be written to the `crontab` file. [GitHub-10040](https://github.com/magento/magento2/issues/10040)
 
-<!--- 63637-->* Magento now moves the `sequence_*` table to the correct database after implementing a split database.
+<!--- 63637 -->
+*  Magento now moves the `sequence_*` table to the correct database after implementing a split database.
 
-<!---71890 -->* Magento no longer throws an exception when the configuration checksum is absent on a new installation.
+<!---71890  -->
+*  Magento no longer throws an exception when the configuration checksum is absent on a new installation.
 
-<!--- 59342-->* Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
+<!--- 59342 -->
+*  Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
 
-<!--- 54722-->* We've removed the sample password from the Setup Wizard
+<!--- 54722 -->
+*  We've removed the sample password from the Setup Wizard
 
-<!--- 71173-->* You can now enable JavaScript minification without error. Previously, after enabling JS minification, the Magento Admin displayed 404 errors when accessing JavaScript elements.
+<!--- 71173 -->
+*  You can now enable JavaScript minification without error. Previously, after enabling JS minification, the Magento Admin displayed 404 errors when accessing JavaScript elements.
 
-<!--- 70869-->* Magento no longer displays console errors after CSS merging and minification is enabled. Previously, when CSS merging and minification was enabled, the storefront was not displayed as expected, and the `styles-l.min.css` and `print.min.css` files could not be found.
+<!--- 70869 -->
+*  Magento no longer displays console errors after CSS merging and minification is enabled. Previously, when CSS merging and minification was enabled, the storefront was not displayed as expected, and the `styles-l.min.css` and `print.min.css` files could not be found.
 
-<!--- 69854-->* You can now successfully use the `config:set` command to set allowed or default currencies.
+<!--- 69854 -->
+*  You can now successfully use the `config:set` command to set allowed or default currencies.
 
-<!--- 46636-->* Nginx now redirects to the setup page when using port 81.
+<!--- 46636 -->
+*  Nginx now redirects to the setup page when using port 81.
 
-<!--- 69544-->* We've added the `dev:template-hints:enable` and `dev:template-hints:disable` commands to manage template hints. *Fix submitted by community member Miguel Balparda in pull request [9778](https://github.com/magento/magento2/pull/9778){: target="_blank"}.*
+<!--- 69544 -->
+*  We've added the `dev:template-hints:enable` and `dev:template-hints:disable` commands to manage template hints. *Fix submitted by community member Miguel Balparda in pull request [9778](https://github.com/magento/magento2/pull/9778){: target="_blank"}.*
 
-<!--- 67501-->* We've added the `dev:query-log:enable` and  `dev:query-log:disable` to manage database query logging.  *Fix submitted by community member Federico Rivollier in pull request [9264](https://github.com/magento/magento2/pull/9264){: target="_blank"}.*
+<!--- 67501 -->
+*  We've added the `dev:query-log:enable` and  `dev:query-log:disable` to manage database query logging.  *Fix submitted by community member Federico Rivollier in pull request [9264](https://github.com/magento/magento2/pull/9264){: target="_blank"}.*
 
-<!---67537 -->* We've added the `varnish:vcl:generate` command to create the Varnish VCL file. *Fix submitted by community member Piotr Kwiecinski in pull request [9286](https://github.com/magento/magento2/pull/9286){: target="_blank"}.*
+<!---67537  -->
+*  We've added the `varnish:vcl:generate` command to create the Varnish VCL file. *Fix submitted by community member Piotr Kwiecinski in pull request [9286](https://github.com/magento/magento2/pull/9286){: target="_blank"}.*
 
-<!--- 69524 -->* Magento now adds a new record to the quote table and adds the  current date and time to the `created_at` field. Previously, this field was not updated.
+<!--- 69524  -->
+*  Magento now adds a new record to the quote table and adds the  current date and time to the `created_at` field. Previously, this field was not updated.
 
-<!--- 57820 -->* The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
+<!--- 57820  -->
+*  The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
 
-<!--- 56743 -->*  We've fixed issues with upgrading installations with split databases.
+<!--- 56743  -->
+*   We've fixed issues with upgrading installations with split databases.
 
-<!--- 57656 -->* The import URL directive now contains base URL and locale placeholders instead of the real URL.
+<!--- 57656  -->
+*  The import URL directive now contains base URL and locale placeholders instead of the real URL.
 
-<!--- 55757 -->* Magento now works as expected on an Apache `php-fpm` environment.
+<!--- 55757  -->
+*  Magento now works as expected on an Apache `php-fpm` environment.
 
-<!--- 63295 -->* The `DOCUMENT_ROOT` directory is now writable. Previously, installation failed because this directory was not writable.
+<!--- 63295  -->
+*  The `DOCUMENT_ROOT` directory is now writable. Previously, installation failed because this directory was not writable.
 
-<!--- 67082-->* When upgrading Magento from 2.1.x to 2.2, the `quote_address.free_shipping` column is the same whether you upgraded from a previous installation of Magento or performed a fresh installation. Previously, different upgrade/installation options affected the contents of this column.
+<!--- 67082 -->
+*  When upgrading Magento from 2.1.x to 2.2, the `quote_address.free_shipping` column is the same whether you upgraded from a previous installation of Magento or performed a fresh installation. Previously, different upgrade/installation options affected the contents of this column.
 
-<!--- 62655-->* Command-line users now have read and write permissions to the  `var/generation` directory. [GitHub-7933](https://github.com/magento/magento2/issues/7933)
+<!--- 62655 -->
+*  Command-line users now have read and write permissions to the  `var/generation` directory. [GitHub-7933](https://github.com/magento/magento2/issues/7933)
 
-<!--- 61431-->* The Magento command-line interface now sets the correct exit codes when an upgrade task fails. [GitHub-7576](https://github.com/magento/magento2/issues/7576)
+<!--- 61431 -->
+*  The Magento command-line interface now sets the correct exit codes when an upgrade task fails. [GitHub-7576](https://github.com/magento/magento2/issues/7576)
 
-<!--- 58849-->* You can now disable the Review module without incurring an error in the Product Edit page. Previously, if you tried to edit a product after disabling the review module, Magento displayed this error: "Something went wrong". [GitHub-6704](https://github.com/magento/magento2/issues/6704)
+<!--- 58849 -->
+*  You can now disable the Review module without incurring an error in the Product Edit page. Previously, if you tried to edit a product after disabling the review module, Magento displayed this error: "Something went wrong". [GitHub-6704](https://github.com/magento/magento2/issues/6704)
 
-<!--- 56816-->* You can now use Component Manager to enable a previously disabled module. Previously, when you ran `bin/magento module:disable Magento_AnyModule`, then tried to re-enable  that module, Magento fails to enable it and any previously enabled cache types, and module installation fails. [GitHub-6078](https://github.com/magento/magento2/issues/6078)
+<!--- 56816 -->
+*  You can now use Component Manager to enable a previously disabled module. Previously, when you ran `bin/magento module:disable Magento_AnyModule`, then tried to re-enable  that module, Magento fails to enable it and any previously enabled cache types, and module installation fails. [GitHub-6078](https://github.com/magento/magento2/issues/6078)
 
-<!--- 58081-->*  Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
+<!--- 58081 -->
+*   Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
 
-<!--- 58132-->* We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
+<!--- 58132 -->
+*  We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
 
 ### Cart and checkout
 
-<!--- 53793 -->* Magento now implements the minicart maximum display recently added item setting to your [shopping cart](https://glossary.magento.com/shopping-cart).  Previously, Magento displayed all the items in the shopping cart, even when the number of items exceeded this limit. [GitHub-4750](https://github.com/magento/magento2/issues/4750)
+<!--- 53793  -->
+*  Magento now implements the minicart maximum display recently added item setting to your [shopping cart](https://glossary.magento.com/shopping-cart).  Previously, Magento displayed all the items in the shopping cart, even when the number of items exceeded this limit. [GitHub-4750](https://github.com/magento/magento2/issues/4750)
 
-<!---58036-->* You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
+<!---58036 -->
+*  You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
 
-<!---58902-->* Custom address attributes now appear in the Checkout summary.
+<!---58902 -->
+*  Custom address attributes now appear in the Checkout summary.
 
-<!---57497-->* Lengthy [Order Status](https://glossary.magento.com/order-status) tables are now paginated as expected.
+<!---57497 -->
+*  Lengthy [Order Status](https://glossary.magento.com/order-status) tables are now paginated as expected.
 
-<!---56956-->* Magento now displays the product add validation message ("Product was added to the cart") only after you have successfully added a product to your cart.
+<!---56956 -->
+*  Magento now displays the product add validation message ("Product was added to the cart") only after you have successfully added a product to your cart.
 
-<!---58057-->* We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
+<!---58057 -->
+*  We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
 
-<!---59209-->* The number of items in the minicart is now updated correctly when you run Magento in mixed HTTP/HTTPS mode. [GitHub-6487](https://github.com/magento/magento2/issues/6487)
+<!---59209 -->
+*  The number of items in the minicart is now updated correctly when you run Magento in mixed HTTP/HTTPS mode. [GitHub-6487](https://github.com/magento/magento2/issues/6487)
 
-<!---57062-->* The minicart now performs as expected in deployments that span multiple websites. Previously, in a Magento installation that had multiple websites, products that you added to one [website](https://glossary.magento.com/website) appeared in the other websites' minicarts.
+<!---57062 -->
+*  The minicart now performs as expected in deployments that span multiple websites. Previously, in a Magento installation that had multiple websites, products that you added to one [website](https://glossary.magento.com/website) appeared in the other websites' minicarts.
 
-<!---57843-->* A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart,  the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
+<!---57843 -->
+*  A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart,  the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
 
-<!---59024-->* Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
+<!---59024 -->
+*  Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
 
-<!---60103-->* Magento no longer lets you add a product variation to your shopping cart if the item is out of stock. Previously, Magento permitted you to select an out-of-stock item and when you added it to your cart, displayed the "Product is out of stock" message.
+<!---60103 -->
+*  Magento no longer lets you add a product variation to your shopping cart if the item is out of stock. Previously, Magento permitted you to select an out-of-stock item and when you added it to your cart, displayed the "Product is out of stock" message.
 
-<!---58090-->* We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
+<!---58090 -->
+*  We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
 
-<!---57168-->* We fixed a [JavaScript](https://glossary.magento.com/javascript) error that occurred on the Checkout page after you changed the country in the **Estimate Shipping and Tax** field.
+<!---57168 -->
+*  We fixed a [JavaScript](https://glossary.magento.com/javascript) error that occurred on the Checkout page after you changed the country in the **Estimate Shipping and Tax** field.
 
-<!---60293 -->* Magento now successfully estimates shipping costs. Previously, when you tried to estimate shipping costs, the load indicator would spin indefinitely, and Magento displayed this exception,```Object doesn't support this action```. [GitHub-5358](https://github.com/magento/magento2/issues/5358), [GitHub-7051](https://github.com/magento/magento2/issues/7051)
+<!---60293  -->
+*  Magento now successfully estimates shipping costs. Previously, when you tried to estimate shipping costs, the load indicator would spin indefinitely, and Magento displayed this exception,```Object doesn't support this action```. [GitHub-5358](https://github.com/magento/magento2/issues/5358), [GitHub-7051](https://github.com/magento/magento2/issues/7051)
 
-<!---56962 -->* Magento now displays the **State/Province** field on the Add New Address page. [GitHub-5279](https://github.com/magento/magento2/issues/5279)
+<!---56962  -->
+*  Magento now displays the **State/Province** field on the Add New Address page. [GitHub-5279](https://github.com/magento/magento2/issues/5279)
 
-<!--- 69657-->* Credit card information now persists as expected after a user enters a promotion code during checkout. Previously, After an user enters credit card information, then discount code and then click **Place Order**. The credit card information fields are emptied and user has to enter the credit card information again to proceed with the order transaction.
+<!--- 69657 -->
+*  Credit card information now persists as expected after a user enters a promotion code during checkout. Previously, After an user enters credit card information, then discount code and then click **Place Order**. The credit card information fields are emptied and user has to enter the credit card information again to proceed with the order transaction.
 
-<!--- 64544-->* You can complete your order after entering a new shipping address during checkout. Previously, Magento would not let you place an order if you entered a new shipping address during checkout.
+<!--- 64544 -->
+*  You can complete your order after entering a new shipping address during checkout. Previously, Magento would not let you place an order if you entered a new shipping address during checkout.
 
-<!--- 64399-->* Magento no longer throws an exception when a customer updates their shopping cart after you've enabled the Minimum Order setting. *Fix submitted by community member <a href="https://github.com/ericrisler" target="_blank">Eric Risler
+<!--- 64399 -->
+*  Magento no longer throws an exception when a customer updates their shopping cart after you've enabled the Minimum Order setting. *Fix submitted by community member <a href="https://github.com/ericrisler" target="_blank">Eric Risler
 </a> in pull request [8474](https://github.com/magento/magento2/pull/8474){: target="_blank"}.*
 
-<!--- 67323-->* You can now translate the  FPT label on the checkout page. *Fix submitted by community member Oleksii Korshenko in pull request [9204](https://github.com/magento/magento2/pull/9204){: target="_blank"}.*
+<!--- 67323 -->
+*  You can now translate the  FPT label on the checkout page. *Fix submitted by community member Oleksii Korshenko in pull request [9204](https://github.com/magento/magento2/pull/9204){: target="_blank"}.*
 
-<!--- 69230-->* Magento no longer truncates bill-to names and ship-to names to 20 characters in the Admin.  *Fix submitted by community member Isolde in pull request [9654](https://github.com/magento/magento2/pull/9654){: target="_blank"}.*
+<!--- 69230 -->
+*  Magento no longer truncates bill-to names and ship-to names to 20 characters in the Admin.  *Fix submitted by community member Isolde in pull request [9654](https://github.com/magento/magento2/pull/9654){: target="_blank"}.*
 
-<!--- 69375-->* You can now delete the last item in your cart when the Minimum Order setting is enabled. *Fix submitted by community member storbahn in pull request [9714](https://github.com/magento/magento2/pull/9714){: target="_blank"}.*
+<!--- 69375 -->
+*  You can now delete the last item in your cart when the Minimum Order setting is enabled. *Fix submitted by community member storbahn in pull request [9714](https://github.com/magento/magento2/pull/9714){: target="_blank"}.*
 
-<!--- 69379-->* You can now create unique checkbox IDs for the Terms and Conditions part of the checkout process. *Fix submitted by community member Bernhard in pull request [9717](https://github.com/magento/magento2/pull/9717){: target="_blank"}.*
+<!--- 69379 -->
+*  You can now create unique checkbox IDs for the Terms and Conditions part of the checkout process. *Fix submitted by community member Bernhard in pull request [9717](https://github.com/magento/magento2/pull/9717){: target="_blank"}.*
 
-<!--- 69533-->* Magento now correctly displays the coupon label in the shopping cart during checkout. *Fix submitted by community member [Sylvain Rayé](https://github.com/diglin){: target="_blank"} in pull request [9721](https://github.com/magento/magento2/pull/9721){: target="_blank"}.*
+<!--- 69533 -->
+*  Magento now correctly displays the coupon label in the shopping cart during checkout. *Fix submitted by community member [Sylvain Rayé](https://github.com/diglin){: target="_blank"} in pull request [9721](https://github.com/magento/magento2/pull/9721){: target="_blank"}.*
 
-<!--- 69848-->* Magento now pre-fills prefixes and suffixes in the quote shipping address *Fix submitted by community member Anton Evers in pull request [9925](https://github.com/magento/magento2/pull/9925){: target="_blank"}.*
+<!--- 69848 -->
+*  Magento now pre-fills prefixes and suffixes in the quote shipping address *Fix submitted by community member Anton Evers in pull request [9925](https://github.com/magento/magento2/pull/9925){: target="_blank"}.*
 
-<!--- 70052-->* The country drop-down box now correctly shows the countries for which the current store and customer account are configured. *Fix submitted by community member Marcel in pull request [9429](https://github.com/magento/magento2/pull/9429){: target="_blank"}.*
+<!--- 70052 -->
+*  The country drop-down box now correctly shows the countries for which the current store and customer account are configured. *Fix submitted by community member Marcel in pull request [9429](https://github.com/magento/magento2/pull/9429){: target="_blank"}.*
 
-<!--- 56411-->* The shopping cart now handles products with custom options. [GitHub-5612](https://github.com/magento/magento2/issues/5612)
+<!--- 56411 -->
+*  The shopping cart now handles products with custom options. [GitHub-5612](https://github.com/magento/magento2/issues/5612)
 
-<!--- 63200-->* Magento now requires completion of the State field during the check out process if this field has been configured as required.
+<!--- 63200 -->
+*  Magento now requires completion of the State field during the check out process if this field has been configured as required.
 
-<!--- 63635-->* Checkout now loads as expected in Safari private mode. [GitHub-7942](https://github.com/magento/magento2/issues/7942), [GitHub-7329](https://github.com/magento/magento2/issues/7329), [GitHub-8358](https://github.com/magento/magento2/issues/8358)
+<!--- 63635 -->
+*  Checkout now loads as expected in Safari private mode. [GitHub-7942](https://github.com/magento/magento2/issues/7942), [GitHub-7329](https://github.com/magento/magento2/issues/7329), [GitHub-8358](https://github.com/magento/magento2/issues/8358)
 
-<!--- 61368-->* Minicart now shows all products you’ve added, whether you added them while signed-in or not. Previously, the minicart contained only products that you added while signed in. [GitHub-7500](https://github.com/magento/magento2/issues/7500)
+<!--- 61368 -->
+*  Minicart now shows all products you’ve added, whether you added them while signed-in or not. Previously, the minicart contained only products that you added while signed in. [GitHub-7500](https://github.com/magento/magento2/issues/7500)
 
-<!--- 60352-->* Magento now displays the correct error message when you enter an invalid discount code when making a payment. [GitHub-7230](https://github.com/magento/magento2/issues/7230)
+<!--- 60352 -->
+*  Magento now displays the correct error message when you enter an invalid discount code when making a payment. [GitHub-7230](https://github.com/magento/magento2/issues/7230)
 
-<!--- 56978-->*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
+<!--- 56978 -->
+*   Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
 
-<!--- 47017-->* You can now directly add a configurable product to your shopping cart from category page. [GitHub-2574](https://github.com/magento/magento2/issues/2574), [GitHub-5850](https://github.com/magento/magento2/issues/5850), [GitHub-5882](https://github.com/magento/magento2/issues/5882), [GitHub-6572](https://github.com/magento/magento2/issues/6572), [GitHub-5558](https://github.com/magento/magento2/issues/5558), [GitHub-4184](https://github.com/magento/magento2/issues/4184)
+<!--- 47017 -->
+*  You can now directly add a configurable product to your shopping cart from category page. [GitHub-2574](https://github.com/magento/magento2/issues/2574), [GitHub-5850](https://github.com/magento/magento2/issues/5850), [GitHub-5882](https://github.com/magento/magento2/issues/5882), [GitHub-6572](https://github.com/magento/magento2/issues/6572), [GitHub-5558](https://github.com/magento/magento2/issues/5558), [GitHub-4184](https://github.com/magento/magento2/issues/4184)
 
-<!--- 58345-->* Magento now displays out-of-stock products in the shopping cart. Previously, if a product’s status changed between the time you added it to the cart and you proceeded to check out, Magento removed the product from your cart. [GitHub-6583](https://github.com/magento/magento2/issues/6583)
+<!--- 58345 -->
+*  Magento now displays out-of-stock products in the shopping cart. Previously, if a product’s status changed between the time you added it to the cart and you proceeded to check out, Magento removed the product from your cart. [GitHub-6583](https://github.com/magento/magento2/issues/6583)
 
-<!--- 60110-->* When you select `New Address` while reviewing order information during check out, Magento now profiles the username and country fields, but leaves the address fields empty. Previously, Magento did not leave the address fields empty, and the checkout process failed. [GitHub-6869](https://github.com/magento/magento2/issues/6869)
+<!--- 60110 -->
+*  When you select `New Address` while reviewing order information during check out, Magento now profiles the username and country fields, but leaves the address fields empty. Previously, Magento did not leave the address fields empty, and the checkout process failed. [GitHub-6869](https://github.com/magento/magento2/issues/6869)
 
-<!--- 57682-->* Checkout agreement validation now works as expected after you change payment method. [GitHub-6224](https://github.com/magento/magento2/issues/6224)
+<!--- 57682 -->
+*  Checkout agreement validation now works as expected after you change payment method. [GitHub-6224](https://github.com/magento/magento2/issues/6224)
 
-<!--- 58059-->* The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
+<!--- 58059 -->
+*  The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
 
-<!--- 59807-->* Magento now displays the ”Thank you for your purchase!" on the checkout success page.
+<!--- 59807 -->
+*  Magento now displays the ”Thank you for your purchase!" on the checkout success page.
 
 ### Catalog
 
-<!--- 65324, 66829 -->*  Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
+<!--- 65324, 66829  -->
+*   Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
 
-<!--- 65251 -->* The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
+<!--- 65251  -->
+*  The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
 
-<!--- 66366 -->* The `\Magento\CatalogInventory\Model\Stock\Status\getStockId()` method now returns the correct values.
+<!--- 66366  -->
+*  The `\Magento\CatalogInventory\Model\Stock\Status\getStockId()` method now returns the correct values.
 
-<!--- 58437-->* The [storefront](https://glossary.magento.com/storefront) gallery now displays all the images associated with a [configurable product](https://glossary.magento.com/configurable-product). Previously, when you clicked on the swatches associated with a configurable product, the gallery displayed only one of several possible images. [GitHub-6195](https://github.com/magento/magento2/issues/6195), [GitHub-4101](https://github.com/magento/magento2/issues/4101)
+<!--- 58437 -->
+*  The [storefront](https://glossary.magento.com/storefront) gallery now displays all the images associated with a [configurable product](https://glossary.magento.com/configurable-product). Previously, when you clicked on the swatches associated with a configurable product, the gallery displayed only one of several possible images. [GitHub-6195](https://github.com/magento/magento2/issues/6195), [GitHub-4101](https://github.com/magento/magento2/issues/4101)
 
-<!---57832 -->* Magento now displays the **This is a required field** message immediately adjacent to the product options as needed during [checkout](https://glossary.magento.com/checkout). Previously, Magento displayed this message at the bottom of the checkout form.
+<!---57832  -->
+*  Magento now displays the **This is a required field** message immediately adjacent to the product options as needed during [checkout](https://glossary.magento.com/checkout). Previously, Magento displayed this message at the bottom of the checkout form.
 
-<!--- 56582, 56868-->* You can now save a product with images multiple times.
+<!--- 56582, 56868 -->
+*  You can now save a product with images multiple times.
 
-<!--- 57420/54320-->* The category page now shows the current price after Magento runs a scheduled update.  Previously, the category page would not update the  price after running a scheduled update. [GitHub-4945](https://github.com/magento/magento2/issues/4945)
+<!--- 57420/54320 -->
+*  The category page now shows the current price after Magento runs a scheduled update.  Previously, the category page would not update the  price after running a scheduled update. [GitHub-4945](https://github.com/magento/magento2/issues/4945)
 
-<!---56742-->* You can now sort and filter on the New Review page. [GitHub-5391](https://github.com/magento/magento2/issues/5391)
+<!---56742 -->
+*  You can now sort and filter on the New Review page. [GitHub-5391](https://github.com/magento/magento2/issues/5391)
 
-<!---58511-->* Magento now displays server-side Ajax error messages.
+<!---58511 -->
+*  Magento now displays server-side Ajax error messages.
 
-<!---56964-->* Magento now validates the uniqueness of product attribute values as you create or edit them. Previously, you could add identically named values to an attribute. [GitHub-4881](https://github.com/magento/magento2/issues/4881)
+<!---56964 -->
+*  Magento now validates the uniqueness of product attribute values as you create or edit them. Previously, you could add identically named values to an attribute. [GitHub-4881](https://github.com/magento/magento2/issues/4881)
 
-<!--- 62229-->* Magento now displays the price of out-of-stock products on the product page.
+<!--- 62229 -->
+*  Magento now displays the price of out-of-stock products on the product page.
 
-<!--- 58895-->* If you remove an item from the Compare Items list that is displayed on any [Category](https://glossary.magento.com/category) page, Magento no longer redirects you to the Compare Products page.
+<!--- 58895 -->
+*  If you remove an item from the Compare Items list that is displayed on any [Category](https://glossary.magento.com/category) page, Magento no longer redirects you to the Compare Products page.
 
-<!--- 72112-->* Subcategories no longer show up in the menu when the parent category is disabled or hidden from the menu. [GitHub-10664](https://github.com/magento/magento2/issues/10664)
+<!--- 72112 -->
+*  Subcategories no longer show up in the menu when the parent category is disabled or hidden from the menu. [GitHub-10664](https://github.com/magento/magento2/issues/10664)
 
-<!--- 57719-->* We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
+<!--- 57719 -->
+*  We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
 
-<!--- 63561-->* The product attribute `category_ids` can have only **Global** scope. Previously, you could change the scope value of `category_ids` to **Store**.
+<!--- 63561 -->
+*  The product attribute `category_ids` can have only **Global** scope. Previously, you could change the scope value of `category_ids` to **Store**.
 
-<!--- 53135-->* A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588), [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041),  [GitHub-6097](https://github.com/magento/magento2/issues/6097)
+<!--- 53135 -->
+*  A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588), [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041),  [GitHub-6097](https://github.com/magento/magento2/issues/6097)
 
-<!--- 56866-->* The prices you assign to custom options no longer change unexpectedly after you save them. [GitHub-6116](https://github.com/magento/magento2/issues/6116)
+<!--- 56866 -->
+*  The prices you assign to custom options no longer change unexpectedly after you save them. [GitHub-6116](https://github.com/magento/magento2/issues/6116)
 
-<!--- 50123-->* You can now create a blank attribute option using the drop-down input option on products that do not require an attribute. [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5485](https://github.com/magento/magento2/issues/5485), [GitHub-4910](https://github.com/magento/magento2/issues/4910)
+<!--- 50123 -->
+*  You can now create a blank attribute option using the drop-down input option on products that do not require an attribute. [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5485](https://github.com/magento/magento2/issues/5485), [GitHub-4910](https://github.com/magento/magento2/issues/4910)
 
-<!--- 54718-->* Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
+<!--- 54718 -->
+*  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
-<!---55346 -->* You can now successfully set an SKU mask to empty. Previously, when a product SKU mask was set to empty, Magento experienced problems loading the Product Add page. [GitHub-5618](https://github.com/magento/magento2/issues/5618)
+<!---55346  -->
+*  You can now successfully set an SKU mask to empty. Previously, when a product SKU mask was set to empty, Magento experienced problems loading the Product Add page. [GitHub-5618](https://github.com/magento/magento2/issues/5618)
 
-<!---47698 -->* Magento now correctly displays custom options at the store-view level. [GitHub-2908](https://github.com/magento/magento2/issues/2908), [GitHub-5885](https://github.com/magento/magento2/issues/5885), [GitHub-5612](https://github.com/magento/magento2/issues/5612)
+<!---47698  -->
+*  Magento now correctly displays custom options at the store-view level. [GitHub-2908](https://github.com/magento/magento2/issues/2908), [GitHub-5885](https://github.com/magento/magento2/issues/5885), [GitHub-5612](https://github.com/magento/magento2/issues/5612)
 
-<!---54648 -->* Magento now provides swatch input for the Admin Scope, and the attribute fall back mechanism now reverts to the default option value
+<!---54648  -->
+*  Magento now provides swatch input for the Admin Scope, and the attribute fall back mechanism now reverts to the default option value
  if no values are specified for specific store view. [GitHub-5143](https://github.com/magento/magento2/issues/5143), [GitHub-5142](https://github.com/magento/magento2/issues/5142)
 
-<!--- 57989 -->* You can now create a custom attribute for a category that successfully uploads a custom image. Previously, you could create the attribute, but could not save the image.
+<!--- 57989  -->
+*  You can now create a custom attribute for a category that successfully uploads a custom image. Previously, you could create the attribute, but could not save the image.
 
-<!--- 57023-->* Sorting configurable products by price now works as expected when a simple product has a special price. [GitHub-4778](https://github.com/magento/magento2/issues/4778)
+<!--- 57023 -->
+*  Sorting configurable products by price now works as expected when a simple product has a special price. [GitHub-4778](https://github.com/magento/magento2/issues/4778)
 
-<!--- 70987 -->* Magento no longer displays an error when you open a product with a Fixed Product Tax attribute enabled.
+<!--- 70987  -->
+*  Magento no longer displays an error when you open a product with a Fixed Product Tax attribute enabled.
 
-<!--- 59315-->* We've improved the process of using the WebAPI interface to save a product stock item. Previously, this type of save action worked inconsistently.
+<!--- 59315 -->
+*  We've improved the process of using the WebAPI interface to save a product stock item. Previously, this type of save action worked inconsistently.
 
-<!---57564 -->* You can no longer change or fake a product price from the Magento [storefront](https://glossary.magento.com/storefront) and then complete an order with that faked price.
+<!---57564  -->
+*  You can no longer change or fake a product price from the Magento [storefront](https://glossary.magento.com/storefront) and then complete an order with that faked price.
 
-<!--- 70750, 67618-->* View permissions to high-level product categories now work as expected. Previously, Magento displayed only the product categories that users who belonged to the NOT_LOGGED_IN customer group were permitted to view, no matter which user logged in. Additionally, a user restricted to browse a category could still see the category in the top-level navigation menu if the page were previously cached in FPC.
+<!--- 70750, 67618 -->
+*  View permissions to high-level product categories now work as expected. Previously, Magento displayed only the product categories that users who belonged to the NOT_LOGGED_IN customer group were permitted to view, no matter which user logged in. Additionally, a user restricted to browse a category could still see the category in the top-level navigation menu if the page were previously cached in FPC.
 
-<!---70877 -->* You can now successfully add a product to the compare list. Previously, when you tried to add a product to a compare list, Magento displayed an error.
+<!---70877  -->
+*  You can now successfully add a product to the compare list. Previously, when you tried to add a product to a compare list, Magento displayed an error.
 
-<!--- 70790-->* You can now remove custom options from simple products. Previously, when you tried to remove a custom option from a product, Magento did not remove the options, and displayed an error message.
+<!--- 70790 -->
+*  You can now remove custom options from simple products. Previously, when you tried to remove a custom option from a product, Magento did not remove the options, and displayed an error message.
 
-<!--- 62637-->* You can now successfully set the **Enable Product** attribute to **no**.
+<!--- 62637 -->
+*  You can now successfully set the **Enable Product** attribute to **no**.
 
-<!--- 61095-->* Magento no longer permits a shopper to place a re-order once you've disabled one of items in the order.
+<!--- 61095 -->
+*  Magento no longer permits a shopper to place a re-order once you've disabled one of items in the order.
 
-<!--- 64250-->* Fixed an issue that occurred in the Catalog Gallery on mobile displays when the `allowfullscreen` setting is enabled. *Fix submitted by community member Dennis van Schaik in pull request [8434](https://github.com/magento/magento2/pull/8434){: target="_blank"}.*
+<!--- 64250 -->
+*  Fixed an issue that occurred in the Catalog Gallery on mobile displays when the `allowfullscreen` setting is enabled. *Fix submitted by community member Dennis van Schaik in pull request [8434](https://github.com/magento/magento2/pull/8434){: target="_blank"}.*
 
-<!--- 64403-->* Magento now successfully loads re-ordered related products when Edge-Mode is activated. *Fix submitted by community member [@kirashet666](https://github.com/kirashet666){: target="_blank"} in pull request [8467](https://github.com/magento/magento2/pull/8467){: target="_blank"}.*
+<!--- 64403 -->
+*  Magento now successfully loads re-ordered related products when Edge-Mode is activated. *Fix submitted by community member [@kirashet666](https://github.com/kirashet666){: target="_blank"} in pull request [8467](https://github.com/magento/magento2/pull/8467){: target="_blank"}.*
 
-<!--- 64999 -->* Magento now displays cross-sells as expected when you use the `product/list/items.phtml` template. *Fix submitted by community member Koen V in pull request [8602](https://github.com/magento/magento2/pull/9662){: target="_blank"}.*
+<!--- 64999  -->
+*  Magento now displays cross-sells as expected when you use the `product/list/items.phtml` template. *Fix submitted by community member Koen V in pull request [8602](https://github.com/magento/magento2/pull/9662){: target="_blank"}.*
 
-<!--- 65364-->* Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
+<!--- 65364 -->
+*  Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
 
-<!--- 65334-->*  Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
+<!--- 65334 -->
+*   Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
 
-<!--- 69297-->* Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
+<!--- 69297 -->
+*  Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
 
-<!---70256 -->* You can now create an `etc/view.xml` file containing an `images` tag with an attribute `module`. *Fix submitted by community member Marius Strajeru in pull request [10052](https://github.com/magento/magento2/pull/10052){: target="_blank"}.*
+<!---70256  -->
+*  You can now create an `etc/view.xml` file containing an `images` tag with an attribute `module`. *Fix submitted by community member Marius Strajeru in pull request [10052](https://github.com/magento/magento2/pull/10052){: target="_blank"}.*
 
-<!--- 70345-->* Magento now displays the Category selection UI under Conditions when you select a rule for editing. *Fix submitted by community member duckchip in pull request [10094](https://github.com/magento/magento2/pull/10094){: target="_blank"}.*
+<!--- 70345 -->
+*  Magento now displays the Category selection UI under Conditions when you select a rule for editing. *Fix submitted by community member duckchip in pull request [10094](https://github.com/magento/magento2/pull/10094){: target="_blank"}.*
 
-<!--- 63062-->* Magento now displays the correct image when you switch between a configurable product's options. Previously, Magento loaded product images from a different product.
+<!--- 63062 -->
+*  Magento now displays the correct image when you switch between a configurable product's options. Previously, Magento loaded product images from a different product.
 
-<!--- 66885-->* The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
+<!--- 66885 -->
+*  The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
 
-<!--- 63601-->*  The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
+<!--- 63601 -->
+*   The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
 
-<!--- 62426-->* Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
+<!--- 62426 -->
+*  Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
 
-<!--- 71445-->*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+<!--- 71445 -->
+*   Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
-<!--- 61826-->*  Magento no longer throws an error when you try to save a product with imported custom options.
+<!--- 61826 -->
+*   Magento no longer throws an error when you try to save a product with imported custom options.
 
-<!--- 62468-->*  Magento now displays the product price even when the product is out-of-stock.
+<!--- 62468 -->
+*   Magento now displays the product price even when the product is out-of-stock.
 
-<!--- 64710-->*  `productWebsiteLink` no longer deletes a product’s custom origins.
+<!--- 64710 -->
+*   `productWebsiteLink` no longer deletes a product’s custom origins.
 
-<!--- 56943-->*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+<!--- 56943 -->
+*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
-<!--- 52577-->* Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
+<!--- 52577 -->
+*  Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
 
-<!--- 60613-->* When you edit a widget’s  existing condition, Magento now loads the SKU grid with all available SKUs. [GitHub-6985](https://github.com/magento/magento2/issues/6985)
+<!--- 60613 -->
+*  When you edit a widget’s  existing condition, Magento now loads the SKU grid with all available SKUs. [GitHub-6985](https://github.com/magento/magento2/issues/6985)
 
-<!--- 60602-->* Combine rule conditions now work as expected for product list  widgets. [GitHub-7274](https://github.com/magento/magento2/issues/7274)
+<!--- 60602 -->
+*  Combine rule conditions now work as expected for product list  widgets. [GitHub-7274](https://github.com/magento/magento2/issues/7274)
 
-<!--- 59256-->* Component Manager now handles custom Composer modules. Previously, when you tried to install a custom extension using **System > Tools > Web Setup > Component Manager**, Magento displayed the spinning widget indefinitely. [GitHub-6718](https://github.com/magento/magento2/issues/6718)
+<!--- 59256 -->
+*  Component Manager now handles custom Composer modules. Previously, when you tried to install a custom extension using **System > Tools > Web Setup > Component Manager**, Magento displayed the spinning widget indefinitely. [GitHub-6718](https://github.com/magento/magento2/issues/6718)
 
-<!--- 59234-->* We’ve fixed an issue with sorting products by tier price. Previously, if you enabled the Used for Sorting in Product Listing field in the Edit Tier Price Attribute page. and then selected sort by tier price on the storefront, Magento displayed an error message. [GitHub-6751](https://github.com/magento/magento2/issues/6751)
+<!--- 59234 -->
+*  We’ve fixed an issue with sorting products by tier price. Previously, if you enabled the Used for Sorting in Product Listing field in the Edit Tier Price Attribute page. and then selected sort by tier price on the storefront, Magento displayed an error message. [GitHub-6751](https://github.com/magento/magento2/issues/6751)
 
-<!--- 59130 -->* Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
+<!--- 59130  -->
+*  Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
 
-<!--- 58053 -->* Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
+<!--- 58053  -->
+*  Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
 
-<!--- 58290 -->* Magento no longer adds an empty product option to each PUT request. Previously, Magento added an empty option even when the options array was empty. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
+<!--- 58290  -->
+*  Magento no longer adds an empty product option to each PUT request. Previously, Magento added an empty option even when the options array was empty. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
 
 ### Configurable products
 
-<!---57055-->*  You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
+<!---57055 -->
+*   You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
 
-<!---56998 -->* Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
+<!---56998  -->
+*  Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
 
-<!---54808 -->* You can now edit a product attribute for multiple configurable products. Previously, when you tried to bulk-edit an attribute on a collection of filtered, configurable products, Magento would complete the process without incorporating your edits, and then incorrectly tell you that the products had been edited.
+<!---54808  -->
+*  You can now edit a product attribute for multiple configurable products. Previously, when you tried to bulk-edit an attribute on a collection of filtered, configurable products, Magento would complete the process without incorporating your edits, and then incorrectly tell you that the products had been edited.
 
-<!---60605-->* Magento no longer throws an [exception](https://glossary.magento.com/exception) when you add a configurable product by [SKU](https://glossary.magento.com/sku) if an associated simple product is out-of-stock.
+<!---60605 -->
+*  Magento no longer throws an [exception](https://glossary.magento.com/exception) when you add a configurable product by [SKU](https://glossary.magento.com/sku) if an associated simple product is out-of-stock.
 
-<!---61055-->* Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
+<!---61055 -->
+*  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
 
-<!---57044-->* A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588),  [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041), [GitHub-6097](https://github.com/magento/magento2/issues/6097)
+<!---57044 -->
+*  A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588),  [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041), [GitHub-6097](https://github.com/magento/magento2/issues/6097)
 
-<!--- 65339 -->* The check that Magento runs to confirm a configurable product's readiness for sale is now faster.  (The `isSalable` method checks that a [configurable product](https://glossary.magento.com/configurable-product) can be sold (that is, is in a salable state)).
+<!--- 65339  -->
+*  The check that Magento runs to confirm a configurable product's readiness for sale is now faster.  (The `isSalable` method checks that a [configurable product](https://glossary.magento.com/configurable-product) can be sold (that is, is in a salable state)).
 
-<!--- 65247 -->* Query optimizations have improved the speed of configurable product price calculation.
+<!--- 65247  -->
+*  Query optimizations have improved the speed of configurable product price calculation.
 
-<!--- 65246 -->*  Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
+<!--- 65246  -->
+*   Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
 
-<!--- 56951-->* Magento now displays configurable products as expected after creation.
+<!--- 56951 -->
+*  Magento now displays configurable products as expected after creation.
 
-<!--- 70346-->* Magento no longer displays a configurable product on the storefront when its child products are deleted and the **show out-of-stock** setting is set to **No**.
+<!--- 70346 -->
+*  Magento no longer displays a configurable product on the storefront when its child products are deleted and the **show out-of-stock** setting is set to **No**.
 
-<!--- 71656-->* Configurable products no longer show up on category page when all children are set to **enable product = No** and **display out-of-stock products = Off**.
+<!--- 71656 -->
+*  Configurable products no longer show up on category page when all children are set to **enable product = No** and **display out-of-stock products = Off**.
 
-<!---59879-->* Magento no longer displays the **as low as** label for a disabled price on the Category page.
+<!---59879 -->
+*  Magento no longer displays the **as low as** label for a disabled price on the Category page.
 
-<!---60098-->* The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
+<!---60098 -->
+*  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
-<!---52717-->*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+<!---52717 -->
+*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
-<!---60483-->* Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
+<!---60483 -->
+*  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
 
-<!--- 61058-->* Magento now displays the correct drop-down option labels for configurable products when using attributes with custom source.
+<!--- 61058 -->
+*  Magento now displays the correct drop-down option labels for configurable products when using attributes with custom source.
 
-<!--- 63014-->* Magento now shows the correct price of a configurable product based in installations that run multiple websites.
+<!--- 63014 -->
+*  Magento now shows the correct price of a configurable product based in installations that run multiple websites.
 
-<!--- 54653-->* We’ve improved the performance of Magento installations that contain configurable products with many (1600+) options.
+<!--- 54653 -->
+*  We’ve improved the performance of Magento installations that contain configurable products with many (1600+) options.
 
-<!--- 56591-->* We’ve resolved some issues with the display of configurable products on the Magento frontend after product creation.
+<!--- 56591 -->
+*  We’ve resolved some issues with the display of configurable products on the Magento frontend after product creation.
 
-<!--- 59307-->* Magento now displays only the set price for a configurable product, not its set price and “as low as” price. Previously, Magento showed both prices if a minimum price was not configured.
+<!--- 59307 -->
+*  Magento now displays only the set price for a configurable product, not its set price and “as low as” price. Previously, Magento showed both prices if a minimum price was not configured.
 
-<!---61596 -->* Magento no longer removes the simple products associated with a configurable product if you click on the **Save** button more than once while saving the configurable product. Previously, if you clicked on **Save** more than once during an attempt to save a configurable product, Magento removed the simple products that were assigned to it.
+<!---61596  -->
+*  Magento no longer removes the simple products associated with a configurable product if you click on the **Save** button more than once while saving the configurable product. Previously, if you clicked on **Save** more than once during an attempt to save a configurable product, Magento removed the simple products that were assigned to it.
 
-<!---64221 -->* Special prices now display correctly for future discounts [GitHub-8375](https://github.com/magento/magento2/issues/8375)
+<!---64221  -->
+*  Special prices now display correctly for future discounts [GitHub-8375](https://github.com/magento/magento2/issues/8375)
 
-<!---52925 -->* Magento no longer applies one simple product's special price to another simple product of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
+<!---52925  -->
+*  Magento no longer applies one simple product's special price to another simple product of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
 
-<!---59512 -->* Magento now shows the correct product price for products that you add to the wish list from the category page. [GitHub-6866](https://github.com/magento/magento2/issues/6866)
+<!---59512  -->
+*  Magento now shows the correct product price for products that you add to the wish list from the category page. [GitHub-6866](https://github.com/magento/magento2/issues/6866)
 
-<!---57279 -->* Users no longer lose configurable product data when you change the interface locale to Chinese (China) or Arabic (Egypt).
+<!---57279  -->
+*  Users no longer lose configurable product data when you change the interface locale to Chinese (China) or Arabic (Egypt).
 
-<!---59649-->*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+<!---59649 -->
+*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
 ### Email
 
-<!---57496-->* Magento now successfully loads the New Order Email templates. [GitHub-5101](https://github.com/magento/magento2/issues/5101)
+<!---57496 -->
+*  Magento now successfully loads the New Order Email templates. [GitHub-5101](https://github.com/magento/magento2/issues/5101)
 
-<!---57204 -->* The **Send Welcome Email From** field now identifies the store that the customer is associated with.
+<!---57204  -->
+*  The **Send Welcome Email From** field now identifies the store that the customer is associated with.
 
-<!---59146 -->* Magento no longer sends email when the **Disable email communication** setting is set to **yes**. Previously, Magento sent email even when this setting was enabled. [GitHub-5988](https://github.com/magento/magento2/issues/5988)
+<!---59146  -->
+*  Magento no longer sends email when the **Disable email communication** setting is set to **yes**. Previously, Magento sent email even when this setting was enabled. [GitHub-5988](https://github.com/magento/magento2/issues/5988)
 
 ### Frameworks
 
-<!--- 60611-->* Static file generation is no longer affected by a race condition that affected merging CSS files. Previously, this race condition interfered with the proper generation of the product frontend.
+<!--- 60611 -->
+*  Static file generation is no longer affected by a race condition that affected merging CSS files. Previously, this race condition interfered with the proper generation of the product frontend.
 
-<!---71257 -->* The ability to disable module output has been removed from Admin. If you disabled module output from Admin in a previous release, you must manually configure these settings. See [Disable module output]({{ page.baseurl }}/config-guide/config/disable-module-output.html) for details.
+<!---71257  -->
+*  The ability to disable module output has been removed from Admin. If you disabled module output from Admin in a previous release, you must manually configure these settings. See [Disable module output]({{ page.baseurl }}/config-guide/config/disable-module-output.html) for details.
 
-<!---69868 -->* Static tests run in a Windows environment no longer fail due to file path mismatches. *Fix submitted by community member barbazul in pull request [9902](https://github.com/magento/magento2/pull/9902){: target="_blank"}.*
+<!---69868  -->
+*  Static tests run in a Windows environment no longer fail due to file path mismatches. *Fix submitted by community member barbazul in pull request [9902](https://github.com/magento/magento2/pull/9902){: target="_blank"}.*
 
-<!---56947 -->* You can now link a simple product to a configurable one. Previously, when you tried to use REST to link a simple product  to a configurable one, the products were not linked even though Magento responded, `Status Code: 200 OK`.
+<!---56947  -->
+*  You can now link a simple product to a configurable one. Previously, when you tried to use REST to link a simple product  to a configurable one, the products were not linked even though Magento responded, `Status Code: 200 OK`.
 
-<!---57995 -->* Videos now play as expected on simple products as they do  for configurable products. Previously, simple product videos were displayed as thumbnail images only.[GitHub-6360](https://github.com/magento/magento2/issues/6360)
+<!---57995  -->
+*  Videos now play as expected on simple products as they do  for configurable products. Previously, simple product videos were displayed as thumbnail images only.[GitHub-6360](https://github.com/magento/magento2/issues/6360)
 
-<!---63154 -->* Magento now displays special characters in store names in email subject lines. Previously, special characters in the store name were converted to numerical character references in the email subject field. [GitHub-8094](https://github.com/magento/magento2/issues/8094)
+<!---63154  -->
+*  Magento now displays special characters in store names in email subject lines. Previously, special characters in the store name were converted to numerical character references in the email subject field. [GitHub-8094](https://github.com/magento/magento2/issues/8094)
 
-<!---69633 -->* Configuration paths `persistent_identifier` & `compression_threshold` for Redis Sessions have been corrected. *Fix submitted by community member Luke Hanley in pull request [9368](https://github.com/magento/magento2/pull/9368){: target="_blank"}.*
+<!---69633  -->
+*  Configuration paths `persistent_identifier` & `compression_threshold` for Redis Sessions have been corrected. *Fix submitted by community member Luke Hanley in pull request [9368](https://github.com/magento/magento2/pull/9368){: target="_blank"}.*
 
 #### Admin framework
 
-<!--- 57805 -->* You can no longer delete a currently logged-in user.
+<!--- 57805  -->
+*  You can no longer delete a currently logged-in user.
 
-<!--- 57629 -->* Inline editing in Admin now includes ACL checks. Previously, the Quick Edit editor did not respect permissions.
+<!--- 57629  -->
+*  Inline editing in Admin now includes ACL checks. Previously, the Quick Edit editor did not respect permissions.
 
 #### Application framework
 
-<!--- 64901 -->* Magento now supports new top level domains for email addresses. [GitHub-4547](https://github.com/magento/magento2/issues/4547)
+<!--- 64901  -->
+*  Magento now supports new top level domains for email addresses. [GitHub-4547](https://github.com/magento/magento2/issues/4547)
 
-<!--- 70010 -->* Page titles in layout files are not translatable. *Fix submitted by community member Anton Evers in pull request [9992](https://github.com/magento/magento2/pull/9992){: target="_blank"}.*
+<!--- 70010  -->
+*  Page titles in layout files are not translatable. *Fix submitted by community member Anton Evers in pull request [9992](https://github.com/magento/magento2/pull/9992){: target="_blank"}.*
 
-<!--- 67500 -->* The `setup:static-content:deploy`, `setup:di:compile` and `deploy:mode:set` commands now return non-zero exit code if an error occurs. *Fix submitted by community member Pablo Ivulic in pull request [7780](https://github.com/magento/magento2/pull/7780){: target="_blank"}.*
+<!--- 67500  -->
+*  The `setup:static-content:deploy`, `setup:di:compile` and `deploy:mode:set` commands now return non-zero exit code if an error occurs. *Fix submitted by community member Pablo Ivulic in pull request [7780](https://github.com/magento/magento2/pull/7780){: target="_blank"}.*
 
-<!--- 67408-->* We've changed the `select` protected property to `query` in the AbstractSearchResult class. *Fix submitted by community member Alex Gusev in pull request [5043](https://github.com/magento/magento2/pull/5043){: target="_blank"}.*
+<!--- 67408 -->
+*  We've changed the `select` protected property to `query` in the AbstractSearchResult class. *Fix submitted by community member Alex Gusev in pull request [5043](https://github.com/magento/magento2/pull/5043){: target="_blank"}.*
 
-<!---67260-->* `\Magento\Framework\Interception\Code\Generator\Interceptor` now supports interceptors for generating for methods that return references. [GitHub-9167](https://github.com/magento/magento2/issues/9167)
+<!---67260 -->
+*  `\Magento\Framework\Interception\Code\Generator\Interceptor` now supports interceptors for generating for methods that return references. [GitHub-9167](https://github.com/magento/magento2/issues/9167)
 
-<!---58394-->* The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [(GITHUB-6442)](https://github.com/magento/magento2/issues/6442){: target="_blank"}
+<!---58394 -->
+*  The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [(GITHUB-6442)](https://github.com/magento/magento2/issues/6442){: target="_blank"}
 
 #### Configuration framework
 
-<!--- 65003 -->* The currency setup in Admin no longer throws an `in_array` error when a single value is selected. *Fix submitted by community member Derik Nel in pull request [8077](https://github.com/magento/magento2/pull/8077){: target="_blank"}.*
+<!--- 65003  -->
+*  The currency setup in Admin no longer throws an `in_array` error when a single value is selected. *Fix submitted by community member Derik Nel in pull request [8077](https://github.com/magento/magento2/pull/8077){: target="_blank"}.*
 
-<!--- 65422 -->* Magento now writes all default configuration values to the `config.php` file.
+<!--- 65422  -->
+*  Magento now writes all default configuration values to the `config.php` file.
 
 #### JavaScript framework
 
-<!--- 71180 -->*  Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
+<!--- 71180  -->
+*   Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
 
-<!--- 58285 -->* Magento now displays server-side Ajax error messages.
+<!--- 58285  -->
+*  Magento now displays server-side Ajax error messages.
 
-<!--- 69674 -->* JavaScript mixins now work when you add a `urlArgs` argument to a `require_js` file. *Fix submitted by community member James Reed in pull request [9665](https://github.com/magento/magento2/pull/9665){: target="_blank"}.*
+<!--- 69674  -->
+*  JavaScript mixins now work when you add a `urlArgs` argument to a `require_js` file. *Fix submitted by community member James Reed in pull request [9665](https://github.com/magento/magento2/pull/9665){: target="_blank"}.*
 
 #### Session framework
 
-<!--- 57118 -->* The Magento storefront and Admin panel no longer share form keys. Previously, if a user were navigating both a storefront and  the Admin simultaneously,  he would be unexpectedly redirected to the Admin dashboard. [GitHub-6201](https://github.com/magento/magento2/issues/6201)
+<!--- 57118  -->
+*  The Magento storefront and Admin panel no longer share form keys. Previously, if a user were navigating both a storefront and  the Admin simultaneously,  he would be unexpectedly redirected to the Admin dashboard. [GitHub-6201](https://github.com/magento/magento2/issues/6201)
 
 #### Zend framework
 
 Thanks to our hardworking Magento Open Source community members for the following contributions!
 
-<!--- 67511-->* We’ve removed  `Zend_Json` from Magento Theme and replaced it with a new serializer class. *Fix submitted by community member David Manners in pull request [9262](https://github.com/magento/magento2/pull/9262){: target="_blank"}.*
+<!--- 67511 -->
+*  We’ve removed  `Zend_Json` from Magento Theme and replaced it with a new serializer class. *Fix submitted by community member David Manners in pull request [9262](https://github.com/magento/magento2/pull/9262){: target="_blank"}.*
 
-<!--- 67510-->* We’ve removed `Zend_Json` from the Weee module. *Fix submitted by community member David Manners We’ve removed pull request [9261](https://github.com/magento/magento2/pull/9261){: target="_blank"}.*
+<!--- 67510 -->
+*  We’ve removed `Zend_Json` from the Weee module. *Fix submitted by community member David Manners We’ve removed pull request [9261](https://github.com/magento/magento2/pull/9261){: target="_blank"}.*
 
-<!--- 69369-->* We’ve replaced the direct usage of `Zend_Json` with a call to the `Json_Help` class. *Fix submitted by community member David Manners in pull request [9344](https://github.com/magento/magento2/pull/9344){: target="_blank"}.*
+<!--- 69369 -->
+*  We’ve replaced the direct usage of `Zend_Json` with a call to the `Json_Help` class. *Fix submitted by community member David Manners in pull request [9344](https://github.com/magento/magento2/pull/9344){: target="_blank"}.*
 
-<!--- 69451-->* We’ve replaced  `Zend_Json` in the configurable product block test. *Fix submitted by community member David Manners in pull request [9753](https://github.com/magento/magento2/pull/9753){: target="_blank"}.*
+<!--- 69451 -->
+*  We’ve replaced  `Zend_Json` in the configurable product block test. *Fix submitted by community member David Manners in pull request [9753](https://github.com/magento/magento2/pull/9753){: target="_blank"}.*
 
-<!--- 69452-->* We’ve removed `Zend_Json` from form elements. *Fix submitted by community member David Manners in pull request [9754](https://github.com/magento/magento2/pull/9754){: target="_blank"}.*
+<!--- 69452 -->
+*  We’ve removed `Zend_Json` from form elements. *Fix submitted by community member David Manners in pull request [9754](https://github.com/magento/magento2/pull/9754){: target="_blank"}.*
 
-<!--- 69371-->* We’ve replaced the Magento Framework's `Zend_Session` interface usage with SessionHandlerInterface. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
+<!--- 69371 -->
+*  We’ve replaced the Magento Framework's `Zend_Session` interface usage with SessionHandlerInterface. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
 
-<!--- 69157-->* We’ve removed `Zend_Wildfire` and `Zend_Controller` from the codebase. *Fix submitted by community member Isolde in pull request [9622](https://github.com/magento/magento2/pull/9622){: target="_blank"}.*
+<!--- 69157 -->
+*  We’ve removed `Zend_Wildfire` and `Zend_Controller` from the codebase. *Fix submitted by community member Isolde in pull request [9622](https://github.com/magento/magento2/pull/9622){: target="_blank"}.*
 
-<!--- 69152-->* We've resolved issues with selecting widgets in TinyMCE. [GitHub-9655](https://github.com/magento/magento2/issues/9655), [GitHub-9518](https://github.com/magento/magento2/issues/9518) *Fixes submitted by community member Pieter Hoste in pull request [9540](https://github.com/magento/magento2/pull/9540){: target="_blank"} and community member Bernhard in pull request [9711](https://github.com/magento/magento2/pull/9711){: target="_blank"}.*
+<!--- 69152 -->
+*  We've resolved issues with selecting widgets in TinyMCE. [GitHub-9655](https://github.com/magento/magento2/issues/9655), [GitHub-9518](https://github.com/magento/magento2/issues/9518) *Fixes submitted by community member Pieter Hoste in pull request [9540](https://github.com/magento/magento2/pull/9540){: target="_blank"} and community member Bernhard in pull request [9711](https://github.com/magento/magento2/pull/9711){: target="_blank"}.*
 
-<!--- 69591-->* We’ve replaced `Zend_Log` with `Psr\Log\LoggerInterface`. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
+<!--- 69591 -->
+*  We’ve replaced `Zend_Log` with `Psr\Log\LoggerInterface`. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
 
-<!--- 68770-->* Magento no longer throws a `Zend_Db_Statement_Exception` when a user opens an empty Category page. *Fix submitted by community member adrian-martinez-interactiv4 in pull request [9400](https://github.com/magento/magento2/pull/9400){: target="_blank"}.*
+<!--- 68770 -->
+*  Magento no longer throws a `Zend_Db_Statement_Exception` when a user opens an empty Category page. *Fix submitted by community member adrian-martinez-interactiv4 in pull request [9400](https://github.com/magento/magento2/pull/9400){: target="_blank"}.*
 
 ### General fixes
 
-<!--- 56892-->*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+<!--- 56892 -->
+*   You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
-<!--- 56126 -->* You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
+<!--- 56126  -->
+*  You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
 
-<!--- 55462/52448-->* Magento now correctly displays customer address during account creation. Previously, when you selected a default billing address during creation of a new customer account, Magento would not display the address.
+<!--- 55462/52448 -->
+*  Magento now correctly displays customer address during account creation. Previously, when you selected a default billing address during creation of a new customer account, Magento would not display the address.
 
-<!--- 60890 -->* Admin users with restricted permissions can now log in successfully as determined by those permissions. Previously, Magento displayed a fatal error when you logged in under these conditions.
+<!--- 60890  -->
+*  Admin users with restricted permissions can now log in successfully as determined by those permissions. Previously, Magento displayed a fatal error when you logged in under these conditions.
 
-<!---55662-->* We've removed the duplicated [PHP](https://glossary.magento.com/php) settings from the sample web server configuration files.
+<!---55662 -->
+*  We've removed the duplicated [PHP](https://glossary.magento.com/php) settings from the sample web server configuration files.
 
-<!---57187-->*  When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
+<!---57187 -->
+*   When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
 
-<!---57351-->* We've removed the sample password from the Setup Wizard.
+<!---57351 -->
+*  We've removed the sample password from the Setup Wizard.
 
-<!---56973-->* You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
+<!---56973 -->
+*  You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
 
-<!---58500-->* The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [GitHub-6442](https://github.com/magento/magento2/issues/6442)
+<!---58500 -->
+*  The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [GitHub-6442](https://github.com/magento/magento2/issues/6442)
 
-<!---57035-->* You can now upload changes to the `robots.txt` file from the Admin panel.
+<!---57035 -->
+*  You can now upload changes to the `robots.txt` file from the Admin panel.
 
-<!---57197-->* We've eliminated difficulties saving product information when logged in as Admin. Previously, the Product Save feature worked erratically for Admin users.
+<!---57197 -->
+*  We've eliminated difficulties saving product information when logged in as Admin. Previously, the Product Save feature worked erratically for Admin users.
 
-<!---59397-->* Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
+<!---59397 -->
+*  Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
 
-<!--- 60248-->* Information set by the **Default Billing Address** and **Default Shipping Address** checkboxes on the Customer page are now saved correctly.
+<!--- 60248 -->
+*  Information set by the **Default Billing Address** and **Default Shipping Address** checkboxes on the Customer page are now saved correctly.
 
-<!---59416 -->* [Admin](https://glossary.magento.com/admin) users with appropriate permissions can now reset the passwords of more than one customer at a time. [GitHub-5260](https://github.com/magento/magento2/issues/5260)
+<!---59416  -->
+*  [Admin](https://glossary.magento.com/admin) users with appropriate permissions can now reset the passwords of more than one customer at a time. [GitHub-5260](https://github.com/magento/magento2/issues/5260)
 
-<!---59142 -->* Admin interface forms now load data as expected after initializing all components. Previously, under certain conditions, the load indicator would spin indefinitely, and Magento would not load data.
+<!---59142  -->
+*  Admin interface forms now load data as expected after initializing all components. Previously, under certain conditions, the load indicator would spin indefinitely, and Magento would not load data.
 
-<!---59810 -->* Showing reports on the **Reports > Coupons** page no longer throws an error when the user is in a non-default Admin locale.  [GitHub-7037](https://github.com/magento/magento2/issues/7037)
+<!---59810  -->
+*  Showing reports on the **Reports > Coupons** page no longer throws an error when the user is in a non-default Admin locale.  [GitHub-7037](https://github.com/magento/magento2/issues/7037)
 
-<!---70318 -->* You can now generate static content without a database connection. [GitHub-10041](https://github.com/magento/magento2/issues/10041)
+<!---70318  -->
+*  You can now generate static content without a database connection. [GitHub-10041](https://github.com/magento/magento2/issues/10041)
 
-<!--- 60185 -->* Static content deployment now generates secure content, whether content included secure or non-secure URLs.
+<!--- 60185  -->
+*  Static content deployment now generates secure content, whether content included secure or non-secure URLs.
 
-<!--- 56062 -->* The Recently Viewed Products block now appears as expected when the full page cache is enabled. [GitHub-3890](https://github.com/magento/magento2/issues/3890)
+<!--- 56062  -->
+*  The Recently Viewed Products block now appears as expected when the full page cache is enabled. [GitHub-3890](https://github.com/magento/magento2/issues/3890)
 
-<!--- 56077 -->* We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
+<!--- 56077  -->
+*  We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
 
-<!--- 52850-->* Widgets now accept UTF-8 special characters type as input parameters. Previously, you could successfully create a widget, but UTF-8 special characters were broken. [GitHub-4232](https://github.com/magento/magento2/issues/4232) *Fix submitted by community member Pieter Hoste in pull request [9333](https://github.com/magento/magento2/pull/9333){: target="_blank"}.*
+<!--- 52850 -->
+*  Widgets now accept UTF-8 special characters type as input parameters. Previously, you could successfully create a widget, but UTF-8 special characters were broken. [GitHub-4232](https://github.com/magento/magento2/issues/4232) *Fix submitted by community member Pieter Hoste in pull request [9333](https://github.com/magento/magento2/pull/9333){: target="_blank"}.*
 
-<!--- 71415-->* Mass actions now work as expected on the Customer grid. Previously, Magento could not process more than 20 items at a time.
+<!--- 71415 -->
+*  Mass actions now work as expected on the Customer grid. Previously, Magento could not process more than 20 items at a time.
 
-<!--- 71179 -->* Customers who subscribe to a newsletter are now subscribed as expected after confirming their account. Previously, Magento unsubscribed customers from the newsletter after confirming their account.
+<!--- 71179  -->
+*  Customers who subscribe to a newsletter are now subscribed as expected after confirming their account. Previously, Magento unsubscribed customers from the newsletter after confirming their account.
 
-<!--- 56778 -->* You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+<!--- 56778  -->
+*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
-<!--- 54725-->* You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
+<!--- 54725 -->
+*  You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
 
-<!--- 59785-->* Magento no longer generates incorrect URLs in the site map when the **Use Secure URLs in Admin** setting is set to **Yes**. [GitHub-8644](https://github.com/magento/magento2/issues/8644)
+<!--- 59785 -->
+*  Magento no longer generates incorrect URLs in the site map when the **Use Secure URLs in Admin** setting is set to **Yes**. [GitHub-8644](https://github.com/magento/magento2/issues/8644)
 
-<!--- 69606-->* We’ve resolved a conflict that occurred after you changed a base URL. Previously, after you changed a `base_url` value (**Stores->Configuration > General > Web > Base URLs (Secure)**), Magento would update the base URL, then resubscribe, potentially resulting in a failure during the next update secure `base_url` call.
+<!--- 69606 -->
+*  We’ve resolved a conflict that occurred after you changed a base URL. Previously, after you changed a `base_url` value (**Stores->Configuration > General > Web > Base URLs (Secure)**), Magento would update the base URL, then resubscribe, potentially resulting in a failure during the next update secure `base_url` call.
 
-<!--- 70683-->* Magento now displays newly registered customers in the Admin customer list as expected.
+<!--- 70683 -->
+*  Magento now displays newly registered customers in the Admin customer list as expected.
 
-<!--- 67619-->* The Customer Segment page no longer shows non-matching customers when a customer logs in and you refresh the Customer Segment page.
+<!--- 67619 -->
+*  The Customer Segment page no longer shows non-matching customers when a customer logs in and you refresh the Customer Segment page.
 
-<!--- 67048-->* You can now add a `translate` attribute to any String argument in the `di.xml` file for any class. This attribute provides an ability on the level of dependency injection configuration to specify that an argument can be translated. The actual translation of strings is handled by another Magento component.
+<!--- 67048 -->
+*  You can now add a `translate` attribute to any String argument in the `di.xml` file for any class. This attribute provides an ability on the level of dependency injection configuration to specify that an argument can be translated. The actual translation of strings is handled by another Magento component.
 
-<!--- 59322-->* Magento frontend scope filters now work as expected. Previously, Magento did not reload product information correctly when you applied a filter using **Catalog > Product**.
+<!--- 59322 -->
+*  Magento frontend scope filters now work as expected. Previously, Magento did not reload product information correctly when you applied a filter using **Catalog > Product**.
 
-<!--- 58298-->* Only users with permission to view a store can view or process the orders placed on it.
+<!--- 58298 -->
+*  Only users with permission to view a store can view or process the orders placed on it.
 
-<!--- 63736-->* You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
+<!--- 63736 -->
+*  You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
 
-<!--- 65000-->* Fixed the location of the `wishlist.js` file. *Fix submitted by community member [Koen V.](https://github.com/koenner01){: target="_blank"} in pull request [8633](https://github.com/magento/magento2/pull/8633){: target="_blank"}.*
+<!--- 65000 -->
+*  Fixed the location of the `wishlist.js` file. *Fix submitted by community member [Koen V.](https://github.com/koenner01){: target="_blank"} in pull request [8633](https://github.com/magento/magento2/pull/8633){: target="_blank"}.*
 
-<!--- 66506-->* You can no longer download products  after you’ve set order state to `STATE_CANCELED`.  *Fix submitted by community member nazarpadalka in pull request [8917](https://github.com/magento/magento2/pull/8917){: target="_blank"}.*
+<!--- 66506 -->
+*  You can no longer download products  after you’ve set order state to `STATE_CANCELED`.  *Fix submitted by community member nazarpadalka in pull request [8917](https://github.com/magento/magento2/pull/8917){: target="_blank"}.*
 
-<!--- 66232-->* Fixed a typo in the Pull Request Template. *Fix submitted by community member tomislavsantek in pull request [8908](https://github.com/magento/magento2/pull/8908){: target="_blank"}.*
+<!--- 66232 -->
+*  Fixed a typo in the Pull Request Template. *Fix submitted by community member tomislavsantek in pull request [8908](https://github.com/magento/magento2/pull/8908){: target="_blank"}.*
 
-<!--- 66694-->* You now receive an error message as expected if you try to submit a product review while not logged in. *Fix submitted by community member quienti in pull request [9001](https://github.com/magento/magento2/pull/9001){: target="_blank"}.*
+<!--- 66694 -->
+*  You now receive an error message as expected if you try to submit a product review while not logged in. *Fix submitted by community member quienti in pull request [9001](https://github.com/magento/magento2/pull/9001){: target="_blank"}.*
 
-<!--- 67042-->* Fixed grammar error in the customer dashboard. *Fix submitted by community member Petar Sambolek in pull request [9080](https://github.com/magento/magento2/pull/9080){: target="_blank"}.*
+<!--- 67042 -->
+*  Fixed grammar error in the customer dashboard. *Fix submitted by community member Petar Sambolek in pull request [9080](https://github.com/magento/magento2/pull/9080){: target="_blank"}.*
 
-<!--- 67320-->* The popup window in the Safari browser now closes properly. *Fix submitted by community member Hans Schouten in pull request [8824](https://github.com/magento/magento2/pull/8824){: target="_blank"}.*
+<!--- 67320 -->
+*  The popup window in the Safari browser now closes properly. *Fix submitted by community member Hans Schouten in pull request [8824](https://github.com/magento/magento2/pull/8824){: target="_blank"}.*
 
-<!--- 67054-->* We've fixed minor performance issues when you use `/pub` as `docroot`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
+<!--- 67054 -->
+*  We've fixed minor performance issues when you use `/pub` as `docroot`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
 
-<!--- 70310-->* The Actions dropdown menu is now properly aligned in the Admin when the action column is not the last column. *Fix submitted by community member Marius Strajeru in pull request [10082](https://github.com/magento/magento2/pull/10082){: target="_blank"}.*
+<!--- 70310 -->
+*  The Actions dropdown menu is now properly aligned in the Admin when the action column is not the last column. *Fix submitted by community member Marius Strajeru in pull request [10082](https://github.com/magento/magento2/pull/10082){: target="_blank"}.*
 
-<!--- 70029-->* Magento now deletes pending entries in `cron_schedule` when you reconfigure a cron job. *Fix submitted by community member Anton Evers in pull request [9957](https://github.com/magento/magento2/pull/9957){: target="_blank"}.*
+<!--- 70029 -->
+*  Magento now deletes pending entries in `cron_schedule` when you reconfigure a cron job. *Fix submitted by community member Anton Evers in pull request [9957](https://github.com/magento/magento2/pull/9957){: target="_blank"}.*
 
-<!--- 69886-->* We’ve fixed the cron timestamp method. *Fix submitted by community member Anton Evers in pull request [9943](https://github.com/magento/magento2/pull/9943){: target="_blank"}.*
+<!--- 69886 -->
+*  We’ve fixed the cron timestamp method. *Fix submitted by community member Anton Evers in pull request [9943](https://github.com/magento/magento2/pull/9943){: target="_blank"}.*
 
-<!--- 69373-->* You can now save customers with unique attributes. *Fix submitted by community member storbahn in pull request [9712](https://github.com/magento/magento2/pull/9712){: target="_blank"}.*
+<!--- 69373 -->
+*  You can now save customers with unique attributes. *Fix submitted by community member storbahn in pull request [9712](https://github.com/magento/magento2/pull/9712){: target="_blank"}.*
 
-<!--- 69555-->* The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
+<!--- 69555 -->
+*  The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
 
-<!--- 59135-->*  Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
+<!--- 59135 -->
+*   Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
 
-<!--- 63116-->* Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
+<!--- 63116 -->
+*  Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
 
-<!--- 60962-->* When you add an address, new custom attributes are now displayed together, along with other address details.
+<!--- 60962 -->
+*  When you add an address, new custom attributes are now displayed together, along with other address details.
 
-<!--- 60746-->* You can now edit the default store view and save it under a different name. [GitHub-7349](https://github.com/magento/magento2/issues/7349)
+<!--- 60746 -->
+*  You can now edit the default store view and save it under a different name. [GitHub-7349](https://github.com/magento/magento2/issues/7349)
 
-<!--- 60633-->* `.htaccess` deny code execution now works as expected for  Apache and  php-fpm. [GitHub-6766](https://github.com/magento/magento2/issues/6766)
+<!--- 60633 -->
+*  `.htaccess` deny code execution now works as expected for  Apache and  php-fpm. [GitHub-6766](https://github.com/magento/magento2/issues/6766)
 
-<!--- 57675-->* Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
+<!--- 57675 -->
+*  Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
 
-<!--- 56014-->* The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
+<!--- 56014 -->
+*  The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
 
-<!--- 57796-->* Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
+<!--- 57796 -->
+*  Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
 
-<!--- 59258-->* When you override `module-directory/etc/zip_codes.xml` from a local module, all country codes  are now included as expected. Previously, only the last country code was included, which affected the custom  check out process. [GitHub-6694](https://github.com/magento/magento2/issues/6694)
+<!--- 59258 -->
+*  When you override `module-directory/etc/zip_codes.xml` from a local module, all country codes  are now included as expected. Previously, only the last country code was included, which affected the custom  check out process. [GitHub-6694](https://github.com/magento/magento2/issues/6694)
 
 ### Google Analytics
 
-<!--- 67427-->* We’ve added the missing single quote (‘) to the Google API Tracking code. *Fix submitted by community member Petar Sambolek in pull request [9084](https://github.com/magento/magento2/pull/9084){: target="_blank"}.*
+<!--- 67427 -->
+*  We’ve added the missing single quote (‘) to the Google API Tracking code. *Fix submitted by community member Petar Sambolek in pull request [9084](https://github.com/magento/magento2/pull/9084){: target="_blank"}.*
 
-<!--- 69374-->* Google Analytics tracking now works when Cookie Restriction is enabled. *Fix submitted by community member Bernhard in pull request [9713](https://github.com/magento/magento2/pull/9713){: target="_blank"}.*
+<!--- 69374 -->
+*  Google Analytics tracking now works when Cookie Restriction is enabled. *Fix submitted by community member Bernhard in pull request [9713](https://github.com/magento/magento2/pull/9713){: target="_blank"}.*
 
 ### HTML
 
-<!--- 67487-->*  The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
+<!--- 67487 -->
+*   The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
 
 ### Images
 
-<!---55447-->* Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
+<!---55447 -->
+*  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
-<!---56944-->*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+<!---56944 -->
+*   Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
-<!---58335, 42954-->* You can now preview uploaded images.
+<!---58335, 42954 -->
+*  You can now preview uploaded images.
 
-<!---56972-->* You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
+<!---56972 -->
+*  You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
 
-<!---55608-->*  Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
+<!---55608 -->
+*   Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
 
-<!--- 55234-->* Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+<!--- 55234 -->
+*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
-<!--- 58031-->*  Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
+<!--- 58031 -->
+*   Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
 
 #### Import/Export
 
-<!---58977-->* You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
+<!---58977 -->
+*  You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
 
-<!---57052-->* You can now import negative quantities. Previously, when importing a product quantity  of '-1',  Magento returned an error.
+<!---57052 -->
+*  You can now import negative quantities. Previously, when importing a product quantity  of '-1',  Magento returned an error.
 
-<!---56018-->* Magento now imports custom options correctly. Previously, when you tried to import a custom option, the import failed, and Magento displayed this error: `Javascript Error: Uncaught RangeError: Maximum call stack size exceeded`. [GitHub-5573](https://github.com/magento/magento2/issues/5573)
+<!---56018 -->
+*  Magento now imports custom options correctly. Previously, when you tried to import a custom option, the import failed, and Magento displayed this error: `Javascript Error: Uncaught RangeError: Maximum call stack size exceeded`. [GitHub-5573](https://github.com/magento/magento2/issues/5573)
 
-<!---57438, 57135-->* We’ve added a new way to import images: You can now successfully import images when you set your document root to `your_Magento_install_dir/pub`. Previously, you needed to set document root to `/magento` to import images. Both ways of importing now work. [GitHub-5359](https://github.com/magento/magento2/issues/5359)
+<!---57438, 57135 -->
+*  We’ve added a new way to import images: You can now successfully import images when you set your document root to `your_Magento_install_dir/pub`. Previously, you needed to set document root to `/magento` to import images. Both ways of importing now work. [GitHub-5359](https://github.com/magento/magento2/issues/5359)
 
-<!---57490-->* Magento now removes category URL keys from the `url_rewrite` table as expected during import. Previously, Magento did not remove these keys, which triggered a failure during import. This subsequently caused Magento to quickly reach the maximum error count, returning this error: "Maximum error count has been reached or system error is occurred!". [GitHub-1471](https://github.com/magento/magento2/issues/1471)
+<!---57490 -->
+*  Magento now removes category URL keys from the `url_rewrite` table as expected during import. Previously, Magento did not remove these keys, which triggered a failure during import. This subsequently caused Magento to quickly reach the maximum error count, returning this error: "Maximum error count has been reached or system error is occurred!". [GitHub-1471](https://github.com/magento/magento2/issues/1471)
 
-<!---57981-->* You can now export a [bundle product](https://glossary.magento.com/bundle-product) that contains a custom text area attribute.  Previously, if you tried to export this type of bundle product, the export would fail, and Magento displayed the message, "There is no data for the export".
+<!---57981 -->
+*  You can now export a [bundle product](https://glossary.magento.com/bundle-product) that contains a custom text area attribute.  Previously, if you tried to export this type of bundle product, the export would fail, and Magento displayed the message, "There is no data for the export".
 
-<!--- 58299 -->* Magento now maintains super attribute ordering of configurable products with multiple super attributes after export or import. Previously, after import or export, the ordering of super attributes was not maintained. [GitHub-6079](https://github.com/magento/magento2/issues/6079)
+<!--- 58299  -->
+*  Magento now maintains super attribute ordering of configurable products with multiple super attributes after export or import. Previously, after import or export, the ordering of super attributes was not maintained. [GitHub-6079](https://github.com/magento/magento2/issues/6079)
 
-<!--- 55237 -->* Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
+<!--- 55237  -->
+*  Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
 
-<!--- 58316-->*  Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
+<!--- 58316 -->
+*   Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
 
-<!--- 71013-->* The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
+<!--- 71013 -->
+*  The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
 
-<!--- 64643, 64856-->* Magento now displays imported product images in this order: first, the base image, then the additional images in the order in which they were listed in the [CSV](https://glossary.magento.com/csv) file. Previously, Magento displayed images in this unexpected order: first, an additional image, then the base image, and finally, all remaining additional images.
+<!--- 64643, 64856 -->
+*  Magento now displays imported product images in this order: first, the base image, then the additional images in the order in which they were listed in the [CSV](https://glossary.magento.com/csv) file. Previously, Magento displayed images in this unexpected order: first, an additional image, then the base image, and finally, all remaining additional images.
 
-<!--- 56588-->* Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
+<!--- 56588 -->
+*  Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
 
-<!--- 53428, 56804-->* We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
+<!--- 53428, 56804 -->
+*  We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
 
-<!--- 65667-->*  Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
+<!--- 65667 -->
+*   Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
 
-<!--- 67240-->* Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
+<!--- 67240 -->
+*  Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
 
-<!--- 61025-->* Magento now exports rows only once when product information contains HTML special characters. Previously, Magento exported rows containing product information that included HTML characters at least twice.
+<!--- 61025 -->
+*  Magento now exports rows only once when product information contains HTML special characters. Previously, Magento exported rows containing product information that included HTML characters at least twice.
 
-<!--- 60067-->* We've improved the import speed of advanced pricing data. Previously, the import process for this information frequently stopped after the import of approximately 300 rows of data, and Magento displayed this message: `Please Wait`.
+<!--- 60067 -->
+*  We've improved the import speed of advanced pricing data. Previously, the import process for this information frequently stopped after the import of approximately 300 rows of data, and Magento displayed this message: `Please Wait`.
 
-<!--- 64902 -->* The CatalogImportExport uploader now handles HTTPS images as expected. *Fix submitted by community member Clement Beudot in pull request [8278](https://github.com/magento/magento2/pull/8278){: target="_blank"}.*
+<!--- 64902  -->
+*  The CatalogImportExport uploader now handles HTTPS images as expected. *Fix submitted by community member Clement Beudot in pull request [8278](https://github.com/magento/magento2/pull/8278){: target="_blank"}.*
 
-<!---58976 -->* You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
+<!---58976  -->
+*  You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
 
-<!---61104 -->* When you delete an image in Admin, Magento no longer deletes it on the server. Previously, Magento deleted it from the server as well, which caused errors for other products (example error message: `Cannot gather stats! Warning!stat(): stat failed for`).
+<!---61104  -->
+*  When you delete an image in Admin, Magento no longer deletes it on the server. Previously, Magento deleted it from the server as well, which caused errors for other products (example error message: `Cannot gather stats! Warning!stat(): stat failed for`).
 
-<!---66270 -->* The exported sheet now generates or renders data for columns that indicate associations for configurable products.
+<!---66270  -->
+*  The exported sheet now generates or renders data for columns that indicate associations for configurable products.
 
-<!---59743 -->* Magento no longer deletes a product after you select the Replace option while importing a product. Previously, Magento deleted the product rather than replacing it.
+<!---59743  -->
+*  Magento no longer deletes a product after you select the Replace option while importing a product. Previously, Magento deleted the product rather than replacing it.
 
-<!---59715 -->* Magento can now import `additional_images` that are tagged with labels that contain a comma separator.
+<!---59715  -->
+*  Magento can now import `additional_images` that are tagged with labels that contain a comma separator.
 
-<!---58289 -->* We've fixed an issue where product URL keys (for SKUs) were not auto-generated as expected during import. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
+<!---58289  -->
+*  We've fixed an issue where product URL keys (for SKUs) were not auto-generated as expected during import. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
 
-<!---58385 -->* Magento now updates attribute sets as expected when importing  products from CSV. [GitHub-5498](https://github.com/magento/magento2/issues/5498)
+<!---58385  -->
+*  Magento now updates attribute sets as expected when importing  products from CSV. [GitHub-5498](https://github.com/magento/magento2/issues/5498)
 
-<!---63835 -->* The CatalogImportExport uploader can now handle HTTPS images. Previously, if the URL of a file contained HTTPS, the uploader  still used the HTTP provider to retrieve the image, which lead to an error. [GitHub-8277](https://github.com/magento/magento2/issues/8277)
+<!---63835  -->
+*  The CatalogImportExport uploader can now handle HTTPS images. Previously, if the URL of a file contained HTTPS, the uploader  still used the HTTP provider to retrieve the image, which lead to an error. [GitHub-8277](https://github.com/magento/magento2/issues/8277)
 
 #### Integrations
 
-<!---56961, 54795-->* With valid permissions, you can now regain access to your Admin account after it is temporarily disabled due to invalid credentials. Previously, you could not unlock the account of a valid Admin user if it were disabled due to multiple invalid login attempts.
+<!---56961, 54795 -->
+*  With valid permissions, you can now regain access to your Admin account after it is temporarily disabled due to invalid credentials. Previously, you could not unlock the account of a valid Admin user if it were disabled due to multiple invalid login attempts.
 
-<!--- 61867-->* Web API tokens now have a default expiration period: 4 hours for Admin tokens and 1 hour for Customer tokens. This can be changed in the [Admin Panel configuration settings]({{ site.baseurl }}/guides/v2.2/get-started/authentication/gs-authentication-token.html#admin-and-customer-access-tokens)
+<!--- 61867 -->
+*  Web API tokens now have a default expiration period: 4 hours for Admin tokens and 1 hour for Customer tokens. This can be changed in the [Admin Panel configuration settings]({{ site.baseurl }}/guides/v2.2/get-started/authentication/gs-authentication-token.html#admin-and-customer-access-tokens)
 
-<!--- 69610-->* You can now edit `authentication_lock` from the Admin. *Fix submitted by community member Elias Kotlyar in pull request [9820](https://github.com/magento/magento2/pull/9820){: target="_blank"}.*
+<!--- 69610 -->
+*  You can now edit `authentication_lock` from the Admin. *Fix submitted by community member Elias Kotlyar in pull request [9820](https://github.com/magento/magento2/pull/9820){: target="_blank"}.*
 
 ### Indexing
 
-<!---56928-->* We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
+<!---56928 -->
+*  We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
 
-<!---58703-->* The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error:  "Error 1114: Table is full".
+<!---58703 -->
+*  The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error:  "Error 1114: Table is full".
 
-<!--- 58893-->* `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
+<!--- 58893 -->
+*  `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
 
-<!--- 59853-->* The Magento flat indexer now collects correct product data for `ROW_ID`.
+<!--- 59853 -->
+*  The Magento flat indexer now collects correct product data for `ROW_ID`.
 
-<!--- 58559-->* The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables.
+<!--- 58559 -->
+*  The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables.
 
-<!--- 65362 -->* Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
+<!--- 65362  -->
+*  Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
 
-<!--- 55154 -->* `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
+<!--- 55154  -->
+*  `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
 
-<!--- 23764-->* The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error: "Error 1114: Table is full".
+<!--- 23764 -->
+*  The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error: "Error 1114: Table is full".
 
-<!---71242 -->* We’ve resolved failures with indexing in installations that implemented catalogs containing at least 5,000 - 6,000 SKUs.
+<!---71242  -->
+*  We’ve resolved failures with indexing in installations that implemented catalogs containing at least 5,000 - 6,000 SKUs.
 
-<!--- 55589-->* We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
+<!--- 55589 -->
+*  We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
 
-<!--- 60824-->* Reindexing no longer results in an SQL error that prevents bundle products from being reindexed, and results in wrong product prices.
+<!--- 60824 -->
+*  Reindexing no longer results in an SQL error that prevents bundle products from being reindexed, and results in wrong product prices.
 
 ### Orders
 
@@ -696,81 +989,116 @@ Thanks to our hardworking Magento Open Source community members for the followin
 
    *  change order status after a credit memo has been created.
 
-<!--- 57077-->* You can now set the customer group when creating a new order from the Admin interface. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+<!--- 57077 -->
+*  You can now set the customer group when creating a new order from the Admin interface. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
 
-<!---57387 -->* You can now print invoices and credit memos from the Order page.
+<!---57387  -->
+*  You can now print invoices and credit memos from the Order page.
 
-<!--- 55598/54787 -->* You can now successfully place orders when the Enable and Configure [Website](https://glossary.magento.com/website) Payments Standard Payment Action attribute is set to Sale. Previously, under these conditions, Magento would display an error message and not allow you to complete the purchase. [GitHub-4785](https://github.com/magento/magento2/issues/4785)
+<!--- 55598/54787  -->
+*  You can now successfully place orders when the Enable and Configure [Website](https://glossary.magento.com/website) Payments Standard Payment Action attribute is set to Sale. Previously, under these conditions, Magento would display an error message and not allow you to complete the purchase. [GitHub-4785](https://github.com/magento/magento2/issues/4785)
 
-<!--- 50026 -->* Attributes of the `salesInvoiceRepository` methods are now more appropriately type cast. (The data type is now a nullable float.)  Previously, due to the use of an incorrect data type, Magento would produce an error when calling the `salesInvoiceRepositoryV1GetList` method. [GitHub-3605](https://github.com/magento/magento2/issues/3605)
+<!--- 50026  -->
+*  Attributes of the `salesInvoiceRepository` methods are now more appropriately type cast. (The data type is now a nullable float.)  Previously, due to the use of an incorrect data type, Magento would produce an error when calling the `salesInvoiceRepositoryV1GetList` method. [GitHub-3605](https://github.com/magento/magento2/issues/3605)
 
-<!--- 58832-->* The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
+<!--- 58832 -->
+*  The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
 
-<!--- 62783-->* Magento now uses the address template from store view level of the placed order (similar to how order confirmation email works). Previously, Magento used the wrong address template for order e-mails.
+<!--- 62783 -->
+*  Magento now uses the address template from store view level of the placed order (similar to how order confirmation email works). Previously, Magento used the wrong address template for order e-mails.
 
-<!--- 59052 -->* Magento now correctly identifies an order being processed when it is placed in a store configured for multiple currencies. Previously, these orders always were identified as potentially fraudulent.
+<!--- 59052  -->
+*  Magento now correctly identifies an order being processed when it is placed in a store configured for multiple currencies. Previously, these orders always were identified as potentially fraudulent.
 
-<!--- 56150-->* The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
+<!--- 56150 -->
+*  The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
 
-<!--- 58074-->* The **Print Shipping Label** link now displays on the product frontend. Previously, the layout for the Shipping and Tracking block did not work properly.
+<!--- 58074 -->
+*  The **Print Shipping Label** link now displays on the product frontend. Previously, the layout for the Shipping and Tracking block did not work properly.
 
-<!---66428 -->* You can now create an order through Admin  if there is a `translate csv` for order-header. *Fix submitted by community member Pascal Brouwers in pull request [6856](https://github.com/magento/magento2/pull/6856){: target="_blank"}.*
+<!---66428  -->
+*  You can now create an order through Admin  if there is a `translate csv` for order-header. *Fix submitted by community member Pascal Brouwers in pull request [6856](https://github.com/magento/magento2/pull/6856){: target="_blank"}.*
 
-<!---69378 -->* You can now use a second credit memo to successfully issue a full refund for a credit memo with adjustment fees. *Fix submitted by community member Max Pronko in pull request [9715](https://github.com/magento/magento2/pull/9715){: target="_blank"}.*
+<!---69378  -->
+*  You can now use a second credit memo to successfully issue a full refund for a credit memo with adjustment fees. *Fix submitted by community member Max Pronko in pull request [9715](https://github.com/magento/magento2/pull/9715){: target="_blank"}.*
 
-<!---69551 -->* Coupon codes are now included in  invoice print outs. *Fix submitted by community member Belgacem Naoui in pull request [9780](https://github.com/magento/magento2/pull/9780){: target="_blank"}.*
+<!---69551  -->
+*  Coupon codes are now included in  invoice print outs. *Fix submitted by community member Belgacem Naoui in pull request [9780](https://github.com/magento/magento2/pull/9780){: target="_blank"}.*
 
-<!---69909 -->* The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
+<!---69909  -->
+*  The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
 
-<!---68795 -->*  Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
+<!---68795  -->
+*   Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
 
-<!--- 60587 -->* We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
+<!--- 60587  -->
+*  We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
 
-<!--- 57312-->* We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
+<!--- 57312 -->
+*  We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
 
-<!--- 59905-->* The Create Order page now works as expected after you select **Update items and quantities**.
+<!--- 59905 -->
+*  The Create Order page now works as expected after you select **Update items and quantities**.
 
-<!--- 59586-->* Magento no longer creates unnecessary  loaders during checkout with an order that contains virtual products.
+<!--- 59586 -->
+*  Magento no longer creates unnecessary  loaders during checkout with an order that contains virtual products.
 
-<!--- 57846-->* New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
+<!--- 57846 -->
+*  New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
 
-<!--- 56938-->* Magento now creates the shipping address as expected when you  use REST to create an order.  Previously, when you used REST to create an order, then subsequently viewed the order from the Admin, Magento threw an error.
+<!--- 56938 -->
+*  Magento now creates the shipping address as expected when you  use REST to create an order.  Previously, when you used REST to create an order, then subsequently viewed the order from the Admin, Magento threw an error.
 
-<!--- 53005-->* Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
+<!--- 53005 -->
+*  Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
 
-<!--- 60692-->*  You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
+<!--- 60692 -->
+*   You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
 
 ### Payment methods
 
-<!--- 72305-->* We’ve added support for the change to the USPS API that USPS implemented on September 1, 2017. After installing or upgrading to this release, Magento will display the Domestic rate for USPS, First-Class Mail Parcel as expected. Previously, the USPS First-Class Mail Parcel option was not available after September 1, 2017 on installations running Magento 2.x.
+<!--- 72305 -->
+*  We’ve added support for the change to the USPS API that USPS implemented on September 1, 2017. After installing or upgrading to this release, Magento will display the Domestic rate for USPS, First-Class Mail Parcel as expected. Previously, the USPS First-Class Mail Parcel option was not available after September 1, 2017 on installations running Magento 2.x.
 
-<!--- 56695-->* You can now successfully complete Paypal checkout with products that have custom options. [GitHub-5938](https://github.com/magento/magento2/issues/5938)
+<!--- 56695 -->
+*  You can now successfully complete Paypal checkout with products that have custom options. [GitHub-5938](https://github.com/magento/magento2/issues/5938)
 
-<!--- 62669-->* Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
+<!--- 62669 -->
+*  Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
 
-<!--- 55612-->* Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
+<!--- 55612 -->
+*  Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
 
-<!--- 57923-->* Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
+<!--- 57923 -->
+*  Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
 
-<!--- 69750-->* Magento now successfully completes checkout when a custom address attribute is added. Previously, an error occurred during checkout when the user added a required custom address attribute.
+<!--- 69750 -->
+*  Magento now successfully completes checkout when a custom address attribute is added. Previously, an error occurred during checkout when the user added a required custom address attribute.
 
-<!--- 66959-->* Removed a duplicate method call to the `getLinkField` method in the `Magento\Catalog\Model\ResourceModel\Category` class. *Fixed by will-b in pull request [9057](https://github.com/magento/magento2/pull/9057){: target="_blank"}.*
+<!--- 66959 -->
+*  Removed a duplicate method call to the `getLinkField` method in the `Magento\Catalog\Model\ResourceModel\Category` class. *Fixed by will-b in pull request [9057](https://github.com/magento/magento2/pull/9057){: target="_blank"}.*
 
-<!--- 54412-->* During order creation, you can now continue with a payment after clicking the **Back** button to the payment selection window. [GitHub-4580](https://github.com/magento/magento2/issues/4580)
+<!--- 54412 -->
+*  During order creation, you can now continue with a payment after clicking the **Back** button to the payment selection window. [GitHub-4580](https://github.com/magento/magento2/issues/4580)
 
-<!--- 64413-->* The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
+<!--- 64413 -->
+*  The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
 
 * We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
 
-<!---56347 -->* We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
+<!---56347  -->
+*  We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
 
-<!--- 56345-->* Error messages associated with the `Authorize.net` payment method are now translated to fit the configured locale. [GitHub-5934](https://github.com/magento/magento2/issues/5934)
+<!--- 56345 -->
+*  Error messages associated with the `Authorize.net` payment method are now translated to fit the configured locale. [GitHub-5934](https://github.com/magento/magento2/issues/5934)
 
-<!--- 58722-->* We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
+<!--- 58722 -->
+*  We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
 
 #### Braintree
 
-<!--- 55530 -->* You can now place orders from the Admin using the Braintree payment method.
+<!--- 55530  -->
+*  You can now place orders from the Admin using the Braintree payment method.
 
 <!---59578 -->
 *  We've enhanced our PayPal and Braintree implementations so that merchants can now:
@@ -779,317 +1107,447 @@ Thanks to our hardworking Magento Open Source community members for the followin
 
    *  Configure dynamic descriptors (Company Name, Phone and URL) for Braintree.  This enhancement supports customers easily identifying a source of transactions in their bank statements. (This will potential simplify the resolution of disputed transactions by supporting the display of the Kount status for Braintree in the Admin interface.)
 
-<!--- 56940-->* Kount and 3D Secure now work as expected for Braintree Vault.
+<!--- 56940 -->
+*  Kount and 3D Secure now work as expected for Braintree Vault.
 
-<!--- 62428-->* Magento now updates you as expected on order comments and order history after you initiate a refund using Braintree. Previously, when you clicked the **Refund** button (to initiate a refund), Magento did not redirect you to order comments and history information.
+<!--- 62428 -->
+*  Magento now updates you as expected on order comments and order history after you initiate a refund using Braintree. Previously, when you clicked the **Refund** button (to initiate a refund), Magento did not redirect you to order comments and history information.
 
-<!--- 54721-->* You can now use Braintree as a payment method when applying reward points or store credit to an order.
+<!--- 54721 -->
+*  You can now use Braintree as a payment method when applying reward points or store credit to an order.
 
-<!---56910-->* The Braintree payment method now works as expected with Vault table prefixing.
+<!---56910 -->
+*  The Braintree payment method now works as expected with Vault table prefixing.
 
-<!---57426-->* Magento no longer encounters an error when using the Braintree Vault payment GET order API call. [GitHub-6215](https://github.com/magento/magento2/issues/6215)
+<!---57426 -->
+*  Magento no longer encounters an error when using the Braintree Vault payment GET order API call. [GitHub-6215](https://github.com/magento/magento2/issues/6215)
 
-<!---59353-->* You can now use JCB and Diners Club credit cards with the Authorize.net payment method.
+<!---59353 -->
+*  You can now use JCB and Diners Club credit cards with the Authorize.net payment method.
 
-<!--- 59124-->* Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
+<!--- 59124 -->
+*  Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
 
-<!---57086-->* You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
+<!---57086 -->
+*  You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
 
-<!---59637-->*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+<!---59637 -->
+*   Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
-<!--- 56344-->* The Braintree payment method now works as expected with Vault table prefixing.
+<!--- 56344 -->
+*  The Braintree payment method now works as expected with Vault table prefixing.
 
-<!--- 71371-->* Merchants can now accept payment on a Suspected Fraud order without Magento altering the amount in Total Paid. Previously, when a merchant accepted payment for an order with a status of Suspected Fraud, Magento doubled the payment amount.
+<!--- 71371 -->
+*  Merchants can now accept payment on a Suspected Fraud order without Magento altering the amount in Total Paid. Previously, when a merchant accepted payment for an order with a status of Suspected Fraud, Magento doubled the payment amount.
 
-<!--- 59573-->* Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+<!--- 59573 -->
+*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
-<!--- 69340-->* The Braintree PayPal locale now has its own setting. [GitHub-9639](https://github.com/magento/magento2/issues/9639)
+<!--- 69340 -->
+*  The Braintree PayPal locale now has its own setting. [GitHub-9639](https://github.com/magento/magento2/issues/9639)
 
-<!--- 63460 -->* You can now modify the product quantities  of a previous order and re-order it using the saved credit card information from the first order.
+<!--- 63460  -->
+*  You can now modify the product quantities  of a previous order and re-order it using the saved credit card information from the first order.
 
 #### PayPal
 
-<!--- 59581-->* We've improved and streamlined the [Magento Admin](https://glossary.magento.com/magento-admin) PayPal configuration interface.
+<!--- 59581 -->
+*  We've improved and streamlined the [Magento Admin](https://glossary.magento.com/magento-admin) PayPal configuration interface.
 
-<!--- 58376-->* PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
+<!--- 58376 -->
+*  PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
 
-<!--- 59036-->* We've fixed an issue with using PayPal Express Checkout to order products with custom options. Previously, although an Admin user could create and configure “File type” custom options, customers could not upload and store files within the order [quote](https://glossary.magento.com/quote). [GitHub-5434](https://github.com/magento/magento2/issues/5434)
+<!--- 59036 -->
+*  We've fixed an issue with using PayPal Express Checkout to order products with custom options. Previously, although an Admin user could create and configure “File type” custom options, customers could not upload and store files within the order [quote](https://glossary.magento.com/quote). [GitHub-5434](https://github.com/magento/magento2/issues/5434)
 
-<!--- 70500-->* Fixed issue related to incorrect stock quantity calculation for bundle and configurable products during place order flow with PayPal Express Checkout.
+<!--- 70500 -->
+*  Fixed issue related to incorrect stock quantity calculation for bundle and configurable products during place order flow with PayPal Express Checkout.
 
-<!--- 62667-->* Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
+<!--- 62667 -->
+*  Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
 
-<!--- 59086-->* Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
+<!--- 59086 -->
+*  Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
 
-<!--- 58676-->* PayPal Express payments no longer fail when there is adequate product inventory to cover your order. Previously, you'd receive this error message: `We can't place the order`. [GitHub-6296](https://github.com/magento/magento2/issues/6296)
+<!--- 58676 -->
+*  PayPal Express payments no longer fail when there is adequate product inventory to cover your order. Previously, you'd receive this error message: `We can't place the order`. [GitHub-6296](https://github.com/magento/magento2/issues/6296)
 
-<!--- 71307-->* Paypal errors no longer occur when Fixed Product Tax (FPT) is enabled. Previously, when a product had a FPT, Paypal Express reported an error when you tried to place the order.
+<!--- 71307 -->
+*  Paypal errors no longer occur when Fixed Product Tax (FPT) is enabled. Previously, when a product had a FPT, Paypal Express reported an error when you tried to place the order.
 
-<!--- 58162-->* PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
+<!--- 58162 -->
+*  PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
 
-<!--- 63551-->* When refunding an order from PayPal, Magento now creates a credit memo  with the correct status.
+<!--- 63551 -->
+*  When refunding an order from PayPal, Magento now creates a credit memo  with the correct status.
 
-<!---  -->* The exported sheet now generates or renders data for columns that indicate associations for configurable products.
+<!---   -->
+*  The exported sheet now generates or renders data for columns that indicate associations for configurable products.
 
-<!---60589-->* We’ve resolved a loader issue with Payflow Pro. The loader image is now invisible after redirecting to the payment page/success page or error page. [GitHub-7159](https://github.com/magento/magento2/issues/7159),  [GitHub-9296](https://github.com/magento/magento2/issues/9296)
+<!---60589 -->
+*  We’ve resolved a loader issue with Payflow Pro. The loader image is now invisible after redirecting to the payment page/success page or error page. [GitHub-7159](https://github.com/magento/magento2/issues/7159),  [GitHub-9296](https://github.com/magento/magento2/issues/9296)
 
-<!---64833-->* PayPal Express checkout no longer discards address line 2 for billing and shipping addresses. [GitHub-8313](https://github.com/magento/magento2/issues/8313)
+<!---64833 -->
+*  PayPal Express checkout no longer discards address line 2 for billing and shipping addresses. [GitHub-8313](https://github.com/magento/magento2/issues/8313)
 
-<!---60572-->* The checkout page no longer freezes when you try to use PayPal to pay for a purchase that contains a downloadable product. Previously, a `PayPal.js` error occurred. [GitHub-7000](https://github.com/magento/magento2/issues/7000)
+<!---60572 -->
+*  The checkout page no longer freezes when you try to use PayPal to pay for a purchase that contains a downloadable product. Previously, a `PayPal.js` error occurred. [GitHub-7000](https://github.com/magento/magento2/issues/7000)
 
 ### Performance
 
 This release includes substantial improvements to Magento caching, image processing, and re-indexing, among other enhancements.
 
-<!--- 52660 -->* We've improved the speed of static asset deployment and now support a variety of asset deployment strategies that can be used to optimize speed and size of assets deployed. Indexers can now be run with 256M of PHP RAM and default MySQL configuration settings.  Developers can further tune memory usage to improve indexer performance (in some cases up to 100% improvement).  Please see [Magento Optimization Guide]({{ page.baseurl }}/config-guide/prod/prod_perf-optimize.html)  for further details.
+<!--- 52660  -->
+*  We've improved the speed of static asset deployment and now support a variety of asset deployment strategies that can be used to optimize speed and size of assets deployed. Indexers can now be run with 256M of PHP RAM and default MySQL configuration settings.  Developers can further tune memory usage to improve indexer performance (in some cases up to 100% improvement).  Please see [Magento Optimization Guide]({{ page.baseurl }}/config-guide/prod/prod_perf-optimize.html)  for further details.
 
-<!--- 55300, 55620, 54682-->* We've improved [storefront](https://glossary.magento.com/storefront) performance when creating 2500 or more product variants.
+<!--- 55300, 55620, 54682 -->
+*  We've improved [storefront](https://glossary.magento.com/storefront) performance when creating 2500 or more product variants.
 
-<!---56927-->* Opening many products from the Admin interface is now faster.
+<!---56927 -->
+*  Opening many products from the Admin interface is now faster.
 
-<!---59708-->* Creating many (2500 - 5000) product variants, both simple and complex [product types](https://glossary.magento.com/product-types) is more efficient.
+<!---59708 -->
+*  Creating many (2500 - 5000) product variants, both simple and complex [product types](https://glossary.magento.com/product-types) is more efficient.
 
-<!--- 57410-->* You can now quickly generate or preview multiple variations of a [configurable product](https://glossary.magento.com/configurable-product). (Saving these variations to the database can be time-consuming, if you have several thousand product options, and our efforts to improve performance continue.) Previously, Magento threw an Invalid Form key error is thrown while you tried to save a configurable product with variations.
+<!--- 57410 -->
+*  You can now quickly generate or preview multiple variations of a [configurable product](https://glossary.magento.com/configurable-product). (Saving these variations to the database can be time-consuming, if you have several thousand product options, and our efforts to improve performance continue.) Previously, Magento threw an Invalid Form key error is thrown while you tried to save a configurable product with variations.
 
-<!--- 65483 -->* Magento no longer performs unnecessary file check operations (for example, `file_exists`, `is_file`), which improves the performance of the category and product pages.
+<!--- 65483  -->
+*  Magento no longer performs unnecessary file check operations (for example, `file_exists`, `is_file`), which improves the performance of the category and product pages.
 
-<!---57905-->* We've optimized compiler performance (that is, the [`setup:di:compile`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) command).
+<!---57905 -->
+*  We've optimized compiler performance (that is, the [`setup:di:compile`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) command).
 
-<!--- 66855-->* We’ve improved the performance of the Display Time for Category Edit page for catalogs with many products or categories.  [GitHub-7469](https://github.com/magento/magento2/issues/7469)
+<!--- 66855 -->
+*  We’ve improved the performance of the Display Time for Category Edit page for catalogs with many products or categories.  [GitHub-7469](https://github.com/magento/magento2/issues/7469)
 
 #### Image processing
 
-<!---60041-->* We've improved the process of resizing images on the [frontend](https://glossary.magento.com/frontend).
+<!---60041 -->
+*  We've improved the process of resizing images on the [frontend](https://glossary.magento.com/frontend).
 
-<!--- 59806 -->* The process of loading many configurable products with multiple images (for example, configurable products with three attributes and 250 options) is more efficient. [(GITHUB-6979)](https://github.com/magento/magento2/issues/6979){: target="_blank"}
+<!--- 59806  -->
+*  The process of loading many configurable products with multiple images (for example, configurable products with three attributes and 250 options) is more efficient. [(GITHUB-6979)](https://github.com/magento/magento2/issues/6979){: target="_blank"}
 
 #### Caching
 
-<!--- 65480 -->* Magento now caches image metadata, which avoids the time-consuming need to read images for [metadata](https://glossary.magento.com/metadata) loading.
+<!--- 65480  -->
+*  Magento now caches image metadata, which avoids the time-consuming need to read images for [metadata](https://glossary.magento.com/metadata) loading.
 
-<!--- 65484 -->* Magento now caches attribute options for the layered navigation feature. This reduces the number of queries to the database, and consequently improves performance.
+<!--- 65484  -->
+*  Magento now caches attribute options for the layered navigation feature. This reduces the number of queries to the database, and consequently improves performance.
 
-<!--- 62691 -->* We’ve optimized and streamlined how we cache EAV attributes by removing unnecessary SQL queries.
+<!--- 62691  -->
+*  We’ve optimized and streamlined how we cache EAV attributes by removing unnecessary SQL queries.
 
 ### PHP
 
-<!--- 69964 -->* PHPCS can now correctly parse the syntax of PHP 7.x return types.
+<!--- 69964  -->
+*  PHPCS can now correctly parse the syntax of PHP 7.x return types.
 
-<!--- 45339 -->* Cart Price rules are now applied as expected to [payment method](https://glossary.magento.com/payment-method) conditions. Previously, discounts set in Cart Price rules were not applied during [checkout](https://glossary.magento.com/checkout).
+<!--- 45339  -->
+*  Cart Price rules are now applied as expected to [payment method](https://glossary.magento.com/payment-method) conditions. Previously, discounts set in Cart Price rules were not applied during [checkout](https://glossary.magento.com/checkout).
 
 ### Sample data
 
-<!--- 67020 -->* Magento now handles the `catalog_product_entity_media_gallery_value.position` value the same whether you’ve installed or upgraded the product. Previously, these values differed depending upon whether you upgraded or freshly installed your Magento code.
+<!--- 67020  -->
+*  Magento now handles the `catalog_product_entity_media_gallery_value.position` value the same whether you’ve installed or upgraded the product. Previously, these values differed depending upon whether you upgraded or freshly installed your Magento code.
 
-<!--- 70299 -->* You can now successfully install Magento with sample data when **auto_increment_increment** is set to **3** in the `options` file. Previously, installation completed successfully, but Magento displayed this error: `Something went wrong while installing sample data. Please check var/log/system.log for details. You can retry installing the data now or just start using Magento.`
+<!--- 70299  -->
+*  You can now successfully install Magento with sample data when **auto_increment_increment** is set to **3** in the `options` file. Previously, installation completed successfully, but Magento displayed this error: `Something went wrong while installing sample data. Please check var/log/system.log for details. You can retry installing the data now or just start using Magento.`
 
 ### SalesRule
 
-<!--- 55184 -->* You can now select and add a category to a Cart Price rule. Previously, Magento displayed this error: "Uncaught ReferenceError: sales_rule_form is not defined", and did not add the selected category to the condition.  [GitHub-5526](https://github.com/magento/magento2/issues/5526)
+<!--- 55184  -->
+*  You can now select and add a category to a Cart Price rule. Previously, Magento displayed this error: "Uncaught ReferenceError: sales_rule_form is not defined", and did not add the selected category to the condition.  [GitHub-5526](https://github.com/magento/magento2/issues/5526)
 
-<!--- 55433 -->* A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart, the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
+<!--- 55433  -->
+*  A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart, the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
 
-<!--- 67089 -->* The SalesRule table  is the same whether you’ve freshly installed or updated Magento 2.2.
+<!--- 67089  -->
+*  The SalesRule table  is the same whether you’ve freshly installed or updated Magento 2.2.
 
-<!--- 62405 -->* Magento no longer discounts items that belong to an excluded category. Previously, you were unable to exclude products assigned to a specific category due to the cart price rule.
+<!--- 62405  -->
+*  Magento no longer discounts items that belong to an excluded category. Previously, you were unable to exclude products assigned to a specific category due to the cart price rule.
 
-<!--- 58677 -->* The Cart Price rule now affects coupon life as expected. Previously, coupons did not persist longer than the current date if they did not have a designated end-date.
+<!--- 58677  -->
+*  The Cart Price rule now affects coupon life as expected. Previously, coupons did not persist longer than the current date if they did not have a designated end-date.
 
-<!--- 60756 -->* Customers can no longer apply a coupon code twice. Previously, the "Uses per Coupon" limit did not work for auto-generated coupons.
+<!--- 60756  -->
+*  Customers can no longer apply a coupon code twice. Previously, the "Uses per Coupon" limit did not work for auto-generated coupons.
 
-<!--- 58334 -->* Magento now implements free shipping  if there is a Cart Price Rule match. [GitHub-6584](https://github.com/magento/magento2/issues/6584)
+<!--- 58334  -->
+*  Magento now implements free shipping  if there is a Cart Price Rule match. [GitHub-6584](https://github.com/magento/magento2/issues/6584)
 
-<!--- 63403 -->* SalesRule now applies to auto-generated coupon codes as expected.
+<!--- 63403  -->
+*  SalesRule now applies to auto-generated coupon codes as expected.
 
-<!--- 59047 -->* You can now create a cart price rule  without any date range restrictions. Previously, if you left the **From** and **To** dates empty, Magento filled them in with the current date. [GitHub-6762](https://github.com/magento/magento2/issues/6762), [GitHub-6122](https://github.com/magento/magento2/issues/6122)
+<!--- 59047  -->
+*  You can now create a cart price rule  without any date range restrictions. Previously, if you left the **From** and **To** dates empty, Magento filled them in with the current date. [GitHub-6762](https://github.com/magento/magento2/issues/6762), [GitHub-6122](https://github.com/magento/magento2/issues/6122)
 
-<!--- 59089 -->* When you change the currency associated with store, Magento also adjusts the currency in all product listings. [GitHub-6746](https://github.com/magento/magento2/issues/6746)
+<!--- 59089  -->
+*  When you change the currency associated with store, Magento also adjusts the currency in all product listings. [GitHub-6746](https://github.com/magento/magento2/issues/6746)
 
-<!--- 56871 -->* Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
+<!--- 56871  -->
+*  Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
 
 ### Scope
 
-<!---54704-->* Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
+<!---54704 -->
+*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
 
-<!---56936 -->*  The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
+<!---56936  -->
+*   The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
 
-<!---57001, 54460-->* A restricted user can now change storeview- or website- level attributes that are defined within his scope.
+<!---57001, 54460 -->
+*  A restricted user can now change storeview- or website- level attributes that are defined within his scope.
 
-<!---59284, 59282-->* You can now select the scope for an action that you are running from the Catalog page's product table.
+<!---59284, 59282 -->
+*  You can now select the scope for an action that you are running from the Catalog page's product table.
 
-<!---59953-->* The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
+<!---59953 -->
+*  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
-<!---54458, 57003-->* The Product page scope selector now displays all related websites associated with a restricted user.
+<!---54458, 57003 -->
+*  The Product page scope selector now displays all related websites associated with a restricted user.
 
 ### Search
 
-<!---59088-->*  Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
+<!---59088 -->
+*   Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
 
-<!---56356 -->* Segmentation faults no longer occur when doing a `catalogsearch_fulltext` re-index, and indexing succeeds. Previously, in a large database (more than 70,000 products), the `catalogsearch_fulltext` (MySQL) re-index failed with a `Segmentation fault` message. [GitHub-7963](https://github.com/magento/magento2/issues/7963)
+<!---56356  -->
+*  Segmentation faults no longer occur when doing a `catalogsearch_fulltext` re-index, and indexing succeeds. Previously, in a large database (more than 70,000 products), the `catalogsearch_fulltext` (MySQL) re-index failed with a `Segmentation fault` message. [GitHub-7963](https://github.com/magento/magento2/issues/7963)
 
-<!---52905-->*  Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
+<!---52905 -->
+*   Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
 
-<!---59477 -->* Attribute weighting now works correctly for the MySQL adapter. [GitHub-9020](https://github.com/magento/magento2/issues/9020)
+<!---59477  -->
+*  Attribute weighting now works correctly for the MySQL adapter. [GitHub-9020](https://github.com/magento/magento2/issues/9020)
 
 ### Shipping
 
-<!---57037-->* UPS now generates shipping rates for Puerto Rico postal codes.
+<!---57037 -->
+*  UPS now generates shipping rates for Puerto Rico postal codes.
 
-<!--- 71749 -->* Magento now displays tracking information when selected for the second shipping label created for the DHL shipping method. Previously, when you tried to display a completed DHL shipping label, Magento displayed an exception.
+<!--- 71749  -->
+*  Magento now displays tracking information when selected for the second shipping label created for the DHL shipping method. Previously, when you tried to display a completed DHL shipping label, Magento displayed an exception.
 
-<!--- 58062-->* Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
+<!--- 58062 -->
+*  Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
 
-<!--- 57992-->* You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
+<!--- 57992 -->
+*  You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
 
-<!--- 70646-->* You can now save the settings you enter when creating a shipping label on an existing shipment. Previously, clicking the **Save** button resulted in an error, and the shipping label was not saved.
+<!--- 70646 -->
+*  You can now save the settings you enter when creating a shipping label on an existing shipment. Previously, clicking the **Save** button resulted in an error, and the shipping label was not saved.
 
-<!--- 67053 -->* Added missing translation to label `argument xml`.  *Fix submitted by community member Mr Khoa in pull request [9095](https://github.com/magento/magento2/pull/9095){: target="_blank"}.*
+<!--- 67053  -->
+*  Added missing translation to label `argument xml`.  *Fix submitted by community member Mr Khoa in pull request [9095](https://github.com/magento/magento2/pull/9095){: target="_blank"}.*
 
-<!--- 64909-->* Magento no longer throws a fatal error when you create a new shipment for a placed order.
+<!--- 64909 -->
+*  Magento no longer throws a fatal error when you create a new shipment for a placed order.
 
-<!--- 62276-->* The State/Province field now changes to an input field as expected after you select United Kingdom when filling out the shipping address during checkout
+<!--- 62276 -->
+*  The State/Province field now changes to an input field as expected after you select United Kingdom when filling out the shipping address during checkout
 
-<!--- 58664-->* The Free Shipping rule now works as expected with table rate shipping. [GitHub-6346](https://github.com/magento/magento2/issues/6346)
+<!--- 58664 -->
+*  The Free Shipping rule now works as expected with table rate shipping. [GitHub-6346](https://github.com/magento/magento2/issues/6346)
 
-<!--- 62662-->* Magento now passes the correct object to the  `\Magento\Shipping\Model\Shipping::collectRatesByAddress` method. [GitHub-7309](https://github.com/magento/magento2/issues/7309)
+<!--- 62662 -->
+*  Magento now passes the correct object to the  `\Magento\Shipping\Model\Shipping::collectRatesByAddress` method. [GitHub-7309](https://github.com/magento/magento2/issues/7309)
 
-<!--- 60523-->* Magento now displays the checkout page or cart as expected when you try to edit a virtual item from the multi shipping page. Previously, Magento displayed a 404 error page instead of redirecting to the checkout page or shopping cart. [GitHub-7257](https://github.com/magento/magento2/issues/7257)
+<!--- 60523 -->
+*  Magento now displays the checkout page or cart as expected when you try to edit a virtual item from the multi shipping page. Previously, Magento displayed a 404 error page instead of redirecting to the checkout page or shopping cart. [GitHub-7257](https://github.com/magento/magento2/issues/7257)
 
-<!--- 59149-->* We've resolved an issue where Magento did not display applicable flat-rate USPS box methods during checkout. [GitHub-6798](https://github.com/magento/magento2/issues/6798)
+<!--- 59149 -->
+*  We've resolved an issue where Magento did not display applicable flat-rate USPS box methods during checkout. [GitHub-6798](https://github.com/magento/magento2/issues/6798)
 
 ### Sitemap
 
-<!--- 70056-->* Sitemap image URLs now match the URLs on product pages. *Fix submitted by community member Petar Sambolek in pull request [9082](https://github.com/magento/magento2/pull/9082){: target="_blank"}.*
+<!--- 70056 -->
+*  Sitemap image URLs now match the URLs on product pages. *Fix submitted by community member Petar Sambolek in pull request [9082](https://github.com/magento/magento2/pull/9082){: target="_blank"}.*
 
-<!--- 70056-->* The sitemap is no longer generated in the wrong folder when `vhost` is connected to `/pub`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
+<!--- 70056 -->
+*  The sitemap is no longer generated in the wrong folder when `vhost` is connected to `/pub`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
 
-<!--- 58730-->* Magento now displays UPS rates on the initial load of the checkout page. Previously, although shipping rates showed up properly at the cart level, the payment page did not load the correct shipping options. [GitHub-6564](https://github.com/magento/magento2/issues/6564)
+<!--- 58730 -->
+*  Magento now displays UPS rates on the initial load of the checkout page. Previously, although shipping rates showed up properly at the cart level, the payment page did not load the correct shipping options. [GitHub-6564](https://github.com/magento/magento2/issues/6564)
 
 ### Static file processing
 
-<!---60603-->* We've corrected a problem with `_requirejs` asset retrieval via `static.php` in [static content](https://glossary.magento.com/static-content) versioning.
+<!---60603 -->
+*  We've corrected a problem with `_requirejs` asset retrieval via `static.php` in [static content](https://glossary.magento.com/static-content) versioning.
 
-<!---56914-->* Versioning of [static files](https://glossary.magento.com/static-files) (including CSS, JS, font, and image files) is now enabled by default.
+<!---56914 -->
+*  Versioning of [static files](https://glossary.magento.com/static-files) (including CSS, JS, font, and image files) is now enabled by default.
 
-<!---57904-->* We've improved the speed of static asset deployment. See [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html){: target="_blank"} for more information about available options.
+<!---57904 -->
+*  We've improved the speed of static asset deployment. See [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html){: target="_blank"} for more information about available options.
 
-<!--- 52614 -->* The `setup:static-content:deploy` command now provides flags that you can use to exclude or include individual themes, areas, and locales. For more information, see [GitHub-4294](https://github.com/magento/magento2/issues/4294).
+<!--- 52614  -->
+*  The `setup:static-content:deploy` command now provides flags that you can use to exclude or include individual themes, areas, and locales. For more information, see [GitHub-4294](https://github.com/magento/magento2/issues/4294).
 
 ### Swatches
 
-<!--- 65404 -->* Magento no longer creates redundant objects when initializing a configurable product on the Category page.
+<!--- 65404  -->
+*  Magento no longer creates redundant objects when initializing a configurable product on the Category page.
 
-<!--- 65403 -->* You can now disable swatches for both the [Catalog](https://glossary.magento.com/catalog) page and search results (quick or advanced). To disable swatches from these requests, disable **Stores > Settings > Configuration > Catalog > Storefront > Show Swatches in Product List**.
+<!--- 65403  -->
+*  You can now disable swatches for both the [Catalog](https://glossary.magento.com/catalog) page and search results (quick or advanced). To disable swatches from these requests, disable **Stores > Settings > Configuration > Catalog > Storefront > Show Swatches in Product List**.
 
-<!--- 65402 -->* We've optimized the logic that Magento uses to validate swatch attributes.
+<!--- 65402  -->
+*  We've optimized the logic that Magento uses to validate swatch attributes.
 
-<!--- 65248 -->* Magento now caches swatch data in the block cache, which improves the responsiveness of the configurable product pages.
+<!--- 65248  -->
+*  Magento now caches swatch data in the block cache, which improves the responsiveness of the configurable product pages.
 
-<!--- 60045 -->* Magento now correctly matches images to products. Previously, after you selected a configurable product, Magento displayed the images for another product.
+<!--- 60045  -->
+*  Magento now correctly matches images to products. Previously, after you selected a configurable product, Magento displayed the images for another product.
 
-<!--- 66417 -->* Magento no longer displays a notice error when you create a text swatch attribute while the **update product preview image** setting  is set to **Yes**. *Fix submitted by community member Pascal Brouwers in pull request [6707](https://github.com/magento/magento2/pull/6707){: target="_blank"}.*
+<!--- 66417  -->
+*  Magento no longer displays a notice error when you create a text swatch attribute while the **update product preview image** setting  is set to **Yes**. *Fix submitted by community member Pascal Brouwers in pull request [6707](https://github.com/magento/magento2/pull/6707){: target="_blank"}.*
 
 ### TargetRule
 
-<!--- 59689 -->* Magento now displays Up-sells on the Product page.
+<!--- 59689  -->
+*  Magento now displays Up-sells on the Product page.
 
-<!--- 70853 -->* We’ve fixed an SQL error that previously caused a logical error during the creation of a TargetRule. (This issue affected the `modifyConditionByCategoryIdsAttribute` function.)
+<!--- 70853  -->
+*  We’ve fixed an SQL error that previously caused a logical error during the creation of a TargetRule. (This issue affected the `modifyConditionByCategoryIdsAttribute` function.)
 
 ### Tax
 
-<!--- 61120 -->* Magento now correctly calculates tax and order totals when a discount is used for prices that include tax and catalog prices excluding tax. Please note this is not a valid tax configuration and can introduce rounding errors.
+<!--- 61120  -->
+*  Magento now correctly calculates tax and order totals when a discount is used for prices that include tax and catalog prices excluding tax. Please note this is not a valid tax configuration and can introduce rounding errors.
 
-<!--- 59801 -->* We’ve improved the performance of the Tax Rules form in installations containing many tax rates.
+<!--- 59801  -->
+*  We’ve improved the performance of the Tax Rules form in installations containing many tax rates.
 
-<!--- 70641 -->* You can now create a tax rule when running Magento in Mozilla Firefox and Internet Explorer. Previously, you could not select a tax rate, and Magento displayed an error.
+<!--- 70641  -->
+*  You can now create a tax rule when running Magento in Mozilla Firefox and Internet Explorer. Previously, you could not select a tax rate, and Magento displayed an error.
 
-<!--- 59514 -->* The `tax_region_id` value is no longer hard-coded in the `\Magento\Tax\Setup\InstallData` file.
+<!--- 59514  -->
+*  The `tax_region_id` value is no longer hard-coded in the `\Magento\Tax\Setup\InstallData` file.
 
 ### Testing
 
-<!--- 62388-->* We've fixed a fatal issue that occurred if you executed the CatalogImportExport test before running a subsequent test. Previously, you'd receive this error: ```Failed asserting that false is true```.
+<!--- 62388 -->
+*  We've fixed a fatal issue that occurred if you executed the CatalogImportExport test before running a subsequent test. Previously, you'd receive this error: ```Failed asserting that false is true```.
 
-<!--- 59680-->* We've fixed a fatal issue that occurred if you ran Travis builds on `imagettfbbox 2.1.2`. Previously, you'd receive this error:
+<!--- 59680 -->
+*  We've fixed a fatal issue that occurred if you ran Travis builds on `imagettfbbox 2.1.2`. Previously, you'd receive this error:
 
    ```terminal
    PHP Fatal error: Call to undefined function Magento\Framework\Image\Adapter\imagettfbbox() in /home/travis/build/magento/magento2/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
    ```
 
-<!--- 64462-->* `StdoTest` is now marked as skipped. *Fix submitted by community member David Manners in pull request [8487](https://github.com/magento/magento2/pull/8487){: target="_blank"}.*
+<!--- 64462 -->
+*  `StdoTest` is now marked as skipped. *Fix submitted by community member David Manners in pull request [8487](https://github.com/magento/magento2/pull/8487){: target="_blank"}.*
 
 ### Tier pricing
 
-<!---70377-->* Magento now correctly calculates the tier price percentage when displayed prices include tax. [GitHub-8833](https://github.com/magento/magento2/issues/8833)
+<!---70377 -->
+*  Magento now correctly calculates the tier price percentage when displayed prices include tax. [GitHub-8833](https://github.com/magento/magento2/issues/8833)
 
-<!---57625-->* Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
+<!---57625 -->
+*  Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
 
-<!---56922-->*  Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
+<!---56922 -->
+*   Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
 
-<!---55055-->*  Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
+<!---55055 -->
+*   Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
 
 ### Translation and locales
 
-<!---67296-->* String localizations now work as expected when phrases include text wrapped with single quotation marks.
+<!---67296 -->
+*  String localizations now work as expected when phrases include text wrapped with single quotation marks.
 
-<!---69728-->* Translations now work for layered navigation attribute options. *Fix submitted by community member Pieter Hoste in pull request [9873](https://github.com/magento/magento2/pull/9873){: target="_blank"}.*
+<!---69728 -->
+*  Translations now work for layered navigation attribute options. *Fix submitted by community member Pieter Hoste in pull request [9873](https://github.com/magento/magento2/pull/9873){: target="_blank"}.*
 
 ### URL rewrites
 
-<!---66480-->* You can now successfully create a product and assign it to a store without encountering the following error: `Unique constraint violation found`. [GitHub-6671](https://github.com/magento/magento2/issues/6671)
+<!---66480 -->
+*  You can now successfully create a product and assign it to a store without encountering the following error: `Unique constraint violation found`. [GitHub-6671](https://github.com/magento/magento2/issues/6671)
 
-<!---67315, 67299 -->* The `catalog_url_rewrite_product_category` table is the same whether you’ve freshly installed or updated Magento 2.2.
+<!---67315, 67299  -->
+*  The `catalog_url_rewrite_product_category` table is the same whether you’ve freshly installed or updated Magento 2.2.
 
-<!---61549-->* The **Use default URL Key** setting now works on the store-view level.
+<!---61549 -->
+*  The **Use default URL Key** setting now works on the store-view level.
 
-<!---70255 -->* We've fixed several issues with how Magento processes URLs with trailing slashes. *Fix submitted by community member Ihor Sviziev in pull request [10043](https://github.com/magento/magento2/pull/10043){: target="_blank"}.*
+<!---70255  -->
+*  We've fixed several issues with how Magento processes URLs with trailing slashes. *Fix submitted by community member Ihor Sviziev in pull request [10043](https://github.com/magento/magento2/pull/10043){: target="_blank"}.*
 
-<!---60037 -->* Admin users can no longer create an empty URL key for a category. Previously, Magento let Admin users create an empty URL key, which lead to category-related errors.
+<!---60037  -->
+*  Admin users can no longer create an empty URL key for a category. Previously, Magento let Admin users create an empty URL key, which lead to category-related errors.
 
-<!---64295 -->* URL rewrites are now correctly generated for multiple store views during product import.  [GitHub-8396](https://github.com/magento/magento2/issues/8396)
+<!---64295  -->
+*  URL rewrites are now correctly generated for multiple store views during product import.  [GitHub-8396](https://github.com/magento/magento2/issues/8396)
 
-<!---56862 -->* Magento now rewrites URLs as expected when you save a product while running Magento in single-store mode. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!---56862  -->
+*  Magento now rewrites URLs as expected when you save a product while running Magento in single-store mode. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!---56863 -->* Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
+<!---56863  -->
+*  Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
 
 ### Varnish
 
-<!---58362-->* We've changed the behavior of the Varnish X-header. Only the parent (meta) SKU is now included in the list -- not the SKUs of all child products. [GitHub-6401](https://github.com/magento/magento2/issues/6401)
+<!---58362 -->
+*  We've changed the behavior of the Varnish X-header. Only the parent (meta) SKU is now included in the list -- not the SKUs of all child products. [GitHub-6401](https://github.com/magento/magento2/issues/6401)
 
-<!--- 69372-->* Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member *Fix submitted by community member Bernhard in pull request 9711.*
+<!--- 69372 -->
+*  Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member *Fix submitted by community member Bernhard in pull request 9711.*
 
 * Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
 
-<!--- 52923-->* Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
+<!--- 52923 -->
+*  Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
 
 ### Web API
 
-<!---61018-->* You can now use REST to add video to a product description. [GitHub-7153](https://github.com/magento/magento2/issues/7153)
+<!---61018 -->
+*  You can now use REST to add video to a product description. [GitHub-7153](https://github.com/magento/magento2/issues/7153)
 
-<!---57039-->* The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
+<!---57039 -->
+*  The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
 
-<!---64047-->* A null value may now be specified to unset the `special_price` attribute.
+<!---64047 -->
+*  A null value may now be specified to unset the `special_price` attribute.
 
-<!---52340 -->* The Swagger documentation erroneously indicated that search queries can return detailed information about multiple objects. The description of these APIs now state which API to use to return detailed information about a single object.
+<!---52340  -->
+*  The Swagger documentation erroneously indicated that search queries can return detailed information about multiple objects. The description of these APIs now state which API to use to return detailed information about a single object.
 
-<!--- 59871-->* You can now use REST to successfully update customer information without unintentionally deleting default billing and shipping address information.
+<!--- 59871 -->
+*  You can now use REST to successfully update customer information without unintentionally deleting default billing and shipping address information.
 
-<!--- 70743-->* You can now use a REST request to retrieve a shopping cart that contained a product with custom options. Previously, you could not use a REST request to retrieve a shopping cart that contained a product with custom options.
+<!--- 70743 -->
+*  You can now use a REST request to retrieve a shopping cart that contained a product with custom options. Previously, you could not use a REST request to retrieve a shopping cart that contained a product with custom options.
 
-<!--- 60908-->* The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
+<!--- 60908 -->
+*  The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
 
-<!---63667 -->* Searching for products via REST API using a store code in the URL returns products from all stores. [GitHub-8121](https://github.com/magento/magento2/issues/8121)
+<!---63667  -->
+*  Searching for products via REST API using a store code in the URL returns products from all stores. [GitHub-8121](https://github.com/magento/magento2/issues/8121)
 
-<!---58348 -->* You can now use the REST API to create a configurable product with a linked child product. [(GITHUB-5243)](https://github.com/magento/magento2/issues/5243){: target="_blank"}
+<!---58348  -->
+*  You can now use the REST API to create a configurable product with a linked child product. [(GITHUB-5243)](https://github.com/magento/magento2/issues/5243){: target="_blank"}
 
-<!---58338 -->* The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
+<!---58338  -->
+*  The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
 
-<!---58269 -->* You can now save a billing address using the REST  ’useForShipping' parameter. Previously use of the parameter resulted in a Rest API V1 error. [GitHub-6557](https://github.com/magento/magento2/issues/6557), [GitHub-5180](https://github.com/magento/magento2/issues/5180)
+<!---58269  -->
+*  You can now save a billing address using the REST  ’useForShipping' parameter. Previously use of the parameter resulted in a Rest API V1 error. [GitHub-6557](https://github.com/magento/magento2/issues/6557), [GitHub-5180](https://github.com/magento/magento2/issues/5180)
 
-<!---58609 -->* We’ve resolved issues updating `default_frontend_label` using REST. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
+<!---58609  -->
+*  We’ve resolved issues updating `default_frontend_label` using REST. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
 
-<!---58652 -->* Magento now sends REST multiselect attribute values in compatible formats. Previously, putting an unchanged GET returned errors on the multiselect attribute, and the only way to clear a multi-select field of all selections was to delete the product and re-create it. [GitHub-6120](https://github.com/magento/magento2/issues/6120)
+<!---58652  -->
+*  Magento now sends REST multiselect attribute values in compatible formats. Previously, putting an unchanged GET returned errors on the multiselect attribute, and the only way to clear a multi-select field of all selections was to delete the product and re-create it. [GitHub-6120](https://github.com/magento/magento2/issues/6120)
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.md
@@ -96,81 +96,118 @@ This release contains hundreds of fixes and enhancements.
 
 ### Installation, upgrade, deployment
 
-<!--- 55357/53777/45357-->* You can now run `magento setup:upgrade --keep-generated` in production mode. Previously, Magento would throw an error when you ran `setup:upgrade` after compiling dependency injection. (This significantly curtailed your ability to deploy continuous integration.) [GitHub-4795](https://github.com/magento/magento2/issues/4795)
+<!--- 55357/53777/45357 -->
+*  You can now run `magento setup:upgrade --keep-generated` in production mode. Previously, Magento would throw an error when you ran `setup:upgrade` after compiling dependency injection. (This significantly curtailed your ability to deploy continuous integration.) [GitHub-4795](https://github.com/magento/magento2/issues/4795)
 
-<!---56397, 58064-->* You can now upgrade your Magento installation when using multiple master databases for checkout, order management, and product data.
+<!---56397, 58064 -->
+*  You can now upgrade your Magento installation when using multiple master databases for checkout, order management, and product data.
 
-<!---56977, 54716-->* We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
+<!---56977, 54716 -->
+*  We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
 
-<!---57343-->*  You can now deploy build processes on a different staging machine than the one you're running your production environment on.
+<!---57343 -->
+*   You can now deploy build processes on a different staging machine than the one you're running your production environment on.
 
-<!---57943-->* Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
+<!---57943 -->
+*  Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
 
-<!--- 62400-->* Third-party command line tools no longer fail when you run `setup:di:compile`.
+<!--- 62400 -->
+*  Third-party command line tools no longer fail when you run `setup:di:compile`.
 
-<!--- 62648-->* Magento now correctly applies [website](https://glossary.magento.com/website) configuration parameters to the corresponding [store view](https://glossary.magento.com/store-view). [GitHub-7943](https://github.com/magento/magento2/issues/7943)
+<!--- 62648 -->
+*  Magento now correctly applies [website](https://glossary.magento.com/website) configuration parameters to the corresponding [store view](https://glossary.magento.com/store-view). [GitHub-7943](https://github.com/magento/magento2/issues/7943)
 
-<!--- 64085-->* Fixed HTML inline style used when sending emails when implementing the upgraded `emorgifier` library. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
+<!--- 64085 -->
+*  Fixed HTML inline style used when sending emails when implementing the upgraded `emorgifier` library. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
 
-<!--- 60835-->* We’ve changed how Magento displays status updates during a product upgrade. Previously, potentially vulnerable information such as full paths and module names were displayed in the product GUI, potentially exposing this information to a malicious user. Magento now restricts this potentially vulnerable information to logs that are available to administrators only.
+<!--- 60835 -->
+*  We’ve changed how Magento displays status updates during a product upgrade. Previously, potentially vulnerable information such as full paths and module names were displayed in the product GUI, potentially exposing this information to a malicious user. Magento now restricts this potentially vulnerable information to logs that are available to administrators only.
 
-<!--- 70314-->* The `cron:install` command now works as expected in Magento 2.2.0. Previously, the configuration for `crontab` commands contained double quotes that were not escaped, which caused invalid commands to be written to the `crontab` file. [GitHub-10040](https://github.com/magento/magento2/issues/10040)
+<!--- 70314 -->
+*  The `cron:install` command now works as expected in Magento 2.2.0. Previously, the configuration for `crontab` commands contained double quotes that were not escaped, which caused invalid commands to be written to the `crontab` file. [GitHub-10040](https://github.com/magento/magento2/issues/10040)
 
-<!--- 63637-->* Magento now moves the `sequence_*` table to the correct database after implementing a split database.
+<!--- 63637 -->
+*  Magento now moves the `sequence_*` table to the correct database after implementing a split database.
 
-<!---71890 -->* Magento no longer throws an exception when the configuration checksum is absent on a new installation.
+<!---71890  -->
+*  Magento no longer throws an exception when the configuration checksum is absent on a new installation.
 
-<!--- 70573-->* It is now possible to configure Redis settings for session storage, default cache, and full page cache from the command line.
+<!--- 70573 -->
+*  It is now possible to configure Redis settings for session storage, default cache, and full page cache from the command line.
 
-<!--- 59342-->* Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
+<!--- 59342 -->
+*  Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
 
-<!--- 54722-->* We've removed the sample password from the Setup Wizard
+<!--- 54722 -->
+*  We've removed the sample password from the Setup Wizard
 
-<!--- 71173-->* You can now enable JavaScript minification without error. Previously, after enabling JS minification, the Magento Admin displayed 404 errors when accessing JavaScript elements.
+<!--- 71173 -->
+*  You can now enable JavaScript minification without error. Previously, after enabling JS minification, the Magento Admin displayed 404 errors when accessing JavaScript elements.
 
-<!--- 70869-->* Magento no longer displays console errors after CSS merging and minification is enabled. Previously, when CSS merging and minification was enabled, the storefront was not displayed as expected, and the `styles-l.min.css` and `print.min.css` files could not be found.
+<!--- 70869 -->
+*  Magento no longer displays console errors after CSS merging and minification is enabled. Previously, when CSS merging and minification was enabled, the storefront was not displayed as expected, and the `styles-l.min.css` and `print.min.css` files could not be found.
 
-<!--- 69854-->* You can now successfully use the `config:set` command to set allowed or default currencies.
+<!--- 69854 -->
+*  You can now successfully use the `config:set` command to set allowed or default currencies.
 
-<!--- 46636-->* Nginx now redirects to the setup page when using port 81.
+<!--- 46636 -->
+*  Nginx now redirects to the setup page when using port 81.
 
-<!--- 69544-->* We've added the `dev:template-hints:enable` and `dev:template-hints:disable` commands to manage template hints. *Fix submitted by community member Miguel Balparda in pull request [9778](https://github.com/magento/magento2/pull/9778){: target="_blank"}.*
+<!--- 69544 -->
+*  We've added the `dev:template-hints:enable` and `dev:template-hints:disable` commands to manage template hints. *Fix submitted by community member Miguel Balparda in pull request [9778](https://github.com/magento/magento2/pull/9778){: target="_blank"}.*
 
-<!--- 67501-->* We've added the `dev:query-log:enable` and  `dev:query-log:disable` to manage database query logging.  *Fix submitted by community member Federico Rivollier in pull request [9264](https://github.com/magento/magento2/pull/9264){: target="_blank"}.*
+<!--- 67501 -->
+*  We've added the `dev:query-log:enable` and  `dev:query-log:disable` to manage database query logging.  *Fix submitted by community member Federico Rivollier in pull request [9264](https://github.com/magento/magento2/pull/9264){: target="_blank"}.*
 
-<!---67537 -->* We've added the `varnish:vcl:generate` command to create the Varnish VCL file. *Fix submitted by community member Piotr Kwiecinski in pull request [9286](https://github.com/magento/magento2/pull/9286){: target="_blank"}.*
+<!---67537  -->
+*  We've added the `varnish:vcl:generate` command to create the Varnish VCL file. *Fix submitted by community member Piotr Kwiecinski in pull request [9286](https://github.com/magento/magento2/pull/9286){: target="_blank"}.*
 
-<!--- 69524 -->* Magento now adds a new record to the quote table and adds the  current date and time to the `created_at` field. Previously, this field was not updated.
+<!--- 69524  -->
+*  Magento now adds a new record to the quote table and adds the  current date and time to the `created_at` field. Previously, this field was not updated.
 
-<!--- 57820 -->* The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
+<!--- 57820  -->
+*  The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
 
-<!--- 56743 -->*  We've fixed issues with upgrading installations with split databases.
+<!--- 56743  -->
+*   We've fixed issues with upgrading installations with split databases.
 
-<!--- 63022 -->* Static content deployment (SCD) now works when multiple languages are specified. Previously, Magento displayed an error if you tried to deploy static content in more than one language (for example, `bin/magento setup:static-content:deploy en_CA fr_CA de_DE`).
+<!--- 63022  -->
+*  Static content deployment (SCD) now works when multiple languages are specified. Previously, Magento displayed an error if you tried to deploy static content in more than one language (for example, `bin/magento setup:static-content:deploy en_CA fr_CA de_DE`).
 
-<!--- 57656 -->* The import URL directive now contains base URL and locale placeholders instead of the real URL.
+<!--- 57656  -->
+*  The import URL directive now contains base URL and locale placeholders instead of the real URL.
 
-<!--- 55757 -->* Magento now works as expected on an Apache `php-fpm` environment.
+<!--- 55757  -->
+*  Magento now works as expected on an Apache `php-fpm` environment.
 
-<!--- 63295 -->* The `DOCUMENT_ROOT` directory is now writable. Previously, installation failed because this directory was not writable.
+<!--- 63295  -->
+*  The `DOCUMENT_ROOT` directory is now writable. Previously, installation failed because this directory was not writable.
 
-<!--- 67082-->* When upgrading Magento from 2.1.x to 2.2, the `quote_address.free_shipping` column is the same whether you upgraded from a previous installation of Magento or performed a fresh installation. Previously, different upgrade/installation options affected the contents of this column.
+<!--- 67082 -->
+*  When upgrading Magento from 2.1.x to 2.2, the `quote_address.free_shipping` column is the same whether you upgraded from a previous installation of Magento or performed a fresh installation. Previously, different upgrade/installation options affected the contents of this column.
 
-<!--- 62655-->* Command-line users now have read and write permissions to the  `var/generation` directory. [GitHub-7933](https://github.com/magento/magento2/issues/7933)
+<!--- 62655 -->
+*  Command-line users now have read and write permissions to the  `var/generation` directory. [GitHub-7933](https://github.com/magento/magento2/issues/7933)
 
-<!--- 61431-->* The Magento command-line interface now sets the correct exit codes when an upgrade task fails. [GitHub-7576](https://github.com/magento/magento2/issues/7576)
+<!--- 61431 -->
+*  The Magento command-line interface now sets the correct exit codes when an upgrade task fails. [GitHub-7576](https://github.com/magento/magento2/issues/7576)
 
-<!--- 58849-->* You can now disable the Review module without incurring an error in the Product Edit page. Previously, if you tried to edit a product after disabling the review module, Magento displayed this error: "Something went wrong". [GitHub-6704](https://github.com/magento/magento2/issues/6704)
+<!--- 58849 -->
+*  You can now disable the Review module without incurring an error in the Product Edit page. Previously, if you tried to edit a product after disabling the review module, Magento displayed this error: "Something went wrong". [GitHub-6704](https://github.com/magento/magento2/issues/6704)
 
-<!--- 56816-->* You can now use Component Manager to enable a previously disabled module. Previously, when you ran `bin/magento module:disable Magento_AnyModule`, then tried to re-enable  that module, Magento fails to enable it and any previously enabled cache types, and module installation fails. [GitHub-6078](https://github.com/magento/magento2/issues/6078)
+<!--- 56816 -->
+*  You can now use Component Manager to enable a previously disabled module. Previously, when you ran `bin/magento module:disable Magento_AnyModule`, then tried to re-enable  that module, Magento fails to enable it and any previously enabled cache types, and module installation fails. [GitHub-6078](https://github.com/magento/magento2/issues/6078)
 
-<!--- 58132-->* We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
+<!--- 58132 -->
+*  We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
 
-<!--- 58132-->* We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
+<!--- 58132 -->
+*  We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
 
 ### AMQP
 
-<!---58654, 57177-->* The `magento queue:consumers:start` command now works correctly when you provide the `max-messages` argument.
+<!---58654, 57177 -->
+*  The `magento queue:consumers:start` command now works correctly when you provide the `max-messages` argument.
 
 <!--- 70516-->
 *  Magento no longer indicates errors when you install without AMQP. Previously, Magento displayed the following error:
@@ -179,639 +216,933 @@ This release contains hundreds of fixes and enhancements.
    `report.CRITICAL: Error Connecting to server (0): Failed to parse address ":" {"exception":"[object] (PhpAmqpLib\\Exception\\AMQPRuntimeException(code: 0): Error Connecting to server (0): Failed to parse address \":\" at /vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/IO/StreamIO.php:106)"} []`
    ```
 
-<!--- 70518-->* You can now override queue publishers configuration through the `env.php` file.
+<!--- 70518 -->
+*  You can now override queue publishers configuration through the `env.php` file.
 
-<!--- 66993-->* Magento now re-processes queue messages if the consumer process is terminated.
+<!--- 66993 -->
+*  Magento now re-processes queue messages if the consumer process is terminated.
 
-<!--- 58081-->*  Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
+<!--- 58081 -->
+*   Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
 
 ### Cart and checkout
 
-<!--- 53793 -->* Magento now implements the minicart maximum display recently added item setting to your [shopping cart](https://glossary.magento.com/shopping-cart).  Previously, Magento displayed all the items in the shopping cart, even when the number of items exceeded this limit. [GitHub-4750](https://github.com/magento/magento2/issues/4750)
+<!--- 53793  -->
+*  Magento now implements the minicart maximum display recently added item setting to your [shopping cart](https://glossary.magento.com/shopping-cart).  Previously, Magento displayed all the items in the shopping cart, even when the number of items exceeded this limit. [GitHub-4750](https://github.com/magento/magento2/issues/4750)
 
-<!---58036-->* You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
+<!---58036 -->
+*  You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
 
-<!---58902-->* Custom address attributes now appear in the Checkout summary.
+<!---58902 -->
+*  Custom address attributes now appear in the Checkout summary.
 
-<!---57497-->* Lengthy [Order Status](https://glossary.magento.com/order-status) tables are now paginated as expected.
+<!---57497 -->
+*  Lengthy [Order Status](https://glossary.magento.com/order-status) tables are now paginated as expected.
 
-<!---56956-->* Magento now displays the product add validation message ("Product was added to the cart") only after you have successfully added a product to your cart.
+<!---56956 -->
+*  Magento now displays the product add validation message ("Product was added to the cart") only after you have successfully added a product to your cart.
 
-<!---58057-->* We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
+<!---58057 -->
+*  We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
 
-<!---59209-->* The number of items in the minicart is now updated correctly when you run Magento in mixed HTTP/HTTPS mode. [GitHub-6487](https://github.com/magento/magento2/issues/6487)
+<!---59209 -->
+*  The number of items in the minicart is now updated correctly when you run Magento in mixed HTTP/HTTPS mode. [GitHub-6487](https://github.com/magento/magento2/issues/6487)
 
-<!---57062-->* The minicart now performs as expected in deployments that span multiple websites. Previously, in a Magento installation that had multiple websites, products that you added to one [website](https://glossary.magento.com/website) appeared in the other websites' minicarts.
+<!---57062 -->
+*  The minicart now performs as expected in deployments that span multiple websites. Previously, in a Magento installation that had multiple websites, products that you added to one [website](https://glossary.magento.com/website) appeared in the other websites' minicarts.
 
-<!---57843-->* A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart,  the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
+<!---57843 -->
+*  A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart,  the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
 
-<!---59024-->* Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
+<!---59024 -->
+*  Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
 
-<!---60103-->* Magento no longer lets you add a product variation to your shopping cart if the item is out of stock. Previously, Magento permitted you to select an out-of-stock item and when you added it to your cart, displayed the "Product is out of stock" message.
+<!---60103 -->
+*  Magento no longer lets you add a product variation to your shopping cart if the item is out of stock. Previously, Magento permitted you to select an out-of-stock item and when you added it to your cart, displayed the "Product is out of stock" message.
 
-<!---58090-->* We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
+<!---58090 -->
+*  We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
 
-<!---57168-->* We fixed a [JavaScript](https://glossary.magento.com/javascript) error that occurred on the Checkout page after you changed the country in the **Estimate Shipping and Tax** field.
+<!---57168 -->
+*  We fixed a [JavaScript](https://glossary.magento.com/javascript) error that occurred on the Checkout page after you changed the country in the **Estimate Shipping and Tax** field.
 
-<!---60293 -->* Magento now successfully estimates shipping costs. Previously, when you tried to estimate shipping costs, the load indicator would spin indefinitely, and Magento displayed this exception,```Object doesn't support this action```. [GitHub-5358](https://github.com/magento/magento2/issues/5358), [GitHub-7051](https://github.com/magento/magento2/issues/7051)
+<!---60293  -->
+*  Magento now successfully estimates shipping costs. Previously, when you tried to estimate shipping costs, the load indicator would spin indefinitely, and Magento displayed this exception,```Object doesn't support this action```. [GitHub-5358](https://github.com/magento/magento2/issues/5358), [GitHub-7051](https://github.com/magento/magento2/issues/7051)
 
-<!---56962 -->* Magento now displays the **State/Province** field on the Add New Address page. [GitHub-5279](https://github.com/magento/magento2/issues/5279)
+<!---56962  -->
+*  Magento now displays the **State/Province** field on the Add New Address page. [GitHub-5279](https://github.com/magento/magento2/issues/5279)
 
-<!--- 69657-->* Credit card information now persists as expected after a user enters a promotion code during checkout. Previously, After an user enters credit card information, then discount code and then click **Place Order**. The credit card information fields are emptied and user has to enter the credit card information again to proceed with the order transaction.
+<!--- 69657 -->
+*  Credit card information now persists as expected after a user enters a promotion code during checkout. Previously, After an user enters credit card information, then discount code and then click **Place Order**. The credit card information fields are emptied and user has to enter the credit card information again to proceed with the order transaction.
 
-<!--- 64544-->* You can complete your order after entering a new shipping address during checkout. Previously, Magento would not let you place an order if you entered a new shipping address during checkout.
+<!--- 64544 -->
+*  You can complete your order after entering a new shipping address during checkout. Previously, Magento would not let you place an order if you entered a new shipping address during checkout.
 
-<!--- 64399-->* Magento no longer throws an exception when a customer updates their shopping cart after you've enabled the Minimum Order setting. *Fix submitted by community member <a href="https://github.com/ericrisler" target="_blank">Eric Risler
+<!--- 64399 -->
+*  Magento no longer throws an exception when a customer updates their shopping cart after you've enabled the Minimum Order setting. *Fix submitted by community member <a href="https://github.com/ericrisler" target="_blank">Eric Risler
 </a> in pull request [8474](https://github.com/magento/magento2/pull/8474){: target="_blank"}.*
 
-<!--- 67323-->* You can now translate the  FPT label on the checkout page. *Fix submitted by community member Oleksii Korshenko in pull request [9204](https://github.com/magento/magento2/pull/9204){: target="_blank"}.*
+<!--- 67323 -->
+*  You can now translate the  FPT label on the checkout page. *Fix submitted by community member Oleksii Korshenko in pull request [9204](https://github.com/magento/magento2/pull/9204){: target="_blank"}.*
 
-<!--- 69230-->* Magento no longer truncates bill-to names and shio-to names to 20 characters in the Admin.  *Fix submitted by community member Isolde in pull request [9654](https://github.com/magento/magento2/pull/9654){: target="_blank"}.*
+<!--- 69230 -->
+*  Magento no longer truncates bill-to names and shio-to names to 20 characters in the Admin.  *Fix submitted by community member Isolde in pull request [9654](https://github.com/magento/magento2/pull/9654){: target="_blank"}.*
 
-<!--- 69375-->* You can now delete the last item in your cart when the Minimum Order setting is enabled. *Fix submitted by community member storbahn in pull request [9714](https://github.com/magento/magento2/pull/9714){: target="_blank"}.*
+<!--- 69375 -->
+*  You can now delete the last item in your cart when the Minimum Order setting is enabled. *Fix submitted by community member storbahn in pull request [9714](https://github.com/magento/magento2/pull/9714){: target="_blank"}.*
 
-<!--- 69379-->* You can now create unique checkbox IDs for the Terms and Conditions part of the checkout process. *Fix submitted by community member Bernhard in pull request [9717](https://github.com/magento/magento2/pull/9717){: target="_blank"}.*
+<!--- 69379 -->
+*  You can now create unique checkbox IDs for the Terms and Conditions part of the checkout process. *Fix submitted by community member Bernhard in pull request [9717](https://github.com/magento/magento2/pull/9717){: target="_blank"}.*
 
-<!--- 69533-->* Magento now correctly displays the coupon label in the shopping cart during checkout. *Fix submitted by community member Sylvain Rayé in pull request [9721](https://github.com/magento/magento2/pull/9721){: target="_blank"}.*
+<!--- 69533 -->
+*  Magento now correctly displays the coupon label in the shopping cart during checkout. *Fix submitted by community member Sylvain Rayé in pull request [9721](https://github.com/magento/magento2/pull/9721){: target="_blank"}.*
 
-<!--- 69848-->* Magento now pre-fills prefixes and suffixes in the quote shipping address *Fix submitted by community member Anton Evers in pull request [9925](https://github.com/magento/magento2/pull/9925){: target="_blank"}.*
+<!--- 69848 -->
+*  Magento now pre-fills prefixes and suffixes in the quote shipping address *Fix submitted by community member Anton Evers in pull request [9925](https://github.com/magento/magento2/pull/9925){: target="_blank"}.*
 
-<!--- 70052-->* The country drop-down box now correctly shows the countries for which the current store and customer account are configured. *Fix submitted by community member Marcel in pull request [9429](https://github.com/magento/magento2/pull/9429){: target="_blank"}.*
+<!--- 70052 -->
+*  The country drop-down box now correctly shows the countries for which the current store and customer account are configured. *Fix submitted by community member Marcel in pull request [9429](https://github.com/magento/magento2/pull/9429){: target="_blank"}.*
 
-<!--- 56411-->* The shopping cart now handles products with custom options. [GitHub-5612](https://github.com/magento/magento2/issues/5612)
+<!--- 56411 -->
+*  The shopping cart now handles products with custom options. [GitHub-5612](https://github.com/magento/magento2/issues/5612)
 
-<!--- 63200-->* Magento now requires completion of the State field during the check out process if this field has been configured as required.
+<!--- 63200 -->
+*  Magento now requires completion of the State field during the check out process if this field has been configured as required.
 
-<!--- 63635-->* Checkout now loads as expected in Safari private mode. [GitHub-7942](https://github.com/magento/magento2/issues/7942), [GitHub-7329](https://github.com/magento/magento2/issues/7329), [GitHub-8358](https://github.com/magento/magento2/issues/8358)
+<!--- 63635 -->
+*  Checkout now loads as expected in Safari private mode. [GitHub-7942](https://github.com/magento/magento2/issues/7942), [GitHub-7329](https://github.com/magento/magento2/issues/7329), [GitHub-8358](https://github.com/magento/magento2/issues/8358)
 
-<!--- 61368-->* Minicart now shows all products you’ve added, whether you added them while signed-in or not. Previously, the minicart contained only products that you added while signed in. [GitHub-7500](https://github.com/magento/magento2/issues/7500)
+<!--- 61368 -->
+*  Minicart now shows all products you’ve added, whether you added them while signed-in or not. Previously, the minicart contained only products that you added while signed in. [GitHub-7500](https://github.com/magento/magento2/issues/7500)
 
-<!--- 59807-->* Magento now displays the ”Thank you for your purchase!" on the checkout success page.
+<!--- 59807 -->
+*  Magento now displays the ”Thank you for your purchase!" on the checkout success page.
 
-<!--- 60352-->* Magento now displays the correct error message when you enter an invalid discount code when making a payment. [GitHub-7230](https://github.com/magento/magento2/issues/7230)
+<!--- 60352 -->
+*  Magento now displays the correct error message when you enter an invalid discount code when making a payment. [GitHub-7230](https://github.com/magento/magento2/issues/7230)
 
-<!--- 47017-->* You can now directly add a configurable product to your shopping cart from category page. [GitHub-2574](https://github.com/magento/magento2/issues/2574), [GitHub-5850](https://github.com/magento/magento2/issues/5850), [GitHub-5882](https://github.com/magento/magento2/issues/5882), [GitHub-6572](https://github.com/magento/magento2/issues/6572), [GitHub-5558](https://github.com/magento/magento2/issues/5558), [GitHub-4184](https://github.com/magento/magento2/issues/4184)
+<!--- 47017 -->
+*  You can now directly add a configurable product to your shopping cart from category page. [GitHub-2574](https://github.com/magento/magento2/issues/2574), [GitHub-5850](https://github.com/magento/magento2/issues/5850), [GitHub-5882](https://github.com/magento/magento2/issues/5882), [GitHub-6572](https://github.com/magento/magento2/issues/6572), [GitHub-5558](https://github.com/magento/magento2/issues/5558), [GitHub-4184](https://github.com/magento/magento2/issues/4184)
 
-<!--- 58345-->* Magento now displays out-of-stock products in the shopping cart. Previously, if a product’s status changed between the time you added it to the cart and you proceeded to check out, Magento removed the product from your cart. [GitHub-6583](https://github.com/magento/magento2/issues/6583)
+<!--- 58345 -->
+*  Magento now displays out-of-stock products in the shopping cart. Previously, if a product’s status changed between the time you added it to the cart and you proceeded to check out, Magento removed the product from your cart. [GitHub-6583](https://github.com/magento/magento2/issues/6583)
 
-<!--- 60110-->* When you select `New Address` while reviewing order information during check out, Magento now profiles the username and country fields, but leaves the address fields empty. Previously, Magento did not leave the address fields empty, and the checkout process failed. [GitHub-6869](https://github.com/magento/magento2/issues/6869)
+<!--- 60110 -->
+*  When you select `New Address` while reviewing order information during check out, Magento now profiles the username and country fields, but leaves the address fields empty. Previously, Magento did not leave the address fields empty, and the checkout process failed. [GitHub-6869](https://github.com/magento/magento2/issues/6869)
 
-<!--- 57682-->* Checkout agreement validation now works as expected after you change payment method. [GitHub-6224](https://github.com/magento/magento2/issues/6224)
+<!--- 57682 -->
+*  Checkout agreement validation now works as expected after you change payment method. [GitHub-6224](https://github.com/magento/magento2/issues/6224)
 
-<!--- 58059-->* The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
+<!--- 58059 -->
+*  The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
 
-<!--- 58059-->* The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
+<!--- 58059 -->
+*  The shopping cart now displays a shipping rate that reflects tax settings. Previously, the prices displayed in your shopping cart were not adjusted to include these settings. [GitHub-6166](https://github.com/magento/magento2/issues/6166)
 
 ### Catalog
 
-<!--- 65324, 66829 -->*  Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
+<!--- 65324, 66829  -->
+*   Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
 
-<!--- 65251 -->* The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
+<!--- 65251  -->
+*  The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
 
-<!--- 66366 -->* The `\Magento\CatalogInventory\Model\Stock\Status\getStockId()` method now returns the correct values.
+<!--- 66366  -->
+*  The `\Magento\CatalogInventory\Model\Stock\Status\getStockId()` method now returns the correct values.
 
-<!--- 58437-->* The [storefront](https://glossary.magento.com/storefront) gallery now displays all the images associated with a [configurable product](https://glossary.magento.com/configurable-product). Previously, when you clicked on the swatches associated with a configurable product, the gallery displayed only one of several possible images. [GitHub-6195](https://github.com/magento/magento2/issues/6195), [GitHub-4101](https://github.com/magento/magento2/issues/4101)
+<!--- 58437 -->
+*  The [storefront](https://glossary.magento.com/storefront) gallery now displays all the images associated with a [configurable product](https://glossary.magento.com/configurable-product). Previously, when you clicked on the swatches associated with a configurable product, the gallery displayed only one of several possible images. [GitHub-6195](https://github.com/magento/magento2/issues/6195), [GitHub-4101](https://github.com/magento/magento2/issues/4101)
 
-<!---57832 -->* Magento now displays the **This is a required field** message immediately adjacent to the product options as needed during [checkout](https://glossary.magento.com/checkout). Previously, Magento displayed this message at the bottom of the checkout form.
+<!---57832  -->
+*  Magento now displays the **This is a required field** message immediately adjacent to the product options as needed during [checkout](https://glossary.magento.com/checkout). Previously, Magento displayed this message at the bottom of the checkout form.
 
-<!--- 57420/54320-->* The category page now shows the current price after Magento runs a scheduled update.  Previously, the category page would not update the  price after running a scheduled update. [GitHub-4945](https://github.com/magento/magento2/issues/4945)
+<!--- 57420/54320 -->
+*  The category page now shows the current price after Magento runs a scheduled update.  Previously, the category page would not update the  price after running a scheduled update. [GitHub-4945](https://github.com/magento/magento2/issues/4945)
 
-<!---56742-->* You can now sort and filter on the New Review page. [GitHub-5391](https://github.com/magento/magento2/issues/5391)
+<!---56742 -->
+*  You can now sort and filter on the New Review page. [GitHub-5391](https://github.com/magento/magento2/issues/5391)
 
-<!---58511-->* Magento now displays server-side Ajax error messages.
+<!---58511 -->
+*  Magento now displays server-side Ajax error messages.
 
-<!---56964-->* Magento now validates the uniqueness of product attribute values as you create or edit them. Previously, you could add identically named values to an attribute. [GitHub-4881](https://github.com/magento/magento2/issues/4881)
+<!---56964 -->
+*  Magento now validates the uniqueness of product attribute values as you create or edit them. Previously, you could add identically named values to an attribute. [GitHub-4881](https://github.com/magento/magento2/issues/4881)
 
-<!--- 62229-->* Magento now displays the price of out-of-stock products on the product page.
+<!--- 62229 -->
+*  Magento now displays the price of out-of-stock products on the product page.
 
-<!--- 58895-->* If you remove an item from the Compare Items list that is displayed on any [Category](https://glossary.magento.com/category) page, Magento no longer redirects you to the Compare Products page.
+<!--- 58895 -->
+*  If you remove an item from the Compare Items list that is displayed on any [Category](https://glossary.magento.com/category) page, Magento no longer redirects you to the Compare Products page.
 
-<!--- 72112-->* Subcategories no longer show up in the menu when the parent category is disabled or hidden from the menu. [GitHub-10664](https://github.com/magento/magento2/issues/10664)
+<!--- 72112 -->
+*  Subcategories no longer show up in the menu when the parent category is disabled or hidden from the menu. [GitHub-10664](https://github.com/magento/magento2/issues/10664)
 
-<!--- 57719-->* We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
+<!--- 57719 -->
+*  We've corrected a problem with Magento throwing an HTTP ERROR 500 intermittently during checkout.
 
-<!--- 63561-->* The product attribute `category_ids` can have only **Global** scope. Previously, you could change the scope value of `category_ids` to **Store**.
+<!--- 63561 -->
+*  The product attribute `category_ids` can have only **Global** scope. Previously, you could change the scope value of `category_ids` to **Store**.
 
-<!--- 53135-->* A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588), [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041),  [GitHub-6097](https://github.com/magento/magento2/issues/6097)
+<!--- 53135 -->
+*  A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588), [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041),  [GitHub-6097](https://github.com/magento/magento2/issues/6097)
 
-<!--- 56866-->* The prices you assign to custom options no longer change unexpectedly after you save them. [GitHub-6116](https://github.com/magento/magento2/issues/6116)
+<!--- 56866 -->
+*  The prices you assign to custom options no longer change unexpectedly after you save them. [GitHub-6116](https://github.com/magento/magento2/issues/6116)
 
-<!--- 50123-->* You can now create a blank attribute option using the drop-down input option on products that do not require an attribute. [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5485](https://github.com/magento/magento2/issues/5485), [GitHub-4910](https://github.com/magento/magento2/issues/4910)
+<!--- 50123 -->
+*  You can now create a blank attribute option using the drop-down input option on products that do not require an attribute. [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5485](https://github.com/magento/magento2/issues/5485), [GitHub-4910](https://github.com/magento/magento2/issues/4910)
 
-<!--- 54718-->* Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
+<!--- 54718 -->
+*  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
-<!---55346 -->* You can now successfully set an SKU mask to empty. Previously, when a product SKU mask was set to empty, Magento experienced problems loading the Product Add page. [GitHub-5618](https://github.com/magento/magento2/issues/5618)
+<!---55346  -->
+*  You can now successfully set an SKU mask to empty. Previously, when a product SKU mask was set to empty, Magento experienced problems loading the Product Add page. [GitHub-5618](https://github.com/magento/magento2/issues/5618)
 
-<!---47698 -->* Magento now correctly displays custom options at the store-view level. [GitHub-2908](https://github.com/magento/magento2/issues/2908), [GitHub-5885](https://github.com/magento/magento2/issues/5885), [GitHub-5612](https://github.com/magento/magento2/issues/5612)
+<!---47698  -->
+*  Magento now correctly displays custom options at the store-view level. [GitHub-2908](https://github.com/magento/magento2/issues/2908), [GitHub-5885](https://github.com/magento/magento2/issues/5885), [GitHub-5612](https://github.com/magento/magento2/issues/5612)
 
-<!---54648 -->* Magento now provides swatch input for the Admin Scope, and the attribute fall back mechanism now reverts to the default option value
+<!---54648  -->
+*  Magento now provides swatch input for the Admin Scope, and the attribute fall back mechanism now reverts to the default option value
  if no values are specified for specific store view. [GitHub-5143](https://github.com/magento/magento2/issues/5143), [GitHub-5142](https://github.com/magento/magento2/issues/5142)
 
-<!--- 57989 -->* You can now create a custom attribute for a category that successfully uploads a custom image. Previously, you could create the attribute, but could not save the image.
+<!--- 57989  -->
+*  You can now create a custom attribute for a category that successfully uploads a custom image. Previously, you could create the attribute, but could not save the image.
 
-<!--- 57023-->* Sorting configurable products by price now works as expected when a simple product has a special price. [GitHub-4778](https://github.com/magento/magento2/issues/4778)
+<!--- 57023 -->
+*  Sorting configurable products by price now works as expected when a simple product has a special price. [GitHub-4778](https://github.com/magento/magento2/issues/4778)
 
-<!--- 70987 -->* Magento no longer displays an error when you open a product with a Fixed Product Tax attribute enabled.
+<!--- 70987  -->
+*  Magento no longer displays an error when you open a product with a Fixed Product Tax attribute enabled.
 
-<!--- 59315-->* We've improved the process of using the WebAPI interface to save a product stock item. Previously, this type of save action worked inconsistently.
+<!--- 59315 -->
+*  We've improved the process of using the WebAPI interface to save a product stock item. Previously, this type of save action worked inconsistently.
 
-<!---57564 -->* You can no longer change or fake a product price from the Magento [storefront](https://glossary.magento.com/storefront) and then complete an order with that faked price.
+<!---57564  -->
+*  You can no longer change or fake a product price from the Magento [storefront](https://glossary.magento.com/storefront) and then complete an order with that faked price.
 
-<!--- 56868, 56582 -->* You can now save a product with images multiple times.
+<!--- 56868, 56582  -->
+*  You can now save a product with images multiple times.
 
-<!--- 70750, 67618-->* View permissions to high-level product categories now work as expected. Previously, Magento displayed only the product categories that users who belonged to the NOT_LOGGED_IN customer group were permitted to view, no matter which user logged in. Additionally, a user restricted to browse a category could still see the category in the top-level navigation menu if the page were previously cached in FPC.
+<!--- 70750, 67618 -->
+*  View permissions to high-level product categories now work as expected. Previously, Magento displayed only the product categories that users who belonged to the NOT_LOGGED_IN customer group were permitted to view, no matter which user logged in. Additionally, a user restricted to browse a category could still see the category in the top-level navigation menu if the page were previously cached in FPC.
 
-<!---70877 -->* You can now successfully add a product to the compare list. Previously, when you tried to add a product to a compare list, Magento displayed an error.
+<!---70877  -->
+*  You can now successfully add a product to the compare list. Previously, when you tried to add a product to a compare list, Magento displayed an error.
 
-<!--- 70790-->* You can now remove custom options from simple products. Previously, when you tried to remove a custom option from a product, Magento did not remove the options, and displayed an error message.
+<!--- 70790 -->
+*  You can now remove custom options from simple products. Previously, when you tried to remove a custom option from a product, Magento did not remove the options, and displayed an error message.
 
-<!--- 62637-->* You can now successfully set the **Enable Product** attribute to **no**.
+<!--- 62637 -->
+*  You can now successfully set the **Enable Product** attribute to **no**.
 
-<!--- 61095-->* Magento no longer permits a shopper to place a re-order once you've disabled one of items in the order.
+<!--- 61095 -->
+*  Magento no longer permits a shopper to place a re-order once you've disabled one of items in the order.
 
-<!--- 64250-->* Fixed an issue that occurred in the Catalog Gallery on mobile displays when the `allowfullscreen` setting is enabled. *Fix submitted by community member Dennis van Schaik in pull request [8434](https://github.com/magento/magento2/pull/8434){: target="_blank"}.*
+<!--- 64250 -->
+*  Fixed an issue that occurred in the Catalog Gallery on mobile displays when the `allowfullscreen` setting is enabled. *Fix submitted by community member Dennis van Schaik in pull request [8434](https://github.com/magento/magento2/pull/8434){: target="_blank"}.*
 
-<!--- 64403-->* Magento now successfully loads re-ordered related products when Edge-Mode is activated. *Fix submitted by community member [@kirashet666](https://github.com/kirashet666){: target="_blank"} in pull request [8467](https://github.com/magento/magento2/pull/8467){: target="_blank"}.*
+<!--- 64403 -->
+*  Magento now successfully loads re-ordered related products when Edge-Mode is activated. *Fix submitted by community member [@kirashet666](https://github.com/kirashet666){: target="_blank"} in pull request [8467](https://github.com/magento/magento2/pull/8467){: target="_blank"}.*
 
-<!--- 64999 -->* Magento now displays cross-sells as expected when you use the `product/list/items.phtml` template. *Fix submitted by community member Koen V in pull request [8602](https://github.com/magento/magento2/pull/9662){: target="_blank"}.*
+<!--- 64999  -->
+*  Magento now displays cross-sells as expected when you use the `product/list/items.phtml` template. *Fix submitted by community member Koen V in pull request [8602](https://github.com/magento/magento2/pull/9662){: target="_blank"}.*
 
-<!--- 65364-->* Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
+<!--- 65364 -->
+*  Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
 
-<!--- 65334-->*  Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
+<!--- 65334 -->
+*   Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
 
-<!--- 69297-->* Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
+<!--- 69297 -->
+*  Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
 
-<!---70256 -->* You can now create an `etc/view.xml` file containing an `images` tag with an attribute `module`. *Fix submitted by community member Marius Strajeru in pull request [10052](https://github.com/magento/magento2/pull/10052){: target="_blank"}.*
+<!---70256  -->
+*  You can now create an `etc/view.xml` file containing an `images` tag with an attribute `module`. *Fix submitted by community member Marius Strajeru in pull request [10052](https://github.com/magento/magento2/pull/10052){: target="_blank"}.*
 
-<!--- 70345-->* Magento now displays the Category selection UI under Conditions when you select a rule for editing. *Fix submitted by community member duckchip in pull request [10094](https://github.com/magento/magento2/pull/10094){: target="_blank"}.*
+<!--- 70345 -->
+*  Magento now displays the Category selection UI under Conditions when you select a rule for editing. *Fix submitted by community member duckchip in pull request [10094](https://github.com/magento/magento2/pull/10094){: target="_blank"}.*
 
-<!--- 63062-->* Magento now displays the correct image when you switch between a configurable product's options. Previously, Magento loaded product images from a different product.
+<!--- 63062 -->
+*  Magento now displays the correct image when you switch between a configurable product's options. Previously, Magento loaded product images from a different product.
 
-<!--- 66885-->* The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
+<!--- 66885 -->
+*  The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
 
-<!--- 63601-->*  The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
+<!--- 63601 -->
+*   The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
 
-<!--- 62426-->* Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
+<!--- 62426 -->
+*  Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
 
-<!--- 71445-->*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+<!--- 71445 -->
+*   Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
-<!--- 67628-->*  You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
+<!--- 67628 -->
+*   You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
 
-<!--- 63320-->* If you’ve enabled persistent shopping cart, you can now check out even after your session has expired.
+<!--- 63320 -->
+*  If you’ve enabled persistent shopping cart, you can now check out even after your session has expired.
 
-<!--- 61826-->*  Magento no longer throws an error when you try to save a product with imported custom options.
+<!--- 61826 -->
+*   Magento no longer throws an error when you try to save a product with imported custom options.
 
-<!--- 62468-->*  Magento now displays the product price even when the product is out-of-stock.
+<!--- 62468 -->
+*   Magento now displays the product price even when the product is out-of-stock.
 
-<!--- 64710-->*  `productWebsiteLink` no longer deletes a product’s custom origins.
+<!--- 64710 -->
+*   `productWebsiteLink` no longer deletes a product’s custom origins.
 
-<!--- 56943-->*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+<!--- 56943 -->
+*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
-<!--- 52577-->* Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
+<!--- 52577 -->
+*  Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
 
-<!--- 60613-->* When you edit a widget’s  existing condition, Magento now loads the SKU grid with all available SKUs. [GitHub-6985](https://github.com/magento/magento2/issues/6985)
+<!--- 60613 -->
+*  When you edit a widget’s  existing condition, Magento now loads the SKU grid with all available SKUs. [GitHub-6985](https://github.com/magento/magento2/issues/6985)
 
-<!--- 56978-->*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
+<!--- 56978 -->
+*   Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
 
-<!--- 60602-->* Combine rule conditions now work as expected for product list  widgets. [GitHub-7274](https://github.com/magento/magento2/issues/7274)
+<!--- 60602 -->
+*  Combine rule conditions now work as expected for product list  widgets. [GitHub-7274](https://github.com/magento/magento2/issues/7274)
 
-<!--- 59256-->* Component Manager now handles custom Composer modules. Previously, when you tried to install a custom extension using **System > Tools > Web Setup > Component Manager**, Magento displayed the spinning widget indefinitely. [GitHub-6718](https://github.com/magento/magento2/issues/6718)
+<!--- 59256 -->
+*  Component Manager now handles custom Composer modules. Previously, when you tried to install a custom extension using **System > Tools > Web Setup > Component Manager**, Magento displayed the spinning widget indefinitely. [GitHub-6718](https://github.com/magento/magento2/issues/6718)
 
-<!--- 59234-->* We’ve fixed an issue with sorting products by tier price. Previously, if you enabled the Used for Sorting in Product Listing field in the Edit Tier Price Attribute page. and then selected sort by tier price on the storefront, Magento displayed an error message. [GitHub-6751](https://github.com/magento/magento2/issues/6751)
+<!--- 59234 -->
+*  We’ve fixed an issue with sorting products by tier price. Previously, if you enabled the Used for Sorting in Product Listing field in the Edit Tier Price Attribute page. and then selected sort by tier price on the storefront, Magento displayed an error message. [GitHub-6751](https://github.com/magento/magento2/issues/6751)
 
-<!--- 59130 -->* Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
+<!--- 59130  -->
+*  Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
 
-<!--- 58053 -->* Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
+<!--- 58053  -->
+*  Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
 
-<!--- 59130 -->* Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
+<!--- 59130  -->
+*  Products returned by an API product paginated search now include `category_ids` as a member of `custom_attributes`. [GitHub-6127](https://github.com/magento/magento2/issues/6127)
 
-<!--- 58053 -->* Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
+<!--- 58053  -->
+*  Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
 
-<!--- 56943-->*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+<!--- 56943 -->
+*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
-<!--- 58290 -->* Magento no longer adds an empty product option to each PUT request. Previously, Magento added an empty option even when the options array was empty. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
+<!--- 58290  -->
+*  Magento no longer adds an empty product option to each PUT request. Previously, Magento added an empty option even when the options array was empty. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
 
 ### Configurable products
 
-<!---57055-->*  You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
+<!---57055 -->
+*   You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
 
-<!---56998 -->* Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
+<!---56998  -->
+*  Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
 
-<!---54808 -->* You can now edit a product attribute for multiple configurable products. Previously, when you tried to bulk-edit an attribute on a collection of filtered, configurable products, Magento would complete the process without incorporating your edits, and then incorrectly tell you that the products had been edited.
+<!---54808  -->
+*  You can now edit a product attribute for multiple configurable products. Previously, when you tried to bulk-edit an attribute on a collection of filtered, configurable products, Magento would complete the process without incorporating your edits, and then incorrectly tell you that the products had been edited.
 
-<!---60605-->* Magento no longer throws an [exception](https://glossary.magento.com/exception) when you add a configurable product by [SKU](https://glossary.magento.com/sku) if an associated simple product is out-of-stock.
+<!---60605 -->
+*  Magento no longer throws an [exception](https://glossary.magento.com/exception) when you add a configurable product by [SKU](https://glossary.magento.com/sku) if an associated simple product is out-of-stock.
 
-<!---61055-->* Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
+<!---61055 -->
+*  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
 
-<!---57044-->* A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588),  [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041), [GitHub-6097](https://github.com/magento/magento2/issues/6097)
+<!---57044 -->
+*  A price change to a custom option affects only that option. Previously, changing the price of a custom option also affected the price of related products. [GitHub-4588](https://github.com/magento/magento2/issues/4588),  [GitHub-5798](https://github.com/magento/magento2/issues/5798), [GitHub-6041](https://github.com/magento/magento2/issues/6041), [GitHub-6097](https://github.com/magento/magento2/issues/6097)
 
-<!--- 65339 -->* The check that Magento runs to confirm a configurable product's readiness for sale is now faster.  (The `isSalable` method checks that a [configurable product](https://glossary.magento.com/configurable-product) can be sold (that is, is in a salable state)).
+<!--- 65339  -->
+*  The check that Magento runs to confirm a configurable product's readiness for sale is now faster.  (The `isSalable` method checks that a [configurable product](https://glossary.magento.com/configurable-product) can be sold (that is, is in a salable state)).
 
-<!--- 65247 -->* Query optimizations have improved the speed of configurable product price calculation.
+<!--- 65247  -->
+*  Query optimizations have improved the speed of configurable product price calculation.
 
-<!--- 65246 -->*  Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
+<!--- 65246  -->
+*   Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
 
-<!--- 56951-->* Magento now displays configurable products as expected after creation.
+<!--- 56951 -->
+*  Magento now displays configurable products as expected after creation.
 
-<!--- 70346-->* Magento no longer displays a configurable product on the storefront when its child products are deleted and the **show out-of-stock** setting is set to **No**.
+<!--- 70346 -->
+*  Magento no longer displays a configurable product on the storefront when its child products are deleted and the **show out-of-stock** setting is set to **No**.
 
-<!--- 71656-->* Configurable products no longer show up on category page when all children are set to **enable product = No** and **display out-of-stock products = Off**.
+<!--- 71656 -->
+*  Configurable products no longer show up on category page when all children are set to **enable product = No** and **display out-of-stock products = Off**.
 
-<!---59879-->* Magento no longer displays the **as low as** label for a disabled price on the Category page.
+<!---59879 -->
+*  Magento no longer displays the **as low as** label for a disabled price on the Category page.
 
-<!---60098-->* The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
+<!---60098 -->
+*  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
-<!---52717, 59649-->*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+<!---52717, 59649 -->
+*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
-<!---60483-->* Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
+<!---60483 -->
+*  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
 
-<!--- 61058-->* Magento now displays the correct drop-down option labels for configurable products when using attributes with custom source.
+<!--- 61058 -->
+*  Magento now displays the correct drop-down option labels for configurable products when using attributes with custom source.
 
-<!--- 63014-->* Magento now shows the correct price of a configurable product based in installations that run multiple websites.
+<!--- 63014 -->
+*  Magento now shows the correct price of a configurable product based in installations that run multiple websites.
 
-<!--- 54653-->* We’ve improved the performance of Magento installations that contain configurable products with many (1600+) options.
+<!--- 54653 -->
+*  We’ve improved the performance of Magento installations that contain configurable products with many (1600+) options.
 
-<!--- 56591-->* We’ve resolved some issues with the display of configurable products on the Magento frontend after product creation.
+<!--- 56591 -->
+*  We’ve resolved some issues with the display of configurable products on the Magento frontend after product creation.
 
-<!--- 59307-->* Magento now displays only the set price for a configurable product, not its set price and “as low as” price. Previously, Magento showed both prices if a minimum price was not configured.
+<!--- 59307 -->
+*  Magento now displays only the set price for a configurable product, not its set price and “as low as” price. Previously, Magento showed both prices if a minimum price was not configured.
 
-<!---61596 -->* Magento no longer removes the simple products associated with a configurable product if you click on the **Save** button more than once while saving the configurable product. Previously, if you clicked on **Save** more than once during an attempt to save a configurable product, Magento removed the simple products that were assigned to it.
+<!---61596  -->
+*  Magento no longer removes the simple products associated with a configurable product if you click on the **Save** button more than once while saving the configurable product. Previously, if you clicked on **Save** more than once during an attempt to save a configurable product, Magento removed the simple products that were assigned to it.
 
-<!---64221 -->* Special prices now display correctly for future discounts [GitHub-8375](https://github.com/magento/magento2/issues/8375)
+<!---64221  -->
+*  Special prices now display correctly for future discounts [GitHub-8375](https://github.com/magento/magento2/issues/8375)
 
-<!---52925 -->* Magento no longer applies one simple product's special price to another simple product of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
+<!---52925  -->
+*  Magento no longer applies one simple product's special price to another simple product of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
 
-<!---59512 -->* Magento now shows the correct product price for products that you add to the wish list from the category page. [GitHub-6866](https://github.com/magento/magento2/issues/6866)
+<!---59512  -->
+*  Magento now shows the correct product price for products that you add to the wish list from the category page. [GitHub-6866](https://github.com/magento/magento2/issues/6866)
 
-<!---57995 -->* Videos now play as expected on simple products as they do  for configurable products. Previously, simple product videos were displayed as thumbnail images only.[GitHub-6360](https://github.com/magento/magento2/issues/6360)
+<!---57995  -->
+*  Videos now play as expected on simple products as they do  for configurable products. Previously, simple product videos were displayed as thumbnail images only.[GitHub-6360](https://github.com/magento/magento2/issues/6360)
 
-<!---57279 -->* Users no longer lose configurable product data when you change the interface locale to Chinese (China) or Arabic (Egypt).
+<!---57279  -->
+*  Users no longer lose configurable product data when you change the interface locale to Chinese (China) or Arabic (Egypt).
 
 ### Email
 
-<!---57496-->* Magento now successfully loads the New Order Email templates. [GitHub-5101](https://github.com/magento/magento2/issues/5101)
+<!---57496 -->
+*  Magento now successfully loads the New Order Email templates. [GitHub-5101](https://github.com/magento/magento2/issues/5101)
 
-<!---57204 -->* The **Send Welcome Email From** field now identifies the store that the customer is associated with.
+<!---57204  -->
+*  The **Send Welcome Email From** field now identifies the store that the customer is associated with.
 
-<!---59146 -->* Magento no longer sends email when the **Disable email communication** setting is set to **yes**. Previously, Magento sent email even when this setting was enabled. [GitHub-5988](https://github.com/magento/magento2/issues/5988)
+<!---59146  -->
+*  Magento no longer sends email when the **Disable email communication** setting is set to **yes**. Previously, Magento sent email even when this setting was enabled. [GitHub-5988](https://github.com/magento/magento2/issues/5988)
 
 ### Frameworks
 
-<!--- 60611-->* Static file generation is no longer affected by a race condition that affected merging CSS files. Previously, this race condition interfered with the proper generation of the product frontend.
+<!--- 60611 -->
+*  Static file generation is no longer affected by a race condition that affected merging CSS files. Previously, this race condition interfered with the proper generation of the product frontend.
 
-<!---71257 -->* The ability to disable module output has been removed from Admin. If you disabled module output from Admin in a previous release, you must manually configure these settings. See [Disable module output]({{ page.baseurl }}/config-guide/config/disable-module-output.html) for details.
+<!---71257  -->
+*  The ability to disable module output has been removed from Admin. If you disabled module output from Admin in a previous release, you must manually configure these settings. See [Disable module output]({{ page.baseurl }}/config-guide/config/disable-module-output.html) for details.
 
-<!---69868 -->* Static tests run in a Windows environment no longer fail due to file path mismatches. *Fix submitted by community member barbazul in pull request [9902](https://github.com/magento/magento2/pull/9902){: target="_blank"}.*
+<!---69868  -->
+*  Static tests run in a Windows environment no longer fail due to file path mismatches. *Fix submitted by community member barbazul in pull request [9902](https://github.com/magento/magento2/pull/9902){: target="_blank"}.*
 
-<!---63154 -->* Magento now displays special characters in store names in email subject lines. Previously, special characters in the store name were converted to numerical character references in the email subject field. [GitHub-8094](https://github.com/magento/magento2/issues/8094)
+<!---63154  -->
+*  Magento now displays special characters in store names in email subject lines. Previously, special characters in the store name were converted to numerical character references in the email subject field. [GitHub-8094](https://github.com/magento/magento2/issues/8094)
 
-<!---56947 -->* You can now link a simple product to a configurable one. Previously, when you tried to use REST to link a simple product  to a configurable one, the products were not linked even though Magento responded, `Status Code: 200 OK`.
+<!---56947  -->
+*  You can now link a simple product to a configurable one. Previously, when you tried to use REST to link a simple product  to a configurable one, the products were not linked even though Magento responded, `Status Code: 200 OK`.
 
 #### Admin framework
 
-<!--- 57805 -->* You can no longer delete a currently logged-in user.
+<!--- 57805  -->
+*  You can no longer delete a currently logged-in user.
 
-<!--- 57629 -->* Inline editing in Admin now includes ACL checks. Previously, the Quick Edit editor did not respect permissions.
+<!--- 57629  -->
+*  Inline editing in Admin now includes ACL checks. Previously, the Quick Edit editor did not respect permissions.
 
 #### Application framework
 
-<!--- 64901 -->* Magento now supports new top level domains for email addresses. [GitHub-4547](https://github.com/magento/magento2/issues/4547)
+<!--- 64901  -->
+*  Magento now supports new top level domains for email addresses. [GitHub-4547](https://github.com/magento/magento2/issues/4547)
 
-<!--- 70010 -->* Page titles in layout files are not translatable. *Fix submitted by community member Anton Evers in pull request [9992](https://github.com/magento/magento2/pull/9992){: target="_blank"}.*
+<!--- 70010  -->
+*  Page titles in layout files are not translatable. *Fix submitted by community member Anton Evers in pull request [9992](https://github.com/magento/magento2/pull/9992){: target="_blank"}.*
 
-<!--- 67500 -->* The `setup:static-content:deploy`, `setup:di:compile` and `deploy:mode:set` commands now return non-zero exit code if an error occurs. *Fix submitted by community member Pablo Ivulic in pull request [7780](https://github.com/magento/magento2/pull/7780){: target="_blank"}.*
+<!--- 67500  -->
+*  The `setup:static-content:deploy`, `setup:di:compile` and `deploy:mode:set` commands now return non-zero exit code if an error occurs. *Fix submitted by community member Pablo Ivulic in pull request [7780](https://github.com/magento/magento2/pull/7780){: target="_blank"}.*
 
-<!--- 67408-->* We've changed the `select` protected property to `query` in the AbstractSearchResult class. *Fix submitted by community member Alex Gusev in pull request [5043](https://github.com/magento/magento2/pull/5043){: target="_blank"}.*
+<!--- 67408 -->
+*  We've changed the `select` protected property to `query` in the AbstractSearchResult class. *Fix submitted by community member Alex Gusev in pull request [5043](https://github.com/magento/magento2/pull/5043){: target="_blank"}.*
 
-<!---67260-->* `\Magento\Framework\Interception\Code\Generator\Interceptor` now supports interceptors for generating for methods that return references. [GitHub-9167](https://github.com/magento/magento2/issues/9167)
+<!---67260 -->
+*  `\Magento\Framework\Interception\Code\Generator\Interceptor` now supports interceptors for generating for methods that return references. [GitHub-9167](https://github.com/magento/magento2/issues/9167)
 
-<!---58394-->* The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [(GITHUB-6442)](https://github.com/magento/magento2/issues/6442){: target="_blank"}
+<!---58394 -->
+*  The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`. [(GITHUB-6442)](https://github.com/magento/magento2/issues/6442){: target="_blank"}
 
 #### Configuration framework
 
-<!--- 69894 -->* Configuration values no longer return NULL when Redis reaches the limit set in the `max_memory` setting. Previously, when Redis met the limit specified in this setting, `ScopeConfig` returned a value of NULL for configuration options, which resulted in significant damage to data (for example, deleting all prices assigned to a website from the database).
+<!--- 69894  -->
+*  Configuration values no longer return NULL when Redis reaches the limit set in the `max_memory` setting. Previously, when Redis met the limit specified in this setting, `ScopeConfig` returned a value of NULL for configuration options, which resulted in significant damage to data (for example, deleting all prices assigned to a website from the database).
 
-<!--- 65003 -->* The currency setup in Admin no longer throws an `in_array` error when a single value is selected. *Fix submitted by community member Derik Nel in pull request [8077](https://github.com/magento/magento2/pull/8077){: target="_blank"}.*
+<!--- 65003  -->
+*  The currency setup in Admin no longer throws an `in_array` error when a single value is selected. *Fix submitted by community member Derik Nel in pull request [8077](https://github.com/magento/magento2/pull/8077){: target="_blank"}.*
 
-<!--- 65422 -->* Magento now writes all default configuration values to the `config.php` file.
+<!--- 65422  -->
+*  Magento now writes all default configuration values to the `config.php` file.
 
 #### JavaScript framework
 
-<!--- 71180 -->*  Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
+<!--- 71180  -->
+*   Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
 
-<!--- 58285 -->* Magento now displays server-side Ajax error messages.
+<!--- 58285  -->
+*  Magento now displays server-side Ajax error messages.
 
-<!--- 69674 -->* JavaScript mixins now work when you add a `urlArgs` argument to a `require_js` file. *Fix submitted by community member James Reed in pull request [9665](https://github.com/magento/magento2/pull/9665){: target="_blank"}.*
+<!--- 69674  -->
+*  JavaScript mixins now work when you add a `urlArgs` argument to a `require_js` file. *Fix submitted by community member James Reed in pull request [9665](https://github.com/magento/magento2/pull/9665){: target="_blank"}.*
 
 #### Session framework
 
-<!--- 57118 -->* The Magento storefront and Admin panel no longer share form keys. Previously, if a user were navigating both a storefront and  the Admin simultaneously,  he would be unexpectedly redirected to the Admin dashboard. [GitHub-6201](https://github.com/magento/magento2/issues/6201)
+<!--- 57118  -->
+*  The Magento storefront and Admin panel no longer share form keys. Previously, if a user were navigating both a storefront and  the Admin simultaneously,  he would be unexpectedly redirected to the Admin dashboard. [GitHub-6201](https://github.com/magento/magento2/issues/6201)
 
 #### Zend framework
 
 Thanks to our hardworking Magento Open Source community members for the following contributions!
 
-<!--- 67511-->* We’ve removed  `Zend_Json` from Magento Theme and replaced it with a new serializer class. *Fix submitted by community member David Manners in pull request [9262](https://github.com/magento/magento2/pull/9262){: target="_blank"}.*
+<!--- 67511 -->
+*  We’ve removed  `Zend_Json` from Magento Theme and replaced it with a new serializer class. *Fix submitted by community member David Manners in pull request [9262](https://github.com/magento/magento2/pull/9262){: target="_blank"}.*
 
-<!--- 67510-->* We’ve removed `Zend_Json` from the Weee module. *Fix submitted by community member David Manners We’ve removed pull request [9261](https://github.com/magento/magento2/pull/9261){: target="_blank"}.*
+<!--- 67510 -->
+*  We’ve removed `Zend_Json` from the Weee module. *Fix submitted by community member David Manners We’ve removed pull request [9261](https://github.com/magento/magento2/pull/9261){: target="_blank"}.*
 
-<!--- 69369-->* We’ve replaced the direct usage of `Zend_Json` with a call to the `Json_Help` class. *Fix submitted by community member David Manners in pull request [9344](https://github.com/magento/magento2/pull/9344){: target="_blank"}.*
+<!--- 69369 -->
+*  We’ve replaced the direct usage of `Zend_Json` with a call to the `Json_Help` class. *Fix submitted by community member David Manners in pull request [9344](https://github.com/magento/magento2/pull/9344){: target="_blank"}.*
 
-<!--- 69451-->* We’ve replaced  `Zend_Json` in the configurable product block test. *Fix submitted by community member David Manners in pull request [9753](https://github.com/magento/magento2/pull/9753){: target="_blank"}.*
+<!--- 69451 -->
+*  We’ve replaced  `Zend_Json` in the configurable product block test. *Fix submitted by community member David Manners in pull request [9753](https://github.com/magento/magento2/pull/9753){: target="_blank"}.*
 
-<!--- 69452-->* We’ve removed `Zend_Json` from form elements. *Fix submitted by community member David Manners in pull request [9754](https://github.com/magento/magento2/pull/9754){: target="_blank"}.*
+<!--- 69452 -->
+*  We’ve removed `Zend_Json` from form elements. *Fix submitted by community member David Manners in pull request [9754](https://github.com/magento/magento2/pull/9754){: target="_blank"}.*
 
-<!--- 69371-->* We’ve replaced the Magento Framework's `Zend_Session` interface usage with SessionHandlerInterface. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
+<!--- 69371 -->
+*  We’ve replaced the Magento Framework's `Zend_Session` interface usage with SessionHandlerInterface. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
 
-<!--- 69157-->* We’ve removed `Zend_Wildfire` and `Zend_Controller` from the codebase. *Fix submitted by community member Isolde in pull request [9622](https://github.com/magento/magento2/pull/9622){: target="_blank"}.*
+<!--- 69157 -->
+*  We’ve removed `Zend_Wildfire` and `Zend_Controller` from the codebase. *Fix submitted by community member Isolde in pull request [9622](https://github.com/magento/magento2/pull/9622){: target="_blank"}.*
 
-<!--- 69152-->* We've resolved issues with selecting widgets in TinyMCE. [GitHub-9655](https://github.com/magento/magento2/issues/9655), [GitHub-9518](https://github.com/magento/magento2/issues/9518) *Fixes submitted by community member Pieter Hoste in pull request [9540](https://github.com/magento/magento2/pull/9540){: target="_blank"} and community member Bernhard in pull request [9711](https://github.com/magento/magento2/pull/9711){: target="_blank"}.*
+<!--- 69152 -->
+*  We've resolved issues with selecting widgets in TinyMCE. [GitHub-9655](https://github.com/magento/magento2/issues/9655), [GitHub-9518](https://github.com/magento/magento2/issues/9518) *Fixes submitted by community member Pieter Hoste in pull request [9540](https://github.com/magento/magento2/pull/9540){: target="_blank"} and community member Bernhard in pull request [9711](https://github.com/magento/magento2/pull/9711){: target="_blank"}.*
 
-<!--- 69591-->* We’ve replaced `Zend_Log` with `Psr\Log\LoggerInterface`. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
+<!--- 69591 -->
+*  We’ve replaced `Zend_Log` with `Psr\Log\LoggerInterface`. *Fix submitted by community member Timon de Groot in pull request [9285](https://github.com/magento/magento2/pull/9285){: target="_blank"}.*
 
-<!--- 68770-->* Magento no longer throws a `Zend_Db_Statement_Exception` when a user opens an empty Category page. *Fix submitted by community member adrian-martinez-interactiv4 in pull request [9400](https://github.com/magento/magento2/pull/9400){: target="_blank"}.*
+<!--- 68770 -->
+*  Magento no longer throws a `Zend_Db_Statement_Exception` when a user opens an empty Category page. *Fix submitted by community member adrian-martinez-interactiv4 in pull request [9400](https://github.com/magento/magento2/pull/9400){: target="_blank"}.*
 
 ### General fixes
 
-<!--- 56892-->*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+<!--- 56892 -->
+*   You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
-<!--- 56126 -->* You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
+<!--- 56126  -->
+*  You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
 
-<!--- 55462/52448-->* Magento now correctly displays customer address during account creation. Previously, when you selected a default billing address during creation of a new customer account, Magento would not display the address.
+<!--- 55462/52448 -->
+*  Magento now correctly displays customer address during account creation. Previously, when you selected a default billing address during creation of a new customer account, Magento would not display the address.
 
-<!--- 60890 -->* Admin users with restricted permissions can now log in successfully as determined by those permissions. Previously, Magento displayed a fatal error when you logged in under these conditions.
+<!--- 60890  -->
+*  Admin users with restricted permissions can now log in successfully as determined by those permissions. Previously, Magento displayed a fatal error when you logged in under these conditions.
 
-<!---55662-->* We've removed the duplicated [PHP](https://glossary.magento.com/php) settings from the sample web server configuration files.
+<!---55662 -->
+*  We've removed the duplicated [PHP](https://glossary.magento.com/php) settings from the sample web server configuration files.
 
-<!---57383-->* You can now make Return Merchandise [Authorization](https://glossary.magento.com/authorization) (RMA) comments visible from the storefront by setting **Stores > Settings > Configuration > Sales > RMA Settings > Enable RMA on Storefront**.
+<!---57383 -->
+*  You can now make Return Merchandise [Authorization](https://glossary.magento.com/authorization) (RMA) comments visible from the storefront by setting **Stores > Settings > Configuration > Sales > RMA Settings > Enable RMA on Storefront**.
 
-<!---57187-->*  When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
+<!---57187 -->
+*   When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
 
-<!---57351-->* We've removed the sample password from the Setup Wizard.
+<!---57351 -->
+*  We've removed the sample password from the Setup Wizard.
 
-<!---56973-->* You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
+<!---56973 -->
+*  You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
 
-<!---58500-->* The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`.  [GitHub-6442](https://github.com/magento/magento2/issues/6442)
+<!---58500 -->
+*  The Magento Framework now makes its dependency upon the `zendframework/zend-stdlib` library explicit in `composer.json`.  [GitHub-6442](https://github.com/magento/magento2/issues/6442)
 
-<!---57035-->* You can now upload changes to the `robots.txt` file from the Admin panel.
+<!---57035 -->
+*  You can now upload changes to the `robots.txt` file from the Admin panel.
 
-<!---57197-->* We've eliminated difficulties saving product information when logged in as Admin. Previously, the Product Save feature worked erratically for Admin users.
+<!---57197 -->
+*  We've eliminated difficulties saving product information when logged in as Admin. Previously, the Product Save feature worked erratically for Admin users.
 
-<!---59397-->* Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
+<!---59397 -->
+*  Custom themes now inherit parent [XML](https://glossary.magento.com/xml) configuration information as expected.
 
-<!--- 60248-->* Information set by the **Default Billing Address** and **Default Shipping Address** checkboxes on the Customer page are now saved correctly.
+<!--- 60248 -->
+*  Information set by the **Default Billing Address** and **Default Shipping Address** checkboxes on the Customer page are now saved correctly.
 
-<!---59416 -->* [Admin](https://glossary.magento.com/admin) users with appropriate permissions can now reset the passwords of more than one customer at a time. [GitHub-5260](https://github.com/magento/magento2/issues/5260)
+<!---59416  -->
+*  [Admin](https://glossary.magento.com/admin) users with appropriate permissions can now reset the passwords of more than one customer at a time. [GitHub-5260](https://github.com/magento/magento2/issues/5260)
 
-<!---59142 -->* Admin interface forms now load data as expected after initializing all components. Previously, under certain conditions, the load indicator would spin indefinitely, and Magento would not load data.
+<!---59142  -->
+*  Admin interface forms now load data as expected after initializing all components. Previously, under certain conditions, the load indicator would spin indefinitely, and Magento would not load data.
 
-<!---59810 -->* Showing reports on the **Reports > Coupons** page no longer throws an error when the user is in a non-default Admin locale.  [GitHub-7037](https://github.com/magento/magento2/issues/7037)
+<!---59810  -->
+*  Showing reports on the **Reports > Coupons** page no longer throws an error when the user is in a non-default Admin locale.  [GitHub-7037](https://github.com/magento/magento2/issues/7037)
 
-<!---70318 -->* You can now generate static content without a database connection. [GitHub-10041](https://github.com/magento/magento2/issues/10041)
+<!---70318  -->
+*  You can now generate static content without a database connection. [GitHub-10041](https://github.com/magento/magento2/issues/10041)
 
-<!--- 60185 -->* Static content deployment now generates secure content, whether content included secure or non-secure URLs.
+<!--- 60185  -->
+*  Static content deployment now generates secure content, whether content included secure or non-secure URLs.
 
-<!--- 56062 -->* The Recently Viewed Products block now appears as expected when the full page cache is enabled. [GitHub-3890](https://github.com/magento/magento2/issues/3890)
+<!--- 56062  -->
+*  The Recently Viewed Products block now appears as expected when the full page cache is enabled. [GitHub-3890](https://github.com/magento/magento2/issues/3890)
 
-<!--- 56077 -->* We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
+<!--- 56077  -->
+*  We've resolved an issue that prevented you from adding more than one product to a [shopping cart](https://glossary.magento.com/shopping-cart) from a wishlist. [GitHub-5282](https://github.com/magento/magento2/issues/5282)
 
-<!--- 52850-->* Widgets now accept UTF-8 special characters type as input parameters. Previously, you could successfully create a widget, but UTF-8 special characters were broken. [GitHub-4232](https://github.com/magento/magento2/issues/4232) *Fix submitted by community member Pieter Hoste in pull request [9333](https://github.com/magento/magento2/pull/9333){: target="_blank"}.*
+<!--- 52850 -->
+*  Widgets now accept UTF-8 special characters type as input parameters. Previously, you could successfully create a widget, but UTF-8 special characters were broken. [GitHub-4232](https://github.com/magento/magento2/issues/4232) *Fix submitted by community member Pieter Hoste in pull request [9333](https://github.com/magento/magento2/pull/9333){: target="_blank"}.*
 
-<!---65631 -->* Magento now sends email that provides updates on the status of RMA authorization.
+<!---65631  -->
+*  Magento now sends email that provides updates on the status of RMA authorization.
 
-<!--- 71415-->* Mass actions now work as expected on the Customer grid. Previously, Magento could not process more than 20 items at a time.
+<!--- 71415 -->
+*  Mass actions now work as expected on the Customer grid. Previously, Magento could not process more than 20 items at a time.
 
-<!--- 71179 -->* Customers who subscribe to a newsletter are now subscribed as expected after confirming their account. Previously, Magento unsubscribed customers from the newsletter after confirming their account.
+<!--- 71179  -->
+*  Customers who subscribe to a newsletter are now subscribed as expected after confirming their account. Previously, Magento unsubscribed customers from the newsletter after confirming their account.
 
-<!---56314 -->* Fixed issue with using the Magento Commerce invitations feature to insert malicious JavaScript and subsequently execute it in the Admin context.
+<!---56314  -->
+*  Fixed issue with using the Magento Commerce invitations feature to insert malicious JavaScript and subsequently execute it in the Admin context.
 
-<!--- 56778 -->* You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+<!--- 56778  -->
+*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
-<!--- 54725-->* You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
+<!--- 54725 -->
+*  You can now assign open-ended start and complete dates for product rules. Previously, if you left the start and end date field blanks when creating a rule, Magento would supply the start and end dates based on the save date.
 
-<!--- 59785-->* Magento no longer generates incorrect URLs in the site map when the **Use Secure URLs in Admin** setting is set to **Yes**. [GitHub-8644](https://github.com/magento/magento2/issues/8644)
+<!--- 59785 -->
+*  Magento no longer generates incorrect URLs in the site map when the **Use Secure URLs in Admin** setting is set to **Yes**. [GitHub-8644](https://github.com/magento/magento2/issues/8644)
 
-<!--- 69606-->* We’ve resolved a conflict that occurred after you changed a base URL. Previously, after you changed a `base_url` value (**Stores->Configuration > General > Web > Base URLs (Secure)**), Magento would update the base URL, then resubscribe, potentially resulting in a failure during the next update secure `base_url` call.
+<!--- 69606 -->
+*  We’ve resolved a conflict that occurred after you changed a base URL. Previously, after you changed a `base_url` value (**Stores->Configuration > General > Web > Base URLs (Secure)**), Magento would update the base URL, then resubscribe, potentially resulting in a failure during the next update secure `base_url` call.
 
-<!--- 70683-->* Magento now displays newly registered customers in the Admin customer list as expected.
+<!--- 70683 -->
+*  Magento now displays newly registered customers in the Admin customer list as expected.
 
-<!--- 67619-->* The Customer Segment page no longer shows non-matching customers when a customer logs in and you refresh the Customer Segment page.
+<!--- 67619 -->
+*  The Customer Segment page no longer shows non-matching customers when a customer logs in and you refresh the Customer Segment page.
 
-<!--- 67048-->* You can now add a `translate` attribute to any String argument in the `di.xml` file for any class. This attribute provides an ability on the level of dependency injection configuration to specify that an argument can be translated. The actual translation of strings is handled by another Magento component.
+<!--- 67048 -->
+*  You can now add a `translate` attribute to any String argument in the `di.xml` file for any class. This attribute provides an ability on the level of dependency injection configuration to specify that an argument can be translated. The actual translation of strings is handled by another Magento component.
 
-<!--- 59322-->* Magento frontend scope filters now work as expected. Previously, Magento did not reload product information correctly when you applied a filter using **Catalog > Product**.
+<!--- 59322 -->
+*  Magento frontend scope filters now work as expected. Previously, Magento did not reload product information correctly when you applied a filter using **Catalog > Product**.
 
-<!--- 58298-->* Only users with permission to view a store can view or process the orders placed on it.
+<!--- 58298 -->
+*  Only users with permission to view a store can view or process the orders placed on it.
 
-<!--- 63736-->* You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
+<!--- 63736 -->
+*  You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
 
-<!--- 59966-->* We fixed an issue where cache-misses sometimes occurred when Fastly cache was implemented. Previously, the header information included in the response sometimes prevented the caching of this page. To minimize this potential problem, Magento now does not include header empty of real content in the response.
+<!--- 59966 -->
+*  We fixed an issue where cache-misses sometimes occurred when Fastly cache was implemented. Previously, the header information included in the response sometimes prevented the caching of this page. To minimize this potential problem, Magento now does not include header empty of real content in the response.
 
-<!--- 65000-->* Fixed the location of the `wishlist.js` file. *Fix submitted by community member [Koen V.](https://github.com/koenner01){: target="_blank"} in pull request [8633](https://github.com/magento/magento2/pull/8633){: target="_blank"}.*
+<!--- 65000 -->
+*  Fixed the location of the `wishlist.js` file. *Fix submitted by community member [Koen V.](https://github.com/koenner01){: target="_blank"} in pull request [8633](https://github.com/magento/magento2/pull/8633){: target="_blank"}.*
 
-<!--- 66506-->* You can no longer download products  after you’ve set order state to `STATE_CANCELED`.  *Fix submitted by community member nazarpadalka in pull request [8917](https://github.com/magento/magento2/pull/8917){: target="_blank"}.*
+<!--- 66506 -->
+*  You can no longer download products  after you’ve set order state to `STATE_CANCELED`.  *Fix submitted by community member nazarpadalka in pull request [8917](https://github.com/magento/magento2/pull/8917){: target="_blank"}.*
 
-<!--- 66232-->* Fixed a typo in the Pull Request Template. *Fix submitted by community member tomislavsantek in pull request [8908](https://github.com/magento/magento2/pull/8908){: target="_blank"}.*
+<!--- 66232 -->
+*  Fixed a typo in the Pull Request Template. *Fix submitted by community member tomislavsantek in pull request [8908](https://github.com/magento/magento2/pull/8908){: target="_blank"}.*
 
-<!--- 66694-->* You now receive an error message as expected if you try to submit a product review while not logged in. *Fix submitted by community member quienti in pull request [9001](https://github.com/magento/magento2/pull/9001){: target="_blank"}.*
+<!--- 66694 -->
+*  You now receive an error message as expected if you try to submit a product review while not logged in. *Fix submitted by community member quienti in pull request [9001](https://github.com/magento/magento2/pull/9001){: target="_blank"}.*
 
-<!--- 67042-->* Fixed grammar error in the customer dashboard. *Fix submitted by community member Petar Sambolek in pull request [9080](https://github.com/magento/magento2/pull/9080){: target="_blank"}.*
+<!--- 67042 -->
+*  Fixed grammar error in the customer dashboard. *Fix submitted by community member Petar Sambolek in pull request [9080](https://github.com/magento/magento2/pull/9080){: target="_blank"}.*
 
-<!--- 67320-->* The popup window in the Safari browser now closes properly. *Fix submitted by community member Hans Schouten in pull request [8824](https://github.com/magento/magento2/pull/8824){: target="_blank"}.*
+<!--- 67320 -->
+*  The popup window in the Safari browser now closes properly. *Fix submitted by community member Hans Schouten in pull request [8824](https://github.com/magento/magento2/pull/8824){: target="_blank"}.*
 
-<!--- 67054-->* We’ve fixed minor performance issues when you use `/pub` as `docroot`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
+<!--- 67054 -->
+*  We’ve fixed minor performance issues when you use `/pub` as `docroot`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
 
-<!--- 70310-->* The Actions dropdown menu is now properly aligned in the Admin when the action column is not the last column. *Fix submitted by community member Marius Strajeru in pull request [10082](https://github.com/magento/magento2/pull/10082){: target="_blank"}.*
+<!--- 70310 -->
+*  The Actions dropdown menu is now properly aligned in the Admin when the action column is not the last column. *Fix submitted by community member Marius Strajeru in pull request [10082](https://github.com/magento/magento2/pull/10082){: target="_blank"}.*
 
-<!--- 70029-->* Magento now deletes pending entries in `cron_schedule` when you reconfigure a cron job. *Fix submitted by community member Anton Evers in pull request [9957](https://github.com/magento/magento2/pull/9957){: target="_blank"}.*
+<!--- 70029 -->
+*  Magento now deletes pending entries in `cron_schedule` when you reconfigure a cron job. *Fix submitted by community member Anton Evers in pull request [9957](https://github.com/magento/magento2/pull/9957){: target="_blank"}.*
 
-<!--- 69886-->* We’ve fixed the cron timestamp method. *Fix submitted by community member Anton Evers in pull request [9943](https://github.com/magento/magento2/pull/9943){: target="_blank"}.*
+<!--- 69886 -->
+*  We’ve fixed the cron timestamp method. *Fix submitted by community member Anton Evers in pull request [9943](https://github.com/magento/magento2/pull/9943){: target="_blank"}.*
 
-<!--- 69373-->* You can now save customers with unique attributes. *Fix submitted by community member storbahn in pull request [9712](https://github.com/magento/magento2/pull/9712){: target="_blank"}.*
+<!--- 69373 -->
+*  You can now save customers with unique attributes. *Fix submitted by community member storbahn in pull request [9712](https://github.com/magento/magento2/pull/9712){: target="_blank"}.*
 
-<!--- 69555-->* The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
+<!--- 69555 -->
+*  The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
 
-<!--- 59135-->*  Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
+<!--- 59135 -->
+*   Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
 
-<!--- 63116-->* Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
+<!--- 63116 -->
+*  Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
 
-<!--- 59590-->* The website column in Customer Segment report now contains correct data. Previously, this column was blank in the **Reports > Customer > Segments** report.
+<!--- 59590 -->
+*  The website column in Customer Segment report now contains correct data. Previously, this column was blank in the **Reports > Customer > Segments** report.
 
-<!--- 60962-->* When you add an address, new custom attributes are now displayed together, along with other address details.
+<!--- 60962 -->
+*  When you add an address, new custom attributes are now displayed together, along with other address details.
 
-<!--- 60746-->* You can now edit the default store view and save it under a different name. [GitHub-7349](https://github.com/magento/magento2/issues/7349)
+<!--- 60746 -->
+*  You can now edit the default store view and save it under a different name. [GitHub-7349](https://github.com/magento/magento2/issues/7349)
 
-<!--- 57553-->* You can now reset a customer password if **website restrictions** is enabled. Previously, you were redirected to `customer/account/login/` with no possibility to reset the password.
+<!--- 57553 -->
+*  You can now reset a customer password if **website restrictions** is enabled. Previously, you were redirected to `customer/account/login/` with no possibility to reset the password.
 
-<!--- 59258-->* When you override `module-directory/etc/zip_codes.xml` from a local module, all country codes  are now included as expected. Previously, only the last country code was included, which affected the custom  check out process. [GitHub-6694](https://github.com/magento/magento2/issues/6694)
+<!--- 59258 -->
+*  When you override `module-directory/etc/zip_codes.xml` from a local module, all country codes  are now included as expected. Previously, only the last country code was included, which affected the custom  check out process. [GitHub-6694](https://github.com/magento/magento2/issues/6694)
 
-<!--- 60633-->* `.htaccess` deny code execution now works as expected for  Apache and  php-fpm. [GitHub-6766](https://github.com/magento/magento2/issues/6766)
+<!--- 60633 -->
+*  `.htaccess` deny code execution now works as expected for  Apache and  php-fpm. [GitHub-6766](https://github.com/magento/magento2/issues/6766)
 
-<!--- 57675-->* Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
+<!--- 57675 -->
+*  Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
 
-<!--- 57796-->* Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
+<!--- 57796 -->
+*  Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
 
 ### Gift cards
 
-<!---57054 -->* Order emails now specify the amount of the [gift card](https://glossary.magento.com/gift-card) that you have purchased.
+<!---57054  -->
+*  Order emails now specify the amount of the [gift card](https://glossary.magento.com/gift-card) that you have purchased.
 
-<!---56932 -->* The Checkout page no longer freezes when you order a virtual gift card using the Authorize.net Payment Action value set to **Authorize and Capture**.
+<!---56932  -->
+*  The Checkout page no longer freezes when you order a virtual gift card using the Authorize.net Payment Action value set to **Authorize and Capture**.
 
-<!---57512-->*  You can now complete the purchase of a gift card in environments where you have set the Braintree [payment method](https://glossary.magento.com/payment-method) Payment Action to **Authorize and Capture**. Previously, any order made under these conditions would remain indefinitely in the processing stage.
+<!---57512 -->
+*   You can now complete the purchase of a gift card in environments where you have set the Braintree [payment method](https://glossary.magento.com/payment-method) Payment Action to **Authorize and Capture**. Previously, any order made under these conditions would remain indefinitely in the processing stage.
 
-<!---57353-->* You can now add a gift card with an undefined amount to the Items Ordered table. Previously,  Magento did not permit you to add a gift card of an open value to this table.
+<!---57353 -->
+*  You can now add a gift card with an undefined amount to the Items Ordered table. Previously,  Magento did not permit you to add a gift card of an open value to this table.
 
-<!---64645-->* Customers can no longer exceed a gift card balance by using the gift card twice.
+<!---64645 -->
+*  Customers can no longer exceed a gift card balance by using the gift card twice.
 
-<!---61013-->* You can now save the configuration settings of a gift card product.
+<!---61013 -->
+*  You can now save the configuration settings of a gift card product.
 
-<!---61353-->* Gift card accounts are now automatically generated after an invoice is created, when the Authorize and Capture payment action on Authorize.net Direct Post is enabled.
+<!---61353 -->
+*  Gift card accounts are now automatically generated after an invoice is created, when the Authorize and Capture payment action on Authorize.net Direct Post is enabled.
 
 ### Gift registry
 
-<!--- 59159 -->* The State/Province dropdown menu now works as expected in the frontend gift registry.
+<!--- 59159  -->
+*  The State/Province dropdown menu now works as expected in the frontend gift registry.
 
-<!--- 69153-->* We’ve fixed inconsistent gift options checkbox labels in  both the  CSV file (`app\code\Magento\GiftMessage\i18n\en_US.csv`) and PHTML file (`app\code\Magento\GiftMessage\view\frontend\templates\inline.phtml`). *Fix submitted by community member vpiyappan in pull request [9421](https://github.com/magento/magento2/pull/9421){: target="_blank"}.*
+<!--- 69153 -->
+*  We’ve fixed inconsistent gift options checkbox labels in  both the  CSV file (`app\code\Magento\GiftMessage\i18n\en_US.csv`) and PHTML file (`app\code\Magento\GiftMessage\view\frontend\templates\inline.phtml`). *Fix submitted by community member vpiyappan in pull request [9421](https://github.com/magento/magento2/pull/9421){: target="_blank"}.*
 
 ### Gift wrapping
 
-<!--- 62721-->*  The **Allow Gift Wrapping for Order Items** setting now works as expected. Previously, when **Stores > Settings > Configuration > Sales > Gift Options** was set to **No**, users  saw the Gift Option link under each product in their [shopping cart](https://glossary.magento.com/shopping-cart).
+<!--- 62721 -->
+*   The **Allow Gift Wrapping for Order Items** setting now works as expected. Previously, when **Stores > Settings > Configuration > Sales > Gift Options** was set to **No**, users  saw the Gift Option link under each product in their [shopping cart](https://glossary.magento.com/shopping-cart).
 
-<!--- 70603-->* You can now add gift options to an order if logged in using a secure URL
+<!--- 70603 -->
+*  You can now add gift options to an order if logged in using a secure URL
 
-<!--- 59821-->* Your gift wrapping selection now appears in the shopping cart regardless of whether you've selected a shipping method. Previously, Magento did not display your gift wrapping choice until you selected a shipping method.
+<!--- 59821 -->
+*  Your gift wrapping selection now appears in the shopping cart regardless of whether you've selected a shipping method. Previously, Magento did not display your gift wrapping choice until you selected a shipping method.
 
-<!--- 59948-->* Magento no longer displays the gift wrap tax when no gift wrap is selected.
+<!--- 59948 -->
+*  Magento no longer displays the gift wrap tax when no gift wrap is selected.
 
-<!--- 56982-->* You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+<!--- 56982 -->
+*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
-<!--- 70267-->* We’ve fixed an issue with fetching quote item by ID. *Fix submitted by community member Mladen Ilic in pull request [10059](https://github.com/magento/magento2/pull/10059){: target="_blank"}.*
+<!--- 70267 -->
+*  We’ve fixed an issue with fetching quote item by ID. *Fix submitted by community member Mladen Ilic in pull request [10059](https://github.com/magento/magento2/pull/10059){: target="_blank"}.*
 
-<!--- 70466-->* We’ve corrected the ACL for the Developer Section resource. *Fix submitted by community member Pascal Brouwers in pull request [10149](https://github.com/magento/magento2/pull/10149){: target="_blank"}.*
+<!--- 70466 -->
+*  We’ve corrected the ACL for the Developer Section resource. *Fix submitted by community member Pascal Brouwers in pull request [10149](https://github.com/magento/magento2/pull/10149){: target="_blank"}.*
 
-<!--- 70469-->* Layout merging no longer fails when you save a widget that contains the grave accent character in the data. *Fix submitted by community member Timon de Groot in pull request [10151](https://github.com/magento/magento2/pull/10151){: target="_blank"}.*
+<!--- 70469 -->
+*  Layout merging no longer fails when you save a widget that contains the grave accent character in the data. *Fix submitted by community member Timon de Groot in pull request [10151](https://github.com/magento/magento2/pull/10151){: target="_blank"}.*
 
-<!--- 70419 -->* Magento now uses the correct order when uploading image to the Admin using  **Content > Design**. *Fix submitted by community member Ihor Sviziev in pull request [10126](https://github.com/magento/magento2/pull/10126){: target="_blank"}.*
+<!--- 70419  -->
+*  Magento now uses the correct order when uploading image to the Admin using  **Content > Design**. *Fix submitted by community member Ihor Sviziev in pull request [10126](https://github.com/magento/magento2/pull/10126){: target="_blank"}.*
 
 ### Google Analytics
 
-<!--- 67427-->* We’ve added the missing single quote (‘) to the Google API Tracking code. *Fix submitted by community member Petar Sambolek in pull request [9084](https://github.com/magento/magento2/pull/9084){: target="_blank"}.*
+<!--- 67427 -->
+*  We’ve added the missing single quote (‘) to the Google API Tracking code. *Fix submitted by community member Petar Sambolek in pull request [9084](https://github.com/magento/magento2/pull/9084){: target="_blank"}.*
 
-<!--- 69374-->* Google Analytics tracking now works when Cookie Restriction is enabled. *Fix submitted by community member Bernhard in pull request [9713](https://github.com/magento/magento2/pull/9713){: target="_blank"}.*
+<!--- 69374 -->
+*  Google Analytics tracking now works when Cookie Restriction is enabled. *Fix submitted by community member Bernhard in pull request [9713](https://github.com/magento/magento2/pull/9713){: target="_blank"}.*
 
 ### HTML
 
-<!--- 67487-->*  The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
+<!--- 67487 -->
+*   The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
 
 ### Images
 
-<!---55447-->* Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
+<!---55447 -->
+*  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
-<!---56944-->*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+<!---56944 -->
+*   Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
-<!---58335, 42954-->* You can now preview uploaded images.
+<!---58335, 42954 -->
+*  You can now preview uploaded images.
 
-<!---56972-->* You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
+<!---56972 -->
+*  You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
 
-<!---55608-->*  Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
+<!---55608 -->
+*   Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
 
-<!--- 55234-->* Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+<!--- 55234 -->
+*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
-<!--- 58031-->*  Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
+<!--- 58031 -->
+*   Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
 
 #### Import/Export
 
-<!---58977-->* You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
+<!---58977 -->
+*  You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
 
-<!---57052-->* You can now import negative quantities. Previously, when importing a product quantity  of '-1',  Magento returned an error.
+<!---57052 -->
+*  You can now import negative quantities. Previously, when importing a product quantity  of '-1',  Magento returned an error.
 
-<!---56018-->* Magento now imports custom options correctly. Previously, when you tried to import a custom option, the import failed, and Magento displayed this error: `Javascript Error: Uncaught RangeError: Maximum call stack size exceeded`. [GitHub-5573](https://github.com/magento/magento2/issues/5573)
+<!---56018 -->
+*  Magento now imports custom options correctly. Previously, when you tried to import a custom option, the import failed, and Magento displayed this error: `Javascript Error: Uncaught RangeError: Maximum call stack size exceeded`. [GitHub-5573](https://github.com/magento/magento2/issues/5573)
 
-<!---57438, 57135-->* We’ve added a new way to import images: You can now successfully import images when you set your document root to `your_Magento_install_dir/pub`. Previously, you needed to set document root to `/magento` to import images. Both ways of importing now work. [GitHub-5359](https://github.com/magento/magento2/issues/5359)
+<!---57438, 57135 -->
+*  We’ve added a new way to import images: You can now successfully import images when you set your document root to `your_Magento_install_dir/pub`. Previously, you needed to set document root to `/magento` to import images. Both ways of importing now work. [GitHub-5359](https://github.com/magento/magento2/issues/5359)
 
-<!---57490-->* Magento now removes category URL keys from the `url_rewrite` table as expected during import. Previously, Magento did not remove these keys, which triggered a failure during import. This subsequently caused Magento to quickly reach the maximum error count, returning this error: "Maximum error count has been reached or system error is occurred!". [GitHub-1471](https://github.com/magento/magento2/issues/1471)
+<!---57490 -->
+*  Magento now removes category URL keys from the `url_rewrite` table as expected during import. Previously, Magento did not remove these keys, which triggered a failure during import. This subsequently caused Magento to quickly reach the maximum error count, returning this error: "Maximum error count has been reached or system error is occurred!". [GitHub-1471](https://github.com/magento/magento2/issues/1471)
 
-<!---57981-->* You can now export a [bundle product](https://glossary.magento.com/bundle-product) that contains a custom text area attribute.  Previously, if you tried to export this type of bundle product, the export would fail, and Magento displayed the message, "There is no data for the export".
+<!---57981 -->
+*  You can now export a [bundle product](https://glossary.magento.com/bundle-product) that contains a custom text area attribute.  Previously, if you tried to export this type of bundle product, the export would fail, and Magento displayed the message, "There is no data for the export".
 
-<!--- 58299 -->* Magento now maintains super attribute ordering of configurable products with multiple super attributes after export or import. Previously, after import or export, the ordering of super attributes was not maintained. [GitHub-6079](https://github.com/magento/magento2/issues/6079)
+<!--- 58299  -->
+*  Magento now maintains super attribute ordering of configurable products with multiple super attributes after export or import. Previously, after import or export, the ordering of super attributes was not maintained. [GitHub-6079](https://github.com/magento/magento2/issues/6079)
 
-<!--- 55237 -->* Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
+<!--- 55237  -->
+*  Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
 
-<!--- 58316-->*  Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
+<!--- 58316 -->
+*   Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
 
-<!--- 71013-->* The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
+<!--- 71013 -->
+*  The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
 
-<!--- 64643, 64856-->* Magento now displays imported product images in this order: first, the base image, then the additional images in the order in which they were listed in the [CSV](https://glossary.magento.com/csv) file. Previously, Magento displayed images in this unexpected order: first, an additional image, then the base image, and finally, all remaining additional images.
+<!--- 64643, 64856 -->
+*  Magento now displays imported product images in this order: first, the base image, then the additional images in the order in which they were listed in the [CSV](https://glossary.magento.com/csv) file. Previously, Magento displayed images in this unexpected order: first, an additional image, then the base image, and finally, all remaining additional images.
 
-<!--- 56588-->* Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
+<!--- 56588 -->
+*  Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
 
-<!--- 53428, 56804-->* We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
+<!--- 53428, 56804 -->
+*  We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
 
-<!--- 65667-->*  Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
+<!--- 65667 -->
+*   Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
 
-<!--- 67240-->* Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
+<!--- 67240 -->
+*  Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
 
-<!--- 61025-->* Magento now exports rows only once when product information contains HTML special characters. Previously, Magento exported rows containing product information that included HTML characters at least twice.
+<!--- 61025 -->
+*  Magento now exports rows only once when product information contains HTML special characters. Previously, Magento exported rows containing product information that included HTML characters at least twice.
 
-<!--- 60067-->* We've improved the import speed of advanced pricing data. Previously, the import process for this information frequently stopped after the import of approximately 300 rows of data, and Magento displayed this message: `Please Wait`.
+<!--- 60067 -->
+*  We've improved the import speed of advanced pricing data. Previously, the import process for this information frequently stopped after the import of approximately 300 rows of data, and Magento displayed this message: `Please Wait`.
 
-<!--- 64902 -->* The CatalogImportExport uploader now handles HTTPS images as expected. *Fix submitted by community member Clement Beudot in pull request [8278](https://github.com/magento/magento2/pull/8278){: target="_blank"}.*
+<!--- 64902  -->
+*  The CatalogImportExport uploader now handles HTTPS images as expected. *Fix submitted by community member Clement Beudot in pull request [8278](https://github.com/magento/magento2/pull/8278){: target="_blank"}.*
 
-<!---58976 -->* You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
+<!---58976  -->
+*  You can now successfully import multiselect attributes that contain special symbols or delimiters. Previously, when you tried to import attributes containing delimiters, data validation (and the import) failed.
 
-<!---61104 -->* When you delete an image in Admin, Magento no longer deletes it on the server. Previously, Magento deleted it from the server as well, which caused errors for other products (example error message: `Cannot gather stats! Warning!stat(): stat failed for`).
+<!---61104  -->
+*  When you delete an image in Admin, Magento no longer deletes it on the server. Previously, Magento deleted it from the server as well, which caused errors for other products (example error message: `Cannot gather stats! Warning!stat(): stat failed for`).
 
-<!---66270 -->* The exported sheet now generates or renders data for columns that indicate associations for configurable products.
+<!---66270  -->
+*  The exported sheet now generates or renders data for columns that indicate associations for configurable products.
 
-<!---59743 -->* Magento no longer deletes a product after you select the Replace option while importing a product. Previously, Magento deleted the product rather than replacing it.
+<!---59743  -->
+*  Magento no longer deletes a product after you select the Replace option while importing a product. Previously, Magento deleted the product rather than replacing it.
 
-<!---59715 -->* Magento can now import `additional_images` that are tagged with labels that contain a comma separator.
+<!---59715  -->
+*  Magento can now import `additional_images` that are tagged with labels that contain a comma separator.
 
-<!---58289 -->* We've fixed an issue where product URL keys (for SKUs) were not auto-generated as expected during import. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
+<!---58289  -->
+*  We've fixed an issue where product URL keys (for SKUs) were not auto-generated as expected during import. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
 
-<!---58385 -->* Magento now updates attribute sets as expected when importing  products from CSV. [GitHub-5498](https://github.com/magento/magento2/issues/5498)
+<!---58385  -->
+*  Magento now updates attribute sets as expected when importing  products from CSV. [GitHub-5498](https://github.com/magento/magento2/issues/5498)
 
-<!---63835 -->* The CatalogImportExport uploader can now handle HTTPS images. Previously, if the URL of a file contained HTTPS, the uploader  still used the HTTP provider to retrieve the image, which lead to an error. [GitHub-8277](https://github.com/magento/magento2/issues/8277)
+<!---63835  -->
+*  The CatalogImportExport uploader can now handle HTTPS images. Previously, if the URL of a file contained HTTPS, the uploader  still used the HTTP provider to retrieve the image, which lead to an error. [GitHub-8277](https://github.com/magento/magento2/issues/8277)
 
-<!--- 57675-->* Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
+<!--- 57675 -->
+*  Magento now displays the WYSIWYG editor as expected. [GitHub-6222](https://github.com/magento/magento2/issues/6222), [GitHub-4828](https://github.com/magento/magento2/issues/4828), [GitHub-6815](https://github.com/magento/magento2/issues/6815)
 
-<!--- 56014-->* The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
+<!--- 56014 -->
+*  The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
 
-<!--- 57796-->* Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
+<!--- 57796 -->
+*  Magento now renders images as expected in the product description area. Previously, Magento did not render images in this area, and would display a broken link. [GitHub-6138](https://github.com/magento/magento2/issues/6138)
 
 #### Integrations
 
-<!---56961, 54795-->* With valid permissions, you can now regain access to your Admin account after it is temporarily disabled due to invalid credentials. Previously, you could not unlock the account of a valid Admin user if it were disabled due to multiple invalid login attempts.
+<!---56961, 54795 -->
+*  With valid permissions, you can now regain access to your Admin account after it is temporarily disabled due to invalid credentials. Previously, you could not unlock the account of a valid Admin user if it were disabled due to multiple invalid login attempts.
 
-<!--- 61867-->* Web API tokens now have a default expiration period: 4 hours for Admin tokens and 1 hour for Customer tokens. This can be changed in the [Admin Panel configuration settings]({{ site.baseurl }}/guides/v2.2/get-started/authentication/gs-authentication-token.html#admin-and-customer-access-tokens)
+<!--- 61867 -->
+*  Web API tokens now have a default expiration period: 4 hours for Admin tokens and 1 hour for Customer tokens. This can be changed in the [Admin Panel configuration settings]({{ site.baseurl }}/guides/v2.2/get-started/authentication/gs-authentication-token.html#admin-and-customer-access-tokens)
 
-<!--- 69610-->* You can now edit `authentication_lock` from the Admin. *Fix submitted by community member Elias Kotlyar in pull request [9820](https://github.com/magento/magento2/pull/9820){: target="_blank"}.*
+<!--- 69610 -->
+*  You can now edit `authentication_lock` from the Admin. *Fix submitted by community member Elias Kotlyar in pull request [9820](https://github.com/magento/magento2/pull/9820){: target="_blank"}.*
 
 ### Indexing
 
-<!---56928-->* We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
+<!---56928 -->
+*  We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
 
-<!---57470 -->* Magento no longer displays an indexing error when Elasticsearch is enabled. Previously, Magento displayed this indexing error when Elasticsearch was enabled:  `mapper_parsing_exception`.
+<!---57470  -->
+*  Magento no longer displays an indexing error when Elasticsearch is enabled. Previously, Magento displayed this indexing error when Elasticsearch was enabled:  `mapper_parsing_exception`.
 
-<!---58703-->* The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error:  "Error 1114: Table is full".
+<!---58703 -->
+*  The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error:  "Error 1114: Table is full".
 
-<!--- 58893-->* `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
+<!--- 58893 -->
+*  `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
 
-<!--- 59853-->* The Magento flat indexer now collects correct product data for `ROW_ID`.
+<!--- 59853 -->
+*  The Magento flat indexer now collects correct product data for `ROW_ID`.
 
-<!--- 58559-->* The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables.
+<!--- 58559 -->
+*  The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables.
 
-<!--- 65362 -->* Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
+<!--- 65362  -->
+*  Magento now runs a selective partial re-indexing operation after import if you enable **Update on Schedule**. Previously, Magento ran a full reindex no matter which index mode was set.
 
-<!--- 55154 -->* `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
+<!--- 55154  -->
+*  `IndexerHandlerFactory` no longer tries to cast the `$indexer` object to a String if an error occurs. Since `$indexer` is an object of type `IndexerInterface` and does not have a `__toString()` method, attempting to cast the `$indexer` object to a String previously resulted in an error. [GitHub-5155](https://github.com/magento/magento2/issues/5155)
 
-<!--- 23764-->* The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error: "Error 1114: Table is full".
+<!--- 23764 -->
+*  The category/product indexer now successfully completes a full reindexing of all indexes on large profiles with 500,000 or more products. Previously, Magento successfully generated a large profile, but failed to complete the reindexing of the categories or products, and displayed the following error: "Error 1114: Table is full".
 
-<!---71242 -->* We’ve resolved failures with indexing in installations that implemented catalogs containing at least 5,000 - 6,000 SKUs.
+<!---71242  -->
+*  We’ve resolved failures with indexing in installations that implemented catalogs containing at least 5,000 - 6,000 SKUs.
 
-<!--- 55589-->* We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
+<!--- 55589 -->
+*  We've improved the performance of the algorithm that Magento uses to calculate batch sizes while indexing categories.
 
-<!--- 60824-->* Reindexing no longer results in an SQL error that prevents bundle products from being reindexed, and results in wrong product prices.
+<!--- 60824 -->
+*  Reindexing no longer results in an SQL error that prevents bundle products from being reindexed, and results in wrong product prices.
 
 ### Orders
 
@@ -824,93 +1155,134 @@ Thanks to our hardworking Magento Open Source community members for the followin
 
    *  change order status after a credit memo has been created.
 
-<!--- 57077-->* You can now set the customer group when creating a new order from the Admin interface. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+<!--- 57077 -->
+*  You can now set the customer group when creating a new order from the Admin interface. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
 
-<!---57387 -->* You can now print invoices and credit memos from the Order page.
+<!---57387  -->
+*  You can now print invoices and credit memos from the Order page.
 
-<!--- 55598/54787 -->* You can now successfully place orders when the Enable and Configure [Website](https://glossary.magento.com/website) Payments Standard Payment Action attribute is set to Sale. Previously, under these conditions, Magento would display an error message and not allow you to complete the purchase. [GitHub-4785](https://github.com/magento/magento2/issues/4785)
+<!--- 55598/54787  -->
+*  You can now successfully place orders when the Enable and Configure [Website](https://glossary.magento.com/website) Payments Standard Payment Action attribute is set to Sale. Previously, under these conditions, Magento would display an error message and not allow you to complete the purchase. [GitHub-4785](https://github.com/magento/magento2/issues/4785)
 
-<!--- 50026 -->* Attributes of the `salesInvoiceRepository` methods are now more appropriately type cast. (The data type is now a nullable float.)  Previously, due to the use of an incorrect data type, Magento would produce an error when calling the `salesInvoiceRepositoryV1GetList` method. [GitHub-3605](https://github.com/magento/magento2/issues/3605)
+<!--- 50026  -->
+*  Attributes of the `salesInvoiceRepository` methods are now more appropriately type cast. (The data type is now a nullable float.)  Previously, due to the use of an incorrect data type, Magento would produce an error when calling the `salesInvoiceRepositoryV1GetList` method. [GitHub-3605](https://github.com/magento/magento2/issues/3605)
 
-<!--- 58832-->* The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
+<!--- 58832 -->
+*  The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
 
-<!--- 62783-->* Magento now uses the address template from store view level of the placed order (similar to how order confirmation email works). Previously, Magento used the wrong address template for order e-mails.
+<!--- 62783 -->
+*  Magento now uses the address template from store view level of the placed order (similar to how order confirmation email works). Previously, Magento used the wrong address template for order e-mails.
 
-<!--- 59052 -->* Magento now correctly identifies an order being processed when it is placed in a store configured for multiple currencies. Previously, these orders always were identified as potentially fraudulent.
+<!--- 59052  -->
+*  Magento now correctly identifies an order being processed when it is placed in a store configured for multiple currencies. Previously, these orders always were identified as potentially fraudulent.
 
-<!--- 56150-->* The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
+<!--- 56150 -->
+*  The order comments history no longer duplicates the time that a comment was made. Previously, the time that a comment was made was listed twice.
 
-<!--- 54813 -->* You can now add a gift card with an undefined amount to the Items Ordered table. Previously, Magento did not permit you to add a gift card of an open value to this table.
+<!--- 54813  -->
+*  You can now add a gift card with an undefined amount to the Items Ordered table. Previously, Magento did not permit you to add a gift card of an open value to this table.
 
-<!--- 58074-->* The **Print Shipping Label** link now displays on the product frontend. Previously, the layout for the Shipping and Tracking block did not work properly.
+<!--- 58074 -->
+*  The **Print Shipping Label** link now displays on the product frontend. Previously, the layout for the Shipping and Tracking block did not work properly.
 
-<!---66428 -->* You can now create an order through Admin  if there is a `translate csv` for order-header. *Fix submitted by community member Pascal Brouwers in pull request [6856](https://github.com/magento/magento2/pull/6856){: target="_blank"}.*
+<!---66428  -->
+*  You can now create an order through Admin  if there is a `translate csv` for order-header. *Fix submitted by community member Pascal Brouwers in pull request [6856](https://github.com/magento/magento2/pull/6856){: target="_blank"}.*
 
-<!---69378 -->* You can now use a second credit memo to successfully issue a full refund for a credit memo with adjustment fees. *Fix submitted by community member Max Pronko in pull request [9715](https://github.com/magento/magento2/pull/9715){: target="_blank"}.*
+<!---69378  -->
+*  You can now use a second credit memo to successfully issue a full refund for a credit memo with adjustment fees. *Fix submitted by community member Max Pronko in pull request [9715](https://github.com/magento/magento2/pull/9715){: target="_blank"}.*
 
-<!---69551 -->* Coupon codes are now included in  invoice print outs. *Fix submitted by community member Belgacem Naoui in pull request [9780](https://github.com/magento/magento2/pull/9780){: target="_blank"}.*
+<!---69551  -->
+*  Coupon codes are now included in  invoice print outs. *Fix submitted by community member Belgacem Naoui in pull request [9780](https://github.com/magento/magento2/pull/9780){: target="_blank"}.*
 
-<!---69909 -->* The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
+<!---69909  -->
+*  The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
 
-<!---68795 -->*  Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
+<!---68795  -->
+*   Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
 
-<!--- 60587 -->* We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
+<!--- 60587  -->
+*  We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
 
-<!--- 57312-->* We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
+<!--- 57312 -->
+*  We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
 
-<!--- 59905-->* The Create Order page now works as expected after you select **Update items and quantities**.
+<!--- 59905 -->
+*  The Create Order page now works as expected after you select **Update items and quantities**.
 
-<!--- 59586-->* Magento no longer creates unnecessary  loaders during checkout with an order that contains virtual products.
+<!--- 59586 -->
+*  Magento no longer creates unnecessary  loaders during checkout with an order that contains virtual products.
 
-<!--- 57846-->* New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
+<!--- 57846 -->
+*  New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
 
-<!--- 60692-->*  You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
+<!--- 60692 -->
+*   You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
 
-<!--- 58722-->* We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
+<!--- 58722 -->
+*  We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
 
-<!--- 56938-->* Magento now creates the shipping address as expected when you  use REST to create an order.  Previously, when you used REST to create an order, then subsequently viewed the order from the Admin, Magento threw an error.
+<!--- 56938 -->
+*  Magento now creates the shipping address as expected when you  use REST to create an order.  Previously, when you used REST to create an order, then subsequently viewed the order from the Admin, Magento threw an error.
 
-<!--- 53005-->* Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
+<!--- 53005 -->
+*  Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
 
-<!--- 57880-->*  You can now cancel an order of a bundle product. [GitHub-5194](https://github.com/magento/magento2/issues/5194)
+<!--- 57880 -->
+*   You can now cancel an order of a bundle product. [GitHub-5194](https://github.com/magento/magento2/issues/5194)
 
-<!--- 57312-->* We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
+<!--- 57312 -->
+*  We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
 
-<!--- 56014-->* The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
+<!--- 56014 -->
+*  The Admin’s Most Viewed Products tab now displays correct product prices. Previously, prices for products in Most Viewed Products tab were incorrectly listed as $0. [GitHub-5660](https://github.com/magento/magento2/issues/5660)
 
-<!--- 57846-->* New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
+<!--- 57846 -->
+*  New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
 
 ### Payment methods
 
-<!--- 72305-->* We’ve added support for the change to the USPS API that USPS implemented on September 1, 2017. After installing or upgrading to this release, Magento will display the Domestic rate for USPS, First-Class Mail Parcel as expected. Previously, the USPS First-Class Mail Parcel option was not available after September 1, 2017 on installations running Magento 2.x.
+<!--- 72305 -->
+*  We’ve added support for the change to the USPS API that USPS implemented on September 1, 2017. After installing or upgrading to this release, Magento will display the Domestic rate for USPS, First-Class Mail Parcel as expected. Previously, the USPS First-Class Mail Parcel option was not available after September 1, 2017 on installations running Magento 2.x.
 
-<!--- 56695-->* You can now successfully complete Paypal checkout with products that have custom options. [GitHub-5938](https://github.com/magento/magento2/issues/5938)
+<!--- 56695 -->
+*  You can now successfully complete Paypal checkout with products that have custom options. [GitHub-5938](https://github.com/magento/magento2/issues/5938)
 
-<!--- 62669-->* Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
+<!--- 62669 -->
+*  Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
 
-<!--- 55612-->* Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
+<!--- 55612 -->
+*  Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
 
-<!--- 57923-->* Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
+<!--- 57923 -->
+*  Magento no longer displays the **No [Payment method](https://glossary.magento.com/payment-method) available** message when a customer tries to ship items to a billing-restricted country.
 
-<!--- 69750-->* Magento now successfully completes checkout when a custom address attribute is added. Previously, an error occurred during checkout when the user added a required custom address attribute.
+<!--- 69750 -->
+*  Magento now successfully completes checkout when a custom address attribute is added. Previously, an error occurred during checkout when the user added a required custom address attribute.
 
-<!--- 66959-->* Removed a duplicate method call to the `getLinkField` method in the `Magento\Catalog\Model\ResourceModel\Category` class. *Fixed by will-b in pull request [9057](https://github.com/magento/magento2/pull/9057){: target="_blank"}.*
+<!--- 66959 -->
+*  Removed a duplicate method call to the `getLinkField` method in the `Magento\Catalog\Model\ResourceModel\Category` class. *Fixed by will-b in pull request [9057](https://github.com/magento/magento2/pull/9057){: target="_blank"}.*
 
-<!--- 54412-->* During order creation, you can now continue with a payment after clicking the **Back** button to the payment selection window. [GitHub-4580](https://github.com/magento/magento2/issues/4580)
+<!--- 54412 -->
+*  During order creation, you can now continue with a payment after clicking the **Back** button to the payment selection window. [GitHub-4580](https://github.com/magento/magento2/issues/4580)
 
-<!--- 64413-->* The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
+<!--- 64413 -->
+*  The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
 
 * We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
 
-<!--- 56345-->* Error messages associated with the `Authorize.net` payment method are now translated to fit the configured locale. [GitHub-5934](https://github.com/magento/magento2/issues/5934)
+<!--- 56345 -->
+*  Error messages associated with the `Authorize.net` payment method are now translated to fit the configured locale. [GitHub-5934](https://github.com/magento/magento2/issues/5934)
 
-<!--- 58722-->* We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
+<!--- 58722 -->
+*  We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
 
-<!---56347 -->* We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
+<!---56347  -->
+*  We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
 
 #### Braintree
 
-<!--- 55530 -->* You can now place orders from the Admin using the Braintree payment method.
+<!--- 55530  -->
+*  You can now place orders from the Admin using the Braintree payment method.
 
 <!---59578 -->
 * We've enhanced our PayPal and Braintree implementations so that merchants can now:
@@ -919,405 +1291,577 @@ Thanks to our hardworking Magento Open Source community members for the followin
 
    *  Configure dynamic descriptors (Company Name, Phone and URL) for Braintree.  This enhancement supports customers easily identifying a source of transactions in their bank statements. (This will potential simplify the resolution of disputed transactions by supporting the display of the Kount status for Braintree in the Admin interface.)
 
-<!--- 56940-->* Kount and 3D Secure now work as expected for Braintree Vault.
+<!--- 56940 -->
+*  Kount and 3D Secure now work as expected for Braintree Vault.
 
-<!--- 62428-->* Magento now updates you as expected on order comments and order history after you initiate a refund using Braintree. Previously, when you clicked the **Refund** button (to initiate a refund), Magento did not redirect you to order comments and history information.
+<!--- 62428 -->
+*  Magento now updates you as expected on order comments and order history after you initiate a refund using Braintree. Previously, when you clicked the **Refund** button (to initiate a refund), Magento did not redirect you to order comments and history information.
 
-<!--- 54721-->* You can now use Braintree as a payment method when applying reward points or store credit to an order.
+<!--- 54721 -->
+*  You can now use Braintree as a payment method when applying reward points or store credit to an order.
 
-<!---56910-->* The Braintree payment method now works as expected with Vault table prefixing.
+<!---56910 -->
+*  The Braintree payment method now works as expected with Vault table prefixing.
 
-<!---57426-->* Magento no longer encounters an error when using the Braintree Vault payment GET order API call. [GitHub-6215](https://github.com/magento/magento2/issues/6215)
+<!---57426 -->
+*  Magento no longer encounters an error when using the Braintree Vault payment GET order API call. [GitHub-6215](https://github.com/magento/magento2/issues/6215)
 
-<!---59353-->* You can now use JCB and Diners Club credit cards with the Authorize.net payment method.
+<!---59353 -->
+*  You can now use JCB and Diners Club credit cards with the Authorize.net payment method.
 
-<!--- 59124-->* Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
+<!--- 59124 -->
+*  Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
 
-<!---57086-->* You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
+<!---57086 -->
+*  You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
 
-<!---59637-->*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+<!---59637 -->
+*   Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
-<!--- 56344-->* The Braintree payment method now works as expected with Vault table prefixing.
+<!--- 56344 -->
+*  The Braintree payment method now works as expected with Vault table prefixing.
 
-<!--- 71371-->* Merchants can now accept payment on a Suspected Fraud order without Magento altering the amount in Total Paid. Previously, when a merchant accepted payment for an order with a status of Suspected Fraud, Magento doubled the payment amount.
+<!--- 71371 -->
+*  Merchants can now accept payment on a Suspected Fraud order without Magento altering the amount in Total Paid. Previously, when a merchant accepted payment for an order with a status of Suspected Fraud, Magento doubled the payment amount.
 
-<!--- 59573-->* Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+<!--- 59573 -->
+*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
-<!--- 69340-->* The Braintree PayPal locale now has its own setting. [GitHub-9639](https://github.com/magento/magento2/issues/9639)
+<!--- 69340 -->
+*  The Braintree PayPal locale now has its own setting. [GitHub-9639](https://github.com/magento/magento2/issues/9639)
 
-<!--- 63460 -->* You can now modify the product quantities  of a previous order and re-order it using the saved credit card information from the first order.
+<!--- 63460  -->
+*  You can now modify the product quantities  of a previous order and re-order it using the saved credit card information from the first order.
 
 #### PayPal
 
-<!--- 59581-->* We've improved and streamlined the [Magento Admin](https://glossary.magento.com/magento-admin) PayPal configuration interface.
+<!--- 59581 -->
+*  We've improved and streamlined the [Magento Admin](https://glossary.magento.com/magento-admin) PayPal configuration interface.
 
-<!--- 58376-->* PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
+<!--- 58376 -->
+*  PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
 
-<!--- 59036-->* We've fixed an issue with using PayPal Express Checkout to order products with custom options. Previously, although an Admin user could create and configure “File type” custom options, customers could not upload and store files within the order [quote](https://glossary.magento.com/quote). [GitHub-5434](https://github.com/magento/magento2/issues/5434)
+<!--- 59036 -->
+*  We've fixed an issue with using PayPal Express Checkout to order products with custom options. Previously, although an Admin user could create and configure “File type” custom options, customers could not upload and store files within the order [quote](https://glossary.magento.com/quote). [GitHub-5434](https://github.com/magento/magento2/issues/5434)
 
-<!--- 70500-->* Fixed issue related to incorrect stock quantity calculation for bundle and configurable products during place order flow with PayPal Express Checkout.
+<!--- 70500 -->
+*  Fixed issue related to incorrect stock quantity calculation for bundle and configurable products during place order flow with PayPal Express Checkout.
 
-<!--- 62667-->* Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
+<!--- 62667 -->
+*  Third-party payment gateways are now visible from the Admin. [GitHub-7891](https://github.com/magento/magento2/issues/7891)
 
-<!--- 59086-->* Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
+<!--- 59086 -->
+*  Fixed issue with credit card capture information failing to remain associated with its first authorization. [GitHub-6716](https://github.com/magento/magento2/issues/6716)
 
-<!--- 58676-->* PayPal Express payments no longer fail when there is adequate product inventory to cover your order. Previously, you'd receive this error message: `We can't place the order`. [GitHub-6296](https://github.com/magento/magento2/issues/6296)
+<!--- 58676 -->
+*  PayPal Express payments no longer fail when there is adequate product inventory to cover your order. Previously, you'd receive this error message: `We can't place the order`. [GitHub-6296](https://github.com/magento/magento2/issues/6296)
 
-<!--- 71307-->* Paypal errors no longer occur when Fixed Product Tax (FPT) is enabled. Previously, when a product had a FPT, Paypal Express reported an error when you tried to place the order.
+<!--- 71307 -->
+*  Paypal errors no longer occur when Fixed Product Tax (FPT) is enabled. Previously, when a product had a FPT, Paypal Express reported an error when you tried to place the order.
 
-<!--- 58162-->* PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
+<!--- 58162 -->
+*  PayPal Payflow Pro now uses the currency you've specified in your store settings. Previously, Magento converted the total price into U.S. dollars, no matter which currency was specified in the store settings.
 
-<!--- 63551-->* When refunding an order from PayPal, Magento now creates a credit memo  with the correct status.
+<!--- 63551 -->
+*  When refunding an order from PayPal, Magento now creates a credit memo  with the correct status.
 
-<!---  -->* The exported sheet now generates or renders data for columns that indicate associations for configurable products.
+<!---   -->
+*  The exported sheet now generates or renders data for columns that indicate associations for configurable products.
 
-<!--- 68833 -->* We’ve fixed errors in processing valid orders using a PayPal account that had been previously used to pay for a valid order that had problems during checkout.
+<!--- 68833  -->
+*  We’ve fixed errors in processing valid orders using a PayPal account that had been previously used to pay for a valid order that had problems during checkout.
 
-<!---60589-->* We’ve resolved a loader issue with Payflow Pro. The loader image is now invisible after redirecting to the payment page/success page or error page. [GitHub-7159](https://github.com/magento/magento2/issues/7159),  [GitHub-9296](https://github.com/magento/magento2/issues/9296)
+<!---60589 -->
+*  We’ve resolved a loader issue with Payflow Pro. The loader image is now invisible after redirecting to the payment page/success page or error page. [GitHub-7159](https://github.com/magento/magento2/issues/7159),  [GitHub-9296](https://github.com/magento/magento2/issues/9296)
 
-<!---64833-->* PayPal Express checkout no longer discards address line 2 for billing and shipping addresses. [GitHub-8313](https://github.com/magento/magento2/issues/8313)
+<!---64833 -->
+*  PayPal Express checkout no longer discards address line 2 for billing and shipping addresses. [GitHub-8313](https://github.com/magento/magento2/issues/8313)
 
-<!---60572-->* The checkout page no longer freezes when you try to use PayPal to pay for a purchase that contains a downloadable product. Previously, a `PayPal.js` error occurred. [GitHub-7000](https://github.com/magento/magento2/issues/7000)
+<!---60572 -->
+*  The checkout page no longer freezes when you try to use PayPal to pay for a purchase that contains a downloadable product. Previously, a `PayPal.js` error occurred. [GitHub-7000](https://github.com/magento/magento2/issues/7000)
 
 ### Performance
 
 This release includes substantial improvements to Magento caching, image processing, and re-indexing, among other enhancements.
 
-<!--- 52660 -->* We've improved the speed of static asset deployment and now support a variety of asset deployment strategies that can be used to optimize speed and size of assets deployed. Indexers can now be run with 256M of PHP RAM and default MySQL configuration settings.  Developers can further tune memory usage to improve indexer performance (in some cases up to 100% improvement).  Please see [Magento Optimization Guide]({{ page.baseurl }}/config-guide/prod/prod_perf-optimize.html)  for further details.
+<!--- 52660  -->
+*  We've improved the speed of static asset deployment and now support a variety of asset deployment strategies that can be used to optimize speed and size of assets deployed. Indexers can now be run with 256M of PHP RAM and default MySQL configuration settings.  Developers can further tune memory usage to improve indexer performance (in some cases up to 100% improvement).  Please see [Magento Optimization Guide]({{ page.baseurl }}/config-guide/prod/prod_perf-optimize.html)  for further details.
 
-<!--- 55300, 55620, 54682-->* We've improved [storefront](https://glossary.magento.com/storefront) performance when creating 2500 or more product variants.
+<!--- 55300, 55620, 54682 -->
+*  We've improved [storefront](https://glossary.magento.com/storefront) performance when creating 2500 or more product variants.
 
-<!--- 58277 -->* The processing speed of category URL rewrites for catalogs containing more than 20,000 products has greatly improved.
+<!--- 58277  -->
+*  The processing speed of category URL rewrites for catalogs containing more than 20,000 products has greatly improved.
 
-<!---56927-->* Opening many products from the Admin interface is now faster.
+<!---56927 -->
+*  Opening many products from the Admin interface is now faster.
 
-<!---59708-->* Creating many (2500 - 5000) product variants, both simple and complex [product types](https://glossary.magento.com/product-types) is more efficient.
+<!---59708 -->
+*  Creating many (2500 - 5000) product variants, both simple and complex [product types](https://glossary.magento.com/product-types) is more efficient.
 
-<!--- 57410-->* You can now quickly generate or preview multiple variations of a [configurable product](https://glossary.magento.com/configurable-product). (Saving these variations to the database can be time-consuming, if you have several thousand product options, and our efforts to improve performance continue.) Previously, Magento threw an Invalid Form key error is thrown while you tried to save a configurable product with variations.
+<!--- 57410 -->
+*  You can now quickly generate or preview multiple variations of a [configurable product](https://glossary.magento.com/configurable-product). (Saving these variations to the database can be time-consuming, if you have several thousand product options, and our efforts to improve performance continue.) Previously, Magento threw an Invalid Form key error is thrown while you tried to save a configurable product with variations.
 
-<!--- 65483 -->* Magento no longer performs unnecessary file check operations (for example, `file_exists`, `is_file`), which improves the performance of the category and product pages.
+<!--- 65483  -->
+*  Magento no longer performs unnecessary file check operations (for example, `file_exists`, `is_file`), which improves the performance of the category and product pages.
 
-<!---57905-->* We've optimized compiler performance (that is, the [`setup:di:compile`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) command).
+<!---57905 -->
+*  We've optimized compiler performance (that is, the [`setup:di:compile`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) command).
 
-<!--- 66855-->* We’ve improved the performance of the Display Time for Category Edit page for catalogs with many products or categories.  [GitHub-7469](https://github.com/magento/magento2/issues/7469)
+<!--- 66855 -->
+*  We’ve improved the performance of the Display Time for Category Edit page for catalogs with many products or categories.  [GitHub-7469](https://github.com/magento/magento2/issues/7469)
 
 #### Image processing
 
-<!---60041-->* We've improved the process of resizing images on the [frontend](https://glossary.magento.com/frontend).
+<!---60041 -->
+*  We've improved the process of resizing images on the [frontend](https://glossary.magento.com/frontend).
 
-<!--- 59806 -->* The process of loading many configurable products with multiple images (for example, configurable products with three attributes and 250 options) is more efficient. [(GITHUB-6979)](https://github.com/magento/magento2/issues/6979){: target="_blank"}
+<!--- 59806  -->
+*  The process of loading many configurable products with multiple images (for example, configurable products with three attributes and 250 options) is more efficient. [(GITHUB-6979)](https://github.com/magento/magento2/issues/6979){: target="_blank"}
 
 #### Caching
 
-<!--- 65480 -->* Magento now caches image metadata, which avoids the time-consuming need to read images for [metadata](https://glossary.magento.com/metadata) loading.
+<!--- 65480  -->
+*  Magento now caches image metadata, which avoids the time-consuming need to read images for [metadata](https://glossary.magento.com/metadata) loading.
 
-<!--- 65484 -->* Magento now caches attribute options for the layered navigation feature. This reduces the number of queries to the database, and consequently improves performance.
+<!--- 65484  -->
+*  Magento now caches attribute options for the layered navigation feature. This reduces the number of queries to the database, and consequently improves performance.
 
-<!--- 62691 -->* We’ve optimized and streamlined how we cache EAV attributes by removing unnecessary SQL queries.
+<!--- 62691  -->
+*  We’ve optimized and streamlined how we cache EAV attributes by removing unnecessary SQL queries.
 
 ### PHP
 
-<!--- 69964 -->* PHPCS can now correctly parse the syntax of PHP 7.x return types.
+<!--- 69964  -->
+*  PHPCS can now correctly parse the syntax of PHP 7.x return types.
 
-<!--- 45339 -->* Cart Price rules are now applied as expected to [payment method](https://glossary.magento.com/payment-method) conditions. Previously, discounts set in Cart Price rules were not applied during [checkout](https://glossary.magento.com/checkout).
+<!--- 45339  -->
+*  Cart Price rules are now applied as expected to [payment method](https://glossary.magento.com/payment-method) conditions. Previously, discounts set in Cart Price rules were not applied during [checkout](https://glossary.magento.com/checkout).
 
 ### Sample data
 
-<!--- 67020 -->* Magento now handles the `catalog_product_entity_media_gallery_value.position` value the same whether you’ve installed or upgraded the product. Previously, these values differed depending upon whether you upgraded or freshly installed your Magento code.
+<!--- 67020  -->
+*  Magento now handles the `catalog_product_entity_media_gallery_value.position` value the same whether you’ve installed or upgraded the product. Previously, these values differed depending upon whether you upgraded or freshly installed your Magento code.
 
-<!--- 70299 -->* You can now successfully install Magento with sample data when **auto_increment_increment** is set to **3** in the `options` file. Previously, installation completed successfully, but Magento displayed this error: `Something went wrong while installing sample data. Please check var/log/system.log for details. You can retry installing the data now or just start using Magento.`
+<!--- 70299  -->
+*  You can now successfully install Magento with sample data when **auto_increment_increment** is set to **3** in the `options` file. Previously, installation completed successfully, but Magento displayed this error: `Something went wrong while installing sample data. Please check var/log/system.log for details. You can retry installing the data now or just start using Magento.`
 
 ### SalesRule
 
-<!--- 55184 -->* You can now select and add a category to a Cart Price rule. Previously, Magento displayed this error: "Uncaught ReferenceError: sales_rule_form is not defined", and did not add the selected category to the condition.  [GitHub-5526](https://github.com/magento/magento2/issues/5526)
+<!--- 55184  -->
+*  You can now select and add a category to a Cart Price rule. Previously, Magento displayed this error: "Uncaught ReferenceError: sales_rule_form is not defined", and did not add the selected category to the condition.  [GitHub-5526](https://github.com/magento/magento2/issues/5526)
 
-<!--- 55433 -->* A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart, the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
+<!--- 55433  -->
+*  A cart rule with a coupon code no longer overrides a cart rule without a coupon code when multiple [cart rules](https://glossary.magento.com/cart-rules) are applied. Previously, when you created two cart rules and applied them to a cart, the rule with a coupon was applied, but the second rule was not. [GitHub-6294](https://github.com/magento/magento2/issues/6294)
 
-<!--- 67089 -->* The SalesRule table  is the same whether you’ve freshly installed or updated Magento 2.2.
+<!--- 67089  -->
+*  The SalesRule table  is the same whether you’ve freshly installed or updated Magento 2.2.
 
-<!--- 62405 -->* Magento no longer discounts items that belong to an excluded category. Previously, you were unable to exclude products assigned to a specific category due to the cart price rule.
+<!--- 62405  -->
+*  Magento no longer discounts items that belong to an excluded category. Previously, you were unable to exclude products assigned to a specific category due to the cart price rule.
 
-<!--- 58677 -->* The Cart Price rule now affects coupon life as expected. Previously, coupons did not persist longer than the current date if they did not have a designated end-date.
+<!--- 58677  -->
+*  The Cart Price rule now affects coupon life as expected. Previously, coupons did not persist longer than the current date if they did not have a designated end-date.
 
-<!--- 60756 -->* Customers can no longer apply a coupon code twice. Previously, the "Uses per Coupon" limit did not work for auto-generated coupons.
+<!--- 60756  -->
+*  Customers can no longer apply a coupon code twice. Previously, the "Uses per Coupon" limit did not work for auto-generated coupons.
 
-<!--- 58334 -->* Magento now implements free shipping  if there is a Cart Price Rule match. [GitHub-6584](https://github.com/magento/magento2/issues/6584)
+<!--- 58334  -->
+*  Magento now implements free shipping  if there is a Cart Price Rule match. [GitHub-6584](https://github.com/magento/magento2/issues/6584)
 
-<!--- 63403 -->* SalesRule now applies to auto-generated coupon codes as expected.
+<!--- 63403  -->
+*  SalesRule now applies to auto-generated coupon codes as expected.
 
-<!--- 59047 -->* You can now create a cart price rule  without any date range restrictions. Previously, if you left the **From** and **To** dates empty, Magento filled them in with the current date. [GitHub-6762](https://github.com/magento/magento2/issues/6762), [GitHub-6122](https://github.com/magento/magento2/issues/6122)
+<!--- 59047  -->
+*  You can now create a cart price rule  without any date range restrictions. Previously, if you left the **From** and **To** dates empty, Magento filled them in with the current date. [GitHub-6762](https://github.com/magento/magento2/issues/6762), [GitHub-6122](https://github.com/magento/magento2/issues/6122)
 
-<!--- 59089 -->* When you change the currency associated with store, Magento also adjusts the currency in all product listings. [GitHub-6746](https://github.com/magento/magento2/issues/6746)
+<!--- 59089  -->
+*  When you change the currency associated with store, Magento also adjusts the currency in all product listings. [GitHub-6746](https://github.com/magento/magento2/issues/6746)
 
-<!--- 56871 -->* Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
+<!--- 56871  -->
+*  Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
 
-<!--- 56871 -->* Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
+<!--- 56871  -->
+*  Non-administrative users with access rights to Products, Marketing, Promotions, and Cart Price rules can now search for categories in Cart Price rules. GitHub-6168](https://github.com/magento/magento2/issues/6168)
 
 ### Scope
 
-<!---54704-->* Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
+<!---54704 -->
+*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
 
-<!---56936 -->*  The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
+<!---56936  -->
+*   The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
 
-<!---57001, 54460-->* A restricted user can now change storeview- or website- level attributes that are defined within his scope.
+<!---57001, 54460 -->
+*  A restricted user can now change storeview- or website- level attributes that are defined within his scope.
 
-<!---59284, 59282-->* You can now select the scope for an action that you are running from the Catalog page's product table.
+<!---59284, 59282 -->
+*  You can now select the scope for an action that you are running from the Catalog page's product table.
 
-<!---59953-->* The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
+<!---59953 -->
+*  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
-<!---54458, 57003-->* The Product page scope selector now displays all related websites associated with a restricted user.
+<!---54458, 57003 -->
+*  The Product page scope selector now displays all related websites associated with a restricted user.
 
 ### Search
 
-<!---59088-->*  Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
+<!---59088 -->
+*   Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
 
-<!---52905-->*  Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
+<!---52905 -->
+*   Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
 
-<!--- 71562 -->* The Elasticsearch indexer search-by-attribute functionality now works as expected.
+<!--- 71562  -->
+*  The Elasticsearch indexer search-by-attribute functionality now works as expected.
 
-<!--- 57868 -->* Elasticsearch does not throw errors when there are more than 100 searchable attributes or when user-defined price attributes are marked searchable.
+<!--- 57868  -->
+*  Elasticsearch does not throw errors when there are more than 100 searchable attributes or when user-defined price attributes are marked searchable.
 
-<!---63249 -->* ElasticSearch now includes data about composite products in its search index. Previously, search results did not include this data.
+<!---63249  -->
+*  ElasticSearch now includes data about composite products in its search index. Previously, search results did not include this data.
 
-<!---65245 -->* Magento now sends the `parent_id` of a deleted configurable product variation to ElasticSearch. Previously, Magento didn’t send this information to the ElasticSearch server if the simple product associated with a configurable product were changed.
+<!---65245  -->
+*  Magento now sends the `parent_id` of a deleted configurable product variation to ElasticSearch. Previously, Magento didn’t send this information to the ElasticSearch server if the simple product associated with a configurable product were changed.
 
-<!---56356 -->* Segmentation faults no longer occur when doing a `catalogsearch_fulltext` re-index, and indexing succeeds. Previously, in a large database (more than 70,000 products), the `catalogsearch_fulltext` (MySQL) re-index failed with a `Segmentation fault` message. [GitHub-7963](https://github.com/magento/magento2/issues/7963)
+<!---56356  -->
+*  Segmentation faults no longer occur when doing a `catalogsearch_fulltext` re-index, and indexing succeeds. Previously, in a large database (more than 70,000 products), the `catalogsearch_fulltext` (MySQL) re-index failed with a `Segmentation fault` message. [GitHub-7963](https://github.com/magento/magento2/issues/7963)
 
-<!---58964 -->* Magento now implements the Attribute Weight Boosting Function for Elasticsearch.
+<!---58964  -->
+*  Magento now implements the Attribute Weight Boosting Function for Elasticsearch.
 
-<!---64367 -->* Magento now handles special characters in an Elasticsearch request as expected. Previously, Magento displayed a MySQL syntax error in search requests that contained special characters. [GitHub-8335](https://github.com/magento/magento2/issues/8335)
+<!---64367  -->
+*  Magento now handles special characters in an Elasticsearch request as expected. Previously, Magento displayed a MySQL syntax error in search requests that contained special characters. [GitHub-8335](https://github.com/magento/magento2/issues/8335)
 
-<!---59477 -->* Attribute weighting now works correctly for the MySQL adapter. [GitHub-9020](https://github.com/magento/magento2/issues/9020)
+<!---59477  -->
+*  Attribute weighting now works correctly for the MySQL adapter. [GitHub-9020](https://github.com/magento/magento2/issues/9020)
 
-<!---56097 -->* Magento no longer throws an indexing error when Elastic search is enabled.
+<!---56097  -->
+*  Magento no longer throws an indexing error when Elastic search is enabled.
 
 ### Shipping
 
-<!---57037-->* UPS now generates shipping rates for Puerto Rico postal codes.
+<!---57037 -->
+*  UPS now generates shipping rates for Puerto Rico postal codes.
 
-<!--- 71749 -->* Magento now displays tracking information when selected for the second shipping label created for the DHL shipping method. Previously, when you tried to display a completed DHL shipping label, Magento displayed an exception.
+<!--- 71749  -->
+*  Magento now displays tracking information when selected for the second shipping label created for the DHL shipping method. Previously, when you tried to display a completed DHL shipping label, Magento displayed an exception.
 
-<!--- 58062-->* Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
+<!--- 58062 -->
+*  Refreshing your browser page while on the Review and Payments page of the checkout process no longer clears information from form fields. Previously, Magento cleared information from the **Ship to** field if you refreshed your browser page during this process.
 
-<!--- 57992-->* You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
+<!--- 57992 -->
+*  You can now reload a page during [checkout](https://glossary.magento.com/checkout) without unintentionally changing shipping information.
 
-<!--- 70646-->* You can now save the settings you enter when creating a shipping label on an existing shipment. Previously, clicking the **Save** button resulted in an error, and the shipping label was not saved.
+<!--- 70646 -->
+*  You can now save the settings you enter when creating a shipping label on an existing shipment. Previously, clicking the **Save** button resulted in an error, and the shipping label was not saved.
 
-<!--- 67053 -->* Added missing translation to label `argument xml`.  *Fix submitted by community member Mr Khoa in pull request [9095](https://github.com/magento/magento2/pull/9095){: target="_blank"}.*
+<!--- 67053  -->
+*  Added missing translation to label `argument xml`.  *Fix submitted by community member Mr Khoa in pull request [9095](https://github.com/magento/magento2/pull/9095){: target="_blank"}.*
 
-<!--- 64909-->* Magento no longer throws a fatal error when you create a new shipment for a placed order.
+<!--- 64909 -->
+*  Magento no longer throws a fatal error when you create a new shipment for a placed order.
 
-<!--- 62276-->* The State/Province field now changes to an input field as expected after you select United Kingdom when filling out the shipping address during checkout
+<!--- 62276 -->
+*  The State/Province field now changes to an input field as expected after you select United Kingdom when filling out the shipping address during checkout
 
-<!--- 58664-->* The Free Shipping rule now works as expected with table rate shipping.[GitHub-6346](https://github.com/magento/magento2/issues/6346)
+<!--- 58664 -->
+*  The Free Shipping rule now works as expected with table rate shipping.[GitHub-6346](https://github.com/magento/magento2/issues/6346)
 
-<!--- 62662-->* Magento now passes the correct object to the  `\Magento\Shipping\Model\Shipping::collectRatesByAddress` method. [GitHub-7309](https://github.com/magento/magento2/issues/7309)
+<!--- 62662 -->
+*  Magento now passes the correct object to the  `\Magento\Shipping\Model\Shipping::collectRatesByAddress` method. [GitHub-7309](https://github.com/magento/magento2/issues/7309)
 
-<!--- 60523-->* Magento now displays the checkout page or cart as expected when you try to edit a virtual item from the multi shipping page. Previously, Magento displayed a 404 error page instead of redirecting to the checkout page or shopping cart. [GitHub-7257](https://github.com/magento/magento2/issues/7257)
+<!--- 60523 -->
+*  Magento now displays the checkout page or cart as expected when you try to edit a virtual item from the multi shipping page. Previously, Magento displayed a 404 error page instead of redirecting to the checkout page or shopping cart. [GitHub-7257](https://github.com/magento/magento2/issues/7257)
 
-<!--- 58730-->* Magento now displays UPS rates on the initial load of the checkout page. Previously, although shipping rates showed up properly at the cart level, the payment page did not load the correct shipping options. [GitHub-6564](https://github.com/magento/magento2/issues/6564)
+<!--- 58730 -->
+*  Magento now displays UPS rates on the initial load of the checkout page. Previously, although shipping rates showed up properly at the cart level, the payment page did not load the correct shipping options. [GitHub-6564](https://github.com/magento/magento2/issues/6564)
 
-<!--- 59149-->* We've resolved an issue where Magento did not display applicable flat-rate USPS box methods during checkout. [GitHub-6798](https://github.com/magento/magento2/issues/6798)
+<!--- 59149 -->
+*  We've resolved an issue where Magento did not display applicable flat-rate USPS box methods during checkout. [GitHub-6798](https://github.com/magento/magento2/issues/6798)
 
-<!--- 58664-->* The Free Shipping rule now works as expected with table rate shipping. [GitHub-6346](https://github.com/magento/magento2/issues/6346)
+<!--- 58664 -->
+*  The Free Shipping rule now works as expected with table rate shipping. [GitHub-6346](https://github.com/magento/magento2/issues/6346)
 
 ### Sitemap
 
-<!--- 60523-->* Sitemap image URLs now match the URLs on product pages. *Fix submitted by community member Petar Sambolek in pull request [9082](https://github.com/magento/magento2/pull/9082){: target="_blank"}.*
+<!--- 60523 -->
+*  Sitemap image URLs now match the URLs on product pages. *Fix submitted by community member Petar Sambolek in pull request [9082](https://github.com/magento/magento2/pull/9082){: target="_blank"}.*
 
-<!--- 70056-->* The sitemap is no longer generated in the wrong folder when `vhost` is connected to `/pub`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
+<!--- 70056 -->
+*  The sitemap is no longer generated in the wrong folder when `vhost` is connected to `/pub`. *Fix submitted by community member Joseph Maxwell in pull request [9094](https://github.com/magento/magento2/pull/9094){: target="_blank"}.*
 
 ### Staging
 
-<!---57346, 53078-->*  The [CMS](https://glossary.magento.com/cms) page now refreshes as expected after an update.
+<!---57346, 53078 -->
+*   The [CMS](https://glossary.magento.com/cms) page now refreshes as expected after an update.
 
-<!---71215-->* Magento no longer creates extraneous database values when you schedule new Staging updates.
+<!---71215 -->
+*  Magento no longer creates extraneous database values when you schedule new Staging updates.
 
-<!--- 65481 -->* Magento no longer performs unnecessary staging-related flag operations on the Category page. Previously, Magento performed staging-related flag operations even when the Staging [module](https://glossary.magento.com/module) was not used.
+<!--- 65481  -->
+*  Magento no longer performs unnecessary staging-related flag operations on the Category page. Previously, Magento performed staging-related flag operations even when the Staging [module](https://glossary.magento.com/module) was not used.
 
-<!--- 55524/48429-->* You can now delete updates from a campaign's page [entity](https://glossary.magento.com/entity) grid.
+<!--- 55524/48429 -->
+*  You can now delete updates from a campaign's page [entity](https://glossary.magento.com/entity) grid.
 
-<!--- 71708-->* You can now create a staging update for a product that contains a unique attribute in its attribute set. Previously, under these conditions, Magento displayed this error: `The value of attribute "test" must be unique’`.
+<!--- 71708 -->
+*  You can now create a staging update for a product that contains a unique attribute in its attribute set. Previously, under these conditions, Magento displayed this error: `The value of attribute "test" must be unique’`.
 
-<!---71373 -->* You can now install Magento Commerce without staging modules.
+<!---71373  -->
+*  You can now install Magento Commerce without staging modules.
 
-<!---56065, 59851-->* The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables. It also now collects correct product data for `ROW_ID`
+<!---56065, 59851 -->
+*  The Magento flat indexer no longer throws an error after flat tables are enabled and reindexed. This fix applies to both product and [catalog](https://glossary.magento.com/catalog) tables. It also now collects correct product data for `ROW_ID`
 
-<!--- 68998, 61425-->* The staging dashboard now loads without error when you sort by status on the dashboard. Previously, the staging dashboard broke and remained in an infinite loop when you attempted to sort by status on the dashboard.
+<!--- 68998, 61425 -->
+*  The staging dashboard now loads without error when you sort by status on the dashboard. Previously, the staging dashboard broke and remained in an infinite loop when you attempted to sort by status on the dashboard.
 
-<!--- 70671-->* You can now preview an update from the dashboard and click on links and see how the entire instance would look like for a store between some dates. Previously, the links from the Preview page were broken.
+<!--- 70671 -->
+*  You can now preview an update from the dashboard and click on links and see how the entire instance would look like for a store between some dates. Previously, the links from the Preview page were broken.
 
-<!--- 70656-->* Magento now displays the correct content on the preview page for a scheduled update.
+<!--- 70656 -->
+*  Magento now displays the correct content on the preview page for a scheduled update.
 
-<!--- 70922-->* Magento now applies all scheduled product changes to all scopes.
+<!--- 70922 -->
+*  Magento now applies all scheduled product changes to all scopes.
 
-<!--- 60556-->* The view/edit option for a scheduled change is now available for the duration that the scheduled change is in progress. Previously, you could not view or edit a scheduled change when it was in progress, which left no way to edit or remove it.
+<!--- 60556 -->
+*  The view/edit option for a scheduled change is now available for the duration that the scheduled change is in progress. Previously, you could not view or edit a scheduled change when it was in progress, which left no way to edit or remove it.
 
-<!--- 60677-->* You can now create a new scheduled update for a product. Previously. when you tried to create an update, Magento displayed this error: `Uncaught TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.`
+<!--- 60677 -->
+*  You can now create a new scheduled update for a product. Previously. when you tried to create an update, Magento displayed this error: `Uncaught TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.`
 
-<!--- 55867 -->* Magento now displays the correct date and time for staging updates. Previously, when your current time in Daylight Saving time, and your target time was in Standard time, your target time was incorrect.
+<!--- 55867  -->
+*  Magento now displays the correct date and time for staging updates. Previously, when your current time in Daylight Saving time, and your target time was in Standard time, your target time was incorrect.
 
-<!--- 65540-->* Magento now correctly assigns images to duplicated products.
+<!--- 65540 -->
+*  Magento now correctly assigns images to duplicated products.
 
-<!--- 58651-->* Scheduled Update no longer removes simple variations from Configurable products. Previously, if you set up a scheduled update to toggle the **New** setting on a configurable product, Magento removes all simple variations from the configurable product once the update takes effect.
+<!--- 58651 -->
+*  Scheduled Update no longer removes simple variations from Configurable products. Previously, if you set up a scheduled update to toggle the **New** setting on a configurable product, Magento removes all simple variations from the configurable product once the update takes effect.
 
-<!--- 63159 -->* Content staging values for fields are now saved in database.
+<!--- 63159  -->
+*  Content staging values for fields are now saved in database.
 
-<!--- 64461 -->*  When you import products  that exist in the CSV file, but not on the store (including categories), Magento now populates the categories as expected.
+<!--- 64461  -->
+*   When you import products  that exist in the CSV file, but not on the store (including categories), Magento now populates the categories as expected.
 
-<!--- 67754 -->* Magento no longer deletes images associated with categories scheduled for update after you modify the image.
+<!--- 67754  -->
+*  Magento no longer deletes images associated with categories scheduled for update after you modify the image.
 
-<!--- 59687 -->*  Once the time frame for the scheduled update has passed, Magento removes the special price and displays the original price.
+<!--- 59687  -->
+*   Once the time frame for the scheduled update has passed, Magento removes the special price and displays the original price.
 
-<!--- 54512 -->* You can now remove a product or category from a campaign.
+<!--- 54512  -->
+*  You can now remove a product or category from a campaign.
 
-<!--- 65657 -->* You can now preview a scheduled update for a category that contains a recently viewed block.
+<!--- 65657  -->
+*  You can now preview a scheduled update for a category that contains a recently viewed block.
 
-<!---60534-->* We’ve resolved a scheduling issue that previously resulted in Magento displaying a 404 error on most frontend pages. This occurred if you deleted a Catalog Rule with an end date, then ran an update.
+<!---60534 -->
+*  We’ve resolved a scheduling issue that previously resulted in Magento displaying a 404 error on most frontend pages. This occurred if you deleted a Catalog Rule with an end date, then ran an update.
 
-<!---62646-->* You can now save simple products created in 2.0.x environments after upgrading to environments running Magento 2.1.x. Previously, you could not successfully save the opened product after upgrading.
+<!---62646 -->
+*  You can now save simple products created in 2.0.x environments after upgrading to environments running Magento 2.1.x. Previously, you could not successfully save the opened product after upgrading.
 
 ### Static file processing
 
-<!---60603-->* We've corrected a problem with `_requirejs` asset retrieval via `static.php` in [static content](https://glossary.magento.com/static-content) versioning.
+<!---60603 -->
+*  We've corrected a problem with `_requirejs` asset retrieval via `static.php` in [static content](https://glossary.magento.com/static-content) versioning.
 
-<!---56914-->* Versioning of [static files](https://glossary.magento.com/static-files) (including CSS, JS, font, and image files) is now enabled by default.
+<!---56914 -->
+*  Versioning of [static files](https://glossary.magento.com/static-files) (including CSS, JS, font, and image files) is now enabled by default.
 
-<!---57904-->* We've improved the speed of static asset deployment. See [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html){: target="_blank"} for more information about available options.
+<!---57904 -->
+*  We've improved the speed of static asset deployment. See [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html){: target="_blank"} for more information about available options.
 
-<!--- 52614 -->* The `setup:static-content:deploy` command now provides flags that you can use to exclude or include individual themes, areas, and locales. For more information, see [GitHub-4294](https://github.com/magento/magento2/issues/4294).
+<!--- 52614  -->
+*  The `setup:static-content:deploy` command now provides flags that you can use to exclude or include individual themes, areas, and locales. For more information, see [GitHub-4294](https://github.com/magento/magento2/issues/4294).
 
 ### Swatches
 
-<!--- 65404 -->* Magento no longer creates redundant objects when initializing a configurable product on the Category page.
+<!--- 65404  -->
+*  Magento no longer creates redundant objects when initializing a configurable product on the Category page.
 
-<!--- 65403 -->* You can now disable swatches for both the [Catalog](https://glossary.magento.com/catalog) page and search results (quick or advanced). To disable swatches from these requests, disable **Stores > Settings > Configuration > Catalog > Storefront > Show Swatches in Product List**.
+<!--- 65403  -->
+*  You can now disable swatches for both the [Catalog](https://glossary.magento.com/catalog) page and search results (quick or advanced). To disable swatches from these requests, disable **Stores > Settings > Configuration > Catalog > Storefront > Show Swatches in Product List**.
 
-<!--- 65402 -->* We've optimized the logic that Magento uses to validate swatch attributes.
+<!--- 65402  -->
+*  We've optimized the logic that Magento uses to validate swatch attributes.
 
-<!--- 65248 -->* Magento now caches swatch data in the block cache, which improves the responsiveness of the configurable product pages.
+<!--- 65248  -->
+*  Magento now caches swatch data in the block cache, which improves the responsiveness of the configurable product pages.
 
-<!--- 60045 -->* Magento now correctly matches images to products. Previously, after you selected a configurable product, Magento displayed the images for another product.
+<!--- 60045  -->
+*  Magento now correctly matches images to products. Previously, after you selected a configurable product, Magento displayed the images for another product.
 
-<!--- 66417 -->* Magento no longer displays a notice error when you create a text swatch attribute while the **update product preview image** setting  is set to **Yes**. *Fix submitted by community member Pascal Brouwers in pull request [6707](https://github.com/magento/magento2/pull/6707){: target="_blank"}.*
+<!--- 66417  -->
+*  Magento no longer displays a notice error when you create a text swatch attribute while the **update product preview image** setting  is set to **Yes**. *Fix submitted by community member Pascal Brouwers in pull request [6707](https://github.com/magento/magento2/pull/6707){: target="_blank"}.*
 
 ### TargetRule
 
-<!--- 59689 -->* Magento now displays Up-sells on the Product page.
+<!--- 59689  -->
+*  Magento now displays Up-sells on the Product page.
 
-<!--- 70853 -->* We’ve fixed an SQL error that previously caused a logical error during the creation of a TargetRule. (This issue affected the `modifyConditionByCategoryIdsAttribute` function.)
+<!--- 70853  -->
+*  We’ve fixed an SQL error that previously caused a logical error during the creation of a TargetRule. (This issue affected the `modifyConditionByCategoryIdsAttribute` function.)
 
 ### Tax
 
-<!--- 61120 -->* Magento now correctly calculates tax and order totals when a discount is used for prices that include tax and catalog prices excluding tax. Please note this is not a valid tax configuration and can introduce rounding errors.
+<!--- 61120  -->
+*  Magento now correctly calculates tax and order totals when a discount is used for prices that include tax and catalog prices excluding tax. Please note this is not a valid tax configuration and can introduce rounding errors.
 
-<!--- 59801 -->* We’ve improved the performance of the Tax Rules form in installations containing many tax rates.
+<!--- 59801  -->
+*  We’ve improved the performance of the Tax Rules form in installations containing many tax rates.
 
-<!--- 70641 -->* You can now create a tax rule when running Magento in Mozilla Firefox and Internet Explorer. Previously, you could not select a tax rate, and Magento displayed an error.
+<!--- 70641  -->
+*  You can now create a tax rule when running Magento in Mozilla Firefox and Internet Explorer. Previously, you could not select a tax rate, and Magento displayed an error.
 
-<!--- 59514 -->* The `tax_region_id` value is no longer hard-coded in the `\Magento\Tax\Setup\InstallData` file.
+<!--- 59514  -->
+*  The `tax_region_id` value is no longer hard-coded in the `\Magento\Tax\Setup\InstallData` file.
 
 ### Testing
 
-<!--- 62388-->* We've fixed a fatal issue that occurred if you executed the CatalogImportExport test before running a subsequent test. Previously, you'd receive this error: ```Failed asserting that false is true```.
+<!--- 62388 -->
+*  We've fixed a fatal issue that occurred if you executed the CatalogImportExport test before running a subsequent test. Previously, you'd receive this error: ```Failed asserting that false is true```.
 
-<!--- 59680-->* We've fixed a fatal issue that occurred if you ran Travis builds on `imagettfbbox 2.1.2`. Previously, you'd receive this error:
+<!--- 59680 -->
+*  We've fixed a fatal issue that occurred if you ran Travis builds on `imagettfbbox 2.1.2`. Previously, you'd receive this error:
 
    ```terminal
    PHP Fatal error: Call to undefined function Magento\Framework\Image\Adapter\imagettfbbox() in /home/travis/build/magento/magento2/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
    ```
 
-<!--- 64462-->* `StdoTest` is now marked as skipped. *Fix submitted by community member David Manners in pull request [8487](https://github.com/magento/magento2/pull/8487){: target="_blank"}.*
+<!--- 64462 -->
+*  `StdoTest` is now marked as skipped. *Fix submitted by community member David Manners in pull request [8487](https://github.com/magento/magento2/pull/8487){: target="_blank"}.*
 
 ### Tier pricing
 
-<!---70377-->* Magento now correctly calculates the tier price percentage when displayed prices include tax. [GitHub-8833](https://github.com/magento/magento2/issues/8833)
+<!---70377 -->
+*  Magento now correctly calculates the tier price percentage when displayed prices include tax. [GitHub-8833](https://github.com/magento/magento2/issues/8833)
 
-<!---57625-->* Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
+<!---57625 -->
+*  Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
 
-<!---56922-->*  Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
+<!---56922 -->
+*   Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
 
-<!---55055-->*  Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
+<!---55055 -->
+*   Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
 
 ### Translation and locales
 
-<!---67296-->* String localizations now work as expected when phrases include text wrapped with single quotation marks.
+<!---67296 -->
+*  String localizations now work as expected when phrases include text wrapped with single quotation marks.
 
-<!---69728-->* Translations now work for layered navigation attribute options. *Fix submitted by community member Pieter Hoste in pull request [9873](https://github.com/magento/magento2/pull/9873){: target="_blank"}.*
+<!---69728 -->
+*  Translations now work for layered navigation attribute options. *Fix submitted by community member Pieter Hoste in pull request [9873](https://github.com/magento/magento2/pull/9873){: target="_blank"}.*
 
 ### URL rewrites
 
-<!---66480-->* You can now successfully create a product and assign it to a store without encountering the following error: `Unique constraint violation found`. [GitHub-6671](https://github.com/magento/magento2/issues/6671)
+<!---66480 -->
+*  You can now successfully create a product and assign it to a store without encountering the following error: `Unique constraint violation found`. [GitHub-6671](https://github.com/magento/magento2/issues/6671)
 
-<!---67315, 67299 -->* The `catalog_url_rewrite_product_category` table is the same whether you’ve freshly installed or updated Magento 2.2.
+<!---67315, 67299  -->
+*  The `catalog_url_rewrite_product_category` table is the same whether you’ve freshly installed or updated Magento 2.2.
 
-<!---70663-->* You can now assign products to a category when **Match Products by rule** is enabled.
+<!---70663 -->
+*  You can now assign products to a category when **Match Products by rule** is enabled.
 
-<!---61549-->* The **Use default URL Key** setting now works on the store-view level.
+<!---61549 -->
+*  The **Use default URL Key** setting now works on the store-view level.
 
-<!---58796-->* You no longer need to delete the URL rewrite to force Magento to display links after adding pages to the CMS hierarchy. Previously, when you added new pages to the CMS hierarchy, Magento did not show the links to the new pages until you deleted the URL rewrites.
+<!---58796 -->
+*  You no longer need to delete the URL rewrite to force Magento to display links after adding pages to the CMS hierarchy. Previously, when you added new pages to the CMS hierarchy, Magento did not show the links to the new pages until you deleted the URL rewrites.
 
-<!---70255 -->* We've fixed several issues with how Magento processes URLs with trailing slashes. *Fix submitted by community member Ihor Sviziev in pull request [10043](https://github.com/magento/magento2/pull/10043){: target="_blank"}.*
+<!---70255  -->
+*  We've fixed several issues with how Magento processes URLs with trailing slashes. *Fix submitted by community member Ihor Sviziev in pull request [10043](https://github.com/magento/magento2/pull/10043){: target="_blank"}.*
 
-<!---60037 -->* Admin users can no longer create an empty URL key for a category. Previously, Magento let Admin users create an empty URL key, which lead to category-related errors.
+<!---60037  -->
+*  Admin users can no longer create an empty URL key for a category. Previously, Magento let Admin users create an empty URL key, which lead to category-related errors.
 
-<!---56862 -->* Magento now rewrites URLs as expected when you save a product while running Magento in single-store mode. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!---56862  -->
+*  Magento now rewrites URLs as expected when you save a product while running Magento in single-store mode. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!---56863 -->* Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
+<!---56863  -->
+*  Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
 
-<!---64295 -->* URL rewrites are now correctly generated for multiple store views during product import.  [GitHub-8396](https://github.com/magento/magento2/issues/8396)
+<!---64295  -->
+*  URL rewrites are now correctly generated for multiple store views during product import.  [GitHub-8396](https://github.com/magento/magento2/issues/8396)
 
-<!---56863 -->* Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
+<!---56863  -->
+*  Magento now rewrites URLs as expected when you save a CMS page while running Magento in single-store mode. [GitHub-5923](https://github.com/magento/magento2/issues/5923)
 
 ### Varnish
 
-<!---58362-->* We've changed the behavior of the Varnish X-header. Only the parent (meta) SKU is now included in the list -- not the SKUs of all child products. [GitHub-6401](https://github.com/magento/magento2/issues/6401)
+<!---58362 -->
+*  We've changed the behavior of the Varnish X-header. Only the parent (meta) SKU is now included in the list -- not the SKUs of all child products. [GitHub-6401](https://github.com/magento/magento2/issues/6401)
 
-<!--- 69372-->* Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member Bernhard in pull request 9711.*
+<!--- 69372 -->
+*  Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member Bernhard in pull request 9711.*
 
 * Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
 
-<!--- 52923-->* Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
+<!--- 52923 -->
+*  Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
 
 ### Visual Merchandiser
 
-<!---58465, 56775-->* The order of products in a category display no longer changes when you add a new product to the category.
+<!---58465, 56775 -->
+*  The order of products in a category display no longer changes when you add a new product to the category.
 
-<!---54491-->* Visual Merchandiser `Match products by rule` now works as expected.
+<!---54491 -->
+*  Visual Merchandiser `Match products by rule` now works as expected.
 
 ### Web API
 
-<!---61018-->* You can now use REST to add video to a product description. [GitHub-7153](https://github.com/magento/magento2/issues/7153)
+<!---61018 -->
+*  You can now use REST to add video to a product description. [GitHub-7153](https://github.com/magento/magento2/issues/7153)
 
-<!---57039-->* The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
+<!---57039 -->
+*  The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
 
-<!---64047-->* A null value may now be specified to unset the `special_price` attribute.
+<!---64047 -->
+*  A null value may now be specified to unset the `special_price` attribute.
 
-<!---52340 -->* The Swagger documentation erroneously indicated that search queries can return detailed information about multiple objects. The description of these APIs now state which API to use to return detailed information about a single object.
+<!---52340  -->
+*  The Swagger documentation erroneously indicated that search queries can return detailed information about multiple objects. The description of these APIs now state which API to use to return detailed information about a single object.
 
-<!--- 59871-->* You can now use REST to successfully update customer information without unintentionally deleting default billing and shipping address information.
+<!--- 59871 -->
+*  You can now use REST to successfully update customer information without unintentionally deleting default billing and shipping address information.
 
-<!--- 70743-->* You can now use a REST request to retrieve a shopping cart that contained a product with custom options. Previously, you could not use a REST request to retrieve a shopping cart that contained a product with custom options.
+<!--- 70743 -->
+*  You can now use a REST request to retrieve a shopping cart that contained a product with custom options. Previously, you could not use a REST request to retrieve a shopping cart that contained a product with custom options.
 
-<!--- 60908-->* The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
+<!--- 60908 -->
+*  The `PUT /V1/products/:sku/media/:entryId` correctly updates a product's media gallery and image role.
 
-<!---63667 -->* Searching for products via REST API using a store code in the URL returns products from all stores. [GitHub-8121](https://github.com/magento/magento2/issues/8121)
+<!---63667  -->
+*  Searching for products via REST API using a store code in the URL returns products from all stores. [GitHub-8121](https://github.com/magento/magento2/issues/8121)
 
-<!---58348 -->* You can now use the REST API to create a configurable product with a linked child product. [(GITHUB-5243)](https://github.com/magento/magento2/issues/5243){: target="_blank"}
+<!---58348  -->
+*  You can now use the REST API to create a configurable product with a linked child product. [(GITHUB-5243)](https://github.com/magento/magento2/issues/5243){: target="_blank"}
 
-<!---58338 -->* The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
+<!---58338  -->
+*  The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
 
-<!---56347 -->* We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
+<!---56347  -->
+*  We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
 
-<!---58269 -->* You can now save a billing address using the REST  ’useForShipping' parameter. Previously use of the parameter resulted in a Rest API V1 error. [GitHub-6557](https://github.com/magento/magento2/issues/6557), [GitHub-5180](https://github.com/magento/magento2/issues/5180)
+<!---58269  -->
+*  You can now save a billing address using the REST  ’useForShipping' parameter. Previously use of the parameter resulted in a Rest API V1 error. [GitHub-6557](https://github.com/magento/magento2/issues/6557), [GitHub-5180](https://github.com/magento/magento2/issues/5180)
 
-<!---58609 -->* We’ve resolved issues updating `default_frontend_label` using REST. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
+<!---58609  -->
+*  We’ve resolved issues updating `default_frontend_label` using REST. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
 
-<!---58652 -->* Magento now sends REST multiselect attribute values in compatible formats. Previously, putting an unchanged GET returned errors on the multiselect attribute, and the only way to clear a multi-select field of all selections was to delete the product and re-create it. [GitHub-6120](https://github.com/magento/magento2/issues/6120)
+<!---58652  -->
+*  Magento now sends REST multiselect attribute values in compatible formats. Previously, putting an unchanged GET returned errors on the multiselect attribute, and the only way to clear a multi-select field of all selections was to delete the product and re-create it. [GitHub-6120](https://github.com/magento/magento2/issues/6120)
 
-<!---58338 -->* The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
+<!---58338  -->
+*  The REST API now successfully handles attribute options that start with a number. [GitHub-5715](https://github.com/magento/magento2/issues/5715)
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.1CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.1CE.md
@@ -37,105 +37,146 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 
 ### Installation, upgrade, deployment
 
-<!--- 80225 -->* We’ve improved the message that Magento displays during upgrade if any schema or data version in the `setup_modules` database is higher than the current module version in the code. *Fix submitted by community member <a href="https://github.com/schmengler" target="_blank">Fabian Schmengler</a> in pull request <a href="https://github.com/magento/magento2/pull/11064" target="_blank">11064</a>.*
+<!--- 80225  -->
+*  We’ve improved the message that Magento displays during upgrade if any schema or data version in the `setup_modules` database is higher than the current module version in the code. *Fix submitted by community member <a href="https://github.com/schmengler" target="_blank">Fabian Schmengler</a> in pull request <a href="https://github.com/magento/magento2/pull/11064" target="_blank">11064</a>.*
 
-<!--- 75452 -->* When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
+<!--- 75452  -->
+*  When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
 
-<!--- 80201 -->*  We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
+<!--- 80201  -->
+*   We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
 
 ### Catalog
 
-<!--- 71520 -->* Magento now displays products that are filtered to a particular store view even when the corresponding store view has been deleted. Previously, Magento displayed a continuously spinning  spinner widget and this error message: **A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.**
+<!--- 71520  -->
+*  Magento now displays products that are filtered to a particular store view even when the corresponding store view has been deleted. Previously, Magento displayed a continuously spinning  spinner widget and this error message: **A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.**
 
-<!--- 75460 -->* `LowestPriceOptionsProvider` now returns products with the `tax_class_id` attribute, which is used for price calculation operations such as  tax adjustment. [GitHub-6729](https://github.com/magento/magento2/issues/6729), [GitHub-6457](https://github.com/magento/magento2/issues/6457), [GitHub-7362](https://github.com/magento/magento2/issues/7362)
+<!--- 75460  -->
+*  `LowestPriceOptionsProvider` now returns products with the `tax_class_id` attribute, which is used for price calculation operations such as  tax adjustment. [GitHub-6729](https://github.com/magento/magento2/issues/6729), [GitHub-6457](https://github.com/magento/magento2/issues/6457), [GitHub-7362](https://github.com/magento/magento2/issues/7362)
 
-<!--- 75453 -->* The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
+<!--- 75453  -->
+*  The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
 
-<!--- 75221 -->*  We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
+<!--- 75221  -->
+*   We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
 
 ### Configurable products
 
-<!--- 72582 -->* Magento no longer displays the inappropriate  product price when a configurable product has two price options. Previously, Magento displayed the  out-of-stock price of a configurable product when both an out-of-stock and in-stock price were configured.
+<!--- 72582  -->
+*  Magento no longer displays the inappropriate  product price when a configurable product has two price options. Previously, Magento displayed the  out-of-stock price of a configurable product when both an out-of-stock and in-stock price were configured.
 
-<!--- 72370 -->* Configurable products no longer show up on category page when all children are disabled by a mass action, and the **display out-of-stock products** setting is off.
+<!--- 72370  -->
+*  Configurable products no longer show up on category page when all children are disabled by a mass action, and the **display out-of-stock products** setting is off.
 
-<!--- 72747 -->* If a configurable product is part of a shipment that is being created by REST, only the parent's quantity will count towards the total quantity of shipped items. Previously, Magento counted both child and parent products when calculating quantity.
+<!--- 72747  -->
+*  If a configurable product is part of a shipment that is being created by REST, only the parent's quantity will count towards the total quantity of shipped items. Previously, Magento counted both child and parent products when calculating quantity.
 
 ### Frameworks
 
-<!--- 67097 -->* You can now run Magento in an environment where Redis cache is installed and the PHPRedis extension is enabled.
+<!--- 67097  -->
+*  You can now run Magento in an environment where Redis cache is installed and the PHPRedis extension is enabled.
 
-<!--- 72860 -->* Magento now properly loads default values for `ArraySerialized` fields.
+<!--- 72860  -->
+*  Magento now properly loads default values for `ArraySerialized` fields.
 
-<!--- 75458 -->* You can now set a default value to fields with config field type `image` or `file`. [GitHub-10253](https://github.com/magento/magento2/issues/10253)
+<!--- 75458  -->
+*  You can now set a default value to fields with config field type `image` or `file`. [GitHub-10253](https://github.com/magento/magento2/issues/10253)
 
-<!--- 80178, 80179, 80185  -->* We’ve removed `Zend_Json` from the data object, test suite, and package information. [GitHub-10306](https://github.com/magento/magento2/issues/10306), [GitHub-10320](https://github.com/magento/magento2/issues/10320), [GitHub-10340](https://github.com/magento/magento2/issues/10340)
+<!--- 80178, 80179, 80185   -->
+*  We’ve removed `Zend_Json` from the data object, test suite, and package information. [GitHub-10306](https://github.com/magento/magento2/issues/10306), [GitHub-10320](https://github.com/magento/magento2/issues/10320), [GitHub-10340](https://github.com/magento/magento2/issues/10340)
 
-<!--- 80180 -->* We’ve replaced the usage of `Zend_Json::encode`  in the setup marketplace tests. [GitHub-10329](https://github.com/magento/magento2/issues/10329)
+<!--- 80180  -->
+*  We’ve replaced the usage of `Zend_Json::encode`  in the setup marketplace tests. [GitHub-10329](https://github.com/magento/magento2/issues/10329)
 
-<!--- 80187 -->* We’ve removed the usage of `Zend_Json` from the JSON controller. [GitHub-10342](https://github.com/magento/magento2/issues/10342)
+<!--- 80187  -->
+*  We’ve removed the usage of `Zend_Json` from the JSON controller. [GitHub-10342](https://github.com/magento/magento2/issues/10342)
 
-<!--- 80186 -->* We’ve removed `Zend_Json` from `Setup/Migration.php`. [GitHub-10341](https://github.com/magento/magento2/issues/10341)
+<!--- 80186  -->
+*  We’ve removed `Zend_Json` from `Setup/Migration.php`. [GitHub-10341](https://github.com/magento/magento2/issues/10341)
 
-<!--- 80177 -->* We have replaced `Zend_Json`  with `\Magento\Framework\Serialize\JsonConverter::convert` in customer data.  [GitHub-10259](https://github.com/magento/magento2/issues/10259)
+<!--- 80177  -->
+*  We have replaced `Zend_Json`  with `\Magento\Framework\Serialize\JsonConverter::convert` in customer data.  [GitHub-10259](https://github.com/magento/magento2/issues/10259)
 
 ### General
 
-<!--- 80096 -->* We've fixed JavaScript date validation on the storefront. Previously, validation of the date of birth field during customer registration when changing the default locale did not work. *Fix submitted by community member <a href="https://github.com/joachimVT" target="_blank">Joachim Vanthuyne</a> in pull request <a href="https://github.com/magento/magento2/pull/11067" target="_blank">11067</a>.*
+<!--- 80096  -->
+*  We've fixed JavaScript date validation on the storefront. Previously, validation of the date of birth field during customer registration when changing the default locale did not work. *Fix submitted by community member <a href="https://github.com/joachimVT" target="_blank">Joachim Vanthuyne</a> in pull request <a href="https://github.com/magento/magento2/pull/11067" target="_blank">11067</a>.*
 
-<!--- 80112 -->* We’ve added a CSS selector to remove an additional top-margin that was rendered when you added  a link widget to the footer in the Luma theme. Previously, when you added new footer links, the block of footer links did not line up with the default footer links. *Fix submitted by community member <a href="https://github.com/fragdochkarl" target="_blank">Sandro Wagner</a> in pull request <a href="https://github.com/magento/magento2/pull/11063" target="_blank">11063</a>.*
+<!--- 80112  -->
+*  We’ve added a CSS selector to remove an additional top-margin that was rendered when you added  a link widget to the footer in the Luma theme. Previously, when you added new footer links, the block of footer links did not line up with the default footer links. *Fix submitted by community member <a href="https://github.com/fragdochkarl" target="_blank">Sandro Wagner</a> in pull request <a href="https://github.com/magento/magento2/pull/11063" target="_blank">11063</a>.*
 
-<!--- 67296 -->* String localizations now work as expected when phrases include text wrapped with single quotation marks.
+<!--- 67296  -->
+*  String localizations now work as expected when phrases include text wrapped with single quotation marks.
 
-<!--- 69964 -->* PHPCS can now correctly parse the syntax of PHP 7.x return types.
+<!--- 69964  -->
+*  PHPCS can now correctly parse the syntax of PHP 7.x return types.
 
-<!--- 75455 -->* You can now generate unsecured URLs even when the current URL is secure.
+<!--- 75455  -->
+*  You can now generate unsecured URLs even when the current URL is secure.
 
-<!--- 80204 -->* The Checkout authentication popup now contains the correct message. [GitHub-9533](https://github.com/magento/magento2/issues/9533), [GitHub-10627](https://github.com/magento/magento2/issues/10627)
+<!--- 80204  -->
+*  The Checkout authentication popup now contains the correct message. [GitHub-9533](https://github.com/magento/magento2/issues/9533), [GitHub-10627](https://github.com/magento/magento2/issues/10627)
 
-<!--- 80192 -->* The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
+<!--- 80192  -->
+*  The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
 
-<!--- 80195 -->* Websites that conduct transactions in multiple currencies can now send currency to Google Analytics. [GitHub-10508](https://github.com/magento/magento2/issues/10508)
+<!--- 80195  -->
+*  Websites that conduct transactions in multiple currencies can now send currency to Google Analytics. [GitHub-10508](https://github.com/magento/magento2/issues/10508)
 
-<!--- 75456 -->* The Products Ordered report now shows the simple (child) products of configurable products.
+<!--- 75456  -->
+*  The Products Ordered report now shows the simple (child) products of configurable products.
 
-<!--- 80198 -->* Creating a new product with a custom attribute set now works as expected. [GitHub-10565](https://github.com/magento/magento2/issues/10565), [GitHub-10575](https://github.com/magento/magento2/issues/10575)
+<!--- 80198  -->
+*  Creating a new product with a custom attribute set now works as expected. [GitHub-10565](https://github.com/magento/magento2/issues/10565), [GitHub-10575](https://github.com/magento/magento2/issues/10575)
 
-<!--- 80194 -->* Cookie lifetime works as expected when you set the form_key value  to zero (0). [GitHub-10528](https://github.com/magento/magento2/issues/10528)
+<!--- 80194  -->
+*  Cookie lifetime works as expected when you set the form_key value  to zero (0). [GitHub-10528](https://github.com/magento/magento2/issues/10528)
 
-<!--- 75457 -->* We’ve fixed an issue where Magento did not retrieve relevant data when displaying reviews if `$displayIfNoReviews` was set to false. [GitHub-4530](https://github.com/magento/magento2/issues/4530)
+<!--- 75457  -->
+*  We’ve fixed an issue where Magento did not retrieve relevant data when displaying reviews if `$displayIfNoReviews` was set to false. [GitHub-4530](https://github.com/magento/magento2/issues/4530)
 
-<!--- 71980 -->* You can now remove the system customer address and customer attributes from specific forms and prevent them from displaying on the frontend.
+<!--- 71980  -->
+*  You can now remove the system customer address and customer attributes from specific forms and prevent them from displaying on the frontend.
 
 ### Indexing
 
-<!--- 72866 -->* We’ve fixed multiple issues where indexes were invalidated as a result of typical import, scheduled import, and catalog permission tasks.
+<!--- 72866  -->
+*  We’ve fixed multiple issues where indexes were invalidated as a result of typical import, scheduled import, and catalog permission tasks.
 
 ### Orders
 
-<!--- 77966 -->* You can now use PayPal Express Checkout  to place an order in a split-database environment.
+<!--- 77966  -->
+*  You can now use PayPal Express Checkout  to place an order in a split-database environment.
 
-<!--- 72393 -->* If a credit card error occurs on an order, the user can now correct the error and successfully create a new order. Previously, Magento displayed the following error on any subsequent order, even when you entered accurate credit card information: "A customer with the same email already exists in an associated website”.
+<!--- 72393  -->
+*  If a credit card error occurs on an order, the user can now correct the error and successfully create a new order. Previously, Magento displayed the following error on any subsequent order, even when you entered accurate credit card information: "A customer with the same email already exists in an associated website”.
 
-<!--- 80102 -->* We’ve added a `name` attribute to the layout default renderer, and you can now add a new column to the Admin Sales > Order table . Previously,  the layout default renderer lacked a `name` attribute. *Fix submitted by community member <a href="https://github.com/gsomoza" target="_blank">Gabriel Somoza</a> in pull request <a href="https://github.com/magento/magento2/pull/11076" target="_blank">11076</a>.*
+<!--- 80102  -->
+*  We’ve added a `name` attribute to the layout default renderer, and you can now add a new column to the Admin Sales > Order table . Previously,  the layout default renderer lacked a `name` attribute. *Fix submitted by community member <a href="https://github.com/gsomoza" target="_blank">Gabriel Somoza</a> in pull request <a href="https://github.com/magento/magento2/pull/11076" target="_blank">11076</a>.*
 
 ### Payment methods
 
-<!--- 72351 -->* Double-clicking the **Place Order** button when using the  Braintree payment method to place an order no longer creates duplicate order requests. [GitHub-10767](https://github.com/magento/magento2/issues/10767)
+<!--- 72351  -->
+*  Double-clicking the **Place Order** button when using the  Braintree payment method to place an order no longer creates duplicate order requests. [GitHub-10767](https://github.com/magento/magento2/issues/10767)
 
-<!--- 71050 -->* Magento now completes processing an order if the customer needs to re-enter credit card information during the order process. Previously, Magento returned this error `No such entity with customerId = 0`.
+<!--- 71050  -->
+*  Magento now completes processing an order if the customer needs to re-enter credit card information during the order process. Previously, Magento returned this error `No such entity with customerId = 0`.
 
 ### Search
 
-<!--- 77777 -->* Search terms from the same synonym group now return the same results.
+<!--- 77777  -->
+*  Search terms from the same synonym group now return the same results.
 
-<!--- 75935 -->* A search query results are now more consistent. Previously, identical search terms entered in different browser tabs resulted in different search results.
+<!--- 75935  -->
+*  A search query results are now more consistent. Previously, identical search terms entered in different browser tabs resulted in different search results.
 
-<!--- 71552 -->* You can now search for attribute values on the store-view level.
+<!--- 71552  -->
+*  You can now search for attribute values on the store-view level.
 
 ### Sitemap
 
-<!--- 75459 -->* Sitemap no longer crashes if the scope of the name attribute is set to global. [GitHub-5941](https://github.com/magento/magento2/issues/5941), [GitHub-8999](https://github.com/magento/magento2/issues/8999)
+<!--- 75459  -->
+*  Sitemap no longer crashes if the scope of the name attribute is set to global. [GitHub-5941](https://github.com/magento/magento2/issues/5941), [GitHub-8999](https://github.com/magento/magento2/issues/8999)
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.md
@@ -37,137 +37,190 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 
 ### Installation, upgrade, deployment
 
-<!--- 80225 -->* We’ve improved the message that Magento displays during upgrade if any schema or data version in the `setup_modules` database is higher than the current module version in the code. *Fix submitted by community member <a href="https://github.com/schmengler" target="_blank">Fabian Schmengler</a> in pull request <a href="https://github.com/magento/magento2/pull/11064" target="_blank">11064</a>.*
+<!--- 80225  -->
+*  We’ve improved the message that Magento displays during upgrade if any schema or data version in the `setup_modules` database is higher than the current module version in the code. *Fix submitted by community member <a href="https://github.com/schmengler" target="_blank">Fabian Schmengler</a> in pull request <a href="https://github.com/magento/magento2/pull/11064" target="_blank">11064</a>.*
 
-<!--- 71893 -->* If you do not specify `—base_url` during installation, all URLs now use the host and port of the current request to create URLs.
+<!--- 71893  -->
+*  If you do not specify `—base_url` during installation, all URLs now use the host and port of the current request to create URLs.
 
-<!--- 75452 -->* When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
+<!--- 75452  -->
+*  When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
 
-<!--- 80201 -->*  We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
+<!--- 80201  -->
+*   We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
 
 ### AMQP
 
-<!--- 72288 -->* The `inventoryQtyCounter` consumer now works without having RabbitMQ installed.
+<!--- 72288  -->
+*  The `inventoryQtyCounter` consumer now works without having RabbitMQ installed.
 
 ### Catalog
 
-<!--- 71520 -->* Magento now displays products that are filtered to a particular store view even when the corresponding store view has been deleted. Previously, Magento displayed a continuously spinning  spinner widget and this error message: **A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.**
+<!--- 71520  -->
+*  Magento now displays products that are filtered to a particular store view even when the corresponding store view has been deleted. Previously, Magento displayed a continuously spinning  spinner widget and this error message: **A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.**
 
-<!--- 72382 -->*  You can now save custom shared catalogs.
+<!--- 72382  -->
+*   You can now save custom shared catalogs.
 
-<!--- 78522 -->*  Magento no longer displays a 404 error when you change category permissions from Product Detail pages when multistore view is enabled.
+<!--- 78522  -->
+*   Magento no longer displays a 404 error when you change category permissions from Product Detail pages when multistore view is enabled.
 
-<!--- 75460 -->* `LowestPriceOptionsProvider` now returns products with the `tax_class_id` attribute, which is used for price calculation operations such as  tax adjustment. [GitHub-6729](https://github.com/magento/magento2/issues/6729), [GitHub-6457](https://github.com/magento/magento2/issues/6457), [GitHub-7362](https://github.com/magento/magento2/issues/7362)
+<!--- 75460  -->
+*  `LowestPriceOptionsProvider` now returns products with the `tax_class_id` attribute, which is used for price calculation operations such as  tax adjustment. [GitHub-6729](https://github.com/magento/magento2/issues/6729), [GitHub-6457](https://github.com/magento/magento2/issues/6457), [GitHub-7362](https://github.com/magento/magento2/issues/7362)
 
-<!--- 75453 -->* The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
+<!--- 75453  -->
+*  The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
 
-<!--- 75221 -->*  We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
+<!--- 75221  -->
+*   We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
 
 ### Cart and checkout
 
-<!--- 71984 -->* Magento now provides a **Login** button so that you can resume your checkout process if you return to the check out page after leaving it mid-order.
+<!--- 71984  -->
+*  Magento now provides a **Login** button so that you can resume your checkout process if you return to the check out page after leaving it mid-order.
 
 ### Configurable products
 
-<!--- 72582 -->* Magento no longer displays the inappropriate  product price when a configurable product has two price options. Previously, Magento displayed the  out-of-stock price of a configurable product when both an out-of-stock and in-stock price were configured.
+<!--- 72582  -->
+*  Magento no longer displays the inappropriate  product price when a configurable product has two price options. Previously, Magento displayed the  out-of-stock price of a configurable product when both an out-of-stock and in-stock price were configured.
 
-<!--- 72370 -->* Configurable products no longer show up on category page when all children are disabled by a mass action, and the **display out-of-stock products** setting is off.
+<!--- 72370  -->
+*  Configurable products no longer show up on category page when all children are disabled by a mass action, and the **display out-of-stock products** setting is off.
 
-<!--- 72747 -->* If a configurable product is part of a shipment that is being created by REST, only the parent's quantity will count towards the total quantity of shipped items. Previously, Magento counted both child and parent products when calculating quantity.
+<!--- 72747  -->
+*  If a configurable product is part of a shipment that is being created by REST, only the parent's quantity will count towards the total quantity of shipped items. Previously, Magento counted both child and parent products when calculating quantity.
 
-<!--- 72582 -->* Configurable product pricing now reflects only in-stock configurations as expected.
+<!--- 72582  -->
+*  Configurable product pricing now reflects only in-stock configurations as expected.
 
 ### Frameworks
 
-<!--- 67097 -->* You can now run Magento in an environment where Redis cache is installed and the PHPRedis extension is enabled.
+<!--- 67097  -->
+*  You can now run Magento in an environment where Redis cache is installed and the PHPRedis extension is enabled.
 
-<!--- 72860 -->* Magento now properly loads default values for `ArraySerialized` fields.
+<!--- 72860  -->
+*  Magento now properly loads default values for `ArraySerialized` fields.
 
-<!--- 75458 -->* You can now set a default value to fields with config field type `image` or `file`. [GitHub-10253](https://github.com/magento/magento2/issues/10253)
+<!--- 75458  -->
+*  You can now set a default value to fields with config field type `image` or `file`. [GitHub-10253](https://github.com/magento/magento2/issues/10253)
 
-<!--- 80178, 80179, 80185  -->* We’ve removed `Zend_Json` from the data object, test suite, and package information. [GitHub-10306](https://github.com/magento/magento2/issues/10306), [GitHub-10320](https://github.com/magento/magento2/issues/10320), [GitHub-10340](https://github.com/magento/magento2/issues/10340)
+<!--- 80178, 80179, 80185   -->
+*  We’ve removed `Zend_Json` from the data object, test suite, and package information. [GitHub-10306](https://github.com/magento/magento2/issues/10306), [GitHub-10320](https://github.com/magento/magento2/issues/10320), [GitHub-10340](https://github.com/magento/magento2/issues/10340)
 
-<!--- 80180 -->* We’ve replaced the usage of `Zend_Json::encode`  in the setup marketplace tests. [GitHub-10329](https://github.com/magento/magento2/issues/10329)
+<!--- 80180  -->
+*  We’ve replaced the usage of `Zend_Json::encode`  in the setup marketplace tests. [GitHub-10329](https://github.com/magento/magento2/issues/10329)
 
-<!--- 80187 -->* We’ve removed the usage of `Zend_Json` from the JSON controller. [GitHub-10342](https://github.com/magento/magento2/issues/10342)
+<!--- 80187  -->
+*  We’ve removed the usage of `Zend_Json` from the JSON controller. [GitHub-10342](https://github.com/magento/magento2/issues/10342)
 
-<!--- 80186 -->* We’ve removed `Zend_Json` from `Setup/Migration.php`. [GitHub-10341](https://github.com/magento/magento2/issues/10341)
+<!--- 80186  -->
+*  We’ve removed `Zend_Json` from `Setup/Migration.php`. [GitHub-10341](https://github.com/magento/magento2/issues/10341)
 
-<!--- 80177 -->* We have replaced `Zend_Json`  with `\Magento\Framework\Serialize\JsonConverter::convert` in customer data.  [GitHub-10259](https://github.com/magento/magento2/issues/10259)
+<!--- 80177  -->
+*  We have replaced `Zend_Json`  with `\Magento\Framework\Serialize\JsonConverter::convert` in customer data.  [GitHub-10259](https://github.com/magento/magento2/issues/10259)
 
 ### General
 
-<!--- 80096 -->* We've fixed JavaScript date validation on the storefront. Previously, validation of the date of birth field during customer registration when changing the default locale did not work. *Fix submitted by community member <a href="https://github.com/joachimVT" target="_blank">Joachim Vanthuyne</a> in pull request <a href="https://github.com/magento/magento2/pull/11067" target="_blank">11067</a>.*
+<!--- 80096  -->
+*  We've fixed JavaScript date validation on the storefront. Previously, validation of the date of birth field during customer registration when changing the default locale did not work. *Fix submitted by community member <a href="https://github.com/joachimVT" target="_blank">Joachim Vanthuyne</a> in pull request <a href="https://github.com/magento/magento2/pull/11067" target="_blank">11067</a>.*
 
-<!--- 80112 -->* We’ve added a CSS selector to remove an additional top-margin that was rendered when you added  a link widget to the footer in the Luma theme. Previously, when you added new footer links, the block of footer links did not line up with the default footer links. *Fix submitted by community member <a href="https://github.com/fragdochkarl" target="_blank">Sandro Wagner</a> in pull request <a href="https://github.com/magento/magento2/pull/11063" target="_blank">11063</a>.*
+<!--- 80112  -->
+*  We’ve added a CSS selector to remove an additional top-margin that was rendered when you added  a link widget to the footer in the Luma theme. Previously, when you added new footer links, the block of footer links did not line up with the default footer links. *Fix submitted by community member <a href="https://github.com/fragdochkarl" target="_blank">Sandro Wagner</a> in pull request <a href="https://github.com/magento/magento2/pull/11063" target="_blank">11063</a>.*
 
-<!--- 71980 -->* You can now remove system customer address and customer attributes from specific forms to prevent them from displaying on the frontend.
+<!--- 71980  -->
+*  You can now remove system customer address and customer attributes from specific forms to prevent them from displaying on the frontend.
 
-<!--- 67296 -->* String localizations now work as expected when phrases include text wrapped with single quotation marks.
+<!--- 67296  -->
+*  String localizations now work as expected when phrases include text wrapped with single quotation marks.
 
-<!--- 69964 -->* PHPCS can now correctly parse the syntax of PHP 7.x return types.
+<!--- 69964  -->
+*  PHPCS can now correctly parse the syntax of PHP 7.x return types.
 
-<!--- 72353 -->* You can now remove custom attributes from the Use in Forms grid.
+<!--- 72353  -->
+*  You can now remove custom attributes from the Use in Forms grid.
 
-<!--- 75455 -->* You can now generate unsecured URLs even when the current URL is secure.
+<!--- 75455  -->
+*  You can now generate unsecured URLs even when the current URL is secure.
 
-<!--- 80204 -->* The Checkout authentication popup now contains the correct message. [GitHub-9533](https://github.com/magento/magento2/issues/9533), [GitHub-10627](https://github.com/magento/magento2/issues/10627)
+<!--- 80204  -->
+*  The Checkout authentication popup now contains the correct message. [GitHub-9533](https://github.com/magento/magento2/issues/9533), [GitHub-10627](https://github.com/magento/magento2/issues/10627)
 
-<!--- 80192 -->* The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
+<!--- 80192  -->
+*  The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
 
-<!--- 80195 -->* Websites that conduct transactions in multiple currencies can now send currency to Google Analytics. [GitHub-10508](https://github.com/magento/magento2/issues/10508)
+<!--- 80195  -->
+*  Websites that conduct transactions in multiple currencies can now send currency to Google Analytics. [GitHub-10508](https://github.com/magento/magento2/issues/10508)
 
-<!--- 75456 -->* The Products Ordered report now shows the simple (child) products of configurable products.
+<!--- 75456  -->
+*  The Products Ordered report now shows the simple (child) products of configurable products.
 
-<!--- 80198 -->* Creating a new product with a custom attribute set now works as expected. [GitHub-10565](https://github.com/magento/magento2/issues/10565), [GitHub-10575](https://github.com/magento/magento2/issues/10575)
+<!--- 80198  -->
+*  Creating a new product with a custom attribute set now works as expected. [GitHub-10565](https://github.com/magento/magento2/issues/10565), [GitHub-10575](https://github.com/magento/magento2/issues/10575)
 
-<!--- 80194 -->* Cookie lifetime works as expected when you set the form_key value  to zero (0). [GitHub-10528](https://github.com/magento/magento2/issues/10528)
+<!--- 80194  -->
+*  Cookie lifetime works as expected when you set the form_key value  to zero (0). [GitHub-10528](https://github.com/magento/magento2/issues/10528)
 
-<!--- 75457 -->* We’ve fixed an issue where Magento did not retrieve relevant data when displaying reviews if `$displayIfNoReviews` was set to false. [GitHub-4530](https://github.com/magento/magento2/issues/4530)
+<!--- 75457  -->
+*  We’ve fixed an issue where Magento did not retrieve relevant data when displaying reviews if `$displayIfNoReviews` was set to false. [GitHub-4530](https://github.com/magento/magento2/issues/4530)
 
-<!--- 71980 -->* You can now remove the system customer address and customer attributes from specific forms and prevent them from displaying on the frontend.
+<!--- 71980  -->
+*  You can now remove the system customer address and customer attributes from specific forms and prevent them from displaying on the frontend.
 
 ### Indexing
 
-<!--- 72866 -->* We’ve fixed multiple issues where indexes were invalidated as a result of typical import, scheduled import, and catalog permission tasks.
+<!--- 72866  -->
+*  We’ve fixed multiple issues where indexes were invalidated as a result of typical import, scheduled import, and catalog permission tasks.
 
 ### Orders
 
-<!--- 77966 -->* You can now use PayPal Express Checkout  to place an order in a split-database environment.
+<!--- 77966  -->
+*  You can now use PayPal Express Checkout  to place an order in a split-database environment.
 
-<!--- 72393 -->* If a credit card error occurs on an order, the user can now correct the error and successfully create a new order. Previously, Magento displayed the following error on any subsequent order, even when you entered accurate credit card information: "A customer with the same email already exists in an associated website”.
+<!--- 72393  -->
+*  If a credit card error occurs on an order, the user can now correct the error and successfully create a new order. Previously, Magento displayed the following error on any subsequent order, even when you entered accurate credit card information: "A customer with the same email already exists in an associated website”.
 
-<!--- 80102 -->* We’ve added a `name` attribute to the layout default renderer, and you can now add a new column to the **Admin Sales > Order table**. Previously,  the layout default renderer lacked a `name` attribute. *Fix submitted by community member <a href="https://github.com/gsomoza" target="_blank">Gabriel Somoza</a> in pull request <a href="https://github.com/magento/magento2/pull/11076" target="_blank">11076</a>.*
+<!--- 80102  -->
+*  We’ve added a `name` attribute to the layout default renderer, and you can now add a new column to the **Admin Sales > Order table**. Previously,  the layout default renderer lacked a `name` attribute. *Fix submitted by community member <a href="https://github.com/gsomoza" target="_blank">Gabriel Somoza</a> in pull request <a href="https://github.com/magento/magento2/pull/11076" target="_blank">11076</a>.*
 
 ### Payment methods
 
-<!--- 72351 -->* Double-clicking the **Place Order** button when using the  Braintree payment method to place an order no longer creates duplicate order requests. [GitHub-10767](https://github.com/magento/magento2/issues/10767)
+<!--- 72351  -->
+*  Double-clicking the **Place Order** button when using the  Braintree payment method to place an order no longer creates duplicate order requests. [GitHub-10767](https://github.com/magento/magento2/issues/10767)
 
-<!--- 71050 -->* Magento now completes processing an order if the customer needs to re-enter credit card information during the order process. Previously, Magento returned this error `No such entity with customerId = 0`.
+<!--- 71050  -->
+*  Magento now completes processing an order if the customer needs to re-enter credit card information during the order process. Previously, Magento returned this error `No such entity with customerId = 0`.
 
 ### Search
 
-<!--- 77777 -->* Search terms from the same synonym group now return the same results.
+<!--- 77777  -->
+*  Search terms from the same synonym group now return the same results.
 
-<!--- 75935 -->* A search query results are now more consistent. Previously, identical search terms entered in different browser tabs resulted in different search results.
+<!--- 75935  -->
+*  A search query results are now more consistent. Previously, identical search terms entered in different browser tabs resulted in different search results.
 
-<!--- 71552 -->* You can now search for attribute values on the store-view level.
+<!--- 71552  -->
+*  You can now search for attribute values on the store-view level.
 
-<!--- 72267 -->* Magento now displays grouped products in the Shared Catalog page when Elasticsearch is enabled.
+<!--- 72267  -->
+*  Magento now displays grouped products in the Shared Catalog page when Elasticsearch is enabled.
 
 ### Sitemap
 
-<!--- 75459 -->* Sitemap no longer crashes if the scope of the name attribute is set to global. [GitHub-5941](https://github.com/magento/magento2/issues/5941), [GitHub-8999](https://github.com/magento/magento2/issues/8999)
+<!--- 75459  -->
+*  Sitemap no longer crashes if the scope of the name attribute is set to global. [GitHub-5941](https://github.com/magento/magento2/issues/5941), [GitHub-8999](https://github.com/magento/magento2/issues/8999)
 
 ### Staging
 
-<!--- 60953 -->* Bundle simple products now reflect expected changes after a scheduled update.
+<!--- 60953  -->
+*  Bundle simple products now reflect expected changes after a scheduled update.
 
 ### Visual Merchandiser
 
-<!--- 71554 -->*  We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
+<!--- 71554  -->
+*   We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
 
-<!--- 71986 -->*  Visual Merchandiser now retains page view options and position after you remove a product. Previously, when you removed a product from a category, and you weren't on the first page, Magento returned you to the first page.
+<!--- 71986  -->
+*   Visual Merchandiser now retains page view options and position after you remove a product. Previously, when you removed a product from a category, and you weren't on the first page, Magento returned you to the first page.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.md
@@ -52,348 +52,495 @@ Looking for more information on these new features as well as many others? Check
 ## Fixed issues
 ### Installation, setup, and deployment
 
-<!--- MAGETWO-82747 -->* We've increased the `memory_limit` of the `.user.ini` files to 2GB. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
+<!--- MAGETWO-82747  -->
+*  We've increased the `memory_limit` of the `.user.ini` files to 2GB. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
 
-<!--- MAGETWO-72301 -->* The contents of the `js-translation.json` files are now correct when you deploy static content with multiple locales.
+<!--- MAGETWO-72301  -->
+*  The contents of the `js-translation.json` files are now correct when you deploy static content with multiple locales.
 
-<!--- MAGETWO-80205 -->* All cron dates are now  saved in a single format and displayed according to user preference or needs. [GitHub-4237](https://github.com/magento/magento2/issues/4237)
+<!--- MAGETWO-80205  -->
+*  All cron dates are now  saved in a single format and displayed according to user preference or needs. [GitHub-4237](https://github.com/magento/magento2/issues/4237)
 
-<!--- MAGETWO-80209 -->* Static versioning and minification no longer  break email font styles. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
+<!--- MAGETWO-80209  -->
+*  Static versioning and minification no longer  break email font styles. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
 
-<!--- MAGETWO-82595 -->* You can now successfully upgrade from 2.1.x to 2.2.0. Previously, when you tried to upgrade from 2.1.9 to 2.2.0, Magento displayed the  **postcode is a required field** error message, and `setup:upgrade` failed. *Fix submitted by Mr. Lewis in pull request 11651*. [GitHub-11095](https://github.com/magento/magento2/issues/11095)
+<!--- MAGETWO-82595  -->
+*  You can now successfully upgrade from 2.1.x to 2.2.0. Previously, when you tried to upgrade from 2.1.9 to 2.2.0, Magento displayed the  **postcode is a required field** error message, and `setup:upgrade` failed. *Fix submitted by Mr. Lewis in pull request 11651*. [GitHub-11095](https://github.com/magento/magento2/issues/11095)
 
-<!--- MAGETWO-82634 -->* We've replaced `FollowSymLinks` with `SymLinksIfOwnerMatch` in the `htaccess` templates. [GitHub-10811](https://github.com/magento/magento2/issues/10811)
+<!--- MAGETWO-82634  -->
+*  We've replaced `FollowSymLinks` with `SymLinksIfOwnerMatch` in the `htaccess` templates. [GitHub-10811](https://github.com/magento/magento2/issues/10811)
 
-<!--- MAGETWO-82292 -->* The `htaccess` template now supports  `apache2.4` commands. *Fix submitted by Jonas Hünig in pull request 11459*. [GitHub-10810](https://github.com/magento/magento2/issues/10810) [GitHub-10810](https://github.com/magento/magento2/issues/10810)
+<!--- MAGETWO-82292  -->
+*  The `htaccess` template now supports  `apache2.4` commands. *Fix submitted by Jonas Hünig in pull request 11459*. [GitHub-10810](https://github.com/magento/magento2/issues/10810) [GitHub-10810](https://github.com/magento/magento2/issues/10810)
 
-<!--- MAGETWO-82001 -->* `configVariables` now contains a variable for VAT numbers. *Fix submitted by JeroenVanLeusden in pull request 11486*.  [GitHub-10996](https://github.com/magento/magento2/issues/10996)
+<!--- MAGETWO-82001  -->
+*  `configVariables` now contains a variable for VAT numbers. *Fix submitted by JeroenVanLeusden in pull request 11486*.  [GitHub-10996](https://github.com/magento/magento2/issues/10996)
 
-<!--- MAGETWO-82463 -->* We've fixed an issue with using the command line to install or remove `crontab`. Previously, installing or removing `crontab` via the command line appended `2>&1` to entries, even those not related to Magento. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11591*. [GitHub-11586](https://github.com/magento/magento2/issues/11586)
+<!--- MAGETWO-82463  -->
+*  We've fixed an issue with using the command line to install or remove `crontab`. Previously, installing or removing `crontab` via the command line appended `2>&1` to entries, even those not related to Magento. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11591*. [GitHub-11586](https://github.com/magento/magento2/issues/11586)
 
-<!--- MAGETWO-81577 -->* You can now install and uninstall `cron` via the `bin/magento cron:install` command. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11359*.
+<!--- MAGETWO-81577  -->
+*  You can now install and uninstall `cron` via the `bin/magento cron:install` command. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11359*.
 
-<!--- MAGETWO-81645 -->* The `admin:user:create` command now recognizes the configured table prefix. *Fix submitted by Oscar Recio in pull request 11199*. [GitHub-11176](https://github.com/magento/magento2/issues/11176)
+<!--- MAGETWO-81645  -->
+*  The `admin:user:create` command now recognizes the configured table prefix. *Fix submitted by Oscar Recio in pull request 11199*. [GitHub-11176](https://github.com/magento/magento2/issues/11176)
 
-<!--- MAGETWO-82102 -->* The default cron success or failure history is now seven days. *Fix submitted by Max Chadwick in pull request 11505*.
+<!--- MAGETWO-82102  -->
+*  The default cron success or failure history is now seven days. *Fix submitted by Max Chadwick in pull request 11505*.
 
-<!--- MAGETWO-82234 -->* The `admin:user:create` command now asks for the input value if a required option is not passed. *Fix submitted by Christian Münch in pull request 11510*.
+<!--- MAGETWO-82234  -->
+*  The `admin:user:create` command now asks for the input value if a required option is not passed. *Fix submitted by Christian Münch in pull request 11510*.
 
-<!--- MAGETWO-82747 -->* The `.user.ini` files at `/.user.ini` and `/pub/.user.ini` now specify a `memory_limit` value of at least 1G to 2G for debugging purposes. *Fix submitted by Mr. Lewis in pull request 11734*. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
+<!--- MAGETWO-82747  -->
+*  The `.user.ini` files at `/.user.ini` and `/pub/.user.ini` now specify a `memory_limit` value of at least 1G to 2G for debugging purposes. *Fix submitted by Mr. Lewis in pull request 11734*. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
 
-<!--- MAGETWO-82754 -->* The `setup:install` command now has an `-i` flag. It validates parameters interactively. *Fix submitted by Denis Ristic in pull request 11425*.
+<!--- MAGETWO-82754  -->
+*  The `setup:install` command now has an `-i` flag. It validates parameters interactively. *Fix submitted by Denis Ristic in pull request 11425*.
 
-<!--- MAGETWO-84646 -->* Magento now restarts cron jobs as needed after a cron job was terminated during execution.
+<!--- MAGETWO-84646  -->
+*  Magento now restarts cron jobs as needed after a cron job was terminated during execution.
 
 ### Catalog
 
-<!--- MAGETWO-83498 -->* You can now enter strings that exceed 255 characters in Admin or frontend input fields. Previously, Magento  saved only the first 255 characters of a long input string. [GitHub-6238](https://github.com/magento/magento2/issues/6238)
+<!--- MAGETWO-83498  -->
+*  You can now enter strings that exceed 255 characters in Admin or frontend input fields. Previously, Magento  saved only the first 255 characters of a long input string. [GitHub-6238](https://github.com/magento/magento2/issues/6238)
 
-<!--- MAGETWO-83477 -->* Magento now renders color attribute swatches correctly for the search result page if sorting for color attribute is enabled.  *Fix submitted by Roman K. in pull request 12077*. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
+<!--- MAGETWO-83477  -->
+*  Magento now renders color attribute swatches correctly for the search result page if sorting for color attribute is enabled.  *Fix submitted by Roman K. in pull request 12077*. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
 
-<!--- MAGETWO-83174, 83169 -->* The `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection` now returns items that have only existing relations in the `catalog_product_entity` table. Previously, Magento loaded quote items with non-existing products.
+<!--- MAGETWO-83174, 83169  -->
+*  The `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection` now returns items that have only existing relations in the `catalog_product_entity` table. Previously, Magento loaded quote items with non-existing products.
 
-<!--- MAGETWO-83085 -->* Magento no longer duplicates attribute option values. Previously, Magento did not confirm the uniqueness of an attribute option value if you created it using REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
+<!--- MAGETWO-83085  -->
+*  Magento no longer duplicates attribute option values. Previously, Magento did not confirm the uniqueness of an attribute option value if you created it using REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
 
-<!--- MAGETWO-83066 -->* Magento now saves the correct background color for images. Previously, product images always had a black background when using the Luma theme. [GitHub-8799](https://github.com/magento/magento2/issues/8799)
+<!--- MAGETWO-83066  -->
+*  Magento now saves the correct background color for images. Previously, product images always had a black background when using the Luma theme. [GitHub-8799](https://github.com/magento/magento2/issues/8799)
 
-<!--- MAGETWO-83036 -->* You can now save a product custom option price with a value of 0 (zero) by simply not entering a price. *Fix submitted by Raul Mateos in pull request 11843*. [GitHub-4808](https://github.com/magento/magento2/issues/4808)
+<!--- MAGETWO-83036  -->
+*  You can now save a product custom option price with a value of 0 (zero) by simply not entering a price. *Fix submitted by Raul Mateos in pull request 11843*. [GitHub-4808](https://github.com/magento/magento2/issues/4808)
 
-<!--- MAGETWO-82972 -->* You can now assign products to categories if those products are already assigned to the category tree. [GitHub-8970](https://github.com/magento/magento2/issues/8970)
+<!--- MAGETWO-82972  -->
+*  You can now assign products to categories if those products are already assigned to the category tree. [GitHub-8970](https://github.com/magento/magento2/issues/8970)
 
-<!--- MAGETWO-82946 -->* The `apply_to` setting for attributes is no longer hard-coded. [GitHub-7225](https://github.com/magento/magento2/issues/7225)
+<!--- MAGETWO-82946  -->
+*  The `apply_to` setting for attributes is no longer hard-coded. [GitHub-7225](https://github.com/magento/magento2/issues/7225)
 
-<!--- MAGETWO-82755 -->* The **Add-to-cart** checkboxes in Related Products are no longer visible on the storefront when **$canItemsAddToCart** is set to **false**.  *Fix submitted by Marc Rodriguez in pull request 11610*. [GitHub-6891](https://github.com/magento/magento2/issues/6891)
+<!--- MAGETWO-82755  -->
+*  The **Add-to-cart** checkboxes in Related Products are no longer visible on the storefront when **$canItemsAddToCart** is set to **false**.  *Fix submitted by Marc Rodriguez in pull request 11610*. [GitHub-6891](https://github.com/magento/magento2/issues/6891)
 
-<!--- MAGETWO-83627 -->* You can now successfully save and duplicate a simple product. Previously, when you clicked the **Save and Duplicate** option for an existing simple product in the Catalog Manager, Magento did not duplicate the product, but threw an error. *Fix submitted by Roman K. in pull request 12001*. [GitHub-11532](https://github.com/magento/magento2/issues/11532)
+<!--- MAGETWO-83627  -->
+*  You can now successfully save and duplicate a simple product. Previously, when you clicked the **Save and Duplicate** option for an existing simple product in the Catalog Manager, Magento did not duplicate the product, but threw an error. *Fix submitted by Roman K. in pull request 12001*. [GitHub-11532](https://github.com/magento/magento2/issues/11532)
 
-<!--- MAGETWO-81967 -->* The Magento Admin Product Edit page now displays product alerts as expected.  *Fix submitted by Raul Mateos in pull request 11445*. [GitHub-10007](https://github.com/magento/magento2/issues/10007)
+<!--- MAGETWO-81967  -->
+*  The Magento Admin Product Edit page now displays product alerts as expected.  *Fix submitted by Raul Mateos in pull request 11445*. [GitHub-10007](https://github.com/magento/magento2/issues/10007)
 
-<!--- MAGETWO-82004 -->* The `StockItemCriteriaInterface` method `setProductsFilter` now accepts an array of IDs. Previously, this method accepted either a single integer or an array, but returned only one item. *Fix submitted by Kirill Morozov in pull request 11500*. [GitHub-7678](https://github.com/magento/magento2/issues/7678)
+<!--- MAGETWO-82004  -->
+*  The `StockItemCriteriaInterface` method `setProductsFilter` now accepts an array of IDs. Previously, this method accepted either a single integer or an array, but returned only one item. *Fix submitted by Kirill Morozov in pull request 11500*. [GitHub-7678](https://github.com/magento/magento2/issues/7678)
 
-<!--- MAGETWO-81456 -->* The `$sortByPostion` flag has been added to the `getChildren()` method. *Fix submitted by Denis Ristic in pull request 11342*. [GitHub-11310](https://github.com/magento/magento2/issues/11310)
+<!--- MAGETWO-81456  -->
+*  The `$sortByPostion` flag has been added to the `getChildren()` method. *Fix submitted by Denis Ristic in pull request 11342*. [GitHub-11310](https://github.com/magento/magento2/issues/11310)
 
-<!--- MAGETWO-82283 -->* `ProductRepository` SKU cache is no longer corrupted when `cacheLimit` is reached . *Fix submitted by Thomas in pull request 11553*.
+<!--- MAGETWO-82283  -->
+*  `ProductRepository` SKU cache is no longer corrupted when `cacheLimit` is reached . *Fix submitted by Thomas in pull request 11553*.
 
-<!--- MAGETWO-82943 -->* Magento no longer displays the perpetual spinner when you  switch custom options types in the Product Edit page. *Fix submitted by Paul Briscoe in pull request 11824*. [GitHub-10291](https://github.com/magento/magento2/issues/10291)
+<!--- MAGETWO-82943  -->
+*  Magento no longer displays the perpetual spinner when you  switch custom options types in the Product Edit page. *Fix submitted by Paul Briscoe in pull request 11824*. [GitHub-10291](https://github.com/magento/magento2/issues/10291)
 
 ### Cart and checkout
 
-<!--- MAGETWO-81665 -->* The default shipping-save-processor now has a payload extender. This feature allows third party extensions to modify the payload for the shipping address selection process. As a result, developers can now add `extension_attributes` while minimizing potential extension conflicts. *Fix submitted by Navarr Barnier in pull request 11249*.
+<!--- MAGETWO-81665  -->
+*  The default shipping-save-processor now has a payload extender. This feature allows third party extensions to modify the payload for the shipping address selection process. As a result, developers can now add `extension_attributes` while minimizing potential extension conflicts. *Fix submitted by Navarr Barnier in pull request 11249*.
 
-<!--- MAGETWO-83476 -->* You can now view the **Products in cart** report if the cart contains a bundle or a grouped product. Previously, when you viewed the Products in Cart report, Magento threw an exception under these conditions. [GitHub-12079](https://github.com/magento/magento2/issues/12079)
+<!--- MAGETWO-83476  -->
+*  You can now view the **Products in cart** report if the cart contains a bundle or a grouped product. Previously, when you viewed the Products in Cart report, Magento threw an exception under these conditions. [GitHub-12079](https://github.com/magento/magento2/issues/12079)
 
-<!--- MAGETWO-83194 -->* Magento now recognizes zip codes without spaces for addresses located in the Netherlands. [GitHub-11898](https://github.com/magento/magento2/issues/11898)
+<!--- MAGETWO-83194  -->
+*  Magento now recognizes zip codes without spaces for addresses located in the Netherlands. [GitHub-11898](https://github.com/magento/magento2/issues/11898)
 
-<!--- MAGETWO-82724 -->* Magento now accepts coupon codes with special characters during checkout. *Fix submitted by Gabriel Queiroz Silva in pull request 11710*. [GitHub-9763](https://github.com/magento/magento2/issues/9763)
+<!--- MAGETWO-82724  -->
+*  Magento now accepts coupon codes with special characters during checkout. *Fix submitted by Gabriel Queiroz Silva in pull request 11710*. [GitHub-9763](https://github.com/magento/magento2/issues/9763)
 
-<!--- MAGETWO-82057 -->* We've improved cache control headers.
+<!--- MAGETWO-82057  -->
+*  We've improved cache control headers.
 
-<!--- MAGETWO-82314 -->* Magento no longer throws an exception when you place an order using a new address. Previously, Magento displayed this error, **An error occurred on the server. Please try to place the order again.**. [GitHub-10583](https://github.com/magento/magento2/issues/10583)
+<!--- MAGETWO-82314  -->
+*  Magento no longer throws an exception when you place an order using a new address. Previously, Magento displayed this error, **An error occurred on the server. Please try to place the order again.**. [GitHub-10583](https://github.com/magento/magento2/issues/10583)
 
-<!--- MAGETWO-81904 -->* Magento now includes the Filter Groups and the Sort Order of the `$searchCriteria` parameter in the `searchCriteria` Object that is provided for the EAV set repository.  *Fix submitted by David Verholen in pull request 11421*. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
+<!--- MAGETWO-81904  -->
+*  Magento now includes the Filter Groups and the Sort Order of the `$searchCriteria` parameter in the `searchCriteria` Object that is provided for the EAV set repository.  *Fix submitted by David Verholen in pull request 11421*. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
 
-<!--- MAGETWO-81994 -->* Magento no longer sets the product price to zero when you use REST to add a product to an empty cart. Previously, Magento displayed an error when you used REST to populate an empty cart. *Fix submitted by Peter Jaap Blaakmeer in pull request 11458*. [GitHub-2991](https://github.com/magento/magento2/issues/2991), [GitHub-2991](https://github.com/magento/magento2/issues/2991)
+<!--- MAGETWO-81994  -->
+*  Magento no longer sets the product price to zero when you use REST to add a product to an empty cart. Previously, Magento displayed an error when you used REST to populate an empty cart. *Fix submitted by Peter Jaap Blaakmeer in pull request 11458*. [GitHub-2991](https://github.com/magento/magento2/issues/2991), [GitHub-2991](https://github.com/magento/magento2/issues/2991)
 
-<!--- MAGETWO-81987 -->* You can now translate the placeholder text for the checkout password field.  *Fix submitted by JeroenVanLeusden in pull request 11493*.
+<!--- MAGETWO-81987  -->
+*  You can now translate the placeholder text for the checkout password field.  *Fix submitted by JeroenVanLeusden in pull request 11493*.
 
-<!--- MAGETWO-83495 -->* Magento now redirects a user to the checkout page if he logs in after selecting the **Checkout** button. Previously,  a user was redirected to the store home page. *Fix submitted by [@p-bystritsky](https://github.com/p-bystritsky) in pull request 11876*. [GitHub-10834](https://github.com/magento/magento2/issues/10834)
+<!--- MAGETWO-83495  -->
+*  Magento now redirects a user to the checkout page if he logs in after selecting the **Checkout** button. Previously,  a user was redirected to the store home page. *Fix submitted by [@p-bystritsky](https://github.com/p-bystritsky) in pull request 11876*. [GitHub-10834](https://github.com/magento/magento2/issues/10834)
 
 ### Configurable products
 
-<!--- MAGETWO-83489 -->* `Magento\ConfigurableProduct\Model\Product\Type\Configurable:::loadUsedProducts` no longer ignores array keys that are returned by product collections. [GitHub-11880](https://github.com/magento/magento2/issues/11880)
+<!--- MAGETWO-83489  -->
+*  `Magento\ConfigurableProduct\Model\Product\Type\Configurable:::loadUsedProducts` no longer ignores array keys that are returned by product collections. [GitHub-11880](https://github.com/magento/magento2/issues/11880)
 
 ### Frameworks
 
-<!--- MAGETWO-82675 -->* The NGINX configuration sample now contains a health check. *Fix submitted by Andrew Howden in pull request 11690*. [GitHub-11157](https://github.com/magento/magento2/issues/11157)
+<!--- MAGETWO-82675  -->
+*  The NGINX configuration sample now contains a health check. *Fix submitted by Andrew Howden in pull request 11690*. [GitHub-11157](https://github.com/magento/magento2/issues/11157)
 
-<!--- MAGETWO-82814 -->* Magento now allows underscore characters in module names and also permits their use when modules add a block to the layout via XML. Previously,  Magento did not support underscore characters in module names to be added to the layout via XML. *Fix submitted by Ben Tideswell in pull request 11765*.
+<!--- MAGETWO-82814  -->
+*  Magento now allows underscore characters in module names and also permits their use when modules add a block to the layout via XML. Previously,  Magento did not support underscore characters in module names to be added to the layout via XML. *Fix submitted by Ben Tideswell in pull request 11765*.
 
-<!--- MAGETWO-81467 -->* You can now save using the mass action **Update attributes** option when multiselect attributes are set. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11349*. [GitHub-11329](https://github.com/magento/magento2/issues/11329)
+<!--- MAGETWO-81467  -->
+*  You can now save using the mass action **Update attributes** option when multiselect attributes are set. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11349*. [GitHub-11329](https://github.com/magento/magento2/issues/11329)
 
 #### App framework
 
-<!--- MAGETWO-83024 -->* Magento now correctly handles all meta keywords and description in categories and in every product in locales that use non-Latin characters. [GitHub-10682](https://github.com/magento/magento2/issues/10682)
+<!--- MAGETWO-83024  -->
+*  Magento now correctly handles all meta keywords and description in categories and in every product in locales that use non-Latin characters. [GitHub-10682](https://github.com/magento/magento2/issues/10682)
 
-<!--- MAGETWO-82851 -->* You can now include negative values in an XML export file and open the file with Office XML handler. Previously, the export files did not open correctly, and an Office XML handler error log was created.  *Fix submitted by hauso in pull request 11757*. [GitHub-11729](https://github.com/magento/magento2/issues/11729), [GitHub-11729](https://github.com/magento/magento2/issues/11729)
+<!--- MAGETWO-82851  -->
+*  You can now include negative values in an XML export file and open the file with Office XML handler. Previously, the export files did not open correctly, and an Office XML handler error log was created.  *Fix submitted by hauso in pull request 11757*. [GitHub-11729](https://github.com/magento/magento2/issues/11729), [GitHub-11729](https://github.com/magento/magento2/issues/11729)
 
-<!--- MAGETWO-81977 -->* The Magento custom URL rewrite functionality now works as expected when you include redirection of Magento controllers. *Fix submitted by Marc Rodriguez in pull request 11470*. [GitHub-10231](https://github.com/magento/magento2/issues/10231), [GitHub-11469](https://github.com/magento/magento2/issues/11469), [GitHub-11471](https://github.com/magento/magento2/issues/11471)
+<!--- MAGETWO-81977  -->
+*  The Magento custom URL rewrite functionality now works as expected when you include redirection of Magento controllers. *Fix submitted by Marc Rodriguez in pull request 11470*. [GitHub-10231](https://github.com/magento/magento2/issues/10231), [GitHub-11469](https://github.com/magento/magento2/issues/11469), [GitHub-11471](https://github.com/magento/magento2/issues/11471)
 
-<!--- MAGETWO-81973 -->* Magento now supports the setting of HTTP response status code in redirected responses. [GitHub-9028](https://github.com/magento/magento2/issues/9028)
+<!--- MAGETWO-81973  -->
+*  Magento now supports the setting of HTTP response status code in redirected responses. [GitHub-9028](https://github.com/magento/magento2/issues/9028)
 
-<!--- MAGETWO-81990 -->* Magento now throws a meaningful exception when a virtual theme does not have a physical parent theme. *Fix submitted by David Fecke in pull request 11240*.
+<!--- MAGETWO-81990  -->
+*  Magento now throws a meaningful exception when a virtual theme does not have a physical parent theme. *Fix submitted by David Fecke in pull request 11240*.
 
-<!--- MAGETWO-82236 -->* `app:config:dump` no longer adds an extra space to multiline array values. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11439*. [GitHub-11328](https://github.com/magento/magento2/issues/11328)
+<!--- MAGETWO-82236  -->
+*  `app:config:dump` no longer adds an extra space to multiline array values. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11439*. [GitHub-11328](https://github.com/magento/magento2/issues/11328)
 
-<!--- MAGETWO-82665 -->* The TRAVIS_BRANCH variable is now surrounded by double-quotes instead of single-quotes . *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11704*.
+<!--- MAGETWO-82665  -->
+*  The TRAVIS_BRANCH variable is now surrounded by double-quotes instead of single-quotes . *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11704*.
 
-<!--- MAGETWO-83035 -->* The doc block of `setValue` in FilterBuilder now reflects that the `setValue` method will accept an array. *Fix submitted by ByteCreation in pull request 11854*.
+<!--- MAGETWO-83035  -->
+*  The doc block of `setValue` in FilterBuilder now reflects that the `setValue` method will accept an array. *Fix submitted by ByteCreation in pull request 11854*.
 
-<!--- MAGETWO-81515 -->* `htaccess` syntax now uses `Options -Indexes`  instead of `Options All -Indexes`. Previously, Magento used  `Options All -Indexes`, which resulted in Magento rendering a 500 error page because of high restrictions for Options overrides in shared hosting environments. *Fix submitted by [@Danny Verkade - Cream](https://github.com/dverkade) in pull request 11327*. [GitHub-10812](https://github.com/magento/magento2/issues/10812)
+<!--- MAGETWO-81515  -->
+*  `htaccess` syntax now uses `Options -Indexes`  instead of `Options All -Indexes`. Previously, Magento used  `Options All -Indexes`, which resulted in Magento rendering a 500 error page because of high restrictions for Options overrides in shared hosting environments. *Fix submitted by [@Danny Verkade - Cream](https://github.com/dverkade) in pull request 11327*. [GitHub-10812](https://github.com/magento/magento2/issues/10812)
 
 #### Configuration framework
 
-<!--- MAGETWO-82887 -->* The X-Magento-Tags header can now contain  white space. *Fix submitted by Malyovanets Nickolas in pull request 11767*. [GitHub-7640](https://github.com/magento/magento2/issues/7640), [GitHub-7640](https://github.com/magento/magento2/issues/7640)
+<!--- MAGETWO-82887  -->
+*  The X-Magento-Tags header can now contain  white space. *Fix submitted by Malyovanets Nickolas in pull request 11767*. [GitHub-7640](https://github.com/magento/magento2/issues/7640), [GitHub-7640](https://github.com/magento/magento2/issues/7640)
 
-<!--- MAGETWO-82535 -->* The config array can now read  all settings from `config`. Previously, the config array was hardcoded to read three settings only. *Fix submitted by Vova Yatsyuk in pull request 11643*.
+<!--- MAGETWO-82535  -->
+*  The config array can now read  all settings from `config`. Previously, the config array was hardcoded to read three settings only. *Fix submitted by Vova Yatsyuk in pull request 11643*.
 
 #### JavaScript framework
 
-<!--- MAGETWO-80207 -->* Magento no longer incorrectly overly encodes UTF-8 files when JavaScript Bundling is enabled. Previously, this issue resulted in poor character encoding on the storefront. [GitHub-10562](https://github.com/magento/magento2/issues/10562), [GitHub-6733](https://github.com/magento/magento2/issues/6733)
+<!--- MAGETWO-80207  -->
+*  Magento no longer incorrectly overly encodes UTF-8 files when JavaScript Bundling is enabled. Previously, this issue resulted in poor character encoding on the storefront. [GitHub-10562](https://github.com/magento/magento2/issues/10562), [GitHub-6733](https://github.com/magento/magento2/issues/6733)
 
-<!--- MAGETWO-81959 -->* Magento now exports the Confirmed email and Account Lock values when you export customer data. Previously, this information was missing from the exported CSV. *Fix submitted by Luke Rodgers in pull request 11437*. [GitHub-10765](https://github.com/magento/magento2/issues/10765), [GitHub-10765](https://github.com/magento/magento2/issues/10765)
+<!--- MAGETWO-81959  -->
+*  Magento now exports the Confirmed email and Account Lock values when you export customer data. Previously, this information was missing from the exported CSV. *Fix submitted by Luke Rodgers in pull request 11437*. [GitHub-10765](https://github.com/magento/magento2/issues/10765), [GitHub-10765](https://github.com/magento/magento2/issues/10765)
 
-<!--- MAGETWO-81146 -->* You can now submit the search form from the keyboard. *Fix submitted by Romain Ruaud in pull request 11250*. [GitHub-10275](https://github.com/magento/magento2/issues/10275)
+<!--- MAGETWO-81146  -->
+*  You can now submit the search form from the keyboard. *Fix submitted by Romain Ruaud in pull request 11250*. [GitHub-10275](https://github.com/magento/magento2/issues/10275)
 
 #### Session framework
 
-<!--- MAGETWO-84106 -->* We've removed the 30-second timeout limit for the session locking mechanism when Redis is used for session storage.
+<!--- MAGETWO-84106  -->
+*  We've removed the 30-second timeout limit for the session locking mechanism when Redis is used for session storage.
 
-<!--- MAGETWO-80912 -->* A typo in `sessionStorage` polyfill has been corrected.  *Fix submitted by mszydlo in pull request 11219*.
+<!--- MAGETWO-80912  -->
+*  A typo in `sessionStorage` polyfill has been corrected.  *Fix submitted by mszydlo in pull request 11219*.
 
 #### Web API framework
 
-<!--- MAGETWO-83095 -->* The `customerAccountManagementV1` interface now provides the `POST /V1/customers/resetPassword` endpoint.
+<!--- MAGETWO-83095  -->
+*  The `customerAccountManagementV1` interface now provides the `POST /V1/customers/resetPassword` endpoint.
 
 ### General
 
-<!--- MAGETWO-83281 -->* XHTML templates now use schema URNs. [GitHub-6661](https://github.com/magento/magento2/issues/6661)
+<!--- MAGETWO-83281  -->
+*  XHTML templates now use schema URNs. [GitHub-6661](https://github.com/magento/magento2/issues/6661)
 
-<!--- MAGETWO-83279 -->* The image size used as a cross-sell product placeholder now equals the size of the image used in product listing placeholder images. Previously, the cross-sell product placeholder image was too small. [GitHub-12017](https://github.com/magento/magento2/issues/12017)
+<!--- MAGETWO-83279  -->
+*  The image size used as a cross-sell product placeholder now equals the size of the image used in product listing placeholder images. Previously, the cross-sell product placeholder image was too small. [GitHub-12017](https://github.com/magento/magento2/issues/12017)
 
-<!--- MAGETWO-82710 -->* Magento now downloads the backup `.tgz` file that you select for downloading. Previously, no matter which backup you selected, Magento downloaded the most recent backup. *Fix submitted by Pieter Cappelle in pull request 11595*. [GitHub-10032](https://github.com/magento/magento2/issues/10032)
+<!--- MAGETWO-82710  -->
+*  Magento now downloads the backup `.tgz` file that you select for downloading. Previously, no matter which backup you selected, Magento downloaded the most recent backup. *Fix submitted by Pieter Cappelle in pull request 11595*. [GitHub-10032](https://github.com/magento/magento2/issues/10032)
 
-<!--- MAGETWO-82809 -->* Magento now leaves a product's date attribute's current date field blank if you do not enter a value. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11749*. [GitHub-9869](https://github.com/magento/magento2/issues/9869), [GitHub-11636](https://github.com/magento/magento2/issues/11636), [GitHub-6661](https://github.com/magento/magento2/issues/6661)
+<!--- MAGETWO-82809  -->
+*  Magento now leaves a product's date attribute's current date field blank if you do not enter a value. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11749*. [GitHub-9869](https://github.com/magento/magento2/issues/9869), [GitHub-11636](https://github.com/magento/magento2/issues/11636), [GitHub-6661](https://github.com/magento/magento2/issues/6661)
 
-<!--- MAGETWO-83277 -->* The Magento store code validation `regex` now supports uppercase letters in store code. [GitHub-11996](https://github.com/magento/magento2/issues/11996)
+<!--- MAGETWO-83277  -->
+*  The Magento store code validation `regex` now supports uppercase letters in store code. [GitHub-11996](https://github.com/magento/magento2/issues/11996)
 
-<!--- MAGETWO-82426 -->* When you use a UI component-based form and add a custom regular expression pattern validation to an input field, the supplied pattern is now properly converted from a string to a JavaScript RegEx object. *Fix submitted by Brett in pull request 11565*. [GitHub-9919](https://github.com/magento/magento2/issues/9919)
+<!--- MAGETWO-82426  -->
+*  When you use a UI component-based form and add a custom regular expression pattern validation to an input field, the supplied pattern is now properly converted from a string to a JavaScript RegEx object. *Fix submitted by Brett in pull request 11565*. [GitHub-9919](https://github.com/magento/magento2/issues/9919)
 
-<!--- MAGETWO-82431 -->* Magento now sets ISO-valid language code in the HTML header. *Fix submitted by Cristian Sanclemente in pull request 11561*. [GitHub-11540](https://github.com/magento/magento2/issues/11540)
+<!--- MAGETWO-82431  -->
+*  Magento now sets ISO-valid language code in the HTML header. *Fix submitted by Cristian Sanclemente in pull request 11561*. [GitHub-11540](https://github.com/magento/magento2/issues/11540)
 
-<!--- MAGETWO-82889 -->* Magento now validates CMS blocks before creating one.  *Fix submitted by thiagolima-bm in pull request 11802*. [GitHub-8236](https://github.com/magento/magento2/issues/8236), [GitHub-4831](https://github.com/magento/magento2/issues/4831)
+<!--- MAGETWO-82889  -->
+*  Magento now validates CMS blocks before creating one.  *Fix submitted by thiagolima-bm in pull request 11802*. [GitHub-8236](https://github.com/magento/magento2/issues/8236), [GitHub-4831](https://github.com/magento/magento2/issues/4831)
 
-<!--- MAGETWO-82537 -->* A custom field's name attribute no longer remains empty during form creation. *Fix submitted by Paul Briscoe in pull request 11637*. [GitHub-9944](https://github.com/magento/magento2/issues/9944)
+<!--- MAGETWO-82537  -->
+*  A custom field's name attribute no longer remains empty during form creation. *Fix submitted by Paul Briscoe in pull request 11637*. [GitHub-9944](https://github.com/magento/magento2/issues/9944)
 
-<!--- MAGETWO-81993 -->* `widget.xml` files can now contain multiple `depends` parameters.  *Fix submitted by Raul E Watson in pull request 11495*. [GitHub-9783](https://github.com/magento/magento2/issues/9783)
+<!--- MAGETWO-81993  -->
+*  `widget.xml` files can now contain multiple `depends` parameters.  *Fix submitted by Raul E Watson in pull request 11495*. [GitHub-9783](https://github.com/magento/magento2/issues/9783)
 
-<!--- MAGETWO-81995 -->* You can now use an `adminhtml` URL that differs from `admin` and set **Add Store Code to Urls** to **Yes**. *Fix submitted by Sylvain Rayé in pull request 11460*. [GitHub-11140](https://github.com/magento/magento2/issues/11140), [GitHub-11140](https://github.com/magento/magento2/issues/11140)
+<!--- MAGETWO-81995  -->
+*  You can now use an `adminhtml` URL that differs from `admin` and set **Add Store Code to Urls** to **Yes**. *Fix submitted by Sylvain Rayé in pull request 11460*. [GitHub-11140](https://github.com/magento/magento2/issues/11140), [GitHub-11140](https://github.com/magento/magento2/issues/11140)
 
-<!--- MAGETWO-82999 -->* You can now add an HTML node to the page XML root of a theme without causing a validation error. [GitHub-11697](https://github.com/magento/magento2/issues/11697)
+<!--- MAGETWO-82999  -->
+*  You can now add an HTML node to the page XML root of a theme without causing a validation error. [GitHub-11697](https://github.com/magento/magento2/issues/11697)
 
-<!--- MAGETWO-82652 -->* The `customer_data_object` firstname is no longer equal to `orig_customer_data_object` after you save an existing user account with a new name or address. *Fix submitted by Roman K. in pull request 11676*. [GitHub-7915](https://github.com/magento/magento2/issues/7915)
+<!--- MAGETWO-82652  -->
+*  The `customer_data_object` firstname is no longer equal to `orig_customer_data_object` after you save an existing user account with a new name or address. *Fix submitted by Roman K. in pull request 11676*. [GitHub-7915](https://github.com/magento/magento2/issues/7915)
 
-<!--- MAGETWO-82658 -->*  A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+<!--- MAGETWO-82658  -->
+*   A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
-<!--- MAGETWO-82761 -->* We’ve fixed the dashboard graph’s y-axis range. *Fix submitted by Oscar Recio in pull request 11751*. [GitHub-7927](https://github.com/magento/magento2/issues/7927)
+<!--- MAGETWO-82761  -->
+*  We’ve fixed the dashboard graph’s y-axis range. *Fix submitted by Oscar Recio in pull request 11751*. [GitHub-7927](https://github.com/magento/magento2/issues/7927)
 
-<!--- MAGETWO-83023 -->* Magento no longer throws an error when you try to load a quote item collection. [GitHub-8954](https://github.com/magento/magento2/issues/8954)
+<!--- MAGETWO-83023  -->
+*  Magento no longer throws an error when you try to load a quote item collection. [GitHub-8954](https://github.com/magento/magento2/issues/8954)
 
-<!--- MAGETWO-82645 -->* Customer Groups are now located in the Magento Admin under **Customers > Customer Groups**. *Fix submitted by Mr. Lewis in pull request 11677*.
+<!--- MAGETWO-82645  -->
+*  Customer Groups are now located in the Magento Admin under **Customers > Customer Groups**. *Fix submitted by Mr. Lewis in pull request 11677*.
 
-<!--- MAGETWO-82810 -->* Magento now wraps long label text by word instead of letter. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11745*. [GitHub-7099](https://github.com/magento/magento2/issues/7099), [GitHub-711727](https://github.com/magento/magento2/issues/11727)
+<!--- MAGETWO-82810  -->
+*  Magento now wraps long label text by word instead of letter. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11745*. [GitHub-7099](https://github.com/magento/magento2/issues/7099), [GitHub-711727](https://github.com/magento/magento2/issues/11727)
 
-<!--- MAGETWO-81580 -->* Magento now displays and expects the format of birth years to match `yyyy` instead of `yy`. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11351*. [GitHub-11332](https://github.com/magento/magento2/issues/11332)
+<!--- MAGETWO-81580  -->
+*  Magento now displays and expects the format of birth years to match `yyyy` instead of `yy`. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11351*. [GitHub-11332](https://github.com/magento/magento2/issues/11332)
 
-<!--- MAGETWO-81675 -->* Magento now displays the State/Province field after you edit the billing address on sales orders.  *Fix submitted by Raul Mateos in pull request 11381*. [GitHub-10441](https://github.com/magento/magento2/issues/10441)
+<!--- MAGETWO-81675  -->
+*  Magento now displays the State/Province field after you edit the billing address on sales orders.  *Fix submitted by Raul Mateos in pull request 11381*. [GitHub-10441](https://github.com/magento/magento2/issues/10441)
 
-<!--- MAGETWO-81680 -->* You can now successfully sync billing and shipping addresses on Admin Reorder and Admin Customer Create Order page for selected, existing addresses. *Fix submitted by Ievgen Sentiabov in pull request 11385*. [GitHub-10856](https://github.com/magento/magento2/issues/10856)
+<!--- MAGETWO-81680  -->
+*  You can now successfully sync billing and shipping addresses on Admin Reorder and Admin Customer Create Order page for selected, existing addresses. *Fix submitted by Ievgen Sentiabov in pull request 11385*. [GitHub-10856](https://github.com/magento/magento2/issues/10856)
 
-<!--- MAGETWO-82854 -->* The `FixAccountManagementTest` unit test now works as expected. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11607*.
+<!--- MAGETWO-82854  -->
+*  The `FixAccountManagementTest` unit test now works as expected. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11607*.
 
-<!--- MAGETWO-82954 -->* You can now submit a form by pressing **Enter**. *Fix submitted by Raul Encinas in pull request 11827*. [GitHub-4696](https://github.com/magento/magento2/issues/4696)
+<!--- MAGETWO-82954  -->
+*  You can now submit a form by pressing **Enter**. *Fix submitted by Raul Encinas in pull request 11827*. [GitHub-4696](https://github.com/magento/magento2/issues/4696)
 
-<!--- MAGETWO-81422 -->* The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
+<!--- MAGETWO-81422  -->
+*  The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
 
-<!--- MAGETWO-83490 -->*  We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
+<!--- MAGETWO-83490  -->
+*   We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
 
-<!--- MAGETWO-83672 -->* Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
+<!--- MAGETWO-83672  -->
+*  Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
 
-<!--- MAGETWO-83682 -->* Disabling and enabling the  WYSIWYG editor with `ui/form/element/helper/service` checkbox now works as expected. *Fix submitted by Vova Yatsyuk in pull request 12141*.
+<!--- MAGETWO-83682  -->
+*  Disabling and enabling the  WYSIWYG editor with `ui/form/element/helper/service` checkbox now works as expected. *Fix submitted by Vova Yatsyuk in pull request 12141*.
 
-<!--- MAGETWO-83145 -->* The `sitemap.xml` `last mod` time stamp now contains the correct date. [GitHub-9151](https://github.com/magento/magento2/issues/9151)
+<!--- MAGETWO-83145  -->
+*  The `sitemap.xml` `last mod` time stamp now contains the correct date. [GitHub-9151](https://github.com/magento/magento2/issues/9151)
 
-<!--- MAGETWO-82955 -->* The Visual Swatch Attribute drop-down menu (accessible from Manage Swatch tab) now works as expected. Previously, when you clicked the **Add Swatch** button from this tab, the drop-down menu was not displayed. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11747*. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
+<!--- MAGETWO-82955  -->
+*  The Visual Swatch Attribute drop-down menu (accessible from Manage Swatch tab) now works as expected. Previously, when you clicked the **Add Swatch** button from this tab, the drop-down menu was not displayed. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11747*. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
 
-<!--- MAGETWO-71458 -->* Users are now subscribed by default to the Advanced Reporting service.
+<!--- MAGETWO-71458  -->
+*  Users are now subscribed by default to the Advanced Reporting service.
 
-<!--- MAGETWO-81679 -->* The design rule hint message no longer includes a typo. *Fix submitted by Javier Villanueva in pull request 11390*. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
+<!--- MAGETWO-81679  -->
+*  The design rule hint message no longer includes a typo. *Fix submitted by Javier Villanueva in pull request 11390*. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
 
-<!--- MAGETWO-81678 -->* Storefront labels and messages now use the American English spelling of “optimization”. *Fix submitted by David Angel in pull request 11345*.
+<!--- MAGETWO-81678  -->
+*  Storefront labels and messages now use the American English spelling of “optimization”. *Fix submitted by David Angel in pull request 11345*.
 
-<!--- MAGETWO-80829 -->* The **Add page** button now works as expected. Previously, when you clicked **Add page** while logged in to the Admin, and clicked **Save**, Magento did not create a new page, but returned you to the **Orders** page, and displayed this message: **Data key is missing: code-entity**. *Fix submitted by Tomasz Gregorczyk in pull request 11205*. [GitHub-11163](https://github.com/magento/magento2/issues/11163)
+<!--- MAGETWO-80829  -->
+*  The **Add page** button now works as expected. Previously, when you clicked **Add page** while logged in to the Admin, and clicked **Save**, Magento did not create a new page, but returned you to the **Orders** page, and displayed this message: **Data key is missing: code-entity**. *Fix submitted by Tomasz Gregorczyk in pull request 11205*. [GitHub-11163](https://github.com/magento/magento2/issues/11163)
 
 ### Import/export
 
-<!--- MAGETWO-83322 -->* To improve performance, Magento now loads all relations  using one query per bunch. Previously, Magento loaded relations one by one (multiple times for multiple attributes types). [GitHub-10920](https://github.com/magento/magento2/issues/10920)
+<!--- MAGETWO-83322  -->
+*  To improve performance, Magento now loads all relations  using one query per bunch. Previously, Magento loaded relations one by one (multiple times for multiple attributes types). [GitHub-10920](https://github.com/magento/magento2/issues/10920)
 
-<!--- MAGETWO-82886 -->* Magento now provides more helpful error messages if problems occur during the import of products and images using  **System > Import Products**. [GitHub-4711](https://github.com/magento/magento2/issues/4711)
+<!--- MAGETWO-82886  -->
+*  Magento now provides more helpful error messages if problems occur during the import of products and images using  **System > Import Products**. [GitHub-4711](https://github.com/magento/magento2/issues/4711)
 
-<!--- MAGETWO-82956 -->* Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
+<!--- MAGETWO-82956  -->
+*  Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
 
-<!--- MAGETWO-81594 -->*  Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
+<!--- MAGETWO-81594  -->
+*   Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
 
-<!--- MAGETWO-83310 -->* Importing an import file to update customer data no longer results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
+<!--- MAGETWO-83310  -->
+*  Importing an import file to update customer data no longer results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
 
 ### Indexing
 
-<!--- MAGETWO-80188 -->* Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
+<!--- MAGETWO-80188  -->
+*  Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
 
-<!--- MAGETWO-80644 -->*  Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
+<!--- MAGETWO-80644  -->
+*   Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
 
 ### Infrastructure
 
-<!--- MAGETWO-82273 -->* New static block tests  now detect blocks without a name attribute. We've also added a missing block name to allow block customization, and added a name for the order items grid default renderer block. *Fix submitted by Ihor Sviziev in pull request 11235*. [GitHub-10824](https://github.com/magento/magento2/issues/10824)
+<!--- MAGETWO-82273  -->
+*  New static block tests  now detect blocks without a name attribute. We've also added a missing block name to allow block customization, and added a name for the order items grid default renderer block. *Fix submitted by Ihor Sviziev in pull request 11235*. [GitHub-10824](https://github.com/magento/magento2/issues/10824)
 
-<!--- MAGETWO-82300 -->* We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
+<!--- MAGETWO-82300  -->
+*  We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
 
-<!--- MAGETWO-82003 -->*  Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
+<!--- MAGETWO-82003  -->
+*   Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
 
-<!--- MAGETWO-82658 -->*  We fixed a typo in the `Paypal/Test/TestCase/OnePageCheckoutTest.xml`. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+<!--- MAGETWO-82658  -->
+*   We fixed a typo in the `Paypal/Test/TestCase/OnePageCheckoutTest.xml`. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
-<!--- MAGETWO-83572 -->*  `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
+<!--- MAGETWO-83572  -->
+*   `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
 
 ### Newsletters
 
-<!--- MAGETWO-83257 -->* Newsletter subscriptions now work as expected. Previously, Magento did not set the `create-date` field, and the `change_status_at` was broken. [GitHub-4004](https://github.com/magento/magento2/issues/4004)
+<!--- MAGETWO-83257  -->
+*  Newsletter subscriptions now work as expected. Previously, Magento did not set the `create-date` field, and the `change_status_at` was broken. [GitHub-4004](https://github.com/magento/magento2/issues/4004)
 
-<!--- MAGETWO-83286 -->* When a customer with the same email address has an account on different stores in the same Magento installation, changes to the newsletter subscription in one account no longer affects the other subscription. *Fix submitted by Sergio Baixauli in pull request 12035*. [GitHub-10014](https://github.com/magento/magento2/issues/10014)
+<!--- MAGETWO-83286  -->
+*  When a customer with the same email address has an account on different stores in the same Magento installation, changes to the newsletter subscription in one account no longer affects the other subscription. *Fix submitted by Sergio Baixauli in pull request 12035*. [GitHub-10014](https://github.com/magento/magento2/issues/10014)
 
-<!--- MAGETWO-81326 -->* Magento now sends email confirmation of newsletter subscription to a user only when the user is newly subscribed. *Fix submitted by Oscar Recio in pull request 11317*. [GitHub-5439](https://github.com/magento/magento2/issues/5439)
+<!--- MAGETWO-81326  -->
+*  Magento now sends email confirmation of newsletter subscription to a user only when the user is newly subscribed. *Fix submitted by Oscar Recio in pull request 11317*. [GitHub-5439](https://github.com/magento/magento2/issues/5439)
 
 ### Orders
 
-<!--- MAGETWO-83271 -->* Magento now retains an order's  `relation_child_id` and `relation_child_real_id` field values when you edit the order. Previously, after you edited an order, the values of the `relation_child_id` and `relation_child_real_id` fields of the old order did not persist. [GitHub-10195](https://github.com/magento/magento2/issues/10195)
+<!--- MAGETWO-83271  -->
+*  Magento now retains an order's  `relation_child_id` and `relation_child_real_id` field values when you edit the order. Previously, after you edited an order, the values of the `relation_child_id` and `relation_child_real_id` fields of the old order did not persist. [GitHub-10195](https://github.com/magento/magento2/issues/10195)
 
-<!--- MAGETWO-83174 -->* Magento no longer duplicates the **Add Products** button after you change the customer group. [GitHub-11868](https://github.com/magento/magento2/issues/11868)
+<!--- MAGETWO-83174  -->
+*  Magento no longer duplicates the **Add Products** button after you change the customer group. [GitHub-11868](https://github.com/magento/magento2/issues/11868)
 
-<!--- MAGETWO-83084 -->* New orders now appear as expected in the Order table after migrating data. [GitHub-10185](https://github.com/magento/magento2/issues/10185)
+<!--- MAGETWO-83084  -->
+*  New orders now appear as expected in the Order table after migrating data. [GitHub-10185](https://github.com/magento/magento2/issues/10185)
 
-<!--- MAGETWO-83745 -->* You can now create an order from the Customer Edit page when working from the Admin. *Fix submitted by Roman K. in pull request 11952*. [GitHub-11832](https://github.com/magento/magento2/issues/11832)
+<!--- MAGETWO-83745  -->
+*  You can now create an order from the Customer Edit page when working from the Admin. *Fix submitted by Roman K. in pull request 11952*. [GitHub-11832](https://github.com/magento/magento2/issues/11832)
 
-<!--- MAGETWO-83668 -->* The `getTracksCollection()` method  now returns collection objects. Previously, this method returned either  collections or arrays.  *Fix submitted by Roman K. in pull request 12173*. [GitHub-8022](https://github.com/magento/magento2/issues/8022)
+<!--- MAGETWO-83668  -->
+*  The `getTracksCollection()` method  now returns collection objects. Previously, this method returned either  collections or arrays.  *Fix submitted by Roman K. in pull request 12173*. [GitHub-8022](https://github.com/magento/magento2/issues/8022)
 
-<!--- MAGETWO-82953 -->* References to `Zend_Pdf_Color_RGB`now correctly use the camel-case class name (`Zend_Pdf_Color_Rgb`). Previously, the former class name resulted in references to wrong or nonexistent classes. *Fix submitted by Danny Verkade - Cream in pull request 11830*. [GitHub-11581](https://github.com/magento/magento2/issues/11581)
+<!--- MAGETWO-82953  -->
+*  References to `Zend_Pdf_Color_RGB`now correctly use the camel-case class name (`Zend_Pdf_Color_Rgb`). Previously, the former class name resulted in references to wrong or nonexistent classes. *Fix submitted by Danny Verkade - Cream in pull request 11830*. [GitHub-11581](https://github.com/magento/magento2/issues/11581)
 
-<!--- MAGETWO-82883 -->* The Order table now accurately reflects changes in order status.
+<!--- MAGETWO-82883  -->
+*  The Order table now accurately reflects changes in order status.
 
-<!--- MAGETWO-82562 -->* Invoices now display coupon code information. *Fix submitted by Cristian Sanclemente in pull request 11635*. [GitHub-10168](https://github.com/magento/magento2/issues/10168)
+<!--- MAGETWO-82562  -->
+*  Invoices now display coupon code information. *Fix submitted by Cristian Sanclemente in pull request 11635*. [GitHub-10168](https://github.com/magento/magento2/issues/10168)
 
-<!--- MAGETWO-81428 -->* Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
+<!--- MAGETWO-81428  -->
+*  Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
 
-<!--- MAGETWO-81647 -->*  `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
+<!--- MAGETWO-81647  -->
+*   `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
 
-<!--- MAGETWO-81340 -->* Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
+<!--- MAGETWO-81340  -->
+*  Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
 
 ### Payment methods
 
-<!--- MAGETWO-82732 -->* Magento PayPal integration now supports the Indian Rupee currency (INR).
+<!--- MAGETWO-82732  -->
+*  Magento PayPal integration now supports the Indian Rupee currency (INR).
 
-<!--- MAGETWO-71966 -->* Braintree online refunds now work when you are using two Braintree accounts on two separate websites. Previously, when using two Braintree accounts for two separate websites, Magento did not process the refund, and displayed this message: **Sorry, but something went wrong**.
+<!--- MAGETWO-71966  -->
+*  Braintree online refunds now work when you are using two Braintree accounts on two separate websites. Previously, when using two Braintree accounts for two separate websites, Magento did not process the refund, and displayed this message: **Sorry, but something went wrong**.
 
-<!--- MAGETWO-83270 -->* Administrators with limited privileges can now log in without errors. Previously, Magento threw an error, but did not log errors in either the server or Magento logs. [GitHub-11700](https://github.com/magento/magento2/issues/11700)
+<!--- MAGETWO-83270  -->
+*  Administrators with limited privileges can now log in without errors. Previously, Magento threw an error, but did not log errors in either the server or Magento logs. [GitHub-11700](https://github.com/magento/magento2/issues/11700)
 
-<!--- MAGETWO-82367 -->* Corrected a typo in a translatable string. *Fix submitted by Danny Verkade - Cream in pull request 11569*.
+<!--- MAGETWO-82367  -->
+*  Corrected a typo in a translatable string. *Fix submitted by Danny Verkade - Cream in pull request 11569*.
 
-<!--- MAGETWO-80894 -->* Magento now displays the correct payment method string as displayed during checkout.  Previously, the translated string associated the payment method title for a particular store view was not consistently displayed. *Fix submitted by Bernhard in pull request 11165*. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
+<!--- MAGETWO-80894  -->
+*  Magento now displays the correct payment method string as displayed during checkout.  Previously, the translated string associated the payment method title for a particular store view was not consistently displayed. *Fix submitted by Bernhard in pull request 11165*. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
 
 ### Reports
 
-<!--- MAGETWO-82179 -->* The search for the Customer Review report now works as expected. *Fix submitted by Oscar Recio in pull request 11522*. [GitHub-10301](https://github.com/magento/magento2/issues/10301)
+<!--- MAGETWO-82179  -->
+*  The search for the Customer Review report now works as expected. *Fix submitted by Oscar Recio in pull request 11522*. [GitHub-10301](https://github.com/magento/magento2/issues/10301)
 
-<!--- MAGETWO-83600 -->* Magento now reports handled exceptions to New Relic. Previously, Magento displayed only fatal errors. *Fix submitted by Max Chadwick in pull request 11944*.
+<!--- MAGETWO-83600  -->
+*  Magento now reports handled exceptions to New Relic. Previously, Magento displayed only fatal errors. *Fix submitted by Max Chadwick in pull request 11944*.
 
 ### SalesRule
 
-<!--- MAGETWO-70323 -->* You can now add a bundle product that includes a simple product with a price of 0 (zero) to your cart. Previously, Magento threw an error. [GitHub-8969](https://github.com/magento/magento2/issues/8969)
+<!--- MAGETWO-70323  -->
+*  You can now add a bundle product that includes a simple product with a price of 0 (zero) to your cart. Previously, Magento threw an error. [GitHub-8969](https://github.com/magento/magento2/issues/8969)
 
-<!--- MAGETWO-81161 -->* Cart Price rules are now applied to products if dropdown attributes are present. Previously, Magento checked only the items that were visible in the cart against the specified conditions. *Fix submitted by Marina Gociu in pull request 11274*. [GitHub-10477](https://github.com/magento/magento2/issues/10477)
+<!--- MAGETWO-81161  -->
+*  Cart Price rules are now applied to products if dropdown attributes are present. Previously, Magento checked only the items that were visible in the cart against the specified conditions. *Fix submitted by Marina Gociu in pull request 11274*. [GitHub-10477](https://github.com/magento/magento2/issues/10477)
 
-<!--- MAGETWO-83540 -->* The Admin's Most Viewed Products tab now displays all the products in all  attribute sets, not simply the default attribute set. [GitHub-9768](https://github.com/magento/magento2/issues/9768)
+<!--- MAGETWO-83540  -->
+*  The Admin's Most Viewed Products tab now displays all the products in all  attribute sets, not simply the default attribute set. [GitHub-9768](https://github.com/magento/magento2/issues/9768)
 
 ### Search
 
-<!--- MAGETWO-82904 -->* The search template now uses the custom URL specified in  `Magento\Search\Helper\getSuggestUrl()` instead of the default. [GitHub-6802](https://github.com/magento/magento2/issues/6802)
+<!--- MAGETWO-82904  -->
+*  The search template now uses the custom URL specified in  `Magento\Search\Helper\getSuggestUrl()` instead of the default. [GitHub-6802](https://github.com/magento/magento2/issues/6802)
 
-<!--- MAGETWO-80203 -->* Magento no longer throws an asymmetric transaction error on re-indexing when you use ElasticSearch as your search engine.
+<!--- MAGETWO-80203  -->
+*  Magento no longer throws an asymmetric transaction error on re-indexing when you use ElasticSearch as your search engine.
 
 ### Shipping
 
 {: .bs-callout-info }
 can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-83278 -->* Magento now displays by default of two shipping address lines even when the `street_lines` setting in customer configuration is set to 0 (zero). [GitHub-7995](https://github.com/magento/magento2/issues/7995)
+<!--- MAGETWO-83278  -->
+*  Magento now displays by default of two shipping address lines even when the `street_lines` setting in customer configuration is set to 0 (zero). [GitHub-7995](https://github.com/magento/magento2/issues/7995)
 
-<!--- MAGETWO-83272 -->* Magent no longer displays a blank page at the shipping stage of checkout when the user tries to return to the Shipping page from the Payments page by clicking **Back**. [GitHub-11197](https://github.com/magento/magento2/issues/11197)
+<!--- MAGETWO-83272  -->
+*  Magent no longer displays a blank page at the shipping stage of checkout when the user tries to return to the Shipping page from the Payments page by clicking **Back**. [GitHub-11197](https://github.com/magento/magento2/issues/11197)
 
-<!--- MAGETWO-83197 -->* The Shipping report available from the Admin now uses the correct currency code. [GitHub-11793](https://github.com/magento/magento2/issues/11793)
+<!--- MAGETWO-83197  -->
+*  The Shipping report available from the Admin now uses the correct currency code. [GitHub-11793](https://github.com/magento/magento2/issues/11793)
 
-<!--- MAGETWO-80191 -->* An invoice's `grand_total` and `base_grand_total` now match as expected. Previously, these values differed, leading to a rounding error when calculating the `base_grand_total`.
+<!--- MAGETWO-80191  -->
+*  An invoice's `grand_total` and `base_grand_total` now match as expected. Previously, these values differed, leading to a rounding error when calculating the `base_grand_total`.
 
-<!--- MAGETWO-81673 -->* Magento now adds a customer note to a shipment invoice when the shipment is created by API and `appendComment` is set to **true**. *Fix submitted by JeroenVanLeusden in pull request 11383*. [GitHub-11207](https://github.com/magento/magento2/issues/11207)
+<!--- MAGETWO-81673  -->
+*  Magento now adds a customer note to a shipment invoice when the shipment is created by API and `appendComment` is set to **true**. *Fix submitted by JeroenVanLeusden in pull request 11383*. [GitHub-11207](https://github.com/magento/magento2/issues/11207)
 
-<!--- MAGETWO-81830 -->* Shipping method radio buttons no longer have duplicate element IDs on the cart page. Previously, these radio buttons had duplicate IDs,  which made it impossible to select the second method. *Fix submitted by Peter Jaap Blaakmeer in pull request 11406*. [GitHub-10795](https://github.com/magento/magento2/issues/10795)
+<!--- MAGETWO-81830  -->
+*  Shipping method radio buttons no longer have duplicate element IDs on the cart page. Previously, these radio buttons had duplicate IDs,  which made it impossible to select the second method. *Fix submitted by Peter Jaap Blaakmeer in pull request 11406*. [GitHub-10795](https://github.com/magento/magento2/issues/10795)
 
-<!--- MAGETWO-81986 -->* The **Shop By** button is now rendered as expected on Android platforms. Previously, the **Shop By** button  and other contents were positioned incorrectly. *Fix submitted by Lorenzo Stramaccia in pull request 11430*. [GitHub-10941](https://github.com/magento/magento2/issues/10941)
+<!--- MAGETWO-81986  -->
+*  The **Shop By** button is now rendered as expected on Android platforms. Previously, the **Shop By** button  and other contents were positioned incorrectly. *Fix submitted by Lorenzo Stramaccia in pull request 11430*. [GitHub-10941](https://github.com/magento/magento2/issues/10941)
 
-<!--- MAGETWO-82748 -->* The `freePackageValue` value is now required to be defined. Previously, this value could be undefined, but in some cases was still accessed. *Fix submitted by Alexander Menk in pull request 11720*.
+<!--- MAGETWO-82748  -->
+*  The `freePackageValue` value is now required to be defined. Previously, this value could be undefined, but in some cases was still accessed. *Fix submitted by Alexander Menk in pull request 11720*.
 
 ### Taxes
 
-<!--- MAGETWO-82753 -->* We've fixed a problem with the **Ignore this notification** setting. *Fix submitted by Cristian Sanclemente in pull request 11410*. [GitHub-11365](https://github.com/magento/magento2/issues/11365)
+<!--- MAGETWO-82753  -->
+*  We've fixed a problem with the **Ignore this notification** setting. *Fix submitted by Cristian Sanclemente in pull request 11410*. [GitHub-11365](https://github.com/magento/magento2/issues/11365)
 
 ### Translations
 
-<!--- MAGETWO-72352 -->* You can now implement translations from themes (in contrast to translations from modules).
+<!--- MAGETWO-72352  -->
+*  You can now implement translations from themes (in contrast to translations from modules).
 
-<!--- MAGETWO-81970 -->* Previously missing translation strings have been added to the UI module. *Fix submitted by JeroenVanLeusden in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
+<!--- MAGETWO-81970  -->
+*  Previously missing translation strings have been added to the UI module. *Fix submitted by JeroenVanLeusden in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
 
-<!--- MAGETWO-82651 -->* We've fixed an issue with the `<![CDATA[]]>` translate phrase in the `system.xml` file. [*Fix submitted by Malyovanets Nickolas in pull request 11675*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
+<!--- MAGETWO-82651  -->
+*  We've fixed an issue with the `<![CDATA[]]>` translate phrase in the `system.xml` file. [*Fix submitted by Malyovanets Nickolas in pull request 11675*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
 
-<!--- MAGETWO-83547 -->* The update `button.phtml` translation has been simplified. *Fix submitted by Karla Saaremäe in pull request 12136*.
+<!--- MAGETWO-83547  -->
+*  The update `button.phtml` translation has been simplified. *Fix submitted by Karla Saaremäe in pull request 12136*.
 
 ### Varnish
 
-<!--- MAGETWO-83152 -->* Cache headers for documents now factor in the cookie for the store code as expected.
+<!--- MAGETWO-83152  -->
+*  Cache headers for documents now factor in the cookie for the store code as expected.
 
 ## Known issues
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
@@ -48,348 +48,495 @@ Looking for more information on these new features as well as many others? Check
 
 ### Installation, setup, and deployment
 
-<!--- MAGETWO-82747 -->* We've increased the `memory_limit` of the `.user.ini` files to 2GB. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
+<!--- MAGETWO-82747  -->
+*  We've increased the `memory_limit` of the `.user.ini` files to 2GB. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
 
-<!--- MAGETWO-72301 -->* The contents of the `js-translation.json` files are now correct when you deploy static content with multiple locales.
+<!--- MAGETWO-72301  -->
+*  The contents of the `js-translation.json` files are now correct when you deploy static content with multiple locales.
 
-<!--- MAGETWO-80205 -->* All cron dates are now  saved in a single format and displayed according to user preference or needs. [GitHub-4237](https://github.com/magento/magento2/issues/4237)
+<!--- MAGETWO-80205  -->
+*  All cron dates are now  saved in a single format and displayed according to user preference or needs. [GitHub-4237](https://github.com/magento/magento2/issues/4237)
 
-<!--- MAGETWO-80209 -->* Static versioning and minification no longer  break email font styles. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
+<!--- MAGETWO-80209  -->
+*  Static versioning and minification no longer  break email font styles. [GitHub-8241](https://github.com/magento/magento2/issues/8241)
 
-<!--- MAGETWO-82595 -->* You can now successfully upgrade from 2.1.x to 2.2.0. Previously, when you tried to upgrade from 2.1.9 to 2.2.0, Magento displayed the  **postcode is a required field** error message, and `setup:upgrade` failed. *Fix submitted by Mr. Lewis in pull request 11651*. [GitHub-11095](https://github.com/magento/magento2/issues/11095)
+<!--- MAGETWO-82595  -->
+*  You can now successfully upgrade from 2.1.x to 2.2.0. Previously, when you tried to upgrade from 2.1.9 to 2.2.0, Magento displayed the  **postcode is a required field** error message, and `setup:upgrade` failed. *Fix submitted by Mr. Lewis in pull request 11651*. [GitHub-11095](https://github.com/magento/magento2/issues/11095)
 
-<!--- MAGETWO-82634 -->* We've replaced `FollowSymLinks` with `SymLinksIfOwnerMatch` in the `htaccess` templates. [GitHub-10811](https://github.com/magento/magento2/issues/10811)
+<!--- MAGETWO-82634  -->
+*  We've replaced `FollowSymLinks` with `SymLinksIfOwnerMatch` in the `htaccess` templates. [GitHub-10811](https://github.com/magento/magento2/issues/10811)
 
-<!--- MAGETWO-82292 -->* The `htaccess` template now supports  `apache2.4` commands. *Fix submitted by Jonas Hünig in pull request 11459*. [GitHub-10810](https://github.com/magento/magento2/issues/10810) [GitHub-10810](https://github.com/magento/magento2/issues/10810)
+<!--- MAGETWO-82292  -->
+*  The `htaccess` template now supports  `apache2.4` commands. *Fix submitted by Jonas Hünig in pull request 11459*. [GitHub-10810](https://github.com/magento/magento2/issues/10810) [GitHub-10810](https://github.com/magento/magento2/issues/10810)
 
-<!--- MAGETWO-82001 -->* `configVariables` now contains a variable for VAT numbers. *Fix submitted by JeroenVanLeusden in pull request 11486*.  [GitHub-10996](https://github.com/magento/magento2/issues/10996)
+<!--- MAGETWO-82001  -->
+*  `configVariables` now contains a variable for VAT numbers. *Fix submitted by JeroenVanLeusden in pull request 11486*.  [GitHub-10996](https://github.com/magento/magento2/issues/10996)
 
-<!--- MAGETWO-82463 -->* We've fixed an issue with using the command line to install or remove `crontab`. Previously, installing or removing `crontab` via the command line appended `2>&1` to entries, even those not related to Magento. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11591*. [GitHub-11586](https://github.com/magento/magento2/issues/11586)
+<!--- MAGETWO-82463  -->
+*  We've fixed an issue with using the command line to install or remove `crontab`. Previously, installing or removing `crontab` via the command line appended `2>&1` to entries, even those not related to Magento. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11591*. [GitHub-11586](https://github.com/magento/magento2/issues/11586)
 
-<!--- MAGETWO-81577 -->* You can now install and uninstall `cron` via the `bin/magento cron:install` command. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11359*.
+<!--- MAGETWO-81577  -->
+*  You can now install and uninstall `cron` via the `bin/magento cron:install` command. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11359*.
 
-<!--- MAGETWO-81645 -->* The `admin:user:create` command now recognizes the configured table prefix. *Fix submitted by Oscar Recio in pull request 11199*. [GitHub-11176](https://github.com/magento/magento2/issues/11176)
+<!--- MAGETWO-81645  -->
+*  The `admin:user:create` command now recognizes the configured table prefix. *Fix submitted by Oscar Recio in pull request 11199*. [GitHub-11176](https://github.com/magento/magento2/issues/11176)
 
-<!--- MAGETWO-82102 -->* The default cron success or failure history is now seven days. *Fix submitted by Max Chadwick in pull request 11505*.
+<!--- MAGETWO-82102  -->
+*  The default cron success or failure history is now seven days. *Fix submitted by Max Chadwick in pull request 11505*.
 
-<!--- MAGETWO-82234 -->* The `admin:user:create` command now asks for the input value if a required option is not passed. *Fix submitted by Christian Münch in pull request 11510*.
+<!--- MAGETWO-82234  -->
+*  The `admin:user:create` command now asks for the input value if a required option is not passed. *Fix submitted by Christian Münch in pull request 11510*.
 
-<!--- MAGETWO-82747 -->* The `.user.ini` files at `/.user.ini` and `/pub/.user.ini` now specify a `memory_limit` value of at least 1G to 2G for debugging purposes. *Fix submitted by Mr. Lewis in pull request 11734*. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
+<!--- MAGETWO-82747  -->
+*  The `.user.ini` files at `/.user.ini` and `/pub/.user.ini` now specify a `memory_limit` value of at least 1G to 2G for debugging purposes. *Fix submitted by Mr. Lewis in pull request 11734*. [GitHub-11322](https://github.com/magento/magento2/issues/11322)
 
-<!--- MAGETWO-82754 -->* The `setup:install` command now has an `-i` flag. It validates parameters interactively. *Fix submitted by Denis Ristic in pull request 11425*.
+<!--- MAGETWO-82754  -->
+*  The `setup:install` command now has an `-i` flag. It validates parameters interactively. *Fix submitted by Denis Ristic in pull request 11425*.
 
-<!--- MAGETWO-84646 -->* Magento now restarts cron jobs as needed after a cron job was terminated during execution.
+<!--- MAGETWO-84646  -->
+*  Magento now restarts cron jobs as needed after a cron job was terminated during execution.
 
 ### Catalog
 
-<!--- MAGETWO-83498 -->* You can now enter strings that exceed 255 characters in Admin or frontend input fields. Previously, Magento  saved only the first 255 characters of a long input string. [GitHub-6238](https://github.com/magento/magento2/issues/6238)
+<!--- MAGETWO-83498  -->
+*  You can now enter strings that exceed 255 characters in Admin or frontend input fields. Previously, Magento  saved only the first 255 characters of a long input string. [GitHub-6238](https://github.com/magento/magento2/issues/6238)
 
-<!--- MAGETWO-83477 -->* Magento now renders color attribute swatches correctly for the search result page if sorting for color attribute is enabled.  *Fix submitted by Roman K. in pull request 12077*. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
+<!--- MAGETWO-83477  -->
+*  Magento now renders color attribute swatches correctly for the search result page if sorting for color attribute is enabled.  *Fix submitted by Roman K. in pull request 12077*. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
 
-<!--- MAGETWO-83174, 83169 -->* The `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection` now returns items that have only existing relations in the `catalog_product_entity` table. Previously, Magento loaded quote items with non-existing products.
+<!--- MAGETWO-83174, 83169  -->
+*  The `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection` now returns items that have only existing relations in the `catalog_product_entity` table. Previously, Magento loaded quote items with non-existing products.
 
-<!--- MAGETWO-83085 -->* Magento no longer duplicates attribute option values. Previously, Magento did not confirm the uniqueness of an attribute option value if you created it using REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
+<!--- MAGETWO-83085  -->
+*  Magento no longer duplicates attribute option values. Previously, Magento did not confirm the uniqueness of an attribute option value if you created it using REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
 
-<!--- MAGETWO-83066 -->* Magento now saves the correct background color for images. Previously, product images always had a black background when using the Luma theme. [GitHub-8799](https://github.com/magento/magento2/issues/8799)
+<!--- MAGETWO-83066  -->
+*  Magento now saves the correct background color for images. Previously, product images always had a black background when using the Luma theme. [GitHub-8799](https://github.com/magento/magento2/issues/8799)
 
-<!--- MAGETWO-83036 -->* You can now save a product custom option price with a value of 0 (zero) by simply not entering a price. *Fix submitted by Raul Mateos in pull request 11843*. [GitHub-4808](https://github.com/magento/magento2/issues/4808)
+<!--- MAGETWO-83036  -->
+*  You can now save a product custom option price with a value of 0 (zero) by simply not entering a price. *Fix submitted by Raul Mateos in pull request 11843*. [GitHub-4808](https://github.com/magento/magento2/issues/4808)
 
-<!--- MAGETWO-82972 -->* You can now assign products to categories if those products are already assigned to the category tree. [GitHub-8970](https://github.com/magento/magento2/issues/8970)
+<!--- MAGETWO-82972  -->
+*  You can now assign products to categories if those products are already assigned to the category tree. [GitHub-8970](https://github.com/magento/magento2/issues/8970)
 
-<!--- MAGETWO-82946 -->* The `apply_to` setting for attributes is no longer hard-coded. [GitHub-7225](https://github.com/magento/magento2/issues/7225)
+<!--- MAGETWO-82946  -->
+*  The `apply_to` setting for attributes is no longer hard-coded. [GitHub-7225](https://github.com/magento/magento2/issues/7225)
 
-<!--- MAGETWO-82755 -->* The **Add to cart** checkboxes in Related Products are no longer visible on the storefront when **$canItemsAddToCart** is set to **false**.  *Fix submitted by Marc Rodriguez in pull request 11610*. [GitHub-6891](https://github.com/magento/magento2/issues/6891)
+<!--- MAGETWO-82755  -->
+*  The **Add to cart** checkboxes in Related Products are no longer visible on the storefront when **$canItemsAddToCart** is set to **false**.  *Fix submitted by Marc Rodriguez in pull request 11610*. [GitHub-6891](https://github.com/magento/magento2/issues/6891)
 
-<!--- MAGETWO-83627 -->* You can now successfully save and duplicate a simple product. Previously, when you clicked the **Save and Duplicate** option for an existing simple product in the Catalog Manager, Magento did not duplicate the product, but threw an error. *Fix submitted by Roman K. in pull request 12001*. [GitHub-11532](https://github.com/magento/magento2/issues/11532)
+<!--- MAGETWO-83627  -->
+*  You can now successfully save and duplicate a simple product. Previously, when you clicked the **Save and Duplicate** option for an existing simple product in the Catalog Manager, Magento did not duplicate the product, but threw an error. *Fix submitted by Roman K. in pull request 12001*. [GitHub-11532](https://github.com/magento/magento2/issues/11532)
 
-<!--- MAGETWO-81967 -->* The Magento Admin Product Edit page now displays product alerts as expected.  *Fix submitted by Raul Mateos in pull request 11445*. [GitHub-10007](https://github.com/magento/magento2/issues/10007)
+<!--- MAGETWO-81967  -->
+*  The Magento Admin Product Edit page now displays product alerts as expected.  *Fix submitted by Raul Mateos in pull request 11445*. [GitHub-10007](https://github.com/magento/magento2/issues/10007)
 
-<!--- MAGETWO-82004 -->* The `StockItemCriteriaInterface` method `setProductsFilter` now accepts an array of IDs. Previously, this method accepted either a single integer or an array, but returned only one item. *Fix submitted by Kirill Morozov in pull request 11500*. [GitHub-7678](https://github.com/magento/magento2/issues/7678)
+<!--- MAGETWO-82004  -->
+*  The `StockItemCriteriaInterface` method `setProductsFilter` now accepts an array of IDs. Previously, this method accepted either a single integer or an array, but returned only one item. *Fix submitted by Kirill Morozov in pull request 11500*. [GitHub-7678](https://github.com/magento/magento2/issues/7678)
 
-<!--- MAGETWO-81456 -->* The `$sortByPostion` flag has been added to the `getChildren()` method. *Fix submitted by Denis Ristic in pull request 11342*. [GitHub-11310](https://github.com/magento/magento2/issues/11310)
+<!--- MAGETWO-81456  -->
+*  The `$sortByPostion` flag has been added to the `getChildren()` method. *Fix submitted by Denis Ristic in pull request 11342*. [GitHub-11310](https://github.com/magento/magento2/issues/11310)
 
-<!--- MAGETWO-82283 -->* `ProductRepository` SKU cache is no longer corrupted when `cacheLimit` is reached . *Fix submitted by Thomas in pull request 11553*.
+<!--- MAGETWO-82283  -->
+*  `ProductRepository` SKU cache is no longer corrupted when `cacheLimit` is reached . *Fix submitted by Thomas in pull request 11553*.
 
-<!--- MAGETWO-82943 -->* Magento no longer displays the perpetual spinner when you  switch custom options types in the Product Edit page. *Fix submitted by Paul Briscoe in pull request 11824*. [GitHub-10291](https://github.com/magento/magento2/issues/10291)
+<!--- MAGETWO-82943  -->
+*  Magento no longer displays the perpetual spinner when you  switch custom options types in the Product Edit page. *Fix submitted by Paul Briscoe in pull request 11824*. [GitHub-10291](https://github.com/magento/magento2/issues/10291)
 
 ### Cart and checkout
 
-<!--- MAGETWO-81665 -->* The default shipping-save-processor now has a payload extender. This feature allows third party extensions to modify the payload for the shipping address selection process. As a result, developers can now add `extension_attributes` while minimizing potential extension conflicts. *Fix submitted by Navarr Barnier in pull request 11249*.
+<!--- MAGETWO-81665  -->
+*  The default shipping-save-processor now has a payload extender. This feature allows third party extensions to modify the payload for the shipping address selection process. As a result, developers can now add `extension_attributes` while minimizing potential extension conflicts. *Fix submitted by Navarr Barnier in pull request 11249*.
 
-<!--- MAGETWO-83476 -->* You can now view the **Products in cart** report if the cart contains a bundle or a grouped product. Previously, when you viewed the Products in Cart report, Magento threw an exception under these conditions. [GitHub-12079](https://github.com/magento/magento2/issues/12079)
+<!--- MAGETWO-83476  -->
+*  You can now view the **Products in cart** report if the cart contains a bundle or a grouped product. Previously, when you viewed the Products in Cart report, Magento threw an exception under these conditions. [GitHub-12079](https://github.com/magento/magento2/issues/12079)
 
-<!--- MAGETWO-83194 -->* Magento now recognizes zip codes without spaces for addresses located in the Netherlands. [GitHub-11898](https://github.com/magento/magento2/issues/11898)
+<!--- MAGETWO-83194  -->
+*  Magento now recognizes zip codes without spaces for addresses located in the Netherlands. [GitHub-11898](https://github.com/magento/magento2/issues/11898)
 
-<!--- MAGETWO-82724 -->* Magento now accepts coupon codes with special characters during checkout. *Fix submitted by Gabriel Queiroz Silva in pull request 11710*. [GitHub-9763](https://github.com/magento/magento2/issues/9763)
+<!--- MAGETWO-82724  -->
+*  Magento now accepts coupon codes with special characters during checkout. *Fix submitted by Gabriel Queiroz Silva in pull request 11710*. [GitHub-9763](https://github.com/magento/magento2/issues/9763)
 
-<!--- MAGETWO-82057 -->* We've improved cache control headers.
+<!--- MAGETWO-82057  -->
+*  We've improved cache control headers.
 
-<!--- MAGETWO-82314 -->* Magento no longer throws an exception when you place an order using a new address. Previously, Magento displayed this error, **An error occurred on the server. Please try to place the order again.**. [GitHub-10583](https://github.com/magento/magento2/issues/10583)
+<!--- MAGETWO-82314  -->
+*  Magento no longer throws an exception when you place an order using a new address. Previously, Magento displayed this error, **An error occurred on the server. Please try to place the order again.**. [GitHub-10583](https://github.com/magento/magento2/issues/10583)
 
-<!--- MAGETWO-81904 -->* Magento now includes the Filter Groups and the Sort Order of the `$searchCriteria` parameter in the `searchCriteria` Object that is provided for the EAV set repository.  *Fix submitted by David Verholen in pull request 11421*. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
+<!--- MAGETWO-81904  -->
+*  Magento now includes the Filter Groups and the Sort Order of the `$searchCriteria` parameter in the `searchCriteria` Object that is provided for the EAV set repository.  *Fix submitted by David Verholen in pull request 11421*. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
 
-<!--- MAGETWO-81994 -->* Magento no longer sets the product price to zero when you use REST to add a product to an empty cart. Previously, Magento displayed an error when you used REST to populate an empty cart. *Fix submitted by Peter Jaap Blaakmeer in pull request 11458*. [GitHub-2991](https://github.com/magento/magento2/issues/2991), [GitHub-2991](https://github.com/magento/magento2/issues/2991)
+<!--- MAGETWO-81994  -->
+*  Magento no longer sets the product price to zero when you use REST to add a product to an empty cart. Previously, Magento displayed an error when you used REST to populate an empty cart. *Fix submitted by Peter Jaap Blaakmeer in pull request 11458*. [GitHub-2991](https://github.com/magento/magento2/issues/2991), [GitHub-2991](https://github.com/magento/magento2/issues/2991)
 
-<!--- MAGETWO-81987 -->* You can now translate the placeholder text for the checkout password field.  *Fix submitted by JeroenVanLeusden in pull request 11493*.
+<!--- MAGETWO-81987  -->
+*  You can now translate the placeholder text for the checkout password field.  *Fix submitted by JeroenVanLeusden in pull request 11493*.
 
-<!--- MAGETWO-83495 -->* Magento now redirects a user to the checkout page if he logs in after selecting the **Checkout** button. Previously,  a user was redirected to the store home page. *Fix submitted by [@p-bystritsky](https://github.com/p-bystritsky) in pull request 11876*. [GitHub-10834](https://github.com/magento/magento2/issues/10834)
+<!--- MAGETWO-83495  -->
+*  Magento now redirects a user to the checkout page if he logs in after selecting the **Checkout** button. Previously,  a user was redirected to the store home page. *Fix submitted by [@p-bystritsky](https://github.com/p-bystritsky) in pull request 11876*. [GitHub-10834](https://github.com/magento/magento2/issues/10834)
 
 ### Configurable products
 
-<!--- MAGETWO-83489 -->* `Magento\ConfigurableProduct\Model\Product\Type\Configurable:::loadUsedProducts` no longer ignores array keys that are returned by product collections. [GitHub-11880](https://github.com/magento/magento2/issues/11880)
+<!--- MAGETWO-83489  -->
+*  `Magento\ConfigurableProduct\Model\Product\Type\Configurable:::loadUsedProducts` no longer ignores array keys that are returned by product collections. [GitHub-11880](https://github.com/magento/magento2/issues/11880)
 
 ### Frameworks
 
-<!--- MAGETWO-82675 -->* The NGINX configuration sample now contains a health check. *Fix submitted by Andrew Howden in pull request 11690*. [GitHub-11157](https://github.com/magento/magento2/issues/11157)
+<!--- MAGETWO-82675  -->
+*  The NGINX configuration sample now contains a health check. *Fix submitted by Andrew Howden in pull request 11690*. [GitHub-11157](https://github.com/magento/magento2/issues/11157)
 
-<!--- MAGETWO-82814 -->* Magento now allows underscore characters in module names and also permits their use when modules add a block to the layout via XML. Previously,  Magento did not support underscore characters in module names to be added to the layout via XML. *Fix submitted by Ben Tideswell in pull request 11765*.
+<!--- MAGETWO-82814  -->
+*  Magento now allows underscore characters in module names and also permits their use when modules add a block to the layout via XML. Previously,  Magento did not support underscore characters in module names to be added to the layout via XML. *Fix submitted by Ben Tideswell in pull request 11765*.
 
-<!--- MAGETWO-81467 -->* You can now save using the mass action **Update attributes** option when multiselect attributes are set. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11349*. [GitHub-11329](https://github.com/magento/magento2/issues/11329)
+<!--- MAGETWO-81467  -->
+*  You can now save using the mass action **Update attributes** option when multiselect attributes are set. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11349*. [GitHub-11329](https://github.com/magento/magento2/issues/11329)
 
 #### App framework
 
-<!--- MAGETWO-83024 -->* Magento now correctly handles all meta keywords and description in categories and in every product in locales that use non-Latin characters. [GitHub-10682](https://github.com/magento/magento2/issues/10682)
+<!--- MAGETWO-83024  -->
+*  Magento now correctly handles all meta keywords and description in categories and in every product in locales that use non-Latin characters. [GitHub-10682](https://github.com/magento/magento2/issues/10682)
 
-<!--- MAGETWO-82851 -->* You can now include negative values in an XML export file and open the file with Office XML handler. Previously, the export files did not open correctly, and an Office XML handler error log was created.  *Fix submitted by hauso in pull request 11757*. [GitHub-11729](https://github.com/magento/magento2/issues/11729), [GitHub-11729](https://github.com/magento/magento2/issues/11729)
+<!--- MAGETWO-82851  -->
+*  You can now include negative values in an XML export file and open the file with Office XML handler. Previously, the export files did not open correctly, and an Office XML handler error log was created.  *Fix submitted by hauso in pull request 11757*. [GitHub-11729](https://github.com/magento/magento2/issues/11729), [GitHub-11729](https://github.com/magento/magento2/issues/11729)
 
-<!--- MAGETWO-81977 -->* The Magento custom URL rewrite functionality now works as expected when you include redirection of Magento controllers. *Fix submitted by Marc Rodriguez in pull request 11470*. [GitHub-10231](https://github.com/magento/magento2/issues/10231), [GitHub-11469](https://github.com/magento/magento2/issues/11469), [GitHub-11471](https://github.com/magento/magento2/issues/11471)
+<!--- MAGETWO-81977  -->
+*  The Magento custom URL rewrite functionality now works as expected when you include redirection of Magento controllers. *Fix submitted by Marc Rodriguez in pull request 11470*. [GitHub-10231](https://github.com/magento/magento2/issues/10231), [GitHub-11469](https://github.com/magento/magento2/issues/11469), [GitHub-11471](https://github.com/magento/magento2/issues/11471)
 
-<!--- MAGETWO-81973 -->* Magento now supports the setting of HTTP response status code in redirected responses. [GitHub-9028](https://github.com/magento/magento2/issues/9028)
+<!--- MAGETWO-81973  -->
+*  Magento now supports the setting of HTTP response status code in redirected responses. [GitHub-9028](https://github.com/magento/magento2/issues/9028)
 
-<!--- MAGETWO-81990 -->* Magento now throws a meaningful exception when a virtual theme does not have a physical parent theme. *Fix submitted by David Fecke in pull request 11240*.
+<!--- MAGETWO-81990  -->
+*  Magento now throws a meaningful exception when a virtual theme does not have a physical parent theme. *Fix submitted by David Fecke in pull request 11240*.
 
-<!--- MAGETWO-82236 -->* `app:config:dump` no longer adds an extra space to multiline array values. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11439*. [GitHub-11328](https://github.com/magento/magento2/issues/11328)
+<!--- MAGETWO-82236  -->
+*  `app:config:dump` no longer adds an extra space to multiline array values. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11439*. [GitHub-11328](https://github.com/magento/magento2/issues/11328)
 
-<!--- MAGETWO-82665 -->* The TRAVIS_BRANCH variable is now surrounded by double-quotes instead of single-quotes . *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11704*.
+<!--- MAGETWO-82665  -->
+*  The TRAVIS_BRANCH variable is now surrounded by double-quotes instead of single-quotes . *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11704*.
 
-<!--- MAGETWO-83035 -->* The doc block of `setValue` in FilterBuilder now reflects that the `setValue` method will accept an array. *Fix submitted by ByteCreation in pull request 11854*.
+<!--- MAGETWO-83035  -->
+*  The doc block of `setValue` in FilterBuilder now reflects that the `setValue` method will accept an array. *Fix submitted by ByteCreation in pull request 11854*.
 
-<!--- MAGETWO-81515 -->* `htaccess` syntax now uses `Options -Indexes`  instead of `Options All -Indexes`. Previously, Magento used  `Options All -Indexes`, which resulted in Magento rendering a 500 error page because of high restrictions for Options overrides in shared hosting environments. *Fix submitted by [@Danny Verkade - Cream](https://github.com/dverkade) in pull request 11327*. [GitHub-10812](https://github.com/magento/magento2/issues/10812)
+<!--- MAGETWO-81515  -->
+*  `htaccess` syntax now uses `Options -Indexes`  instead of `Options All -Indexes`. Previously, Magento used  `Options All -Indexes`, which resulted in Magento rendering a 500 error page because of high restrictions for Options overrides in shared hosting environments. *Fix submitted by [@Danny Verkade - Cream](https://github.com/dverkade) in pull request 11327*. [GitHub-10812](https://github.com/magento/magento2/issues/10812)
 
 #### Configuration framework
 
-<!--- MAGETWO-82887 -->* The X-Magento-Tags header can now contain  white space. *Fix submitted by Malyovanets Nickolas in pull request 11767*. [GitHub-7640](https://github.com/magento/magento2/issues/7640), [GitHub-7640](https://github.com/magento/magento2/issues/7640)
+<!--- MAGETWO-82887  -->
+*  The X-Magento-Tags header can now contain  white space. *Fix submitted by Malyovanets Nickolas in pull request 11767*. [GitHub-7640](https://github.com/magento/magento2/issues/7640), [GitHub-7640](https://github.com/magento/magento2/issues/7640)
 
-<!--- MAGETWO-82535 -->* The config array can now read  all settings from `config`. Previously, the config array was hardcoded to read three settings only. *Fix submitted by Vova Yatsyuk in pull request 11643*.
+<!--- MAGETWO-82535  -->
+*  The config array can now read  all settings from `config`. Previously, the config array was hardcoded to read three settings only. *Fix submitted by Vova Yatsyuk in pull request 11643*.
 
 #### JavaScript framework
 
-<!--- MAGETWO-80207 -->* Magento no longer incorrectly overly encodes UTF-8 files when JavaScript Bundling is enabled. Previously, this issue resulted in poor character encoding on the storefront. [GitHub-10562](https://github.com/magento/magento2/issues/10562), [GitHub-6733](https://github.com/magento/magento2/issues/6733)
+<!--- MAGETWO-80207  -->
+*  Magento no longer incorrectly overly encodes UTF-8 files when JavaScript Bundling is enabled. Previously, this issue resulted in poor character encoding on the storefront. [GitHub-10562](https://github.com/magento/magento2/issues/10562), [GitHub-6733](https://github.com/magento/magento2/issues/6733)
 
-<!--- MAGETWO-81959 -->* Magento now exports the Confirmed email and Account Lock values when you export customer data. Previously, this information was missing from the exported CSV. *Fix submitted by Luke Rodgers in pull request 11437*. [GitHub-10765](https://github.com/magento/magento2/issues/10765), [GitHub-10765](https://github.com/magento/magento2/issues/10765)
+<!--- MAGETWO-81959  -->
+*  Magento now exports the Confirmed email and Account Lock values when you export customer data. Previously, this information was missing from the exported CSV. *Fix submitted by Luke Rodgers in pull request 11437*. [GitHub-10765](https://github.com/magento/magento2/issues/10765), [GitHub-10765](https://github.com/magento/magento2/issues/10765)
 
-<!--- MAGETWO-81146 -->* You can now submit the search form from the keyboard. *Fix submitted by Romain Ruaud in pull request 11250*. [GitHub-10275](https://github.com/magento/magento2/issues/10275)
+<!--- MAGETWO-81146  -->
+*  You can now submit the search form from the keyboard. *Fix submitted by Romain Ruaud in pull request 11250*. [GitHub-10275](https://github.com/magento/magento2/issues/10275)
 
 #### Session framework
 
-<!--- MAGETWO-84106 -->* We've removed the 30-second timeout limit for the session locking mechanism when Redis is used for session storage.
+<!--- MAGETWO-84106  -->
+*  We've removed the 30-second timeout limit for the session locking mechanism when Redis is used for session storage.
 
-<!--- MAGETWO-80912 -->* A typo in `sessionStorage` polyfill has been corrected.  *Fix submitted by mszydlo in pull request 11219*.
+<!--- MAGETWO-80912  -->
+*  A typo in `sessionStorage` polyfill has been corrected.  *Fix submitted by mszydlo in pull request 11219*.
 
 #### Web API framework
 
-<!--- MAGETWO-83095 -->* The `customerAccountManagementV1` interface now provides the `POST /V1/customers/resetPassword` endpoint.
+<!--- MAGETWO-83095  -->
+*  The `customerAccountManagementV1` interface now provides the `POST /V1/customers/resetPassword` endpoint.
 
 ### General
 
-<!--- MAGETWO-83281 -->* XHTML templates now use schema URNs. [GitHub-6661](https://github.com/magento/magento2/issues/6661)
+<!--- MAGETWO-83281  -->
+*  XHTML templates now use schema URNs. [GitHub-6661](https://github.com/magento/magento2/issues/6661)
 
-<!--- MAGETWO-83279 -->* The image size used as a cross-sell product placeholder now equals the size of the image used in product listing placeholder images. Previously, the cross-sell product placeholder image was too small. [GitHub-12017](https://github.com/magento/magento2/issues/12017)
+<!--- MAGETWO-83279  -->
+*  The image size used as a cross-sell product placeholder now equals the size of the image used in product listing placeholder images. Previously, the cross-sell product placeholder image was too small. [GitHub-12017](https://github.com/magento/magento2/issues/12017)
 
-<!--- MAGETWO-82710 -->* Magento now downloads the backup `.tgz` file that you select for downloading. Previously, no matter which backup you selected, Magento downloaded the most recent backup. *Fix submitted by Pieter Cappelle in pull request 11595*. [GitHub-10032](https://github.com/magento/magento2/issues/10032)
+<!--- MAGETWO-82710  -->
+*  Magento now downloads the backup `.tgz` file that you select for downloading. Previously, no matter which backup you selected, Magento downloaded the most recent backup. *Fix submitted by Pieter Cappelle in pull request 11595*. [GitHub-10032](https://github.com/magento/magento2/issues/10032)
 
-<!--- MAGETWO-82809 -->* Magento now leaves a product's date attribute's current date field blank if you do not enter a value. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11749*. [GitHub-9869](https://github.com/magento/magento2/issues/9869), [GitHub-11636](https://github.com/magento/magento2/issues/11636), [GitHub-6661](https://github.com/magento/magento2/issues/6661)
+<!--- MAGETWO-82809  -->
+*  Magento now leaves a product's date attribute's current date field blank if you do not enter a value. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11749*. [GitHub-9869](https://github.com/magento/magento2/issues/9869), [GitHub-11636](https://github.com/magento/magento2/issues/11636), [GitHub-6661](https://github.com/magento/magento2/issues/6661)
 
-<!--- MAGETWO-83277 -->* The Magento store code validation `regex` now supports uppercase letters in store code. [GitHub-11996](https://github.com/magento/magento2/issues/11996)
+<!--- MAGETWO-83277  -->
+*  The Magento store code validation `regex` now supports uppercase letters in store code. [GitHub-11996](https://github.com/magento/magento2/issues/11996)
 
-<!--- MAGETWO-82426 -->* When you use a UI component-based form and add a custom regular expression pattern validation to an input field, the supplied pattern is now properly converted from a string to a JavaScript RegEx object. *Fix submitted by Brett in pull request 11565*. [GitHub-9919](https://github.com/magento/magento2/issues/9919)
+<!--- MAGETWO-82426  -->
+*  When you use a UI component-based form and add a custom regular expression pattern validation to an input field, the supplied pattern is now properly converted from a string to a JavaScript RegEx object. *Fix submitted by Brett in pull request 11565*. [GitHub-9919](https://github.com/magento/magento2/issues/9919)
 
-<!--- MAGETWO-82431 -->* Magento now sets ISO-valid language code in the HTML header. *Fix submitted by Cristian Sanclemente in pull request 11561*. [GitHub-11540](https://github.com/magento/magento2/issues/11540)
+<!--- MAGETWO-82431  -->
+*  Magento now sets ISO-valid language code in the HTML header. *Fix submitted by Cristian Sanclemente in pull request 11561*. [GitHub-11540](https://github.com/magento/magento2/issues/11540)
 
-<!--- MAGETWO-82889 -->* Magento now validates CMS blocks before creating one.  *Fix submitted by thiagolima-bm in pull request 11802*. [GitHub-8236](https://github.com/magento/magento2/issues/8236), [GitHub-4831](https://github.com/magento/magento2/issues/4831)
+<!--- MAGETWO-82889  -->
+*  Magento now validates CMS blocks before creating one.  *Fix submitted by thiagolima-bm in pull request 11802*. [GitHub-8236](https://github.com/magento/magento2/issues/8236), [GitHub-4831](https://github.com/magento/magento2/issues/4831)
 
-<!--- MAGETWO-82537 -->* A custom field's name attribute no longer remains empty during form creation. *Fix submitted by Paul Briscoe in pull request 11637*. [GitHub-9944](https://github.com/magento/magento2/issues/9944)
+<!--- MAGETWO-82537  -->
+*  A custom field's name attribute no longer remains empty during form creation. *Fix submitted by Paul Briscoe in pull request 11637*. [GitHub-9944](https://github.com/magento/magento2/issues/9944)
 
-<!--- MAGETWO-81993 -->* `widget.xml` files can now contain multiple `depends` parameters.  *Fix submitted by Raul E Watson in pull request 11495*. [GitHub-9783](https://github.com/magento/magento2/issues/9783)
+<!--- MAGETWO-81993  -->
+*  `widget.xml` files can now contain multiple `depends` parameters.  *Fix submitted by Raul E Watson in pull request 11495*. [GitHub-9783](https://github.com/magento/magento2/issues/9783)
 
-<!--- MAGETWO-81995 -->* You can now use an `adminhtml` URL that differs from `admin` and set **Add Store Code to Urls** to **Yes**. *Fix submitted by Sylvain Rayé in pull request 11460*. [GitHub-11140](https://github.com/magento/magento2/issues/11140), [GitHub-11140](https://github.com/magento/magento2/issues/11140)
+<!--- MAGETWO-81995  -->
+*  You can now use an `adminhtml` URL that differs from `admin` and set **Add Store Code to Urls** to **Yes**. *Fix submitted by Sylvain Rayé in pull request 11460*. [GitHub-11140](https://github.com/magento/magento2/issues/11140), [GitHub-11140](https://github.com/magento/magento2/issues/11140)
 
-<!--- MAGETWO-82999 -->* You can now add an HTML node to the page XML root of a theme without causing a validation error. [GitHub-11697](https://github.com/magento/magento2/issues/11697)
+<!--- MAGETWO-82999  -->
+*  You can now add an HTML node to the page XML root of a theme without causing a validation error. [GitHub-11697](https://github.com/magento/magento2/issues/11697)
 
-<!--- MAGETWO-82652 -->* The `customer_data_object` firstname is no longer equal to `orig_customer_data_object` after you save an existing user account with a new name or address. *Fix submitted by Roman K. in pull request 11676*. [GitHub-7915](https://github.com/magento/magento2/issues/7915)
+<!--- MAGETWO-82652  -->
+*  The `customer_data_object` firstname is no longer equal to `orig_customer_data_object` after you save an existing user account with a new name or address. *Fix submitted by Roman K. in pull request 11676*. [GitHub-7915](https://github.com/magento/magento2/issues/7915)
 
-<!--- MAGETWO-82658 -->* We removed a typo in the Paypal Module. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+<!--- MAGETWO-82658  -->
+*  We removed a typo in the Paypal Module. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
-<!--- MAGETWO-82761 -->* We’ve fixed the dashboard graph’s y-axis range. *Fix submitted by Oscar Recio in pull request 11751*. [GitHub-7927](https://github.com/magento/magento2/issues/7927)
+<!--- MAGETWO-82761  -->
+*  We’ve fixed the dashboard graph’s y-axis range. *Fix submitted by Oscar Recio in pull request 11751*. [GitHub-7927](https://github.com/magento/magento2/issues/7927)
 
-<!--- MAGETWO-83023 -->* Magento no longer throws an error when you try to load a quote item collection. [GitHub-8954](https://github.com/magento/magento2/issues/8954)
+<!--- MAGETWO-83023  -->
+*  Magento no longer throws an error when you try to load a quote item collection. [GitHub-8954](https://github.com/magento/magento2/issues/8954)
 
-<!--- MAGETWO-82645 -->* Customer Groups are now located in the Magento Admin under **Customers > Customer Groups**. *Fix submitted by Mr. Lewis in pull request 11677*.
+<!--- MAGETWO-82645  -->
+*  Customer Groups are now located in the Magento Admin under **Customers > Customer Groups**. *Fix submitted by Mr. Lewis in pull request 11677*.
 
-<!--- MAGETWO-82810 -->* Magento now wraps long label text by word instead of letter. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11745*. [GitHub-7099](https://github.com/magento/magento2/issues/7099), [GitHub-711727](https://github.com/magento/magento2/issues/11727)
+<!--- MAGETWO-82810  -->
+*  Magento now wraps long label text by word instead of letter. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11745*. [GitHub-7099](https://github.com/magento/magento2/issues/7099), [GitHub-711727](https://github.com/magento/magento2/issues/11727)
 
-<!--- MAGETWO-81580 -->* Magento now displays and expects the format of birth years to match `yyyy` instead of `yy`. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11351*. [GitHub-11332](https://github.com/magento/magento2/issues/11332)
+<!--- MAGETWO-81580  -->
+*  Magento now displays and expects the format of birth years to match `yyyy` instead of `yy`. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11351*. [GitHub-11332](https://github.com/magento/magento2/issues/11332)
 
-<!--- MAGETWO-81675 -->* Magento now displays the State/Province field after you edit the billing address on sales orders.  *Fix submitted by Raul Mateos in pull request 11381*. [GitHub-10441](https://github.com/magento/magento2/issues/10441)
+<!--- MAGETWO-81675  -->
+*  Magento now displays the State/Province field after you edit the billing address on sales orders.  *Fix submitted by Raul Mateos in pull request 11381*. [GitHub-10441](https://github.com/magento/magento2/issues/10441)
 
-<!--- MAGETWO-81680 -->* You can now successfully sync billing and shipping addresses on Admin Reorder and Admin Customer Create Order page for selected, existing addresses. *Fix submitted by Ievgen Sentiabov in pull request 11385*. [GitHub-10856](https://github.com/magento/magento2/issues/10856)
+<!--- MAGETWO-81680  -->
+*  You can now successfully sync billing and shipping addresses on Admin Reorder and Admin Customer Create Order page for selected, existing addresses. *Fix submitted by Ievgen Sentiabov in pull request 11385*. [GitHub-10856](https://github.com/magento/magento2/issues/10856)
 
-<!--- MAGETWO-82854 -->* The `FixAccountManagementTest` unit test now works as expected. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11607*.
+<!--- MAGETWO-82854  -->
+*  The `FixAccountManagementTest` unit test now works as expected. *Fix submitted by [@adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request 11607*.
 
-<!--- MAGETWO-82954 -->* You can now submit a form by pressing **Enter**. *Fix submitted by Raul Encinas in pull request 11827*. [GitHub-4696](https://github.com/magento/magento2/issues/4696)
+<!--- MAGETWO-82954  -->
+*  You can now submit a form by pressing **Enter**. *Fix submitted by Raul Encinas in pull request 11827*. [GitHub-4696](https://github.com/magento/magento2/issues/4696)
 
-<!--- MAGETWO-81422 -->* The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
+<!--- MAGETWO-81422  -->
+*  The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
 
-<!--- MAGETWO-83490 -->*  We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
+<!--- MAGETWO-83490  -->
+*   We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
 
-<!--- MAGETWO-83672 -->* Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
+<!--- MAGETWO-83672  -->
+*  Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
 
-<!--- MAGETWO-83682 -->* Disabling and enabling the  WYSIWYG editor with `ui/form/element/helper/service` checkbox now works as expected. *Fix submitted by Vova Yatsyuk in pull request 12141*.
+<!--- MAGETWO-83682  -->
+*  Disabling and enabling the  WYSIWYG editor with `ui/form/element/helper/service` checkbox now works as expected. *Fix submitted by Vova Yatsyuk in pull request 12141*.
 
-<!--- MAGETWO-83145 -->* The `sitemap.xml` `last mod` time stamp now contains the correct date. [GitHub-9151](https://github.com/magento/magento2/issues/9151)
+<!--- MAGETWO-83145  -->
+*  The `sitemap.xml` `last mod` time stamp now contains the correct date. [GitHub-9151](https://github.com/magento/magento2/issues/9151)
 
-<!--- MAGETWO-82955 -->* The Visual Swatch Attribute drop-down menu (accessible from Manage Swatch tab) now works as expected. Previously, when you clicked the **Add Swatch** button from this tab, the drop-down menu was not displayed. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11747*. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
+<!--- MAGETWO-82955  -->
+*  The Visual Swatch Attribute drop-down menu (accessible from Manage Swatch tab) now works as expected. Previously, when you clicked the **Add Swatch** button from this tab, the drop-down menu was not displayed. *Fix submitted by [@enriquei4](https://github.com/enriquei4) in pull request 11747*. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
 
-<!--- MAGETWO-71458 -->* Users are now subscribed by default to the Advanced Reporting service.
+<!--- MAGETWO-71458  -->
+*  Users are now subscribed by default to the Advanced Reporting service.
 
-<!--- MAGETWO-81679 -->* The design rule hint message no longer includes a typo. *Fix submitted by Javier Villanueva in pull request 11390*. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
+<!--- MAGETWO-81679  -->
+*  The design rule hint message no longer includes a typo. *Fix submitted by Javier Villanueva in pull request 11390*. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
 
-<!--- MAGETWO-81678 -->* Storefront labels and messages now use the American English spelling of “optimization”. *Fix submitted by David Angel in pull request 11345*.
+<!--- MAGETWO-81678  -->
+*  Storefront labels and messages now use the American English spelling of “optimization”. *Fix submitted by David Angel in pull request 11345*.
 
-<!--- MAGETWO-80829 -->* The **Add page** button now works as expected. Previously, when you clicked **Add page** while logged in to the Admin, and clicked **Save**, Magento did not create a new page, but returned you to the **Orders** page, and displayed this message: **Data key is missing: code-entity**. *Fix submitted by Tomasz Gregorczyk in pull request 11205*. [GitHub-11163](https://github.com/magento/magento2/issues/11163)
+<!--- MAGETWO-80829  -->
+*  The **Add page** button now works as expected. Previously, when you clicked **Add page** while logged in to the Admin, and clicked **Save**, Magento did not create a new page, but returned you to the **Orders** page, and displayed this message: **Data key is missing: code-entity**. *Fix submitted by Tomasz Gregorczyk in pull request 11205*. [GitHub-11163](https://github.com/magento/magento2/issues/11163)
 
 ### Import/export
 
-<!--- MAGETWO-83322 -->* To improve performance, Magento now loads all relations  using one query per bunch. Previously, Magento loaded relations one by one (multiple times for multiple attributes types). [GitHub-10920](https://github.com/magento/magento2/issues/10920)
+<!--- MAGETWO-83322  -->
+*  To improve performance, Magento now loads all relations  using one query per bunch. Previously, Magento loaded relations one by one (multiple times for multiple attributes types). [GitHub-10920](https://github.com/magento/magento2/issues/10920)
 
-<!--- MAGETWO-82886 -->* Magento now provides more helpful error messages if problems occur during the import of products and images using  **System > Import Products**. [GitHub-4711](https://github.com/magento/magento2/issues/4711)
+<!--- MAGETWO-82886  -->
+*  Magento now provides more helpful error messages if problems occur during the import of products and images using  **System > Import Products**. [GitHub-4711](https://github.com/magento/magento2/issues/4711)
 
-<!--- MAGETWO-82956 -->* Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
+<!--- MAGETWO-82956  -->
+*  Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
 
-<!--- MAGETWO-81594 -->*  Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
+<!--- MAGETWO-81594  -->
+*   Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
 
-<!--- MAGETWO-83310 -->* Importing an import file to update customer data no loner results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
+<!--- MAGETWO-83310  -->
+*  Importing an import file to update customer data no loner results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
 
 ### Indexing
 
-<!--- MAGETWO-80188 -->* Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
+<!--- MAGETWO-80188  -->
+*  Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
 
-<!--- MAGETWO-80644 -->*  Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
+<!--- MAGETWO-80644  -->
+*   Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
 
 ### Infrastructure
 
-<!--- MAGETWO-82273 -->* New static block tests  now detect blocks without a name attribute. We've also added a missing block name to allow block customization, and added a name for the order items grid default renderer block. *Fix submitted by Ihor Sviziev in pull request 11235*. [GitHub-10824](https://github.com/magento/magento2/issues/10824)
+<!--- MAGETWO-82273  -->
+*  New static block tests  now detect blocks without a name attribute. We've also added a missing block name to allow block customization, and added a name for the order items grid default renderer block. *Fix submitted by Ihor Sviziev in pull request 11235*. [GitHub-10824](https://github.com/magento/magento2/issues/10824)
 
-<!--- MAGETWO-82300 -->* We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
+<!--- MAGETWO-82300  -->
+*  We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
 
-<!--- MAGETWO-82003 -->*  Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
+<!--- MAGETWO-82003  -->
+*   Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
 
-<!--- MAGETWO-82658 -->*  A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+<!--- MAGETWO-82658  -->
+*   A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
-<!--- MAGETWO-83572 -->*  `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
+<!--- MAGETWO-83572  -->
+*   `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
 
 ### Newsletters
 
-<!--- MAGETWO-83257 -->* Newsletter subscriptions now work as expected. Previously, Magento did not set the `create-date` field, and the `change_status_at` was broken. [GitHub-4004](https://github.com/magento/magento2/issues/4004)
+<!--- MAGETWO-83257  -->
+*  Newsletter subscriptions now work as expected. Previously, Magento did not set the `create-date` field, and the `change_status_at` was broken. [GitHub-4004](https://github.com/magento/magento2/issues/4004)
 
-<!--- MAGETWO-83286 -->* When a customer with the same email address has an account on different stores in the same Magento installation, changes to the newsletter subscription in one account no longer affects the other subscription. *Fix submitted by Sergio Baixauli in pull request 12035*. [GitHub-10014](https://github.com/magento/magento2/issues/10014)
+<!--- MAGETWO-83286  -->
+*  When a customer with the same email address has an account on different stores in the same Magento installation, changes to the newsletter subscription in one account no longer affects the other subscription. *Fix submitted by Sergio Baixauli in pull request 12035*. [GitHub-10014](https://github.com/magento/magento2/issues/10014)
 
-<!--- MAGETWO-81326 -->* Magento now sends email confirmation of newsletter subscription to a user only when the user is newly subscribed. *Fix submitted by Oscar Recio in pull request 11317*. [GitHub-5439](https://github.com/magento/magento2/issues/5439)
+<!--- MAGETWO-81326  -->
+*  Magento now sends email confirmation of newsletter subscription to a user only when the user is newly subscribed. *Fix submitted by Oscar Recio in pull request 11317*. [GitHub-5439](https://github.com/magento/magento2/issues/5439)
 
 ### Orders
 
-<!--- MAGETWO-83271 -->* Magento now retains an order's  `relation_child_id` and `relation_child_real_id` field values when you edit the order. Previously, after you edited an order, the values of the `relation_child_id` and `relation_child_real_id` fields of the old order did not persist. [GitHub-10195](https://github.com/magento/magento2/issues/10195)
+<!--- MAGETWO-83271  -->
+*  Magento now retains an order's  `relation_child_id` and `relation_child_real_id` field values when you edit the order. Previously, after you edited an order, the values of the `relation_child_id` and `relation_child_real_id` fields of the old order did not persist. [GitHub-10195](https://github.com/magento/magento2/issues/10195)
 
-<!--- MAGETWO-83174 -->* Magento no longer duplicates the **Add Products** button after you change the customer group. [GitHub-11868](https://github.com/magento/magento2/issues/11868)
+<!--- MAGETWO-83174  -->
+*  Magento no longer duplicates the **Add Products** button after you change the customer group. [GitHub-11868](https://github.com/magento/magento2/issues/11868)
 
-<!--- MAGETWO-83084 -->* New orders now appear as expected in the Order table after you migrating data. [GitHub-10185](https://github.com/magento/magento2/issues/10185)
+<!--- MAGETWO-83084  -->
+*  New orders now appear as expected in the Order table after you migrating data. [GitHub-10185](https://github.com/magento/magento2/issues/10185)
 
-<!--- MAGETWO-83745 -->* You can now create an order from the Customer Edit page when working from the Admin. *Fix submitted by Roman K. in pull request 11952*. [GitHub-11832](https://github.com/magento/magento2/issues/11832)
+<!--- MAGETWO-83745  -->
+*  You can now create an order from the Customer Edit page when working from the Admin. *Fix submitted by Roman K. in pull request 11952*. [GitHub-11832](https://github.com/magento/magento2/issues/11832)
 
-<!--- MAGETWO-83668 -->* The `getTracksCollection()` method  now returns collection objects. Previously, this method returned either  collections or arrays.  *Fix submitted by Roman K. in pull request 12173*. [GitHub-8022](https://github.com/magento/magento2/issues/8022)
+<!--- MAGETWO-83668  -->
+*  The `getTracksCollection()` method  now returns collection objects. Previously, this method returned either  collections or arrays.  *Fix submitted by Roman K. in pull request 12173*. [GitHub-8022](https://github.com/magento/magento2/issues/8022)
 
-<!--- MAGETWO-82953 -->* References to `Zend_Pdf_Color_RGB`now correctly use the camel-case class name (`Zend_Pdf_Color_Rgb`). Previously, the former class name resulted in references to wrong or nonexistent classes. *Fix submitted by Danny Verkade - Cream in pull request 11830*. [GitHub-11581](https://github.com/magento/magento2/issues/11581)
+<!--- MAGETWO-82953  -->
+*  References to `Zend_Pdf_Color_RGB`now correctly use the camel-case class name (`Zend_Pdf_Color_Rgb`). Previously, the former class name resulted in references to wrong or nonexistent classes. *Fix submitted by Danny Verkade - Cream in pull request 11830*. [GitHub-11581](https://github.com/magento/magento2/issues/11581)
 
-<!--- MAGETWO-82883 -->* The Order table now accurately reflects changes in order status.
+<!--- MAGETWO-82883  -->
+*  The Order table now accurately reflects changes in order status.
 
-<!--- MAGETWO-82562 -->* Invoices now display coupon code information. *Fix submitted by Cristian Sanclemente in pull request 11635*. [GitHub-10168](https://github.com/magento/magento2/issues/10168)
+<!--- MAGETWO-82562  -->
+*  Invoices now display coupon code information. *Fix submitted by Cristian Sanclemente in pull request 11635*. [GitHub-10168](https://github.com/magento/magento2/issues/10168)
 
-<!--- MAGETWO-81428 -->* Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
+<!--- MAGETWO-81428  -->
+*  Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
 
-<!--- MAGETWO-81647 -->*  `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
+<!--- MAGETWO-81647  -->
+*   `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
 
-<!--- MAGETWO-81340 -->* Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
+<!--- MAGETWO-81340  -->
+*  Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
 
 ### Payment methods
 
-<!--- MAGETWO-82732 -->* Magento PayPal integration now supports the Indian Rupee currency (INR).
+<!--- MAGETWO-82732  -->
+*  Magento PayPal integration now supports the Indian Rupee currency (INR).
 
-<!--- MAGETWO-71966 -->* Braintree online refunds now work when you are using two Braintree accounts on two separate websites. Previously, when using two Braintree accounts for two separate websites, Magento did not process the refund, and displayed this message: **Sorry, but something went wrong**.
+<!--- MAGETWO-71966  -->
+*  Braintree online refunds now work when you are using two Braintree accounts on two separate websites. Previously, when using two Braintree accounts for two separate websites, Magento did not process the refund, and displayed this message: **Sorry, but something went wrong**.
 
-<!--- MAGETWO-83270 -->* Administrators with limited privileges can now log in without errors. Previously, Magento threw an error, but did not log errors in either the server or Magento logs. [GitHub-11700](https://github.com/magento/magento2/issues/11700)
+<!--- MAGETWO-83270  -->
+*  Administrators with limited privileges can now log in without errors. Previously, Magento threw an error, but did not log errors in either the server or Magento logs. [GitHub-11700](https://github.com/magento/magento2/issues/11700)
 
-<!--- MAGETWO-82367 -->* Corrected a typo in a translatable string. *Fix submitted by Danny Verkade - Cream in pull request 11569*.
+<!--- MAGETWO-82367  -->
+*  Corrected a typo in a translatable string. *Fix submitted by Danny Verkade - Cream in pull request 11569*.
 
-<!--- MAGETWO-80894 -->* Magento now displays the correct payment method string as displayed during checkout.  Previously, the translated string associated the payment method title for a particular store view was not consistently displayed. *Fix submitted by Bernhard in pull request 11165*. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
+<!--- MAGETWO-80894  -->
+*  Magento now displays the correct payment method string as displayed during checkout.  Previously, the translated string associated the payment method title for a particular store view was not consistently displayed. *Fix submitted by Bernhard in pull request 11165*. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
 
 ### Reports
 
-<!--- MAGETWO-82179 -->* The search for the Customer Review report now works as expected. *Fix submitted by Oscar Recio in pull request 11522*. [GitHub-10301](https://github.com/magento/magento2/issues/10301)
+<!--- MAGETWO-82179  -->
+*  The search for the Customer Review report now works as expected. *Fix submitted by Oscar Recio in pull request 11522*. [GitHub-10301](https://github.com/magento/magento2/issues/10301)
 
-<!--- MAGETWO-83600 -->* Magento now reports handled exceptions to New Relic. Previously, Magento displayed only fatal errors. *Fix submitted by Max Chadwick in pull request 11944*.
+<!--- MAGETWO-83600  -->
+*  Magento now reports handled exceptions to New Relic. Previously, Magento displayed only fatal errors. *Fix submitted by Max Chadwick in pull request 11944*.
 
-<!--- MAGETWO-83540 -->* The Admin's Most Viewed Products tab now displays all the products in all  attribute sets, not simply the default attribute set. [GitHub-9768](https://github.com/magento/magento2/issues/9768)
+<!--- MAGETWO-83540  -->
+*  The Admin's Most Viewed Products tab now displays all the products in all  attribute sets, not simply the default attribute set. [GitHub-9768](https://github.com/magento/magento2/issues/9768)
 
 ### SalesRule
 
-<!--- MAGETWO-70323 -->* You can now add a bundle product that includes a simple product with a price of 0 (zero) to your cart. Previously, Magento threw an error. [GitHub-8969](https://github.com/magento/magento2/issues/8969)
+<!--- MAGETWO-70323  -->
+*  You can now add a bundle product that includes a simple product with a price of 0 (zero) to your cart. Previously, Magento threw an error. [GitHub-8969](https://github.com/magento/magento2/issues/8969)
 
-<!--- MAGETWO-81161 -->* Cart Price rules are now applied to products if dropdown attributes are present. Previously, Magento checked only the items that were visible in the cart against the specified conditions. *Fix submitted by Marina Gociu in pull request 11274*. [GitHub-10477](https://github.com/magento/magento2/issues/10477)
+<!--- MAGETWO-81161  -->
+*  Cart Price rules are now applied to products if dropdown attributes are present. Previously, Magento checked only the items that were visible in the cart against the specified conditions. *Fix submitted by Marina Gociu in pull request 11274*. [GitHub-10477](https://github.com/magento/magento2/issues/10477)
 
 ### Search
 
-<!--- MAGETWO-82904 -->* The search template now uses the custom URL specified in  `Magento\Search\Helper\getSuggestUrl()` instead of the default. [GitHub-6802](https://github.com/magento/magento2/issues/6802)
+<!--- MAGETWO-82904  -->
+*  The search template now uses the custom URL specified in  `Magento\Search\Helper\getSuggestUrl()` instead of the default. [GitHub-6802](https://github.com/magento/magento2/issues/6802)
 
-<!--- MAGETWO-80203 -->* Magento no longer throws an asymmetric transaction error on re-indexing when you use ElasticSearch as your search engine.
+<!--- MAGETWO-80203  -->
+*  Magento no longer throws an asymmetric transaction error on re-indexing when you use ElasticSearch as your search engine.
 
 ### Shipping
 
 {: .bs-callout-info }
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-83278 -->* Magento now displays by default of two shipping address lines even when the `street_lines` setting in customer configuration is set to 0 (zero). [GitHub-7995](https://github.com/magento/magento2/issues/7995)
+<!--- MAGETWO-83278  -->
+*  Magento now displays by default of two shipping address lines even when the `street_lines` setting in customer configuration is set to 0 (zero). [GitHub-7995](https://github.com/magento/magento2/issues/7995)
 
-<!--- MAGETWO-83272 -->* Magento no longer displays a blank page at the shipping stage of checkout when the user tries to return to the Shipping page from the Payments page by clicking **Back**. [GitHub-11197](https://github.com/magento/magento2/issues/11197)
+<!--- MAGETWO-83272  -->
+*  Magento no longer displays a blank page at the shipping stage of checkout when the user tries to return to the Shipping page from the Payments page by clicking **Back**. [GitHub-11197](https://github.com/magento/magento2/issues/11197)
 
-<!--- MAGETWO-83197 -->* The Shipping report available from the Admin now uses the correct currency code. [GitHub-11793](https://github.com/magento/magento2/issues/11793)
+<!--- MAGETWO-83197  -->
+*  The Shipping report available from the Admin now uses the correct currency code. [GitHub-11793](https://github.com/magento/magento2/issues/11793)
 
-<!--- MAGETWO-80191 -->* An invoice's `grand_total` and `base_grand_total` now match as expected. Previously, these values differed, leading to a rounding error when calculating the `base_grand_total`.
+<!--- MAGETWO-80191  -->
+*  An invoice's `grand_total` and `base_grand_total` now match as expected. Previously, these values differed, leading to a rounding error when calculating the `base_grand_total`.
 
-<!--- MAGETWO-81673 -->* Magento now adds a customer note to a shipment invoice when the shipment is created by API and `appendComment` is set to **true**. *Fix submitted by JeroenVanLeusden in pull request 11383*. [GitHub-11207](https://github.com/magento/magento2/issues/11207)
+<!--- MAGETWO-81673  -->
+*  Magento now adds a customer note to a shipment invoice when the shipment is created by API and `appendComment` is set to **true**. *Fix submitted by JeroenVanLeusden in pull request 11383*. [GitHub-11207](https://github.com/magento/magento2/issues/11207)
 
-<!--- MAGETWO-81830 -->* Shipping method radio buttons no longer have duplicate element IDs on the cart page. Previously, these radio buttons had duplicate IDs,  which made it impossible to select the second method. *Fix submitted by Peter Jaap Blaakmeer in pull request 11406*. [GitHub-10795](https://github.com/magento/magento2/issues/10795)
+<!--- MAGETWO-81830  -->
+*  Shipping method radio buttons no longer have duplicate element IDs on the cart page. Previously, these radio buttons had duplicate IDs,  which made it impossible to select the second method. *Fix submitted by Peter Jaap Blaakmeer in pull request 11406*. [GitHub-10795](https://github.com/magento/magento2/issues/10795)
 
-<!--- MAGETWO-81986 -->* The **Shop By** button is now rendered as expected on Android platforms. Previously, the **Shop By** button  and other contents were positioned incorrectly. *Fix submitted by Lorenzo Stramaccia in pull request 11430*. [GitHub-10941](https://github.com/magento/magento2/issues/10941)
+<!--- MAGETWO-81986  -->
+*  The **Shop By** button is now rendered as expected on Android platforms. Previously, the **Shop By** button  and other contents were positioned incorrectly. *Fix submitted by Lorenzo Stramaccia in pull request 11430*. [GitHub-10941](https://github.com/magento/magento2/issues/10941)
 
-<!--- MAGETWO-82748 -->* The `freePackageValue` value is now required to be defined. Previously, this value could be undefined, but in some cases was still accessed. *Fix submitted by Alexander Menk in pull request 11720*.
+<!--- MAGETWO-82748  -->
+*  The `freePackageValue` value is now required to be defined. Previously, this value could be undefined, but in some cases was still accessed. *Fix submitted by Alexander Menk in pull request 11720*.
 
 ### Tax
 
-<!--- MAGETWO-82753 -->* We've fixed a problem with the **Ignore this notification** setting. *Fix submitted by Cristian Sanclemente in pull request 11410*. [GitHub-11365](https://github.com/magento/magento2/issues/11365)
+<!--- MAGETWO-82753  -->
+*  We've fixed a problem with the **Ignore this notification** setting. *Fix submitted by Cristian Sanclemente in pull request 11410*. [GitHub-11365](https://github.com/magento/magento2/issues/11365)
 
 ### Translations
 
-<!--- MAGETWO-72352 -->* You can now implement translations from themes (in contrast to translations from modules).
+<!--- MAGETWO-72352  -->
+*  You can now implement translations from themes (in contrast to translations from modules).
 
-<!--- MAGETWO-81970 -->* Previously missing translation strings have been added to the UI module. *Fix submitted by JeroenVanLeusden in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
+<!--- MAGETWO-81970  -->
+*  Previously missing translation strings have been added to the UI module. *Fix submitted by JeroenVanLeusden in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
 
-<!--- MAGETWO-82651 -->* We've fixed an issue with the `<![CDATA[]]>` translate phrase in the `system.xml` file. [*Fix submitted by Malyovanets Nickolas in pull request 11675*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
+<!--- MAGETWO-82651  -->
+*  We've fixed an issue with the `<![CDATA[]]>` translate phrase in the `system.xml` file. [*Fix submitted by Malyovanets Nickolas in pull request 11675*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
 
-<!--- MAGETWO-83547 -->* The update `button.phtml` translation has been simplified. *Fix submitted by Karla Saaremäe in pull request 12136*.
+<!--- MAGETWO-83547  -->
+*  The update `button.phtml` translation has been simplified. *Fix submitted by Karla Saaremäe in pull request 12136*.
 
 ### Varnish
 
-<!--- MAGETWO-83152 -->* Cache headers for documents now factor in the cookie for the store code as expected.
+<!--- MAGETWO-83152  -->
+*  Cache headers for documents now factor in the cookie for the store code as expected.
 
 ## Known issues
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
@@ -22,7 +22,8 @@ Look for the following highlights in this release:
 
 * **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
 
-<!--- MAGETWO-84775 -->* **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
+<!--- MAGETWO-84775  -->
+*  **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
 
 * **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS  removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.md
@@ -17,7 +17,8 @@ Look for the following highlights in this release:
 
 * **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
 
-<!--- MAGETWO-84775 -->* **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
+<!--- MAGETWO-84775  -->
+*  **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
 
 * **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.md
@@ -30,15 +30,20 @@ Looking for more information on these new features as well as many others? Check
 
 This section describes changes in this release that are not full-fledged features or bug fixes, but that add noticeable improvements to product performance or ease-of-use.
 
-<!--- MAGETWO-87293-->* The admin global search is now translatable, extensible,  and  takes into account the ACL settings for the current user. See [Using global search](http://docs.magento.com/m2/ce/user_guide/stores/admin-global-search.html) for more information. *Fix submitted by Roman K. in pull request 1167*. [GitHub-7698](https://github.com/magento/magento2/issues/7698)
+<!--- MAGETWO-87293 -->
+*  The admin global search is now translatable, extensible,  and  takes into account the ACL settings for the current user. See [Using global search](http://docs.magento.com/m2/ce/user_guide/stores/admin-global-search.html) for more information. *Fix submitted by Roman K. in pull request 1167*. [GitHub-7698](https://github.com/magento/magento2/issues/7698)
 
-<!--- MAGETWO-84815 -->* Magento has an automated checker to enforce the short array syntax convention that we are now enforcing in new code. This standard complies with all requirements of PSR-2. *Fix submitted by Nickolas Malyovanets in pull request 12499*.
+<!--- MAGETWO-84815  -->
+*  Magento has an automated checker to enforce the short array syntax convention that we are now enforcing in new code. This standard complies with all requirements of PSR-2. *Fix submitted by Nickolas Malyovanets in pull request 12499*.
 
-<!--- MAGETWO-86940 -->* Magento now provides dedicated payment and shipping debug log files to store information specific to those functional areas.
+<!--- MAGETWO-86940  -->
+*  Magento now provides dedicated payment and shipping debug log files to store information specific to those functional areas.
 
-<!--- MAGETWO-87124 -->*  The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
+<!--- MAGETWO-87124  -->
+*   The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
 
-<!--- MAGETWO-86744, MAGETWO-86743, MAGETWO-86746, MAGETWO-86742-->* We've replaced `is_null` with strict comparison only for models and block in the following modules: `Catalog`, `Tax`, `Sales`, and `EAV`. *Fixes submitted by Alexander Shkurko in pull requests 13171, 13170, 1163*.
+<!--- MAGETWO-86744, MAGETWO-86743, MAGETWO-86746, MAGETWO-86742 -->
+*  We've replaced `is_null` with strict comparison only for models and block in the following modules: `Catalog`, `Tax`, `Sales`, and `EAV`. *Fixes submitted by Alexander Shkurko in pull requests 13171, 13170, 1163*.
 
 #### dotmailer enhancements
 
@@ -68,21 +73,29 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 
 ### Installation, setup, and deployment
 
-<!--- MAGETWO-86496 -->* The `backup` command now works as expected.  *Fix submitted by Jagriti Joshi in pull request 13066*. [GitHub-12877](https://github.com/magento/magento2/issues/12877)
+<!--- MAGETWO-86496  -->
+*  The `backup` command now works as expected.  *Fix submitted by Jagriti Joshi in pull request 13066*. [GitHub-12877](https://github.com/magento/magento2/issues/12877)
 
-<!--- MAGETWO-86045 -->* Links to Magento installation documentation in `setup/view/magento/readiness-check/progress.html` are now correct. *Fix submitted by Jonas Hünig in pull request 12857*.
+<!--- MAGETWO-86045  -->
+*  Links to Magento installation documentation in `setup/view/magento/readiness-check/progress.html` are now correct. *Fix submitted by Jonas Hünig in pull request 12857*.
 
-<!--- MAGETWO-84506 -->* You can now use the `app:config:status` command to check whether configuration propagation is up-to-date.  *Fix submitted by Juan Alonso in pull request 12441*.
+<!--- MAGETWO-84506  -->
+*  You can now use the `app:config:status` command to check whether configuration propagation is up-to-date.  *Fix submitted by Juan Alonso in pull request 12441*.
 
-<!--- MAGETWO-84125 -->* The `bin/magento setup:rollback -d filename.sql` command now works as expected. Previously, this database rollback operation failed on certain versions of Magento (for example, 2.1.9).  *Fix submitted by Roman K. in pull request 12108*. [GitHub-12064](https://github.com/magento/magento2/issues/12064)
+<!--- MAGETWO-84125  -->
+*  The `bin/magento setup:rollback -d filename.sql` command now works as expected. Previously, this database rollback operation failed on certain versions of Magento (for example, 2.1.9).  *Fix submitted by Roman K. in pull request 12108*. [GitHub-12064](https://github.com/magento/magento2/issues/12064)
 
-<!--- MAGETWO-84081 -->* You can now set API access to integrations for Admin roles, which gives privileged users the ability to grant limited access to users such as third-party integrators. [GitHub-9684](https://github.com/magento/magento2/issues/9684)
+<!--- MAGETWO-84081  -->
+*  You can now set API access to integrations for Admin roles, which gives privileged users the ability to grant limited access to users such as third-party integrators. [GitHub-9684](https://github.com/magento/magento2/issues/9684)
 
-<!--- MAGETWO-81841 -->* You can now enable or disable the Magento Profiler from the command line. [GitHub-9277](https://github.com/magento/magento2/issues/9277)
+<!--- MAGETWO-81841  -->
+*  You can now enable or disable the Magento Profiler from the command line. [GitHub-9277](https://github.com/magento/magento2/issues/9277)
 
-<!--- MAGETWO-81740 -->* The icons for Extension Manager and Module Manager are now consistent with the main content area and left-hand menu of the Web Setup Wizard. *Fix submitted by Danny Verkade in pull request 11388*. [GitHub-11236](https://github.com/magento/magento2/issues/11236)
+<!--- MAGETWO-81740  -->
+*  The icons for Extension Manager and Module Manager are now consistent with the main content area and left-hand menu of the Web Setup Wizard. *Fix submitted by Danny Verkade in pull request 11388*. [GitHub-11236](https://github.com/magento/magento2/issues/11236)
 
-<!--- MAGETWO-80111 -->* Magento now continues operating in maintenance mode if it was previously enabled. Previously, Magento disabled maintenance mode  when you used one of these commands:
+<!--- MAGETWO-80111  -->
+*  Magento now continues operating in maintenance mode if it was previously enabled. Previously, Magento disabled maintenance mode  when you used one of these commands:
 
     * `bin\magento module:uninstall`
     * `bin\magento setup:backup`
@@ -92,720 +105,1031 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 
 *Fix submitted by Joke Puts in pull request 11052*. [GitHub-9918](https://github.com/magento/magento2/issues/9918)
 
-<!--- MAGETWO-85778 -->* You can specify a custom version for static files being deployed, and now nginx sample config files can match these custom  versions, too. *Fix submitted by Scott Buchanan in pull request 12521*.
+<!--- MAGETWO-85778  -->
+*  You can specify a custom version for static files being deployed, and now nginx sample config files can match these custom  versions, too. *Fix submitted by Scott Buchanan in pull request 12521*.
 
-<!--- MAGETWO-85274 -->* The `CrontabManager.php` file has been updated as follows: If `crontab` has already been populated, the `php bin/magento cron:install` command adds `#~ MAGENTO START` and the rest of code directly to the last row of crontab without any spaces. *Fix submitted by Michele Fantetti in pull request*.
+<!--- MAGETWO-85274  -->
+*  The `CrontabManager.php` file has been updated as follows: If `crontab` has already been populated, the `php bin/magento cron:install` command adds `#~ MAGENTO START` and the rest of code directly to the last row of crontab without any spaces. *Fix submitted by Michele Fantetti in pull request*.
 
-<!--- MAGETWO-85744 -->*  The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
+<!--- MAGETWO-85744  -->
+*   The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
 
-<!--- MAGETWO-88149 -->* The `cache_lifetime` default setting for the `Magento\Theme\Block\Html\Footer` block is no longer set to **false**, and the new default setting is **3600**. *Fix submitted by zolat in pull request 13762*.
+<!--- MAGETWO-88149  -->
+*  The `cache_lifetime` default setting for the `Magento\Theme\Block\Html\Footer` block is no longer set to **false**, and the new default setting is **3600**. *Fix submitted by zolat in pull request 13762*.
 
-<!--- MAGETWO-87975 -->* The `magento maintenance:allow-ips` command now has the `--add` flag, which appends a new IP address to the list of allowed IP addresses. Previously, when you added a new IP address, you had to copy the existing addresses. *Fix submitted by Barry vd. Heuvel in pull request 13586*.
+<!--- MAGETWO-87975  -->
+*  The `magento maintenance:allow-ips` command now has the `--add` flag, which appends a new IP address to the list of allowed IP addresses. Previously, when you added a new IP address, you had to copy the existing addresses. *Fix submitted by Barry vd. Heuvel in pull request 13586*.
 
-<!--- MAGETWO-87900 -->*  The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
+<!--- MAGETWO-87900  -->
+*   The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
 
-<!--- MAGETWO-87859 -->*  In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
+<!--- MAGETWO-87859  -->
+*   In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
 
-<!--- MAGETWO-87856 -->*  You can now deploy static content on demand while in production mode.
+<!--- MAGETWO-87856  -->
+*   You can now deploy static content on demand while in production mode.
 
-<!--- MAGETWO-87838 -->* The output of the `magento maintenance:status` command no longer inserts a comma in between IP addresses, making it easier to copy and paste the values. *Fix submitted by Barry vd. Heuvel in pull request 13587*.
+<!--- MAGETWO-87838  -->
+*  The output of the `magento maintenance:status` command no longer inserts a comma in between IP addresses, making it easier to copy and paste the values. *Fix submitted by Barry vd. Heuvel in pull request 13587*.
 
-<!--- MAGETWO-87744 -->* The `DeploymentConfig` reader now always returns an array. *Fix submitted by Barry vd. Heuvel in pull request 13584*.
+<!--- MAGETWO-87744  -->
+*  The `DeploymentConfig` reader now always returns an array. *Fix submitted by Barry vd. Heuvel in pull request 13584*.
 
-<!--- MAGETWO-83782 -->*  Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
+<!--- MAGETWO-83782  -->
+*   Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
 
-<!--- MAGETWO-82288 -->* Magento now includes a helper object to facilitate access to styling objects in the Symfony console. *Fix submitted by Wesley Guthrie in pull request 11504*.
+<!--- MAGETWO-82288  -->
+*  Magento now includes a helper object to facilitate access to styling objects in the Symfony console. *Fix submitted by Wesley Guthrie in pull request 11504*.
 
-<!--- MAGETWO-83120 -->* Magento no longer throws an error when you try to generate an URN catalog for an empty `misc.xml` file. *Fix submitted by Timon de Groot in pull request 11686*. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
+<!--- MAGETWO-83120  -->
+*  Magento no longer throws an error when you try to generate an URN catalog for an empty `misc.xml` file. *Fix submitted by Timon de Groot in pull request 11686*. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
 
-<!--- MAGETWO-84180 -->* The `sampledata:deploy` and `remove` commands now have `no-update` options. *Fix submitted by Fabian Schmengler in pull request 12359*.
+<!--- MAGETWO-84180  -->
+*  The `sampledata:deploy` and `remove` commands now have `no-update` options. *Fix submitted by Fabian Schmengler in pull request 12359*.
 
-<!--- MAGETWO-88155 -->*  The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
+<!--- MAGETWO-88155  -->
+*   The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
 
-<!--- MAGETWO-82666 -->* A database backup created by `setup:backup --db` and restored with `setup:rollback -d` now includes triggers as expected.  Previously, the restored database did not include triggers, which meant that indexes could not work correctly. *Fix submitted by Denis Ristic in pull request 11369*. [GitHub-9036](https://github.com/magento/magento2/issues/9036)
+<!--- MAGETWO-82666  -->
+*  A database backup created by `setup:backup --db` and restored with `setup:rollback -d` now includes triggers as expected.  Previously, the restored database did not include triggers, which meant that indexes could not work correctly. *Fix submitted by Denis Ristic in pull request 11369*. [GitHub-9036](https://github.com/magento/magento2/issues/9036)
 
 ### Bundle products
 
-<!--- MAGETWO-86022 -->* Save operations now work as expected for bundle products. *Fix submitted by dzianis-yurevich in pull request 12734*. [GitHub-6916](https://github.com/magento/magento2/issues/6916)
+<!--- MAGETWO-86022  -->
+*  Save operations now work as expected for bundle products. *Fix submitted by dzianis-yurevich in pull request 12734*. [GitHub-6916](https://github.com/magento/magento2/issues/6916)
 
-<!--- MAGETWO-86882 -->* You can now duplicate a bundle product without stripping the original bundle product of its options.  *Fix submitted by MattUnity in pull request 1217*.
+<!--- MAGETWO-86882  -->
+*  You can now duplicate a bundle product without stripping the original bundle product of its options.  *Fix submitted by MattUnity in pull request 1217*.
 
 ### Catalog
 
-<!--- MAGETWO-87447 -->*  Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
+<!--- MAGETWO-87447  -->
+*   Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
 
-<!--- MAGETWO-73262 -->*  When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
+<!--- MAGETWO-73262  -->
+*   When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
 
-<!--- MAGETWO-87477 -->*  The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
+<!--- MAGETWO-87477  -->
+*   The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
 
-<!--- MAGETWO-73696 -->* When sorting by price, Magento now displays the same number of products no matter how it sorts products in the Catalog Product list. Previously, Magento reduced the product count by the number of disabled products when sorting by price.
+<!--- MAGETWO-73696  -->
+*  When sorting by price, Magento now displays the same number of products no matter how it sorts products in the Catalog Product list. Previously, Magento reduced the product count by the number of disabled products when sorting by price.
 
-<!--- MAGETWO-75786 -->* The category filter used for layered navigation for configurable products with no available options now counts products accurately.
+<!--- MAGETWO-75786  -->
+*  The category filter used for layered navigation for configurable products with no available options now counts products accurately.
 
-<!--- MAGETWO-81916 -->* When you set the `category_ids` attribute to be visible in the storefront catalog, Magento now displays catalog listings as expected. Previously, Magento threw an exception. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11389*. [GitHub-11341](https://github.com/magento/magento2/issues/11341)
+<!--- MAGETWO-81916  -->
+*  When you set the `category_ids` attribute to be visible in the storefront catalog, Magento now displays catalog listings as expected. Previously, Magento threw an exception. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11389*. [GitHub-11341](https://github.com/magento/magento2/issues/11341)
 
-<!--- MAGETWO-81942 -->* Product display issues within categories that have been filtered by price have been resolved: Products are no longer repeated within a category, and random products are no longer included. *Fix submitted by Mayank Zalavadia in pull request 11429*. [GitHub-11139](https://github.com/magento/magento2/issues/11139)
+<!--- MAGETWO-81942  -->
+*  Product display issues within categories that have been filtered by price have been resolved: Products are no longer repeated within a category, and random products are no longer included. *Fix submitted by Mayank Zalavadia in pull request 11429*. [GitHub-11139](https://github.com/magento/magento2/issues/11139)
 
-<!--- MAGETWO-82313 -->* Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) *Fix submitted by adrian-martinez-interactiv4 in pull request 11444*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82313  -->
+*  Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) *Fix submitted by adrian-martinez-interactiv4 in pull request 11444*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- MAGETWO-82464 -->* Magento no longer throws an error when you re-save a product attribute with a new name. *Fix submitted by Raul Mateos in pull request 11617*. [GitHub-6770](https://github.com/magento/magento2/issues/6770)
+<!--- MAGETWO-82464  -->
+*  Magento no longer throws an error when you re-save a product attribute with a new name. *Fix submitted by Raul Mateos in pull request 11617*. [GitHub-6770](https://github.com/magento/magento2/issues/6770)
 
-<!--- MAGETWO-83399 -->* You can now successfully remove a toolbar from a product listing page. Previously, you could explicitly remove the toolbar from layout configuration, but Magento would return `product_list_toolbar` to the layout. *Fix submitted by mariuscris in pull request 11473*. [GitHub-9413](https://github.com/magento/magento2/issues/9413)
+<!--- MAGETWO-83399  -->
+*  You can now successfully remove a toolbar from a product listing page. Previously, you could explicitly remove the toolbar from layout configuration, but Magento would return `product_list_toolbar` to the layout. *Fix submitted by mariuscris in pull request 11473*. [GitHub-9413](https://github.com/magento/magento2/issues/9413)
 
-<!--- MAGETWO-84018 -->* The `getAttributeText($attributeCode)` method now returns string values as expected. Previously, this method returned an array of attribute values. *Fix submitted by p-bystritsky in pull request 12003*.
+<!--- MAGETWO-84018  -->
+*  The `getAttributeText($attributeCode)` method now returns string values as expected. Previously, this method returned an array of attribute values. *Fix submitted by p-bystritsky in pull request 12003*.
 
-<!--- MAGETWO-84087 -->* You can now add customizable options to a product. Previously, when you tried to add a custom option to  product, Magento threw this error: `A 'Uncaught TypeError: Cannot read property 'apply' of undefined' error`. *Fix submitted by Roman K. in pull request 11965*. [GitHub-11792](https://github.com/magento/magento2/issues/11792)
+<!--- MAGETWO-84087  -->
+*  You can now add customizable options to a product. Previously, when you tried to add a custom option to  product, Magento threw this error: `A 'Uncaught TypeError: Cannot read property 'apply' of undefined' error`. *Fix submitted by Roman K. in pull request 11965*. [GitHub-11792](https://github.com/magento/magento2/issues/11792)
 
-<!--- MAGETWO-84311 -->* Magento now correctly decodes single quotation marks in the Admin attribute option input fields. *Fix submitted by erfanimani in pull request 12133*. [GitHub-12127](https://github.com/magento/magento2/issues/12127)
+<!--- MAGETWO-84311  -->
+*  Magento now correctly decodes single quotation marks in the Admin attribute option input fields. *Fix submitted by erfanimani in pull request 12133*. [GitHub-12127](https://github.com/magento/magento2/issues/12127)
 
-<!--- MAGETWO-84367 -->* You can now save emojis in custom product options. *Fix submitted by Carlos Lizaga in pull request 12253*.
+<!--- MAGETWO-84367  -->
+*  You can now save emojis in custom product options. *Fix submitted by Carlos Lizaga in pull request 12253*.
 
-<!--- MAGETWO-84498 -->* The `delay` parameter now works as expected, which permits you to set the delay on the JQuery widget opening or closing. Previously, this parameter was documented, but did not work as expected. *Fix submitted by Sam Carr in pull request 12161*.
+<!--- MAGETWO-84498  -->
+*  The `delay` parameter now works as expected, which permits you to set the delay on the JQuery widget opening or closing. Previously, this parameter was documented, but did not work as expected. *Fix submitted by Sam Carr in pull request 12161*.
 
-<!--- MAGETWO-84515 -->* Third-party category images now have `size` and `type` properties. *Fix submitted by Vova Yatsyuk in pull request 12161*.
+<!--- MAGETWO-84515  -->
+*  Third-party category images now have `size` and `type` properties. *Fix submitted by Vova Yatsyuk in pull request 12161*.
 
-<!--- MAGETWO-84652 -->* Category page X-Magento-Tags headers no longer contain product cache identities  when category display mode is set to **Static block only**. *Fix submitted by Atish Goswami in pull request 12466*.
+<!--- MAGETWO-84652  -->
+*  Category page X-Magento-Tags headers no longer contain product cache identities  when category display mode is set to **Static block only**. *Fix submitted by Atish Goswami in pull request 12466*.
 
-<!--- MAGETWO-84665 -->* You can now delete rows in the `dynamicRows` component. *Fix submitted by Roman K. in pull request 921*. [GitHub-8830](https://github.com/magento/magento2/issues/8830)
+<!--- MAGETWO-84665  -->
+*  You can now delete rows in the `dynamicRows` component. *Fix submitted by Roman K. in pull request 921*. [GitHub-8830](https://github.com/magento/magento2/issues/8830)
 
-<!--- MAGETWO-84808 -->* You can now add a new product with custom attributes that has the same name and attributes as a previously deleted product. Previously, Magento did not let you add this new product because a `request_path` with the same value already existed in `table url_rewrite` from the previous product. *Fix submitted by Nickolas Malyovanets in pull request 12167*. [GitHub-12110](https://github.com/magento/magento2/issues/12110)
+<!--- MAGETWO-84808  -->
+*  You can now add a new product with custom attributes that has the same name and attributes as a previously deleted product. Previously, Magento did not let you add this new product because a `request_path` with the same value already existed in `table url_rewrite` from the previous product. *Fix submitted by Nickolas Malyovanets in pull request 12167*. [GitHub-12110](https://github.com/magento/magento2/issues/12110)
 
-<!--- MAGETWO-84949 -->* The `og:type` meta tag content value has been corrected from `<meta property="og:type" content="og:product" />` to `<meta property="og:type" content="product" />`. *Fix submitted by Atish Goswami in pull request 12530*.
+<!--- MAGETWO-84949  -->
+*  The `og:type` meta tag content value has been corrected from `<meta property="og:type" content="og:product" />` to `<meta property="og:type" content="product" />`. *Fix submitted by Atish Goswami in pull request 12530*.
 
-<!--- MAGETWO-85293 -->*  The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
+<!--- MAGETWO-85293  -->
+*   The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
 
-<!--- MAGETWO-85294 -->* Magento no longer creates an extraneous new product when you save an existing product whose SKU you've changed.  *Fix submitted by Nickolas Malyovanets in pull request 984*. [GitHub-12535](https://github.com/magento/magento2/issues/12535)
+<!--- MAGETWO-85294  -->
+*  Magento no longer creates an extraneous new product when you save an existing product whose SKU you've changed.  *Fix submitted by Nickolas Malyovanets in pull request 984*. [GitHub-12535](https://github.com/magento/magento2/issues/12535)
 
-<!--- MAGETWO-85301 -->* cURL requests to delete a product's tier pricing when used on store code **all** now works as expected. Previously, this cURL request deleted the tier pricing but also all the image selections for the product. *Fix submitted by Nickolas Malyovanets in pull request 977*. [GitHub-10797](https://github.com/magento/magento2/issues/10797)
+<!--- MAGETWO-85301  -->
+*  cURL requests to delete a product's tier pricing when used on store code **all** now works as expected. Previously, this cURL request deleted the tier pricing but also all the image selections for the product. *Fix submitted by Nickolas Malyovanets in pull request 977*. [GitHub-10797](https://github.com/magento/magento2/issues/10797)
 
-<!--- MAGETWO-85307 -->* Sort by Price now works as expected on the catalog search page. *Fix submitted by Roman K. in pull request 929*.  [GitHub-12468](https://github.com/magento/magento2/issues/12468)
+<!--- MAGETWO-85307  -->
+*  Sort by Price now works as expected on the catalog search page. *Fix submitted by Roman K. in pull request 929*.  [GitHub-12468](https://github.com/magento/magento2/issues/12468)
 
-<!--- MAGETWO-85545 -->* If an error occurs when you run `catalog:images:resize`, Magento now includes an entry into the log file. Previously, Magento displayed an error message, but did not add an entry into any log files. *Fix submitted by Roman K. in pull request 1000*. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
+<!--- MAGETWO-85545  -->
+*  If an error occurs when you run `catalog:images:resize`, Magento now includes an entry into the log file. Previously, Magento displayed an error message, but did not add an entry into any log files. *Fix submitted by Roman K. in pull request 1000*. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
 
-<!--- MAGETWO-85546 -->* You can now duplicate and save a product successfully. Previously, you could not successfully duplicate a product, and Magento displayed this message: `Notice: Undefined offset: 0 in /home/software/public_html/vendor/magento/module-catalog/Model/Category/Link/SaveHandler.php on line 124`. *Fix submitted by p-bystritsky in pull request 983*.  [GitHub-12259](https://github.com/magento/magento2/issues/12259)
+<!--- MAGETWO-85546  -->
+*  You can now duplicate and save a product successfully. Previously, you could not successfully duplicate a product, and Magento displayed this message: `Notice: Undefined offset: 0 in /home/software/public_html/vendor/magento/module-catalog/Model/Category/Link/SaveHandler.php on line 124`. *Fix submitted by p-bystritsky in pull request 983*.  [GitHub-12259](https://github.com/magento/magento2/issues/12259)
 
-<!--- MAGETWO-85636 -->* The REST API now saves all product properties as expected. Previously, Magento did not save the price and weight, and these attributes were not returned in the result of the POST request. *Fix submitted by Nickolas Malyovanets in pull request 1018*. [GitHub-6486](https://github.com/magento/magento2/issues/6486)
+<!--- MAGETWO-85636  -->
+*  The REST API now saves all product properties as expected. Previously, Magento did not save the price and weight, and these attributes were not returned in the result of the POST request. *Fix submitted by Nickolas Malyovanets in pull request 1018*. [GitHub-6486](https://github.com/magento/magento2/issues/6486)
 
-<!--- MAGETWO-86016 -->* Duplicate `email` IDs no longer occur on the Magento default contact page when running Google Chrome  { Version 63.0.3239.84 (Official Build) (64-bit) }. *Fix submitted by serhii-balko in pull request 1036*. [GitHub-12712](https://github.com/magento/magento2/issues/12712)
+<!--- MAGETWO-86016  -->
+*  Duplicate `email` IDs no longer occur on the Magento default contact page when running Google Chrome  { Version 63.0.3239.84 (Official Build) (64-bit) }. *Fix submitted by serhii-balko in pull request 1036*. [GitHub-12712](https://github.com/magento/magento2/issues/12712)
 
-<!--- MAGETWO-86019 -->* The `hasDataChanges` attribute for loaded EAV collection items now returns `true` or `false` as expected. Previously, this attribute always returned `true`. *Fix submitted by virtual97 in pull request 12736*. [GitHub-12374](https://github.com/magento/magento2/issues/12374)
+<!--- MAGETWO-86019  -->
+*  The `hasDataChanges` attribute for loaded EAV collection items now returns `true` or `false` as expected. Previously, this attribute always returned `true`. *Fix submitted by virtual97 in pull request 12736*. [GitHub-12374](https://github.com/magento/magento2/issues/12374)
 
-<!--- MAGETWO-86021 -->* `ajax:addToCart` now contains the `eventData` parameter, with variables for SKU and quantity. *Fix submitted by Renon Stewart in pull request 12875*.
+<!--- MAGETWO-86021  -->
+*  `ajax:addToCart` now contains the `eventData` parameter, with variables for SKU and quantity. *Fix submitted by Renon Stewart in pull request 12875*.
 
-<!--- MAGETWO-86023 -->* You can now successfully save a new option for a product custom attribute when the value of Admin scope is empty. Previously, Magento threw an exception. *Fix submitted by virtual97 in pull request 12755*.
+<!--- MAGETWO-86023  -->
+*  You can now successfully save a new option for a product custom attribute when the value of Admin scope is empty. Previously, Magento threw an exception. *Fix submitted by virtual97 in pull request 12755*.
 
-<!--- MAGETWO-86662 -->* You can now sort product collections by the `is_saleable` attribute. *Fix submitted by Nickolas Malyovanets in pull request 1045*. [GitHub-7768](https://github.com/magento/magento2/issues/7768)
+<!--- MAGETWO-86662  -->
+*  You can now sort product collections by the `is_saleable` attribute. *Fix submitted by Nickolas Malyovanets in pull request 1045*. [GitHub-7768](https://github.com/magento/magento2/issues/7768)
 
-<!--- MAGETWO-86547 -->* We've added a failsafe to the `items.phtml` file.  *Fix submitted by Sam Granger in pull request 13086*.
+<!--- MAGETWO-86547  -->
+*  We've added a failsafe to the `items.phtml` file.  *Fix submitted by Sam Granger in pull request 13086*.
 
-<!--- MAGETWO-84267 -->* You can now save a product with customizable options. Previously, if you were trying to add a customizable option (for example, a customer group) to a product, Magento did not let you save the product, the form did not close, and a validation issue was triggered. *Fix submitted by luismiguelyangehuaman in pull request 12048*. [GitHub-11528](https://github.com/magento/magento2/issues/11528)
+<!--- MAGETWO-84267  -->
+*  You can now save a product with customizable options. Previously, if you were trying to add a customizable option (for example, a customer group) to a product, Magento did not let you save the product, the form did not close, and a validation issue was triggered. *Fix submitted by luismiguelyangehuaman in pull request 12048*. [GitHub-11528](https://github.com/magento/magento2/issues/11528)
 
-<!--- MAGETWO-85288 -->* Magento now correctly displays stock status for products. *Fix submitted by Roman K. in pull request 955*.
+<!--- MAGETWO-85288  -->
+*  Magento now correctly displays stock status for products. *Fix submitted by Roman K. in pull request 955*.
 
-<!--- MAGETWO-86663 -->* The catalog product list widget now works with multiple SKUs. Previously, Magento displayed this error, `We're sorry, an error has occurred while generating this email`. *Fix submitted by Nickolas Malyovanets in pull request 1050*.
+<!--- MAGETWO-86663  -->
+*  The catalog product list widget now works with multiple SKUs. Previously, Magento displayed this error, `We're sorry, an error has occurred while generating this email`. *Fix submitted by Nickolas Malyovanets in pull request 1050*.
  [GitHub-11897](https://github.com/magento/magento2/issues/11897)
 
-<!--- MAGETWO-85876 -->* Magento now loads type-dependent layout handles before more specific ID/SKU layout handles. Previously, when Magento updated a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml`, some changes were overwritten by a less specific `catalog_product_view_type_<product_type>.xml`. *Fix submitted by Andreas Schrammel in pull request 12807*.
+<!--- MAGETWO-85876  -->
+*  Magento now loads type-dependent layout handles before more specific ID/SKU layout handles. Previously, when Magento updated a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml`, some changes were overwritten by a less specific `catalog_product_view_type_<product_type>.xml`. *Fix submitted by Andreas Schrammel in pull request 12807*.
 
-<!--- MAGETWO-87897 -->*  Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
+<!--- MAGETWO-87897  -->
+*   Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
 
-<!--- MAGETWO-87847 -->* Language switching now works as expected on the Catalog and Product pages. Previously, language switching did not work on these pages in production mode. *Fix submitted by p-bystritsky in pull request 1143*. [GitHub-11963](https://github.com/magento/magento2/issues/11963)
+<!--- MAGETWO-87847  -->
+*  Language switching now works as expected on the Catalog and Product pages. Previously, language switching did not work on these pages in production mode. *Fix submitted by p-bystritsky in pull request 1143*. [GitHub-11963](https://github.com/magento/magento2/issues/11963)
 
-<!--- MAGETWO-87526 -->* The subcategory URL path is now updated for a store view according to the URL path of its parent category.
+<!--- MAGETWO-87526  -->
+*  The subcategory URL path is now updated for a store view according to the URL path of its parent category.
 
-<!--- MAGETWO-87514 -->* In cases where  `imagebuilder` makes multiple calls, it no longer re-uses attributes from the first call if attributes from a second call are empty. Previously, `imagebuilder` re-used the attributes from the first call, which lead to unexpected results in storefront image display. *Fix submitted by Ihor Sviziev in pull request 13438*.
+<!--- MAGETWO-87514  -->
+*  In cases where  `imagebuilder` makes multiple calls, it no longer re-uses attributes from the first call if attributes from a second call are empty. Previously, `imagebuilder` re-used the attributes from the first call, which lead to unexpected results in storefront image display. *Fix submitted by Ihor Sviziev in pull request 13438*.
 
-<!--- MAGETWO-87496 -->*  `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
+<!--- MAGETWO-87496  -->
+*   `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
 
-<!--- MAGETWO-87294 -->* An unused constructor dependency has been removed from the Product Link Save handler. *Fix submitted by Ihor Sviziev in pull request 13436*.
+<!--- MAGETWO-87294  -->
+*  An unused constructor dependency has been removed from the Product Link Save handler. *Fix submitted by Ihor Sviziev in pull request 13436*.
 
-<!--- MAGETWO-88116 -->* The Low Stock report now accurately lists all out-of-stock products. Previously, this report was not accurate when the All Websites view was selected. *Fix submitted by gwharton in pull request 13682*. [GitHub-10595](https://github.com/magento/magento2/issues/10595)
+<!--- MAGETWO-88116  -->
+*  The Low Stock report now accurately lists all out-of-stock products. Previously, this report was not accurate when the All Websites view was selected. *Fix submitted by gwharton in pull request 13682*. [GitHub-10595](https://github.com/magento/magento2/issues/10595)
 
-<!--- MAGETWO-85163 -->*  We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
+<!--- MAGETWO-85163  -->
+*   We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
 
-<!--- MAGETWO-85575 -->* Magento now correctly sets a `product_links` position attribute even when the attribute value is not set in a GET request. Previously, only the first two of each link type were shown in the backend or in a GET request response, even though Magento correctly added the product links to the database. *Fix submitted by Mohammad Haj-Salem in pull request 12650*.
+<!--- MAGETWO-85575  -->
+*  Magento now correctly sets a `product_links` position attribute even when the attribute value is not set in a GET request. Previously, only the first two of each link type were shown in the backend or in a GET request response, even though Magento correctly added the product links to the database. *Fix submitted by Mohammad Haj-Salem in pull request 12650*.
 
 ### Cart and checkout
 
-<!--- MAGETWO-83780 -->* Magento no longer adds addresses with `saveInAddressBook` set to **0**  to the address book for new customers. Previously, if you placed an order as a guest and set the `save_in_address_book` setting for an address to **0**, Magento still copied that address  to the customer address book when registering as a new customer on the checkout success page. [GitHub-7691](https://github.com/magento/magento2/issues/7691)
+<!--- MAGETWO-83780  -->
+*  Magento no longer adds addresses with `saveInAddressBook` set to **0**  to the address book for new customers. Previously, if you placed an order as a guest and set the `save_in_address_book` setting for an address to **0**, Magento still copied that address  to the customer address book when registering as a new customer on the checkout success page. [GitHub-7691](https://github.com/magento/magento2/issues/7691)
 
-<!--- MAGETWO-85297 -->* Magento no longer combines the Custom Checkout and Shipping steps when Magento loads the checkout page. *Fix submitted by Roman K. in pull request 975*.
+<!--- MAGETWO-85297  -->
+*  Magento no longer combines the Custom Checkout and Shipping steps when Magento loads the checkout page. *Fix submitted by Roman K. in pull request 975*.
 
-<!--- MAGETWO-85317 -->* You can now successfully change currency for an order before you complete the order. Previously, if you changed currency, when you  proceeded with  checkout by choosing as Bank Transfer Payment as Payment Method, Magento displayed, **Your credit card will be charged for**. *Fix submitted by Roman K. in pull request 993*. [GitHub-12526](https://github.com/magento/magento2/issues/12526)
+<!--- MAGETWO-85317  -->
+*  You can now successfully change currency for an order before you complete the order. Previously, if you changed currency, when you  proceeded with  checkout by choosing as Bank Transfer Payment as Payment Method, Magento displayed, **Your credit card will be charged for**. *Fix submitted by Roman K. in pull request 993*. [GitHub-12526](https://github.com/magento/magento2/issues/12526)
 
-<!--- MAGETWO-86506 -->* Magento no longer throws a JavaScript error on the cart from postcode validation when **United States** is deselected in the **Allowed Countries** Admin option (**Admin > Stores > Settings > Configuration > General > Default Country**). *Fix submitted by codekipple in pull request 13051*.
+<!--- MAGETWO-86506  -->
+*  Magento no longer throws a JavaScript error on the cart from postcode validation when **United States** is deselected in the **Allowed Countries** Admin option (**Admin > Stores > Settings > Configuration > General > Default Country**). *Fix submitted by codekipple in pull request 13051*.
 
-<!--- MAGETWO-86543 -->* Street format spacing when multiple streets are present is now consistent across **Shipping** and **Review & Payments** checkout steps. *Fix submitted by nfourteen in pull request 13082*.
+<!--- MAGETWO-86543  -->
+*  Street format spacing when multiple streets are present is now consistent across **Shipping** and **Review & Payments** checkout steps. *Fix submitted by nfourteen in pull request 13082*.
 
-<!--- MAGETWO-86896 -->* Magento now displays text on the New Cart Rules page correctly. Previously, labels listed in the Store View Specific Labels section of this page were sometimes truncated or duplicated. *Fix submitted by serhii-balko in pull request 1146*. [GitHub-12231](https://github.com/magento/magento2/issues/12231)
+<!--- MAGETWO-86896  -->
+*  Magento now displays text on the New Cart Rules page correctly. Previously, labels listed in the Store View Specific Labels section of this page were sometimes truncated or duplicated. *Fix submitted by serhii-balko in pull request 1146*. [GitHub-12231](https://github.com/magento/magento2/issues/12231)
 
-<!--- MAGETWO-86617 -->* When you check out as guest  and click **Create an account** on the success page, you can now click on the customer name to jump to the customer record. *Fix submitted by Renon Stewart in pull request 12998*.
+<!--- MAGETWO-86617  -->
+*  When you check out as guest  and click **Create an account** on the success page, you can now click on the customer name to jump to the customer record. *Fix submitted by Renon Stewart in pull request 12998*.
 
-<!--- MAGETWO-87340 -->* The `XML_PATH_CUSTOMER_MUST_BE_LOGGED` constant has been deprecated. *Fix submitted by Roman K. in pull request 1148*. [GitHub-7848](https://github.com/magento/magento2/issues/7848)
+<!--- MAGETWO-87340  -->
+*  The `XML_PATH_CUSTOMER_MUST_BE_LOGGED` constant has been deprecated. *Fix submitted by Roman K. in pull request 1148*. [GitHub-7848](https://github.com/magento/magento2/issues/7848)
 
-<!--- MAGETWO-88332 -->* `dropdownDialog` is now required when the minicart is available. *Fix submitted by Alexander Menk in pull request 13830*.
+<!--- MAGETWO-88332  -->
+*  `dropdownDialog` is now required when the minicart is available. *Fix submitted by Alexander Menk in pull request 13830*.
 
-<!--- MAGETWO-87196 -->* The Check Out with Multiple Addresses page now displays an empty state field as expected when a customer changes from one address to another. *Fix submitted by enriquei4 in pull request 13364*. [GitHub-8621](https://github.com/magento/magento2/issues/8621)
+<!--- MAGETWO-87196  -->
+*  The Check Out with Multiple Addresses page now displays an empty state field as expected when a customer changes from one address to another. *Fix submitted by enriquei4 in pull request 13364*. [GitHub-8621](https://github.com/magento/magento2/issues/8621)
 
 ### Configurable products
 
-<!--- MAGETWO-86781 -->* You can now use custom price symbols when assigning prices to configurable prices. Previously, Magento did not properly display prices for configurable products when you used a custom price symbol when assigning prices. *Fix submitted by pradeep-wagento in pull request 13025*. [GitHub-12430](https://github.com/magento/magento2/issues/12430)
+<!--- MAGETWO-86781  -->
+*  You can now use custom price symbols when assigning prices to configurable prices. Previously, Magento did not properly display prices for configurable products when you used a custom price symbol when assigning prices. *Fix submitted by pradeep-wagento in pull request 13025*. [GitHub-12430](https://github.com/magento/magento2/issues/12430)
 
-<!--- MAGETWO-86311 -->*  Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
+<!--- MAGETWO-86311  -->
+*   Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
 
-<!--- MAGETWO-85782 -->* Magento now displays elements of the **Catalog > Products > Create Configurations** page correctly. Previously, the currency symbol overlapped with the attribute option's price during creation of a configurable product. *Fix submitted by Vasilina in pull request*.
+<!--- MAGETWO-85782  -->
+*  Magento now displays elements of the **Catalog > Products > Create Configurations** page correctly. Previously, the currency symbol overlapped with the attribute option's price during creation of a configurable product. *Fix submitted by Vasilina in pull request*.
 
-<!--- MAGETWO-85777 -->* If you enter an invalid value for an SKU during the creation of the configurable product, Magento now displays a warning and does not let you save the product. Previously, you were not warned about invalid SKU values, and when you clicked **Save**, all the product information you entered was lost. *Fix submitted by Zamaroka in pull request 12737*. [GitHub-11953](https://github.com/magento/magento2/issues/11953)
+<!--- MAGETWO-85777  -->
+*  If you enter an invalid value for an SKU during the creation of the configurable product, Magento now displays a warning and does not let you save the product. Previously, you were not warned about invalid SKU values, and when you clicked **Save**, all the product information you entered was lost. *Fix submitted by Zamaroka in pull request 12737*. [GitHub-11953](https://github.com/magento/magento2/issues/11953)
 
-<!--- MAGETWO-85634 -->* Magento now correctly runs a partial attribute (EAV) reindex of configurable products whose child products' visibility is set to **Not Visible Individually**. *Fix submitted by Roman K. in pull request 1023*. [GitHub-12667](https://github.com/magento/magento2/issues/12667)
+<!--- MAGETWO-85634  -->
+*  Magento now correctly runs a partial attribute (EAV) reindex of configurable products whose child products' visibility is set to **Not Visible Individually**. *Fix submitted by Roman K. in pull request 1023*. [GitHub-12667](https://github.com/magento/magento2/issues/12667)
 
-<!--- MAGETWO-85286 -->*  Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
+<!--- MAGETWO-85286  -->
+*   Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
 
-<!--- MAGETWO-82888 -->* The product price indexer (`catalog_product_price reindex`) no longer stalls during reindexing.
+<!--- MAGETWO-82888  -->
+*  The product price indexer (`catalog_product_price reindex`) no longer stalls during reindexing.
 
-<!--- MAGETWO-86918 -->* Product records inside the `catalog_product_super_link` table are no longer updated needlessly when you save a configurable product. Previously, saving configurable product erased and then reinserted records in the `catalog_product_super_link` table even when child products were not changed. This practice quickly resulted in an unnecessarily large `catalog_product_super_link` table, especially in multi-website installations.
+<!--- MAGETWO-86918  -->
+*  Product records inside the `catalog_product_super_link` table are no longer updated needlessly when you save a configurable product. Previously, saving configurable product erased and then reinserted records in the `catalog_product_super_link` table even when child products were not changed. This practice quickly resulted in an unnecessarily large `catalog_product_super_link` table, especially in multi-website installations.
 
 ### Customer accounts
 
-<!--- MAGETWO-86427 -->* Magento now trims trailing and leading spaces when saving the name of a new contact. *Fix submitted by wardcapp in pull request 12964*. [GitHub-10415](https://github.com/magento/magento2/issues/10415)
+<!--- MAGETWO-86427  -->
+*  Magento now trims trailing and leading spaces when saving the name of a new contact. *Fix submitted by wardcapp in pull request 12964*. [GitHub-10415](https://github.com/magento/magento2/issues/10415)
 
-<!--- MAGETWO-85580 -->* We fixed the invalid parameter configuration that was provided for the `$block` argument of `Magento\\Ui\\Component\\HtmlContent`. *Fix submitted by Tomasz Gregorczyk in pull request 12964*.
+<!--- MAGETWO-85580  -->
+*  We fixed the invalid parameter configuration that was provided for the `$block` argument of `Magento\\Ui\\Component\\HtmlContent`. *Fix submitted by Tomasz Gregorczyk in pull request 12964*.
 
-<!--- MAGETWO-85300 -->* Magento now successfully sends email (with content) even when you make a mistake in the email template file name. Previously, when the template name was incorrect, Magento sent the email with no content. *Fix submitted by Roman K. in pull request 970*. [GitHub-8437](https://github.com/magento/magento2/issues/8437)
+<!--- MAGETWO-85300  -->
+*  Magento now successfully sends email (with content) even when you make a mistake in the email template file name. Previously, when the template name was incorrect, Magento sent the email with no content. *Fix submitted by Roman K. in pull request 970*. [GitHub-8437](https://github.com/magento/magento2/issues/8437)
 
-<!--- MAGETWO-85653 -->*  You can now import customer addresses from websites with country restrictions.
+<!--- MAGETWO-85653  -->
+*   You can now import customer addresses from websites with country restrictions.
 
-<!--- MAGETWO-84862 -->* Magento no longer displays the `Too many password reset requests` error when the **max wait time between password resets** setting has been disabled. Previously, when you attempted to reset a customer's password through the Admin, Magento threw an error even when you disabled the `max wait time between password resets` setting in the store configuration settings. *Fix submitted by Cole Hafner in pull request*. [GitHub-11409](https://github.com/magento/magento2/issues/11409)
+<!--- MAGETWO-84862  -->
+*  Magento no longer displays the `Too many password reset requests` error when the **max wait time between password resets** setting has been disabled. Previously, when you attempted to reset a customer's password through the Admin, Magento threw an error even when you disabled the `max wait time between password resets` setting in the store configuration settings. *Fix submitted by Cole Hafner in pull request*. [GitHub-11409](https://github.com/magento/magento2/issues/11409)
 
-<!--- MAGETWO-84439 -->* Magento no longer throws an exception when you try to open your account address book immediately after creating a customer. *Fix submitted by Chris Pook in pull request 12220*. [GitHub-12180](https://github.com/magento/magento2/issues/12180)
+<!--- MAGETWO-84439  -->
+*  Magento no longer throws an exception when you try to open your account address book immediately after creating a customer. *Fix submitted by Chris Pook in pull request 12220*. [GitHub-12180](https://github.com/magento/magento2/issues/12180)
 
-<!--- MAGETWO-83026 -->* The `isConfirmationRequired` method in the `AccountManagement` class is now public, which makes it available for plugins. (For example, you can now develop custom business logic to decide if confirmation is required (yes/no) for certain customers.) *Fix submitted by Derrick Heesbeen in pull request 11878*.
+<!--- MAGETWO-83026  -->
+*  The `isConfirmationRequired` method in the `AccountManagement` class is now public, which makes it available for plugins. (For example, you can now develop custom business logic to decide if confirmation is required (yes/no) for certain customers.) *Fix submitted by Derrick Heesbeen in pull request 11878*.
 
-<!--- MAGETWO-82635 -->* When configuring a customer account, you can now leave the prefix or suffix fields as optional. Previously, if you did not select an option for these fields, Magento defaulted to selecting the first option in the list. *Fix submitted by Andreas von Studnitz in pull request 11462*. [GitHub-7241](https://github.com/magento/magento2/issues/7241)
+<!--- MAGETWO-82635  -->
+*  When configuring a customer account, you can now leave the prefix or suffix fields as optional. Previously, if you did not select an option for these fields, Magento defaulted to selecting the first option in the list. *Fix submitted by Andreas von Studnitz in pull request 11462*. [GitHub-7241](https://github.com/magento/magento2/issues/7241)
 
-<!--- MAGETWO-85741 -->* The storefront **Back to Sign in** button now works as expected. Previously, when you clicked that button, Magento simply reloaded the current page. *Fix submitted by StasKozar in pull request 12759*. [GitHub-12715](https://github.com/magento/magento2/issues/12715)
+<!--- MAGETWO-85741  -->
+*  The storefront **Back to Sign in** button now works as expected. Previously, when you clicked that button, Magento simply reloaded the current page. *Fix submitted by StasKozar in pull request 12759*. [GitHub-12715](https://github.com/magento/magento2/issues/12715)
 
-<!--- MAGETWO-85672 -->* The `window.checkout.customerLoginUrl` now contains a URL that includes the referrer in base64 encoding (for example, https://myshop.com/customer/account/login/referrer/aHR0cHM6Ly9teXNob3AuY29tL2NoZWNrb3V0). Previously, the login URL did not include a referrer (for example, https://myshop.com/customer/account/login). *Fix submitted by Tommy Quissens in pull request 12630*. [GitHub-12627](https://github.com/magento/magento2/issues/12627)
+<!--- MAGETWO-85672  -->
+*  The `window.checkout.customerLoginUrl` now contains a URL that includes the referrer in base64 encoding (for example, https://myshop.com/customer/account/login/referrer/aHR0cHM6Ly9teXNob3AuY29tL2NoZWNrb3V0). Previously, the login URL did not include a referrer (for example, https://myshop.com/customer/account/login). *Fix submitted by Tommy Quissens in pull request 12630*. [GitHub-12627](https://github.com/magento/magento2/issues/12627)
 
-<!--- MAGETWO-86989 -->* When you are on the cart page and click a product's  **Edit** link, the product page now correctly displays the product quantity currently in the cart. *Fix submitted by Arnoud Beekman in pull request 13310*.
+<!--- MAGETWO-86989  -->
+*  When you are on the cart page and click a product's  **Edit** link, the product page now correctly displays the product quantity currently in the cart. *Fix submitted by Arnoud Beekman in pull request 13310*.
 
-<!--- MAGETWO-87657 -->* You can now create a custom attribute of type file for Customer objects as expected. Previously,  you could create the custom attribute, but the file would not upload. *Fix submitted by Mkennethsmith in pull request 13563*. [GitHub-11252](https://github.com/magento/magento2/issues/11252)
+<!--- MAGETWO-87657  -->
+*  You can now create a custom attribute of type file for Customer objects as expected. Previously,  you could create the custom attribute, but the file would not upload. *Fix submitted by Mkennethsmith in pull request 13563*. [GitHub-11252](https://github.com/magento/magento2/issues/11252)
 
-<!--- MAGETWO-87950 -->*  The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file.. *Fix submitted by Renon Stewart in pull request 13661*.
+<!--- MAGETWO-87950  -->
+*   The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file.. *Fix submitted by Renon Stewart in pull request 13661*.
 
-<!--- MAGETWO-71829 -->* The `is_subscribed` extended parameter is now returned when a web API is used to modify or return information about a customer.
+<!--- MAGETWO-71829  -->
+*  The `is_subscribed` extended parameter is now returned when a web API is used to modify or return information about a customer.
 
 ### Dashboard
 
-<!--- MAGETWO-86443 -->* The `top destinations` configuration field is now configurable on a store level. Previously, it was configurable on the global level only. *Fix submitted by Andreas von Studnitz in pull request 13052*.
+<!--- MAGETWO-86443  -->
+*  The `top destinations` configuration field is now configurable on a store level. Previously, it was configurable on the global level only. *Fix submitted by Andreas von Studnitz in pull request 13052*.
 
-<!--- MAGETWO-86205 -->* When multiple validation errors occur while saving a customer address, Magento now shows unique messages in the `adminhtml` customer edit page. *Fix submitted by adrian-martinez-interactiv4 in pull request 12922*.
+<!--- MAGETWO-86205  -->
+*  When multiple validation errors occur while saving a customer address, Magento now shows unique messages in the `adminhtml` customer edit page. *Fix submitted by adrian-martinez-interactiv4 in pull request 12922*.
 
-<!--- MAGETWO-86203 -->* The scroll bar on the Admin store switcher is now scrollable on machines running OSX. *Fix submitted by Juan Alonso in pull request 12931*.
+<!--- MAGETWO-86203  -->
+*  The scroll bar on the Admin store switcher is now scrollable on machines running OSX. *Fix submitted by Juan Alonso in pull request 12931*.
 
 ### Directory
 
-<!--- MAGETWO-85659 -->* The `\Magento\Directory\Model\PriceCurrency::format()` method no longer fails if you do not configure a conversion rate from the base to the specified currency. Previously, if you did not specify this conversion rate, Magento rendered the price (amount) in the base currency, not the specified currency. *Fix submitted by Nickolas Malyovanets in pull request 1022*. [GitHub-6965](https://github.com/magento/magento2/issues/6965)
+<!--- MAGETWO-85659  -->
+*  The `\Magento\Directory\Model\PriceCurrency::format()` method no longer fails if you do not configure a conversion rate from the base to the specified currency. Previously, if you did not specify this conversion rate, Magento rendered the price (amount) in the base currency, not the specified currency. *Fix submitted by Nickolas Malyovanets in pull request 1022*. [GitHub-6965](https://github.com/magento/magento2/issues/6965)
 
-<!--- MAGETWO-85583 -->* Magento now requires that customers select State/Province when shipping orders to India, and the checkout page now provides a drop-down field with appropriate values. *Fix submitted by p-bystritsky in pull request*. [GitHub-12378](https://github.com/magento/magento2/issues/12378)
+<!--- MAGETWO-85583  -->
+*  Magento now requires that customers select State/Province when shipping orders to India, and the checkout page now provides a drop-down field with appropriate values. *Fix submitted by p-bystritsky in pull request*. [GitHub-12378](https://github.com/magento/magento2/issues/12378)
 
-<!--- MAGETWO-86170 -->* You can now disable the **State is Required for** field. *Fix submitted by Burlacu Vasilii in pull request 12917*. [GitHub-12894](https://github.com/magento/magento2/issues/12894)
+<!--- MAGETWO-86170  -->
+*  You can now disable the **State is Required for** field. *Fix submitted by Burlacu Vasilii in pull request 12917*. [GitHub-12894](https://github.com/magento/magento2/issues/12894)
 
 ### EAV attributes
 
-<!--- MAGETWO-86240 -->* Creating new configuration attributes no longer causes naming collisions in the JavaScript UI registry. Previously, when you created a new default attribute and then subsequently created a new product, JavaScript errors occurred.  *Fix submitted by Volodymyr Zaets in pull request 12945*. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-86240  -->
+*  Creating new configuration attributes no longer causes naming collisions in the JavaScript UI registry. Previously, when you created a new default attribute and then subsequently created a new product, JavaScript errors occurred.  *Fix submitted by Volodymyr Zaets in pull request 12945*. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
-<!--- MAGETWO-85875 -->* You can now use a single query to retrieve attribute groups from multiple attribute sets. *Fix submitted by Marius Strajeru in pull request 12105*. [GitHub-11936](https://github.com/magento/magento2/issues/11936)
+<!--- MAGETWO-85875  -->
+*  You can now use a single query to retrieve attribute groups from multiple attribute sets. *Fix submitted by Marius Strajeru in pull request 12105*. [GitHub-11936](https://github.com/magento/magento2/issues/11936)
 
-<!--- MAGETWO-85772 -->* Magento now saves multiselect attribute for a product that has a related product using another attribute set. Previously, multiselect attribute values were not saved for a product in the Admin panel when it had a related product that used another attribute set. *Fix submitted by awarche in pull request 12767*.
+<!--- MAGETWO-85772  -->
+*  Magento now saves multiselect attribute for a product that has a related product using another attribute set. Previously, multiselect attribute values were not saved for a product in the Admin panel when it had a related product that used another attribute set. *Fix submitted by awarche in pull request 12767*.
 
-<!--- MAGETWO-85579 -->* The product attribute repository save method  no longer resets the source model to null when you create a new product attribute through code. *Fix submitted by Nickolas Malyovanets in pull request 1012*. [GitHub-10814](https://github.com/magento/magento2/issues/10814)
+<!--- MAGETWO-85579  -->
+*  The product attribute repository save method  no longer resets the source model to null when you create a new product attribute through code. *Fix submitted by Nickolas Malyovanets in pull request 1012*. [GitHub-10814](https://github.com/magento/magento2/issues/10814)
 
-<!--- MAGETWO-85302 -->* Magento now uses the correct  `entity_model` in `table eav_entity_type` for invoices (`Magento\Sales\Model\ResourceModel\Order\Invoice`). Previously, in `table eav_entity_type` for `entity_type_code = "invoice"` the `entity_model` was `Magento\Sales\Model\ResourceModel\Order`. *Fix submitted by Nickolas Malyovanets in pull request 980*. [GitHub-10123](https://github.com/magento/magento2/issues/10123)
+<!--- MAGETWO-85302  -->
+*  Magento now uses the correct  `entity_model` in `table eav_entity_type` for invoices (`Magento\Sales\Model\ResourceModel\Order\Invoice`). Previously, in `table eav_entity_type` for `entity_type_code = "invoice"` the `entity_model` was `Magento\Sales\Model\ResourceModel\Order`. *Fix submitted by Nickolas Malyovanets in pull request 980*. [GitHub-10123](https://github.com/magento/magento2/issues/10123)
 
-<!--- MAGETWO-84272 -->* When a validation message is returned, Magento no longer displays the attribute code (`$attrCode`), but instead returns the label (`$label`). This change makes it easier to translate messages. *Fix submitted by Hewerson Freitas in pull request 12120*.
+<!--- MAGETWO-84272  -->
+*  When a validation message is returned, Magento no longer displays the attribute code (`$attrCode`), but instead returns the label (`$label`). This change makes it easier to translate messages. *Fix submitted by Hewerson Freitas in pull request 12120*.
 
-<!--- MAGETWO-72597 -->* You can now perform a mass update on products that have more than 60 attributes.
+<!--- MAGETWO-72597  -->
+*  You can now perform a mass update on products that have more than 60 attributes.
 
-<!--- MAGETWO-85833 -->* `Magento\Eav\Model\Config::getAttribute` now stops the Profiler before it returns Profiler run time. Previously, `Magento\Eav\Model\Config::getAttribute` did not stop the Profiler from returning early, and consequently reported incorrect run time. *Fix submitted by Nick Anstee in pull request 12810*.
+<!--- MAGETWO-85833  -->
+*  `Magento\Eav\Model\Config::getAttribute` now stops the Profiler before it returns Profiler run time. Previously, `Magento\Eav\Model\Config::getAttribute` did not stop the Profiler from returning early, and consequently reported incorrect run time. *Fix submitted by Nick Anstee in pull request 12810*.
 
-<!--- MAGETWO-87588 -->*  The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product, and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
+<!--- MAGETWO-87588  -->
+*   The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product, and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
 
-<!--- MAGETWO-87354 -->* The deprecated `each()` function has been removed from the code. *Fix submitted by Ihor Sviziev in pull request*.
+<!--- MAGETWO-87354  -->
+*  The deprecated `each()` function has been removed from the code. *Fix submitted by Ihor Sviziev in pull request*.
 
 ### Email
 
-<!--- MAGETWO-83741 -->* Order confirmation emails from the Admin in multistore environments no longer default to the primary store, but instead are sent from the store that the customer used. *Fix submitted by Roman K. in pull request*. [GitHub-11740](https://github.com/magento/magento2/issues/11740)
+<!--- MAGETWO-83741  -->
+*  Order confirmation emails from the Admin in multistore environments no longer default to the primary store, but instead are sent from the store that the customer used. *Fix submitted by Roman K. in pull request*. [GitHub-11740](https://github.com/magento/magento2/issues/11740)
 
-<!--- MAGETWO-86881 -->* Magento no longer sends misleading feedback when sending tracking information email. Previously, instead of sending a notice that a shipment was underway, this response was sent, **You sent the shipment**. *Fix submitted by Nickolas Malyovanets in pull request 1245*. [GitHub-5697](https://github.com/magento/magento2/issues/5697)
+<!--- MAGETWO-86881  -->
+*  Magento no longer sends misleading feedback when sending tracking information email. Previously, instead of sending a notice that a shipment was underway, this response was sent, **You sent the shipment**. *Fix submitted by Nickolas Malyovanets in pull request 1245*. [GitHub-5697](https://github.com/magento/magento2/issues/5697)
 
 ### Frameworks
 
-<!--- MAGETWO-86337 -->* You can now switch to default mode from production mode. Previously, if you tried to switch back to default mode, Magento displayed this error, `Cannot switch into given mode 'default'`. *Fix submitted by Etty in pull request 12752*. [GitHub-4292](https://github.com/magento/magento2/issues/4292)
+<!--- MAGETWO-86337  -->
+*  You can now switch to default mode from production mode. Previously, if you tried to switch back to default mode, Magento displayed this error, `Cannot switch into given mode 'default'`. *Fix submitted by Etty in pull request 12752*. [GitHub-4292](https://github.com/magento/magento2/issues/4292)
 
-<!--- MAGETWO- 86654-->* `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*. [GitHub-12967](https://github.com/magento/magento2/issues/12967)
+<!--- MAGETWO- 86654 -->
+*  `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*. [GitHub-12967](https://github.com/magento/magento2/issues/12967)
 
-<!--- MAGETWO-85290 -->* The `filePutContents('file.txt')` now contains content as expected. Previously, Magento threw this error, `The specified "file.text" file could not be written`.  *Fix submitted by Nickolas Malyovanets in pull request 962*. [GitHub-7467](https://github.com/magento/magento2/issues/7467)
+<!--- MAGETWO-85290  -->
+*  The `filePutContents('file.txt')` now contains content as expected. Previously, Magento threw this error, `The specified "file.text" file could not be written`.  *Fix submitted by Nickolas Malyovanets in pull request 962*. [GitHub-7467](https://github.com/magento/magento2/issues/7467)
 
-<!--- MAGETWO-85770 -->* You can now subscribe to events that contain a number in their name.  *Fix submitted by Mobecls in pull request 12758*. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
+<!--- MAGETWO-85770  -->
+*  You can now subscribe to events that contain a number in their name.  *Fix submitted by Mobecls in pull request 12758*. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
 
-<!--- MAGETWO-85872 -->* PhpDoc now shows correct parameter types. Previously, PhpDoc showed only a type of `string`, although `array` was also a valid parameter type. *Fix submitted by Freek Vandeursen in pull request 12826*.
+<!--- MAGETWO-85872  -->
+*  PhpDoc now shows correct parameter types. Previously, PhpDoc showed only a type of `string`, although `array` was also a valid parameter type. *Fix submitted by Freek Vandeursen in pull request 12826*.
 
-<!--- MAGETWO-86484 -->* Content no longer jumps when pages are reloaded on the Admin because  `notices-wrapper` now has a `min-height` setting. *Fix submitted by Anna Völkl in pull request 12985*.
+<!--- MAGETWO-86484  -->
+*  Content no longer jumps when pages are reloaded on the Admin because  `notices-wrapper` now has a `min-height` setting. *Fix submitted by Anna Völkl in pull request 12985*.
 
-<!--- MAGETWO-86277 -->* We've corrected a typo in the `Magento\Ui\Controller\Adminhtml\Index\Render` action. *Fix submitted by Nick in pull request 12951*.
+<!--- MAGETWO-86277  -->
+*  We've corrected a typo in the `Magento\Ui\Controller\Adminhtml\Index\Render` action. *Fix submitted by Nick in pull request 12951*.
 
-<!--- MAGETWO-86154 -->* `X-Magento-Vary` and `PHPSESSID` now have the same expiration time. Previously, the  `X-Magento-Vary` cookie had an expiration of `session`, which meant it was not considered expired until the browser was closed. In contrast, the `PHPSESSID` cookie had a finite expiration time (not `session`). At times, this resulted in  Magento caching the wrong page for the logged-in user.
+<!--- MAGETWO-86154  -->
+*  `X-Magento-Vary` and `PHPSESSID` now have the same expiration time. Previously, the  `X-Magento-Vary` cookie had an expiration of `session`, which meant it was not considered expired until the browser was closed. In contrast, the `PHPSESSID` cookie had a finite expiration time (not `session`). At times, this resulted in  Magento caching the wrong page for the logged-in user.
 
-<!--- MAGETWO-85992 -->* `\Magento\Config\Model\Config\Structure\Reader::processingDocument`  now throws a more helpful validation exception. *Fix submitted by Patrick McLain in pull request 12859*.
+<!--- MAGETWO-85992  -->
+*  `\Magento\Config\Model\Config\Structure\Reader::processingDocument`  now throws a more helpful validation exception. *Fix submitted by Patrick McLain in pull request 12859*.
 
-<!--- MAGETWO-88146 -->* Creating an observer that uses `ObserverInterface` no longer triggers a patch-level dependency on `magento/framework`. *Fix submitted by Kristof in pull request 13759*.
+<!--- MAGETWO-88146  -->
+*  Creating an observer that uses `ObserverInterface` no longer triggers a patch-level dependency on `magento/framework`. *Fix submitted by Kristof in pull request 13759*.
 
-<!--- MAGETWO-88115 -->* RewriteBase directive has been added to the `.htaccess` file in `pub/static` to support the potential installation of Magento code under a directory inside the web root. *Fix submitted by Cristiano Casciotti in pull request 13678*.
+<!--- MAGETWO-88115  -->
+*  RewriteBase directive has been added to the `.htaccess` file in `pub/static` to support the potential installation of Magento code under a directory inside the web root. *Fix submitted by Cristiano Casciotti in pull request 13678*.
 
-<!--- MAGETWO-87261 -->*  The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
+<!--- MAGETWO-87261  -->
+*   The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
 
-<!--- MAGETWO-82069 -->* The report processor now returns an HTTP 500 status code (which better communicates the need for user action) instead of a 503 status code. *Fix submitted by Andrew Howden in pull request 11513*. [GitHub-11512](https://github.com/magento/magento2/issues/11512)
+<!--- MAGETWO-82069  -->
+*  The report processor now returns an HTTP 500 status code (which better communicates the need for user action) instead of a 503 status code. *Fix submitted by Andrew Howden in pull request 11513*. [GitHub-11512](https://github.com/magento/magento2/issues/11512)
 
 #### App framework
 
-<!--- MAGETWO-81802 -->* The customer grid indexer now works as expected.  Previously, this indexer did not work when reindexing using the command-line interface during upgrade. *Fix submitted by Leonid Poluyanov in pull request 10838*. [GitHub-10838](https://github.com/magento/magento2/issues/10838)
+<!--- MAGETWO-81802  -->
+*  The customer grid indexer now works as expected.  Previously, this indexer did not work when reindexing using the command-line interface during upgrade. *Fix submitted by Leonid Poluyanov in pull request 10838*. [GitHub-10838](https://github.com/magento/magento2/issues/10838)
 
-<!--- MAGETWO-80223 -->*  `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
+<!--- MAGETWO-80223  -->
+*   `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
 
-<!--- MAGETWO-84003 -->*  The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
+<!--- MAGETWO-84003  -->
+*   The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
 
-<!--- MAGETWO-84016 -->* Customers with an empty **Date of Birth** field can now be saved even when the field is not marked (or checked on the JavaScript side) as mandatory. *Fix submitted by Vova Yatsyuk in pull request 12302*. [GitHub-12146](https://github.com/magento/magento2/issues/12146)
+<!--- MAGETWO-84016  -->
+*  Customers with an empty **Date of Birth** field can now be saved even when the field is not marked (or checked on the JavaScript side) as mandatory. *Fix submitted by Vova Yatsyuk in pull request 12302*. [GitHub-12146](https://github.com/magento/magento2/issues/12146)
 
-<!--- MAGETWO-84371 -->* You can now alter the transport variable in the `email_invoice_set_template_vars_before` event. *Fix submitted by Roman K. in pull request 12132*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!--- MAGETWO-84371  -->
+*  You can now alter the transport variable in the `email_invoice_set_template_vars_before` event. *Fix submitted by Roman K. in pull request 12132*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!--- MAGETWO-84372 -->* Validation of South Korean zip codes now supports current South Korean zip code format. *Fix submitted by Roman K. in pull request 903*. [GitHub-9515](https://github.com/magento/magento2/issues/9515)
+<!--- MAGETWO-84372  -->
+*  Validation of South Korean zip codes now supports current South Korean zip code format. *Fix submitted by Roman K. in pull request 903*. [GitHub-9515](https://github.com/magento/magento2/issues/9515)
 
 #### Configuration framework
 
-<!--- MAGETWO-84464 -->* Scope-based configuration now decrypts data as expected. Previously, scope-based configuration failed to decrypt data on the default store only. *Fix submitted by DubovykOleksandr in pull request 8591*.
+<!--- MAGETWO-84464  -->
+*  Scope-based configuration now decrypts data as expected. Previously, scope-based configuration failed to decrypt data on the default store only. *Fix submitted by DubovykOleksandr in pull request 8591*.
 
 #### JavaScript framework
 
-<!--- MAGETWO-83401 -->* The `depends` field now works for fields of type `radio` in `system.xml`. *Fix submitted by Javier Villanueva in pull request 11539*.
+<!--- MAGETWO-83401  -->
+*  The `depends` field now works for fields of type `radio` in `system.xml`. *Fix submitted by Javier Villanueva in pull request 11539*.
 
-<!--- MAGETWO-83993 -->* Magento now sorts fields and amounts as expected  when you extend a dynamic-row element in a `ui_component` and add a sort order attribute with an amount that falls between the other elements' amount. *Fix submitted by Harald Deiser in pull request 11846*.
+<!--- MAGETWO-83993  -->
+*  Magento now sorts fields and amounts as expected  when you extend a dynamic-row element in a `ui_component` and add a sort order attribute with an amount that falls between the other elements' amount. *Fix submitted by Harald Deiser in pull request 11846*.
 
 #### Session framework
 
-<!--- MAGETWO-83373 -->* The Setup Wizard page now loads successfully when the session storage method is memcache.  Previously, Magento returned an HTTP 500 error when you navigated to **System > Tools > Web Setup Wizard Setup Wizard**  in installations where you've configured the session storage method to memcache in `env.php`. *Fix submitted by Marty S in pull request 11608*. [GitHub-9633](https://github.com/magento/magento2/issues/9633)
+<!--- MAGETWO-83373  -->
+*  The Setup Wizard page now loads successfully when the session storage method is memcache.  Previously, Magento returned an HTTP 500 error when you navigated to **System > Tools > Web Setup Wizard Setup Wizard**  in installations where you've configured the session storage method to memcache in `env.php`. *Fix submitted by Marty S in pull request 11608*. [GitHub-9633](https://github.com/magento/magento2/issues/9633)
 
-<!--- MAGETWO-83287 -->* When you add a product to your wish list after logging out, Magento now redirects you to your account wish list page and adds the product. Previously, you were redirected to your wish list page, but Magento did not add the product. *Fix submitted by Oscar Recio in pull request 12038*. [GitHub-11825](https://github.com/magento/magento2/issues/11825)
+<!--- MAGETWO-83287  -->
+*  When you add a product to your wish list after logging out, Magento now redirects you to your account wish list page and adds the product. Previously, you were redirected to your wish list page, but Magento did not add the product. *Fix submitted by Oscar Recio in pull request 12038*. [GitHub-11825](https://github.com/magento/magento2/issues/11825)
 
-<!--- MAGETWO-86880 -->* Anonymous calls using REST no longer trigger the creation of PHP sessions. *Fix submitted by serhii-balko in pull request 1247*. [GitHub-7213](https://github.com/magento/magento2/issues/7213)
+<!--- MAGETWO-86880  -->
+*  Anonymous calls using REST no longer trigger the creation of PHP sessions. *Fix submitted by serhii-balko in pull request 1247*. [GitHub-7213](https://github.com/magento/magento2/issues/7213)
 
 #### Web API framework
 
-<!--- MAGETWO-83854 -->* A user who has been denied permissions for negotiable quote editing can now create customer addresses.
+<!--- MAGETWO-83854  -->
+*  A user who has been denied permissions for negotiable quote editing can now create customer addresses.
 
-<!--- MAGETWO-84979 -->* Swagger now works as expected on instances of Magento that are running on non-standard ports. *Fix submitted by JeroenVanLeusden in pull request 12541*.
+<!--- MAGETWO-84979  -->
+*  Swagger now works as expected on instances of Magento that are running on non-standard ports. *Fix submitted by JeroenVanLeusden in pull request 12541*.
 
-<!--- MAGETWO-84994 -->* You can now set attribute values to empty strings using REST. Previously, Magento would not let you use REST to pass the following attributes with empty values: `special_from_date`, `special_to_date`, and `special_price`. *Fix submitted by Roman K. in pull request 916*. [GitHub-8862](https://github.com/magento/magento2/issues/8862)
+<!--- MAGETWO-84994  -->
+*  You can now set attribute values to empty strings using REST. Previously, Magento would not let you use REST to pass the following attributes with empty values: `special_from_date`, `special_to_date`, and `special_price`. *Fix submitted by Roman K. in pull request 916*. [GitHub-8862](https://github.com/magento/magento2/issues/8862)
 
-<!--- MAGETWO-85534 -->* We've updated the `webapi` module to improve the order of how arguments are merged in multiple `di.xml` files. *Fix submitted by serhii-balko in pull request 995*. [GitHub-8647](https://github.com/magento/magento2/issues/8647)
+<!--- MAGETWO-85534  -->
+*  We've updated the `webapi` module to improve the order of how arguments are merged in multiple `di.xml` files. *Fix submitted by serhii-balko in pull request 995*. [GitHub-8647](https://github.com/magento/magento2/issues/8647)
 
-<!--- MAGETWO-85538 -->* `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets in pull request 1003*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
+<!--- MAGETWO-85538  -->
+*  `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets in pull request 1003*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
 
-<!--- MAGETWO-84666 -->* Anonymous Web API access to the Admin now unlocks REST catalog calls without requiring `auth` tokens. *Fix submitted by Roman K. in pull request 904*. [GitHub-9468](https://github.com/magento/magento2/issues/9468)
+<!--- MAGETWO-84666  -->
+*  Anonymous Web API access to the Admin now unlocks REST catalog calls without requiring `auth` tokens. *Fix submitted by Roman K. in pull request 904*. [GitHub-9468](https://github.com/magento/magento2/issues/9468)
 
 #### Zend framework
 
-<!--- MAGETWO-86654 -->* `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*.
+<!--- MAGETWO-86654  -->
+*  `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*.
 
 ### General
 
-<!--- MAGETWO-86727 -->*  A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
+<!--- MAGETWO-86727  -->
+*   A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
 
-<!--- MAGETWO-87341 -->* Magento now displays notification messages for only the expected duration. Previously, Magento displayed these messages indefinitely within a session. *Fix submitted by p-bystritsky in pull request 1111*. [GitHub-11527](https://github.com/magento/magento2/issues/11527)
+<!--- MAGETWO-87341  -->
+*  Magento now displays notification messages for only the expected duration. Previously, Magento displayed these messages indefinitely within a session. *Fix submitted by p-bystritsky in pull request 1111*. [GitHub-11527](https://github.com/magento/magento2/issues/11527)
 
-<!--- MAGETWO-87342 -->*  Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
+<!--- MAGETWO-87342  -->
+*   Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
 
-<!--- MAGETWO-86748 -->* We've removed the `Magento\ProductAlert\Controller\Add\TestObserver` class. *Fix submitted by Alexander Shkurko in pull request 13174*.
+<!--- MAGETWO-86748  -->
+*  We've removed the `Magento\ProductAlert\Controller\Add\TestObserver` class. *Fix submitted by Alexander Shkurko in pull request 13174*.
 
-<!--- MAGETWO-86722 -->* In the top-level README file in the Magento Open Source repository, all links to DevDocs have been updated to 2.2. *Fix submitted by Bhargav Mehta in pull request 13161*.
+<!--- MAGETWO-86722  -->
+*  In the top-level README file in the Magento Open Source repository, all links to DevDocs have been updated to 2.2. *Fix submitted by Bhargav Mehta in pull request 13161*.
 
-<!--- MAGETWO-87033 -->* Elements within an array in `store_website` table are now correctly formatted. *Fix submitted by Nolwennig Guilbert in pull request 13324*.
+<!--- MAGETWO-87033  -->
+*  Elements within an array in `store_website` table are now correctly formatted. *Fix submitted by Nolwennig Guilbert in pull request 13324*.
 
-<!--- MAGETWO-86886 -->* A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. *Fix submitted by p-bystritsky in pull request 12993*. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
+<!--- MAGETWO-86886  -->
+*  A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. *Fix submitted by p-bystritsky in pull request 12993*. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
 
-<!--- MAGETWO-86883 -->*  The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
+<!--- MAGETWO-86883  -->
+*   The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
 
-<!--- MAGETWO-86840 -->* The `<![CDATA[]]>` statement in the `system.xml` file  now works as expected. Previously, when you entered an XML layout update with CDATA for the first time,  it worked as expected. After you saved the file, however, the `CDATA` tag disappeared. *Fix submitted by serhii-balko in pull request 1163*. [GitHub-12322](https://github.com/magento/magento2/issues/12322)
+<!--- MAGETWO-86840  -->
+*  The `<![CDATA[]]>` statement in the `system.xml` file  now works as expected. Previously, when you entered an XML layout update with CDATA for the first time,  it worked as expected. After you saved the file, however, the `CDATA` tag disappeared. *Fix submitted by serhii-balko in pull request 1163*. [GitHub-12322](https://github.com/magento/magento2/issues/12322)
 
-<!--- MAGETWO-87899 -->* Magento now strips out unnecessary whitespace in the attribute value IDs used on the review form. Previously, rating titles with whitespace resulted in broken ID attributes. *Fix submitted by Nickolas Malyovanets in pull request 1119*. [GitHub-5451](https://github.com/magento/magento2/issues/5451)
+<!--- MAGETWO-87899  -->
+*  Magento now strips out unnecessary whitespace in the attribute value IDs used on the review form. Previously, rating titles with whitespace resulted in broken ID attributes. *Fix submitted by Nickolas Malyovanets in pull request 1119*. [GitHub-5451](https://github.com/magento/magento2/issues/5451)
 
-<!--- MAGETWO-86723 -->* The header label **Price** in the invoice PDF is now correctly aligned with the invoice item's price. *Fix submitted by serhii-balko in pull request 1216*. [GitHub-8453](https://github.com/magento/magento2/issues/8453)
+<!--- MAGETWO-86723  -->
+*  The header label **Price** in the invoice PDF is now correctly aligned with the invoice item's price. *Fix submitted by serhii-balko in pull request 1216*. [GitHub-8453](https://github.com/magento/magento2/issues/8453)
 
-<!--- MAGETWO-86630 -->* Google Analytics `pageview` is no longer triggered twice. *Fix submitted by Bhargav Mehta in pull request 13034*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
+<!--- MAGETWO-86630  -->
+*  Google Analytics `pageview` is no longer triggered twice. *Fix submitted by Bhargav Mehta in pull request 13034*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
 
-<!--- MAGETWO-86564 -->* Minor display issues on the Magento home product page  have been resolved.  *Fix submitted by Punit Vaswani in pull request 13081*. [GitHub-11796](https://github.com/magento/magento2/issues/11796)
+<!--- MAGETWO-86564  -->
+*  Minor display issues on the Magento home product page  have been resolved.  *Fix submitted by Punit Vaswani in pull request 13081*. [GitHub-11796](https://github.com/magento/magento2/issues/11796)
 
-<!--- MAGETWO-88145 -->*  We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
+<!--- MAGETWO-88145  -->
+*   We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
 
-<!--- MAGETWO-86433 -->* The copyright year has been updated to 2018. *Fix submitted by Bhargav Mehta in pull request 13027*.
+<!--- MAGETWO-86433  -->
+*  The copyright year has been updated to 2018. *Fix submitted by Bhargav Mehta in pull request 13027*.
 
-<!--- MAGETWO-86431 -->* Magento now displays the Contact Us page in the menu as expected. Previously, Magento displayed unnecessary space between the category page and the main footer. *Fix submitted by Sanjay Patel in pull request 13026*. [GitHub-12601](https://github.com/magento/magento2/issues/12601)
+<!--- MAGETWO-86431  -->
+*  Magento now displays the Contact Us page in the menu as expected. Previously, Magento displayed unnecessary space between the category page and the main footer. *Fix submitted by Sanjay Patel in pull request 13026*. [GitHub-12601](https://github.com/magento/magento2/issues/12601)
 
-<!--- MAGETWO-86248 -->* The `Learn More Link` widget option in the Recently Viewed Products widget now respects its setting. *Fix submitted by JeroenVanLeusden in pull request 12946*.
+<!--- MAGETWO-86248  -->
+*  The `Learn More Link` widget option in the Recently Viewed Products widget now respects its setting. *Fix submitted by JeroenVanLeusden in pull request 12946*.
 
-<!--- MAGETWO-86035 -->* An unused `if` statement in the order invoice `Save.php` has been removed. *Fix submitted by JeroenVanLeusden in pull request 12887*.
+<!--- MAGETWO-86035  -->
+*  An unused `if` statement in the order invoice `Save.php` has been removed. *Fix submitted by JeroenVanLeusden in pull request 12887*.
 
-<!--- MAGETWO-85780 -->* The `sid` variable no longer appears in the storefront URL even if it has been  disabled in the Admin. Previously, even when the Magento setting **General > Web > Session Validation Settings > Use SID on Storefront** was set to **No**, the `sid` variable no longer appears in the URL. *Fix submitted by Roman Strelenko in pull request 12743*. [GitHub-9453](https://github.com/magento/magento2/issues/9453)
+<!--- MAGETWO-85780  -->
+*  The `sid` variable no longer appears in the storefront URL even if it has been  disabled in the Admin. Previously, even when the Magento setting **General > Web > Session Validation Settings > Use SID on Storefront** was set to **No**, the `sid` variable no longer appears in the URL. *Fix submitted by Roman Strelenko in pull request 12743*. [GitHub-9453](https://github.com/magento/magento2/issues/9453)
 
-<!--- MAGETWO-85779 -->* The menu item handling has been refactored to read item data from two different sources:
+<!--- MAGETWO-85779  -->
+*  The menu item handling has been refactored to read item data from two different sources:
 
     * from original XML definition if the cache is empty
     * from transformed item data when available in the cache. *Fix submitted by Pavel in pull request 12747*. [GitHub-9720](https://github.com/magento/magento2/issues/9720)
 
-<!--- MAGETWO-85773 -->* A typo in the `SINGLE_PRODUCT_LAYOUT_HANLDE` constant has been fixed. *Fix submitted by Andreas Schrammel in pull request 12786*.
+<!--- MAGETWO-85773  -->
+*  A typo in the `SINGLE_PRODUCT_LAYOUT_HANLDE` constant has been fixed. *Fix submitted by Andreas Schrammel in pull request 12786*.
 
-<!--- MAGETWO-85713 -->*  The tracking link no longer returns a 404 error in the Admin. *Fix submitted by Ihor Sviziev in pull request*. [GitHub-12206](https://github.com/magento/magento2/issues/12206)
+<!--- MAGETWO-85713  -->
+*   The tracking link no longer returns a 404 error in the Admin. *Fix submitted by Ihor Sviziev in pull request*. [GitHub-12206](https://github.com/magento/magento2/issues/12206)
 
-<!--- MAGETWO-85643 -->* The product option value price calculation has been improved. Previously, tier prices and customs options were not calculated correctly. *Fix submitted by Marina Gociu in pull request 11563*. [GitHub-5774](https://github.com/magento/magento2/issues/5774)
+<!--- MAGETWO-85643  -->
+*  The product option value price calculation has been improved. Previously, tier prices and customs options were not calculated correctly. *Fix submitted by Marina Gociu in pull request 11563*. [GitHub-5774](https://github.com/magento/magento2/issues/5774)
 
-<!--- MAGETWO-85610 -->* White space that is prepended to a coupon code no longer causes an error. Previously, Magento did not apply the coupon and displayed this message: `Coupon code is not valid`. *Fix submitted by Roman K. in pull request 1021*. [GitHub-12656](https://github.com/magento/magento2/issues/12656)
+<!--- MAGETWO-85610  -->
+*  White space that is prepended to a coupon code no longer causes an error. Previously, Magento did not apply the coupon and displayed this message: `Coupon code is not valid`. *Fix submitted by Roman K. in pull request 1021*. [GitHub-12656](https://github.com/magento/magento2/issues/12656)
 
-<!--- MAGETWO-85502 -->* The **modified** date field on editing pages is now updated as expected. *Fix submitted by Oscar Recio in pull request*. [GitHub-12625](https://github.com/magento/magento2/issues/12625)
+<!--- MAGETWO-85502  -->
+*  The **modified** date field on editing pages is now updated as expected. *Fix submitted by Oscar Recio in pull request*. [GitHub-12625](https://github.com/magento/magento2/issues/12625)
 
-<!--- MAGETWO-85499 -->* Links to Magento Connect on the Partners and Extensions page have been removed and replaced with links to Magento Marketplace. *Fix submitted by Miguel Balparda in pull request 12633*. [GitHub-12632](https://github.com/magento/magento2/issues/12632)
+<!--- MAGETWO-85499  -->
+*  Links to Magento Connect on the Partners and Extensions page have been removed and replaced with links to Magento Marketplace. *Fix submitted by Miguel Balparda in pull request 12633*. [GitHub-12632](https://github.com/magento/magento2/issues/12632)
 
-<!--- MAGETWO-85298 -->* HTML tags have been removed from the display of  attribute names in the dropdown menu of the Catalog Product list. *Fix submitted by Nickolas Malyovanets in pull request 968*. [GitHub-8011](https://github.com/magento/magento2/issues/8011)
+<!--- MAGETWO-85298  -->
+*  HTML tags have been removed from the display of  attribute names in the dropdown menu of the Catalog Product list. *Fix submitted by Nickolas Malyovanets in pull request 968*. [GitHub-8011](https://github.com/magento/magento2/issues/8011)
 
-<!--- MAGETWO-85207 -->* Magento now displays the orders that are associated with customer accounts on the Orders page.  Previously, in the Admin display of customer accounts that have orders associated with them, Magento did not display  orders on the  Orders tab but instead displayed a blank page.
+<!--- MAGETWO-85207  -->
+*  Magento now displays the orders that are associated with customer accounts on the Orders page.  Previously, in the Admin display of customer accounts that have orders associated with them, Magento did not display  orders on the  Orders tab but instead displayed a blank page.
 
-<!--- MAGETWO-81128 -->* The credit card form is now available when you create an order from the Admin, even when only one payment method is enabled. Previously, when only one payment method was enabled, the Admin did not render this form.
+<!--- MAGETWO-81128  -->
+*  The credit card form is now available when you create an order from the Admin, even when only one payment method is enabled. Previously, when only one payment method was enabled, the Admin did not render this form.
 
-<!--- MAGETWO-72865 -->* Full Page Cache is no longer invalidated after you save a predictor category. Previously, all product-related cache data was invalidated, when only a narrow subset of cache tags associated with the `product_id` should have been.
+<!--- MAGETWO-72865  -->
+*  Full Page Cache is no longer invalidated after you save a predictor category. Previously, all product-related cache data was invalidated, when only a narrow subset of cache tags associated with the `product_id` should have been.
 
-<!--- MAGETWO-88040 -->*  Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
+<!--- MAGETWO-88040  -->
+*   Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
 
-<!--- MAGETWO-87908 -->* Magento now displays a more meaningful error message when a module name is misspelled in `registration.php`. *Fix submitted by Jānis Elmeris in pull request 12843*.
+<!--- MAGETWO-87908  -->
+*  Magento now displays a more meaningful error message when a module name is misspelled in `registration.php`. *Fix submitted by Jānis Elmeris in pull request 12843*.
 
-<!--- MAGETWO-87940 -->*  In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
+<!--- MAGETWO-87940  -->
+*   In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
 
-<!--- MAGETWO-87921 -->* The incorrect field value in the joined `variable_value` table has been replaced with two values: `plain_value` and `html_value`. *Fix submitted by Maksymilian Szydło in pull request 13596*.
+<!--- MAGETWO-87921  -->
+*  The incorrect field value in the joined `variable_value` table has been replaced with two values: `plain_value` and `html_value`. *Fix submitted by Maksymilian Szydło in pull request 13596*.
 
-<!--- MAGETWO-84880 -->* Duplicate array keys in `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` and  `app/code/Magento/Downloadable/Helper/File.php`  have been removed. *Fix submitted by Leandro F. L. in pull request 12513*.
+<!--- MAGETWO-84880  -->
+*  Duplicate array keys in `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` and  `app/code/Magento/Downloadable/Helper/File.php`  have been removed. *Fix submitted by Leandro F. L. in pull request 12513*.
 
-<!--- MAGETWO-84856 -->* The typo in the  `getDispretionPath`  function name has been corrected to `getDispersionPath`. *Fix submitted by PascalBrouwers in pull request 12507*. [GitHub-12506](https://github.com/magento/magento2/issues/12506)
+<!--- MAGETWO-84856  -->
+*  The typo in the  `getDispretionPath`  function name has been corrected to `getDispersionPath`. *Fix submitted by PascalBrouwers in pull request 12507*. [GitHub-12506](https://github.com/magento/magento2/issues/12506)
 
-<!--- MAGETWO-84474 -->* Magento now saves new orders created by guest accounts to the Order display as expected. Previously, Magento did not display the order with the customer information assigned to it, and although Magento sent email containing the order ID,  the email did not contain information about the ordered items. *Fix submitted by Roman K. in pull request 12241*. [GitHub-10128](https://github.com/magento/magento2/issues/10128)
+<!--- MAGETWO-84474  -->
+*  Magento now saves new orders created by guest accounts to the Order display as expected. Previously, Magento did not display the order with the customer information assigned to it, and although Magento sent email containing the order ID,  the email did not contain information about the ordered items. *Fix submitted by Roman K. in pull request 12241*. [GitHub-10128](https://github.com/magento/magento2/issues/10128)
 
-<!--- MAGETWO-84284 -->* CAPTCHA labels now reflect both the symbols and letters associated with the CAPTCHA image. Previously, the text labels referred to the CAPTCHA image referred to letters only, despite there being numbers in the CAPTCHA images, too. This ambiguity had the potential to mislead users about which  text to enter. *Fix submitted by RhodriOwainDavies in pull request 12387*.
+<!--- MAGETWO-84284  -->
+*  CAPTCHA labels now reflect both the symbols and letters associated with the CAPTCHA image. Previously, the text labels referred to the CAPTCHA image referred to letters only, despite there being numbers in the CAPTCHA images, too. This ambiguity had the potential to mislead users about which  text to enter. *Fix submitted by RhodriOwainDavies in pull request 12387*.
 
-<!--- MAGETWO-84006 -->* The `robots.txt` response header content type is now plain text. *Fix submitted by Milan Osztromok in pull request 12310*.
+<!--- MAGETWO-84006  -->
+*  The `robots.txt` response header content type is now plain text. *Fix submitted by Milan Osztromok in pull request 12310*.
 
-<!--- MAGETWO-84098 -->* Customers can now successfully use RSS to share their wish lists. Previously, when a logged-in user added products to the wish list and then tried to share them using RSS, Magento threw this exception: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as child to 'root', because the latter doesn't exist` *Fix submitted by mediactbv in pull request*.
+<!--- MAGETWO-84098  -->
+*  Customers can now successfully use RSS to share their wish lists. Previously, when a logged-in user added products to the wish list and then tried to share them using RSS, Magento threw this exception: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as child to 'root', because the latter doesn't exist` *Fix submitted by mediactbv in pull request*.
 
-<!--- MAGETWO-87242 -->*  When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
+<!--- MAGETWO-87242  -->
+*   When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
 
-<!--- MAGETWO-85311 -->* Issues with displaying full-screen images and video on the configurable product page have been resolved. Previously, Magento displayed video associated with product options on this page as images, rather than video, and full-screen mode for images ignored the configurations settings in `view.xml`. *Fix submitted by Ievgen Shakhsuvarov in pull request 991*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
+<!--- MAGETWO-85311  -->
+*  Issues with displaying full-screen images and video on the configurable product page have been resolved. Previously, Magento displayed video associated with product options on this page as images, rather than video, and full-screen mode for images ignored the configurations settings in `view.xml`. *Fix submitted by Ievgen Shakhsuvarov in pull request 991*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
 
-<!--- MAGETWO-84764 -->* We've fixed issues with the "report module enable/disable changes as deployment markers" functionality in the `Magento_NewRelicReporting` module. Previously, if New Relic's cron was enabled,  Magento  sent a New Relic deployment marker for every enabled module once per cron period. This resulted in an excessive number of events. *Fix submitted by Kristof in pull request 12477*.
+<!--- MAGETWO-84764  -->
+*  We've fixed issues with the "report module enable/disable changes as deployment markers" functionality in the `Magento_NewRelicReporting` module. Previously, if New Relic's cron was enabled,  Magento  sent a New Relic deployment marker for every enabled module once per cron period. This resulted in an excessive number of events. *Fix submitted by Kristof in pull request 12477*.
 
-<!--- MAGETWO-86240 -->* The New Product Configuration process now works as expected from the Admin.  Previously, on the last step of this process, Magento displayed the `the element.disabled is not a function` message, and did not create the product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-86240  -->
+*  The New Product Configuration process now works as expected from the Admin.  Previously, on the last step of this process, Magento displayed the `the element.disabled is not a function` message, and did not create the product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
-<!--- MAGETWO-88278 -->* Save operations on CMS pages now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13814*.
+<!--- MAGETWO-88278  -->
+*  Save operations on CMS pages now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13814*.
 
-<!--- MAGETWO-88435 -->* Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
+<!--- MAGETWO-88435  -->
+*  Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
 
 ### Import/export
 
-<!--- MAGETWO-81368 -->* You can now successfully import product images and image labels from CSV files. Previously after import, the  alt text field on the Admin was empty, even though the label was imported and was visible on the product list page as alt attribute, and the Product Detail page missed the alt attribute on image fields. *Fix submitted by Ben Robie in pull request 11323*. [GitHub-9931](https://github.com/magento/magento2/issues/9931)
+<!--- MAGETWO-81368  -->
+*  You can now successfully import product images and image labels from CSV files. Previously after import, the  alt text field on the Admin was empty, even though the label was imported and was visible on the product list page as alt attribute, and the Product Detail page missed the alt attribute on image fields. *Fix submitted by Ben Robie in pull request 11323*. [GitHub-9931](https://github.com/magento/magento2/issues/9931)
 
-<!--- MAGETWO-83726 -->* The CSV file created by using **System > Export** now incorporates the value of `hide_for_product_page`.
+<!--- MAGETWO-83726  -->
+*  The CSV file created by using **System > Export** now incorporates the value of `hide_for_product_page`.
 *Fix submitted by Nickolas Malyovanets in pull request 11926*.
 
-<!--- MAGETWO-83957 -->* You can now import a value of zero (0) into a custom attribute when using the Admin product import feature. *Fix submitted by p-bystritsky in pull request 12283*. [GitHub-12083](https://github.com/magento/magento2/issues/12083)
+<!--- MAGETWO-83957  -->
+*  You can now import a value of zero (0) into a custom attribute when using the Admin product import feature. *Fix submitted by p-bystritsky in pull request 12283*. [GitHub-12083](https://github.com/magento/magento2/issues/12083)
 
-<!--- MAGETWO-84448 -->* You can now import or export a specific store view that includes custom options and bundle product options. Previously, the import/export feature did not include store view-level edits for  custom options.
+<!--- MAGETWO-84448  -->
+*  You can now import or export a specific store view that includes custom options and bundle product options. Previously, the import/export feature did not include store view-level edits for  custom options.
 
-<!--- MAGETWO-85629 -->* Import no longer fails when you import products with image filenames containing round brackets from a CSV file. *Fix submitted by p-bystritsky in pull request 1017*. [GitHub-12084](https://github.com/magento/magento2/issues/12084)
+<!--- MAGETWO-85629  -->
+*  Import no longer fails when you import products with image filenames containing round brackets from a CSV file. *Fix submitted by p-bystritsky in pull request 1017*. [GitHub-12084](https://github.com/magento/magento2/issues/12084)
 
-<!--- MAGETWO-86657 -->* When you import information about existing customers, Magento now changes only the specific rows for this customer. If rows for other customer attributes (for example, `group_id`, `store_id`, `created_at`) are absent in the import file, these values are included unchanged.
+<!--- MAGETWO-86657  -->
+*  When you import information about existing customers, Magento now changes only the specific rows for this customer. If rows for other customer attributes (for example, `group_id`, `store_id`, `created_at`) are absent in the import file, these values are included unchanged.
 
-<!--- MAGETWO-88044 -->* Magento now provides a test for adding values in the system variable collection unit test. *Fix submitted by Nickolas Malyovanets in pull request 13742*.
+<!--- MAGETWO-88044  -->
+*  Magento now provides a test for adding values in the system variable collection unit test. *Fix submitted by Nickolas Malyovanets in pull request 13742*.
 
-<!--- MAGETWO-74042 -->* You can now successfully  import configurable products with specified configurable links when the `store_view_code` setting isn't set. Previously, you could successfully import a configurable product with both configurable and additional attributes, but when you viewed the category to which the product belonged, the product was not displayed. [GitHub-5876](https://github.com/magento/magento2/issues/5876)
+<!--- MAGETWO-74042  -->
+*  You can now successfully  import configurable products with specified configurable links when the `store_view_code` setting isn't set. Previously, you could successfully import a configurable product with both configurable and additional attributes, but when you viewed the category to which the product belonged, the product was not displayed. [GitHub-5876](https://github.com/magento/magento2/issues/5876)
 
-<!--- MAGETWO-88251 -->* Save operations on CMS blocks now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13796*.
+<!--- MAGETWO-88251  -->
+*  Save operations on CMS blocks now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13796*.
 
-<!--- MAGETWO-86448 -->* The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled. *Fix submitted by Paresh Pansuriya in pull request 13038*. [GitHub-12711](https://github.com/magento/magento2/issues/12711)
+<!--- MAGETWO-86448  -->
+*  The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled. *Fix submitted by Paresh Pansuriya in pull request 13038*. [GitHub-12711](https://github.com/magento/magento2/issues/12711)
 
-<!--- MAGETWO-88340 -->* You can now use the layout update XML field to include custom CSS in CMS pages. [GitHub-4454](https://github.com/magento/magento2/issues/4454)
+<!--- MAGETWO-88340  -->
+*  You can now use the layout update XML field to include custom CSS in CMS pages. [GitHub-4454](https://github.com/magento/magento2/issues/4454)
 
-<!--- MAGETWO-88435 -->* Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
+<!--- MAGETWO-88435  -->
+*  Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
 
 ### Indexing
 
-<!--- MAGETWO-86446 -->* The URL that points to Magento `crontab` documentation has been updated to reflect current cron documentation in `app/code/Magento/Indexer/Model/Message/Invalid.php`. *Fix submitted by Robbie Thompson in pull request 13050*.
+<!--- MAGETWO-86446  -->
+*  The URL that points to Magento `crontab` documentation has been updated to reflect current cron documentation in `app/code/Magento/Indexer/Model/Message/Invalid.php`. *Fix submitted by Robbie Thompson in pull request 13050*.
 
-<!--- MAGETWO-83503 -->* You can now view the state of the mview queue in real time, which can be useful when debugging indexing issues. You can now view how many items are in the queue pending processing, as well as view information from the `mview_state` table. *Fix submitted by Luke Rodgers in pull request 12122*.
+<!--- MAGETWO-83503  -->
+*  You can now view the state of the mview queue in real time, which can be useful when debugging indexing issues. You can now view how many items are in the queue pending processing, as well as view information from the `mview_state` table. *Fix submitted by Luke Rodgers in pull request 12122*.
 
 ### Infrastructure
 
-<!--- MAGETWO-86542 -->* Zoom now works as expected when using dropdown menus. Previously, zoom worked fine, but when you hovered over the category dropdown menu to the overlap area of product image and dropdown menu, the zoom was abnormally active,  even though the mouse was still on the dropdown menu. *Fix submitted by Mayank Zalavadia in pull request 13084*. [GitHub-5129](https://github.com/magento/magento2/issues/5129)
+<!--- MAGETWO-86542  -->
+*  Zoom now works as expected when using dropdown menus. Previously, zoom worked fine, but when you hovered over the category dropdown menu to the overlap area of product image and dropdown menu, the zoom was abnormally active,  even though the mouse was still on the dropdown menu. *Fix submitted by Mayank Zalavadia in pull request 13084*. [GitHub-5129](https://github.com/magento/magento2/issues/5129)
 
-<!--- MAGETWO-86505 -->* RequireJS loading issues that occur when ad blockers are active have been resolved. Previously, `uBlock` (or any ad blocker) forbade the `trackingCode.js` file from loading, which prompted RequireJS to throw  an  exception. This exception broke the JavaScript execution flow and caused unexpected issues throughout the storefront. *Fix submitted by Yonn Trimoreau in pull request 13061*.
+<!--- MAGETWO-86505  -->
+*  RequireJS loading issues that occur when ad blockers are active have been resolved. Previously, `uBlock` (or any ad blocker) forbade the `trackingCode.js` file from loading, which prompted RequireJS to throw  an  exception. This exception broke the JavaScript execution flow and caused unexpected issues throughout the storefront. *Fix submitted by Yonn Trimoreau in pull request 13061*.
 
-<!--- MAGETWO-86501 -->* `continue()` has been removed from templates. *Fix submitted by Ihor Sviziev in pull request 13076*.
+<!--- MAGETWO-86501  -->
+*  `continue()` has been removed from templates. *Fix submitted by Ihor Sviziev in pull request 13076*.
 
-<!--- MAGETWO-85698 -->* The comment that marks the `\Magento\Checkout\Model\Cart` class as deprecated now includes a pointer to an alternative class. This fix is part of an ongoing effort to add pointers to valid replacements when marking methods and classes as deprecated. *Fix submitted by Fabian Schmengler in pull request 13061*. [GitHub-10133](https://github.com/magento/magento2/issues/11070)
+<!--- MAGETWO-85698  -->
+*  The comment that marks the `\Magento\Checkout\Model\Cart` class as deprecated now includes a pointer to an alternative class. This fix is part of an ongoing effort to add pointers to valid replacements when marking methods and classes as deprecated. *Fix submitted by Fabian Schmengler in pull request 13061*. [GitHub-10133](https://github.com/magento/magento2/issues/11070)
 
-<!--- MAGETWO-85694 -->* A new file (`CODE_OF_CONDUCT.md`) that defines  standards for how to engage in the community has been added. *Fix submitted by Ievgen Shakhsuvarov in pull request 12723*.
+<!--- MAGETWO-85694  -->
+*  A new file (`CODE_OF_CONDUCT.md`) that defines  standards for how to engage in the community has been added. *Fix submitted by Ievgen Shakhsuvarov in pull request 12723*.
 
-<!--- MAGETWO-85292 -->* `\Magento\Framework\Data\Tree::getNodeById()` no longer contains an invalid type in its PHPDoc block.  *Fix submitted by Roman K. in pull request 964*. [GitHub-8507](https://github.com/magento/magento2/issues/8507)
+<!--- MAGETWO-85292  -->
+*  `\Magento\Framework\Data\Tree::getNodeById()` no longer contains an invalid type in its PHPDoc block.  *Fix submitted by Roman K. in pull request 964*. [GitHub-8507](https://github.com/magento/magento2/issues/8507)
 
-<!--- MAGETWO-85179 -->* We’ve resolved naming collisions that previously occurred  in the Javascript UI registry. Previously, these naming collisions resulted in the following behaviors: Magento displayed the `element.disabled is not a function` message, and did not create product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-85179  -->
+*  We’ve resolved naming collisions that previously occurred  in the Javascript UI registry. Previously, these naming collisions resulted in the following behaviors: Magento displayed the `element.disabled is not a function` message, and did not create product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
 ### Newsletters
 
-<!--- MAGETWO-83999 -->* The **About Us** and **Customer Service** links of the Order Confirmation email (and  other emails sent to the customer) now work as expected. *Fix submitted by Roman K. in pull request*. [GitHub-12261](https://github.com/magento/magento2/issues/12261)
+<!--- MAGETWO-83999  -->
+*  The **About Us** and **Customer Service** links of the Order Confirmation email (and  other emails sent to the customer) now work as expected. *Fix submitted by Roman K. in pull request*. [GitHub-12261](https://github.com/magento/magento2/issues/12261)
 
-<!--- MAGETWO-85783 -->* Magento now sends the newsletter subscription success email as expected when a customer successfully subscribes to a newsletter.
+<!--- MAGETWO-85783  -->
+*  Magento now sends the newsletter subscription success email as expected when a customer successfully subscribes to a newsletter.
 *Fix submitted by Styopchik in pull request*. [GitHub-12439](https://github.com/magento/magento2/issues/12439)
 
-<!--- MAGETWO-86435 -->* Magento now uses indexes to retrieve subscriber information during the creation of email to newsletter subscribers. Previously, Magento did not use indexes for this task, and performance was poor. *Fix submitted by Amit Bera in pull request*. [GitHub-12787](https://github.com/magento/magento2/issues/12787)
+<!--- MAGETWO-86435  -->
+*  Magento now uses indexes to retrieve subscriber information during the creation of email to newsletter subscribers. Previously, Magento did not use indexes for this task, and performance was poor. *Fix submitted by Amit Bera in pull request*. [GitHub-12787](https://github.com/magento/magento2/issues/12787)
 
-<!--- MAGETWO-86562 -->* Magento no longer sends multiple confirmation emails when a customer successfully subscribes to a newsletter. *Fix submitted by Torben Höhn in pull request 13044*. [GitHub-12876](https://github.com/magento/magento2/issues/12876)
+<!--- MAGETWO-86562  -->
+*  Magento no longer sends multiple confirmation emails when a customer successfully subscribes to a newsletter. *Fix submitted by Torben Höhn in pull request 13044*. [GitHub-12876](https://github.com/magento/magento2/issues/12876)
 
-<!--- MAGETWO-86447 -->* The text of the  **Subscribe to Newsletter** button now wraps correctly. *Fix submitted by monaemipro in pull request 13041*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
+<!--- MAGETWO-86447  -->
+*  The text of the  **Subscribe to Newsletter** button now wraps correctly. *Fix submitted by monaemipro in pull request 13041*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
 
 ### Orders
 
-<!--- MAGETWO-75840 -->* Magento now shows all products as expected in the Recently Ordered list when a customer places an order that contains products from multiple stores. Previously, in installations with two storefronts, if a customer added products from both stores to the same shopping cart, and placed a single order, the recently ordered product list would not show all ordered products.
+<!--- MAGETWO-75840  -->
+*  Magento now shows all products as expected in the Recently Ordered list when a customer places an order that contains products from multiple stores. Previously, in installations with two storefronts, if a customer added products from both stores to the same shopping cart, and placed a single order, the recently ordered product list would not show all ordered products.
 
-<!--- MAGETWO-82577 -->*  The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
+<!--- MAGETWO-82577  -->
+*   The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
 
-<!--- MAGETWO-83410 -->*  You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
+<!--- MAGETWO-83410  -->
+*   You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
 
-<!--- MAGETWO-83552 -->* Magento now saves an invoice ID on the credit memo when you create a credit memo from the invoice in the Admin. Previously,
+<!--- MAGETWO-83552  -->
+*  Magento now saves an invoice ID on the credit memo when you create a credit memo from the invoice in the Admin. Previously,
 the invoice ID was not included.  *Fix submitted by Anton Evers in pull request 11067*. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
 
-<!--- MAGETWO-83740 -->* Credit memos can have the state open (`\Magento\Sales\Model\Order\Creditmemo::STATE_OPEN`). As a result, you can create a credit memo with an ID that still has to be refunded, and existing credit memos should be refundable if their state is open. *Fix submitted by Anton Evers in pull request 11550*.
+<!--- MAGETWO-83740  -->
+*  Credit memos can have the state open (`\Magento\Sales\Model\Order\Creditmemo::STATE_OPEN`). As a result, you can create a credit memo with an ID that still has to be refunded, and existing credit memos should be refundable if their state is open. *Fix submitted by Anton Evers in pull request 11550*.
 
-<!--- MAGETWO-83783 -->* The `Magento\Sales\Service\V1\OrderCreateTest` test now has the correct shipping method fixture. Previously, this test contained an incorrect shipping method fixture, which produced an error whenever an order's shipping method was treated an object. *Fix submitted by andrew-garside-temando in pull request 12227*.
+<!--- MAGETWO-83783  -->
+*  The `Magento\Sales\Service\V1\OrderCreateTest` test now has the correct shipping method fixture. Previously, this test contained an incorrect shipping method fixture, which produced an error whenever an order's shipping method was treated an object. *Fix submitted by andrew-garside-temando in pull request 12227*.
 
-<!--- MAGETWO-84219 -->* When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
+<!--- MAGETWO-84219  -->
+*  When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
 
-<!--- MAGETWO-84256 -->* The `getReservedOrderId()` method now uses the current store as expected instead of the default store. *Fix submitted by Timon de Groot in pull request 11702*. [GitHub-9055](https://github.com/magento/magento2/issues/9055)
+<!--- MAGETWO-84256  -->
+*  The `getReservedOrderId()` method now uses the current store as expected instead of the default store. *Fix submitted by Timon de Groot in pull request 11702*. [GitHub-9055](https://github.com/magento/magento2/issues/9055)
 
-<!--- MAGETWO-85305 -->* When you are editing an order's shipping or billing address, Magento now displays the allowed countries from the correct store view. Previously, possible addresses were derived from the wrong store view. *Fix submitted by Roman K. in pull request*. [GitHub-12560](https://github.com/magento/magento2/issues/12560)
+<!--- MAGETWO-85305  -->
+*  When you are editing an order's shipping or billing address, Magento now displays the allowed countries from the correct store view. Previously, possible addresses were derived from the wrong store view. *Fix submitted by Roman K. in pull request*. [GitHub-12560](https://github.com/magento/magento2/issues/12560)
 
-<!--- MAGETWO-85660 -->* The `\Magento\Sales\Model\Order\Pdf\AbstractPdf::drawLineBlocks` method now works as expected. Previously, when a text block spanned more than one page, Magento threw a `Zend_Pdf_Exception` error, and displayed this error: `Font has not been set`. *Fix submitted by serhii-balko in pull request 1016*. [GitHub-11743](https://github.com/magento/magento2/issues/11743)
+<!--- MAGETWO-85660  -->
+*  The `\Magento\Sales\Model\Order\Pdf\AbstractPdf::drawLineBlocks` method now works as expected. Previously, when a text block spanned more than one page, Magento threw a `Zend_Pdf_Exception` error, and displayed this error: `Font has not been set`. *Fix submitted by serhii-balko in pull request 1016*. [GitHub-11743](https://github.com/magento/magento2/issues/11743)
 
-<!--- MAGETWO-86845 -->* Magento no longer exports extra records when you export invoices for multiple orders. *Fix submitted by Sanjay Patel in pull request 13208*. [GitHub-12714](https://github.com/magento/magento2/issues/12714)
+<!--- MAGETWO-86845  -->
+*  Magento no longer exports extra records when you export invoices for multiple orders. *Fix submitted by Sanjay Patel in pull request 13208*. [GitHub-12714](https://github.com/magento/magento2/issues/12714)
 
-<!--- MAGETWO-80233 -->* You can now place orders using PayPal when **Payment Action = Order**. Previously, when **Payment Action = Order**, Magento displayed this error when you reached the order review page: `We can't place the order.`
+<!--- MAGETWO-80233  -->
+*  You can now place orders using PayPal when **Payment Action = Order**. Previously, when **Payment Action = Order**, Magento displayed this error when you reached the order review page: `We can't place the order.`
 
-<!--- MAGETWO-86258 -->* The cancel order and restore quote methods now accurately calculate the amount of stock to be returned to inventory when an order is canceled. Previously, when you canceled an order, some of these methods did not accurately calculate the amount of restored stock. *Fix submitted by Danny Verkade in pull request 12668*. [GitHub-9969](https://github.com/magento/magento2/issues/9969)
+<!--- MAGETWO-86258  -->
+*  The cancel order and restore quote methods now accurately calculate the amount of stock to be returned to inventory when an order is canceled. Previously, when you canceled an order, some of these methods did not accurately calculate the amount of restored stock. *Fix submitted by Danny Verkade in pull request 12668*. [GitHub-9969](https://github.com/magento/magento2/issues/9969)
 
-<!--- MAGETWO-87292 -->*  Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
+<!--- MAGETWO-87292  -->
+*   Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
 
-<!--- MAGETWO-87291 -->* The Shipment Tracking REST API now throws an error as expected if the specified order doesn't exist. *Fix submitted by Roman K. in pull request 1162*.
+<!--- MAGETWO-87291  -->
+*  The Shipment Tracking REST API now throws an error as expected if the specified order doesn't exist. *Fix submitted by Roman K. in pull request 1162*.
 
-<!--- MAGETWO-83868 -->* Invoices now display the exact quantity of a product ordered, even if it is a fractional unit (for example,  6.5). Previously, when Magento tried to invoice an order that had products with quantities that required decimals, it rounded down the quantity to the nearest whole number in the invoice. *Fix submitted by Nickolas Malyovanets in pull request 11997*.  [GitHub-11941](https://github.com/magento/magento2/issues/11941)
+<!--- MAGETWO-83868  -->
+*  Invoices now display the exact quantity of a product ordered, even if it is a fractional unit (for example,  6.5). Previously, when Magento tried to invoice an order that had products with quantities that required decimals, it rounded down the quantity to the nearest whole number in the invoice. *Fix submitted by Nickolas Malyovanets in pull request 11997*.  [GitHub-11941](https://github.com/magento/magento2/issues/11941)
 
 ### Payment methods
 
-<!--- MAGETWO-84588,MAGETWO-84587, MAGETWO-84590 -->* The multishipping checkout  flow now supports the CyberSource payment method. This payment method is supported on Magento Commerce only. However,  as part of the process of adding CyberSource support, we've made improvements to the Multishipping module to simplify integration process for other payment methods.
+<!--- MAGETWO-84588,MAGETWO-84587, MAGETWO-84590  -->
+*  The multishipping checkout  flow now supports the CyberSource payment method. This payment method is supported on Magento Commerce only. However,  as part of the process of adding CyberSource support, we've made improvements to the Multishipping module to simplify integration process for other payment methods.
 
-<!--- MAGETWO-75497 -->* Logged-out customers can no longer see previously saved credit cards. Previously, users logged in as guest could see some payment information from an earlier, canceled order.
+<!--- MAGETWO-75497  -->
+*  Logged-out customers can no longer see previously saved credit cards. Previously, users logged in as guest could see some payment information from an earlier, canceled order.
 
-<!--- MAGETWO-81395 -->* Third-party developers can now customize payment errors messages for payment integrations based on the Magento Payment Provider Gateway.
+<!--- MAGETWO-81395  -->
+*  Third-party developers can now customize payment errors messages for payment integrations based on the Magento Payment Provider Gateway.
 
-<!--- MAGETWO-82910 -->* PayPal Express Checkout now appears as a payment option on the Checkout page when the PayPal buttons are available on the shopping cart page. Previously, PayPal did not appear as a payment method on the Checkout page when the billing agreement was disabled, although the PayPal buttons were still available on the shopping cart page.
+<!--- MAGETWO-82910  -->
+*  PayPal Express Checkout now appears as a payment option on the Checkout page when the PayPal buttons are available on the shopping cart page. Previously, PayPal did not appear as a payment method on the Checkout page when the billing agreement was disabled, although the PayPal buttons were still available on the shopping cart page.
 
-<!--- MAGETWO-83959-->* You can now view order details for an order created with a custom offline payment method. Previously, Magento displayed  PHP warning (undefined index) instead of the order details. *Fix submitted by Alex in pull request 12296*. [GitHub-3596](https://github.com/magento/magento2/issues/3596)
+<!--- MAGETWO-83959 -->
+*  You can now view order details for an order created with a custom offline payment method. Previously, Magento displayed  PHP warning (undefined index) instead of the order details. *Fix submitted by Alex in pull request 12296*. [GitHub-3596](https://github.com/magento/magento2/issues/3596)
 
-<!--- MAGETWO-86112 -->*  Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
+<!--- MAGETWO-86112  -->
+*   Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
 
-<!--- MAGETWO-86297 -->* The  `is_active` and `is_visible` columns now default to true even when column default values are not set in the `vault_payment_token` installation script. *Fix submitted by helloitsluke in pull request 12965*.
+<!--- MAGETWO-86297  -->
+*  The  `is_active` and `is_visible` columns now default to true even when column default values are not set in the `vault_payment_token` installation script. *Fix submitted by helloitsluke in pull request 12965*.
 
-<!--- MAGETWO-86308 -->* If you've chosen a custom payment method that is offline when you create an order, Magento now displays that payment method's name as expected when you view order details in **Payment & Shipping**. *Fix submitted by zamoroka in pull request 12731*. [GitHub-12209](https://github.com/magento/magento2/issues/12209)
+<!--- MAGETWO-86308  -->
+*  If you've chosen a custom payment method that is offline when you create an order, Magento now displays that payment method's name as expected when you view order details in **Payment & Shipping**. *Fix submitted by zamoroka in pull request 12731*. [GitHub-12209](https://github.com/magento/magento2/issues/12209)
 
-<!--- MAGETWO-86351 -->* PayPal now works as expected with virtual products such as gift cards. Previously, when you tried to place an order for a virtual product using PayPal, Magento did not display the PayPal popup when you clicked **Continue PayPal** during checkout.
+<!--- MAGETWO-86351  -->
+*  PayPal now works as expected with virtual products such as gift cards. Previously, when you tried to place an order for a virtual product using PayPal, Magento did not display the PayPal popup when you clicked **Continue PayPal** during checkout.
 
-<!--- MAGETWO-84639 -->* Magento now correctly adds checkout agreements data to  requests and validates payment information when you place an order using PayPal Express. Previously, you could check this box, but Magento did not parse  the agreements data  or pass it  to the set-payment-information API. This failure in turn triggered the `CheckoutAgreements` validation plugin,  which failed to validate. *Fix submitted by Ričards Zālītis in pull request 12401*.
+<!--- MAGETWO-84639  -->
+*  Magento now correctly adds checkout agreements data to  requests and validates payment information when you place an order using PayPal Express. Previously, you could check this box, but Magento did not parse  the agreements data  or pass it  to the set-payment-information API. This failure in turn triggered the `CheckoutAgreements` validation plugin,  which failed to validate. *Fix submitted by Ričards Zālītis in pull request 12401*.
 
-<!--- MAGETWO-86426 -->* Magento no longer archives active orders that are placed using PayPal Express Checkout. Previously, if you placed an order using PayPal Express Checkout, Magento would place the order as expected but also add it to the list of archived orders.
+<!--- MAGETWO-86426  -->
+*  Magento no longer archives active orders that are placed using PayPal Express Checkout. Previously, if you placed an order using PayPal Express Checkout, Magento would place the order as expected but also add it to the list of archived orders.
 
-<!--- MAGETWO-84647 -->* Magento now correctly displays transparent `.PNG` watermarks on JPEG images. Previously, Magento did not correctly display a transparent watermark as expected on an image, but instead displayed a white outline of the box where the watermark should be. *Fix submitted by Elze Kool in pull request 11060*. [GitHub-10661](https://github.com/magento/magento2/issues/10661)
+<!--- MAGETWO-84647  -->
+*  Magento now correctly displays transparent `.PNG` watermarks on JPEG images. Previously, Magento did not correctly display a transparent watermark as expected on an image, but instead displayed a white outline of the box where the watermark should be. *Fix submitted by Elze Kool in pull request 11060*. [GitHub-10661](https://github.com/magento/magento2/issues/10661)
 
-<!--- MAGETWO-88235 -->* We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced. *Fix submitted by Marcin Kwiatkowski in pull request 13777*.
+<!--- MAGETWO-88235  -->
+*  We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced. *Fix submitted by Marcin Kwiatkowski in pull request 13777*.
 [GitHub-13315](https://github.com/magento/magento2/issues/13315)
 
-<!--- MAGETWO-87289 -->* Magento now correctly updates the credit memo total when a merchant issues a refund. *Fix submitted by serhii-balko in pull request 1185*. [GitHub-11798](https://github.com/magento/magento2/issues/11798)
+<!--- MAGETWO-87289  -->
+*  Magento now correctly updates the credit memo total when a merchant issues a refund. *Fix submitted by serhii-balko in pull request 1185*. [GitHub-11798](https://github.com/magento/magento2/issues/11798)
 
 ### Performance
 
-<!--- MAGETWO-84480 -->* The addition of a cache for the `getimagesize()` function has improved product image loading.
+<!--- MAGETWO-84480  -->
+*  The addition of a cache for the `getimagesize()` function has improved product image loading.
 
-<!--- MAGETWO-45775 -->* Each cache type now has its own separate cache storage.
+<!--- MAGETWO-45775  -->
+*  Each cache type now has its own separate cache storage.
 
-<!--- MAGETWO-86736 -->* We’ve optimized the initialization of the Product View block, which gives an 11% performance improvement for simple product views.
+<!--- MAGETWO-86736  -->
+*  We’ve optimized the initialization of the Product View block, which gives an 11% performance improvement for simple product views.
 
-<!--- MAGETWO-75769 -->* Magento now caches  search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached. This enhancement can result in up to a 36% improvement for cacheable search terms.
+<!--- MAGETWO-75769  -->
+*  Magento now caches  search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached. This enhancement can result in up to a 36% improvement for cacheable search terms.
 
 ### Quote
 
-<!--- MAGETWO-86439 -->* If a customer changes the currency type of his order-in-progress while viewing the shopping cart, Magento displays a message that shows the minimum order necessary in the new currency. Previously, this minimum was calculated incorrectly. *Fix submitted by Neeta Kangiya in pull request 13039*.
+<!--- MAGETWO-86439  -->
+*  If a customer changes the currency type of his order-in-progress while viewing the shopping cart, Magento displays a message that shows the minimum order necessary in the new currency. Previously, this minimum was calculated incorrectly. *Fix submitted by Neeta Kangiya in pull request 13039*.
 
-<!--- MAGETWO-86434 -->* Magento no longer truncates very long telephone numbers in the order page. Previously, Magento cut off very long phone numbers at 20 digits. *Fix submitted by Danny Verkade in pull request 13015*. [GitHub-10869](https://github.com/magento/magento2/issues/10869)
+<!--- MAGETWO-86434  -->
+*  Magento no longer truncates very long telephone numbers in the order page. Previously, Magento cut off very long phone numbers at 20 digits. *Fix submitted by Danny Verkade in pull request 13015*. [GitHub-10869](https://github.com/magento/magento2/issues/10869)
 
-<!--- MAGETWO-86430 -->* You can now implement a product attribute that sets **Catalog Input Type for Store Owner** equal to **Fixed Product Tax** in a multistore environment. *Fix submitted by Danny Verkade in pull request 13019*.
+<!--- MAGETWO-86430  -->
+*  You can now implement a product attribute that sets **Catalog Input Type for Store Owner** equal to **Fixed Product Tax** in a multistore environment. *Fix submitted by Danny Verkade in pull request 13019*.
 [GitHub-12393](https://github.com/magento/magento2/issues/12393)
 
-<!--- MAGETWO-85518 -->* When a customer is on the payment page and tries to reorder or retrace her steps backward through the checkout process, Magento now displays all the relevant shipping methods. Previously, Magento displayed only one shipping method under these circumstances.
+<!--- MAGETWO-85518  -->
+*  When a customer is on the payment page and tries to reorder or retrace her steps backward through the checkout process, Magento now displays all the relevant shipping methods. Previously, Magento displayed only one shipping method under these circumstances.
 
-<!--- MAGETWO-86595 -->* An integrity constraint violation error no longer occurs after you reorder a product with custom options. *Fix submitted by Vinay Shah in pull request 13036*. [GitHub-12705](https://github.com/magento/magento2/issues/12705)
+<!--- MAGETWO-86595  -->
+*  An integrity constraint violation error no longer occurs after you reorder a product with custom options. *Fix submitted by Vinay Shah in pull request 13036*. [GitHub-12705](https://github.com/magento/magento2/issues/12705)
 
 ### Reports
 
-<!--- MAGETWO-84981 -->* The Products in Cart report is now accurate. Previously, if you created a Products in Cart report (**Open Reports** > Marketing > **Products in Cart**) after deleting a product from the catalog, the report displayed a blank list of products. *Fix submitted by angelo983 in pull request 12539*.
+<!--- MAGETWO-84981  -->
+*  The Products in Cart report is now accurate. Previously, if you created a Products in Cart report (**Open Reports** > Marketing > **Products in Cart**) after deleting a product from the catalog, the report displayed a blank list of products. *Fix submitted by angelo983 in pull request 12539*.
 
-<!--- MAGETWO-88173 -->* You can now successfully export the Ordered Products report to a CSV file. Previously, the export file contained no report data.
+<!--- MAGETWO-88173  -->
+*  You can now successfully export the Ordered Products report to a CSV file. Previously, the export file contained no report data.
 
 ### SalesRule
 
-<!--- MAGETWO-71393 -->* Magento now displays the correct catalog rule price for bundle products with custom options.
+<!--- MAGETWO-71393  -->
+*  Magento now displays the correct catalog rule price for bundle products with custom options.
 
-<!--- MAGETWO-86780 -->* Cart prices now displays the Cart Price Rule shipping discount correctly. Previously, when you placed an order, Magento displayed this error: `Payment method is not available`.
+<!--- MAGETWO-86780  -->
+*  Cart prices now displays the Cart Price Rule shipping discount correctly. Previously, when you placed an order, Magento displayed this error: `Payment method is not available`.
 
-<!--- MAGETWO-86786-->* Magento now displays the exact label value that was given in the Admin during the cart price rule creation. *Fix submitted by Ihor Sviziev in pull request 13141*. [GitHub-11428](https://github.com/magento/magento2/issues/11428), [GitHub-11497](https://github.com/magento/magento2/issues/11497)
+<!--- MAGETWO-86786 -->
+*  Magento now displays the exact label value that was given in the Admin during the cart price rule creation. *Fix submitted by Ihor Sviziev in pull request 13141*. [GitHub-11428](https://github.com/magento/magento2/issues/11428), [GitHub-11497](https://github.com/magento/magento2/issues/11497)
 
-<!--- MAGETWO-87013-->*  Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
+<!--- MAGETWO-87013 -->
+*   Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
 
-<!--- MAGETWO-85960-->* Coupon codes that a customer applies to a subsequently canceled order are now available for re-use as expected. Previously, once a customer canceled this order, he could not apply the coupon code to another order. *Fix submitted by p-bystritsky in pull request*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
+<!--- MAGETWO-85960 -->
+*  Coupon codes that a customer applies to a subsequently canceled order are now available for re-use as expected. Previously, once a customer canceled this order, he could not apply the coupon code to another order. *Fix submitted by p-bystritsky in pull request*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
 
 ### Search
 
-<!--- MAGETWO-85637 -->* Magento now displays popular search terms in **SEO & Search > Search Terms** as expected. *Fix submitted by p-bystritsky in pull request 1024*. [GitHub-10743](https://github.com/magento/magento2/issues/10743)
+<!--- MAGETWO-85637  -->
+*  Magento now displays popular search terms in **SEO & Search > Search Terms** as expected. *Fix submitted by p-bystritsky in pull request 1024*. [GitHub-10743](https://github.com/magento/magento2/issues/10743)
 
-<!--- MAGETWO-84370-->* Layered navigation now displays the correct product count. Previously, the layered navigation product count incorrectly included only in-stock products. *Fix submitted by Roman K. in pull request 12063*. [GitHub-11946](https://github.com/magento/magento2/issues/11946)
+<!--- MAGETWO-84370 -->
+*  Layered navigation now displays the correct product count. Previously, the layered navigation product count incorrectly included only in-stock products. *Fix submitted by Roman K. in pull request 12063*. [GitHub-11946](https://github.com/magento/magento2/issues/11946)
 
-<!--- MAGETWO-85827-->* Grid filtration now handles MySQL special characters as expected. *Fix submitted by laconica-sergey in pull request 12749*.
+<!--- MAGETWO-85827 -->
+*  Grid filtration now handles MySQL special characters as expected. *Fix submitted by laconica-sergey in pull request 12749*.
 
 ### Shipping
 
 {: .bs-callout-info }
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-86306,  MAGETWO-87934-->* The handling fee configuration of shipping methods is now explicitly cast to 0 to  avoid warnings from PHP 7.1. *Fix submitted by Fabian Schmengler in pull request 13680*.
+<!--- MAGETWO-86306,  MAGETWO-87934 -->
+*  The handling fee configuration of shipping methods is now explicitly cast to 0 to  avoid warnings from PHP 7.1. *Fix submitted by Fabian Schmengler in pull request 13680*.
 
-<!--- MAGETWO-86400 -->* Unused `count($_items)` in templates have been removed. *Fix submitted by Alexander Shkurko in pull request 12901*.
+<!--- MAGETWO-86400  -->
+*  Unused `count($_items)` in templates have been removed. *Fix submitted by Alexander Shkurko in pull request 12901*.
 
-<!--- MAGETWO-85291 -->* Magento now enforces the minimum order amount during checkout as expected. Previously, you could bypass the minimum order amount logic by clicking **Check Out with Multiple Addresses**, removing products from the order,and then clicking **Update Qty & Addresses**. *Fix submitted by Roman K. in pull request 963*.
+<!--- MAGETWO-85291  -->
+*  Magento now enforces the minimum order amount during checkout as expected. Previously, you could bypass the minimum order amount logic by clicking **Check Out with Multiple Addresses**, removing products from the order,and then clicking **Update Qty & Addresses**. *Fix submitted by Roman K. in pull request 963*.
 
-<!--- MAGETWO-85586 -->* DHL product codes now match those published in the latest DHL products and services guide. Previously, three  DHL product codes in the DHL Shipping module were incorrect. *Fix submitted by gwharton in pull request 12666*.
+<!--- MAGETWO-85586  -->
+*  DHL product codes now match those published in the latest DHL products and services guide. Previously, three  DHL product codes in the DHL Shipping module were incorrect. *Fix submitted by gwharton in pull request 12666*.
 
 ### Sitemap
 
-<!--- MAGETWO-86349 -->*  `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
+<!--- MAGETWO-86349  -->
+*   `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
 
-<!--- MAGETWO-85285 -->* Sitemaps generated in a multi-store environment now include the correct URLs for each store (that is, `http://storename.com/` instead of `http://defaultstore.com/`). *Fix submitted by Roman K. in pull request 935*. [GitHub-12482](https://github.com/magento/magento2/issues/12482)
+<!--- MAGETWO-85285  -->
+*  Sitemaps generated in a multi-store environment now include the correct URLs for each store (that is, `http://storename.com/` instead of `http://defaultstore.com/`). *Fix submitted by Roman K. in pull request 935*. [GitHub-12482](https://github.com/magento/magento2/issues/12482)
 
-<!--- MAGETWO-81525 -->* Magento now handles errors that occur during sitemap generation in a less intrusive way. If Magento throws an exception when generating a sitemap, it now sends the errors through email as configured in the sitemap configuration XML. The former `_translateModel` property is not used anymore, and the inline translation is correctly suspended using the `inlineTranslation` property instead. *Fix submitted by Marina Gociu in pull request*. [GitHub-10502](https://github.com/magento/magento2/issues/10502)
+<!--- MAGETWO-81525  -->
+*  Magento now handles errors that occur during sitemap generation in a less intrusive way. If Magento throws an exception when generating a sitemap, it now sends the errors through email as configured in the sitemap configuration XML. The former `_translateModel` property is not used anymore, and the inline translation is correctly suspended using the `inlineTranslation` property instead. *Fix submitted by Marina Gociu in pull request*. [GitHub-10502](https://github.com/magento/magento2/issues/10502)
 
 ### Swagger
 
-<!--- MAGETWO-87444 -->* The code formatting in the Swagger block and template has been updated. *Fix submitted by JeroenVanLeusden in pull request 13485*.
+<!--- MAGETWO-87444  -->
+*  The code formatting in the Swagger block and template has been updated. *Fix submitted by JeroenVanLeusden in pull request 13485*.
 
 ### Swatches
 
-<!--- MAGETWO-83290-->* You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute.  *Fix submitted by gonzalopelon in pull request 12044*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
+<!--- MAGETWO-83290 -->
+*  You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute.  *Fix submitted by gonzalopelon in pull request 12044*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
 
-<!--- MAGETWO-86576 -->* Visual swatches that have a color assigned now show that color in the swatch box. Previously, Magento did not display any color in the color swatch box. *Fix submitted by Chris Pook in pull request 13101*. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
+<!--- MAGETWO-86576  -->
+*  Visual swatches that have a color assigned now show that color in the swatch box. Previously, Magento did not display any color in the color swatch box. *Fix submitted by Chris Pook in pull request 13101*. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
 
-<!--- MAGETWO-86665 -->* The error message displayed when you do not supply enough information during swatch creation has been edited for clarity and grammatical accuracy. *Fix submitted by Nickolas Malyovanets in pull request 1117*. [GitHub-5550](https://github.com/magento/magento2/issues/5550)
+<!--- MAGETWO-86665  -->
+*  The error message displayed when you do not supply enough information during swatch creation has been edited for clarity and grammatical accuracy. *Fix submitted by Nickolas Malyovanets in pull request 1117*. [GitHub-5550](https://github.com/magento/magento2/issues/5550)
 
 ### Tax
 
-<!--- MAGETWO-87941 -->*  The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multiselect. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
+<!--- MAGETWO-87941  -->
+*   The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multiselect. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
 
-<!--- MAGETWO-87352 -->* We've removed the redundant default discount tax calculation (`tax/calculation/discount_tax`) from `Magento/Tax/etc/config.xml`. *Fix submitted by Vincent Marmiesse in pull request 13449*.
+<!--- MAGETWO-87352  -->
+*  We've removed the redundant default discount tax calculation (`tax/calculation/discount_tax`) from `Magento/Tax/etc/config.xml`. *Fix submitted by Vincent Marmiesse in pull request 13449*.
 
-<!--- MAGETWO-87339 -->* The **Not yet calculated** text string immediately adjacent to the string **Tax** on the checkout page is now translated as expected. *Fix submitted by Roman K. in pull request 1147*. [GitHub-7849](https://github.com/magento/magento2/issues/7849)
+<!--- MAGETWO-87339  -->
+*  The **Not yet calculated** text string immediately adjacent to the string **Tax** on the checkout page is now translated as expected. *Fix submitted by Roman K. in pull request 1147*. [GitHub-7849](https://github.com/magento/magento2/issues/7849)
 
-<!--- MAGETWO-83402 -->* Magento no longer displays incorrect tax amounts for orders when using a non-default tax configuration.. *Fix submitted by Pieter Cappelle in pull request 12639*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
+<!--- MAGETWO-83402  -->
+*  Magento no longer displays incorrect tax amounts for orders when using a non-default tax configuration.. *Fix submitted by Pieter Cappelle in pull request 12639*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
 
 ### Testing
 
-<!--- MAGETWO-87290 -->* `ConfigurationTest` no longer fails when you install Magento using Composer. *Fix submitted by Nickolas Malyovanets in pull request 1161*. [GitHub-12574](https://github.com/magento/magento2/issues/12574)
+<!--- MAGETWO-87290  -->
+*  `ConfigurationTest` no longer fails when you install Magento using Composer. *Fix submitted by Nickolas Malyovanets in pull request 1161*. [GitHub-12574](https://github.com/magento/magento2/issues/12574)
 
-<!--- MAGETWO-87984 -->* We've added `MagentoStyle` as console Input/output in Travis tests.
+<!--- MAGETWO-87984  -->
+*  We've added `MagentoStyle` as console Input/output in Travis tests.
 
-<!--- MAGETWO-86859 -->* We've reimplemented tests using Jasmine as part of the process of removing the legacy JavaScript test framework and completely removing `JSTestDriver` support.  *Fix submitted by Carlos Lizaga in pull request*. [GitHub-12342](https://github.com/magento/magento2/issues/12342)
+<!--- MAGETWO-86859  -->
+*  We've reimplemented tests using Jasmine as part of the process of removing the legacy JavaScript test framework and completely removing `JSTestDriver` support.  *Fix submitted by Carlos Lizaga in pull request*. [GitHub-12342](https://github.com/magento/magento2/issues/12342)
 
-<!--- MAGETWO-86005 -->* `functional.suite.dist.yml` now  handles custom backend names. Previously, the value for the `backend_name` configuration was hardcoded. *Fix submitted by scribam in pull request 12884*.
+<!--- MAGETWO-86005  -->
+*  `functional.suite.dist.yml` now  handles custom backend names. Previously, the value for the `backend_name` configuration was hardcoded. *Fix submitted by scribam in pull request 12884*.
 
-<!--- MAGETWO-85940 -->* We've added a missing preference for `ObjectManager\ConfigInterface` in integration tests. *Fix submitted by Fabian Schmengler in pull request 12845*. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
+<!--- MAGETWO-85940  -->
+*  We've added a missing preference for `ObjectManager\ConfigInterface` in integration tests. *Fix submitted by Fabian Schmengler in pull request 12845*. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
 
-<!--- MAGETWO-85537 -->* Integration Test Annotation `magentoAppArea` no longer breaks with valid values. *Fix submitted by Nickolas Malyovanets in pull request 996*. [GitHub-2907](https://github.com/magento/magento2/issues/2907)
+<!--- MAGETWO-85537  -->
+*  Integration Test Annotation `magentoAppArea` no longer breaks with valid values. *Fix submitted by Nickolas Malyovanets in pull request 996*. [GitHub-2907](https://github.com/magento/magento2/issues/2907)
 
-<!--- MAGETWO-85520 -->* The inline documentation of the static test for XSS vulnerabilities now reflects that `@escapeNotVerified` is disallowed in Magento versions equal or greater than 2.2. *Fix submitted by Matthias Zeis in pull request 12639*.
+<!--- MAGETWO-85520  -->
+*  The inline documentation of the static test for XSS vulnerabilities now reflects that `@escapeNotVerified` is disallowed in Magento versions equal or greater than 2.2. *Fix submitted by Matthias Zeis in pull request 12639*.
 
-<!--- MAGETWO-88174 -->* We've added integration tests for product URL rewrite generation. *Fix submitted by Adrien Louis-Rossignol in pull request 13567*. [GitHub-5863](https://github.com/magento/magento2/issues/5863), [GitHub-8227](https://github.com/magento/magento2/issues/8227), [GitHub-8957](https://github.com/magento/magento2/issues/8957), [GitHub-10073](https://github.com/magento/magento2/issues/10073), [GitHub-13240](https://github.com/magento/magento2/issues/13240)
+<!--- MAGETWO-88174  -->
+*  We've added integration tests for product URL rewrite generation. *Fix submitted by Adrien Louis-Rossignol in pull request 13567*. [GitHub-5863](https://github.com/magento/magento2/issues/5863), [GitHub-8227](https://github.com/magento/magento2/issues/8227), [GitHub-8957](https://github.com/magento/magento2/issues/8957), [GitHub-10073](https://github.com/magento/magento2/issues/10073), [GitHub-13240](https://github.com/magento/magento2/issues/13240)
 
 ### Themes
 
-<!--- MAGETWO-72898 -->* Magento no longer caches warning messages as often as a customer clicks the  **Update Shopping Cart** button while the  shopping cart page loads. Previously, Magento cached a warning message each time a customer clicked this button while  the page loaded in Firefox or Chrome, and this action  resulted in multiple warning messages appearing on the top of the shopping cart page.
+<!--- MAGETWO-72898  -->
+*  Magento no longer caches warning messages as often as a customer clicks the  **Update Shopping Cart** button while the  shopping cart page loads. Previously, Magento cached a warning message each time a customer clicked this button while  the page loaded in Firefox or Chrome, and this action  resulted in multiple warning messages appearing on the top of the shopping cart page.
 
-<!--- MAGETWO-85785 -->* If a customer is logged in while  Magento loads, then the welcome message displays the customer's full name. *Fix submitted by Oleh Kravets in pull request 12738*. [GitHub-12719](https://github.com/magento/magento2/issues/12719)
+<!--- MAGETWO-85785  -->
+*  If a customer is logged in while  Magento loads, then the welcome message displays the customer's full name. *Fix submitted by Oleh Kravets in pull request 12738*. [GitHub-12719](https://github.com/magento/magento2/issues/12719)
 
-<!--- MAGETWO-85549 -->* You can now disable the full screen gallery on mobile devices *Fix submitted by p-bystritsky in pull request 1006*. [GitHub-12490](https://github.com/magento/magento2/issues/12490), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
+<!--- MAGETWO-85549  -->
+*  You can now disable the full screen gallery on mobile devices *Fix submitted by p-bystritsky in pull request 1006*. [GitHub-12490](https://github.com/magento/magento2/issues/12490), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
 
-<!--- MAGETWO-86310 -->* Protected method `getHtml` now checks each child for an existing class and then appends the `$outermostClass` if true. Previously, when creating a dependency injection for the `Magento\Theme\Block\Html\Topmenu` class, you could not change class names on children in a `beforeGetHtml` method because  `getHtml` declares `setClass()` on all child items. *Fix submitted by jonshipman in pull request 12862*.
+<!--- MAGETWO-86310  -->
+*  Protected method `getHtml` now checks each child for an existing class and then appends the `$outermostClass` if true. Previously, when creating a dependency injection for the `Magento\Theme\Block\Html\Topmenu` class, you could not change class names on children in a `beforeGetHtml` method because  `getHtml` declares `setClass()` on all child items. *Fix submitted by jonshipman in pull request 12862*.
 
-<!--- MAGETWO-85708 -->* Customers  can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full screen zoom for any product image, he  could not close the full screen zoom.
+<!--- MAGETWO-85708  -->
+*  Customers  can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full screen zoom for any product image, he  could not close the full screen zoom.
 
 ### Translations and locale
 
-<!--- MAGETWO-86286 -->* Inline translations and custom translators now work for Knockout templates. *Fix submitted by Dmitry Fedyuk in pull request 12953*. [GitHub-2156](https://github.com/magento/magento2/issues/2156)
+<!--- MAGETWO-86286  -->
+*  Inline translations and custom translators now work for Knockout templates. *Fix submitted by Dmitry Fedyuk in pull request 12953*. [GitHub-2156](https://github.com/magento/magento2/issues/2156)
 
-<!--- MAGETWO-86778 -->* Magento now provides a locale for Swedish (Finland). *Fix submitted by Nickolas Malyovanets in pull request 1207*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
+<!--- MAGETWO-86778  -->
+*  Magento now provides a locale for Swedish (Finland). *Fix submitted by Nickolas Malyovanets in pull request 1207*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
 
-<!--- MAGETWO-87226 -->* Magento now uses current locale (as defined in **Stores > Settings > Configuration > Advanced Reporting**) when translating the time zone label. Previously, Magento used operating system settings instead of current locale. *Fix submitted by adrian-martinez-interactiv4 in pull request 13408*.
+<!--- MAGETWO-87226  -->
+*  Magento now uses current locale (as defined in **Stores > Settings > Configuration > Advanced Reporting**) when translating the time zone label. Previously, Magento used operating system settings instead of current locale. *Fix submitted by adrian-martinez-interactiv4 in pull request 13408*.
 
-<!--- MAGETWO-86436 -->* Newsletter labels can now handle Chinese language. *Fix submitted by Dasharth patel in pull request 13029*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
+<!--- MAGETWO-86436  -->
+*  Newsletter labels can now handle Chinese language. *Fix submitted by Dasharth patel in pull request 13029*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
 
-<!--- MAGETWO-87575 -->* The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags such as `<translate args="This won't be translated"`.  *Fix submitted by Matti Vapa in pull request 13528*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
+<!--- MAGETWO-87575  -->
+*  The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags such as `<translate args="This won't be translated"`.  *Fix submitted by Matti Vapa in pull request 13528*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
 
 ### User interface
 
-<!--- MAGETWO-85784-->* You can now configure a form field with validation range-words. As a result, Category Name is validated, and Category is created (or displays the correct error message, if validation fails). Previously, Magento displayed an error message in the console. *Fix submitted by Robin Huy in pull request 12739*.
+<!--- MAGETWO-85784 -->
+*  You can now configure a form field with validation range-words. As a result, Category Name is validated, and Category is created (or displays the correct error message, if validation fails). Previously, Magento displayed an error message in the console. *Fix submitted by Robin Huy in pull request 12739*.
 
-<!--- MAGETWO-86025 -->* The **Save Block** button on the Add New Block page no longer ignores clicks if the content editor is empty.
+<!--- MAGETWO-86025  -->
+*  The **Save Block** button on the Add New Block page no longer ignores clicks if the content editor is empty.
 *Fix submitted by Roman K. in pull request 1032*. [GitHub-8114](https://github.com/magento/magento2/issues/8114)
 
-<!--- MAGETWO-86438 -->* Magento now disables the promo code input box after a user applies a promo code. *Fix submitted by Chirag P in pull request 13030*.
+<!--- MAGETWO-86438  -->
+*  Magento now disables the promo code input box after a user applies a promo code. *Fix submitted by Chirag P in pull request 13030*.
 
-<!--- MAGETWO-84903 -->* Magento now displays video and images as expected when you select a video or click to view a full-screen image for a configurable product. *Fix submitted by Chumak Roman in pull request 12469*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
+<!--- MAGETWO-84903  -->
+*  Magento now displays video and images as expected when you select a video or click to view a full-screen image for a configurable product. *Fix submitted by Chumak Roman in pull request 12469*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
 
-<!--- MAGETWO-83815 -->* The PHP notice that Magento displays when an invalid `ui_component` configuration is used has been improved. *Fix submitted by Vova Yatsyuk in pull request 12239*.
+<!--- MAGETWO-83815  -->
+*  The PHP notice that Magento displays when an invalid `ui_component` configuration is used has been improved. *Fix submitted by Vova Yatsyuk in pull request 12239*.
 
-<!--- MAGETWO-83293 -->* Magento has added verification for previously set filters in `Magento/Ui/Component/Filters`, which has eliminated duplication of filters in collection `where` conditions.
+<!--- MAGETWO-83293  -->
+*  Magento has added verification for previously set filters in `Magento/Ui/Component/Filters`, which has eliminated duplication of filters in collection `where` conditions.
 
-<!--- MAGETWO-87994 -->* Inconsistency in the animation of the Admin spinner progress indicator has been corrected. *Fix submitted by Neill Robson in pull request 13700*.
+<!--- MAGETWO-87994  -->
+*  Inconsistency in the animation of the Admin spinner progress indicator has been corrected. *Fix submitted by Neill Robson in pull request 13700*.
 
 ### URL rewrites
 
-<!--- MAGETWO-84955 -->* When using a store code in a URL, Magento now retrieves the value of `Store_Code` from the store if the store code value is empty. Previously, under these circumstances, Magento threw an error. *Fix submitted by Oscar Recio in pull request 12529*. [GitHub-8615](https://github.com/magento/magento2/issues/12450)
+<!--- MAGETWO-84955  -->
+*  When using a store code in a URL, Magento now retrieves the value of `Store_Code` from the store if the store code value is empty. Previously, under these circumstances, Magento threw an error. *Fix submitted by Oscar Recio in pull request 12529*. [GitHub-8615](https://github.com/magento/magento2/issues/12450)
 
 ### Web API framework
 
-<!--- MAGETWO-85287 -->* You can now use the REST API  to make requests that include a slash (/) in an SKU. *Fix submitted by Roman K. in pull request 949*. [GitHub-8615](https://github.com/magento/magento2/issues/8615)
+<!--- MAGETWO-85287  -->
+*  You can now use the REST API  to make requests that include a slash (/) in an SKU. *Fix submitted by Roman K. in pull request 949*. [GitHub-8615](https://github.com/magento/magento2/issues/8615)
 
 ### Wish list
 
-<!--- MAGETWO-69634 -->* Magento now correctly displays a product's special price when you add it to a wish list. Previously, if you added a product with a special price to the wish list, Magento displayed the product with its regular price.
+<!--- MAGETWO-69634  -->
+*  Magento now correctly displays a product's special price when you add it to a wish list. Previously, if you added a product with a special price to the wish list, Magento displayed the product with its regular price.
 
-<!--- MAGETWO-85303 -->* You can now remove an item description from a wish list. *Fix submitted by p-bystritsky in pull request 981*. [GitHub-12582](https://github.com/magento/magento2/issues/12582)
+<!--- MAGETWO-85303  -->
+*  You can now remove an item description from a wish list. *Fix submitted by p-bystritsky in pull request 981*. [GitHub-12582](https://github.com/magento/magento2/issues/12582)
 
 <!--- NOT NEEDED MAGETWO-87169 MAGETWO-87132  MAGETWO-86846 MAGETWO-80908  MAGETWO-84992  MAGETWO-84480 MAGETWO-83329 MAGETWO-86117 MAGETWO-83977 MAGETWO-84804 MAGETWO-84413 MAGETWO-83974 MAGETWO-82062 MAGETWO-80342     MAGETWO-85661 MAGETWO-77840  MAGETWO-73303 MAGETWO-83343 MAGETWO-83910 MAGETWO-70725  MAGETWO-75217 MAGETWO-83958 MAGETWO-87023 MAGETWO-82078 MAGETWO-84397 MAGETWO-87030 MAGETWO-86452  MAGETWO-85205 MAGETWO-84967 MAGETWO-84884 MAGETWO-83621 MAGETWO-82451 MAGETWO-81431 MAGETWO-81189 MAGETWO-73002  MAGETWO-71790 MAGETWO-71272  MAGETWO-83366 MAGETWO-85590 MAGETWO-85650 MAGETWO-87844 MAGETWO-89306 MAGETWO-85842 MAGETWO-88282 MAGETWO-88111 MAGETWO-71374 MAGETWO-85904 MAGETWO-87445 MAGETWO-86736 MAGETWO-83899 MAGETWO-86938 MAGETWO-88108 MAGETWO-87963 MAGETWO-87815 MAGETWO-45775 MAGETWO-89538 MAGETWO-89453 MAGETWO-89337 MAGETWO-89261 MAGETWO-89273 MAGETWO-89080 MAGETWO-84507 MAGETWO-86670 MAGETWO-84883 MAGETWO-89248 MAGETWO-82571 MAGETWO-83659 MAGETWO-84649 MAGETWO-83328 MAGETWO-80622 MAGETWO-87865 MAGETWO-71608 MAGETWO-83571 MAGETWO-83869 MAGETWO-84650-->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.4EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.4EE.md
@@ -30,17 +30,23 @@ Looking for more information on these new features as well as many others? Check
 
 This section describes changes in this release that are not full-fledged features or bug fixes, but that add noticeable improvements to product performance or ease-of-use.
 
-<!--- MAGETWO-87293-->* The admin global search is now translatable, extensible,  and  takes into account the ACL settings for the current user. See [Using global search](http://docs.magento.com/m2/ee/user_guide/stores/admin-global-search.html) for more information. *Fix submitted by Roman K. in pull request 1167*. [GitHub-7698](https://github.com/magento/magento2/issues/7698)
+<!--- MAGETWO-87293 -->
+*  The admin global search is now translatable, extensible,  and  takes into account the ACL settings for the current user. See [Using global search](http://docs.magento.com/m2/ee/user_guide/stores/admin-global-search.html) for more information. *Fix submitted by Roman K. in pull request 1167*. [GitHub-7698](https://github.com/magento/magento2/issues/7698)
 
-<!--- MAGETWO-84588,MAGETWO-84587 MAGETWO-84589 -->* The multi-shipping checkout  flow now supports the CyberSource payment method. This payment method is supported by Magento Commerce only. As part of the process of adding CyberSource support, we've made improvements to the Multi-shipping module to simplify integration process for other payment methods.
+<!--- MAGETWO-84588,MAGETWO-84587 MAGETWO-84589  -->
+*  The multi-shipping checkout  flow now supports the CyberSource payment method. This payment method is supported by Magento Commerce only. As part of the process of adding CyberSource support, we've made improvements to the Multi-shipping module to simplify integration process for other payment methods.
 
-<!--- MAGETWO-84815 -->* Magento has an automated checker to enforce the short array syntax convention that we are now enforcing in new code. This standard complies with all requirements of PSR-2. *Fix submitted by Nickolas Malyovanets in pull request 12499*.
+<!--- MAGETWO-84815  -->
+*  Magento has an automated checker to enforce the short array syntax convention that we are now enforcing in new code. This standard complies with all requirements of PSR-2. *Fix submitted by Nickolas Malyovanets in pull request 12499*.
 
-<!--- MAGETWO-86940 -->* Magento now provides dedicated payment and shipping debug log files to store information specific to those functional areas.
+<!--- MAGETWO-86940  -->
+*  Magento now provides dedicated payment and shipping debug log files to store information specific to those functional areas.
 
-<!--- MAGETWO-87124 -->*  The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
+<!--- MAGETWO-87124  -->
+*   The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
 
-<!--- MAGETWO-86744, MAGETWO-86743, MAGETWO-86746, MAGETWO-86742 -->* We've replaced `is_null` with strict comparison only for models and block in the following modules: `Catalog`, `Tax`, `Sales`, and `EAV`. *Fixes submitted by Alexander Shkurko in pull requests 13171, 13170, 1163*.
+<!--- MAGETWO-86744, MAGETWO-86743, MAGETWO-86746, MAGETWO-86742  -->
+*  We've replaced `is_null` with strict comparison only for models and block in the following modules: `Catalog`, `Tax`, `Sales`, and `EAV`. *Fixes submitted by Alexander Shkurko in pull requests 13171, 13170, 1163*.
 
 #### dotmailer enhancements
 
@@ -70,21 +76,29 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 
 ### Installation, setup, and deployment
 
-<!--- MAGETWO-86496 -->* The `backup` command now works as expected.  *Fix submitted by Jagriti Joshi in pull request 13066*. [GitHub-12877](https://github.com/magento/magento2/issues/12877)
+<!--- MAGETWO-86496  -->
+*  The `backup` command now works as expected.  *Fix submitted by Jagriti Joshi in pull request 13066*. [GitHub-12877](https://github.com/magento/magento2/issues/12877)
 
-<!--- MAGETWO-86045 -->* Links to Magento installation documentation in `setup/view/magento/readiness-check/progress.html` are now correct. *Fix submitted by Jonas Hünig in pull request 12857*.
+<!--- MAGETWO-86045  -->
+*  Links to Magento installation documentation in `setup/view/magento/readiness-check/progress.html` are now correct. *Fix submitted by Jonas Hünig in pull request 12857*.
 
-<!--- MAGETWO-84506 -->* You can now use the `app:config:status` command to check whether configuration propagation is up-to-date.  *Fix submitted by Juan Alonso in pull request 12441*.
+<!--- MAGETWO-84506  -->
+*  You can now use the `app:config:status` command to check whether configuration propagation is up-to-date.  *Fix submitted by Juan Alonso in pull request 12441*.
 
-<!--- MAGETWO-84125 -->* The `bin/magento setup:rollback -d filename.sql` command now works as expected. Previously, this database rollback operation failed on certain versions of Magento (for example, 2.1.9).  *Fix submitted by Roman K. in pull request 12108*. [GitHub-12064](https://github.com/magento/magento2/issues/12064)
+<!--- MAGETWO-84125  -->
+*  The `bin/magento setup:rollback -d filename.sql` command now works as expected. Previously, this database rollback operation failed on certain versions of Magento (for example, 2.1.9).  *Fix submitted by Roman K. in pull request 12108*. [GitHub-12064](https://github.com/magento/magento2/issues/12064)
 
-<!--- MAGETWO-84081 -->* You can now set API access to integrations for Admin roles, which gives privileged users the ability to grant limited access to users such as third-party integrators. [GitHub-9684](https://github.com/magento/magento2/issues/9684)
+<!--- MAGETWO-84081  -->
+*  You can now set API access to integrations for Admin roles, which gives privileged users the ability to grant limited access to users such as third-party integrators. [GitHub-9684](https://github.com/magento/magento2/issues/9684)
 
-<!--- MAGETWO-81841 -->* You can now enable or disable the Magento Profiler from the command line. [GitHub-9277](https://github.com/magento/magento2/issues/9277)
+<!--- MAGETWO-81841  -->
+*  You can now enable or disable the Magento Profiler from the command line. [GitHub-9277](https://github.com/magento/magento2/issues/9277)
 
-<!--- MAGETWO-81740 -->* The icons for Extension Manager and Module Manager are now consistent with the main content area and left-hand menu of the Web Setup Wizard. *Fix submitted by Danny Verkade in pull request 11388*. [GitHub-11236](https://github.com/magento/magento2/issues/11236)
+<!--- MAGETWO-81740  -->
+*  The icons for Extension Manager and Module Manager are now consistent with the main content area and left-hand menu of the Web Setup Wizard. *Fix submitted by Danny Verkade in pull request 11388*. [GitHub-11236](https://github.com/magento/magento2/issues/11236)
 
-<!--- MAGETWO-80111 -->* Magento now continues operating in maintenance mode if it was previously enabled. Previously, Magento disabled maintenance mode  when you used one of these commands:
+<!--- MAGETWO-80111  -->
+*  Magento now continues operating in maintenance mode if it was previously enabled. Previously, Magento disabled maintenance mode  when you used one of these commands:
 
     * `bin\magento module:uninstall`
     * `bin\magento setup:backup`
@@ -94,741 +108,1060 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 
 *Fix submitted by Joke Puts in pull request 11052*. [GitHub-9918](https://github.com/magento/magento2/issues/9918)
 
-<!--- MAGETWO-85778 -->* You can specify a custom version for static files being deployed, and now nginx sample config files can match these custom  versions, too. *Fix submitted by Scott Buchanan in pull request 12521*.
+<!--- MAGETWO-85778  -->
+*  You can specify a custom version for static files being deployed, and now nginx sample config files can match these custom  versions, too. *Fix submitted by Scott Buchanan in pull request 12521*.
 
-<!--- MAGETWO-85274 -->* The `CrontabManager.php` file has been updated as follows: If `crontab` has already been populated, the `bin/magento cron:install` command adds `#~ MAGENTO START` and the rest of code directly to the last row of crontab without any spaces. *Fix submitted by Michele Fantetti in pull request*.
+<!--- MAGETWO-85274  -->
+*  The `CrontabManager.php` file has been updated as follows: If `crontab` has already been populated, the `bin/magento cron:install` command adds `#~ MAGENTO START` and the rest of code directly to the last row of crontab without any spaces. *Fix submitted by Michele Fantetti in pull request*.
 
-<!--- MAGETWO-85744 -->*  The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
+<!--- MAGETWO-85744  -->
+*   The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
 
-<!--- MAGETWO-88149 -->* The `cache_lifetime` default setting for the `Magento\Theme\Block\Html\Footer` block is no longer set to **false**, and the new default setting is **3600**. *Fix submitted by zolat in pull request 13762*.
+<!--- MAGETWO-88149  -->
+*  The `cache_lifetime` default setting for the `Magento\Theme\Block\Html\Footer` block is no longer set to **false**, and the new default setting is **3600**. *Fix submitted by zolat in pull request 13762*.
 
-<!--- MAGETWO-87975 -->* The `bin/magento maintenance:allow-ips` command now has the `--add` flag, which appends a new IP address to the list of allowed IP addresses. Previously, when you added a new IP address, you had to copy the existing addresses. *Fix submitted by Barry vd. Heuvel in pull request 13586*.
+<!--- MAGETWO-87975  -->
+*  The `bin/magento maintenance:allow-ips` command now has the `--add` flag, which appends a new IP address to the list of allowed IP addresses. Previously, when you added a new IP address, you had to copy the existing addresses. *Fix submitted by Barry vd. Heuvel in pull request 13586*.
 
-<!--- MAGETWO-87900 -->*  The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
+<!--- MAGETWO-87900  -->
+*   The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
 
-<!--- MAGETWO-87859 -->*  In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
+<!--- MAGETWO-87859  -->
+*   In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
 
-<!--- MAGETWO-87856 -->*  You can now deploy static content on demand while in production mode.
+<!--- MAGETWO-87856  -->
+*   You can now deploy static content on demand while in production mode.
 
-<!--- MAGETWO-87838 -->* The output of the `Magento maintenance:status` command no longer inserts a comma in between IP addresses, making it easier to copy and paste the values. *Fix submitted by Barry vd. Heuvel in pull request 13587*.
+<!--- MAGETWO-87838  -->
+*  The output of the `Magento maintenance:status` command no longer inserts a comma in between IP addresses, making it easier to copy and paste the values. *Fix submitted by Barry vd. Heuvel in pull request 13587*.
 
-<!--- MAGETWO-87744 -->* The `DeploymentConfig` reader now always returns an array. *Fix submitted by Barry vd. Heuvel in pull request 13584*.
+<!--- MAGETWO-87744  -->
+*  The `DeploymentConfig` reader now always returns an array. *Fix submitted by Barry vd. Heuvel in pull request 13584*.
 
-<!--- MAGETWO-83782 -->*  Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
+<!--- MAGETWO-83782  -->
+*   Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
 
-<!--- MAGETWO-82288 -->* Magento now includes a helper object to facilitate access to styling objects in the Symfony console. *Fix submitted by Wesley Guthrie in pull request 11504*.
+<!--- MAGETWO-82288  -->
+*  Magento now includes a helper object to facilitate access to styling objects in the Symfony console. *Fix submitted by Wesley Guthrie in pull request 11504*.
 
-<!--- MAGETWO-83120 -->* Magento no longer throws an error when you try to generate a URN catalog for an empty `misc.xml` file. *Fix submitted by Timon de Groot in pull request 11686*. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
+<!--- MAGETWO-83120  -->
+*  Magento no longer throws an error when you try to generate a URN catalog for an empty `misc.xml` file. *Fix submitted by Timon de Groot in pull request 11686*. [GitHub-5188](https://github.com/magento/magento2/issues/5188)
 
-<!--- MAGETWO-84180 -->* The `sampledata:deploy` and `remove` commands now have `no-update` options. *Fix submitted by Fabian Schmengler in pull request 12359*.
+<!--- MAGETWO-84180  -->
+*  The `sampledata:deploy` and `remove` commands now have `no-update` options. *Fix submitted by Fabian Schmengler in pull request 12359*.
 
-<!--- MAGETWO-88155 -->*  The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
+<!--- MAGETWO-88155  -->
+*   The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
 
 ### Bundle products
 
-<!--- MAGETWO-86022 -->* Save operations now work as expected for bundle products. *Fix submitted by dzianis-yurevich in pull request 12734*. [GitHub-6916](https://github.com/magento/magento2/issues/6916)
+<!--- MAGETWO-86022  -->
+*  Save operations now work as expected for bundle products. *Fix submitted by dzianis-yurevich in pull request 12734*. [GitHub-6916](https://github.com/magento/magento2/issues/6916)
 
-<!--- MAGETWO-86882 -->* You can now duplicate a bundle product without stripping the original bundle product of its options. *Fix submitted by MattUnity in pull request 1217*.
+<!--- MAGETWO-86882  -->
+*  You can now duplicate a bundle product without stripping the original bundle product of its options. *Fix submitted by MattUnity in pull request 1217*.
 
 ### Catalog
 
-<!--- MAGETWO-87447 -->*  Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
+<!--- MAGETWO-87447  -->
+*   Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
 
-<!--- MAGETWO-73262 -->*  When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
+<!--- MAGETWO-73262  -->
+*   When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
 
-<!--- MAGETWO-87477 -->*  The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
+<!--- MAGETWO-87477  -->
+*   The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
 
-<!--- MAGETWO-73696 -->* When sorting by price, Magento now displays the same number of products no matter how it sorts products in the Catalog Product list. Previously, Magento reduced the product count by the number of disabled products when sorting by price.
+<!--- MAGETWO-73696  -->
+*  When sorting by price, Magento now displays the same number of products no matter how it sorts products in the Catalog Product list. Previously, Magento reduced the product count by the number of disabled products when sorting by price.
 
-<!--- MAGETWO-75786 -->* The category filter used for layered navigation for configurable products with no available options now counts products accurately.
+<!--- MAGETWO-75786  -->
+*  The category filter used for layered navigation for configurable products with no available options now counts products accurately.
 
-<!--- MAGETWO-81916 -->* When you set the `category_ids` attribute to be visible in the storefront catalog, Magento now displays catalog listings as expected. Previously, Magento threw an exception. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11389*. [GitHub-11341](https://github.com/magento/magento2/issues/11341)
+<!--- MAGETWO-81916  -->
+*  When you set the `category_ids` attribute to be visible in the storefront catalog, Magento now displays catalog listings as expected. Previously, Magento threw an exception. *Fix submitted by Manu Gonzalez Rodriguez in pull request 11389*. [GitHub-11341](https://github.com/magento/magento2/issues/11341)
 
-<!--- MAGETWO-81942 -->* Product display issues within categories that have been filtered by price have been resolved: Products are no longer repeated within a category, and random products are no longer included. *Fix submitted by Mayank Zalavadia in pull request 11429*. [GitHub-11139](https://github.com/magento/magento2/issues/11139)
+<!--- MAGETWO-81942  -->
+*  Product display issues within categories that have been filtered by price have been resolved: Products are no longer repeated within a category, and random products are no longer included. *Fix submitted by Mayank Zalavadia in pull request 11429*. [GitHub-11139](https://github.com/magento/magento2/issues/11139)
 
-<!--- MAGETWO-82313 -->* Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) *Fix submitted by adrian-martinez-interactiv4 in pull request 11444*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82313  -->
+*  Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) *Fix submitted by adrian-martinez-interactiv4 in pull request 11444*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- MAGETWO-82464 -->* Magento no longer throws an error when you re-save a product attribute with a new name. *Fix submitted by Raul Mateos in pull request 11617*. [GitHub-6770](https://github.com/magento/magento2/issues/6770)
+<!--- MAGETWO-82464  -->
+*  Magento no longer throws an error when you re-save a product attribute with a new name. *Fix submitted by Raul Mateos in pull request 11617*. [GitHub-6770](https://github.com/magento/magento2/issues/6770)
 
-<!--- MAGETWO-83399 -->* You can now successfully remove a toolbar from a product listing page. Previously, you could explicitly remove the toolbar from layout configuration, but Magento would return `product_list_toolbar` to the layout. *Fix submitted by mariuscris in pull request 11473*. [GitHub-9413](https://github.com/magento/magento2/issues/9413)
+<!--- MAGETWO-83399  -->
+*  You can now successfully remove a toolbar from a product listing page. Previously, you could explicitly remove the toolbar from layout configuration, but Magento would return `product_list_toolbar` to the layout. *Fix submitted by mariuscris in pull request 11473*. [GitHub-9413](https://github.com/magento/magento2/issues/9413)
 
-<!--- MAGETWO-84018 -->* The `getAttributeText($attributeCode)` method now returns string values as expected. Previously, this method returned an array of attribute values. *Fix submitted by p-bystritsky in pull request 12003*.
+<!--- MAGETWO-84018  -->
+*  The `getAttributeText($attributeCode)` method now returns string values as expected. Previously, this method returned an array of attribute values. *Fix submitted by p-bystritsky in pull request 12003*.
 
-<!--- MAGETWO-84087 -->* You can now add customizable options to a product. Previously, when you tried to add a custom option to the product, Magento threw this error: `A 'Uncaught TypeError: Cannot read property 'apply' of undefined' error`. *Fix submitted by Roman K. in pull request 11965*. [GitHub-11792](https://github.com/magento/magento2/issues/11792)
+<!--- MAGETWO-84087  -->
+*  You can now add customizable options to a product. Previously, when you tried to add a custom option to the product, Magento threw this error: `A 'Uncaught TypeError: Cannot read property 'apply' of undefined' error`. *Fix submitted by Roman K. in pull request 11965*. [GitHub-11792](https://github.com/magento/magento2/issues/11792)
 
-<!--- MAGETWO-84311 -->* Magento now correctly decodes single quotation marks in the Admin attribute option input fields. *Fix submitted by erfanimani in pull request 12133*. [GitHub-12127](https://github.com/magento/magento2/issues/12127)
+<!--- MAGETWO-84311  -->
+*  Magento now correctly decodes single quotation marks in the Admin attribute option input fields. *Fix submitted by erfanimani in pull request 12133*. [GitHub-12127](https://github.com/magento/magento2/issues/12127)
 
-<!--- MAGETWO-84367 -->* You can now save emojis in custom product options. *Fix submitted by Carlos Lizaga in pull request 12253*.
+<!--- MAGETWO-84367  -->
+*  You can now save emojis in custom product options. *Fix submitted by Carlos Lizaga in pull request 12253*.
 
-<!--- MAGETWO-84411 -->* Magento no longer displays unused product attributes  with a value of N/A or NO on the storefront. *Fix submitted by p-bystritsky in pull request 12057*. [GitHub-6634](https://github.com/magento/magento2/issues/6634), [GitHub-9961](https://github.com/magento/magento2/issues/9961)
+<!--- MAGETWO-84411  -->
+*  Magento no longer displays unused product attributes  with a value of N/A or NO on the storefront. *Fix submitted by p-bystritsky in pull request 12057*. [GitHub-6634](https://github.com/magento/magento2/issues/6634), [GitHub-9961](https://github.com/magento/magento2/issues/9961)
 
-<!--- MAGETWO-84498 -->* The `delay` parameter now works as expected, which permits you to set the delay on the JQuery widget opening or closing. Previously, this parameter was documented, but did not work as expected. *Fix submitted by Sam Carr in pull request 12161*.
+<!--- MAGETWO-84498  -->
+*  The `delay` parameter now works as expected, which permits you to set the delay on the JQuery widget opening or closing. Previously, this parameter was documented, but did not work as expected. *Fix submitted by Sam Carr in pull request 12161*.
 
-<!--- MAGETWO-84515 -->* Third-party category images now have `size` and `type` properties. *Fix submitted by Vova Yatsyuk in pull request 12161*.
+<!--- MAGETWO-84515  -->
+*  Third-party category images now have `size` and `type` properties. *Fix submitted by Vova Yatsyuk in pull request 12161*.
 
-<!--- MAGETWO-84652 -->* Category page X-Magento-Tags headers no longer contain product cache identities  when category display mode is set to **Static block only**. *Fix submitted by Atish Goswami in pull request 12466*.
+<!--- MAGETWO-84652  -->
+*  Category page X-Magento-Tags headers no longer contain product cache identities  when category display mode is set to **Static block only**. *Fix submitted by Atish Goswami in pull request 12466*.
 
-<!--- MAGETWO-84665 -->* You can now delete rows in the `dynamicRows` component. *Fix submitted by Roman K. in pull request 921*. [GitHub-8830](https://github.com/magento/magento2/issues/8830)
+<!--- MAGETWO-84665  -->
+*  You can now delete rows in the `dynamicRows` component. *Fix submitted by Roman K. in pull request 921*. [GitHub-8830](https://github.com/magento/magento2/issues/8830)
 
-<!--- MAGETWO-84808 -->* You can now add a new product with custom attributes that have the same name and attributes as a previously deleted product. Previously, Magento did not let you add this new product because a `request_path` with the same value already existed in `table url_rewrite` from the previous product. *Fix submitted by Nickolas Malyovanets in pull request 12167*. [GitHub-12110](https://github.com/magento/magento2/issues/12110)
+<!--- MAGETWO-84808  -->
+*  You can now add a new product with custom attributes that have the same name and attributes as a previously deleted product. Previously, Magento did not let you add this new product because a `request_path` with the same value already existed in `table url_rewrite` from the previous product. *Fix submitted by Nickolas Malyovanets in pull request 12167*. [GitHub-12110](https://github.com/magento/magento2/issues/12110)
 
-<!--- MAGETWO-84949 -->* The `og:type` meta tag content value has been corrected from `<meta property="og:type" content="og:product" />` to `<meta property="og:type" content="product" />`. *Fix submitted by Atish Goswami in pull request 12530*.
+<!--- MAGETWO-84949  -->
+*  The `og:type` meta tag content value has been corrected from `<meta property="og:type" content="og:product" />` to `<meta property="og:type" content="product" />`. *Fix submitted by Atish Goswami in pull request 12530*.
 
-<!--- MAGETWO-85293 -->*  The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
+<!--- MAGETWO-85293  -->
+*   The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
 
-<!--- MAGETWO-85294 -->* Magento no longer creates an extraneous new product when you save an existing product whose SKU you've changed.  *Fix submitted by Nickolas Malyovanets in pull request 984*. [GitHub-12535](https://github.com/magento/magento2/issues/12535)
+<!--- MAGETWO-85294  -->
+*  Magento no longer creates an extraneous new product when you save an existing product whose SKU you've changed.  *Fix submitted by Nickolas Malyovanets in pull request 984*. [GitHub-12535](https://github.com/magento/magento2/issues/12535)
 
-<!--- MAGETWO-85301 -->* cURL requests to delete a product's tier pricing when used on store code **all** now works as expected. Previously, this cURL request deleted the tier pricing but also all the image selections for the product. *Fix submitted by Nickolas Malyovanets in pull request 977*. [GitHub-10797](https://github.com/magento/magento2/issues/10797)
+<!--- MAGETWO-85301  -->
+*  cURL requests to delete a product's tier pricing when used on store code **all** now works as expected. Previously, this cURL request deleted the tier pricing but also all the image selections for the product. *Fix submitted by Nickolas Malyovanets in pull request 977*. [GitHub-10797](https://github.com/magento/magento2/issues/10797)
 
-<!--- MAGETWO-85307 -->* Sort by Price now works as expected on the catalog search page. *Fix submitted by Roman K. in pull request 929*.  [GitHub-12468](https://github.com/magento/magento2/issues/12468)
+<!--- MAGETWO-85307  -->
+*  Sort by Price now works as expected on the catalog search page. *Fix submitted by Roman K. in pull request 929*.  [GitHub-12468](https://github.com/magento/magento2/issues/12468)
 
-<!--- MAGETWO-85545 -->* If an error occurs when you run `catalog:images:resize`, Magento now includes an entry into the log file. Previously, Magento displayed an error message, but did not add an entry into any log files. *Fix submitted by Roman K. in pull request 1000*. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
+<!--- MAGETWO-85545  -->
+*  If an error occurs when you run `catalog:images:resize`, Magento now includes an entry into the log file. Previously, Magento displayed an error message, but did not add an entry into any log files. *Fix submitted by Roman K. in pull request 1000*. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
 
-<!--- MAGETWO-85546 -->* You can now duplicate and save a product successfully. Previously, you could not successfully duplicate a product, and Magento displayed this message: `Notice: Undefined offset: 0 in /home/software/public_html/vendor/magento/module-catalog/Model/Category/Link/SaveHandler.php on line 124`. *Fix submitted by p-bystritsky in pull request 983*.  [GitHub-12259](https://github.com/magento/magento2/issues/12259)
+<!--- MAGETWO-85546  -->
+*  You can now duplicate and save a product successfully. Previously, you could not successfully duplicate a product, and Magento displayed this message: `Notice: Undefined offset: 0 in /home/software/public_html/vendor/magento/module-catalog/Model/Category/Link/SaveHandler.php on line 124`. *Fix submitted by p-bystritsky in pull request 983*.  [GitHub-12259](https://github.com/magento/magento2/issues/12259)
 
-<!--- MAGETWO-85636 -->* The REST API now saves all product properties as expected. Previously, Magento did not save the price and weight, and these attributes were not returned in the result of the POST request. *Fix submitted by Nickolas Malyovanets in pull request 1018*. [GitHub-6486](https://github.com/magento/magento2/issues/6486)
+<!--- MAGETWO-85636  -->
+*  The REST API now saves all product properties as expected. Previously, Magento did not save the price and weight, and these attributes were not returned in the result of the POST request. *Fix submitted by Nickolas Malyovanets in pull request 1018*. [GitHub-6486](https://github.com/magento/magento2/issues/6486)
 
-<!--- MAGETWO-86016 -->* Duplicate `email` IDs no longer occur on the Magento default contact page when running Google Chrome  { Version 63.0.3239.84 (Official Build) (64-bit) }. *Fix submitted by serhii-balko in pull request 1036*. [GitHub-12712](https://github.com/magento/magento2/issues/12712)
+<!--- MAGETWO-86016  -->
+*  Duplicate `email` IDs no longer occur on the Magento default contact page when running Google Chrome  { Version 63.0.3239.84 (Official Build) (64-bit) }. *Fix submitted by serhii-balko in pull request 1036*. [GitHub-12712](https://github.com/magento/magento2/issues/12712)
 
-<!--- MAGETWO-86019 -->* The `hasDataChanges` attribute for loaded EAV collection items now returns `true` or `false` as expected. Previously, this attribute always returned `true`. *Fix submitted by virtual97 in pull request 12736*. [GitHub-12374](https://github.com/magento/magento2/issues/12374)
+<!--- MAGETWO-86019  -->
+*  The `hasDataChanges` attribute for loaded EAV collection items now returns `true` or `false` as expected. Previously, this attribute always returned `true`. *Fix submitted by virtual97 in pull request 12736*. [GitHub-12374](https://github.com/magento/magento2/issues/12374)
 
-<!--- MAGETWO-86021 -->* `ajax:addToCart` now contains the `eventData` parameter, with variables for SKU and quantity. *Fix submitted by Renon Stewart in pull request 12875*.
+<!--- MAGETWO-86021  -->
+*  `ajax:addToCart` now contains the `eventData` parameter, with variables for SKU and quantity. *Fix submitted by Renon Stewart in pull request 12875*.
 
-<!--- MAGETWO-86023 -->* You can now successfully save a new option for a product custom attribute when the value of Admin scope is empty. Previously, Magento threw an exception. *Fix submitted by virtual97 in pull request 12755*.
+<!--- MAGETWO-86023  -->
+*  You can now successfully save a new option for a product custom attribute when the value of Admin scope is empty. Previously, Magento threw an exception. *Fix submitted by virtual97 in pull request 12755*.
 
-<!--- MAGETWO-86662 -->* You can now sort product collections by the `is_saleable` attribute. *Fix submitted by Nickolas Malyovanets in pull request 1045*. [GitHub-7768](https://github.com/magento/magento2/issues/7768)
+<!--- MAGETWO-86662  -->
+*  You can now sort product collections by the `is_saleable` attribute. *Fix submitted by Nickolas Malyovanets in pull request 1045*. [GitHub-7768](https://github.com/magento/magento2/issues/7768)
 
-<!--- MAGETWO-86547 -->* We've added a failsafe to the `items.phtml` file.  *Fix submitted by Sam Granger in pull request 13086*.
+<!--- MAGETWO-86547  -->
+*  We've added a failsafe to the `items.phtml` file.  *Fix submitted by Sam Granger in pull request 13086*.
 
-<!--- MAGETWO-84267 -->* You can now save a product with customizable options. Previously, if you were trying to add a customizable option (for example, a customer group) to a product, Magento did not let you save the product, the form did not close, and a validation issue was triggered. *Fix submitted by luismiguelyangehuaman in pull request 12048*. [GitHub-11528](https://github.com/magento/magento2/issues/11528)
+<!--- MAGETWO-84267  -->
+*  You can now save a product with customizable options. Previously, if you were trying to add a customizable option (for example, a customer group) to a product, Magento did not let you save the product, the form did not close, and a validation issue was triggered. *Fix submitted by luismiguelyangehuaman in pull request 12048*. [GitHub-11528](https://github.com/magento/magento2/issues/11528)
 
-<!--- MAGETWO-85288 -->* Magento now correctly displays stock status for products. *Fix submitted by Roman K. in pull request 955*.
+<!--- MAGETWO-85288  -->
+*  Magento now correctly displays stock status for products. *Fix submitted by Roman K. in pull request 955*.
 
-<!--- MAGETWO-82949 -->* Visual Merchandiser now includes website scope when displaying the correct prices and availability of configurable products.
+<!--- MAGETWO-82949  -->
+*  Visual Merchandiser now includes website scope when displaying the correct prices and availability of configurable products.
 
-<!--- MAGETWO-86663 -->* The catalog product list widget now works with multiple SKUs. Previously, Magento displayed this error, `We're sorry, an error has occurred while generating this email`. *Fix submitted by Nickolas Malyovanets in pull request 1050*.
+<!--- MAGETWO-86663  -->
+*  The catalog product list widget now works with multiple SKUs. Previously, Magento displayed this error, `We're sorry, an error has occurred while generating this email`. *Fix submitted by Nickolas Malyovanets in pull request 1050*.
  [GitHub-11897](https://github.com/magento/magento2/issues/11897)
 
-<!--- MAGETWO-85876 -->* Magento now loads type-dependent layout handles before more specific ID/SKU layout handles. Previously, when Magento updated a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml`, some changes were overwritten by a less specific `catalog_product_view_type_<product_type>.xml`. *Fix submitted by Andreas Schrammel in pull request 12807*.
+<!--- MAGETWO-85876  -->
+*  Magento now loads type-dependent layout handles before more specific ID/SKU layout handles. Previously, when Magento updated a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml`, some changes were overwritten by a less specific `catalog_product_view_type_<product_type>.xml`. *Fix submitted by Andreas Schrammel in pull request 12807*.
 
-<!--- MAGETWO-87897 -->*  Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
+<!--- MAGETWO-87897  -->
+*   Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
 
-<!--- MAGETWO-87847 -->* Language switching now works as expected on the Catalog and Product pages. Previously, language switching did not work on these pages in production mode. *Fix submitted by p-bystritsky in pull request 1143*. [GitHub-11963](https://github.com/magento/magento2/issues/11963)
+<!--- MAGETWO-87847  -->
+*  Language switching now works as expected on the Catalog and Product pages. Previously, language switching did not work on these pages in production mode. *Fix submitted by p-bystritsky in pull request 1143*. [GitHub-11963](https://github.com/magento/magento2/issues/11963)
 
-<!--- MAGETWO-87526 -->* The subcategory URL path is now updated for a store view according to the URL path of its parent category.
+<!--- MAGETWO-87526  -->
+*  The subcategory URL path is now updated for a store view according to the URL path of its parent category.
 
-<!--- MAGETWO-87514 -->* In cases where  `imagebuilder` makes multiple calls, it no longer re-uses attributes from the first call if attributes from a second call are empty. Previously, `imagebuilder` re-used the attributes from the first call, which lead to unexpected results in storefront image display. *Fix submitted by Ihor Sviziev in pull request 13438*.
+<!--- MAGETWO-87514  -->
+*  In cases where  `imagebuilder` makes multiple calls, it no longer re-uses attributes from the first call if attributes from a second call are empty. Previously, `imagebuilder` re-used the attributes from the first call, which lead to unexpected results in storefront image display. *Fix submitted by Ihor Sviziev in pull request 13438*.
 
-<!--- MAGETWO-87496 -->*  `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
+<!--- MAGETWO-87496  -->
+*   `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
 
-<!--- MAGETWO-87294 -->* An unused constructor dependency has been removed from the Product Link Save handler. *Fix submitted by Ihor Sviziev in pull request 13436*.
+<!--- MAGETWO-87294  -->
+*  An unused constructor dependency has been removed from the Product Link Save handler. *Fix submitted by Ihor Sviziev in pull request 13436*.
 
-<!--- MAGETWO-82666 -->* A database backup created by `setup:backup --db` and restored with `setup:rollback -d` now includes triggers as expected.  Previously, the restored database did not include triggers, which meant that indexes could not work correctly. *Fix submitted by Denis Ristic in pull request 11369*. [GitHub-9036](https://github.com/magento/magento2/issues/9036)
+<!--- MAGETWO-82666  -->
+*  A database backup created by `setup:backup --db` and restored with `setup:rollback -d` now includes triggers as expected.  Previously, the restored database did not include triggers, which meant that indexes could not work correctly. *Fix submitted by Denis Ristic in pull request 11369*. [GitHub-9036](https://github.com/magento/magento2/issues/9036)
 
-<!--- MAGETWO-88116 -->* The Low Stock report now accurately lists all out-of-stock products. Previously, this report was not accurate when the All Websites view was selected. *Fix submitted by gwharton in pull request 13682*. [GitHub-10595](https://github.com/magento/magento2/issues/10595)
+<!--- MAGETWO-88116  -->
+*  The Low Stock report now accurately lists all out-of-stock products. Previously, this report was not accurate when the All Websites view was selected. *Fix submitted by gwharton in pull request 13682*. [GitHub-10595](https://github.com/magento/magento2/issues/10595)
 
-<!--- MAGETWO-85163 -->*  We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
+<!--- MAGETWO-85163  -->
+*   We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
 
-<!--- MAGETWO-85575 -->* Magento now correctly sets a `product_links` position attribute even when the attribute value is not set in a GET request. Previously, only the first two of each link type was shown in the backend or in a GET request response, even though Magento correctly added the product links to the database. *Fix submitted by Mohammad Haj-Salem in pull request 12650*.
+<!--- MAGETWO-85575  -->
+*  Magento now correctly sets a `product_links` position attribute even when the attribute value is not set in a GET request. Previously, only the first two of each link type was shown in the backend or in a GET request response, even though Magento correctly added the product links to the database. *Fix submitted by Mohammad Haj-Salem in pull request 12650*.
 
-<!--- MAGETWO-83560 -->* We’re resolved issues with product creation that occurred on installations of Magento Commerce with B2B installed and Update by Schedule indexer mode set.
+<!--- MAGETWO-83560  -->
+*  We’re resolved issues with product creation that occurred on installations of Magento Commerce with B2B installed and Update by Schedule indexer mode set.
 
 ### Cart and checkout
 
-<!--- MAGETWO-83780 -->* Magento no longer adds addresses with `saveInAddressBook` set to **0**  to the address book for new customers. Previously, if you placed an order as a guest and set the `save_in_address_book` setting for an address to **0**, Magento still copied that address  to the customer address book when registering as a new customer on the checkout success page. [GitHub-7691](https://github.com/magento/magento2/issues/7691)
+<!--- MAGETWO-83780  -->
+*  Magento no longer adds addresses with `saveInAddressBook` set to **0**  to the address book for new customers. Previously, if you placed an order as a guest and set the `save_in_address_book` setting for an address to **0**, Magento still copied that address  to the customer address book when registering as a new customer on the checkout success page. [GitHub-7691](https://github.com/magento/magento2/issues/7691)
 
-<!--- MAGETWO-85297 -->* Magento no longer combines the Custom Checkout and Shipping steps when Magento loads the checkout page. *Fix submitted by Roman K. in pull request 975*.
+<!--- MAGETWO-85297  -->
+*  Magento no longer combines the Custom Checkout and Shipping steps when Magento loads the checkout page. *Fix submitted by Roman K. in pull request 975*.
 
-<!--- MAGETWO-85317 -->* You can now successfully change currency for an order before you complete the order. Previously, if you changed currency, when you  proceeded to checkout by choosing a Bank Transfer Payment as Payment Method, Magento displayed, **Your credit card will be charged for**. *Fix submitted by Roman K. in pull request 993*. [GitHub-12526](https://github.com/magento/magento2/issues/12526)
+<!--- MAGETWO-85317  -->
+*  You can now successfully change currency for an order before you complete the order. Previously, if you changed currency, when you  proceeded to checkout by choosing a Bank Transfer Payment as Payment Method, Magento displayed, **Your credit card will be charged for**. *Fix submitted by Roman K. in pull request 993*. [GitHub-12526](https://github.com/magento/magento2/issues/12526)
 
-<!--- MAGETWO-86506 -->* Magento no longer throws a JavaScript error on the cart from postcode validation when the **United States** is deselected in the **Allowed Countries** Admin option (**Admin > Stores > Settings > Configuration > General > Default Country**). *Fix submitted by codekipple in pull request 13051*.
+<!--- MAGETWO-86506  -->
+*  Magento no longer throws a JavaScript error on the cart from postcode validation when the **United States** is deselected in the **Allowed Countries** Admin option (**Admin > Stores > Settings > Configuration > General > Default Country**). *Fix submitted by codekipple in pull request 13051*.
 
-<!--- MAGETWO-86543 -->* Street format spacing when multiple streets are present is now consistent across **Shipping** and **Review & Payments** checkout steps. *Fix submitted by nfourteen in pull request 13082*.
+<!--- MAGETWO-86543  -->
+*  Street format spacing when multiple streets are present is now consistent across **Shipping** and **Review & Payments** checkout steps. *Fix submitted by nfourteen in pull request 13082*.
 
-<!--- MAGETWO-86896 -->* Magento now displays text on the New Cart Rules page correctly. Previously, labels listed in the Store View Specific Labels section of this page was sometimes truncated or duplicated. *Fix submitted by serhii-balko in pull request 1146*. [GitHub-12231](https://github.com/magento/magento2/issues/12231)
+<!--- MAGETWO-86896  -->
+*  Magento now displays text on the New Cart Rules page correctly. Previously, labels listed in the Store View Specific Labels section of this page was sometimes truncated or duplicated. *Fix submitted by serhii-balko in pull request 1146*. [GitHub-12231](https://github.com/magento/magento2/issues/12231)
 
-<!--- MAGETWO-86617 -->* When you check out as a guest  and click **Create an account** on the success page, you can now click on the customer name to jump to the customer record. *Fix submitted by Renon Stewart in pull request 12998*.
+<!--- MAGETWO-86617  -->
+*  When you check out as a guest  and click **Create an account** on the success page, you can now click on the customer name to jump to the customer record. *Fix submitted by Renon Stewart in pull request 12998*.
 
-<!--- MAGETWO-87340 -->* The `XML_PATH_CUSTOMER_MUST_BE_LOGGED` constant has been deprecated. *Fix submitted by Roman K. in pull request 1148*. [GitHub-7848](https://github.com/magento/magento2/issues/7848)
+<!--- MAGETWO-87340  -->
+*  The `XML_PATH_CUSTOMER_MUST_BE_LOGGED` constant has been deprecated. *Fix submitted by Roman K. in pull request 1148*. [GitHub-7848](https://github.com/magento/magento2/issues/7848)
 
-<!--- MAGETWO-88332 -->* `dropdownDialog` is now required when the mini cart is available. *Fix submitted by Alexander Menk in pull request 13830*.
+<!--- MAGETWO-88332  -->
+*  `dropdownDialog` is now required when the mini cart is available. *Fix submitted by Alexander Menk in pull request 13830*.
 
-<!--- MAGETWO-87196 -->* The Check Out with Multiple Addresses page now displays an empty state field as expected when a customer changes from one address to another. *Fix submitted by enriquei4 in pull request 13364*. [GitHub-8621](https://github.com/magento/magento2/issues/8621)
+<!--- MAGETWO-87196  -->
+*  The Check Out with Multiple Addresses page now displays an empty state field as expected when a customer changes from one address to another. *Fix submitted by enriquei4 in pull request 13364*. [GitHub-8621](https://github.com/magento/magento2/issues/8621)
 
 ### Configurable products
 
-<!--- MAGETWO-86781 -->* You can now use custom price symbols when assigning prices to configurable prices. Previously, Magento did not properly display prices for configurable products when you used a custom price symbol when assigning prices. *Fix submitted by pradeep-wagento in pull request 13025*. [GitHub-12430](https://github.com/magento/magento2/issues/12430)
+<!--- MAGETWO-86781  -->
+*  You can now use custom price symbols when assigning prices to configurable prices. Previously, Magento did not properly display prices for configurable products when you used a custom price symbol when assigning prices. *Fix submitted by pradeep-wagento in pull request 13025*. [GitHub-12430](https://github.com/magento/magento2/issues/12430)
 
-<!--- MAGETWO-86311 -->*  Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
+<!--- MAGETWO-86311  -->
+*   Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
 
-<!--- MAGETWO-85782 -->* Magento now displays elements of the **Catalog > Products > Create Configurations** page correctly. Previously, the currency symbol overlapped with the attribute option's price during the creation of a configurable product. *Fix submitted by Vasilina in a pull request*.
+<!--- MAGETWO-85782  -->
+*  Magento now displays elements of the **Catalog > Products > Create Configurations** page correctly. Previously, the currency symbol overlapped with the attribute option's price during the creation of a configurable product. *Fix submitted by Vasilina in a pull request*.
 
-<!--- MAGETWO-85777 -->* If you enter an invalid value for an SKU during the creation of the configurable product, Magento now displays a warning and does not let you save the product. Previously, you were not warned about invalid SKU values, and when you clicked **Save**, all the product information you entered was lost. *Fix submitted by Zamaroka in pull request 12737*. [GitHub-11953](https://github.com/magento/magento2/issues/11953)
+<!--- MAGETWO-85777  -->
+*  If you enter an invalid value for an SKU during the creation of the configurable product, Magento now displays a warning and does not let you save the product. Previously, you were not warned about invalid SKU values, and when you clicked **Save**, all the product information you entered was lost. *Fix submitted by Zamaroka in pull request 12737*. [GitHub-11953](https://github.com/magento/magento2/issues/11953)
 
-<!--- MAGETWO-85634 -->* Magento now correctly runs a partial attribute (EAV) reindex of configurable products whose child products' visibility is set to **Not Visible Individually**. *Fix submitted by Roman K. in pull request 1023*. [GitHub-12667](https://github.com/magento/magento2/issues/12667)
+<!--- MAGETWO-85634  -->
+*  Magento now correctly runs a partial attribute (EAV) reindex of configurable products whose child products' visibility is set to **Not Visible Individually**. *Fix submitted by Roman K. in pull request 1023*. [GitHub-12667](https://github.com/magento/magento2/issues/12667)
 
-<!--- MAGETWO-85286 -->*  Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
+<!--- MAGETWO-85286  -->
+*   Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
 
-<!--- MAGETWO-82888 -->* The product price indexer (`catalog_product_price reindex`) no longer stalls during reindexing.
+<!--- MAGETWO-82888  -->
+*  The product price indexer (`catalog_product_price reindex`) no longer stalls during reindexing.
 
-<!--- MAGETWO-86918 -->* Product records inside the `catalog_product_super_link` table are no longer updated needlessly when you save a configurable product. Previously, saving configurable product erased and then reinserted records in the `catalog_product_super_link` table even when child products were not changed. This practice quickly resulted in an unnecessarily large `catalog_product_super_link` table, especially in multi-website installations.
+<!--- MAGETWO-86918  -->
+*  Product records inside the `catalog_product_super_link` table are no longer updated needlessly when you save a configurable product. Previously, saving configurable product erased and then reinserted records in the `catalog_product_super_link` table even when child products were not changed. This practice quickly resulted in an unnecessarily large `catalog_product_super_link` table, especially in multi-website installations.
 
 ### Customer accounts
 
-<!--- MAGETWO-86427 -->* Magento now trims trailing and leading spaces when saving the name of a new contact. *Fix submitted by wardcapp in pull request 12964*. [GitHub-10415](https://github.com/magento/magento2/issues/10415)
+<!--- MAGETWO-86427  -->
+*  Magento now trims trailing and leading spaces when saving the name of a new contact. *Fix submitted by wardcapp in pull request 12964*. [GitHub-10415](https://github.com/magento/magento2/issues/10415)
 
-<!--- MAGETWO-85580 -->* We fixed the invalid parameter configuration that was provided for the `$block` argument of `Magento\\Ui\\Component\\HtmlContent`. *Fix submitted by Tomasz Gregorczyk in pull request 12964*.
+<!--- MAGETWO-85580  -->
+*  We fixed the invalid parameter configuration that was provided for the `$block` argument of `Magento\\Ui\\Component\\HtmlContent`. *Fix submitted by Tomasz Gregorczyk in pull request 12964*.
 
-<!--- MAGETWO-85300 -->* Magento now successfully sends an email (with content) even when you make a mistake in the email template file name. Previously, when the template name was incorrect, Magento sent the email with no content. *Fix submitted by Roman K. in pull request 970*. [GitHub-8437](https://github.com/magento/magento2/issues/8437)
+<!--- MAGETWO-85300  -->
+*  Magento now successfully sends an email (with content) even when you make a mistake in the email template file name. Previously, when the template name was incorrect, Magento sent the email with no content. *Fix submitted by Roman K. in pull request 970*. [GitHub-8437](https://github.com/magento/magento2/issues/8437)
 
-<!--- MAGETWO-85653 -->*  You can now import customer addresses from websites with country restrictions.
+<!--- MAGETWO-85653  -->
+*   You can now import customer addresses from websites with country restrictions.
 
-<!--- MAGETWO-84862 -->* Magento no longer displays the `Too many passwords reset requests` error when the **max wait time between password resets** setting has been disabled. Previously, when you attempted to reset a customer's password through the Admin, Magento threw an error even when you disabled the `max wait time between password resets` setting in the store configuration settings. *Fix submitted by Cole Hafner in a pull request*. [GitHub-11409](https://github.com/magento/magento2/issues/11409)
+<!--- MAGETWO-84862  -->
+*  Magento no longer displays the `Too many passwords reset requests` error when the **max wait time between password resets** setting has been disabled. Previously, when you attempted to reset a customer's password through the Admin, Magento threw an error even when you disabled the `max wait time between password resets` setting in the store configuration settings. *Fix submitted by Cole Hafner in a pull request*. [GitHub-11409](https://github.com/magento/magento2/issues/11409)
 
-<!--- MAGETWO-84439 -->* Magento no longer throws an exception when you try to open your account address book immediately after creating a customer. *Fix submitted by Chris Pook in pull request 12220*. [GitHub-12180](https://github.com/magento/magento2/issues/12180)
+<!--- MAGETWO-84439  -->
+*  Magento no longer throws an exception when you try to open your account address book immediately after creating a customer. *Fix submitted by Chris Pook in pull request 12220*. [GitHub-12180](https://github.com/magento/magento2/issues/12180)
 
-<!--- MAGETWO-83026 -->* The `isConfirmationRequired` method in the `AccountManagement` class is now public, which makes it available for plugins. (For example, you can now develop custom business logic to decide if confirmation is required (yes/no) for certain customers.) *Fix submitted by Derrick Heesbeen in pull request 11878*.
+<!--- MAGETWO-83026  -->
+*  The `isConfirmationRequired` method in the `AccountManagement` class is now public, which makes it available for plugins. (For example, you can now develop custom business logic to decide if confirmation is required (yes/no) for certain customers.) *Fix submitted by Derrick Heesbeen in pull request 11878*.
 
-<!--- MAGETWO-82635 -->* When configuring a customer account, you can now leave the prefix or suffix fields as optional. Previously, if you did not select an option for these fields, Magento defaulted to selecting the first option in the list. *Fix submitted by Andreas von Studnitz in pull request 11462*. [GitHub-7241](https://github.com/magento/magento2/issues/7241)
+<!--- MAGETWO-82635  -->
+*  When configuring a customer account, you can now leave the prefix or suffix fields as optional. Previously, if you did not select an option for these fields, Magento defaulted to selecting the first option in the list. *Fix submitted by Andreas von Studnitz in pull request 11462*. [GitHub-7241](https://github.com/magento/magento2/issues/7241)
 
-<!--- MAGETWO-85741 -->* The storefront **Back to Sign in** button now works as expected. Previously, when you clicked that button, Magento simply reloaded the current page. *Fix submitted by StasKozar in pull request 12759*. [GitHub-12715](https://github.com/magento/magento2/issues/12715)
+<!--- MAGETWO-85741  -->
+*  The storefront **Back to Sign in** button now works as expected. Previously, when you clicked that button, Magento simply reloaded the current page. *Fix submitted by StasKozar in pull request 12759*. [GitHub-12715](https://github.com/magento/magento2/issues/12715)
 
-<!--- MAGETWO-85672 -->* The `window.checkout.customerLoginUrl` now contains a URL that includes the referrer in base64 encoding (for example, https://myShop.com/customer/account/login/referrer/aHR0cHM6Ly9teXNob3AuY29tL2NoZWNrb3V0). Previously, the login URL did not include a referrer (for example, https://myShop.com/customer/account/login). *Fix submitted by Tommy Quissens in pull request 12630*. [GitHub-12627](https://github.com/magento/magento2/issues/12627)
+<!--- MAGETWO-85672  -->
+*  The `window.checkout.customerLoginUrl` now contains a URL that includes the referrer in base64 encoding (for example, https://myShop.com/customer/account/login/referrer/aHR0cHM6Ly9teXNob3AuY29tL2NoZWNrb3V0). Previously, the login URL did not include a referrer (for example, https://myShop.com/customer/account/login). *Fix submitted by Tommy Quissens in pull request 12630*. [GitHub-12627](https://github.com/magento/magento2/issues/12627)
 
-<!--- MAGETWO-86989 -->* When you are on the cart page and click a product's  **Edit** link, the product page now correctly displays the product quantity currently in the cart. *Fix submitted by Arnoud Beekman in pull request 13310*.
+<!--- MAGETWO-86989  -->
+*  When you are on the cart page and click a product's  **Edit** link, the product page now correctly displays the product quantity currently in the cart. *Fix submitted by Arnoud Beekman in pull request 13310*.
 
-<!--- MAGETWO-87657 -->* You can now create a custom attribute of type file for Customer objects as expected. Previously,  you could create the custom attribute, but the file would not upload. *Fix submitted by Mkennethsmith in pull request 13563*. [GitHub-11252](https://github.com/magento/magento2/issues/11252)
+<!--- MAGETWO-87657  -->
+*  You can now create a custom attribute of type file for Customer objects as expected. Previously,  you could create the custom attribute, but the file would not upload. *Fix submitted by Mkennethsmith in pull request 13563*. [GitHub-11252](https://github.com/magento/magento2/issues/11252)
 
-<!--- MAGETWO-87950 -->*  The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file. *Fix submitted by Renon Stewart in pull request 13661*.
+<!--- MAGETWO-87950  -->
+*   The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file. *Fix submitted by Renon Stewart in pull request 13661*.
 
-<!--- MAGETWO-71829 -->* The `is_subscribed` extended parameter is now returned when a web API is used to modify or return information about a customer.
+<!--- MAGETWO-71829  -->
+*  The `is_subscribed` extended parameter is now returned when a web API is used to modify or return information about a customer.
 
 ### Dashboard
 
-<!--- MAGETWO-86443 -->* The `top destinations` configuration field is now configurable on a store level. Previously, it was configurable on the global level only. *Fix submitted by Andreas von Studnitz in pull request 13052*.
+<!--- MAGETWO-86443  -->
+*  The `top destinations` configuration field is now configurable on a store level. Previously, it was configurable on the global level only. *Fix submitted by Andreas von Studnitz in pull request 13052*.
 
-<!--- MAGETWO-86205 -->* When multiple validation errors occur while saving a customer address, Magento now shows unique messages in the `adminhtml` customer edit page. *Fix submitted by adrian-martinez-interactiv4 in pull request 12922*.
+<!--- MAGETWO-86205  -->
+*  When multiple validation errors occur while saving a customer address, Magento now shows unique messages in the `adminhtml` customer edit page. *Fix submitted by adrian-martinez-interactiv4 in pull request 12922*.
 
-<!--- MAGETWO-86203 -->* The scrollbar on the Admin store switcher is now scrollable on machines running OSX. *Fix submitted by Juan Alonso in pull request 12931*.
+<!--- MAGETWO-86203  -->
+*  The scrollbar on the Admin store switcher is now scrollable on machines running OSX. *Fix submitted by Juan Alonso in pull request 12931*.
 
 ### Directory
 
-<!--- MAGETWO-85659 -->* The `\Magento\Directory\Model\PriceCurrency::format()` method no longer fails if you do not configure a conversion rate from the base to the specified currency. Previously, if you did not specify this conversion rate, Magento rendered the price (amount) in the base currency, not the specified currency. *Fix submitted by Nickolas Malyovanets in pull request 1022*. [GitHub-6965](https://github.com/magento/magento2/issues/6965)
+<!--- MAGETWO-85659  -->
+*  The `\Magento\Directory\Model\PriceCurrency::format()` method no longer fails if you do not configure a conversion rate from the base to the specified currency. Previously, if you did not specify this conversion rate, Magento rendered the price (amount) in the base currency, not the specified currency. *Fix submitted by Nickolas Malyovanets in pull request 1022*. [GitHub-6965](https://github.com/magento/magento2/issues/6965)
 
-<!--- MAGETWO-85583 -->* Magento now requires that customers select State/Province when shipping orders to India, and the checkout page now provides a drop-down field with appropriate values. *Fix submitted by p-bystritsky in pull request*. [GitHub-12378](https://github.com/magento/magento2/issues/12378)
+<!--- MAGETWO-85583  -->
+*  Magento now requires that customers select State/Province when shipping orders to India, and the checkout page now provides a drop-down field with appropriate values. *Fix submitted by p-bystritsky in pull request*. [GitHub-12378](https://github.com/magento/magento2/issues/12378)
 
-<!--- MAGETWO-86170 -->* You can now disable the **State is Required for** field. *Fix submitted by Burlacu Vasilii in pull request 12917*. [GitHub-12894](https://github.com/magento/magento2/issues/12894)
+<!--- MAGETWO-86170  -->
+*  You can now disable the **State is Required for** field. *Fix submitted by Burlacu Vasilii in pull request 12917*. [GitHub-12894](https://github.com/magento/magento2/issues/12894)
 
 ### EAV attributes
 
-<!--- MAGETWO-86240 -->* Creating new configuration attributes no longer causes naming collisions in the JavaScript UI registry. Previously, when you created a new default attribute and then subsequently created a new product, JavaScript errors occurred.  *Fix submitted by Volodymyr Zaets in pull request 12945*. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-86240  -->
+*  Creating new configuration attributes no longer causes naming collisions in the JavaScript UI registry. Previously, when you created a new default attribute and then subsequently created a new product, JavaScript errors occurred.  *Fix submitted by Volodymyr Zaets in pull request 12945*. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
-<!--- MAGETWO-85875 -->* You can now use a single query to retrieve attribute groups from multiple attribute sets. *Fix submitted by Marius Strajeru in pull request 12105*. [GitHub-11936](https://github.com/magento/magento2/issues/11936)
+<!--- MAGETWO-85875  -->
+*  You can now use a single query to retrieve attribute groups from multiple attribute sets. *Fix submitted by Marius Strajeru in pull request 12105*. [GitHub-11936](https://github.com/magento/magento2/issues/11936)
 
-<!--- MAGETWO-85772 -->* Magento now saves multi-select attributes for a product that has a related product using another attribute set. Previously, multi-select attribute values were not saved for a product in the Admin panel when it had a related product that used another attribute set. *Fix submitted by awarche in pull request 12767*.
+<!--- MAGETWO-85772  -->
+*  Magento now saves multi-select attributes for a product that has a related product using another attribute set. Previously, multi-select attribute values were not saved for a product in the Admin panel when it had a related product that used another attribute set. *Fix submitted by awarche in pull request 12767*.
 
-<!--- MAGETWO-85579 -->* The product attribute repository save method  no longer resets the source model to null when you create a new product attribute through code. *Fix submitted by Nickolas Malyovanets in pull request 1012*. [GitHub-10814](https://github.com/magento/magento2/issues/10814)
+<!--- MAGETWO-85579  -->
+*  The product attribute repository save method  no longer resets the source model to null when you create a new product attribute through code. *Fix submitted by Nickolas Malyovanets in pull request 1012*. [GitHub-10814](https://github.com/magento/magento2/issues/10814)
 
-<!--- MAGETWO-85302 -->* Magento now uses the correct  `entity_model` in `table eav_entity_type` for invoices (`Magento\Sales\Model\ResourceModel\Order\Invoice`). Previously, in `table eav_entity_type` for `entity_type_code = "invoice"` the `entity_model` was `Magento\Sales\Model\ResourceModel\Order`. *Fix submitted by Nickolas Malyovanets in pull request 980*. [GitHub-10123](https://github.com/magento/magento2/issues/10123)
+<!--- MAGETWO-85302  -->
+*  Magento now uses the correct  `entity_model` in `table eav_entity_type` for invoices (`Magento\Sales\Model\ResourceModel\Order\Invoice`). Previously, in `table eav_entity_type` for `entity_type_code = "invoice"` the `entity_model` was `Magento\Sales\Model\ResourceModel\Order`. *Fix submitted by Nickolas Malyovanets in pull request 980*. [GitHub-10123](https://github.com/magento/magento2/issues/10123)
 
-<!--- MAGETWO-84272 -->* When a validation message is returned, Magento no longer displays the attribute code (`$attrCode`), but instead returns the label (`$label`). This change makes it easier to translate messages. *Fix submitted by Hewerson Freitas in pull request 12120*.
+<!--- MAGETWO-84272  -->
+*  When a validation message is returned, Magento no longer displays the attribute code (`$attrCode`), but instead returns the label (`$label`). This change makes it easier to translate messages. *Fix submitted by Hewerson Freitas in pull request 12120*.
 
-<!--- MAGETWO-72597 -->* You can now perform a mass update on products that have more than 60 attributes.
+<!--- MAGETWO-72597  -->
+*  You can now perform a mass update on products that have more than 60 attributes.
 
-<!--- MAGETWO-85833 -->* `Magento\Eav\Model\Config::getAttribute` now stops the Profiler before it returns Profiler runtime. Previously, `Magento\Eav\Model\Config::getAttribute` did not stop the Profiler from returning early and consequently reported incorrect runtime. *Fix submitted by Nick Anstee in pull request 12810*.
+<!--- MAGETWO-85833  -->
+*  `Magento\Eav\Model\Config::getAttribute` now stops the Profiler before it returns Profiler runtime. Previously, `Magento\Eav\Model\Config::getAttribute` did not stop the Profiler from returning early and consequently reported incorrect runtime. *Fix submitted by Nick Anstee in pull request 12810*.
 
-<!--- MAGETWO-87588 -->*  The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
+<!--- MAGETWO-87588  -->
+*   The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
 
-<!--- MAGETWO-87354 -->* The deprecated `each()` function has been removed from the code. *Fix submitted by Ihor Sviziev in a pull request*.
+<!--- MAGETWO-87354  -->
+*  The deprecated `each()` function has been removed from the code. *Fix submitted by Ihor Sviziev in a pull request*.
 
 ### Email
 
-<!--- MAGETWO-83741 -->* Order confirmation emails from the Admin in multistore environments no longer default to the primary store, but instead are sent from the store that the customer used. *Fix submitted by Roman K. in pull request*. [GitHub-11740](https://github.com/magento/magento2/issues/11740)
+<!--- MAGETWO-83741  -->
+*  Order confirmation emails from the Admin in multistore environments no longer default to the primary store, but instead are sent from the store that the customer used. *Fix submitted by Roman K. in pull request*. [GitHub-11740](https://github.com/magento/magento2/issues/11740)
 
-<!--- MAGETWO-86881 -->* Magento no longer sends misleading feedback when sending tracking information email. Previously, instead of sending a notice that a shipment was underway, this response was sent, **You sent the shipment**. *Fix submitted by Nickolas Malyovanets in pull request 1245*. [GitHub-5697](https://github.com/magento/magento2/issues/5697)
+<!--- MAGETWO-86881  -->
+*  Magento no longer sends misleading feedback when sending tracking information email. Previously, instead of sending a notice that a shipment was underway, this response was sent, **You sent the shipment**. *Fix submitted by Nickolas Malyovanets in pull request 1245*. [GitHub-5697](https://github.com/magento/magento2/issues/5697)
 
 ### Frameworks
 
-<!--- MAGETWO-86337 -->* You can now switch to default mode from production mode. Previously, if you tried to switch back to default mode, Magento displayed this error, `Cannot switch into given mode 'default'`. *Fix submitted by Etty in pull request 12752*. [GitHub-4292](https://github.com/magento/magento2/issues/4292)
+<!--- MAGETWO-86337  -->
+*  You can now switch to default mode from production mode. Previously, if you tried to switch back to default mode, Magento displayed this error, `Cannot switch into given mode 'default'`. *Fix submitted by Etty in pull request 12752*. [GitHub-4292](https://github.com/magento/magento2/issues/4292)
 
-<!--- MAGETWO- 86654-->* `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*. [GitHub-12967](https://github.com/magento/magento2/issues/12967)
+<!--- MAGETWO- 86654 -->
+*  `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*. [GitHub-12967](https://github.com/magento/magento2/issues/12967)
 
-<!--- MAGETWO-85290 -->* The `filePutContents('file.txt')` now contains content as expected. Previously, Magento threw this error, `The specified "file.text" file could not be written*`.  *Fix submitted by Nickolas Malyovanets in pull request 962*. [GitHub-7467](https://github.com/magento/magento2/issues/7467)
+<!--- MAGETWO-85290  -->
+*  The `filePutContents('file.txt')` now contains content as expected. Previously, Magento threw this error, `The specified "file.text" file could not be written*`.  *Fix submitted by Nickolas Malyovanets in pull request 962*. [GitHub-7467](https://github.com/magento/magento2/issues/7467)
 
-<!--- MAGETWO-85770 -->* You can now subscribe to events that contain a number in their name.  *Fix submitted by Mobecls in pull request 12758*. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
+<!--- MAGETWO-85770  -->
+*  You can now subscribe to events that contain a number in their name.  *Fix submitted by Mobecls in pull request 12758*. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
 
-<!--- MAGETWO-85872 -->* PhpDoc now shows correct parameter types. Previously, PhpDoc showed only a type of `string`, although `array` was also a valid parameter type. *Fix submitted by Freek Vandeursen in pull request 12826*.
+<!--- MAGETWO-85872  -->
+*  PhpDoc now shows correct parameter types. Previously, PhpDoc showed only a type of `string`, although `array` was also a valid parameter type. *Fix submitted by Freek Vandeursen in pull request 12826*.
 
-<!--- MAGETWO-86484 -->* Content no longer jumps when pages are reloaded on the Admin because `notices-wrapper` now has a `min-height` setting. *Fix submitted by Anna Völkl in pull request 12985*.
+<!--- MAGETWO-86484  -->
+*  Content no longer jumps when pages are reloaded on the Admin because `notices-wrapper` now has a `min-height` setting. *Fix submitted by Anna Völkl in pull request 12985*.
 
-<!--- MAGETWO-86277 -->* We've corrected a typo in the `Magento\Ui\Controller\Adminhtml\Index\Render` action. *Fix submitted by Nick in pull request 12951*.
+<!--- MAGETWO-86277  -->
+*  We've corrected a typo in the `Magento\Ui\Controller\Adminhtml\Index\Render` action. *Fix submitted by Nick in pull request 12951*.
 
-<!--- MAGETWO-86154 -->* `X-Magento-Vary` and `PHPSESSID` now have the same expiration time. Previously, the  `X-Magento-Vary` cookie had an expiration of `session`, which meant it was not considered expired until the browser was closed. In contrast, the `PHPSESSID` cookie had a finite expiration time (not `session`). At times, this resulted in  Magento caching the wrong page for the logged-in user.
+<!--- MAGETWO-86154  -->
+*  `X-Magento-Vary` and `PHPSESSID` now have the same expiration time. Previously, the  `X-Magento-Vary` cookie had an expiration of `session`, which meant it was not considered expired until the browser was closed. In contrast, the `PHPSESSID` cookie had a finite expiration time (not `session`). At times, this resulted in  Magento caching the wrong page for the logged-in user.
 
-<!--- MAGETWO-85992 -->* `\Magento\Config\Model\Config\Structure\Reader::processingDocument`  now throws a more helpful validation exception. *Fix submitted by Patrick McLain in pull request 12859*.
+<!--- MAGETWO-85992  -->
+*  `\Magento\Config\Model\Config\Structure\Reader::processingDocument`  now throws a more helpful validation exception. *Fix submitted by Patrick McLain in pull request 12859*.
 
-<!--- MAGETWO-88146 -->* Creating an observer that uses `ObserverInterface` no longer triggers a patch-level dependency on `magento/framework`. *Fix submitted by Kristof in pull request 13759*.
+<!--- MAGETWO-88146  -->
+*  Creating an observer that uses `ObserverInterface` no longer triggers a patch-level dependency on `magento/framework`. *Fix submitted by Kristof in pull request 13759*.
 
-<!--- MAGETWO-88115 -->* RewriteBase directive has been added to the `.htaccess` file in `pub/static` to support the potential installation of Magento code under a directory inside the web root. *Fix submitted by Cristiano Casciotti in pull request 13678*.
+<!--- MAGETWO-88115  -->
+*  RewriteBase directive has been added to the `.htaccess` file in `pub/static` to support the potential installation of Magento code under a directory inside the web root. *Fix submitted by Cristiano Casciotti in pull request 13678*.
 
-<!--- MAGETWO-87261 -->*  The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
+<!--- MAGETWO-87261  -->
+*   The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
 
-<!--- MAGETWO-82069 -->* The report processor now returns an HTTP 500 status code (which better communicates the need for user action) instead of a 503 status code. *Fix submitted by Andrew Howden in pull request 11513*. [GitHub-11512](https://github.com/magento/magento2/issues/11512)
+<!--- MAGETWO-82069  -->
+*  The report processor now returns an HTTP 500 status code (which better communicates the need for user action) instead of a 503 status code. *Fix submitted by Andrew Howden in pull request 11513*. [GitHub-11512](https://github.com/magento/magento2/issues/11512)
 
 #### App framework
 
-<!--- MAGETWO-81802 -->* The customer grid indexer now works as expected.  Previously, this indexer did not work when reindexing using the command-line interface during the upgrade. *Fix submitted by Leonid Poluyanov in pull request 10838*. [GitHub-10838](https://github.com/magento/magento2/issues/10838)
+<!--- MAGETWO-81802  -->
+*  The customer grid indexer now works as expected.  Previously, this indexer did not work when reindexing using the command-line interface during the upgrade. *Fix submitted by Leonid Poluyanov in pull request 10838*. [GitHub-10838](https://github.com/magento/magento2/issues/10838)
 
-<!--- MAGETWO-80223 -->*  `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
+<!--- MAGETWO-80223  -->
+*   `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
 
-<!--- MAGETWO-84003 -->*  The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
+<!--- MAGETWO-84003  -->
+*   The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
 
-<!--- MAGETWO-84016 -->* Customers with an empty **Date of Birth** field can now be saved even when the field is not marked (or checked on the JavaScript side) as mandatory. *Fix submitted by Vova Yatsyuk in pull request 12302*. [GitHub-12146](https://github.com/magento/magento2/issues/12146)
+<!--- MAGETWO-84016  -->
+*  Customers with an empty **Date of Birth** field can now be saved even when the field is not marked (or checked on the JavaScript side) as mandatory. *Fix submitted by Vova Yatsyuk in pull request 12302*. [GitHub-12146](https://github.com/magento/magento2/issues/12146)
 
-<!--- MAGETWO-84371 -->* You can now alter the transport variable in the `email_invoice_set_template_vars_before` event. *Fix submitted by Roman K. in pull request 12132*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!--- MAGETWO-84371  -->
+*  You can now alter the transport variable in the `email_invoice_set_template_vars_before` event. *Fix submitted by Roman K. in pull request 12132*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!--- MAGETWO-84372 -->* Validation of South Korean zip codes now supports current South Korean zip code format. *Fix submitted by Roman K. in pull request 903*. [GitHub-9515](https://github.com/magento/magento2/issues/9515)
+<!--- MAGETWO-84372  -->
+*  Validation of South Korean zip codes now supports current South Korean zip code format. *Fix submitted by Roman K. in pull request 903*. [GitHub-9515](https://github.com/magento/magento2/issues/9515)
 
 #### Configuration framework
 
-<!--- MAGETWO-84464 -->* Scope-based configuration now decrypts data as expected. Previously, scope-based configuration failed to decrypt data on the default store only. *Fix submitted by DubovykOleksandr in pull request 8591*.
+<!--- MAGETWO-84464  -->
+*  Scope-based configuration now decrypts data as expected. Previously, scope-based configuration failed to decrypt data on the default store only. *Fix submitted by DubovykOleksandr in pull request 8591*.
 
 #### JavaScript framework
 
-<!--- MAGETWO-83401 -->* The `depends` field now works for fields of type `radio` in `system.xml`. *Fix submitted by Javier Villanueva in pull request 11539*.
+<!--- MAGETWO-83401  -->
+*  The `depends` field now works for fields of type `radio` in `system.xml`. *Fix submitted by Javier Villanueva in pull request 11539*.
 
-<!--- MAGETWO-83993 -->* Magento now sorts fields and amounts as expected  when you extend a dynamic-row element in a `ui_component` and add a sort order attribute with an amount that falls between the other elements' amount. *Fix submitted by Harald Deiser in pull request 11846*.
+<!--- MAGETWO-83993  -->
+*  Magento now sorts fields and amounts as expected  when you extend a dynamic-row element in a `ui_component` and add a sort order attribute with an amount that falls between the other elements' amount. *Fix submitted by Harald Deiser in pull request 11846*.
 
 #### Session framework
 
-<!--- MAGETWO-83373 -->* The Setup Wizard page now loads successfully when the session storage method is Memcache.  Previously, Magento returned an HTTP 500 error when you navigated to **System > Tools > Web Setup Wizard Setup Wizard**  in installations where you've configured the session storage method to Memcache in `env.php`. *Fix submitted by Marty S in pull request 11608*. [GitHub-9633](https://github.com/magento/magento2/issues/9633)
+<!--- MAGETWO-83373  -->
+*  The Setup Wizard page now loads successfully when the session storage method is Memcache.  Previously, Magento returned an HTTP 500 error when you navigated to **System > Tools > Web Setup Wizard Setup Wizard**  in installations where you've configured the session storage method to Memcache in `env.php`. *Fix submitted by Marty S in pull request 11608*. [GitHub-9633](https://github.com/magento/magento2/issues/9633)
 
-<!--- MAGETWO-83287 -->* When you add a product to your wish list after logging out, Magento now redirects you to your account Wish list page and adds the product. Previously, you were redirected to your wishlist page, but Magento did not add the product. *Fix submitted by Oscar Recio in pull request 12038*. [GitHub-11825](https://github.com/magento/magento2/issues/11825)
+<!--- MAGETWO-83287  -->
+*  When you add a product to your wish list after logging out, Magento now redirects you to your account Wish list page and adds the product. Previously, you were redirected to your wishlist page, but Magento did not add the product. *Fix submitted by Oscar Recio in pull request 12038*. [GitHub-11825](https://github.com/magento/magento2/issues/11825)
 
-<!--- MAGETWO-86880 -->* Anonymous calls using REST no longer trigger the creation of PHP sessions. *Fix submitted by serhii-balko in pull request 1247*. [GitHub-7213](https://github.com/magento/magento2/issues/7213)
+<!--- MAGETWO-86880  -->
+*  Anonymous calls using REST no longer trigger the creation of PHP sessions. *Fix submitted by serhii-balko in pull request 1247*. [GitHub-7213](https://github.com/magento/magento2/issues/7213)
 
 #### Web API framework
 
-<!--- MAGETWO-83854 -->* A user who has been denied permissions for negotiable quote editing can now create customer addresses.
+<!--- MAGETWO-83854  -->
+*  A user who has been denied permissions for negotiable quote editing can now create customer addresses.
 
-<!--- MAGETWO-84979 -->* Swagger now works as expected on instances of Magento that are running on non-standard ports. *Fix submitted by JeroenVanLeusden in pull request 12541*.
+<!--- MAGETWO-84979  -->
+*  Swagger now works as expected on instances of Magento that are running on non-standard ports. *Fix submitted by JeroenVanLeusden in pull request 12541*.
 
-<!--- MAGETWO-84994 -->* You can now set attribute values to empty strings using REST. Previously, Magento would not let you use REST to pass the following attributes with empty values: `special_from_date`, `special_to_date`, and `special_price`. *Fix submitted by Roman K. in pull request 916*. [GitHub-8862](https://github.com/magento/magento2/issues/8862)
+<!--- MAGETWO-84994  -->
+*  You can now set attribute values to empty strings using REST. Previously, Magento would not let you use REST to pass the following attributes with empty values: `special_from_date`, `special_to_date`, and `special_price`. *Fix submitted by Roman K. in pull request 916*. [GitHub-8862](https://github.com/magento/magento2/issues/8862)
 
-<!--- MAGETWO-85534 -->* We've updated the `webapi` module to improve the order of how arguments are merged in multiple `di.xml` files. *Fix submitted by serhii-balko in pull request 995*. [GitHub-8647](https://github.com/magento/magento2/issues/8647)
+<!--- MAGETWO-85534  -->
+*  We've updated the `webapi` module to improve the order of how arguments are merged in multiple `di.xml` files. *Fix submitted by serhii-balko in pull request 995*. [GitHub-8647](https://github.com/magento/magento2/issues/8647)
 
-<!--- MAGETWO-85538 -->* `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets in pull request 1003*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
+<!--- MAGETWO-85538  -->
+*  `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets in pull request 1003*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
 
-<!--- MAGETWO-84666 -->* Anonymous Web API access to the Admin now unlocks REST catalog calls without requiring `auth` tokens. *Fix submitted by Roman K. in pull request 904*. [GitHub-9468](https://github.com/magento/magento2/issues/9468)
+<!--- MAGETWO-84666  -->
+*  Anonymous Web API access to the Admin now unlocks REST catalog calls without requiring `auth` tokens. *Fix submitted by Roman K. in pull request 904*. [GitHub-9468](https://github.com/magento/magento2/issues/9468)
 
 #### Zend framework
 
-<!--- MAGETWO-86654 -->* `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*.
+<!--- MAGETWO-86654  -->
+*  `vendor/magento/framework/composer.json` now declares a dependency on `magento/zendframework1`. Previously, packages depending on `magento/framework` packages failed to execute. *Fix submitted by Ihor Sviziev in pull request 12990*.
 
 ### General
 
-<!--- MAGETWO-86727 -->*  A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
+<!--- MAGETWO-86727  -->
+*   A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
 
-<!--- MAGETWO-87341 -->* Magento now displays notification messages for only the expected duration. Previously, Magento displayed these messages indefinitely within a session. *Fix submitted by p-bystritsky in pull request 1111*. [GitHub-11527](https://github.com/magento/magento2/issues/11527)
+<!--- MAGETWO-87341  -->
+*  Magento now displays notification messages for only the expected duration. Previously, Magento displayed these messages indefinitely within a session. *Fix submitted by p-bystritsky in pull request 1111*. [GitHub-11527](https://github.com/magento/magento2/issues/11527)
 
-<!--- MAGETWO-87342 -->*  Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
+<!--- MAGETWO-87342  -->
+*   Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
 
-<!--- MAGETWO-86748 -->* We've removed the `Magento\ProductAlert\Controller\Add\TestObserver` class. *Fix submitted by Alexander Shkurko in pull request 13174*.
+<!--- MAGETWO-86748  -->
+*  We've removed the `Magento\ProductAlert\Controller\Add\TestObserver` class. *Fix submitted by Alexander Shkurko in pull request 13174*.
 
-<!--- MAGETWO-86722 -->* In the top-level README file in the Magento Open Source repository, all links to DevDocs have been updated to 2.2. *Fix submitted by Bhargav Mehta in pull request 13161*.
+<!--- MAGETWO-86722  -->
+*  In the top-level README file in the Magento Open Source repository, all links to DevDocs have been updated to 2.2. *Fix submitted by Bhargav Mehta in pull request 13161*.
 
-<!--- MAGETWO-87033 -->* Elements within an array in `store_website` table are now correctly formatted. *Fix submitted by Nolwennig Guilbert in pull request 13324*.
+<!--- MAGETWO-87033  -->
+*  Elements within an array in `store_website` table are now correctly formatted. *Fix submitted by Nolwennig Guilbert in pull request 13324*.
 
-<!--- MAGETWO-86886 -->* A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. *Fix submitted by p-bystritsky in pull request 12993*. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
+<!--- MAGETWO-86886  -->
+*  A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. *Fix submitted by p-bystritsky in pull request 12993*. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
 
-<!--- MAGETWO-86883 -->*  The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
+<!--- MAGETWO-86883  -->
+*   The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
 
-<!--- MAGETWO-86840 -->* The `<![CDATA[]]>` statement in the `system.xml` file  now works as expected. Previously, when you entered an XML layout update with CDATA for the first time,  it worked as expected. After you saved the file, however, the `CDATA` tag disappeared. *Fix submitted by serhii-balko in pull request 1163*. [GitHub-12322](https://github.com/magento/magento2/issues/12322)
+<!--- MAGETWO-86840  -->
+*  The `<![CDATA[]]>` statement in the `system.xml` file  now works as expected. Previously, when you entered an XML layout update with CDATA for the first time,  it worked as expected. After you saved the file, however, the `CDATA` tag disappeared. *Fix submitted by serhii-balko in pull request 1163*. [GitHub-12322](https://github.com/magento/magento2/issues/12322)
 
-<!--- MAGETWO-87899 -->* Magento now strips out unnecessary whitespace in the attribute value IDs used on the review form. Previously, rating titles with whitespace resulted in broken ID attributes. *Fix submitted by Nickolas Malyovanets in pull request 1119*. [GitHub-5451](https://github.com/magento/magento2/issues/5451)
+<!--- MAGETWO-87899  -->
+*  Magento now strips out unnecessary whitespace in the attribute value IDs used on the review form. Previously, rating titles with whitespace resulted in broken ID attributes. *Fix submitted by Nickolas Malyovanets in pull request 1119*. [GitHub-5451](https://github.com/magento/magento2/issues/5451)
 
-<!--- MAGETWO-86723 -->* The header label **Price** in the invoice PDF is now correctly aligned with the invoice item's price. *Fix submitted by serhii-balko in pull request 1216*. [GitHub-8453](https://github.com/magento/magento2/issues/8453)
+<!--- MAGETWO-86723  -->
+*  The header label **Price** in the invoice PDF is now correctly aligned with the invoice item's price. *Fix submitted by serhii-balko in pull request 1216*. [GitHub-8453](https://github.com/magento/magento2/issues/8453)
 
-<!--- MAGETWO-86630 -->* Google Analytics `pageview` is no longer triggered twice. *Fix submitted by Bhargav Mehta in pull request 13034*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
+<!--- MAGETWO-86630  -->
+*  Google Analytics `pageview` is no longer triggered twice. *Fix submitted by Bhargav Mehta in pull request 13034*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
 
-<!--- MAGETWO-86564 -->* Minor display issues on the Magento home product page  have been resolved.  *Fix submitted by Punit Vaswani in pull request 13081*. [GitHub-11796](https://github.com/magento/magento2/issues/11796)
+<!--- MAGETWO-86564  -->
+*  Minor display issues on the Magento home product page  have been resolved.  *Fix submitted by Punit Vaswani in pull request 13081*. [GitHub-11796](https://github.com/magento/magento2/issues/11796)
 
-<!--- MAGETWO-88145 -->*  We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
+<!--- MAGETWO-88145  -->
+*   We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
 
-<!--- MAGETWO-86433 -->* The copyright year has been updated to 2018. *Fix submitted by Bhargav Mehta in pull request 13027*.
+<!--- MAGETWO-86433  -->
+*  The copyright year has been updated to 2018. *Fix submitted by Bhargav Mehta in pull request 13027*.
 
-<!--- MAGETWO-86431 -->* Magento now displays the Contact Us page on the menu as expected. Previously, Magento displayed unnecessary space between the category page and the main footer. *Fix submitted by Sanjay Patel in pull request 13026*. [GitHub-12601](https://github.com/magento/magento2/issues/12601)
+<!--- MAGETWO-86431  -->
+*  Magento now displays the Contact Us page on the menu as expected. Previously, Magento displayed unnecessary space between the category page and the main footer. *Fix submitted by Sanjay Patel in pull request 13026*. [GitHub-12601](https://github.com/magento/magento2/issues/12601)
 
-<!--- MAGETWO-86248 -->* The `Learn More Link` widget option in the Recently Viewed Products widget now respects its setting. *Fix submitted by JeroenVanLeusden in pull request 12946*.
+<!--- MAGETWO-86248  -->
+*  The `Learn More Link` widget option in the Recently Viewed Products widget now respects its setting. *Fix submitted by JeroenVanLeusden in pull request 12946*.
 
-<!--- MAGETWO-86035 -->* An unused `if` statement in the order invoice `Save.php` has been removed. *Fix submitted by JeroenVanLeusden in pull request 12887*.
+<!--- MAGETWO-86035  -->
+*  An unused `if` statement in the order invoice `Save.php` has been removed. *Fix submitted by JeroenVanLeusden in pull request 12887*.
 
-<!--- MAGETWO-85780 -->* The `sid` variable no longer appears in the storefront URL even if it has been  disabled in the Admin. Previously, even when the Magento setting **General > Web > Session Validation Settings > Use SID on Storefront** was set to **No**, the `sid` variable no longer appears in the URL. *Fix submitted by Roman Strelenko in pull request 12743*. [GitHub-9453](https://github.com/magento/magento2/issues/9453)
+<!--- MAGETWO-85780  -->
+*  The `sid` variable no longer appears in the storefront URL even if it has been  disabled in the Admin. Previously, even when the Magento setting **General > Web > Session Validation Settings > Use SID on Storefront** was set to **No**, the `sid` variable no longer appears in the URL. *Fix submitted by Roman Strelenko in pull request 12743*. [GitHub-9453](https://github.com/magento/magento2/issues/9453)
 
-<!--- MAGETWO-85779 -->* The menu item handling has been refactored to read item data from two different sources:
+<!--- MAGETWO-85779  -->
+*  The menu item handling has been refactored to read item data from two different sources:
 
     * from original XML definition if the cache is empty
     * from transformed item data when available in the cache. *Fix submitted by Pavel in pull request 12747*. [GitHub-9720](https://github.com/magento/magento2/issues/9720)
 
-<!--- MAGETWO-85773 -->* A typo in the `SINGLE_PRODUCT_LAYOUT_HANLDE` constant has been fixed. *Fix submitted by Andreas Schrammel in pull request 12786*.
+<!--- MAGETWO-85773  -->
+*  A typo in the `SINGLE_PRODUCT_LAYOUT_HANLDE` constant has been fixed. *Fix submitted by Andreas Schrammel in pull request 12786*.
 
-<!--- MAGETWO-85713 -->*  The tracking link no longer returns a 404 error in the Admin. *Fix submitted by Ihor Sviziev in pull request*. [GitHub-12206](https://github.com/magento/magento2/issues/12206)
+<!--- MAGETWO-85713  -->
+*   The tracking link no longer returns a 404 error in the Admin. *Fix submitted by Ihor Sviziev in pull request*. [GitHub-12206](https://github.com/magento/magento2/issues/12206)
 
-<!--- MAGETWO-85643 -->* The product option value price calculation has been improved. Previously, tier prices and customs options were not calculated correctly. *Fix submitted by Marina Gociu in pull request 11563*. [GitHub-5774](https://github.com/magento/magento2/issues/5774)
+<!--- MAGETWO-85643  -->
+*  The product option value price calculation has been improved. Previously, tier prices and customs options were not calculated correctly. *Fix submitted by Marina Gociu in pull request 11563*. [GitHub-5774](https://github.com/magento/magento2/issues/5774)
 
-<!--- MAGETWO-85610 -->* White space that is prepended to a coupon code no longer causes an error. Previously, Magento did not apply the coupon and displayed this message: `Coupon code is not valid`. *Fix submitted by Roman K. in pull request 1021*. [GitHub-12656](https://github.com/magento/magento2/issues/12656)
+<!--- MAGETWO-85610  -->
+*  White space that is prepended to a coupon code no longer causes an error. Previously, Magento did not apply the coupon and displayed this message: `Coupon code is not valid`. *Fix submitted by Roman K. in pull request 1021*. [GitHub-12656](https://github.com/magento/magento2/issues/12656)
 
-<!--- MAGETWO-85502 -->* The **modified** date field on editing pages is now updated as expected. *Fix submitted by Oscar Recio in pull request*. [GitHub-12625](https://github.com/magento/magento2/issues/12625)
+<!--- MAGETWO-85502  -->
+*  The **modified** date field on editing pages is now updated as expected. *Fix submitted by Oscar Recio in pull request*. [GitHub-12625](https://github.com/magento/magento2/issues/12625)
 
-<!--- MAGETWO-85499 -->* Links to Magento Connect on the Partners and Extensions page have been removed and replaced with links to Magento Marketplace. *Fix submitted by Miguel Balparda in pull request 12633*. [GitHub-12632](https://github.com/magento/magento2/issues/12632)
+<!--- MAGETWO-85499  -->
+*  Links to Magento Connect on the Partners and Extensions page have been removed and replaced with links to Magento Marketplace. *Fix submitted by Miguel Balparda in pull request 12633*. [GitHub-12632](https://github.com/magento/magento2/issues/12632)
 
-<!--- MAGETWO-85298 -->* HTML tags have been removed from the display of  attribute names in the dropdown menu of the Catalog Product list. *Fix submitted by Nickolas Malyovanets in pull request 968*. [GitHub-8011](https://github.com/magento/magento2/issues/8011)
+<!--- MAGETWO-85298  -->
+*  HTML tags have been removed from the display of  attribute names in the dropdown menu of the Catalog Product list. *Fix submitted by Nickolas Malyovanets in pull request 968*. [GitHub-8011](https://github.com/magento/magento2/issues/8011)
 
-<!--- MAGETWO-85207 -->* Magento now displays the orders that are associated with customer accounts on the Orders page.  Previously, in the Admin display of customer accounts that have orders associated with them, Magento did not display  orders on the  Orders tab but instead displayed a blank page.
+<!--- MAGETWO-85207  -->
+*  Magento now displays the orders that are associated with customer accounts on the Orders page.  Previously, in the Admin display of customer accounts that have orders associated with them, Magento did not display  orders on the  Orders tab but instead displayed a blank page.
 
-<!--- MAGETWO-82866 -->* Magento now displays information messages about both successful and failed actions when a company administrator adds or deletes entries in the  Company Users section. Previously, Magento displayed this error message, `Something went wrong`  in the response body, and did not display a message.
+<!--- MAGETWO-82866  -->
+*  Magento now displays information messages about both successful and failed actions when a company administrator adds or deletes entries in the  Company Users section. Previously, Magento displayed this error message, `Something went wrong`  in the response body, and did not display a message.
 
-<!--- MAGETWO-81128 -->* The credit card form is now available when you create an order from the Admin, even when only one payment method is enabled. Previously, when only one payment method was enabled, the Admin did not render this form.
+<!--- MAGETWO-81128  -->
+*  The credit card form is now available when you create an order from the Admin, even when only one payment method is enabled. Previously, when only one payment method was enabled, the Admin did not render this form.
 
-<!--- MAGETWO-72865 -->* Full Page Cache is no longer invalidated after you save a predictor category. Previously, all product-related cache data was invalidated, when only a narrow subset of cache tags associated with the `product_id` should have been.
+<!--- MAGETWO-72865  -->
+*  Full Page Cache is no longer invalidated after you save a predictor category. Previously, all product-related cache data was invalidated, when only a narrow subset of cache tags associated with the `product_id` should have been.
 
-<!--- MAGETWO-88040 -->*  Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
+<!--- MAGETWO-88040  -->
+*   Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
 
-<!--- MAGETWO-87908 -->* Magento now displays a more meaningful error message when a module name is misspelled in `registration.php`. *Fix submitted by Jānis Elmeris in pull request 12843*.
+<!--- MAGETWO-87908  -->
+*  Magento now displays a more meaningful error message when a module name is misspelled in `registration.php`. *Fix submitted by Jānis Elmeris in pull request 12843*.
 
-<!--- MAGETWO-87940 -->*  In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
+<!--- MAGETWO-87940  -->
+*   In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
 
-<!--- MAGETWO-87921 -->* The incorrect field value in the joined `variable_value` table has been replaced with two values: `plain_value` and `html_value`. *Fix submitted by Maksymilian Szydło in pull request 13596*.
+<!--- MAGETWO-87921  -->
+*  The incorrect field value in the joined `variable_value` table has been replaced with two values: `plain_value` and `html_value`. *Fix submitted by Maksymilian Szydło in pull request 13596*.
 
-<!--- MAGETWO-85503 -->* `Magento/Rma/Block/Adminhtml/Rma/Edit/Item/Form/Element/Boolean` is a new block element that allows rendering ability for the Boolean RMA attributes on the Admin.
+<!--- MAGETWO-85503  -->
+*  `Magento/Rma/Block/Adminhtml/Rma/Edit/Item/Form/Element/Boolean` is a new block element that allows rendering ability for the Boolean RMA attributes on the Admin.
 
-<!--- MAGETWO-84880 -->* Duplicate array keys in `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` and  `app/code/Magento/Downloadable/Helper/File.php`  have been removed. *Fix submitted by Leandro F. L. in pull request 12513*.
+<!--- MAGETWO-84880  -->
+*  Duplicate array keys in `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` and  `app/code/Magento/Downloadable/Helper/File.php`  have been removed. *Fix submitted by Leandro F. L. in pull request 12513*.
 
-<!--- MAGETWO-84856 -->* The typo in the  `getDispretionPath`  function name has been corrected to `getDispersionPath`. *Fix submitted by PascalBrouwers in pull request 12507*. [GitHub-12506](https://github.com/magento/magento2/issues/12506)
+<!--- MAGETWO-84856  -->
+*  The typo in the  `getDispretionPath`  function name has been corrected to `getDispersionPath`. *Fix submitted by PascalBrouwers in pull request 12507*. [GitHub-12506](https://github.com/magento/magento2/issues/12506)
 
-<!--- MAGETWO-84474 -->* Magento now saves new orders created by guest accounts to the Order display as expected. Previously, Magento did not display the order with the customer information assigned to it, and although Magento sent an email containing the order ID,  the email did not contain information about the ordered items. *Fix submitted by Roman K. in pull request 12241*. [GitHub-10128](https://github.com/magento/magento2/issues/10128)
+<!--- MAGETWO-84474  -->
+*  Magento now saves new orders created by guest accounts to the Order display as expected. Previously, Magento did not display the order with the customer information assigned to it, and although Magento sent an email containing the order ID,  the email did not contain information about the ordered items. *Fix submitted by Roman K. in pull request 12241*. [GitHub-10128](https://github.com/magento/magento2/issues/10128)
 
-<!--- MAGETWO-84284 -->* CAPTCHA labels now reflect both the symbols and letters associated with the CAPTCHA image. Previously, the text labels referred to the CAPTCHA image referred to letters only, despite there being numbers in the CAPTCHA images, too. This ambiguity had the potential to mislead users about which text to enter. *Fix submitted by RhodriOwainDavies in pull request 12387*.
+<!--- MAGETWO-84284  -->
+*  CAPTCHA labels now reflect both the symbols and letters associated with the CAPTCHA image. Previously, the text labels referred to the CAPTCHA image referred to letters only, despite there being numbers in the CAPTCHA images, too. This ambiguity had the potential to mislead users about which text to enter. *Fix submitted by RhodriOwainDavies in pull request 12387*.
 
-<!--- MAGETWO-84006 -->* The `robots.txt` response header content type is now plain text. *Fix submitted by Milan Osztromok in pull request 12310*.
+<!--- MAGETWO-84006  -->
+*  The `robots.txt` response header content type is now plain text. *Fix submitted by Milan Osztromok in pull request 12310*.
 
-<!--- MAGETWO-84098 -->* Customers can now successfully use RSS to share their wish lists. Previously, when a logged-in user added products to the wish list and then tried to share them using RSS, Magento threw this exception: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as a child to 'root', because the latter doesn't exist` *Fix submitted by mediactbv in a pull request*.
+<!--- MAGETWO-84098  -->
+*  Customers can now successfully use RSS to share their wish lists. Previously, when a logged-in user added products to the wish list and then tried to share them using RSS, Magento threw this exception: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as a child to 'root', because the latter doesn't exist` *Fix submitted by mediactbv in a pull request*.
 
-<!--- MAGETWO-87242 -->*  When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
+<!--- MAGETWO-87242  -->
+*   When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
 
-<!--- MAGETWO-85311 -->* Issues with displaying full-screen images and video on the configurable product page have been resolved. Previously, Magento displayed video associated with product options on this page as images, rather than video, and full-screen mode for images ignored the configurations settings in `view.xml`. *Fix submitted by Ievgen Shakhsuvarov in pull request 991*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
+<!--- MAGETWO-85311  -->
+*  Issues with displaying full-screen images and video on the configurable product page have been resolved. Previously, Magento displayed video associated with product options on this page as images, rather than video, and full-screen mode for images ignored the configurations settings in `view.xml`. *Fix submitted by Ievgen Shakhsuvarov in pull request 991*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
 
-<!--- MAGETWO-84764 -->* We've fixed issues with the "report module enable/disable changes as deployment markers" functionality in the `Magento_NewRelicReporting` module. Previously, if New Relic's cron was enabled,  Magento  sent a New Relic deployment marker for every enabled module once per cron period. This resulted in an excessive number of events. *Fix submitted by Kristof in pull request 12477*.
+<!--- MAGETWO-84764  -->
+*  We've fixed issues with the "report module enable/disable changes as deployment markers" functionality in the `Magento_NewRelicReporting` module. Previously, if New Relic's cron was enabled,  Magento  sent a New Relic deployment marker for every enabled module once per cron period. This resulted in an excessive number of events. *Fix submitted by Kristof in pull request 12477*.
 
-<!--- MAGETWO-86240 -->* The New Product Configuration process now works as expected from the Admin.  Previously, on the last step of this process, Magento displayed `the element.disabled is not a function` message and did not create the product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-86240  -->
+*  The New Product Configuration process now works as expected from the Admin.  Previously, on the last step of this process, Magento displayed `the element.disabled is not a function` message and did not create the product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
-<!--- MAGETWO-88278 -->* Save operations on CMS pages now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13814*.
+<!--- MAGETWO-88278  -->
+*  Save operations on CMS pages now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13814*.
 
-<!--- MAGETWO-88435 -->* Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
+<!--- MAGETWO-88435  -->
+*  Magento now correctly displays product titles when displaying Sales information in Google Analytics.  Previously, Magento replaced spaces in product names with their HTML values (for example, `\u0020`). *Fix submitted by Julien Anquetil in pull request 13844*. [GitHub-13827](https://github.com/magento/magento2/issues/13827), [GitHub-13350](https://github.com/magento/magento2/issues/13350)
 
 ### Gift card
 
-<!--- MAGETWO-88105 -->* Magento now includes a gift card recipient's email address in the gift card account history. Previously, Magento did not include the gift card recipient's name and email address in the gift card account history, even though Magento successfully sent the email.
+<!--- MAGETWO-88105  -->
+*  Magento now includes a gift card recipient's email address in the gift card account history. Previously, Magento did not include the gift card recipient's name and email address in the gift card account history, even though Magento successfully sent the email.
 
 ### Import/export
 
-<!--- MAGETWO-81368 -->* You can now successfully import product images and image labels from CSV files. Previously after import, the  alt text field on the Admin was empty, even though the label was imported and was visible on the product list page as alt attribute, and the Product Detail page missed the alt attribute on image fields. *Fix submitted by Ben Robie in pull request 11323*. [GitHub-9931](https://github.com/magento/magento2/issues/9931)
+<!--- MAGETWO-81368  -->
+*  You can now successfully import product images and image labels from CSV files. Previously after import, the  alt text field on the Admin was empty, even though the label was imported and was visible on the product list page as alt attribute, and the Product Detail page missed the alt attribute on image fields. *Fix submitted by Ben Robie in pull request 11323*. [GitHub-9931](https://github.com/magento/magento2/issues/9931)
 
-<!--- MAGETWO-83726 -->* The CSV file created by using **System > Export** now incorporates the value of `hide_for_product_page`.
+<!--- MAGETWO-83726  -->
+*  The CSV file created by using **System > Export** now incorporates the value of `hide_for_product_page`.
 *Fix submitted by Nickolas Malyovanets in pull request 11926*.
 
-<!--- MAGETWO-83957 -->* You can now import a value of zero (0) into a custom attribute when using the Admin product import feature. *Fix submitted by p-bystritsky in pull request 12283*. [GitHub-12083](https://github.com/magento/magento2/issues/12083)
+<!--- MAGETWO-83957  -->
+*  You can now import a value of zero (0) into a custom attribute when using the Admin product import feature. *Fix submitted by p-bystritsky in pull request 12283*. [GitHub-12083](https://github.com/magento/magento2/issues/12083)
 
-<!--- MAGETWO-84448 -->* You can now import or export a specific store view that includes custom options and bundle product options. Previously, the import/export feature did not include store view-level edits for  custom options.
+<!--- MAGETWO-84448  -->
+*  You can now import or export a specific store view that includes custom options and bundle product options. Previously, the import/export feature did not include store view-level edits for  custom options.
 
-<!--- MAGETWO-85629 -->* Import no longer fails when you import products with image filenames containing round brackets from a CSV file. *Fix submitted by p-bystritsky in pull request 1017*. [GitHub-12084](https://github.com/magento/magento2/issues/12084)
+<!--- MAGETWO-85629  -->
+*  Import no longer fails when you import products with image filenames containing round brackets from a CSV file. *Fix submitted by p-bystritsky in pull request 1017*. [GitHub-12084](https://github.com/magento/magento2/issues/12084)
 
-<!--- MAGETWO-86657 -->* When you import information about existing customers, Magento now changes only the specific rows for this customer. If rows for other customer attributes (for example, `group_id`, `store_id`, `created_at`) are absent in the import file, these values are included unchanged.
+<!--- MAGETWO-86657  -->
+*  When you import information about existing customers, Magento now changes only the specific rows for this customer. If rows for other customer attributes (for example, `group_id`, `store_id`, `created_at`) are absent in the import file, these values are included unchanged.
 
-<!--- MAGETWO-88044 -->* Magento now provides a test for adding values to the system variable collection unit test. *Fix submitted by Nickolas Malyovanets in pull request 13742*.
+<!--- MAGETWO-88044  -->
+*  Magento now provides a test for adding values to the system variable collection unit test. *Fix submitted by Nickolas Malyovanets in pull request 13742*.
 
-<!--- MAGETWO-74042 -->* You can now successfully import  configurable products with specified configurable links when the `store_view_code` setting isn't set. Previously, you could successfully import a configurable product with both configurable and additional attributes, but when you viewed the category to which the product belonged, the product was not displayed. [GitHub-5876](https://github.com/magento/magento2/issues/5876)
+<!--- MAGETWO-74042  -->
+*  You can now successfully import  configurable products with specified configurable links when the `store_view_code` setting isn't set. Previously, you could successfully import a configurable product with both configurable and additional attributes, but when you viewed the category to which the product belonged, the product was not displayed. [GitHub-5876](https://github.com/magento/magento2/issues/5876)
 
-<!--- MAGETWO-88251 -->* Save operations on CMS blocks now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13796*.
+<!--- MAGETWO-88251  -->
+*  Save operations on CMS blocks now load from `pageRepository`. *Fix submitted by JeroenVanLeusden in pull request 13796*.
 
-<!--- MAGETWO-86448 -->* The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled. *Fix submitted by Paresh Pansuriya in pull request 13038*. [GitHub-12711](https://github.com/magento/magento2/issues/12711)
+<!--- MAGETWO-86448  -->
+*  The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled. *Fix submitted by Paresh Pansuriya in pull request 13038*. [GitHub-12711](https://github.com/magento/magento2/issues/12711)
 
-<!--- MAGETWO-88340 -->* You can now use the layout update XML field to include custom CSS in CMS pages. [GitHub-4454](https://github.com/magento/magento2/issues/4454)
+<!--- MAGETWO-88340  -->
+*  You can now use the layout update XML field to include custom CSS in CMS pages. [GitHub-4454](https://github.com/magento/magento2/issues/4454)
 
-<!--- MAGETWO-88276 -->* We've added an @api annotation to the  block argument marker interface. This identifies this interface as requiring only a minor version dependency. See [Dependencies]({{ site.baseurl }}/guides/v2.2/extension-dev-guide/versioning/dependencies.html) for more information. *Fix submitted by Vinai Kopp in pull request 13816*.
+<!--- MAGETWO-88276  -->
+*  We've added an @api annotation to the  block argument marker interface. This identifies this interface as requiring only a minor version dependency. See [Dependencies]({{ site.baseurl }}/guides/v2.2/extension-dev-guide/versioning/dependencies.html) for more information. *Fix submitted by Vinai Kopp in pull request 13816*.
 
 ### Indexing
 
-<!--- MAGETWO-86446 -->* The URL that points to Magento `crontab` documentation has been updated to reflect current cron documentation in `app/code/Magento/Indexer/Model/Message/Invalid.php`. *Fix submitted by Robbie Thompson in pull request 13050*.
+<!--- MAGETWO-86446  -->
+*  The URL that points to Magento `crontab` documentation has been updated to reflect current cron documentation in `app/code/Magento/Indexer/Model/Message/Invalid.php`. *Fix submitted by Robbie Thompson in pull request 13050*.
 
-<!--- MAGETWO-83503 -->* You can now view the state of the mview queue in real time, which can be useful when debugging indexing issues. Specifically, you can now view how many items are in the queue pending processing, as well as view information from the `mview_state` table. *Fix submitted by Luke Rodgers in pull request 12122*.
+<!--- MAGETWO-83503  -->
+*  You can now view the state of the mview queue in real time, which can be useful when debugging indexing issues. Specifically, you can now view how many items are in the queue pending processing, as well as view information from the `mview_state` table. *Fix submitted by Luke Rodgers in pull request 12122*.
 
 ### Infrastructure
 
-<!--- MAGETWO-86542 -->* Zoom now works as expected when using dropdown menus. Previously, zoom worked fine, but when you hovered over the category dropdown menu to the overlap area of product image and dropdown menu, the zoom was abnormally active,  even though the mouse was still on the dropdown menu. *Fix submitted by Mayank Zalavadia in pull request 13084*. [GitHub-5129](https://github.com/magento/magento2/issues/5129)
+<!--- MAGETWO-86542  -->
+*  Zoom now works as expected when using dropdown menus. Previously, zoom worked fine, but when you hovered over the category dropdown menu to the overlap area of product image and dropdown menu, the zoom was abnormally active,  even though the mouse was still on the dropdown menu. *Fix submitted by Mayank Zalavadia in pull request 13084*. [GitHub-5129](https://github.com/magento/magento2/issues/5129)
 
-<!--- MAGETWO-86505 -->* RequireJS loading issues that occur when ad blockers are active have been resolved. Previously, `uBlock` (or any ad blocker) forbade the `trackingCode.js` file from loading, which prompted RequireJS to throw  an  exception. This exception broke the JavaScript execution flow and caused unexpected issues throughout the storefront. *Fix submitted by Yonn Trimoreau in pull request 13061*.
+<!--- MAGETWO-86505  -->
+*  RequireJS loading issues that occur when ad blockers are active have been resolved. Previously, `uBlock` (or any ad blocker) forbade the `trackingCode.js` file from loading, which prompted RequireJS to throw  an  exception. This exception broke the JavaScript execution flow and caused unexpected issues throughout the storefront. *Fix submitted by Yonn Trimoreau in pull request 13061*.
 
-<!--- MAGETWO-86501 -->* `continue()` has been removed from templates. *Fix submitted by Ihor Sviziev in pull request 13076*.
+<!--- MAGETWO-86501  -->
+*  `continue()` has been removed from templates. *Fix submitted by Ihor Sviziev in pull request 13076*.
 
-<!--- MAGETWO-85698 -->* The comment that marks the `\Magento\Checkout\Model\Cart` class as deprecated now includes a pointer to an alternative class. This fix is part of an ongoing effort to add pointers to valid replacements when marking methods and classes as deprecated. *Fix submitted by Fabian Schmengler in pull request 13061*. [GitHub-10133](https://github.com/magento/magento2/issues/11070)
+<!--- MAGETWO-85698  -->
+*  The comment that marks the `\Magento\Checkout\Model\Cart` class as deprecated now includes a pointer to an alternative class. This fix is part of an ongoing effort to add pointers to valid replacements when marking methods and classes as deprecated. *Fix submitted by Fabian Schmengler in pull request 13061*. [GitHub-10133](https://github.com/magento/magento2/issues/11070)
 
-<!--- MAGETWO-85694 -->* A new file (`CODE_OF_CONDUCT.md`) that defines  standards for how to engage in the community has been added. *Fix submitted by Ievgen Shakhsuvarov in pull request 12723*.
+<!--- MAGETWO-85694  -->
+*  A new file (`CODE_OF_CONDUCT.md`) that defines  standards for how to engage in the community has been added. *Fix submitted by Ievgen Shakhsuvarov in pull request 12723*.
 
-<!--- MAGETWO-85292 -->* `\Magento\Framework\Data\Tree::getNodeById()` no longer contains an invalid type in its PHPDoc block.  *Fix submitted by Roman K. in pull request 964*. [GitHub-8507](https://github.com/magento/magento2/issues/8507)
+<!--- MAGETWO-85292  -->
+*  `\Magento\Framework\Data\Tree::getNodeById()` no longer contains an invalid type in its PHPDoc block.  *Fix submitted by Roman K. in pull request 964*. [GitHub-8507](https://github.com/magento/magento2/issues/8507)
 
-<!--- MAGETWO-85179 -->* We’ve resolved naming collisions that previously occurred  in the Javascript UI registry. Previously, these naming collisions resulted in the following behaviors: Magento displayed the `element.disabled is not a function` message, and did not create product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
+<!--- MAGETWO-85179  -->
+*  We’ve resolved naming collisions that previously occurred  in the Javascript UI registry. Previously, these naming collisions resulted in the following behaviors: Magento displayed the `element.disabled is not a function` message, and did not create product variations as expected. [GitHub-12555](https://github.com/magento/magento2/issues/12555)
 
 ### Newsletters
 
-<!--- MAGETWO-83999 -->* The **About Us** and **Customer Service** links of the Order Confirmation email (and  other emails sent to the customer) now work as expected. *Fix submitted by Roman K. in pull request*. [GitHub-12261](https://github.com/magento/magento2/issues/12261)
+<!--- MAGETWO-83999  -->
+*  The **About Us** and **Customer Service** links of the Order Confirmation email (and  other emails sent to the customer) now work as expected. *Fix submitted by Roman K. in pull request*. [GitHub-12261](https://github.com/magento/magento2/issues/12261)
 
-<!--- MAGETWO-85783 -->* Magento now sends the newsletter subscription success email as expected when a customer successfully subscribes to a newsletter. *Fix submitted by Styopchik in pull request*. [GitHub-12439](https://github.com/magento/magento2/issues/12439)
+<!--- MAGETWO-85783  -->
+*  Magento now sends the newsletter subscription success email as expected when a customer successfully subscribes to a newsletter. *Fix submitted by Styopchik in pull request*. [GitHub-12439](https://github.com/magento/magento2/issues/12439)
 
-<!--- MAGETWO-86435 -->* Magento now uses indexes to retrieve subscriber information during the creation of email to newsletter subscribers. Previously, Magento did not use indexes for this task, and performance was poor. *Fix submitted by Amit Bera in pull request*. [GitHub-12787](https://github.com/magento/magento2/issues/12787)
+<!--- MAGETWO-86435  -->
+*  Magento now uses indexes to retrieve subscriber information during the creation of email to newsletter subscribers. Previously, Magento did not use indexes for this task, and performance was poor. *Fix submitted by Amit Bera in pull request*. [GitHub-12787](https://github.com/magento/magento2/issues/12787)
 
-<!--- MAGETWO-86562 -->* Magento no longer sends multiple confirmation emails when a customer successfully subscribes to a newsletter. *Fix submitted by Torben Höhn in pull request 13044*. [GitHub-12876](https://github.com/magento/magento2/issues/12876)
+<!--- MAGETWO-86562  -->
+*  Magento no longer sends multiple confirmation emails when a customer successfully subscribes to a newsletter. *Fix submitted by Torben Höhn in pull request 13044*. [GitHub-12876](https://github.com/magento/magento2/issues/12876)
 
-<!--- MAGETWO-86447 -->* The text of the  **Subscribe to Newsletter** button now wraps correctly. *Fix submitted by monaemipro in pull request 13041*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
+<!--- MAGETWO-86447  -->
+*  The text of the  **Subscribe to Newsletter** button now wraps correctly. *Fix submitted by monaemipro in pull request 13041*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
 
 ### Orders
 
-<!--- MAGETWO-75840 -->* Magento now shows all products as expected in the Recently Ordered list when a customer places an order that contains products from multiple stores. Previously, in installations with two storefronts, if a customer added products from both stores to the same shopping cart, and placed a single order, the recently ordered product list would not show all ordered products.
+<!--- MAGETWO-75840  -->
+*  Magento now shows all products as expected in the Recently Ordered list when a customer places an order that contains products from multiple stores. Previously, in installations with two storefronts, if a customer added products from both stores to the same shopping cart, and placed a single order, the recently ordered product list would not show all ordered products.
 
-<!--- MAGETWO-82577 -->*  The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
+<!--- MAGETWO-82577  -->
+*   The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
 
-<!--- MAGETWO-83410 -->*  You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
+<!--- MAGETWO-83410  -->
+*   You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
 
-<!--- MAGETWO-83552 -->* Magento now saves an invoice ID on the credit memo when you create a credit memo from the invoice in the Admin. Previously,
+<!--- MAGETWO-83552  -->
+*  Magento now saves an invoice ID on the credit memo when you create a credit memo from the invoice in the Admin. Previously,
 the invoice ID was not included.  *Fix submitted by Anton Evers in pull request 11067*. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
 
-<!--- MAGETWO-83740 -->* Credit memos can have the state open (`\Magento\Sales\Model\Order\Creditmemo::STATE_OPEN`). As a result, you can create a credit memo with an ID that still has to be refunded, and existing credit memos should be refundable if their state is open. *Fix submitted by Anton Evers in pull request 11550*.
+<!--- MAGETWO-83740  -->
+*  Credit memos can have the state open (`\Magento\Sales\Model\Order\Creditmemo::STATE_OPEN`). As a result, you can create a credit memo with an ID that still has to be refunded, and existing credit memos should be refundable if their state is open. *Fix submitted by Anton Evers in pull request 11550*.
 
-<!--- MAGETWO-83783 -->* The `Magento\Sales\Service\V1\OrderCreateTest` test now has the correct shipping method fixture. Previously, this test contained an incorrect shipping method fixture, which produced an error whenever an order's shipping method was treated as an object. *Fix submitted by andrew-garside-temando in pull request 12227*.
+<!--- MAGETWO-83783  -->
+*  The `Magento\Sales\Service\V1\OrderCreateTest` test now has the correct shipping method fixture. Previously, this test contained an incorrect shipping method fixture, which produced an error whenever an order's shipping method was treated as an object. *Fix submitted by andrew-garside-temando in pull request 12227*.
 
-<!--- MAGETWO-84219 -->* When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
+<!--- MAGETWO-84219  -->
+*  When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
 
-<!--- MAGETWO-84256 -->* The `getReservedOrderId()` method now uses the current store as expected instead of the default store. *Fix submitted by Timon de Groot in pull request 11702*. [GitHub-9055](https://github.com/magento/magento2/issues/9055)
+<!--- MAGETWO-84256  -->
+*  The `getReservedOrderId()` method now uses the current store as expected instead of the default store. *Fix submitted by Timon de Groot in pull request 11702*. [GitHub-9055](https://github.com/magento/magento2/issues/9055)
 
-<!--- MAGETWO-85305 -->* When you are editing an order's shipping or billing address, Magento now displays the allowed countries from the correct store view. Previously, possible addresses were derived from the wrong store view. *Fix submitted by Roman K. in a pull request*. [GitHub-12560](https://github.com/magento/magento2/issues/12560)
+<!--- MAGETWO-85305  -->
+*  When you are editing an order's shipping or billing address, Magento now displays the allowed countries from the correct store view. Previously, possible addresses were derived from the wrong store view. *Fix submitted by Roman K. in a pull request*. [GitHub-12560](https://github.com/magento/magento2/issues/12560)
 
-<!--- MAGETWO-85660 -->* The `\Magento\Sales\Model\Order\Pdf\AbstractPdf::drawLineBlocks` method now works as expected. Previously, when a text block spanned more than one page, Magento threw a `Zend_Pdf_Exception` error, and displayed this error: `Font has not been set`. *Fix submitted by serhii-balko in pull request 1016*. [GitHub-11743](https://github.com/magento/magento2/issues/11743)
+<!--- MAGETWO-85660  -->
+*  The `\Magento\Sales\Model\Order\Pdf\AbstractPdf::drawLineBlocks` method now works as expected. Previously, when a text block spanned more than one page, Magento threw a `Zend_Pdf_Exception` error, and displayed this error: `Font has not been set`. *Fix submitted by serhii-balko in pull request 1016*. [GitHub-11743](https://github.com/magento/magento2/issues/11743)
 
-<!--- MAGETWO-86845 -->* Magento no longer exports extra records when you export invoices for multiple orders. *Fix submitted by Sanjay Patel in pull request 13208*. [GitHub-12714](https://github.com/magento/magento2/issues/12714)
+<!--- MAGETWO-86845  -->
+*  Magento no longer exports extra records when you export invoices for multiple orders. *Fix submitted by Sanjay Patel in pull request 13208*. [GitHub-12714](https://github.com/magento/magento2/issues/12714)
 
-<!--- MAGETWO-80233 -->* You can now place orders using PayPal when **Payment Action = Order**. Previously, when **Payment Action = Order**, Magento displayed this error when you reached the order review page: `We can't place the order.`
+<!--- MAGETWO-80233  -->
+*  You can now place orders using PayPal when **Payment Action = Order**. Previously, when **Payment Action = Order**, Magento displayed this error when you reached the order review page: `We can't place the order.`
 
-<!--- MAGETWO-86258 -->* The cancel order and restore quote methods now accurately calculate the amount of stock to be returned to inventory when an order is canceled. Previously, when you canceled an order, some of these methods did not accurately calculate the amount of restored stock. *Fix submitted by Danny Verkade in pull request 12668*. [GitHub-9969](https://github.com/magento/magento2/issues/9969)
+<!--- MAGETWO-86258  -->
+*  The cancel order and restore quote methods now accurately calculate the amount of stock to be returned to inventory when an order is canceled. Previously, when you canceled an order, some of these methods did not accurately calculate the amount of restored stock. *Fix submitted by Danny Verkade in pull request 12668*. [GitHub-9969](https://github.com/magento/magento2/issues/9969)
 
-<!--- MAGETWO-87292 -->*  Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
+<!--- MAGETWO-87292  -->
+*   Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
 
-<!--- MAGETWO-87291 -->* The Shipment Tracking REST API now throws an error as expected if the specified order doesn't exist. *Fix submitted by Roman K. in pull request 1162*.
+<!--- MAGETWO-87291  -->
+*  The Shipment Tracking REST API now throws an error as expected if the specified order doesn't exist. *Fix submitted by Roman K. in pull request 1162*.
 
-<!--- MAGETWO-83868 -->* Invoices now display the exact quantity of a product ordered, even if it is a fractional unit (for example,  6.5). Previously, when Magento tried to invoice an order that had products with quantities that required decimals, it rounded down the quantity to the nearest whole number in the invoice. *Fix submitted by Nickolas Malyovanets in pull request 11997*.  [GitHub-11941](https://github.com/magento/magento2/issues/11941)
+<!--- MAGETWO-83868  -->
+*  Invoices now display the exact quantity of a product ordered, even if it is a fractional unit (for example,  6.5). Previously, when Magento tried to invoice an order that had products with quantities that required decimals, it rounded down the quantity to the nearest whole number in the invoice. *Fix submitted by Nickolas Malyovanets in pull request 11997*.  [GitHub-11941](https://github.com/magento/magento2/issues/11941)
 
 ### Payment methods
 
-<!--- MAGETWO-84588,MAGETWO-84587, MAGETWO-84590 -->* The multi-shipping checkout  flow now supports the CyberSource payment method. This payment method is supported by Magento Commerce only. However,  as part of the process of adding CyberSource support, we've made improvements to the Multi-shipping module to simplify integration process for other payment methods.
+<!--- MAGETWO-84588,MAGETWO-84587, MAGETWO-84590  -->
+*  The multi-shipping checkout  flow now supports the CyberSource payment method. This payment method is supported by Magento Commerce only. However,  as part of the process of adding CyberSource support, we've made improvements to the Multi-shipping module to simplify integration process for other payment methods.
 
 Users of the CyberSource payment method should note that CyberSource uses the Magento Vault module only to store and retrieve tokens. Stored CyberSource tokens won't be displayed on the checkout page or customer account.
 
-<!--- MAGETWO-75497 -->* Logged-out customers can no longer see previously saved credit cards. Previously, users logged in as guest could see some payment information from an earlier, canceled order.
+<!--- MAGETWO-75497  -->
+*  Logged-out customers can no longer see previously saved credit cards. Previously, users logged in as guest could see some payment information from an earlier, canceled order.
 
-<!--- MAGETWO-81395 -->* Third-party developers can now customize payment errors messages for payment integrations based on the Magento Payment Provider Gateway.
+<!--- MAGETWO-81395  -->
+*  Third-party developers can now customize payment errors messages for payment integrations based on the Magento Payment Provider Gateway.
 
-<!--- MAGETWO-82910 -->* PayPal Express Checkout now appears as a payment option on the Checkout page when the PayPal buttons are available on the shopping cart page. Previously, PayPal did not appear as a payment method on the Checkout page when the billing agreement was disabled, although the PayPal buttons were still available on the shopping cart page.
+<!--- MAGETWO-82910  -->
+*  PayPal Express Checkout now appears as a payment option on the Checkout page when the PayPal buttons are available on the shopping cart page. Previously, PayPal did not appear as a payment method on the Checkout page when the billing agreement was disabled, although the PayPal buttons were still available on the shopping cart page.
 
-<!--- MAGETWO-83959-->* You can now view order details for an order created with a custom offline payment method. Previously, Magento displayed  PHP warning (undefined index) instead of the order details. *Fix submitted by Alex in pull request 12296*. [GitHub-3596](https://github.com/magento/magento2/issues/3596)
+<!--- MAGETWO-83959 -->
+*  You can now view order details for an order created with a custom offline payment method. Previously, Magento displayed  PHP warning (undefined index) instead of the order details. *Fix submitted by Alex in pull request 12296*. [GitHub-3596](https://github.com/magento/magento2/issues/3596)
 
-<!--- MAGETWO-86112 -->*  Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
+<!--- MAGETWO-86112  -->
+*   Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
 
-<!--- MAGETWO-86297 -->* The  `is_active` and `is_visible` columns now default to true even when column default values are not set in the `vault_payment_token` installation script. *Fix submitted by helloitsluke in pull request 12965*.
+<!--- MAGETWO-86297  -->
+*  The  `is_active` and `is_visible` columns now default to true even when column default values are not set in the `vault_payment_token` installation script. *Fix submitted by helloitsluke in pull request 12965*.
 
-<!--- MAGETWO-86308 -->* If you've chosen a custom payment method that is offline when you create an order, Magento now displays that payment method's name as expected when you view order details in **Payment & Shipping**. *Fix submitted by zamoroka in pull request 12731*. [GitHub-12209](https://github.com/magento/magento2/issues/12209)
+<!--- MAGETWO-86308  -->
+*  If you've chosen a custom payment method that is offline when you create an order, Magento now displays that payment method's name as expected when you view order details in **Payment & Shipping**. *Fix submitted by zamoroka in pull request 12731*. [GitHub-12209](https://github.com/magento/magento2/issues/12209)
 
-<!--- MAGETWO-86351 -->* PayPal now works as expected with virtual products such as gift cards. Previously, when you tried to place an order for a virtual product using PayPal, Magento did not display the PayPal popup when you clicked **Continue PayPal** during checkout.
+<!--- MAGETWO-86351  -->
+*  PayPal now works as expected with virtual products such as gift cards. Previously, when you tried to place an order for a virtual product using PayPal, Magento did not display the PayPal popup when you clicked **Continue PayPal** during checkout.
 
-<!--- MAGETWO-84639 -->* Magento now correctly adds checkout agreements data to  requests and validates payment information when you place an order using PayPal Express. Previously, you could check this box, but Magento did not parse  the agreements data  or pass it  to the set-payment-information API. This failure in turn triggered the `CheckoutAgreements` validation plugin,  which failed to validate. *Fix submitted by Ričards Zālītis in pull request 12401*.
+<!--- MAGETWO-84639  -->
+*  Magento now correctly adds checkout agreements data to  requests and validates payment information when you place an order using PayPal Express. Previously, you could check this box, but Magento did not parse  the agreements data  or pass it  to the set-payment-information API. This failure in turn triggered the `CheckoutAgreements` validation plugin,  which failed to validate. *Fix submitted by Ričards Zālītis in pull request 12401*.
 
-<!--- MAGETWO-86426 -->* Magento no longer archives active orders that are placed using PayPal Express Checkout. Previously, if you placed an order using PayPal Express Checkout, Magento would place the order as expected but also add it to the list of archived orders.
+<!--- MAGETWO-86426  -->
+*  Magento no longer archives active orders that are placed using PayPal Express Checkout. Previously, if you placed an order using PayPal Express Checkout, Magento would place the order as expected but also add it to the list of archived orders.
 
-<!--- MAGETWO-84647 -->* Magento now correctly displays transparent `PNG` watermarks on JPEG images. Previously, Magento did not correctly display a transparent watermark as expected on an image, but instead displayed a white outline of the box where the watermark should be. *Fix submitted by Elze Kool in pull request 11060*. [GitHub-10661](https://github.com/magento/magento2/issues/10661)
+<!--- MAGETWO-84647  -->
+*  Magento now correctly displays transparent `PNG` watermarks on JPEG images. Previously, Magento did not correctly display a transparent watermark as expected on an image, but instead displayed a white outline of the box where the watermark should be. *Fix submitted by Elze Kool in pull request 11060*. [GitHub-10661](https://github.com/magento/magento2/issues/10661)
 
-<!--- MAGETWO-88235 -->* We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced. *Fix submitted by Marcin Kwiatkowski in pull request 13777*.
+<!--- MAGETWO-88235  -->
+*  We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced. *Fix submitted by Marcin Kwiatkowski in pull request 13777*.
 [GitHub-13315](https://github.com/magento/magento2/issues/13315)
 
-<!--- MAGETWO-87289 -->* Magento now correctly updates the credit memo total when a merchant issues a refund. *Fix submitted by serhii-balko in pull request 1185*. [GitHub-11798](https://github.com/magento/magento2/issues/11798)
+<!--- MAGETWO-87289  -->
+*  Magento now correctly updates the credit memo total when a merchant issues a refund. *Fix submitted by serhii-balko in pull request 1185*. [GitHub-11798](https://github.com/magento/magento2/issues/11798)
 
 ### Performance
 
-<!--- MAGETWO-84480 -->* The addition of a cache for the `getimagesize()` function has improved product image loading.
+<!--- MAGETWO-84480  -->
+*  The addition of a cache for the `getimagesize()` function has improved product image loading.
 
-<!--- MAGETWO-45775 -->* Each cache type now has its own separate cache storage.
+<!--- MAGETWO-45775  -->
+*  Each cache type now has its own separate cache storage.
 
-<!--- MAGETWO-86736 -->* We’ve optimized the initialization of the Product View block, which gives an 11% performance improvement for simple product views.
+<!--- MAGETWO-86736  -->
+*  We’ve optimized the initialization of the Product View block, which gives an 11% performance improvement for simple product views.
 
-<!--- MAGETWO-75769 -->* Magento now caches search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached. This enhancement can result in up to a 36% improvement for cacheable search terms.
+<!--- MAGETWO-75769  -->
+*  Magento now caches search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached. This enhancement can result in up to a 36% improvement for cacheable search terms.
 
 ### Quote
 
-<!--- MAGETWO-86439 -->* If a customer changes the currency type of his order-in-progress while viewing the shopping cart, Magento displays a message that shows the minimum order necessary in the new currency. Previously, this minimum was calculated incorrectly. *Fix submitted by Neeta Kangiya in pull request 13039*.
+<!--- MAGETWO-86439  -->
+*  If a customer changes the currency type of his order-in-progress while viewing the shopping cart, Magento displays a message that shows the minimum order necessary in the new currency. Previously, this minimum was calculated incorrectly. *Fix submitted by Neeta Kangiya in pull request 13039*.
 
-<!--- MAGETWO-86434 -->* Magento no longer truncates very long telephone numbers on the order page. Previously, Magento cut off very long phone numbers at 20 digits. *Fix submitted by Danny Verkade in pull request 13015*. [GitHub-10869](https://github.com/magento/magento2/issues/10869)
+<!--- MAGETWO-86434  -->
+*  Magento no longer truncates very long telephone numbers on the order page. Previously, Magento cut off very long phone numbers at 20 digits. *Fix submitted by Danny Verkade in pull request 13015*. [GitHub-10869](https://github.com/magento/magento2/issues/10869)
 
-<!--- MAGETWO-86430 -->* You can now implement a product attribute that sets **Catalog Input Type for Store Owner** equal to  **Fixed Product Tax** in a multi-store environment. *Fix submitted by Danny Verkade in pull request 13019*.
+<!--- MAGETWO-86430  -->
+*  You can now implement a product attribute that sets **Catalog Input Type for Store Owner** equal to  **Fixed Product Tax** in a multi-store environment. *Fix submitted by Danny Verkade in pull request 13019*.
 [GitHub-12393](https://github.com/magento/magento2/issues/12393)
 
-<!--- MAGETWO-85518 -->* When a customer is on the payment page and tries to reorder or retrace her steps backward through the checkout process, Magento now displays all the relevant shipping methods. Previously, Magento displayed only one shipping method under these circumstances.
+<!--- MAGETWO-85518  -->
+*  When a customer is on the payment page and tries to reorder or retrace her steps backward through the checkout process, Magento now displays all the relevant shipping methods. Previously, Magento displayed only one shipping method under these circumstances.
 
-<!--- MAGETWO-86595 -->* An integrity constraint violation error no longer occurs after you reorder a product with custom options. *Fix submitted by Vinay Shah in pull request 13036*. [GitHub-12705](https://github.com/magento/magento2/issues/12705)
+<!--- MAGETWO-86595  -->
+*  An integrity constraint violation error no longer occurs after you reorder a product with custom options. *Fix submitted by Vinay Shah in pull request 13036*. [GitHub-12705](https://github.com/magento/magento2/issues/12705)
 
 ### Reports
 
-<!--- MAGETWO-84981 -->* The Products in Cart report is now accurate. Previously, if you created a Products in Cart report (**Open Reports** > Marketing > **Products in Cart**) after deleting a product from the catalog, the report displayed a blank list of products. *Fix submitted by angelo983 in pull request 12539*.
+<!--- MAGETWO-84981  -->
+*  The Products in Cart report is now accurate. Previously, if you created a Products in Cart report (**Open Reports** > Marketing > **Products in Cart**) after deleting a product from the catalog, the report displayed a blank list of products. *Fix submitted by angelo983 in pull request 12539*.
 
-<!--- MAGETWO-88173 -->* You can now successfully export the Ordered Products report to a CSV file. Previously, the export file contained no report data.
+<!--- MAGETWO-88173  -->
+*  You can now successfully export the Ordered Products report to a CSV file. Previously, the export file contained no report data.
 
 ### SalesRule
 
-<!--- MAGETWO-71393 -->* Magento now display the correct catalog rule price for bundle products with custom options.
+<!--- MAGETWO-71393  -->
+*  Magento now display the correct catalog rule price for bundle products with custom options.
 
-<!--- MAGETWO-86780 -->* Cart prices now displays the Cart Price Rule shipping discount correctly. Previously, when you placed an order, Magento displayed this error: `Payment method is not available`.
+<!--- MAGETWO-86780  -->
+*  Cart prices now displays the Cart Price Rule shipping discount correctly. Previously, when you placed an order, Magento displayed this error: `Payment method is not available`.
 
-<!--- MAGETWO-86786-->* Magento now displays the exact label value that was given in the Admin during the cart price rule creation. *Fix submitted by Ihor Sviziev in pull request 13141*. [GitHub-11428](https://github.com/magento/magento2/issues/11428), [GitHub-11497](https://github.com/magento/magento2/issues/11497)
+<!--- MAGETWO-86786 -->
+*  Magento now displays the exact label value that was given in the Admin during the cart price rule creation. *Fix submitted by Ihor Sviziev in pull request 13141*. [GitHub-11428](https://github.com/magento/magento2/issues/11428), [GitHub-11497](https://github.com/magento/magento2/issues/11497)
 
-<!--- MAGETWO-87013-->*  Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
+<!--- MAGETWO-87013 -->
+*   Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
 
-<!--- MAGETWO-85960-->* Coupon codes that a customer has applied to a subsequently canceled order are now available for re-use as expected. Previously, once a customer canceled this order, she could not apply the coupon code to another order. *Fix submitted by p-bystritsky in a pull request*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
+<!--- MAGETWO-85960 -->
+*  Coupon codes that a customer has applied to a subsequently canceled order are now available for re-use as expected. Previously, once a customer canceled this order, she could not apply the coupon code to another order. *Fix submitted by p-bystritsky in a pull request*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
 
 ### Search
 
-<!--- MAGETWO-85637 -->* Magento now displays popular search terms in **SEO & Search > Search Terms** as expected. *Fix submitted by p-bystritsky in pull request 1024*. [GitHub-10743](https://github.com/magento/magento2/issues/10743)
+<!--- MAGETWO-85637  -->
+*  Magento now displays popular search terms in **SEO & Search > Search Terms** as expected. *Fix submitted by p-bystritsky in pull request 1024*. [GitHub-10743](https://github.com/magento/magento2/issues/10743)
 
-<!--- MAGETWO-84370-->* Layered navigation now displays the correct product count. Previously, the layered navigation product count incorrectly included only in-stock products. *Fix submitted by Roman K. in pull request 12063*. [GitHub-11946](https://github.com/magento/magento2/issues/11946)
+<!--- MAGETWO-84370 -->
+*  Layered navigation now displays the correct product count. Previously, the layered navigation product count incorrectly included only in-stock products. *Fix submitted by Roman K. in pull request 12063*. [GitHub-11946](https://github.com/magento/magento2/issues/11946)
 
-<!--- MAGETWO-85827-->* Grid filtration now handles MySQL special characters as expected. *Fix submitted by laconica-sergey in pull request 12749*.
+<!--- MAGETWO-85827 -->
+*  Grid filtration now handles MySQL special characters as expected. *Fix submitted by laconica-sergey in pull request 12749*.
 
-<!--- MAGETWO-88331 -->* Magento no longer throws an error when you submit the search form in the header with an empty value. *Fix submitted by Koen V. in pull request 13811*. [GitHub-13791](https://github.com/magento/magento2/issues/13791)
+<!--- MAGETWO-88331  -->
+*  Magento no longer throws an error when you submit the search form in the header with an empty value. *Fix submitted by Koen V. in pull request 13811*. [GitHub-13791](https://github.com/magento/magento2/issues/13791)
 
 ### Shipping
 
 {: .bs-callout-info }
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-86306,  MAGETWO-87934-->* The handling fee configuration of shipping methods is now explicitly cast to 0 to  avoid warnings from PHP 7.1. *Fix submitted by Fabian Schmengler in pull request 13680*.
+<!--- MAGETWO-86306,  MAGETWO-87934 -->
+*  The handling fee configuration of shipping methods is now explicitly cast to 0 to  avoid warnings from PHP 7.1. *Fix submitted by Fabian Schmengler in pull request 13680*.
 
-<!--- MAGETWO-86400 -->* Unused `count($_items)` in templates have been removed. *Fix submitted by Alexander Shkurko in pull request 12901*.
+<!--- MAGETWO-86400  -->
+*  Unused `count($_items)` in templates have been removed. *Fix submitted by Alexander Shkurko in pull request 12901*.
 
-<!--- MAGETWO-85291 -->* Magento now enforces the minimum order amount during checkout as expected. Previously, you could bypass the minimum order amount logic by clicking **Check Out with Multiple Addresses**, removing products from the order and then clicking **Update Qty & Addresses**. *Fix submitted by Roman K. in pull request 963*.
+<!--- MAGETWO-85291  -->
+*  Magento now enforces the minimum order amount during checkout as expected. Previously, you could bypass the minimum order amount logic by clicking **Check Out with Multiple Addresses**, removing products from the order and then clicking **Update Qty & Addresses**. *Fix submitted by Roman K. in pull request 963*.
 
-<!--- MAGETWO-85586 -->* DHL product codes now match those published in the latest DHL products and services guide. Previously, three  DHL product codes in the DHL Shipping module were incorrect. *Fix submitted by gwharton in pull request 12666*.
+<!--- MAGETWO-85586  -->
+*  DHL product codes now match those published in the latest DHL products and services guide. Previously, three  DHL product codes in the DHL Shipping module were incorrect. *Fix submitted by gwharton in pull request 12666*.
 
 ### Sitemap
 
-<!--- MAGETWO-86349 -->*  `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
+<!--- MAGETWO-86349  -->
+*   `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
 
-<!--- MAGETWO-85285 -->* Sitemaps generated in a multi-store environment now include the correct URLs for each store (that is, `http://storename.com/` instead of `http://defaultstore.com/`). *Fix submitted by Roman K. in pull request 935*. [GitHub-12482](https://github.com/magento/magento2/issues/12482)
+<!--- MAGETWO-85285  -->
+*  Sitemaps generated in a multi-store environment now include the correct URLs for each store (that is, `http://storename.com/` instead of `http://defaultstore.com/`). *Fix submitted by Roman K. in pull request 935*. [GitHub-12482](https://github.com/magento/magento2/issues/12482)
 
-<!--- MAGETWO-81525 -->* Magento now handles errors that occur during sitemap generation in a less intrusive way. If Magento throws an exception when generating a sitemap, it now sends the errors through email as configured in the sitemap configuration XML. The former `_translateModel` property is not used anymore, and the inline translation is correctly suspended using the `inlineTranslation` property instead. *Fix submitted by Marina Gociu in a pull request*. [GitHub-10502](https://github.com/magento/magento2/issues/10502)
+<!--- MAGETWO-81525  -->
+*  Magento now handles errors that occur during sitemap generation in a less intrusive way. If Magento throws an exception when generating a sitemap, it now sends the errors through email as configured in the sitemap configuration XML. The former `_translateModel` property is not used anymore, and the inline translation is correctly suspended using the `inlineTranslation` property instead. *Fix submitted by Marina Gociu in a pull request*. [GitHub-10502](https://github.com/magento/magento2/issues/10502)
 
 ### Swagger
 
-<!--- MAGETWO-87444 -->* The code formatting in the Swagger block and template has been updated. *Fix submitted by JeroenVanLeusden in pull request 13485*.
+<!--- MAGETWO-87444  -->
+*  The code formatting in the Swagger block and template has been updated. *Fix submitted by JeroenVanLeusden in pull request 13485*.
 
 ### Swatches
 
-<!--- MAGETWO-83290-->* You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute.  *Fix submitted by gonzalopelon in pull request 12044*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
+<!--- MAGETWO-83290 -->
+*  You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute.  *Fix submitted by gonzalopelon in pull request 12044*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
 
-<!--- MAGETWO-86576 -->* Visual swatches that have a color assigned now show that color in the swatch box. Previously, Magento did not display any color in the color swatch box. *Fix submitted by Chris Pook in pull request 13101*. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
+<!--- MAGETWO-86576  -->
+*  Visual swatches that have a color assigned now show that color in the swatch box. Previously, Magento did not display any color in the color swatch box. *Fix submitted by Chris Pook in pull request 13101*. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
 
-<!--- MAGETWO-86665 -->* The error message displayed when you do not supply enough information during swatch creation has been edited for clarity and grammatical accuracy. *Fix submitted by Nickolas Malyovanets in pull request 1117*. [GitHub-5550](https://github.com/magento/magento2/issues/5550)
+<!--- MAGETWO-86665  -->
+*  The error message displayed when you do not supply enough information during swatch creation has been edited for clarity and grammatical accuracy. *Fix submitted by Nickolas Malyovanets in pull request 1117*. [GitHub-5550](https://github.com/magento/magento2/issues/5550)
 
 ### TargetRule
 
-<!--- MAGETWO-86013 -->* You can now successfully save a Related Product rule.
+<!--- MAGETWO-86013  -->
+*  You can now successfully save a Related Product rule.
 
 ### Tax
 
-<!--- MAGETWO-87941 -->*  The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multi-select. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
+<!--- MAGETWO-87941  -->
+*   The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multi-select. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
 
-<!--- MAGETWO-87352 -->* We've removed the redundant default discount tax calculation (`tax/calculation/discount_tax`) from `Magento/Tax/etc/config.xml`. *Fix submitted by Vincent Marmiesse in pull request 13449*.
+<!--- MAGETWO-87352  -->
+*  We've removed the redundant default discount tax calculation (`tax/calculation/discount_tax`) from `Magento/Tax/etc/config.xml`. *Fix submitted by Vincent Marmiesse in pull request 13449*.
 
-<!--- MAGETWO-87339 -->* The **Not yet calculated** text string immediately adjacent to the string **Tax** on the checkout page is now translated as expected. *Fix submitted by Roman K. in pull request 1147*. [GitHub-7849](https://github.com/magento/magento2/issues/7849)
+<!--- MAGETWO-87339  -->
+*  The **Not yet calculated** text string immediately adjacent to the string **Tax** on the checkout page is now translated as expected. *Fix submitted by Roman K. in pull request 1147*. [GitHub-7849](https://github.com/magento/magento2/issues/7849)
 
-<!--- MAGETWO-83402 -->* Magento no longer displays incorrect tax amounts for orders when using a non-default tax configuration. *Fix submitted by Pieter Cappelle in pull request 12639*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
+<!--- MAGETWO-83402  -->
+*  Magento no longer displays incorrect tax amounts for orders when using a non-default tax configuration. *Fix submitted by Pieter Cappelle in pull request 12639*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
 
 ### Testing
 
-<!--- MAGETWO-87290 -->* `ConfigurationTest` no longer fails when you install Magento using Composer. *Fix submitted by Nickolas Malyovanets in pull request 1161*. [GitHub-12574](https://github.com/magento/magento2/issues/12574)
+<!--- MAGETWO-87290  -->
+*  `ConfigurationTest` no longer fails when you install Magento using Composer. *Fix submitted by Nickolas Malyovanets in pull request 1161*. [GitHub-12574](https://github.com/magento/magento2/issues/12574)
 
-<!--- MAGETWO-87984 -->* We've added `MagentoStyle` to console input and output in Travis tests.
+<!--- MAGETWO-87984  -->
+*  We've added `MagentoStyle` to console input and output in Travis tests.
 
-<!--- MAGETWO-86859 -->* We've re-implemented tests using Jasmine as part of the process of removing the legacy JavaScript test framework and completely removing `JSTestDriver` support.  *Fix submitted by Carlos Lizaga in a pull request*. [GitHub-12342](https://github.com/magento/magento2/issues/12342)
+<!--- MAGETWO-86859  -->
+*  We've re-implemented tests using Jasmine as part of the process of removing the legacy JavaScript test framework and completely removing `JSTestDriver` support.  *Fix submitted by Carlos Lizaga in a pull request*. [GitHub-12342](https://github.com/magento/magento2/issues/12342)
 
-<!--- MAGETWO-86005 -->* `functional.suite.dist.yml` now  handles custom backend names. Previously, the value for the `backend_name` configuration was hardcoded. *Fix submitted by scribam in pull request 12884*.
+<!--- MAGETWO-86005  -->
+*  `functional.suite.dist.yml` now  handles custom backend names. Previously, the value for the `backend_name` configuration was hardcoded. *Fix submitted by scribam in pull request 12884*.
 
-<!--- MAGETWO-85940 -->* We've added a missing preference for `ObjectManager\ConfigInterface` in integration tests. *Fix submitted by Fabian Schmengler in pull request 12845*. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
+<!--- MAGETWO-85940  -->
+*  We've added a missing preference for `ObjectManager\ConfigInterface` in integration tests. *Fix submitted by Fabian Schmengler in pull request 12845*. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
 
-<!--- MAGETWO-85537 -->* Integration Test Annotation `magentoAppArea` no longer breaks with valid values. *Fix submitted by Nickolas Malyovanets in pull request 996*. [GitHub-2907](https://github.com/magento/magento2/issues/2907)
+<!--- MAGETWO-85537  -->
+*  Integration Test Annotation `magentoAppArea` no longer breaks with valid values. *Fix submitted by Nickolas Malyovanets in pull request 996*. [GitHub-2907](https://github.com/magento/magento2/issues/2907)
 
-<!--- MAGETWO-85520 -->* The inline documentation of the static test for XSS vulnerabilities now reflects that `@escapeNotVerified` is disallowed in Magento versions equal or greater than 2.2. *Fix submitted by Matthias Zeis in pull request 12639*.
+<!--- MAGETWO-85520  -->
+*  The inline documentation of the static test for XSS vulnerabilities now reflects that `@escapeNotVerified` is disallowed in Magento versions equal or greater than 2.2. *Fix submitted by Matthias Zeis in pull request 12639*.
 
-<!--- MAGETWO-88174 -->* We've added integration tests for product URL rewrite generation. *Fix submitted by Adrien Louis-Rossignol in pull request 13567*. [GitHub-5863](https://github.com/magento/magento2/issues/5863), [GitHub-8227](https://github.com/magento/magento2/issues/8227), [GitHub-8957](https://github.com/magento/magento2/issues/8957), [GitHub-10073](https://github.com/magento/magento2/issues/10073), [GitHub-13240](https://github.com/magento/magento2/issues/13240)
+<!--- MAGETWO-88174  -->
+*  We've added integration tests for product URL rewrite generation. *Fix submitted by Adrien Louis-Rossignol in pull request 13567*. [GitHub-5863](https://github.com/magento/magento2/issues/5863), [GitHub-8227](https://github.com/magento/magento2/issues/8227), [GitHub-8957](https://github.com/magento/magento2/issues/8957), [GitHub-10073](https://github.com/magento/magento2/issues/10073), [GitHub-13240](https://github.com/magento/magento2/issues/13240)
 
 ### Themes
 
-<!--- MAGETWO-72898 -->* Magento no longer caches warning messages as often as a customer clicks the  **Update Shopping Cart** button while the  shopping cart page loads. Previously, Magento cached a warning message each time a customer clicked this button while  the page loaded in Firefox or Chrome, and this action  resulted in multiple warning messages appearing on the top of the shopping cart page.
+<!--- MAGETWO-72898  -->
+*  Magento no longer caches warning messages as often as a customer clicks the  **Update Shopping Cart** button while the  shopping cart page loads. Previously, Magento cached a warning message each time a customer clicked this button while  the page loaded in Firefox or Chrome, and this action  resulted in multiple warning messages appearing on the top of the shopping cart page.
 
-<!--- MAGETWO-85785 -->* If a customer is logged in while  Magento loads, then the welcome message displays the customer's full name. *Fix submitted by Oleh Kravets in pull request 12738*. [GitHub-12719](https://github.com/magento/magento2/issues/12719)
+<!--- MAGETWO-85785  -->
+*  If a customer is logged in while  Magento loads, then the welcome message displays the customer's full name. *Fix submitted by Oleh Kravets in pull request 12738*. [GitHub-12719](https://github.com/magento/magento2/issues/12719)
 
-<!--- MAGETWO-85549 -->* You can now disable the full-screen gallery on mobile devices *Fix submitted by p-bystritsky in pull request 1006*. [GitHub-12490](https://github.com/magento/magento2/issues/12490), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
+<!--- MAGETWO-85549  -->
+*  You can now disable the full-screen gallery on mobile devices *Fix submitted by p-bystritsky in pull request 1006*. [GitHub-12490](https://github.com/magento/magento2/issues/12490), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
 
-<!--- MAGETWO-86310 -->* Protected method `getHtml` now checks each child for an existing class and then appends the `$outermostClass` if true. Previously, when creating a dependency injection for the `Magento\Theme\Block\Html\Topmenu` class, you could not change class names on children in a `beforeGetHtml` method because  `getHtml` declares `setClass()` on all child items. *Fix submitted by jonshipman in pull request 12862*.
+<!--- MAGETWO-86310  -->
+*  Protected method `getHtml` now checks each child for an existing class and then appends the `$outermostClass` if true. Previously, when creating a dependency injection for the `Magento\Theme\Block\Html\Topmenu` class, you could not change class names on children in a `beforeGetHtml` method because  `getHtml` declares `setClass()` on all child items. *Fix submitted by jonshipman in pull request 12862*.
 
-<!--- MAGETWO-85708 -->* Customers can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full-screen zoom for any product image, he could not close the full-screen zoom.
+<!--- MAGETWO-85708  -->
+*  Customers can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full-screen zoom for any product image, he could not close the full-screen zoom.
 
 ### Translations and locale
 
-<!--- MAGETWO-86286 -->* Inline translations and custom translators now work for Knockout templates. *Fix submitted by Dmitry Fedyuk in pull request 12953*. [GitHub-2156](https://github.com/magento/magento2/issues/2156)
+<!--- MAGETWO-86286  -->
+*  Inline translations and custom translators now work for Knockout templates. *Fix submitted by Dmitry Fedyuk in pull request 12953*. [GitHub-2156](https://github.com/magento/magento2/issues/2156)
 
-<!--- MAGETWO-86778 -->* Magento now provides a locale for Swedish (Finland). *Fix submitted by Nickolas Malyovanets in pull request 1207*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
+<!--- MAGETWO-86778  -->
+*  Magento now provides a locale for Swedish (Finland). *Fix submitted by Nickolas Malyovanets in pull request 1207*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
 
-<!--- MAGETWO-87226 -->* Magento now uses current locale (as defined in **Stores > Settings > Configuration > Advanced Reporting**) when translating the time zone label. Previously, Magento used operating system settings instead of the current locale. *Fix submitted by adrian-martinez-interactiv4 in pull request 13408*.
+<!--- MAGETWO-87226  -->
+*  Magento now uses current locale (as defined in **Stores > Settings > Configuration > Advanced Reporting**) when translating the time zone label. Previously, Magento used operating system settings instead of the current locale. *Fix submitted by adrian-martinez-interactiv4 in pull request 13408*.
 
-<!--- MAGETWO-86436 -->* Newsletter labels can now handle the Chinese language. *Fix submitted by Dasharth patel in pull request 13029*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
+<!--- MAGETWO-86436  -->
+*  Newsletter labels can now handle the Chinese language. *Fix submitted by Dasharth patel in pull request 13029*. [GitHub-12320](https://github.com/magento/magento2/issues/12320)
 
-<!--- MAGETWO-87575 -->* The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags such as `<translate args="This won't be translated"`.  *Fix submitted by Matti Vapa in pull request 13528*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
+<!--- MAGETWO-87575  -->
+*  The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags such as `<translate args="This won't be translated"`.  *Fix submitted by Matti Vapa in pull request 13528*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
 
 ### User interface
 
-<!--- MAGETWO-85784-->* You can now configure a form field with validation range words. As a result, the category name is validated, and the category is created (or displays the correct error message, if validation fails). Previously, Magento displayed an error message on the console. *Fix submitted by Robin Huy in pull request 12739*.
+<!--- MAGETWO-85784 -->
+*  You can now configure a form field with validation range words. As a result, the category name is validated, and the category is created (or displays the correct error message, if validation fails). Previously, Magento displayed an error message on the console. *Fix submitted by Robin Huy in pull request 12739*.
 
-<!--- MAGETWO-86025 -->* The **Save Block** button on the Add New Block page no longer ignores clicks if the content editor is empty.
+<!--- MAGETWO-86025  -->
+*  The **Save Block** button on the Add New Block page no longer ignores clicks if the content editor is empty.
 *Fix submitted by Roman K. in pull request 1032*. [GitHub-8114](https://github.com/magento/magento2/issues/8114)
 
-<!--- MAGETWO-86438 -->* Magento now disables the promo code input box after a user applies a promo code. *Fix submitted by Chirag P in pull request 13030*.
+<!--- MAGETWO-86438  -->
+*  Magento now disables the promo code input box after a user applies a promo code. *Fix submitted by Chirag P in pull request 13030*.
 
-<!--- MAGETWO-84903 -->* Magento now displays video and images as expected when you select a video or click to view a full-screen image for a configurable product. *Fix submitted by Chumak Roman in pull request 12469*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
+<!--- MAGETWO-84903  -->
+*  Magento now displays video and images as expected when you select a video or click to view a full-screen image for a configurable product. *Fix submitted by Chumak Roman in pull request 12469*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
 
-<!--- MAGETWO-83815 -->* The PHP notice that Magento displays when an invalid `ui_component` configuration is used has been improved. *Fix submitted by Vova Yatsyuk in pull request 12239*.
+<!--- MAGETWO-83815  -->
+*  The PHP notice that Magento displays when an invalid `ui_component` configuration is used has been improved. *Fix submitted by Vova Yatsyuk in pull request 12239*.
 
-<!--- MAGETWO-83293 -->* Magento has added verification for previously set filters in `Magento/Ui/Component/Filters`, which has eliminated duplication of filters in the collection `where` conditions.
+<!--- MAGETWO-83293  -->
+*  Magento has added verification for previously set filters in `Magento/Ui/Component/Filters`, which has eliminated duplication of filters in the collection `where` conditions.
 
-<!--- MAGETWO-87994 -->* Inconsistency in the animation of the Admin spinner progress indicator has been corrected. *Fix submitted by Neill Robson in pull request 13700*.
+<!--- MAGETWO-87994  -->
+*  Inconsistency in the animation of the Admin spinner progress indicator has been corrected. *Fix submitted by Neill Robson in pull request 13700*.
 
 ### URL rewrites
 
-<!--- MAGETWO-84955 -->* When using a store code in a URL, Magento now retrieves the value of `Store_Code` from the store if the store code value is empty. Previously, under these circumstances, Magento threw an error. *Fix submitted by Oscar Recio in pull request 12529*. [GitHub-8615](https://github.com/magento/magento2/issues/12450)
+<!--- MAGETWO-84955  -->
+*  When using a store code in a URL, Magento now retrieves the value of `Store_Code` from the store if the store code value is empty. Previously, under these circumstances, Magento threw an error. *Fix submitted by Oscar Recio in pull request 12529*. [GitHub-8615](https://github.com/magento/magento2/issues/12450)
 
 ### Web API framework
 
-<!--- MAGETWO-85287 -->* You can now use the REST API  to make requests that include a slash (/) in an SKU. *Fix submitted by Roman K. in pull request 949*. [GitHub-8615](https://github.com/magento/magento2/issues/8615)
+<!--- MAGETWO-85287  -->
+*  You can now use the REST API  to make requests that include a slash (/) in an SKU. *Fix submitted by Roman K. in pull request 949*. [GitHub-8615](https://github.com/magento/magento2/issues/8615)
 
 ### Wish list
 
-<!--- MAGETWO-69634 -->* Magento now correctly displays a product's special price when you add it to a wish list. Previously, if you added a product with a special price to the wish list, Magento displayed the product with its regular price.
+<!--- MAGETWO-69634  -->
+*  Magento now correctly displays a product's special price when you add it to a wish list. Previously, if you added a product with a special price to the wish list, Magento displayed the product with its regular price.
 
-<!--- MAGETWO-85303 -->* You can now remove an item description from a wish list. *Fix submitted by p-bystritsky in pull request 981*. [GitHub-12582](https://github.com/magento/magento2/issues/12582)
+<!--- MAGETWO-85303  -->
+*  You can now remove an item description from a wish list. *Fix submitted by p-bystritsky in pull request 981*. [GitHub-12582](https://github.com/magento/magento2/issues/12582)
 
 <!--- NOT NEEDED MAGETWO-87169 MAGETWO-87132  MAGETWO-86846 MAGETWO-80908  MAGETWO-84992  MAGETWO-84480 MAGETWO-83329 MAGETWO-86117 MAGETWO-83977 MAGETWO-84804 MAGETWO-84413 MAGETWO-83974 MAGETWO-82062 MAGETWO-80342     MAGETWO-85661 MAGETWO-77840  MAGETWO-73303 MAGETWO-83343 MAGETWO-83910 MAGETWO-70725  MAGETWO-75217 MAGETWO-83958 MAGETWO-87023 MAGETWO-82078 MAGETWO-84397 MAGETWO-87030 MAGETWO-86452  MAGETWO-85205 MAGETWO-84967 MAGETWO-84884 MAGETWO-83621 MAGETWO-82451 MAGETWO-81431 MAGETWO-81189 MAGETWO-73002  MAGETWO-71790 MAGETWO-71272  MAGETWO-83366 MAGETWO-85590 MAGETWO-85650 MAGETWO-87844 MAGETWO-89306 MAGETWO-85842 MAGETWO-88282 MAGETWO-88111 MAGETWO-71374 MAGETWO-85904 MAGETWO-87445 MAGETWO-86736 MAGETWO-83899 MAGETWO-86938 MAGETWO-88108 MAGETWO-87963 MAGETWO-87815 MAGETWO-45775 MAGETWO-89538 MAGETWO-89453 MAGETWO-89337 MAGETWO-89261 MAGETWO-89273 MAGETWO-89080 MAGETWO-84507 MAGETWO-86670 MAGETWO-84883 MAGETWO-89248 MAGETWO-82571 MAGETWO-83659 MAGETWO-84649 MAGETWO-83328 MAGETWO-80622 MAGETWO-87865 MAGETWO-71608 MAGETWO-83571 MAGETWO-83869 MAGETWO-84650-->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -66,134 +66,179 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- MAGETWO-88237 -->  * Magento no longer permits you to re-run an already running cron job. *Fix submitted by Paavo Pokkinen in pull request 12497*. [GitHub-10650](https://github.com/magento/magento2/issues/10650)
+<!-- MAGETWO-88237 -->
+*  Magento no longer permits you to re-run an already running cron job. *Fix submitted by Paavo Pokkinen in pull request 12497*. [GitHub-10650](https://github.com/magento/magento2/issues/10650)
 
 ### Bundle products
 
-<!--- MAGETWO-86354 -->* You can now successfully delete an option from a bundle product.
+<!--- MAGETWO-86354  -->
+*  You can now successfully delete an option from a bundle product.
 
-<!--- MAGETWO-73479 -->* Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+<!--- MAGETWO-73479  -->
+*  Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
 ### Catalog
 
-<!--- MAGETWO-88808 -->* Merchants can now run the catalog search full text indexer and category product indexer in parallel mode by store view.
+<!--- MAGETWO-88808  -->
+*  Merchants can now run the catalog search full text indexer and category product indexer in parallel mode by store view.
 
-<!--- MAGETWO-88107 -->* The `Category\Collection::joinUrlRewrite` method now returns the URL of the store  whose `storeId` is set on the collection. Previously, this method returned the name of the default store. *Fix submitted by Alessandro Pagnin in pull request 13716*. [GitHub-13704](https://github.com/magento/magento2/issues/13704)
+<!--- MAGETWO-88107  -->
+*  The `Category\Collection::joinUrlRewrite` method now returns the URL of the store  whose `storeId` is set on the collection. Previously, this method returned the name of the default store. *Fix submitted by Alessandro Pagnin in pull request 13716*. [GitHub-13704](https://github.com/magento/magento2/issues/13704)
 
-<!--- MAGETWO-81957 -->* Sorting products by price now applies catalog rules as expected.
+<!--- MAGETWO-81957  -->
+*  Sorting products by price now applies catalog rules as expected.
 
-<!--- MAGETWO-73419 -->* Sorting products with required custom options by price now works as expected.
+<!--- MAGETWO-73419  -->
+*  Sorting products with required custom options by price now works as expected.
 
-<!--- MAGETWO-73008 -->* Tier pricing for a single product unit now works as expected. If a tier price is set for one product unit, and this price is lower than the product price or special price, then the product price index table is populated with the tier price.
+<!--- MAGETWO-73008  -->
+*  Tier pricing for a single product unit now works as expected. If a tier price is set for one product unit, and this price is lower than the product price or special price, then the product price index table is populated with the tier price.
 
-<!--- MAGETWO-71936 -->* Magento now successfully saves products when using a locale that formats dates in this way: DD/MM/YYYY. Previously, when you tried to save a product in a locale where dates were formatted this way, Magento did not save the product, and displayed this error: `Invalid input datetime format`. [GitHub-10485](https://github.com/magento/magento2/issues/10485)
+<!--- MAGETWO-71936  -->
+*  Magento now successfully saves products when using a locale that formats dates in this way: DD/MM/YYYY. Previously, when you tried to save a product in a locale where dates were formatted this way, Magento did not save the product, and displayed this error: `Invalid input datetime format`. [GitHub-10485](https://github.com/magento/magento2/issues/10485)
 
-<!--- MAGETWO-54740 -->* When you import new products using a CSV file, Magento no longer lists as in stock any products whose CSV values indicate that they should be represented as out-of-stock.
+<!--- MAGETWO-54740  -->
+*  When you import new products using a CSV file, Magento no longer lists as in stock any products whose CSV values indicate that they should be represented as out-of-stock.
 
 ### CMS content
 
-<!--- MAGETWO-89281 -->* When working in the media gallery, you can now successfully delete  any files and folders that are symlinked in `pub/media`. Previously, any files or folders that were symlinked inside the `pub/media` directory could not be deleted because there was a validation check that used `realpath` to test whether the file was outside the media directory base path. Since `realpath` resolved symlinks to actual paths, this check would fail if the actual path were outside  the base path, and would prevent action from being completed.
+<!--- MAGETWO-89281  -->
+*  When working in the media gallery, you can now successfully delete  any files and folders that are symlinked in `pub/media`. Previously, any files or folders that were symlinked inside the `pub/media` directory could not be deleted because there was a validation check that used `realpath` to test whether the file was outside the media directory base path. Since `realpath` resolved symlinks to actual paths, this check would fail if the actual path were outside  the base path, and would prevent action from being completed.
 
 ### Configurable products
 
-<!--- MAGETWO-88925 -->* Magento now displays the correct  status for a backordered configurable product on the order view page.
+<!--- MAGETWO-88925  -->
+*  Magento now displays the correct  status for a backordered configurable product on the order view page.
 
-<!--- MAGETWO-86661 -->* Magento now displays the correct image for a configurable product on the wishlist. Previously, Magento displayed the image for the parent product rather than for the selected variant. *Fix submitted by Roman K. in pull request 1031*. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!--- MAGETWO-86661  -->
+*  Magento now displays the correct image for a configurable product on the wishlist. Previously, Magento displayed the image for the parent product rather than for the selected variant. *Fix submitted by Roman K. in pull request 1031*. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
-<!--- MAGETWO-87570 -->* The **Hide from Product Page** option now works for the child product of a configurable product.
+<!--- MAGETWO-87570  -->
+*  The **Hide from Product Page** option now works for the child product of a configurable product.
 
-<!--- MAGETWO-71662 -->* The **Update on Save** re-index operation now works as expected when re-indexing configurable products after changing options. Previously,  when you manually re-indexed from the command line, your changes to configurable product options were not saved.
+<!--- MAGETWO-71662  -->
+*  The **Update on Save** re-index operation now works as expected when re-indexing configurable products after changing options. Previously,  when you manually re-indexed from the command line, your changes to configurable product options were not saved.
 
 ### Frameworks
 
-<!--- MAGETWO-87964 -->* We've bumped the required minimal PHP version to 7.0.13.
+<!--- MAGETWO-87964  -->
+*  We've bumped the required minimal PHP version to 7.0.13.
 
 ### General
 
-<!--- MAGETWO-85296 -->* The product repository now uses `store_id` (if set)  when saving attributes for an existing product. Previously, Magento always saved attribute values for an existing product at the default store level. *Fix submitted by p-bystritsky in pull request 967*. [GitHub-7720](https://github.com/magento/magento2/issues/7720), [GitHub-12395](https://github.com/magento/magento2/issues/12395), [GitHub-12186](https://github.com/magento/magento2/issues/12186)
+<!--- MAGETWO-85296  -->
+*  The product repository now uses `store_id` (if set)  when saving attributes for an existing product. Previously, Magento always saved attribute values for an existing product at the default store level. *Fix submitted by p-bystritsky in pull request 967*. [GitHub-7720](https://github.com/magento/magento2/issues/7720), [GitHub-12395](https://github.com/magento/magento2/issues/12395), [GitHub-12186](https://github.com/magento/magento2/issues/12186)
 
-<!--- MAGETWO-82417 -->* The placement of Google Tag Manager code now follows the guidelines in the [Google Tag Manager Developer Guide](https://developers.google.com/tag-manager/devguide). (Previously, the Google Tag Manager code was inserted before the `dataLayer` variable was defined.)
+<!--- MAGETWO-82417  -->
+*  The placement of Google Tag Manager code now follows the guidelines in the [Google Tag Manager Developer Guide](https://developers.google.com/tag-manager/devguide). (Previously, the Google Tag Manager code was inserted before the `dataLayer` variable was defined.)
 
-<!--- MAGETWO-77754 -->* The Related Products rule for up-sell products with customer segments set to **Specified** now works as expected.
+<!--- MAGETWO-77754  -->
+*  The Related Products rule for up-sell products with customer segments set to **Specified** now works as expected.
 
 ### Import/export
 
-<!--- MAGETWO-88265 -->* The data check on imported customer information now completes as expected. Previously, when you clicked **Check Data** on a large CSV file created by **System** > **Data Transfer** > **Import**, the request failed, and Magento displayed the timeout spinner.
+<!--- MAGETWO-88265  -->
+*  The data check on imported customer information now completes as expected. Previously, when you clicked **Check Data** on a large CSV file created by **System** > **Data Transfer** > **Import**, the request failed, and Magento displayed the timeout spinner.
 
-<!--- MAGETWO- 84942-->* If you remove a product's custom options from the CSV file created during product import,  Magento no longer displays the custom options on the storefront.
+<!--- MAGETWO- 84942 -->
+*  If you remove a product's custom options from the CSV file created during product import,  Magento no longer displays the custom options on the storefront.
 
 ### Indexing
 
-<!--- MAGETWO-80789 -->* The search indexer is now scoped and multithreaded, which improves  layered navigation, search, and indexing actions for complex sites with multiple store views and shared catalogs.
+<!--- MAGETWO-80789  -->
+*  The search indexer is now scoped and multithreaded, which improves  layered navigation, search, and indexing actions for complex sites with multiple store views and shared catalogs.
 
 ### Orders
 
-<!--- MAGETWO-87197 -->* Magento now filters recent orders by store on the customer account page  as expected. *Fix submitted by Alexander Shkurko in pull request 13257*.
+<!--- MAGETWO-87197  -->
+*  Magento now filters recent orders by store on the customer account page  as expected. *Fix submitted by Alexander Shkurko in pull request 13257*.
 
-<!--- MAGETWO-86399 -->* The performance and logic of `Magento\Sales\Helper\Guest` has been improved. *Fix submitted by Alexander Shkurko in pull request 12893*.
+<!--- MAGETWO-86399  -->
+*  The performance and logic of `Magento\Sales\Helper\Guest` has been improved. *Fix submitted by Alexander Shkurko in pull request 12893*.
 
 ### Payment methods
 
-<!--- MAGETWO-87832 -->* In multistore environments, Magento now retrieves the correct PayPal Payflow Pro credentials. Previously, Magento always retrieved the credentials that are configured for the default store.
+<!--- MAGETWO-87832  -->
+*  In multistore environments, Magento now retrieves the correct PayPal Payflow Pro credentials. Previously, Magento always retrieved the credentials that are configured for the default store.
 
 ### Performance
 
-<!--- MAGETWO-86745 -->* We've removed the `count()` method from the condition section for some loops in a small subset of backend files. When this method is used in a loop condition,  it will be executed at every iteration, which can degrade performance. *Fix submitted by Alexander Shkurko in pull request 13173*.
+<!--- MAGETWO-86745  -->
+*  We've removed the `count()` method from the condition section for some loops in a small subset of backend files. When this method is used in a loop condition,  it will be executed at every iteration, which can degrade performance. *Fix submitted by Alexander Shkurko in pull request 13173*.
 
 ### Search
 
-<!--- MAGETWO-81901 -->* Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+<!--- MAGETWO-81901  -->
+*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
-<!--- MAGETWO-75769 -->* Magento now caches popular search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached.
+<!--- MAGETWO-75769  -->
+*  Magento now caches popular search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached.
 
 ### Shipping
 
 {: .bs-callout-info }
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{page.baseurl}}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-84257 -->* Merchants can now choose whether to request and include tax information from UPS in the rate charged to the customer during checkout.  (This permits merchants  to pass on the tax costs to their customer as part of the overall shipping rate.) *Fix submitted by gwharton in pull request 11707*.
+<!--- MAGETWO-84257  -->
+*  Merchants can now choose whether to request and include tax information from UPS in the rate charged to the customer during checkout.  (This permits merchants  to pass on the tax costs to their customer as part of the overall shipping rate.) *Fix submitted by gwharton in pull request 11707*.
 
 ### Swagger
 
-<!--- MAGETWO-84921 -->* Swagger now displays the text area that contains the payload structure of all POST and PUT operations.
+<!--- MAGETWO-84921  -->
+*  Swagger now displays the text area that contains the payload structure of all POST and PUT operations.
 
 ### Swatches
 
-<!--- MAGETWO-86332 -->*  You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- MAGETWO-86332  -->
+*   You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### Testing
 
-<!--- MAGETWO-88291 -->* You can now use REST to update the `available_payment_methods` company extension attribute. Previously, Magento set to null any value you passed to the database  `company_payment` table.
+<!--- MAGETWO-88291  -->
+*  You can now use REST to update the `available_payment_methods` company extension attribute. Previously, Magento set to null any value you passed to the database  `company_payment` table.
 
-<!--- MAGETWO-87487 -->* The `phpunit.xml` configuration file is now blacklisted during schema validation static tests (particularly `Magento/Test/Integrity/Xml/SchemaTest.php`).
+<!--- MAGETWO-87487  -->
+*  The `phpunit.xml` configuration file is now blacklisted during schema validation static tests (particularly `Magento/Test/Integrity/Xml/SchemaTest.php`).
 
-<!--- MAGETWO-81742 MAGETWO-89250 -->* The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request 11376*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- MAGETWO-81742 MAGETWO-89250  -->
+*  The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request 11376*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### URL rewrites
 
-<!--- MAGETWO-86554 -->* Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
+<!--- MAGETWO-86554  -->
+*  Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
 
 ### Vertex
 
-<!--- BUNDLE-841 -->* The correct tax amount is now included as expected in the Order Total that is listed under the Order Summary section of the Orders page. Previously, the **Tax amount** field was missing from the Order Summary section, which resulted in an incorrect Order Total.
+<!--- BUNDLE-841  -->
+*  The correct tax amount is now included as expected in the Order Total that is listed under the Order Summary section of the Orders page. Previously, the **Tax amount** field was missing from the Order Summary section, which resulted in an incorrect Order Total.
 
-<!--- BUNDLE-966 -->* The **including tax** and **excluding tax** fields on the Checkout page now contain correctly calculated prices. Previously, Magento displayed  the same price in these fields.
+<!--- BUNDLE-966  -->
+*  The **including tax** and **excluding tax** fields on the Checkout page now contain correctly calculated prices. Previously, Magento displayed  the same price in these fields.
 
-<!--- BUNDLE-977 -->* Magento now displays the **Tax amount** field in the Order Summary section of the Checkout page for orders that contain virtual products.
+<!--- BUNDLE-977  -->
+*  Magento now displays the **Tax amount** field in the Order Summary section of the Checkout page for orders that contain virtual products.
 
-<!--- BUNDLE-904 -->* Merchants can now create a Vertex invoice refund as expected after an order has been canceled.
+<!--- BUNDLE-904  -->
+*  Merchants can now create a Vertex invoice refund as expected after an order has been canceled.
 
-<!--- BUNDLE-1044 -->* We’ve improved the performance of the **Admin Create Order** and **Performance Compare Report in Plain Text - Catalog** (server side) actions.
+<!--- BUNDLE-1044  -->
+*  We’ve improved the performance of the **Admin Create Order** and **Performance Compare Report in Plain Text - Catalog** (server side) actions.
 
-<!--- BUNDLE-976 -->* Magento now prompts you to select order status if a customer does not select an option from the Order Status drop down list when setting the **When to send Invoice to Vertex** option.
+<!--- BUNDLE-976  -->
+*  Magento now prompts you to select order status if a customer does not select an option from the Order Status drop down list when setting the **When to send Invoice to Vertex** option.
 
-<!--- BUNDLE-903 -->* The **Allow tax quote request at shopping cart page** option has been removed from the Vertex Setting tab.
+<!--- BUNDLE-903  -->
+*  The **Allow tax quote request at shopping cart page** option has been removed from the Vertex Setting tab.
 
-<!--- BUNDLE-945 -->* Magento now disables Vertex API Status as expected when you set the **Enable Vertex Tax Calculation** option to **no**.
+<!--- BUNDLE-945  -->
+*  Magento now disables Vertex API Status as expected when you set the **Enable Vertex Tax Calculation** option to **no**.
 
-<!--- BUNDLE-902 -->* Magento now displays the green checkmark and **Vertex invoice has been sent** message as expected when you set an order’s status to **Suspected Fraud**.
+<!--- BUNDLE-902  -->
+*  Magento now displays the green checkmark and **Vertex invoice has been sent** message as expected when you set an order’s status to **Suspected Fraud**.
 
-<!--- BUNDLE-905 -->* Customers no longer receive a notice about negative tax amount after a merchant creates a refund on Vertex Cloud.
+<!--- BUNDLE-905  -->
+*  Customers no longer receive a notice about negative tax amount after a merchant creates a refund on Vertex Cloud.
 
 <!--- NOT NEEDED
 MAGETWO-91014 MAGETWO-90943 MAGETWO-90541 MAGETWO-90413 MAGETWO-90362 MAGETWO-90071 MAGETWO-90067 MAGETWO-90041 MAGETWO-89974  MAGETWO-89613 MAGETWO-89610  MAGETWO-88890 MAGETWO-88817 MAGETWO-88812 MAGETWO-88646 MAGETWO-88643 MAGETWO-88601 MAGETWO-88509 MAGETWO-88436 MAGETWO-88326 MAGETWO-88289 MAGETWO-87467 MAGETWO-86990 MAGETWO-86046 MAGETWO-85871 MAGETWO-85135 MAGETWO-80093 MAGETWO-73694 MAGETWO-80908
@@ -209,57 +254,79 @@ The Amazon Pay, Magento Shipping, and Vertex extensions have the following known
 
 * Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
 
-<!-- BUNDLE--1480 -->*  Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
+<!-- BUNDLE--1480  -->
+*   Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
 
-<!-- BUNDLE--15453 -->*  Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
+<!-- BUNDLE--15453  -->
+*   Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
 
-<!-- BUNDLE--1450 -->*  Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
+<!-- BUNDLE--1450  -->
+*   Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
 
-<!-- BUNDLE--1427 -->* Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
+<!-- BUNDLE--1427  -->
+*  Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
 
-<!-- BUNDLE--1426 -->* Customer cannot return to standard checkout flow by clicking the **Return to standard checkout** button.
+<!-- BUNDLE--1426  -->
+*  Customer cannot return to standard checkout flow by clicking the **Return to standard checkout** button.
 
-<!-- BUNDLE--1425 -->* Customer cannot leave the Amazon Pay checkout page and return to the generic checkout page when an order contains virtual products.
+<!-- BUNDLE--1425  -->
+*  Customer cannot leave the Amazon Pay checkout page and return to the generic checkout page when an order contains virtual products.
 
-<!-- BUNDLE--1424 -->* Customers cannot add a new shipping address to an order that contains virtual products.
+<!-- BUNDLE--1424  -->
+*  Customers cannot add a new shipping address to an order that contains virtual products.
 
 ### dotmailer known issues
 
 The following Dotmailer behaviors have been observed when Magento Commerce for B2B is deployed with split databases:
 
-<!-- BUNDLE--1390 -->* Customer, subscriber, and guest data are not being successfully synced. As a result, newly created contacts display the  **Not imported** status in the contact report, and the relevant address books in dotmailer remain empty.
+<!-- BUNDLE--1390  -->
+*  Customer, subscriber, and guest data are not being successfully synced. As a result, newly created contacts display the  **Not imported** status in the contact report, and the relevant address books in dotmailer remain empty.
 
-<!-- BUNDLE--1408 -->* Review remainder email cannot be sent to a subscribed customer if review remainder emails are not enabled for non-subscribed customers.
+<!-- BUNDLE--1408  -->
+*  Review remainder email cannot be sent to a subscribed customer if review remainder emails are not enabled for non-subscribed customers.
 
-<!-- BUNDLE--1398 -->* Magento cannot send Customer and Guest Abandoned Cart email if these emails are not allowed for non-subscribed contacts.
+<!-- BUNDLE--1398  -->
+*  Magento cannot send Customer and Guest Abandoned Cart email if these emails are not allowed for non-subscribed contacts.
 
-<!-- BUNDLE--1389 -->* When a merchant clicks the **Run Contact Sync** button, Magento throws an exception when a merchant clicks the Run Contact Sync button.
+<!-- BUNDLE--1389  -->
+*  When a merchant clicks the **Run Contact Sync** button, Magento throws an exception when a merchant clicks the Run Contact Sync button.
 
-<!-- BUNDLE--526 -->* Magento throws an error during the creation of a subscriber or customer, but still creates the new subscriber or customer.
+<!-- BUNDLE--526  -->
+*  Magento throws an error during the creation of a subscriber or customer, but still creates the new subscriber or customer.
 
 ### Magento Shipping known issues
 
-<!-- BUNDLE--1448 -->*  A merchant can create multiple return shipments for an already shipped return.
+<!-- BUNDLE--1448  -->
+*   A merchant can create multiple return shipments for an already shipped return.
 
 ### Vertex known issues
 
-<!-- BUNDLE--1446 -->* The order amount on Vertex Cloud differs from the order information displayed by Magento  when Catalog Price Rule is applied.
+<!-- BUNDLE--1446  -->
+*  The order amount on Vertex Cloud differs from the order information displayed by Magento  when Catalog Price Rule is applied.
 
-<!-- BUNDLE--910 -->* Magento applies taxes to a custom price even when the **Original Price only** option from the fApply Tax On drop-down list has been selected.
+<!-- BUNDLE--910  -->
+*  Magento applies taxes to a custom price even when the **Original Price only** option from the fApply Tax On drop-down list has been selected.
 
-<!-- BUNDLE--1385 -->* Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
+<!-- BUNDLE--1385  -->
+*  Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
 
-<!-- BUNDLE--1399 -->*  The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
+<!-- BUNDLE--1399  -->
+*   The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
 
-<!-- BUNDLE--1405 -->*  The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
+<!-- BUNDLE--1405  -->
+*   The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
 
-<!-- BUNDLE--1410 -->*  When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
+<!-- BUNDLE--1410  -->
+*   When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
 
-<!-- BUNDLE--1457 -->* Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.
+<!-- BUNDLE--1457  -->
+*  Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.
 
-<!-- BUNDLE--1325 -->* Magento does not display the Vertex customer code field on the All Customers page as expected, which undermines the ability to filter by customer code.
+<!-- BUNDLE--1325  -->
+*  Magento does not display the Vertex customer code field on the All Customers page as expected, which undermines the ability to filter by customer code.
 
-<!-- BUNDLE--1432 -->* Magento does not display the tax section of the Order Summary that is included on the Review and Payments page during checkout when the shopping cart includes a virtual product.
+<!-- BUNDLE--1432  -->
+*  Magento does not display the tax section of the Order Summary that is included on the Review and Payments page during checkout when the shopping cart includes a virtual product.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -66,148 +66,197 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- MAGETWO-88237 -->* Magento no longer permits you to re-run an already running cron job. *Fix submitted by Paavo Pokkinen in pull request 12497*. [GitHub-10650](https://github.com/magento/magento2/issues/10650)
+<!-- MAGETWO-88237  -->
+*  Magento no longer permits you to re-run an already running cron job. *Fix submitted by Paavo Pokkinen in pull request 12497*. [GitHub-10650](https://github.com/magento/magento2/issues/10650)
 
 ### Bundle products
 
-<!--- MAGETWO-86354 -->* You can now successfully delete an option from a bundle product.
+<!--- MAGETWO-86354  -->
+*  You can now successfully delete an option from a bundle product.
 
-<!--- MAGETWO-73479 -->* Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+<!--- MAGETWO-73479  -->
+*  Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
 ### Catalog
 
-<!--- MAGETWO-88808 -->* Merchants can now run the catalog search full text indexer and category product indexer in parallel mode by store view.
+<!--- MAGETWO-88808  -->
+*  Merchants can now run the catalog search full text indexer and category product indexer in parallel mode by store view.
 
-<!--- MAGETWO-88107 -->* The `Category\Collection::joinUrlRewrite` method now returns the URL of the store  whose `storeId` is set on the collection. Previously, this method returned the name of the default store. *Fix submitted by Alessandro Pagnin in pull request 13716*. [GitHub-13704](https://github.com/magento/magento2/issues/13704)
+<!--- MAGETWO-88107  -->
+*  The `Category\Collection::joinUrlRewrite` method now returns the URL of the store  whose `storeId` is set on the collection. Previously, this method returned the name of the default store. *Fix submitted by Alessandro Pagnin in pull request 13716*. [GitHub-13704](https://github.com/magento/magento2/issues/13704)
 
-<!--- MAGETWO-81957 -->* Sorting products by price now applies catalog rules as expected.
+<!--- MAGETWO-81957  -->
+*  Sorting products by price now applies catalog rules as expected.
 
-<!--- MAGETWO-73419 -->* Sorting products with required custom options by price now works as expected.
+<!--- MAGETWO-73419  -->
+*  Sorting products with required custom options by price now works as expected.
 
-<!--- MAGETWO-73008 -->* Tier pricing for a single product unit now works as expected. If a tier price is set for one product unit, and this price is lower than the product price or special price, then the product price index table is populated with the tier price.
+<!--- MAGETWO-73008  -->
+*  Tier pricing for a single product unit now works as expected. If a tier price is set for one product unit, and this price is lower than the product price or special price, then the product price index table is populated with the tier price.
 
-<!--- MAGETWO-71936 -->* Magento now successfully saves products when using a locale that formats dates in this way: DD/MM/YYYY. Previously, when you tried to save a product in a locale where dates are formatted this way, Magento did not save the product, and displayed this error: `Invalid input datetime format`. [GitHub-10485](https://github.com/magento/magento2/issues/10485)
+<!--- MAGETWO-71936  -->
+*  Magento now successfully saves products when using a locale that formats dates in this way: DD/MM/YYYY. Previously, when you tried to save a product in a locale where dates are formatted this way, Magento did not save the product, and displayed this error: `Invalid input datetime format`. [GitHub-10485](https://github.com/magento/magento2/issues/10485)
 
-<!--- MAGETWO-54740 -->* When you import new products using CSV, Magento no longer lists as in stock any products whose CSV values indicate that they should be represented as out-of-stock.
+<!--- MAGETWO-54740  -->
+*  When you import new products using CSV, Magento no longer lists as in stock any products whose CSV values indicate that they should be represented as out-of-stock.
 
 ### CMS content
 
-<!--- MAGETWO-89281 -->* When working in the media gallery, you can now successfully delete  any files and folders that are symlinked in `pub/media`. Previously, any files or folders that were symlinked inside the `pub/media` directory could not be deleted because there was a validation check that used `realpath` to test whether the file was outside the media directory base path. Since `realpath` resolved symlinks to actual paths, this check would fail if the actual path were outside  the base path, and would prevent action from being completed.
+<!--- MAGETWO-89281  -->
+*  When working in the media gallery, you can now successfully delete  any files and folders that are symlinked in `pub/media`. Previously, any files or folders that were symlinked inside the `pub/media` directory could not be deleted because there was a validation check that used `realpath` to test whether the file was outside the media directory base path. Since `realpath` resolved symlinks to actual paths, this check would fail if the actual path were outside  the base path, and would prevent action from being completed.
 
 ### Configurable products
 
-<!--- MAGETWO-88925 -->* Magento now displays the correct  status for a backordered configurable product on the order view page.
+<!--- MAGETWO-88925  -->
+*  Magento now displays the correct  status for a backordered configurable product on the order view page.
 
-<!--- MAGETWO-86661 -->* Magento now displays the correct image for a configurable product on the wishlist. Previously, Magento displayed the image for the parent product rather than for the selected variant. *Fix submitted by Roman K. in pull request 1031*. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!--- MAGETWO-86661  -->
+*  Magento now displays the correct image for a configurable product on the wishlist. Previously, Magento displayed the image for the parent product rather than for the selected variant. *Fix submitted by Roman K. in pull request 1031*. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
-<!--- MAGETWO-87570 -->* The **Hide from Product Page** option now works for the child product of a configurable product.
+<!--- MAGETWO-87570  -->
+*  The **Hide from Product Page** option now works for the child product of a configurable product.
 
-<!--- MAGETWO-71662 -->* The **Update on Save** re-index operation now works as expected when re-indexing configurable products after changing options. Previously,  when you manually re-indexed from the command line, your changes to configurable product options were not saved.
+<!--- MAGETWO-71662  -->
+*  The **Update on Save** re-index operation now works as expected when re-indexing configurable products after changing options. Previously,  when you manually re-indexed from the command line, your changes to configurable product options were not saved.
 
 ### Frameworks
 
-<!--- MAGETWO-87964 -->* We've bumped the required minimal PHP version to 7.0.13.
+<!--- MAGETWO-87964  -->
+*  We've bumped the required minimal PHP version to 7.0.13.
 
 ### General
 
-<!--- MAGETWO-85296 -->* The product repository now uses `store_id` (if set)  when saving attributes for an existing product. Previously, Magento always saved attribute values for an existing product at the default store level. *Fix submitted by p-bystritsky in pull request 967*. [GitHub-7720](https://github.com/magento/magento2/issues/7720), [GitHub-12395](https://github.com/magento/magento2/issues/12395), [GitHub-12186](https://github.com/magento/magento2/issues/12186)
+<!--- MAGETWO-85296  -->
+*  The product repository now uses `store_id` (if set)  when saving attributes for an existing product. Previously, Magento always saved attribute values for an existing product at the default store level. *Fix submitted by p-bystritsky in pull request 967*. [GitHub-7720](https://github.com/magento/magento2/issues/7720), [GitHub-12395](https://github.com/magento/magento2/issues/12395), [GitHub-12186](https://github.com/magento/magento2/issues/12186)
 
-<!--- MAGETWO-82417 -->* The placement of Google Tag Manager code now follows the guidelines in the [Google Tag Manager Developer Guide](https://developers.google.com/tag-manager/devguide). (Previously, the Google Tag Manager code was inserted before the `dataLayer` variable was defined.)
+<!--- MAGETWO-82417  -->
+*  The placement of Google Tag Manager code now follows the guidelines in the [Google Tag Manager Developer Guide](https://developers.google.com/tag-manager/devguide). (Previously, the Google Tag Manager code was inserted before the `dataLayer` variable was defined.)
 
-<!--- MAGETWO-77754 -->* The Related Products rule for up-sell products with customer segments set to **Specified** now works as expected.
+<!--- MAGETWO-77754  -->
+*  The Related Products rule for up-sell products with customer segments set to **Specified** now works as expected.
 
 ### Gift card
 
-<!--- MAGETWO-85536 -->* Magento now displays the correct subtotal when a customer adds multiple gift cards of different amounts to his cart.
+<!--- MAGETWO-85536  -->
+*  Magento now displays the correct subtotal when a customer adds multiple gift cards of different amounts to his cart.
 
 ### Import/export
 
-<!--- MAGETWO-88265 -->* The data check on imported customer information now completes as expected. Previously, when you clicked **Check Data** on a large CSV file created by **System** > **Data Transfer** > **Import**, the request failed, and Magento displayed the timeout spinner.
+<!--- MAGETWO-88265  -->
+*  The data check on imported customer information now completes as expected. Previously, when you clicked **Check Data** on a large CSV file created by **System** > **Data Transfer** > **Import**, the request failed, and Magento displayed the timeout spinner.
 
-<!--- MAGETWO- 84942-->* If you remove a product's custom options from the CSV file created during product import,  Magento no longer displays the custom options on the storefront.
+<!--- MAGETWO- 84942 -->
+*  If you remove a product's custom options from the CSV file created during product import,  Magento no longer displays the custom options on the storefront.
 
 ### Indexing
 
-<!--- MAGETWO-80789 -->* The search indexer is now scoped and multithreaded, which improves  layered navigation, search and indexing actions for complex sites with multiple store views and shared catalogs.
+<!--- MAGETWO-80789  -->
+*  The search indexer is now scoped and multithreaded, which improves  layered navigation, search and indexing actions for complex sites with multiple store views and shared catalogs.
 
 ### Orders
 
-<!--- MAGETWO-87197 -->* Magento now filters recent orders by store on the customer account page  as expected. *Fix submitted by Alexander Shkurko in pull request 13257*.
+<!--- MAGETWO-87197  -->
+*  Magento now filters recent orders by store on the customer account page  as expected. *Fix submitted by Alexander Shkurko in pull request 13257*.
 
-<!--- MAGETWO-86399 -->* The performance and logic of `Magento\Sales\Helper\Guest` has been improved. *Fix submitted by Alexander Shkurko in pull request 12893*.
+<!--- MAGETWO-86399  -->
+*  The performance and logic of `Magento\Sales\Helper\Guest` has been improved. *Fix submitted by Alexander Shkurko in pull request 12893*.
 
 ### Payment methods
 
-<!--- MAGETWO-87832 -->* In multistore environments, Magento now retrieves the correct PayPal Payflow Pro credentials. Previously, Magento always retrieved the credentials that are configured for the default store.
+<!--- MAGETWO-87832  -->
+*  In multistore environments, Magento now retrieves the correct PayPal Payflow Pro credentials. Previously, Magento always retrieved the credentials that are configured for the default store.
 
 ### Performance
 
-<!--- MAGETWO-86745 -->* We've removed the `count()` method from the condition section for some loops in a small subset of backend files. When this method is used in a loop condition,  it will be executed at every iteration, which can degrade performance. *Fix submitted by Alexander Shkurko in pull request 13173*.
+<!--- MAGETWO-86745  -->
+*  We've removed the `count()` method from the condition section for some loops in a small subset of backend files. When this method is used in a loop condition,  it will be executed at every iteration, which can degrade performance. *Fix submitted by Alexander Shkurko in pull request 13173*.
 
 ### Search
 
-<!--- MAGETWO-81901 -->* Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+<!--- MAGETWO-81901  -->
+*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
-<!--- MAGETWO-75769 -->* Magento now caches popular search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached.
+<!--- MAGETWO-75769  -->
+*  Magento now caches popular search results for faster response time on popular searches. A system administrator can configure how many top search queries can be cached.
 
 ### Shipping
 
 {: .bs-callout-info }
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{page.baseurl}}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 
-<!--- MAGETWO-84257 -->* Merchants can now choose whether to request and include tax information from UPS in the rate charged to the customer during checkout.  (This permits merchants  to pass on the tax costs to their customer as part of the overall shipping rate.) *Fix submitted by gwharton in pull request 11707*.
+<!--- MAGETWO-84257  -->
+*  Merchants can now choose whether to request and include tax information from UPS in the rate charged to the customer during checkout.  (This permits merchants  to pass on the tax costs to their customer as part of the overall shipping rate.) *Fix submitted by gwharton in pull request 11707*.
 
 ### Staging
 
-<!--- MAGETWO-87855 -->* Magento now correctly renders the dates on a Cart Rule staging update when an administrator uses a locale with a different date and time format. Previously, these dates were corrupted.
+<!--- MAGETWO-87855  -->
+*  Magento now correctly renders the dates on a Cart Rule staging update when an administrator uses a locale with a different date and time format. Previously, these dates were corrupted.
 
-<!--- MAGETWO-85559 -->* You can now successfully edit the start date and time for a Catalog Price Rule schedule update. Previously, if you edited this date or time, Magento threw a 404 error when the new start time arrived.
+<!--- MAGETWO-85559  -->
+*  You can now successfully edit the start date and time for a Catalog Price Rule schedule update. Previously, if you edited this date or time, Magento threw a 404 error when the new start time arrived.
 
 ### Swagger
 
-<!--- MAGETWO-84921 -->* Swagger now displays the text area that contains the payload structure of all POST and PUT operations.
+<!--- MAGETWO-84921  -->
+*  Swagger now displays the text area that contains the payload structure of all POST and PUT operations.
 
 ### Swatches
 
-<!--- MAGETWO-86332 -->*  You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- MAGETWO-86332  -->
+*   You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### Testing
 
-<!--- MAGETWO-88291 -->* You can now use REST to update the `available_payment_methods` company extension attribute. Previously, Magento set to null whatever  value you passed to the database  `company_payment` table.
+<!--- MAGETWO-88291  -->
+*  You can now use REST to update the `available_payment_methods` company extension attribute. Previously, Magento set to null whatever  value you passed to the database  `company_payment` table.
 
-<!--- MAGETWO-87487 -->* The `phpunit.xml` configuration file is now blacklisted during schema validation static tests (particularly `Magento/Test/Integrity/Xml/SchemaTest.php`).
+<!--- MAGETWO-87487  -->
+*  The `phpunit.xml` configuration file is now blacklisted during schema validation static tests (particularly `Magento/Test/Integrity/Xml/SchemaTest.php`).
 
-<!--- MAGETWO-81742 MAGETWO-89250 -->* The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request 11376*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- MAGETWO-81742 MAGETWO-89250  -->
+*  The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request 11376*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### URL rewrites
 
-<!--- MAGETWO-86554 -->* Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
+<!--- MAGETWO-86554  -->
+*  Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
 
 ### Vertex
 
-<!--- BUNDLE-841 -->* The correct tax amount is now included as expected in the Order Total that is listed under the Order Summary section of the Orders page. Previously, the **Tax amount** field was missing from the Order Summary section, which resulted in an incorrect Order Total.
+<!--- BUNDLE-841  -->
+*  The correct tax amount is now included as expected in the Order Total that is listed under the Order Summary section of the Orders page. Previously, the **Tax amount** field was missing from the Order Summary section, which resulted in an incorrect Order Total.
 
-<!--- BUNDLE-966 -->* The **including tax** and **excluding tax** fields on the Checkout page now contain correctly calculated prices. Previously, Magento displayed  the same price in these fields.
+<!--- BUNDLE-966  -->
+*  The **including tax** and **excluding tax** fields on the Checkout page now contain correctly calculated prices. Previously, Magento displayed  the same price in these fields.
 
-<!--- BUNDLE-977 -->* Magento now displays the **Tax amount** field in the Order Summary section of the Checkout page for orders that contain virtual products.
+<!--- BUNDLE-977  -->
+*  Magento now displays the **Tax amount** field in the Order Summary section of the Checkout page for orders that contain virtual products.
 
-<!--- BUNDLE-904 -->* Merchants can now create a Vertex invoice refund as expected after an order has been canceled.
+<!--- BUNDLE-904  -->
+*  Merchants can now create a Vertex invoice refund as expected after an order has been canceled.
 
-<!--- BUNDLE-1044 -->* We’ve improved the performance of the **Admin Create Order** and **Performance Compare Report in Plain Text - Catalog** (server side) actions.
+<!--- BUNDLE-1044  -->
+*  We’ve improved the performance of the **Admin Create Order** and **Performance Compare Report in Plain Text - Catalog** (server side) actions.
 
-<!--- BUNDLE-976 -->* Magento now prompts you to select order status if a customer does not select an option from the Order Status drop down list when setting the **When to send Invoice to Vertex** option.
+<!--- BUNDLE-976  -->
+*  Magento now prompts you to select order status if a customer does not select an option from the Order Status drop down list when setting the **When to send Invoice to Vertex** option.
 
-<!--- BUNDLE-903 -->* The **Allow tax quote request at shopping cart page** option has been removed from the Vertex Setting tab.
+<!--- BUNDLE-903  -->
+*  The **Allow tax quote request at shopping cart page** option has been removed from the Vertex Setting tab.
 
-<!--- BUNDLE-945 -->* Magento now disables Vertex API Status as expected when you set the **Enable Vertex Tax Calculation** option to **no**.
+<!--- BUNDLE-945  -->
+*  Magento now disables Vertex API Status as expected when you set the **Enable Vertex Tax Calculation** option to **no**.
 
-<!--- BUNDLE-902 -->* Magento now displays the green checkmark and **Vertex invoice has been sent** message as expected when you set an order’s status to **Suspected Fraud**.
+<!--- BUNDLE-902  -->
+*  Magento now displays the green checkmark and **Vertex invoice has been sent** message as expected when you set an order’s status to **Suspected Fraud**.
 
-<!--- BUNDLE-905 -->* Customers no longer receive a notice about negative tax amount after a merchant creates a refund on Vertex Cloud.
+<!--- BUNDLE-905  -->
+*  Customers no longer receive a notice about negative tax amount after a merchant creates a refund on Vertex Cloud.
 
 ### Visual Merchandiser
 
-<!--- MAGETWO-71554 -->* We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
+<!--- MAGETWO-71554  -->
+*  We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
 
 <!--- NOT NEEDED
 MAGETWO-91014 MAGETWO-90943 MAGETWO-90541 MAGETWO-90413 MAGETWO-90362 MAGETWO-90071 MAGETWO-90067 MAGETWO-90041 MAGETWO-89974  MAGETWO-89613 MAGETWO-89610  MAGETWO-88890 MAGETWO-88817 MAGETWO-88812 MAGETWO-88646 MAGETWO-88643 MAGETWO-88601 MAGETWO-88509 MAGETWO-88436 MAGETWO-88326 MAGETWO-88289 MAGETWO-87467 MAGETWO-86990 MAGETWO-86046 MAGETWO-85871 MAGETWO-85135 MAGETWO-80093 MAGETWO-73694 MAGETWO-80908
@@ -223,57 +272,79 @@ The Amazon Pay. dotmailer, Magento Shipping, and Vertex extensions have the foll
 
 * Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
 
-<!-- BUNDLE--1480 -->*  Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
+<!-- BUNDLE--1480  -->
+*   Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
 
-<!-- BUNDLE--15453 -->*  Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
+<!-- BUNDLE--15453  -->
+*   Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
 
-<!-- BUNDLE--1450 -->*  Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
+<!-- BUNDLE--1450  -->
+*   Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
 
-<!-- BUNDLE--1427 -->* Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
+<!-- BUNDLE--1427  -->
+*  Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
 
-<!-- BUNDLE--1426 -->* Customer cannot return to standard checkout flow by clicking the **Return to standard checkout** button.
+<!-- BUNDLE--1426  -->
+*  Customer cannot return to standard checkout flow by clicking the **Return to standard checkout** button.
 
-<!-- BUNDLE--1425 -->* Customer cannot leave the Amazon Pay checkout page and return to the generic checkout page when an order contains virtual products.
+<!-- BUNDLE--1425  -->
+*  Customer cannot leave the Amazon Pay checkout page and return to the generic checkout page when an order contains virtual products.
 
-<!-- BUNDLE--1424 -->* Customers cannot add a new shipping address to an order that contains virtual products.
+<!-- BUNDLE--1424  -->
+*  Customers cannot add a new shipping address to an order that contains virtual products.
 
 ### dotmailer known issues
 
 The following Dotmailer behaviors have been observed when Magento Commerce for B2B is deployed with split databases:
 
-<!-- BUNDLE--1390 -->* Customer, subscriber, and guest data are not being successfully synced. As a result, newly created contacts display the  **Not imported** status in the contact report, and the relevant address books in dotmailer remain empty.
+<!-- BUNDLE--1390  -->
+*  Customer, subscriber, and guest data are not being successfully synced. As a result, newly created contacts display the  **Not imported** status in the contact report, and the relevant address books in dotmailer remain empty.
 
-<!-- BUNDLE--1408 -->* Review remainder email cannot be sent to a subscribed customer if review remainder emails are not enabled for non-subscribed customers.
+<!-- BUNDLE--1408  -->
+*  Review remainder email cannot be sent to a subscribed customer if review remainder emails are not enabled for non-subscribed customers.
 
-<!-- BUNDLE--1398 -->* Magento cannot send Customer and Guest Abandoned Cart email if these emails are not allowed for non-subscribed contacts.
+<!-- BUNDLE--1398  -->
+*  Magento cannot send Customer and Guest Abandoned Cart email if these emails are not allowed for non-subscribed contacts.
 
-<!-- BUNDLE--1389 -->* When a merchant clicks the **Run Contact Sync** button, Magento throws an exception when a merchant clicks the Run Contact Sync button.
+<!-- BUNDLE--1389  -->
+*  When a merchant clicks the **Run Contact Sync** button, Magento throws an exception when a merchant clicks the Run Contact Sync button.
 
-<!-- BUNDLE--526 -->* Magento throws an error during the creation of a subscriber or customer, but still creates the new subscriber or customer.
+<!-- BUNDLE--526  -->
+*  Magento throws an error during the creation of a subscriber or customer, but still creates the new subscriber or customer.
 
 ### Magento Shipping known issues
 
-<!-- BUNDLE--1448 -->*  A merchant can create multiple return shipments for an already shipped return.
+<!-- BUNDLE--1448  -->
+*   A merchant can create multiple return shipments for an already shipped return.
 
 ### Vertex known issues
 
-<!-- BUNDLE--1446 -->* The order amount on Vertex Cloud differs from the order information displayed by Magento  when Catalog Price Rule is applied.
+<!-- BUNDLE--1446  -->
+*  The order amount on Vertex Cloud differs from the order information displayed by Magento  when Catalog Price Rule is applied.
 
-<!-- BUNDLE--910 -->* Magento applies taxes to a custom price even when the **Original Price only** option from the Apply Tax On drop-down list has been selected.
+<!-- BUNDLE--910  -->
+*  Magento applies taxes to a custom price even when the **Original Price only** option from the Apply Tax On drop-down list has been selected.
 
-<!-- BUNDLE--1385 -->* Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
+<!-- BUNDLE--1385  -->
+*  Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
 
-<!-- BUNDLE--1399 -->*  The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
+<!-- BUNDLE--1399  -->
+*   The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
 
-<!-- BUNDLE--1405 -->*  The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
+<!-- BUNDLE--1405  -->
+*   The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
 
-<!-- BUNDLE--1410 -->*  When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
+<!-- BUNDLE--1410  -->
+*   When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
 
-<!-- BUNDLE--1457 -->* Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.
+<!-- BUNDLE--1457  -->
+*  Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.
 
-<!-- BUNDLE--1325 -->* Magento does not display the Vertex customer code field on the All Customers page as expected, which undermines the ability to filter by customer code.
+<!-- BUNDLE--1325  -->
+*  Magento does not display the Vertex customer code field on the All Customers page as expected, which undermines the ability to filter by customer code.
 
-<!-- BUNDLE--1432 -->* Magento does not display the tax section of the Order Summary that is included on the Review and Payments page during checkout when the shopping cart includes a virtual product.
+<!-- BUNDLE--1432  -->
+*  Magento does not display the tax section of the Order Summary that is included on the Review and Payments page during checkout when the shopping cart includes a virtual product.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
@@ -23,37 +23,49 @@ This release includes significant performance improvements to the core Magento c
 
 Performance-tuning enhancements focus on catalog indexing and include:
 
-<!-- MAGETWO-87430 -->* Category product indexer logic has been optimized, and re-indexing time has decreased up to 98%, from 40 minutes to one minute for 100,000 categories.  Previously, when your store contained many categories (100,0000), Magento could take up to 40 minutes to re-index product catalogs.
+<!-- MAGETWO-87430  -->
+*  Category product indexer logic has been optimized, and re-indexing time has decreased up to 98%, from 40 minutes to one minute for 100,000 categories.  Previously, when your store contained many categories (100,0000), Magento could take up to 40 minutes to re-index product catalogs.
 
-<!-- MAGETWO-91164 -->* The `catalog:images:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
+<!-- MAGETWO-91164  -->
+*  The `catalog:images:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
 
     * Remove   `pub/media/catalog/product/cache` . (Removing this folder frees up space.)
 
     * Run `bin/magento catalog:images:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
 
-<!-- MAGETWO-47320 -->* The catalog rule re-indexing operation has been optimized, and the average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
+<!-- MAGETWO-47320  -->
+*  The catalog rule re-indexing operation has been optimized, and the average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
 
-<!-- MAGETWO-92447 -->* The catalog price indexer is now scoped and multithreaded, which improves the performance of layered navigation, search, and indexing actions for Magento instances with multiple websites and stores. This makes it possible to parallelize catalog price indexing by websites and customer groups. To re-index in parallel mode, add the `MAGE_INDEXER_THREADS_COUNT` environment variable to `env.php`.
+<!-- MAGETWO-92447  -->
+*  The catalog price indexer is now scoped and multithreaded, which improves the performance of layered navigation, search, and indexing actions for Magento instances with multiple websites and stores. This makes it possible to parallelize catalog price indexing by websites and customer groups. To re-index in parallel mode, add the `MAGE_INDEXER_THREADS_COUNT` environment variable to `env.php`.
 
-<!-- MAGETWO-90572 -->* The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for scenarios with a large number of product attribute sets. (Performance will not noticeably improve for deployments with only one attribute set configured with 500 attributes. However, deployments with many attribute sets that contain only a few attributes will show significant performance improvement. For example, a deployment with 100 attribute sets, each of which contains 50 attributes, might see a 40-90% reduction in load time.)
+<!-- MAGETWO-90572  -->
+*  The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for scenarios with a large number of product attribute sets. (Performance will not noticeably improve for deployments with only one attribute set configured with 500 attributes. However, deployments with many attribute sets that contain only a few attributes will show significant performance improvement. For example, a deployment with 100 attribute sets, each of which contains 50 attributes, might see a 40-90% reduction in load time.)
 
-<!-- MAGETWO-88670 -->* The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
+<!-- MAGETWO-88670  -->
+*  The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
 
-<!-- MAGETWO-86143 -->* Merchants can now improve store performance by disabling Magento Report functionality. A new configuration setting  (**System Configuration:** **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
+<!-- MAGETWO-86143  -->
+*  Merchants can now improve store performance by disabling Magento Report functionality. A new configuration setting  (**System Configuration:** **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
 
 #### **Improvements to the reliability and ease of the checkout process**
 
-<!-- MAGETWO-86490 -->* A shopping cart’s contents remain constant even when the checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart, and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
+<!-- MAGETWO-86490  -->
+*  A shopping cart’s contents remain constant even when the checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart, and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
 
-<!-- MAGETWO-90053-->* Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout page affected information entered into form fields for a guest checkout.
+<!-- MAGETWO-90053 -->
+*  Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout page affected information entered into form fields for a guest checkout.
 
-<!-- MAGETWO-89222-->* The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
+<!-- MAGETWO-89222 -->
+*  The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
 
 #### **Additional enhancements**
 
-<!-- MAGETWO-86125-->* Configurable products are now sorted by visible prices  as expected. Previously, sorting a catalog by price produced sort results that included the prices of out-of-stock products and disabled child products.
+<!-- MAGETWO-86125 -->
+*  Configurable products are now sorted by visible prices  as expected. Previously, sorting a catalog by price produced sort results that included the prices of out-of-stock products and disabled child products.
 
-<!-- MAGETWO-91411 -->*  Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
+<!-- MAGETWO-91411  -->
+*   Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
 
 ### **Magento Cloud highlights**
 
@@ -148,31 +160,44 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- ENGCOM-1537 -->* You can now use the `app:config:status` command to check whether configuration propagation is up-to-date. (This fix restores this command, which was inadvertently deleted in a previous release.)  *Fix submitted by Pieter Hoste in pull request [15174](https://github.com/magento/magento2/pull/15174)*. [GitHub-14104](https://github.com/magento/magento2/issues/14104)
+<!-- ENGCOM-1537  -->
+*  You can now use the `app:config:status` command to check whether configuration propagation is up-to-date. (This fix restores this command, which was inadvertently deleted in a previous release.)  *Fix submitted by Pieter Hoste in pull request [15174](https://github.com/magento/magento2/pull/15174)*. [GitHub-14104](https://github.com/magento/magento2/issues/14104)
 
-<!-- MAGETWO-84651 -->* The `app:config:dump` command now has an argument that supports dumping only the specified settings that are required to prepare static content on a build system, not all system settings. This new option (`config-types`) makes it possible to dump scopes and themes automatically (which are needed for a build system) while managing system settings manually using `config:set --lock-config`. *Fix submitted by Juan Alonso in pull request [12410](https://github.com/magento/magento2/pull/12410)*. [GitHub-11396](https://github.com/magento/magento2/issues/11396)
+<!-- MAGETWO-84651  -->
+*  The `app:config:dump` command now has an argument that supports dumping only the specified settings that are required to prepare static content on a build system, not all system settings. This new option (`config-types`) makes it possible to dump scopes and themes automatically (which are needed for a build system) while managing system settings manually using `config:set --lock-config`. *Fix submitted by Juan Alonso in pull request [12410](https://github.com/magento/magento2/pull/12410)*. [GitHub-11396](https://github.com/magento/magento2/issues/11396)
 
-<!-- MAGETWO-93192 -->* Configuration backend models are now populated as expected with all fieldset data, which makes it possible to access all configured values from a current group. [GitHub-16712](https://github.com/magento/magento2/issues/16712)
+<!-- MAGETWO-93192  -->
+*  Configuration backend models are now populated as expected with all fieldset data, which makes it possible to access all configured values from a current group. [GitHub-16712](https://github.com/magento/magento2/issues/16712)
 
-<!-- MAGETWO-90860 -->* The `magento-deploy-ignore` setting in `composer.json` now works as expected. Previously, files specified in this setting were overwritten during deployment.
+<!-- MAGETWO-90860  -->
+*  The `magento-deploy-ignore` setting in `composer.json` now works as expected. Previously, files specified in this setting were overwritten during deployment.
 
-<!-- MAGETWO-87120 -->* The `timestamp` fields in `oauth_nonce` now include indexes to avoid deadlocks while erasing old records. *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
+<!-- MAGETWO-87120  -->
+*  The `timestamp` fields in `oauth_nonce` now include indexes to avoid deadlocks while erasing old records. *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
-<!-- ENGCOM-1972 -->* Sorting has been disabled in the  `glob` and `scandir` functions to improve performance. *Fix submitted by Leandro F. L. in pull request [16052](https://github.com/magento/magento2/pull/16052)*.
+<!-- ENGCOM-1972  -->
+*  Sorting has been disabled in the  `glob` and `scandir` functions to improve performance. *Fix submitted by Leandro F. L. in pull request [16052](https://github.com/magento/magento2/pull/16052)*.
 
-<!-- ENGCOM-2407 -->* The `nginx.config.sample` file no longer includes an option for PHP 5.x. (Magento 2.2.x is not compatible with PHP 5.x.) *Fix submitted by Sean Breeden in pull request [16883](https://github.com/magento/magento2/pull/16883)*.
+<!-- ENGCOM-2407  -->
+*  The `nginx.config.sample` file no longer includes an option for PHP 5.x. (Magento 2.2.x is not compatible with PHP 5.x.) *Fix submitted by Sean Breeden in pull request [16883](https://github.com/magento/magento2/pull/16883)*.
 
-<!-- ENGCOM-2315 -->* Autoloading performance has improved on production environments as a result of the reduction in `file_exists` calls. *Fix submitted by Pieter Hoste in pull request [16435](https://github.com/magento/magento2/pull/16435)*.
+<!-- ENGCOM-2315  -->
+*  Autoloading performance has improved on production environments as a result of the reduction in `file_exists` calls. *Fix submitted by Pieter Hoste in pull request [16435](https://github.com/magento/magento2/pull/16435)*.
 
-<!-- ENGCOM-2029 -->* Setting deploy mode to production mode by  using the `--skip-compilation` flag no longer clears generated code in `generated/code/` and `generated/metadata/`. *Fix submitted by platformvaimo in pull request [16211](https://github.com/magento/magento2/pull/16211)*.
+<!-- ENGCOM-2029  -->
+*  Setting deploy mode to production mode by  using the `--skip-compilation` flag no longer clears generated code in `generated/code/` and `generated/metadata/`. *Fix submitted by platformvaimo in pull request [16211](https://github.com/magento/magento2/pull/16211)*.
 
-<!-- ENGCOM-1673 -->* We've made two changes to `Magento/Config` module: `Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php::testGetElementHtmlWithValue()` method no longer references a invalid backend model, and  the anonymous function no longer has an unused `$data` in `Magento/Config/Model/Config/Importer.php`. *Fix submitted by Marcel Hauri in pull request [15511](https://github.com/magento/magento2/pull/15511)*.
+<!-- ENGCOM-1673  -->
+*  We've made two changes to `Magento/Config` module: `Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php::testGetElementHtmlWithValue()` method no longer references a invalid backend model, and  the anonymous function no longer has an unused `$data` in `Magento/Config/Model/Config/Importer.php`. *Fix submitted by Marcel Hauri in pull request [15511](https://github.com/magento/magento2/pull/15511)*.
 
-<!-- ENGCOM-1448 -->* The upgrade check implemented during setup now indicates success if the latest version of Magento is already installed. Previously, the message indicated that the latest product version was already installed was presented as error. *Fix submitted by Daniel Ruf in pull request [15012](https://github.com/magento/magento2/pull/15012)*.
+<!-- ENGCOM-1448  -->
+*  The upgrade check implemented during setup now indicates success if the latest version of Magento is already installed. Previously, the message indicated that the latest product version was already installed was presented as error. *Fix submitted by Daniel Ruf in pull request [15012](https://github.com/magento/magento2/pull/15012)*.
 
-<!-- ENGCOM-1431 -->* The **Add Block Names to Hints** configuration setting has been renamed to **Add Block Class Type to Hints**. *Fix submitted by Chris Pook in pull request [14939](https://github.com/magento/magento2/pull/14939)*.
+<!-- ENGCOM-1431  -->
+*  The **Add Block Names to Hints** configuration setting has been renamed to **Add Block Class Type to Hints**. *Fix submitted by Chris Pook in pull request [14939](https://github.com/magento/magento2/pull/14939)*.
 
-<!-- MAGETWO-93758 -->* The `cron:run` command now reads `cron/enabled` configuration setting and if this value is set to **1** (the default value), then the `cron:run` command will execute. A value of **0** determines that `cron:run` will not be executed, and prompts Magento to send the customer email indicating that `cron` is disabled.
+<!-- MAGETWO-93758  -->
+*  The `cron:run` command now reads `cron/enabled` configuration setting and if this value is set to **1** (the default value), then the `cron:run` command will execute. A value of **0** determines that `cron:run` will not be executed, and prompts Magento to send the customer email indicating that `cron` is disabled.
 
 <!-- MAGETWO-93981 -->
 *  New command-line interface (CLI) commands support setting and showing indexer dimension modes:
@@ -183,218 +208,320 @@ In addition to security enhancements, this release contains the following functi
 
 ### Amazon Pay
 
-<!-- BUNDLE-1453 -->* Amazon Pay no longer appears as an option during checkout when a customer selects  **Check Out with Multiple Addresses**. Previously, Magento displayed Amazon Pay as an option, even though Amazon Pay does not support multishipping.
+<!-- BUNDLE-1453  -->
+*  Amazon Pay no longer appears as an option during checkout when a customer selects  **Check Out with Multiple Addresses**. Previously, Magento displayed Amazon Pay as an option, even though Amazon Pay does not support multishipping.
 
-<!-- BUNDLE-1324 -->*  You can now change and save Amazon Pay configuration settings from **Configuration**  > **Sales** > **Payment Methods**  > **Amazon Pay** when deploying Magento in a Cloud environment. Previously, Magento did not save changed settings.
+<!-- BUNDLE-1324  -->
+*   You can now change and save Amazon Pay configuration settings from **Configuration**  > **Sales** > **Payment Methods**  > **Amazon Pay** when deploying Magento in a Cloud environment. Previously, Magento did not save changed settings.
 
 ### Bundle products
 
-<!-- MAGETWO-90999 -->* Magento now successfully imports bundle products. Previously, bundle products were not visible in the product catalog, and were listed as out-of-stock on the storefront.
+<!-- MAGETWO-90999  -->
+*  Magento now successfully imports bundle products. Previously, bundle products were not visible in the product catalog, and were listed as out-of-stock on the storefront.
 
-<!--  ENGCOM-1863-->* The `Magento_Bundle` module name has been added to the relevant template files to meet Magento standard coding format. *Fix submitted by Namrata in pull request [15825](https://github.com/magento/magento2/pull/15825)*.
+<!--  ENGCOM-1863 -->
+*  The `Magento_Bundle` module name has been added to the relevant template files to meet Magento standard coding format. *Fix submitted by Namrata in pull request [15825](https://github.com/magento/magento2/pull/15825)*.
 
-<!--  ENGCOM-2176-->* The `option` variable has been renamed to `quoteItemOption` to improve code readability in `app/code/Magento/Bundle/Model/Product/Type.php`. *Fix submitted by Leandro F. L. in pull request [16143](https://github.com/magento/magento2/pull/16143)*.
+<!--  ENGCOM-2176 -->
+*  The `option` variable has been renamed to `quoteItemOption` to improve code readability in `app/code/Magento/Bundle/Model/Product/Type.php`. *Fix submitted by Leandro F. L. in pull request [16143](https://github.com/magento/magento2/pull/16143)*.
 
-<!-- MAGETWO-86218-->* Magento now accurately displays the status of bundle product stock when **Add to Cart** is enabled for bundle products. Previously, bundle products with the **User Defined** field unchecked could not be back ordered as expected.
+<!-- MAGETWO-86218 -->
+*  Magento now accurately displays the status of bundle product stock when **Add to Cart** is enabled for bundle products. Previously, bundle products with the **User Defined** field unchecked could not be back ordered as expected.
 [GitHub-10061](https://github.com/magento/magento2/issues/10061)
 
 ### Catalog
 
-<!-- ENGCOM-1539 -->* The breadcrumbs component no longer relies on the `mageMenu` widget. *Fix submitted by Vova Yatsyuk in pull request [15178](https://github.com/magento/magento2/pull/15178)*. [GitHub-14987](https://github.com/magento/magento2/issues/14987)
+<!-- ENGCOM-1539  -->
+*  The breadcrumbs component no longer relies on the `mageMenu` widget. *Fix submitted by Vova Yatsyuk in pull request [15178](https://github.com/magento/magento2/pull/15178)*. [GitHub-14987](https://github.com/magento/magento2/issues/14987)
 
-<!-- ENGCOM-1622 -->* The `data-container` class name is now based on view mode. *Fix submitted by sunilit42 in pull request [15350](https://github.com/magento/magento2/pull/15350)*. [GitHub-15319](https://github.com/magento/magento2/issues/15319)
+<!-- ENGCOM-1622  -->
+*  The `data-container` class name is now based on view mode. *Fix submitted by sunilit42 in pull request [15350](https://github.com/magento/magento2/pull/15350)*. [GitHub-15319](https://github.com/magento/magento2/issues/15319)
 
-<!-- ENGCOM-1617 -->* Breadcrumbs now work as expected when a product name contains quotation marks. Previously, the breadcrumbs on the product details page caused this syntax error to be thrown, `SyntaxError: Unexpected token x in JSON`. *Fix submitted by Jignesh Baldha in pull request [15347](https://github.com/magento/magento2/pull/15347)*. [GitHub-15037](https://github.com/magento/magento2/issues/15037)
+<!-- ENGCOM-1617  -->
+*  Breadcrumbs now work as expected when a product name contains quotation marks. Previously, the breadcrumbs on the product details page caused this syntax error to be thrown, `SyntaxError: Unexpected token x in JSON`. *Fix submitted by Jignesh Baldha in pull request [15347](https://github.com/magento/magento2/pull/15347)*. [GitHub-15037](https://github.com/magento/magento2/issues/15037)
 
-<!-- ENGCOM-1463 -->* Disabling a product now removes it from the flat index as expected. *Fix submitted by Mr. Lewis in pull request [15019](https://github.com/magento/magento2/pull/15019)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
+<!-- ENGCOM-1463  -->
+*  Disabling a product now removes it from the flat index as expected. *Fix submitted by Mr. Lewis in pull request [15019](https://github.com/magento/magento2/pull/15019)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
 
-<!-- ENGCOM-1051 -->* The success message that Magento displays when a customer adds a product to the compare list now contains a link to the comparison list. *Fix submitted by Andreas von Studnitz in pull request [13862](https://github.com/magento/magento2/pull/13862)*.
+<!-- ENGCOM-1051  -->
+*  The success message that Magento displays when a customer adds a product to the compare list now contains a link to the comparison list. *Fix submitted by Andreas von Studnitz in pull request [13862](https://github.com/magento/magento2/pull/13862)*.
 
-<!-- ENGCOM-1953 -->* Cache problems no longer occur when currencies are used without a currency symbol. *Fix submitted by Dmytro Cheshun in pull request [15902](https://github.com/magento/magento2/pull/15902)*.
+<!-- ENGCOM-1953  -->
+*  Cache problems no longer occur when currencies are used without a currency symbol. *Fix submitted by Dmytro Cheshun in pull request [15902](https://github.com/magento/magento2/pull/15902)*.
 
-<!-- ENGCOM-1927 -->* Catalog component blocks now contain correct return type suggestions, and typos have been corrected where needed in the PHPDocs. *Fix submitted by Dmytro Cheshun in pull request [15913](https://github.com/magento/magento2/pull/15913)*.
+<!-- ENGCOM-1927  -->
+*  Catalog component blocks now contain correct return type suggestions, and typos have been corrected where needed in the PHPDocs. *Fix submitted by Dmytro Cheshun in pull request [15913](https://github.com/magento/magento2/pull/15913)*.
 
-<!-- ENGCOM-1287 -->* Widget cache errors that resulted in one widget being loaded twice on the storefront have been resolved. *Fix submitted by Alexandr Kozyr in pull request [12764](https://github.com/magento/magento2/pull/12764)*. [GitHub-4389](https://github.com/magento/magento2/issues/4389)
+<!-- ENGCOM-1287  -->
+*  Widget cache errors that resulted in one widget being loaded twice on the storefront have been resolved. *Fix submitted by Alexandr Kozyr in pull request [12764](https://github.com/magento/magento2/pull/12764)*. [GitHub-4389](https://github.com/magento/magento2/issues/4389)
 
-<!-- ENGCOM-1059 -->* Magento no longer makes redundant requests on the 'customer data' on the checkout  page. *Fix submitted by Andrey Bezyazychnyy in pull request [14314](https://github.com/magento/magento2/pull/14314)*. [GitHub-13765](https://github.com/magento/magento2/issues/13765)
+<!-- ENGCOM-1059  -->
+*  Magento no longer makes redundant requests on the 'customer data' on the checkout  page. *Fix submitted by Andrey Bezyazychnyy in pull request [14314](https://github.com/magento/magento2/pull/14314)*. [GitHub-13765](https://github.com/magento/magento2/issues/13765)
 
-<!-- MAGETWO-93196 -->* Administrators with permission to change product names on one website only cannot change product names on any other sites. Previously, an administrator with permission to change a product name on one site only could change product names on all websites in a multisite deployment.
+<!-- MAGETWO-93196  -->
+*  Administrators with permission to change product names on one website only cannot change product names on any other sites. Previously, an administrator with permission to change a product name on one site only could change product names on all websites in a multisite deployment.
 
-<!-- MAGETWO-93103 -->* Administrators with limited privileges can now save products as expected.
+<!-- MAGETWO-93103  -->
+*  Administrators with limited privileges can now save products as expected.
 
-<!-- MAGETWO-93071 -->* Magento now uses the current date as expected when setting the start date for a special price. Previously, Magento set the start date for a special price a few years in the future, which prevented the special price for being active.
+<!-- MAGETWO-93071  -->
+*  Magento now uses the current date as expected when setting the start date for a special price. Previously, Magento set the start date for a special price a few years in the future, which prevented the special price for being active.
 
-<!-- MAGETWO-92907 -->* Magento now reliably displays category images on the custom store view level.  Previously, the category image on custom store view level alternately disappeared and appeared after every save operation.
+<!-- MAGETWO-92907  -->
+*  Magento now reliably displays category images on the custom store view level.  Previously, the category image on custom store view level alternately disappeared and appeared after every save operation.
 
-<!-- MAGETWO-92574 -->* Magento no longer removes downloadable product links after an attribute is updated.
+<!-- MAGETWO-92574  -->
+*  Magento no longer removes downloadable product links after an attribute is updated.
 
-<!-- MAGETWO-92502 -->* Extra POST requests are no longer sent if the  **Synchronize widget products with backend storage** option is set to **yes**.
+<!-- MAGETWO-92502  -->
+*  Extra POST requests are no longer sent if the  **Synchronize widget products with backend storage** option is set to **yes**.
 
-<!-- MAGETWO-92389 -->* You can now create a product date attribute that contains a day value than exceeds 12 (in the format dd/mm/yyyy). Previously, when you created a product attribute with a default date specifying a day greater than 12, Magento did not save the attribute, but instead displayed this error, `Invalid default date`.
+<!-- MAGETWO-92389  -->
+*  You can now create a product date attribute that contains a day value than exceeds 12 (in the format dd/mm/yyyy). Previously, when you created a product attribute with a default date specifying a day greater than 12, Magento did not save the attribute, but instead displayed this error, `Invalid default date`.
 
-<!-- MAGETWO-91402 -->* You can now use the `Magento\Catalog\Model\ProductRepository` class to assign a product to one website as expected. Previously, using this class to save a product assigned the product to all existing websites, not just the specified one.
+<!-- MAGETWO-91402  -->
+*  You can now use the `Magento\Catalog\Model\ProductRepository` class to assign a product to one website as expected. Previously, using this class to save a product assigned the product to all existing websites, not just the specified one.
 
-<!-- MAGETWO-91163 -->* Images now load as expected on the product display page (PDP) when the image name contains double quotation marks.
+<!-- MAGETWO-91163  -->
+*  Images now load as expected on the product display page (PDP) when the image name contains double quotation marks.
 
-<!-- MAGETWO-90940 -->* The SEO-friendly URL for the Category page now works as expected.
+<!-- MAGETWO-90940  -->
+*  The SEO-friendly URL for the Category page now works as expected.
 
-<!-- MAGETWO-90768 -->* The **Use Default Value** checkboxes in the design section of the category page are now enabled by default as expected.
+<!-- MAGETWO-90768  -->
+*  The **Use Default Value** checkboxes in the design section of the category page are now enabled by default as expected.
 
-<!-- MAGETWO-92280 -->* Customers can now use the **Add Product By SKU** button to add configurable products to a sales order.
+<!-- MAGETWO-92280  -->
+*  Customers can now use the **Add Product By SKU** button to add configurable products to a sales order.
 
-<!-- MAGETWO-90569 -->* Empty dropdown or swatch type product attributes are no longer visible on the product page.
+<!-- MAGETWO-90569  -->
+*  Empty dropdown or swatch type product attributes are no longer visible on the product page.
 
-<!-- MAGETWO-90367 -->* Attributes that have empty values across all products being compared are not displayed as rows in the comparison table. Previously, Magento displayed these attributes  with an N/A value on the  Compare Products page.
+<!-- MAGETWO-90367  -->
+*  Attributes that have empty values across all products being compared are not displayed as rows in the comparison table. Previously, Magento displayed these attributes  with an N/A value on the  Compare Products page.
 
-<!-- MAGETWO-89732 -->* The Catalog page now displays breadcrumbs as expected.
+<!-- MAGETWO-89732  -->
+*  The Catalog page now displays breadcrumbs as expected.
 
-<!-- MAGETWO-88504 -->* Tiered pricing and quantity increments now work as expected with decimal-based inventories.
+<!-- MAGETWO-88504  -->
+*  Tiered pricing and quantity increments now work as expected with decimal-based inventories.
 
-<!-- MAGETWO-88102 -->* Magento now updates the `catalog_category_product_index` table as expected after a category is deleted.
+<!-- MAGETWO-88102  -->
+*  Magento now updates the `catalog_category_product_index` table as expected after a category is deleted.
 
-<!-- MAGETWO-87721 -->* Customizable options are now configured the same for all websites to which a product is added. Previously, when a merchant added a product with customizable options to an additional site, the options were corrupted.
+<!-- MAGETWO-87721  -->
+*  Customizable options are now configured the same for all websites to which a product is added. Previously, when a merchant added a product with customizable options to an additional site, the options were corrupted.
 
-<!-- MAGETWO-87589 -->* The **Use default value** option is no longer unchecked unless the user overrides the value of the attribute in the store view scope. Previously, after creating an item, if the user changed to store view scope and did not make any modifications to the item's attributes and only clicked **Save**, most of the attributes that were set as **Use default value** became unchecked.
+<!-- MAGETWO-87589  -->
+*  The **Use default value** option is no longer unchecked unless the user overrides the value of the attribute in the store view scope. Previously, after creating an item, if the user changed to store view scope and did not make any modifications to the item's attributes and only clicked **Save**, most of the attributes that were set as **Use default value** became unchecked.
 
-<!-- MAGETWO-87430 -->* Category product indexer logic has been optimized, and re-indexing time has been noticeably reduced.  Previously, when you had many categories (100,000), Magento could take up to 40 minutes to re-index product catalogs.
+<!-- MAGETWO-87430  -->
+*  Category product indexer logic has been optimized, and re-indexing time has been noticeably reduced.  Previously, when you had many categories (100,000), Magento could take up to 40 minutes to re-index product catalogs.
 
-<!-- MAGETWO-86710 -->* Widget selection by Enabled Products no longer causes a fatal error on a storefront when the **Flat Product** is configured.
+<!-- MAGETWO-86710  -->
+*  Widget selection by Enabled Products no longer causes a fatal error on a storefront when the **Flat Product** is configured.
 
-<!-- MAGETWO-86295 -->* Merchants can now change the `status` and `update` attributes from the product page. Previously, Magento returned a 404 page when bulk enabling or disabling products in the Admin with a restricted user role that is limited to a specific website.
+<!-- MAGETWO-86295  -->
+*  Merchants can now change the `status` and `update` attributes from the product page. Previously, Magento returned a 404 page when bulk enabling or disabling products in the Admin with a restricted user role that is limited to a specific website.
 
-<!-- MAGETWO-85682 -->* Magento now maintains the default setting for a product's `status` attribute when you create a new product. Previously, when creating a new product after changing the default option from Enabled to Disabled for this attribute, the status is incorrectly set to enabled by default.
+<!-- MAGETWO-85682  -->
+*  Magento now maintains the default setting for a product's `status` attribute when you create a new product. Previously, when creating a new product after changing the default option from Enabled to Disabled for this attribute, the status is incorrectly set to enabled by default.
 
-<!-- MAGETWO-84891 -->* The print preview of product comparison results (that is, the page of results that Magento produces when you click **Compare** after selecting two or more products) now displays as expected. Previously, only a subset of page elements was displayed.
+<!-- MAGETWO-84891  -->
+*  The print preview of product comparison results (that is, the page of results that Magento produces when you click **Compare** after selecting two or more products) now displays as expected. Previously, only a subset of page elements was displayed.
 
-<!-- MAGETWO-82116 -->* Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date. [GitHub-11517](https://github.com/magento/magento2/issues/11517)
+<!-- MAGETWO-82116  -->
+*  Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date. [GitHub-11517](https://github.com/magento/magento2/issues/11517)
 
-<!-- MAGETWO-75427 -->* As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
+<!-- MAGETWO-75427  -->
+*  As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
 
-<!-- MAGETWO-60573 -->* Merchants can now set custom option fixed prices with  negative values in the Admin. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
+<!-- MAGETWO-60573  -->
+*  Merchants can now set custom option fixed prices with  negative values in the Admin. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
 
-<!-- MAGETWO-73739 -->* You can now unset a category image on the store-view level when the image is defined on all store views.
+<!-- MAGETWO-73739  -->
+*  You can now unset a category image on the store-view level when the image is defined on all store views.
 
-<!-- MAGETWO-74021 -->* The Catalog Products List widget can now display products on the storefront that have specific attributes.
+<!-- MAGETWO-74021  -->
+*  The Catalog Products List widget can now display products on the storefront that have specific attributes.
 
-<!--  ENGCOM-2383 -->* The shopping cart now correctly displays images of configurable products that have only size options (that is, no color options). Previously, when a customer added a configurable product that had only size options to her shopping cart, the shopping cart did not display the expected product image. *Fix submitted by Ronak Patel in pull request [16863](https://github.com/magento/magento2/pull/16863)*. [GitHub-16843](https://github.com/magento/magento2/issues/16843)
+<!--  ENGCOM-2383  -->
+*  The shopping cart now correctly displays images of configurable products that have only size options (that is, no color options). Previously, when a customer added a configurable product that had only size options to her shopping cart, the shopping cart did not display the expected product image. *Fix submitted by Ronak Patel in pull request [16863](https://github.com/magento/magento2/pull/16863)*. [GitHub-16843](https://github.com/magento/magento2/issues/16843)
 
-<!--  ENGCOM-2313 -->* Magento now throws an exception as expected  when a user tries to submit a product review without selecting a star rating. Previously, if a user submitted a product review without selecting a star rating, Magento assigned a one-star rating.
+<!--  ENGCOM-2313  -->
+*  Magento now throws an exception as expected  when a user tries to submit a product review without selecting a star rating. Previously, if a user submitted a product review without selecting a star rating, Magento assigned a one-star rating.
 
-<!--  ENGCOM-2213 -->* Magento now successfully displays product prices in currencies without minor units if the price amount is less then the number group size.  [GitHub-11711](https://github.com/magento/magento2/issues/11711)
+<!--  ENGCOM-2213  -->
+*  Magento now successfully displays product prices in currencies without minor units if the price amount is less then the number group size.  [GitHub-11711](https://github.com/magento/magento2/issues/11711)
 
-<!-- ENGCOM-2193 -->* Magento now displays the correct  price on the product page for storefronts running Japanese locales. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11711](https://github.com/magento/magento2/issues/11711)
+<!-- ENGCOM-2193  -->
+*  Magento now displays the correct  price on the product page for storefronts running Japanese locales. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11711](https://github.com/magento/magento2/issues/11711)
 
-<!-- ENGCOM-1106 -->* Magento now correctly saves the value of a product's custom options. Previously, Magento saved all objects by using the same value object for all values. *Fix submitted by Jeroen Van Leusden in pull request [13569](https://github.com/magento/magento2/pull/13569)*. [GitHub-5067](https://github.com/magento/magento2/issues/5067)
+<!-- ENGCOM-1106  -->
+*  Magento now correctly saves the value of a product's custom options. Previously, Magento saved all objects by using the same value object for all values. *Fix submitted by Jeroen Van Leusden in pull request [13569](https://github.com/magento/magento2/pull/13569)*. [GitHub-5067](https://github.com/magento/magento2/issues/5067)
 
-<!-- ENGCOM-1911 -->* Magento now displays the product name as browser title as expected. Previously, the meta title tag was missing, which prevented Magento from displaying the product name. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
+<!-- ENGCOM-1911  -->
+*  Magento now displays the product name as browser title as expected. Previously, the meta title tag was missing, which prevented Magento from displaying the product name. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
 
-<!-- ENGCOM-2042 -->* Magento now maintains the default products sort order of “newest first” when you upgrade your Magento deployment to 2.2.4. Previously, after upgrade, the default products order in categories changed from “newest first” to “oldest first”. *Fix submitted by Danny Verkade in pull request [15629](https://github.com/magento/magento2/pull/15629)*. [GitHub-15627](https://github.com/magento/magento2/issues/15627)
+<!-- ENGCOM-2042  -->
+*  Magento now maintains the default products sort order of “newest first” when you upgrade your Magento deployment to 2.2.4. Previously, after upgrade, the default products order in categories changed from “newest first” to “oldest first”. *Fix submitted by Danny Verkade in pull request [15629](https://github.com/magento/magento2/pull/15629)*. [GitHub-15627](https://github.com/magento/magento2/issues/15627)
 
-<!-- ENGCOM-1909-->* Links on product pages are now linkable as expected. Previously, when Magento displayed a product page, none of the provided links were clickable. *Fix submitted by simonjanguapa in pull request [15687](https://github.com/magento/magento2/pull/15687)*. [GitHub-15393](https://github.com/magento/magento2/issues/15393)
+<!-- ENGCOM-1909 -->
+*  Links on product pages are now linkable as expected. Previously, when Magento displayed a product page, none of the provided links were clickable. *Fix submitted by simonjanguapa in pull request [15687](https://github.com/magento/magento2/pull/15687)*. [GitHub-15393](https://github.com/magento/magento2/issues/15393)
 
-<!-- ENGCOM-2408-->* Deprecated methods in Message Manager have been replaced with valid methods. *Fix submitted by Tiago Sampaio in pull request [16924](https://github.com/magento/magento2/pull/16924)*.
+<!-- ENGCOM-2408 -->
+*  Deprecated methods in Message Manager have been replaced with valid methods. *Fix submitted by Tiago Sampaio in pull request [16924](https://github.com/magento/magento2/pull/16924)*.
 
-<!-- ENGCOM-2390-->* Array short syntax usage has been standardized in these files: `app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php`, `app/code/Magento/GroupedProduct/Test/Unit/Model/ProductTest.php`, and `setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php`. *Fix submitted by Leandro F. L. in pull request [16880](https://github.com/magento/magento2/pull/16880)*.
+<!-- ENGCOM-2390 -->
+*  Array short syntax usage has been standardized in these files: `app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php`, `app/code/Magento/GroupedProduct/Test/Unit/Model/ProductTest.php`, and `setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php`. *Fix submitted by Leandro F. L. in pull request [16880](https://github.com/magento/magento2/pull/16880)*.
 
-<!-- ENGCOM-2132-->* The error message that Magento displayed when a duplicate error key occurred during product import has been improved. *Fix submitted by Vishal Gelani in pull request [16389](https://github.com/magento/magento2/pull/16389)*.
+<!-- ENGCOM-2132 -->
+*  The error message that Magento displayed when a duplicate error key occurred during product import has been improved. *Fix submitted by Vishal Gelani in pull request [16389](https://github.com/magento/magento2/pull/16389)*.
 
-<!-- ENGCOM-2093-->* We've removed the direct use of the object manager when saving Admin attribute sets. *Fix submitted by AnshuMishra17 in pull request [16217](https://github.com/magento/magento2/pull/16217)*.
+<!-- ENGCOM-2093 -->
+*  We've removed the direct use of the object manager when saving Admin attribute sets. *Fix submitted by AnshuMishra17 in pull request [16217](https://github.com/magento/magento2/pull/16217)*.
 
-<!-- ENGCOM-1703-->* Breadcrumb JSON configuration has been moved to the view model and serialized using the Magento JSON serializer. *Fix submitted by Diederick Bruin in pull request [15521](https://github.com/magento/magento2/pull/15521)*.
+<!-- ENGCOM-1703 -->
+*  Breadcrumb JSON configuration has been moved to the view model and serialized using the Magento JSON serializer. *Fix submitted by Diederick Bruin in pull request [15521](https://github.com/magento/magento2/pull/15521)*.
 
-<!-- ENGCOM-1464-->* `row_id` has been added to the flat action indexer,  ensuring that index values are not set to `0` for new products when using index on save. Previously, if you used `\Magento\Framework\Api\SearchCriteriaBuilder`, and the flat `product row_id` is set to `0`, Magento did not show the product in the `getList` of the `ProductRepository`. *Fix submitted by Mr. Lewis in pull request [15010](https://github.com/magento/magento2/pull/15010)*.
+<!-- ENGCOM-1464 -->
+*  `row_id` has been added to the flat action indexer,  ensuring that index values are not set to `0` for new products when using index on save. Previously, if you used `\Magento\Framework\Api\SearchCriteriaBuilder`, and the flat `product row_id` is set to `0`, Magento did not show the product in the `getList` of the `ProductRepository`. *Fix submitted by Mr. Lewis in pull request [15010](https://github.com/magento/magento2/pull/15010)*.
 
-<!-- ENGCOM-1444-->* Magento no longer inserts redundant links to the homepage  into breadcrumbs on the product page. *Fix submitted by Vova Yatsyuk in pull request [14994](https://github.com/magento/magento2/pull/14994)*.
+<!-- ENGCOM-1444 -->
+*  Magento no longer inserts redundant links to the homepage  into breadcrumbs on the product page. *Fix submitted by Vova Yatsyuk in pull request [14994](https://github.com/magento/magento2/pull/14994)*.
 
-<!-- ENGCOM-1553-->* Magento now correctly displays product information for products that have a negative price as a custom option.  *Fix submitted by Danny Verkade in pull request [15202](https://github.com/magento/magento2/pull/15202)*.
+<!-- ENGCOM-1553 -->
+*  Magento now correctly displays product information for products that have a negative price as a custom option.  *Fix submitted by Danny Verkade in pull request [15202](https://github.com/magento/magento2/pull/15202)*.
 
-<!-- ENGCOM-1530-->* Product names can now contain a double quotation mark character (`"`). Previously, when a product name contained this character, Magento threw a JavaScript error. *Fix submitted by Vova Yatsyuk in pull request [15162](https://github.com/magento/magento2/pull/15162)*.
+<!-- ENGCOM-1530 -->
+*  Product names can now contain a double quotation mark character (`"`). Previously, when a product name contained this character, Magento threw a JavaScript error. *Fix submitted by Vova Yatsyuk in pull request [15162](https://github.com/magento/magento2/pull/15162)*.
 
-<!-- ENGCOM-1404-->* Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page. *Fix submitted by Neos2007 in pull request [14886](https://github.com/magento/magento2/pull/14886)*.
+<!-- ENGCOM-1404 -->
+*  Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page. *Fix submitted by Neos2007 in pull request [14886](https://github.com/magento/magento2/pull/14886)*.
 
-<!-- ENGCOM-1336-->* Magento now updates product options and quantity by checking the item ID when updating a cart that contains configurable products with different options. *Fix submitted by Nitin Khalasi in pull request [14765](https://github.com/magento/magento2/pull/14765)*.
+<!-- ENGCOM-1336 -->
+*  Magento now updates product options and quantity by checking the item ID when updating a cart that contains configurable products with different options. *Fix submitted by Nitin Khalasi in pull request [14765](https://github.com/magento/magento2/pull/14765)*.
 
-<!-- ENGCOM-1239-->* Product meta descriptions no longer contain unnecessary HTML tags. *Fix submitted by David Windell in pull request [14538](https://github.com/magento/magento2/pull/14538)*.
+<!-- ENGCOM-1239 -->
+*  Product meta descriptions no longer contain unnecessary HTML tags. *Fix submitted by David Windell in pull request [14538](https://github.com/magento/magento2/pull/14538)*.
 
-<!-- MAGETWO-90367-->* Attributes that have empty values across all products being compared are not displayed on the Compare Products page as rows in the comparison table. Previously, these attributes were displayed with a value of **N/A**.
+<!-- MAGETWO-90367 -->
+*  Attributes that have empty values across all products being compared are not displayed on the Compare Products page as rows in the comparison table. Previously, these attributes were displayed with a value of **N/A**.
 
-<!-- MAGETWO-82116-->* Inputted data in filter fields now persists unchanged after you leave the product edit page. Previously, the values in the **Set Product as New from Date** field were not saved as expected.
+<!-- MAGETWO-82116 -->
+*  Inputted data in filter fields now persists unchanged after you leave the product edit page. Previously, the values in the **Set Product as New from Date** field were not saved as expected.
 
-<!-- MAGETWO-92823-->* Company Admin can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
+<!-- MAGETWO-92823 -->
+*  Company Admin can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
 
 ### CAPTCHA
 
-<!-- MAGETWO-91840 -->* Customers can now successfully log in when guest checkout is disabled and CAPTCHA is enabled. Previously, Magento threw the `Provided form does not exist` error when a customer tried to log in under these conditions.
+<!-- MAGETWO-91840  -->
+*  Customers can now successfully log in when guest checkout is disabled and CAPTCHA is enabled. Previously, Magento threw the `Provided form does not exist` error when a customer tried to log in under these conditions.
 
-<!-- MAGETWO-89615 -->* CAPTCHA validation now works when the **Website Restrictions** setting is enabled.
+<!-- MAGETWO-89615  -->
+*  CAPTCHA validation now works when the **Website Restrictions** setting is enabled.
 
-<!-- ENGCOM-1973 -->* The `\Magento\Captcha\Observer\CaptchaStringResolver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16065](https://github.com/magento/magento2/pull/16065)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
+<!-- ENGCOM-1973  -->
+*  The `\Magento\Captcha\Observer\CaptchaStringResolver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16065](https://github.com/magento/magento2/pull/16065)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
 
-<!-- ENGCOM-2013 -->* The `CheckRegisterCheckoutObserver` class  is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16160](https://github.com/magento/magento2/pull/16160)*.
+<!-- ENGCOM-2013  -->
+*  The `CheckRegisterCheckoutObserver` class  is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16160](https://github.com/magento/magento2/pull/16160)*.
 
-<!-- ENGCOM-2268 -->* The `\Magento\Captcha\Observer\CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
+<!-- ENGCOM-2268  -->
+*  The `\Magento\Captcha\Observer\CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
 
-<!-- ENGCOM-2531 -->* Autocomplete for CAPTCHA inputs has been disabled. *Fix submitted by Denis Belevtsov in pull request [17114](https://github.com/magento/magento2/pull/17114)*.
+<!-- ENGCOM-2531  -->
+*  Autocomplete for CAPTCHA inputs has been disabled. *Fix submitted by Denis Belevtsov in pull request [17114](https://github.com/magento/magento2/pull/17114)*.
 
-<!-- ENGCOM-2090 -->* Integration tests now check that customer login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16306](https://github.com/magento/magento2/pull/16306)*.
+<!-- ENGCOM-2090  -->
+*  Integration tests now check that customer login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16306](https://github.com/magento/magento2/pull/16306)*.
 
-<!-- ENGCOM-2087 -->* Integration tests now check that administrator login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16300](https://github.com/magento/magento2/pull/16300)*.
+<!-- ENGCOM-2087  -->
+*  Integration tests now check that administrator login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16300](https://github.com/magento/magento2/pull/16300)*.
 
-<!-- ENGCOM-2268 -->* The `CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
+<!-- ENGCOM-2268  -->
+*  The `CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
 
 ### Cart and checkout
 
-<!-- ENGCOM-2126 -->* Placeholders for the password field  no longer suggest that a password is optional. Previously, the placeholder for the password field in the checkout page suggested that the password was optional, but after validation, Magento indicated that the password field  was mandatory. *Fix submitted by hitesh-wagento in pull request [16379](https://github.com/magento/magento2/pull/16379)*. [GitHub-16378](https://github.com/magento/magento2/issues/16378)
+<!-- ENGCOM-2126  -->
+*  Placeholders for the password field  no longer suggest that a password is optional. Previously, the placeholder for the password field in the checkout page suggested that the password was optional, but after validation, Magento indicated that the password field  was mandatory. *Fix submitted by hitesh-wagento in pull request [16379](https://github.com/magento/magento2/pull/16379)*. [GitHub-16378](https://github.com/magento/magento2/issues/16378)
 
-<!-- ENGCOM-1941 -->* The dropdown toggle icon on the shopping cart now works as expected. Previously, the arrow did not change direction as expected when you toggled the Discount or Tax options. *Fix submitted by Karla Saaremäe in pull request [15991](https://github.com/magento/magento2/pull/15991)*.
+<!-- ENGCOM-1941  -->
+*  The dropdown toggle icon on the shopping cart now works as expected. Previously, the arrow did not change direction as expected when you toggled the Discount or Tax options. *Fix submitted by Karla Saaremäe in pull request [15991](https://github.com/magento/magento2/pull/15991)*.
 
-<!-- ENGCOM-1951 -->* The shopping cart icon on the checkout page on mobile screens now displays hover color and regular color as expected. *Fix submitted by Karla Saaremäe in pull request [16002](https://github.com/magento/magento2/pull/16002)*.
+<!-- ENGCOM-1951  -->
+*  The shopping cart icon on the checkout page on mobile screens now displays hover color and regular color as expected. *Fix submitted by Karla Saaremäe in pull request [16002](https://github.com/magento/magento2/pull/16002)*.
 
-<!-- ENGCOM-1154 -->* Customers are not unexpectedly logged out if the customers hits the F5 key twice during checkout. *Fix submitted by adrian-martinez-interactiv4 in pull request [14428](https://github.com/magento/magento2/pull/14428)*. [GitHub-4301](https://github.com/magento/magento2/issues/4301), [GitHub-12362](https://github.com/magento/magento2/issues/12362), [GitHub-13427](https://github.com/magento/magento2/issues/13427)
+<!-- ENGCOM-1154  -->
+*  Customers are not unexpectedly logged out if the customers hits the F5 key twice during checkout. *Fix submitted by adrian-martinez-interactiv4 in pull request [14428](https://github.com/magento/magento2/pull/14428)*. [GitHub-4301](https://github.com/magento/magento2/issues/4301), [GitHub-12362](https://github.com/magento/magento2/issues/12362), [GitHub-13427](https://github.com/magento/magento2/issues/13427)
 
-<!-- ENGCOM-1646 -->* The **Purchased Order Form** button is now correctly aligned. *Fix submitted by Neeta Kangiya in pull request [15331](https://github.com/magento/magento2/pull/15331)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
+<!-- ENGCOM-1646  -->
+*  The **Purchased Order Form** button is now correctly aligned. *Fix submitted by Neeta Kangiya in pull request [15331](https://github.com/magento/magento2/pull/15331)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
 
-<!-- ENGCOM-1634-->* The **Purchased Order Form** button is now visible. *Fix submitted by hitesh-wagento in pull request [15372](https://github.com/magento/magento2/pull/15372)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
+<!-- ENGCOM-1634 -->
+*  The **Purchased Order Form** button is now visible. *Fix submitted by hitesh-wagento in pull request [15372](https://github.com/magento/magento2/pull/15372)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
 
-<!-- ENGCOM-1713 -->* Magento no longer displays duplicate element IDs on the Checkout page. *Fix submitted by Julien ANQUETIL in pull request [15585](https://github.com/magento/magento2/pull/15585)*. [GitHub-13415](https://github.com/magento/magento2/issues/13415)
+<!-- ENGCOM-1713  -->
+*  Magento no longer displays duplicate element IDs on the Checkout page. *Fix submitted by Julien ANQUETIL in pull request [15585](https://github.com/magento/magento2/pull/15585)*. [GitHub-13415](https://github.com/magento/magento2/issues/13415)
 
-<!-- ENGCOM-1988 -->* During the payment step of checkout, a customer can now successfully deselect the **Billing save-in address book** checkbox in a selected payment method other than the default method.  *Fix submitted by Rakesh Gangani in pull request [15344](https://github.com/magento/magento2/pull/15344)*. [GitHub-13692](https://github.com/magento/magento2/issues/13692)
+<!-- ENGCOM-1988  -->
+*  During the payment step of checkout, a customer can now successfully deselect the **Billing save-in address book** checkbox in a selected payment method other than the default method.  *Fix submitted by Rakesh Gangani in pull request [15344](https://github.com/magento/magento2/pull/15344)*. [GitHub-13692](https://github.com/magento/magento2/issues/13692)
 
-<!-- ENGCOM-1298 -->* The `.block-minicart` element on the mini cart dropdown menu no longer has an empty class. *Fix submitted by Karla Saaremäe in pull request [14715](https://github.com/magento/magento2/pull/14715)*. [GitHub-14669](https://github.com/magento/magento2/issues/14669)
+<!-- ENGCOM-1298  -->
+*  The `.block-minicart` element on the mini cart dropdown menu no longer has an empty class. *Fix submitted by Karla Saaremäe in pull request [14715](https://github.com/magento/magento2/pull/14715)*. [GitHub-14669](https://github.com/magento/magento2/issues/14669)
 
-<!-- MAGETWO-92573 -->* Customers can now add configurable products to their shopping cart when Magento is running on Internet Explorer 11.x.
+<!-- MAGETWO-92573  -->
+*  Customers can now add configurable products to their shopping cart when Magento is running on Internet Explorer 11.x.
 
-<!--MAGETWO-87872 -->* The free shipping cart price rule now works as expected when the UPS shipping method is enabled. Previously, UPS Ground shipping method was not available for free shipping at checkout when the UPS shipping method was enabled.
+<!--MAGETWO-87872  -->
+*  The free shipping cart price rule now works as expected when the UPS shipping method is enabled. Previously, UPS Ground shipping method was not available for free shipping at checkout when the UPS shipping method was enabled.
 
-<!-- MAGETWO-82132 -->* Cart price rule condition values now handle commas as expected.
+<!-- MAGETWO-82132  -->
+*  Cart price rule condition values now handle commas as expected.
 
-<!-- MAGETWO-69940 -->* Free shipping coupons now work as expected with Table Rates shipping. Previously, Magento displayed this message when a customer tried to use a free shipping coupon: `Sorry, no quotes are available for this order`.  [GitHub-8172](https://github.com/magento/magento2/issues/8172)
+<!-- MAGETWO-69940  -->
+*  Free shipping coupons now work as expected with Table Rates shipping. Previously, Magento displayed this message when a customer tried to use a free shipping coupon: `Sorry, no quotes are available for this order`.  [GitHub-8172](https://github.com/magento/magento2/issues/8172)
 
-<!-- MAGETWO-91112 -->* Magento now displays correct store view prices for cases when a merchant uses a CSV file to add products by SKU  from the Admin.
+<!-- MAGETWO-91112  -->
+*  Magento now displays correct store view prices for cases when a merchant uses a CSV file to add products by SKU  from the Admin.
 
-<!-- MAGETWO-90190 -->* A merchant can successfully use SKU values that contain capital letters to  add a product  to a cart from the Admin.
+<!-- MAGETWO-90190  -->
+*  A merchant can successfully use SKU values that contain capital letters to  add a product  to a cart from the Admin.
 
-<!-- MAGETWO-90053 -->* Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout out page affected information entered into form fields for a guest checkout.
+<!-- MAGETWO-90053  -->
+*  Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout out page affected information entered into form fields for a guest checkout.
 
-<!-- MAGETWO-89222 -->* The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
+<!-- MAGETWO-89222  -->
+*  The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
 
-<!-- MAGETWO-73537 -->* Magento now maintains browser history as expected when a user navigates from the checkout contact information page to the checkout payment information page.  Previously, when a user tried to retrace her steps after landing on the payment information page, Magento did not return them to the checkout contact information page, but instead landed on a product page.
+<!-- MAGETWO-73537  -->
+*  Magento now maintains browser history as expected when a user navigates from the checkout contact information page to the checkout payment information page.  Previously, when a user tried to retrace her steps after landing on the payment information page, Magento did not return them to the checkout contact information page, but instead landed on a product page.
 
-<!-- MAGETWO-73736 -->* Magento now displays a message  when a gift card  card is removed during checkout.
+<!-- MAGETWO-73736  -->
+*  Magento now displays a message  when a gift card  card is removed during checkout.
 
-<!-- MAGETWO-86470 -->* Guest orders placed with gift cards can now be canceled.
+<!-- MAGETWO-86470  -->
+*  Guest orders placed with gift cards can now be canceled.
 
-<!-- MAGETWO-86490 -->* A shopping cart’s contents remains constant even when the Checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
+<!-- MAGETWO-86490  -->
+*  A shopping cart’s contents remains constant even when the Checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
 
-<!-- ENGCOM-840 -->* The message that Magento displays when a customer has successfully added a product to his shopping cart now contains a link to the cart.  *Fix submitted by Andreas von Studnitz in pull request [13904](https://github.com/magento/magento2/pull/13904)*.
+<!-- ENGCOM-840  -->
+*  The message that Magento displays when a customer has successfully added a product to his shopping cart now contains a link to the cart.  *Fix submitted by Andreas von Studnitz in pull request [13904](https://github.com/magento/magento2/pull/13904)*.
 
-<!-- ENGCOM-1430 -->* The Update button now behaves the same whether product quantity is manually edited or changed by JavaScript. *Fix submitted by Valerij Ivashchenko in pull request [14935](https://github.com/magento/magento2/pull/14935)*.
+<!-- ENGCOM-1430  -->
+*  The Update button now behaves the same whether product quantity is manually edited or changed by JavaScript. *Fix submitted by Valerij Ivashchenko in pull request [14935](https://github.com/magento/magento2/pull/14935)*.
 
-<!-- ENGCOM-1399 -->* Magento no longer displays the infinite checkout loader when a module that is loading  makes a `require` call, but the dependency is not returned (typically due to network error). *Fix submitted by Vova Yatsyuk in pull request [14874](https://github.com/magento/magento2/pull/14874)*.
+<!-- ENGCOM-1399  -->
+*  Magento no longer displays the infinite checkout loader when a module that is loading  makes a `require` call, but the dependency is not returned (typically due to network error). *Fix submitted by Vova Yatsyuk in pull request [14874](https://github.com/magento/magento2/pull/14874)*.
 
-<!-- ENGCOM-1299 -->* The minicart quantity label no longer has a fixed length. *Fix submitted by Karla Saaremäe in pull request [14716](https://github.com/magento/magento2/pull/14716)*.
+<!-- ENGCOM-1299  -->
+*  The minicart quantity label no longer has a fixed length. *Fix submitted by Karla Saaremäe in pull request [14716](https://github.com/magento/magento2/pull/14716)*.
 
-<!-- MAGETWO-93347 -->* Double-clicking on the **Proceed to checkout** button from the minicart no longer returns an empty shopping cart.
+<!-- MAGETWO-93347  -->
+*  Double-clicking on the **Proceed to checkout** button from the minicart no longer returns an empty shopping cart.
 
 ### Cleanup
 
@@ -402,225 +529,329 @@ Our community contributors have made many helpful, minor corrections to spelling
 
 #### Spelling corrections
 
-<!-- ENGCOM-2290 -->* Corrected misspelling of `formatedPrice` throughout the code base. *Fix submitted by Arnoud Beekman in pull request [16726](https://github.com/magento/magento2/pull/16726)*.
+<!-- ENGCOM-2290  -->
+*  Corrected misspelling of `formatedPrice` throughout the code base. *Fix submitted by Arnoud Beekman in pull request [16726](https://github.com/magento/magento2/pull/16726)*.
 
-<!-- ENGCOM-2280 -->* Corrected return message from `ProductRuleTest.php`. *Fix submitted by Namrata in pull request [16721](https://github.com/magento/magento2/pull/16721)*.
+<!-- ENGCOM-2280  -->
+*  Corrected return message from `ProductRuleTest.php`. *Fix submitted by Namrata in pull request [16721](https://github.com/magento/magento2/pull/16721)*.
 
-<!-- ENGCOM-2297 -->* Replaced the `proccessAdditionalValidation` method with `processAdditionalValidation`. *Fix submitted by Tiago Sampaio in pull request [16414](https://github.com/magento/magento2/pull/16414)*.
+<!-- ENGCOM-2297  -->
+*  Replaced the `proccessAdditionalValidation` method with `processAdditionalValidation`. *Fix submitted by Tiago Sampaio in pull request [16414](https://github.com/magento/magento2/pull/16414)*.
 
-<!-- ENGCOM-2276 -->* Corrected misspelling in `SynonymGroupRepositoryInterface`. *Fix submitted by AnshuMishra17 in pull request [16711](https://github.com/magento/magento2/pull/16711)*.
+<!-- ENGCOM-2276  -->
+*  Corrected misspelling in `SynonymGroupRepositoryInterface`. *Fix submitted by AnshuMishra17 in pull request [16711](https://github.com/magento/magento2/pull/16711)*.
 
-<!-- ENGCOM-2170 -->* Corrected misspelling in  library file. *Fix submitted by Namrata in pull request [16495](https://github.com/magento/magento2/pull/16495)*.
+<!-- ENGCOM-2170  -->
+*  Corrected misspelling in  library file. *Fix submitted by Namrata in pull request [16495](https://github.com/magento/magento2/pull/16495)*.
 
-<!-- ENGCOM-2165 -->* Corrected punctuation in the message displayed on **CONTENT** > **Design** > **Configuration**. *Fix submitted by Erik Hansen in pull request [16489](https://github.com/magento/magento2/pull/16489)*.
+<!-- ENGCOM-2165  -->
+*  Corrected punctuation in the message displayed on **CONTENT** > **Design** > **Configuration**. *Fix submitted by Erik Hansen in pull request [16489](https://github.com/magento/magento2/pull/16489)*.
 
-<!-- ENGCOM-2040 -->* Correct misspellings in Model and library files. *Fix submitted by Namarata in pull request [16230](https://github.com/magento/magento2/pull/16230)*.
+<!-- ENGCOM-2040  -->
+*  Correct misspellings in Model and library files. *Fix submitted by Namarata in pull request [16230](https://github.com/magento/magento2/pull/16230)*.
 
-<!-- ENGCOM-1581 -->* Corrected misspelling in  `_exportAddressses` method name. *Fix submitted by Marcel Hauri in pull request [15275](https://github.com/magento/magento2/pull/15275)*.
+<!-- ENGCOM-1581  -->
+*  Corrected misspelling in  `_exportAddressses` method name. *Fix submitted by Marcel Hauri in pull request [15275](https://github.com/magento/magento2/pull/15275)*.
 
-<!-- ENGCOM-1647 -->* Corrected misspelling in comments for `addTaxPercents()` in `app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php`. *Fix submitted by AnshuMishra17 in pull request [15431](https://github.com/magento/magento2/pull/15431)*.
+<!-- ENGCOM-1647  -->
+*  Corrected misspelling in comments for `addTaxPercents()` in `app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php`. *Fix submitted by AnshuMishra17 in pull request [15431](https://github.com/magento/magento2/pull/15431)*.
 
-<!-- ENGCOM-1637 -->* Corrected misspelling in `abstract.js`. *Fix submitted by VitaliyBoyko in pull request [15411](https://github.com/magento/magento2/pull/15411)*.
+<!-- ENGCOM-1637  -->
+*  Corrected misspelling in `abstract.js`. *Fix submitted by VitaliyBoyko in pull request [15411](https://github.com/magento/magento2/pull/15411)*.
 
-<!-- ENGCOM-1797 -->* Corrected misspellings in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebar.php`, `app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js`, `app/code/Magento/Ui/view/base/web/js/form/components/group.js`,  `setup/pub/angular-sanitize/angular-sanitize.js`, and `setup/pub/angular-sanitize/angular-sanitize.min.js.map`.  *Fix submitted by Danny Verkade in pull request [15715](https://github.com/magento/magento2/pull/15715)*.
+<!-- ENGCOM-1797  -->
+*  Corrected misspellings in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebar.php`, `app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js`, `app/code/Magento/Ui/view/base/web/js/form/components/group.js`,  `setup/pub/angular-sanitize/angular-sanitize.js`, and `setup/pub/angular-sanitize/angular-sanitize.min.js.map`.  *Fix submitted by Danny Verkade in pull request [15715](https://github.com/magento/magento2/pull/15715)*.
 
-<!-- ENGCOM-1692 -->* Corrected misspelling in `app/code/Magento/Catalog/Model/Product/Type/AbstractType.php`. *Fix submitted by Saurabh Parekh in pull request [15519](https://github.com/magento/magento2/pull/15519)*.
+<!-- ENGCOM-1692  -->
+*  Corrected misspelling in `app/code/Magento/Catalog/Model/Product/Type/AbstractType.php`. *Fix submitted by Saurabh Parekh in pull request [15519](https://github.com/magento/magento2/pull/15519)*.
 
-<!-- ENGCOM-1676 -->* Corrected misspellings in Multishipping and User modules. *Fix submitted by Anna Völkl in pull request [15513](https://github.com/magento/magento2/pull/15513)*.
+<!-- ENGCOM-1676  -->
+*  Corrected misspellings in Multishipping and User modules. *Fix submitted by Anna Völkl in pull request [15513](https://github.com/magento/magento2/pull/15513)*.
 
-<!-- ENGCOM-1599-->* Corrected a misspelling in function comment in `app/code/Magento/Paypal/Model/Api/Nvp.php` *Fix submitted by Namrata in pull request [15302](https://github.com/magento/magento2/pull/15302)*.
+<!-- ENGCOM-1599 -->
+*  Corrected a misspelling in function comment in `app/code/Magento/Paypal/Model/Api/Nvp.php` *Fix submitted by Namrata in pull request [15302](https://github.com/magento/magento2/pull/15302)*.
 
-<!-- ENGCOM-1588-->*  Corrected misspellings in PHPDocs and comments. *Fix submitted by Dmytro Cheshun in pull request [15293](https://github.com/magento/magento2/pull/15293)*.
+<!-- ENGCOM-1588 -->
+*   Corrected misspellings in PHPDocs and comments. *Fix submitted by Dmytro Cheshun in pull request [15293](https://github.com/magento/magento2/pull/15293)*.
 
-<!-- ENGCOM-1580-->* Corrected typo in method name `_getCharg[e]ableOptionPrice`. *Fix submitted by Marcel Hauri in pull request [15276](https://github.com/magento/magento2/pull/15276)*.
+<!-- ENGCOM-1580 -->
+*  Corrected typo in method name `_getCharg[e]ableOptionPrice`. *Fix submitted by Marcel Hauri in pull request [15276](https://github.com/magento/magento2/pull/15276)*.
 
-<!-- ENGCOM-1586-->* Corrected typo in database column comment in `app/code/Magento/Catalog/Setup/InstallSchema.php`. *Fix submitted by VitaliyBoyko in pull request [15291](https://github.com/magento/magento2/pull/15291)*.
+<!-- ENGCOM-1586 -->
+*  Corrected typo in database column comment in `app/code/Magento/Catalog/Setup/InstallSchema.php`. *Fix submitted by VitaliyBoyko in pull request [15291](https://github.com/magento/magento2/pull/15291)*.
 
-<!-- ENGCOM-1584-->* Corrected misspelling in the name of private method `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniq[ue]ImageIndex`. *Fix submitted by Marcel Hauri in pull request [15282](https://github.com/magento/magento2/pull/15282)*.
+<!-- ENGCOM-1584 -->
+*  Corrected misspelling in the name of private method `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniq[ue]ImageIndex`. *Fix submitted by Marcel Hauri in pull request [15282](https://github.com/magento/magento2/pull/15282)*.
 
-<!-- ENGCOM-1582-->* Corrected typo in the `\Magento\Framework\Image::open` exception message. *Fix submitted by Tom Richards in pull request [15269](https://github.com/magento/magento2/pull/15269)*.
+<!-- ENGCOM-1582 -->
+*  Corrected typo in the `\Magento\Framework\Image::open` exception message. *Fix submitted by Tom Richards in pull request [15269](https://github.com/magento/magento2/pull/15269)*.
 
-<!-- ENGCOM-1406-->* Corrected misspelling in `ResourceModel\Coupon.php:updateSpecificCoupons`. *Fix submitted by Stephen Biston in pull request [14891](https://github.com/magento/magento2/pull/14891)*.
+<!-- ENGCOM-1406 -->
+*  Corrected misspelling in `ResourceModel\Coupon.php:updateSpecificCoupons`. *Fix submitted by Stephen Biston in pull request [14891](https://github.com/magento/magento2/pull/14891)*.
 
-<!-- ENGCOM-1575-->* Corrected typo in the name of the `\Magento\Framework\App\Request\Http::removeRepitedSlashes` method. *Fix submitted by Igor Tripolskiy in pull request [15256](https://github.com/magento/magento2/pull/15256)*.
+<!-- ENGCOM-1575 -->
+*  Corrected typo in the name of the `\Magento\Framework\App\Request\Http::removeRepitedSlashes` method. *Fix submitted by Igor Tripolskiy in pull request [15256](https://github.com/magento/magento2/pull/15256)*.
 
-<!-- ENGCOM-1470-->* Corrected misspelling in `app/code/Magento/CatalogSearch/Block/Advanced/Form.php`. *Fix submitted by Jeevan M R in pull request [15053](https://github.com/magento/magento2/pull/15053)*.
+<!-- ENGCOM-1470 -->
+*  Corrected misspelling in `app/code/Magento/CatalogSearch/Block/Advanced/Form.php`. *Fix submitted by Jeevan M R in pull request [15053](https://github.com/magento/magento2/pull/15053)*.
 
-<!-- ENGCOM-1458-->* Corrected misspelling in `.less` files. *Fix submitted by Kalpesh Mehta in pull request [15023](https://github.com/magento/magento2/pull/15023)*.
+<!-- ENGCOM-1458 -->
+*  Corrected misspelling in `.less` files. *Fix submitted by Kalpesh Mehta in pull request [15023](https://github.com/magento/magento2/pull/15023)*.
 
-<!-- ENGCOM-2057 -->* Removed double occurrence of 'it' from sentences and corrected minor grammar error. *Fix submitted by Namrata in pull request [16240](https://github.com/magento/magento2/pull/16240)*.
+<!-- ENGCOM-2057  -->
+*  Removed double occurrence of 'it' from sentences and corrected minor grammar error. *Fix submitted by Namrata in pull request [16240](https://github.com/magento/magento2/pull/16240)*.
 
-<!-- ENGCOM-2097 -->* Fixed typo in `app/code/Magento/Checkout/etc/webapi.xml`. *Fix submitted by Markus Haack in pull request [15845](https://github.com/magento/magento2/pull/15845)*.
+<!-- ENGCOM-2097  -->
+*  Fixed typo in `app/code/Magento/Checkout/etc/webapi.xml`. *Fix submitted by Markus Haack in pull request [15845](https://github.com/magento/magento2/pull/15845)*.
 
-<!-- ENGCOM-1897 -->* Corrected misspelling in `file-uploader.js` and `storage-manager.js`. *Fix submitted by Saurabh Parekh in pull request [15888](https://github.com/magento/magento2/pull/15888)*.
+<!-- ENGCOM-1897  -->
+*  Corrected misspelling in `file-uploader.js` and `storage-manager.js`. *Fix submitted by Saurabh Parekh in pull request [15888](https://github.com/magento/magento2/pull/15888)*.
 
-<!-- ENGCOM-1925 -->* Corrected misspelling in `scripts.js`. *Fix submitted by Ledian Hymetllari in pull request [15878](https://github.com/magento/magento2/pull/15907)*.
+<!-- ENGCOM-1925  -->
+*  Corrected misspelling in `scripts.js`. *Fix submitted by Ledian Hymetllari in pull request [15878](https://github.com/magento/magento2/pull/15907)*.
 
-<!-- ENGCOM-2545 -->* Corrected grammar error in the "What is this" tooltip for the Braintree vault tool tip. *Fix submitted by kreativedev in pull request [17151](https://github.com/magento/magento2/pull/17151)*.
+<!-- ENGCOM-2545  -->
+*  Corrected grammar error in the "What is this" tooltip for the Braintree vault tool tip. *Fix submitted by kreativedev in pull request [17151](https://github.com/magento/magento2/pull/17151)*.
 
-<!-- ENGCOM-2456 -->* Renamed `_requesetd` to `_requested` in  `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`. *Fix submitted by Valerij Ivashchenko in pull request [16971](https://github.com/magento/magento2/pull/16971)*.
+<!-- ENGCOM-2456  -->
+*  Renamed `_requesetd` to `_requested` in  `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`. *Fix submitted by Valerij Ivashchenko in pull request [16971](https://github.com/magento/magento2/pull/16971)*.
 
-<!-- ENGCOM-2238 -->* Removed double occurrences of words from the lib and dev test function comments and from these modules: `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, and `Magento_Sales`. *Fix submitted by Namrata in pull request [16644](https://github.com/magento/magento2/pull/16644)*.
+<!-- ENGCOM-2238  -->
+*  Removed double occurrences of words from the lib and dev test function comments and from these modules: `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, and `Magento_Sales`. *Fix submitted by Namrata in pull request [16644](https://github.com/magento/magento2/pull/16644)*.
 
-<!-- ENGCOM-2206 -->* Removed double occurrences from `jQuery`, Angular JS files and the `Magento_Setup` module's scan function's comment. *Fix submitted by Namrata in pull request [16581](https://github.com/magento/magento2/pull/16581)*.
+<!-- ENGCOM-2206  -->
+*  Removed double occurrences from `jQuery`, Angular JS files and the `Magento_Setup` module's scan function's comment. *Fix submitted by Namrata in pull request [16581](https://github.com/magento/magento2/pull/16581)*.
 
-<!--  ENGCOM-1589 -->* Correct misspelling in method name and result in these files: `dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Onepage/Shipping/Method.php` and `dev/tests/functional/tests/app/Magento/Shipping/Test/Constraint/AssertCityBasedShippingRateChanged.php`. *Fix submitted by Dmytro Cheshun in pull request [15297](https://github.com/magento/magento2/pull/15297)*.
+<!--  ENGCOM-1589  -->
+*  Correct misspelling in method name and result in these files: `dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Onepage/Shipping/Method.php` and `dev/tests/functional/tests/app/Magento/Shipping/Test/Constraint/AssertCityBasedShippingRateChanged.php`. *Fix submitted by Dmytro Cheshun in pull request [15297](https://github.com/magento/magento2/pull/15297)*.
 
 #### Minor corrections to code and code formatting
 
-<!-- ENGCOM-2385 -->* Removed extra spaces from `Magento/Ui`. *Fix submitted by Ronak Patel in pull request [16872](https://github.com/magento/magento2/pull/16872)*.
+<!-- ENGCOM-2385  -->
+*  Removed extra spaces from `Magento/Ui`. *Fix submitted by Ronak Patel in pull request [16872](https://github.com/magento/magento2/pull/16872)*.
 
-<!-- ENGCOM-2354 -->* Improved code formatting. *Fix submitted by Pratik Oza in pull request [16821](https://github.com/magento/magento2/pull/16821)*.
+<!-- ENGCOM-2354  -->
+*  Improved code formatting. *Fix submitted by Pratik Oza in pull request [16821](https://github.com/magento/magento2/pull/16821)*.
 
-<!-- ENGCOM-2305 -->* Removed comments and unnecessary spaces. *Fix submitted by Ronak Patel in pull request [16748](https://github.com/magento/magento2/pull/16748)*.
+<!-- ENGCOM-2305  -->
+*  Removed comments and unnecessary spaces. *Fix submitted by Ronak Patel in pull request [16748](https://github.com/magento/magento2/pull/16748)*.
 
-<!-- ENGCOM-2283 -->* Removed space before ending sentence throughout code base. *Fix submitted by Namrata in pull request [16717](https://github.com/magento/magento2/pull/16717)*.
+<!-- ENGCOM-2283  -->
+*  Removed space before ending sentence throughout code base. *Fix submitted by Namrata in pull request [16717](https://github.com/magento/magento2/pull/16717)*.
 
-<!-- ENGCOM-2249 -->* Removed unnecessary spaces in `app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php`. *Fix submitted by Ronak Patel in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
+<!-- ENGCOM-2249  -->
+*  Removed unnecessary spaces in `app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php`. *Fix submitted by Ronak Patel in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
 
-<!-- ENGCOM-2195 -->* Removed extra space from the value of the `is_required` XML node in `SynonymGroup.xml`. *Fix submitted by Namrata in pull request [16557](https://github.com/magento/magento2/pull/16557)*.
+<!-- ENGCOM-2195  -->
+*  Removed extra space from the value of the `is_required` XML node in `SynonymGroup.xml`. *Fix submitted by Namrata in pull request [16557](https://github.com/magento/magento2/pull/16557)*.
 
-<!--  ENGCOM-2366 -->* Minor corrections to code throughout the code base. *Fix submitted by GraysonChiang in pull request [16841](https://github.com/magento/magento2/pull/16841)*.
+<!--  ENGCOM-2366  -->
+*  Minor corrections to code throughout the code base. *Fix submitted by GraysonChiang in pull request [16841](https://github.com/magento/magento2/pull/16841)*.
 
-<!-- ENGCOM-2186 -->* Removed unused data from `app/code/Magento/Ui/Model/Export/ConvertToCsv.php` and `app/code/Magento/Ui/Model/Export/ConvertToXml.php`. *Fix submitted by Vishal Gelani in pull request [16524](https://github.com/magento/magento2/pull/16524)*.
+<!-- ENGCOM-2186  -->
+*  Removed unused data from `app/code/Magento/Ui/Model/Export/ConvertToCsv.php` and `app/code/Magento/Ui/Model/Export/ConvertToXml.php`. *Fix submitted by Vishal Gelani in pull request [16524](https://github.com/magento/magento2/pull/16524)*.
 
-<!-- ENGCOM-2086 -->* Removed unnecessary translations for label and comment tags and added missing translation strings. *Fix submitted by Yogesh Suhagiya in pull request [16090](https://github.com/magento/magento2/pull/16090)*.
+<!-- ENGCOM-2086  -->
+*  Removed unnecessary translations for label and comment tags and added missing translation strings. *Fix submitted by Yogesh Suhagiya in pull request [16090](https://github.com/magento/magento2/pull/16090)*.
 
-<!-- ENGCOM-2177 -->* Removed redundant plug-in information (`dev:di:info`). *Fix submitted by Alexander Shkurko in pull request [16474](https://github.com/magento/magento2/pull/16474)*.
+<!-- ENGCOM-2177  -->
+*  Removed redundant plug-in information (`dev:di:info`). *Fix submitted by Alexander Shkurko in pull request [16474](https://github.com/magento/magento2/pull/16474)*.
 
-<!-- ENGCOM-1711 -->* Removed redundant semicolon from these files: `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.phpMagento/Multishipping/Test/Unit/Block/Checkout/SuccessTest.php` and  `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php`. *Fix submitted by Saurabh Parekh in pull request [15594](https://github.com/magento/magento2/pull/15594)*.
+<!-- ENGCOM-1711  -->
+*  Removed redundant semicolon from these files: `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.phpMagento/Multishipping/Test/Unit/Block/Checkout/SuccessTest.php` and  `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php`. *Fix submitted by Saurabh Parekh in pull request [15594](https://github.com/magento/magento2/pull/15594)*.
 
-<!-- ENGCOM-1700 -->* Corrected errors in method description in `app/code/Magento/Config/Block/System/Config/Form.php`,  `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`, and  `app/code/Magento/Customer/Model/Session.php`. *Fix submitted by Vishal Gelani in pull request [15549](https://github.com/magento/magento2/pull/15549)*.
+<!-- ENGCOM-1700  -->
+*  Corrected errors in method description in `app/code/Magento/Config/Block/System/Config/Form.php`,  `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`, and  `app/code/Magento/Customer/Model/Session.php`. *Fix submitted by Vishal Gelani in pull request [15549](https://github.com/magento/magento2/pull/15549)*.
 
-<!-- ENGCOM-1697 -->* Removed extra space and formatted the code in `app/code/Magento/Captcha/i18n/en_US.csv`. *Fix submitted by Saurabh Parekh in pull request [15552](https://github.com/magento/magento2/pull/15552)*.
+<!-- ENGCOM-1697  -->
+*  Removed extra space and formatted the code in `app/code/Magento/Captcha/i18n/en_US.csv`. *Fix submitted by Saurabh Parekh in pull request [15552](https://github.com/magento/magento2/pull/15552)*.
 
-<!-- ENGCOM-1651 -->* Removed the redundant `else` statement in `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`. *Fix submitted by Yaroslav Rogoza in pull request [15435](https://github.com/magento/magento2/pull/15435)*.
+<!-- ENGCOM-1651  -->
+*  Removed the redundant `else` statement in `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`. *Fix submitted by Yaroslav Rogoza in pull request [15435](https://github.com/magento/magento2/pull/15435)*.
 
-<!-- ENGCOM-2270-->* Fixed misplaced bracket in `Option/Type/Text.php`. *Fix submitted by Valerij Ivashchenko in pull request [16566](https://github.com/magento/magento2/pull/16566)*.
+<!-- ENGCOM-2270 -->
+*  Fixed misplaced bracket in `Option/Type/Text.php`. *Fix submitted by Valerij Ivashchenko in pull request [16566](https://github.com/magento/magento2/pull/16566)*.
 
-<!-- ENGCOM-1592 -->* Removed a duplicate line and added comment in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Discount.php`. *Fix submitted by Vishal Gelani in pull request [15362](https://github.com/magento/magento2/pull/15362)*.
+<!-- ENGCOM-1592  -->
+*  Removed a duplicate line and added comment in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Discount.php`. *Fix submitted by Vishal Gelani in pull request [15362](https://github.com/magento/magento2/pull/15362)*.
 
-<!-- ENGCOM-1593 -->* Removed unused variable in `lib/web/css/source/lib/variables/_typography.less`. *Fix submitted by VitaliyBoyko in pull request [15386](https://github.com/magento/magento2/pull/15386)*.
+<!-- ENGCOM-1593  -->
+*  Removed unused variable in `lib/web/css/source/lib/variables/_typography.less`. *Fix submitted by VitaliyBoyko in pull request [15386](https://github.com/magento/magento2/pull/15386)*.
 
-<!-- ENGCOM-1602-->* Corrected variable names in `LockAdminUserWhenEditingIntegrationTest` and `AssertCityBasedShippingRateChanged`, among others. *Fix submitted by Dmytro Cheshun in pull request [15294](https://github.com/magento/magento2/pull/15294)*.
+<!-- ENGCOM-1602 -->
+*  Corrected variable names in `LockAdminUserWhenEditingIntegrationTest` and `AssertCityBasedShippingRateChanged`, among others. *Fix submitted by Dmytro Cheshun in pull request [15294](https://github.com/magento/magento2/pull/15294)*.
 
-<!-- ENGCOM-1587-->* Corrected property name in  `dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php`. *Fix submitted by Dmytro Cheshun in pull request [15292](https://github.com/magento/magento2/pull/15292)*.
+<!-- ENGCOM-1587 -->
+*  Corrected property name in  `dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php`. *Fix submitted by Dmytro Cheshun in pull request [15292](https://github.com/magento/magento2/pull/15292)*.
 
-<!-- ENGCOM-1572-->* Removed non-existing argument from the constructor's comment block in  `app/code/Magento/Translation/Block/Html/Head/Config.php` and added space where needed in  `app/code/Magento/Translation/Model/Json/PreProcessor.php`. *Fix submitted by Yogesh Suhagiya in pull request [15249](https://github.com/magento/magento2/pull/15249)*.
+<!-- ENGCOM-1572 -->
+*  Removed non-existing argument from the constructor's comment block in  `app/code/Magento/Translation/Block/Html/Head/Config.php` and added space where needed in  `app/code/Magento/Translation/Model/Json/PreProcessor.php`. *Fix submitted by Yogesh Suhagiya in pull request [15249](https://github.com/magento/magento2/pull/15249)*.
 
-<!-- ENGCOM-1427-->* Removed redundant close tag from `app/code/Magento/Review/view/frontend/templates/view.phtml`. *Fix submitted by Yogesh Suhagiya in pull request [14928](https://github.com/magento/magento2/pull/14928)*.
+<!-- ENGCOM-1427 -->
+*  Removed redundant close tag from `app/code/Magento/Review/view/frontend/templates/view.phtml`. *Fix submitted by Yogesh Suhagiya in pull request [14928](https://github.com/magento/magento2/pull/14928)*.
 
-<!-- ENGCOM-1409-->* Removed extra spaces from a key-value pair in the `en_US.csv`language file. *Fix submitted by Yogesh Suhagiya in pull request [14896](https://github.com/magento/magento2/pull/14896)*.
+<!-- ENGCOM-1409 -->
+*  Removed extra spaces from a key-value pair in the `en_US.csv`language file. *Fix submitted by Yogesh Suhagiya in pull request [14896](https://github.com/magento/magento2/pull/14896)*.
 
-<!-- ENGCOM-1306-->* Cleaned up `foreach` and `break` statements in `app/code/Magento/Rule/Model/Condition/AbstractCondition.php`. *Fix submitted by Thomas Klein in pull request [14609](https://github.com/magento/magento2/pull/14609)*.
+<!-- ENGCOM-1306 -->
+*  Cleaned up `foreach` and `break` statements in `app/code/Magento/Rule/Model/Condition/AbstractCondition.php`. *Fix submitted by Thomas Klein in pull request [14609](https://github.com/magento/magento2/pull/14609)*.
 
-<!--  ENGCOM-1384 -->* Corrected grammar in `README.md`. *Fix submitted by Stanislav Idolov in pull request [14844](https://github.com/magento/magento2/pull/14844)*.
+<!--  ENGCOM-1384  -->
+*  Corrected grammar in `README.md`. *Fix submitted by Stanislav Idolov in pull request [14844](https://github.com/magento/magento2/pull/14844)*.
 
-<!--  ENGCOM-2218 -->* Corrected type hints in `Webapi/Controller/Soap/Request/Handler.php` and `Webapi/Model/Plugin/GuestAuthorization.php`. Also corrected case in property annotation  in `Soap\Server.php` and added undefined property `_appState` in `Controller\Soap.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
+<!--  ENGCOM-2218  -->
+*  Corrected type hints in `Webapi/Controller/Soap/Request/Handler.php` and `Webapi/Model/Plugin/GuestAuthorization.php`. Also corrected case in property annotation  in `Soap\Server.php` and added undefined property `_appState` in `Controller\Soap.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
 
-<!--  ENGCOM-2218 -->* Corrected `Magento\Webapi\Model\Soap\Fault::toXml()` method invocation in `Soap\FaultTest.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
+<!--  ENGCOM-2218  -->
+*  Corrected `Magento\Webapi\Model\Soap\Fault::toXml()` method invocation in `Soap\FaultTest.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
 
-<!-- ENGCOM-1853 -->* We've removed an unused class from the `lib/_forms.less` file. *Fix submitted by Chirag Matholiya in pull request [15791](https://github.com/magento/magento2/pull/15791)*.
+<!-- ENGCOM-1853  -->
+*  We've removed an unused class from the `lib/_forms.less` file. *Fix submitted by Chirag Matholiya in pull request [15791](https://github.com/magento/magento2/pull/15791)*.
 
-<!-- ENGCOM-1861 -->* We've removed unnecessary CSS code from  `_actions-toolbar.less`. *Fix submitted by Chirag Matholiya in pull request [15789](https://github.com/magento/magento2/pull/15789)*.
+<!-- ENGCOM-1861  -->
+*  We've removed unnecessary CSS code from  `_actions-toolbar.less`. *Fix submitted by Chirag Matholiya in pull request [15789](https://github.com/magento/magento2/pull/15789)*.
 
-<!-- ENGCOM-1850 -->* We've removed the unnecessary double semicolon from the style sheets. *Fix submitted by Namrata in pull request [15795](https://github.com/magento/magento2/pull/15795)*.
+<!-- ENGCOM-1850  -->
+*  We've removed the unnecessary double semicolon from the style sheets. *Fix submitted by Namrata in pull request [15795](https://github.com/magento/magento2/pull/15795)*.
 
-<!-- ENGCOM-1880 -->* We've removed the unused code from `docs.less`. *Fix submitted by Daniel Ruf in pull request [15871](https://github.com/magento/magento2/pull/15871)*.
+<!-- ENGCOM-1880  -->
+*  We've removed the unused code from `docs.less`. *Fix submitted by Daniel Ruf in pull request [15871](https://github.com/magento/magento2/pull/15871)*.
 
-<!-- ENGCOM-1923 -->* Removed extraneous negative margin on product list and product list items. *Fix submitted by Steven de Jong in pull request [15936](https://github.com/magento/magento2/pull/15936)*. [GitHub-15308](https://github.com/magento/magento2/issues/15308)
+<!-- ENGCOM-1923  -->
+*  Removed extraneous negative margin on product list and product list items. *Fix submitted by Steven de Jong in pull request [15936](https://github.com/magento/magento2/pull/15936)*. [GitHub-15308](https://github.com/magento/magento2/issues/15308)
 
-<!-- ENGCOM-1959 -->* Indentation issues with LESS files have been resolved. *Fix submitted by hitesh-wagento in pull request [15811](https://github.com/magento/magento2/pull/15811)*.
+<!-- ENGCOM-1959  -->
+*  Indentation issues with LESS files have been resolved. *Fix submitted by hitesh-wagento in pull request [15811](https://github.com/magento/magento2/pull/15811)*.
 
-<!-- ENGCOM-2016 -->* The syntax for before-after operators in LESS files has been corrected. *Fix submitted by Namrata in pull request [16181](https://github.com/magento/magento2/pull/16181)*.
+<!-- ENGCOM-2016  -->
+*  The syntax for before-after operators in LESS files has been corrected. *Fix submitted by Namrata in pull request [16181](https://github.com/magento/magento2/pull/16181)*.
 
-<!-- ENGCOM-2018 -->* Redundant keywords have been removed from miscellaneous files. *Fix submitted by Namrata in pull request [16182](https://github.com/magento/magento2/pull/16182)*.
+<!-- ENGCOM-2018  -->
+*  Redundant keywords have been removed from miscellaneous files. *Fix submitted by Namrata in pull request [16182](https://github.com/magento/magento2/pull/16182)*.
 
-<!-- ENGCOM-2019 -->* We've corrected misspellings in the  comment section of `OrderFixture.php`.  *Fix submitted by Namrata in pull request [16183](https://github.com/magento/magento2/pull/16183)*.
+<!-- ENGCOM-2019  -->
+*  We've corrected misspellings in the  comment section of `OrderFixture.php`.  *Fix submitted by Namrata in pull request [16183](https://github.com/magento/magento2/pull/16183)*.
 
-<!-- ENGCOM-1680 -->* Unnecessary leading and trailing spaces have been removed from the customer account login page email field. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-1680  -->
+*  Unnecessary leading and trailing spaces have been removed from the customer account login page email field. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2023 -->* Unnecessary leading and trailing spaces have been removed from fields in the customer account create and login forms. *Fix submitted by Piyush Dankhara in pull request [16192](https://github.com/magento/magento2/pull/16192)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2023  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in the customer account create and login forms. *Fix submitted by Piyush Dankhara in pull request [16192](https://github.com/magento/magento2/pull/16192)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2198 -->* Unnecessary leading and trailing spaces have been removed from fields in newsletter, forgot password, checkout login and email to a friend forms. *Fix submitted by Piyush Dankhara in pull request [16564](https://github.com/magento/magento2/pull/16564)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2198  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in newsletter, forgot password, checkout login and email to a friend forms. *Fix submitted by Piyush Dankhara in pull request [16564](https://github.com/magento/magento2/pull/16564)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2381 -->* Unnecessary leading and trailing spaces have been removed from fields in the customer confirmation form. *Fix submitted by Vishal Gelani in pull request [16595](https://github.com/magento/magento2/pull/16595)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2381  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in the customer confirmation form. *Fix submitted by Vishal Gelani in pull request [16595](https://github.com/magento/magento2/pull/16595)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2507 -->* Removed unnecessary commented code from these files: `app/code/Magento/Review/Model/ResourceModel/Rating/Collection.php`, `app/code/Magento/Sales/Model/Order/Creditmemo.php`, `lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php`, and `lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php`. *Fix submitted by Pratik Oza in pull request [17077](https://github.com/magento/magento2/pull/17077)*.
+<!-- ENGCOM-2507  -->
+*  Removed unnecessary commented code from these files: `app/code/Magento/Review/Model/ResourceModel/Rating/Collection.php`, `app/code/Magento/Sales/Model/Order/Creditmemo.php`, `lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php`, and `lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php`. *Fix submitted by Pratik Oza in pull request [17077](https://github.com/magento/magento2/pull/17077)*.
 
-<!-- ENGCOM-2485 -->* Removed unnecessary spaces from the price value in `app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml`. *Fix submitted by Valerij Ivashchenko in pull request [17027](https://github.com/magento/magento2/pull/17027)*.
+<!-- ENGCOM-2485  -->
+*  Removed unnecessary spaces from the price value in `app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml`. *Fix submitted by Valerij Ivashchenko in pull request [17027](https://github.com/magento/magento2/pull/17027)*.
 
-<!-- ENGCOM-2461 -->* Remove unused comments from `_initDiscount()` function. *Fix submitted by Prince Patel in pull request [17002](https://github.com/magento/magento2/pull/17002)*.
+<!-- ENGCOM-2461  -->
+*  Remove unused comments from `_initDiscount()` function. *Fix submitted by Prince Patel in pull request [17002](https://github.com/magento/magento2/pull/17002)*.
 
-<!-- ENGCOM-2451 -->* Corrected misspellings in multiple files, including `app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php`, `app/code/Magento/Catalog/view/adminhtml/web/js/product/weight-handler.js`, `app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php`, `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`, and `dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php`. *Fix submitted by Pratik Oza in pull request [16980](https://github.com/magento/magento2/pull/16980)*.
+<!-- ENGCOM-2451  -->
+*  Corrected misspellings in multiple files, including `app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php`, `app/code/Magento/Catalog/view/adminhtml/web/js/product/weight-handler.js`, `app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php`, `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`, and `dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php`. *Fix submitted by Pratik Oza in pull request [16980](https://github.com/magento/magento2/pull/16980)*.
 
-<!-- ENGCOM-2194 -->* Fixed the DocBlock for `hasInvoices()`, `hasShipments()`, and `hasCreditmemos()` in `app/code/Magento/Sales/Model/Order.php`. *Fix submitted by Lyzun Oleksandr in pull request [16554](https://github.com/magento/magento2/pull/16554)*.
+<!-- ENGCOM-2194  -->
+*  Fixed the DocBlock for `hasInvoices()`, `hasShipments()`, and `hasCreditmemos()` in `app/code/Magento/Sales/Model/Order.php`. *Fix submitted by Lyzun Oleksandr in pull request [16554](https://github.com/magento/magento2/pull/16554)*.
 
-<!-- ENGCOM-2145 -->* Fixed type hints and docs for the Downloadable Samples block. *Fix submitted by Björn Kraus in pull request [16408](https://github.com/magento/magento2/pull/16408)*.
+<!-- ENGCOM-2145  -->
+*  Fixed type hints and docs for the Downloadable Samples block. *Fix submitted by Björn Kraus in pull request [16408](https://github.com/magento/magento2/pull/16408)*.
 
-<!-- ENGCOM-2071 -->* Removed redundant `@throws` hinting and unused import for `AdvancedPricingImportExport` module classes. *Fix submitted by Dmytro Cheshun in pull request [15872](https://github.com/magento/magento2/pull/15872)*.
+<!-- ENGCOM-2071  -->
+*  Removed redundant `@throws` hinting and unused import for `AdvancedPricingImportExport` module classes. *Fix submitted by Dmytro Cheshun in pull request [15872](https://github.com/magento/magento2/pull/15872)*.
 
-<!-- ENGCOM-2034 -->* Added missing PHPDoc to methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [16215](https://github.com/magento/magento2/pull/16215)*.
+<!-- ENGCOM-2034  -->
+*  Added missing PHPDoc to methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [16215](https://github.com/magento/magento2/pull/16215)*.
 
-<!-- ENGCOM-2045 -->* Fixed mismatches in case between class and method name spellings. *Fix submitted by Leandro F. L. in pull request [16141](https://github.com/magento/magento2/pull/16141)*.
+<!-- ENGCOM-2045  -->
+*  Fixed mismatches in case between class and method name spellings. *Fix submitted by Leandro F. L. in pull request [16141](https://github.com/magento/magento2/pull/16141)*.
 
-<!-- ENGCOM-1760 -->* Removed an unnecessary comma from the `translate` attribute in `app/code/Magento/Sales/etc/adminhtml/system.xml`. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1760  -->
+*  Removed an unnecessary comma from the `translate` attribute in `app/code/Magento/Sales/etc/adminhtml/system.xml`. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
 ### CMS content
 
-<!-- MAGETWO-92611-->* Page layout issues that resulted from incorrect module sequence have been corrected. Previously, the  `Magento_theme` module was loaded too late, which resulted in unexpected display issues.
+<!-- MAGETWO-92611 -->
+*  Page layout issues that resulted from incorrect module sequence have been corrected. Previously, the  `Magento_theme` module was loaded too late, which resulted in unexpected display issues.
 
-<!-- ENGCOM-1407-->* Corrected use statements and return values in `AggregationInterface`. *Fix submitted by Yaroslav Rogoza in pull request [14893](https://github.com/magento/magento2/pull/14893)*.
+<!-- ENGCOM-1407 -->
+*  Corrected use statements and return values in `AggregationInterface`. *Fix submitted by Yaroslav Rogoza in pull request [14893](https://github.com/magento/magento2/pull/14893)*.
 
 ### Configurable products
 
-<!-- ENGCOM-1686 -->* Customers can now successfully complete checkout when their order contains a configurable product with a configurable option. Previously, customers could not check out when there is a configurable product in the cart with a configurable option, which is now deleted, shopping cart could not be loaded. *Fix submitted by jonshipman in pull request [15468](https://github.com/magento/magento2/pull/15468)*. [GitHub-15467](https://github.com/magento/magento2/issues/15467)
+<!-- ENGCOM-1686  -->
+*  Customers can now successfully complete checkout when their order contains a configurable product with a configurable option. Previously, customers could not check out when there is a configurable product in the cart with a configurable option, which is now deleted, shopping cart could not be loaded. *Fix submitted by jonshipman in pull request [15468](https://github.com/magento/magento2/pull/15468)*. [GitHub-15467](https://github.com/magento/magento2/issues/15467)
 
-<!-- MAGETWO-87047 -->* Magento now displays the manufacturer attribute on the Admin on the Catalog page for configurable products. Previously, Magento displayed these attributes on the simple products catalog page, but not on the configurable products catalog page.
+<!-- MAGETWO-87047  -->
+*  Magento now displays the manufacturer attribute on the Admin on the Catalog page for configurable products. Previously, Magento displayed these attributes on the simple products catalog page, but not on the configurable products catalog page.
 
-<!-- MAGETWO-86125 -->* Configurable products are now sorted by only visible prices as expected. Previously, sorting a catalog by price resulted in sort results that included the prices of out-of-stock products and disabled child products.
+<!-- MAGETWO-86125  -->
+*  Configurable products are now sorted by only visible prices as expected. Previously, sorting a catalog by price resulted in sort results that included the prices of out-of-stock products and disabled child products.
 
-<!-- ENGCOM-2188 -->* When two simple products of a configurable product have different prices, Magento now uses the lowest price as the default price on the product detail page. Previously, if one of the simple products had price=0, Magento did not use it as the default. *Fix submitted by Torrey Tsui in pull request [16540](https://github.com/magento/magento2/pull/16540)*.
+<!-- ENGCOM-2188  -->
+*  When two simple products of a configurable product have different prices, Magento now uses the lowest price as the default price on the product detail page. Previously, if one of the simple products had price=0, Magento did not use it as the default. *Fix submitted by Torrey Tsui in pull request [16540](https://github.com/magento/magento2/pull/16540)*.
 
-<!-- ENGCOM-1512 -->* The missing check for a `false` value has been added  to  `ConfiguredRegularPrice`. Previously, when the parent method returned false, Magento threw this fatal error: `NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24`. *Fix submitted by Tibor Kotosz in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
+<!-- ENGCOM-1512  -->
+*  The missing check for a `false` value has been added  to  `ConfiguredRegularPrice`. Previously, when the parent method returned false, Magento threw this fatal error: `NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24`. *Fix submitted by Tibor Kotosz in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
 
-<!-- ENGCOM-1439 -->* Corrected formatting of the JavaScript code in the `app/code/Magento/Ui/view/base/templates/control/button/split.phtml` and `app/code/Magento/Ui/view/base/web/js/grid/controls/button/split.jstemplate` files. *Fix submitted by Yogesh Suhagiya in pull request [14967](https://github.com/magento/magento2/pull/14967)*.
+<!-- ENGCOM-1439  -->
+*  Corrected formatting of the JavaScript code in the `app/code/Magento/Ui/view/base/templates/control/button/split.phtml` and `app/code/Magento/Ui/view/base/web/js/grid/controls/button/split.jstemplate` files. *Fix submitted by Yogesh Suhagiya in pull request [14967](https://github.com/magento/magento2/pull/14967)*.
 
 ### Cookies
 
-<!-- ENGCOM-2403 -->* Magento now responds to a customer accepting a cookie notice by simply hiding the notice. Previously, Magento reloaded the entire site when a user accepted the cookie notice. *Fix submitted by Torben Höhn in pull request [16890](https://github.com/magento/magento2/pull/16890)*.
+<!-- ENGCOM-2403  -->
+*  Magento now responds to a customer accepting a cookie notice by simply hiding the notice. Previously, Magento reloaded the entire site when a user accepted the cookie notice. *Fix submitted by Torben Höhn in pull request [16890](https://github.com/magento/magento2/pull/16890)*.
 
 ### Customer account
 
-<!-- MAGETWO-92989 -->* Magento no longer logs out a customer after a successful password change.
+<!-- MAGETWO-92989  -->
+*  Magento no longer logs out a customer after a successful password change.
 
-<!-- MAGETWO-92507 -->* Magento no longer displays the State/Province instead of the State field on U.S. customer address forms.
+<!-- MAGETWO-92507  -->
+*  Magento no longer displays the State/Province instead of the State field on U.S. customer address forms.
 
-<!-- MAGETWO-91327 -->* Customer attributes are now correctly validated on the Admin Order form. Previously, Magento validated attributes\length  after an order has been submitted, but not on the Admin Order form.
+<!-- MAGETWO-91327  -->
+*  Customer attributes are now correctly validated on the Admin Order form. Previously, Magento validated attributes\length  after an order has been submitted, but not on the Admin Order form.
 
-<!-- MAGETWO-89624 -->* Customers no longer lose their session when they switch stores on different domains.
+<!-- MAGETWO-89624  -->
+*  Customers no longer lose their session when they switch stores on different domains.
 
-<!-- MAGETWO-89849 -->* Non-U.S. and non-Canadian addresses that are displayed in the  **Address Book summary**  field now display the State/Province values as expected if that information was provided.
+<!-- MAGETWO-89849  -->
+*  Non-U.S. and non-Canadian addresses that are displayed in the  **Address Book summary**  field now display the State/Province values as expected if that information was provided.
 
-<!-- MAGETWO-89034 -->* The checkout page no longer displays custom address attributes when **Show on frontend** is set to **no**.
+<!-- MAGETWO-89034  -->
+*  The checkout page no longer displays custom address attributes when **Show on frontend** is set to **no**.
 
-<!-- MAGETWO-88411 -->* Magento now displays the default value for a new Customer attribute that is created from the Admin. Previously, Magento set this value to **no** by default.
+<!-- MAGETWO-88411  -->
+*  Magento now displays the default value for a new Customer attribute that is created from the Admin. Previously, Magento set this value to **no** by default.
 
-<!-- MAGETWO-73827 -->* Administrators can see all customers when the **Share Customer Accounts** value is set to Global.
+<!-- MAGETWO-73827  -->
+*  Administrators can see all customers when the **Share Customer Accounts** value is set to Global.
 
-<!--  ENGCOM-1680 -->* User login email validation no longer fails if the field contains a leading or trailing space on Internet Explorer 11.x. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!--  ENGCOM-1680  -->
+*  User login email validation no longer fails if the field contains a leading or trailing space on Internet Explorer 11.x. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!--  ENGCOM-1987 -->* Customer accounts are now unlocked as expected after a password reset. *Fix submitted by Andrea Gaspardo in pull request [15255](https://github.com/magento/magento2/pull/15255)*. [GitHub-15534](https://github.com/magento/magento2/issues/15534)
+<!--  ENGCOM-1987  -->
+*  Customer accounts are now unlocked as expected after a password reset. *Fix submitted by Andrea Gaspardo in pull request [15255](https://github.com/magento/magento2/pull/15255)*. [GitHub-15534](https://github.com/magento/magento2/issues/15534)
 
-<!--  ENGCOM-1625 -->* Magento no longer changes the format of Date of Birth information when this field is enabled on the Create New Customer Account page, and an existing customer tries to re-register. *Fix submitted by KaushikChavda in pull request [15272](https://github.com/magento/magento2/pull/15272)*.
+<!--  ENGCOM-1625  -->
+*  Magento no longer changes the format of Date of Birth information when this field is enabled on the Create New Customer Account page, and an existing customer tries to re-register. *Fix submitted by KaushikChavda in pull request [15272](https://github.com/magento/magento2/pull/15272)*.
 
-<!--  ENGCOM-2089 -->*  When saving a customer group, Magento now copies extension attributes to the new data model that is returned. Previously, this action was not completed, and Magento behaved unpredictably. *Fix submitted by Joseph Maxwell in pull request [16254](https://github.com/magento/magento2/pull/16254)*.
+<!--  ENGCOM-2089  -->
+*   When saving a customer group, Magento now copies extension attributes to the new data model that is returned. Previously, this action was not completed, and Magento behaved unpredictably. *Fix submitted by Joseph Maxwell in pull request [16254](https://github.com/magento/magento2/pull/16254)*.
 
-<!--  ENGCOM-1432 -->* The `customer.account.dashboard.info.extra` block has been moved to contact information from the newsletter section in `app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml`. *Fix submitted by JeroenVanLeusden in pull request [14923](https://github.com/magento/magento2/pull/14923)*.
+<!--  ENGCOM-1432  -->
+*  The `customer.account.dashboard.info.extra` block has been moved to contact information from the newsletter section in `app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml`. *Fix submitted by JeroenVanLeusden in pull request [14923](https://github.com/magento/magento2/pull/14923)*.
 
 ### Directory
 
-<!--  ENGCOM-2281 -->* You can now configure different Allowed Countries for default and store scopes. *Fix submitted by Oleksandr Kravchuk in pull request [16693](https://github.com/magento/magento2/pull/16693)*.
+<!--  ENGCOM-2281  -->
+*  You can now configure different Allowed Countries for default and store scopes. *Fix submitted by Oleksandr Kravchuk in pull request [16693](https://github.com/magento/magento2/pull/16693)*.
 
 ### dotmailer
 
@@ -634,303 +865,434 @@ Our community contributors have made many helpful, minor corrections to spelling
 
 * Unexpected errors during subscriber or customer creation no longer occur.
 
-<!-- BUNDLE-526 -->* A merchant can now successfully create a new user and displays the appropriate welcome message. Previously, Magento threw an error during the creation of a customer or subscriber, although the new user/subscriber was created.
+<!-- BUNDLE-526  -->
+*  A merchant can now successfully create a new user and displays the appropriate welcome message. Previously, Magento threw an error during the creation of a customer or subscriber, although the new user/subscriber was created.
 
 ### EAV
 
-<!-- MAGETWO- 90576-->* Magento now correctly renders multiselect product attributes with a custom source model in  `adminhtml`. Previously, the selected value was saved the first time in the `catalog_product_entity_varchar` table, and the attribute was added to the `eav_attribute` table, but the selected options were not highlighted against the attribute.
+<!-- MAGETWO- 90576 -->
+*  Magento now correctly renders multiselect product attributes with a custom source model in  `adminhtml`. Previously, the selected value was saved the first time in the `catalog_product_entity_varchar` table, and the attribute was added to the `eav_attribute` table, but the selected options were not highlighted against the attribute.
 
-<!-- MAGETWO-73062-->* Magento now displays the fixed product tax attribute label as expected according to the specified store view.
+<!-- MAGETWO-73062 -->
+*  Magento now displays the fixed product tax attribute label as expected according to the specified store view.
 
-<!-- MAGETWO-90576-->* You can now successfully save a product after setting its special requirements  multiselect attribute. (This means that attribute values are saved as expected to the database, checked in `_catalog_product_entity_varchar_ table`,  and displayed as non-selected on product page in the Admin.)
+<!-- MAGETWO-90576 -->
+*  You can now successfully save a product after setting its special requirements  multiselect attribute. (This means that attribute values are saved as expected to the database, checked in `_catalog_product_entity_varchar_ table`,  and displayed as non-selected on product page in the Admin.)
 
 ### Frameworks
 
-<!-- ENGCOM-2370 -->* `@api` annotation has been added to the `magento/framework` component of the Filter Group and Sort Order classes. *Fix submitted by Ronak Patel in pull request [16845](https://github.com/magento/magento2/pull/16845)*.
+<!-- ENGCOM-2370  -->
+*  `@api` annotation has been added to the `magento/framework` component of the Filter Group and Sort Order classes. *Fix submitted by Ronak Patel in pull request [16845](https://github.com/magento/magento2/pull/16845)*.
 
-<!--  ENGCOM-2532 -->* `app/code/Magento/Theme/etc/di.xml` now uses `Translate` instead of `TranslateInterface`. *Fix submitted by Wouter Samaey in pull request [17124](https://github.com/magento/magento2/pull/17124)*.
+<!--  ENGCOM-2532  -->
+*  `app/code/Magento/Theme/etc/di.xml` now uses `Translate` instead of `TranslateInterface`. *Fix submitted by Wouter Samaey in pull request [17124](https://github.com/magento/magento2/pull/17124)*.
 
-<!--  ENGCOM-1981 -->* Classes with methods that contain variadic arguments can be also used in proxy classes. *Fix submitted by Vishal Gelani in pull request [16080](https://github.com/magento/magento2/pull/16080)*.
+<!--  ENGCOM-1981  -->
+*  Classes with methods that contain variadic arguments can be also used in proxy classes. *Fix submitted by Vishal Gelani in pull request [16080](https://github.com/magento/magento2/pull/16080)*.
 
-<!--  ENGCOM-1915 -->* The annotation in  `_toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php` has been corrected. *Fix submitted by Namrata in pull request [15892](https://github.com/magento/magento2/pull/15892)*.
+<!--  ENGCOM-1915  -->
+*  The annotation in  `_toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php` has been corrected. *Fix submitted by Namrata in pull request [15892](https://github.com/magento/magento2/pull/15892)*.
 
-<!--  ENGCOM-1374 -->* Scheduled XML sitemap generation now works as expected. Previously, you could schedule sitemap generation (**Admin** > **Store** > **Configuration** > **Catalog** > **XML sitemap**), but Magento would not generate the sitemap. *Fix submitted by James Halsall in pull request [14822](https://github.com/magento/magento2/pull/14822)*. [GitHub-5768](https://github.com/magento/magento2/issues/5768)
+<!--  ENGCOM-1374  -->
+*  Scheduled XML sitemap generation now works as expected. Previously, you could schedule sitemap generation (**Admin** > **Store** > **Configuration** > **Catalog** > **XML sitemap**), but Magento would not generate the sitemap. *Fix submitted by James Halsall in pull request [14822](https://github.com/magento/magento2/pull/14822)*. [GitHub-5768](https://github.com/magento/magento2/issues/5768)
 
-<!--  ENGCOM-1356 -->* In multi-site deployments, a customer requesting a password reset on a non-default store should receive the password reset email from the non-default, not the primary, store. Previously, this password reset email was sent from the default store. *Fix submitted by Rodrigo Mourão in pull request [14800](https://github.com/magento/magento2/pull/14800)*. [GitHub-5726](https://github.com/magento/magento2/issues/5726)
+<!--  ENGCOM-1356  -->
+*  In multi-site deployments, a customer requesting a password reset on a non-default store should receive the password reset email from the non-default, not the primary, store. Previously, this password reset email was sent from the default store. *Fix submitted by Rodrigo Mourão in pull request [14800](https://github.com/magento/magento2/pull/14800)*. [GitHub-5726](https://github.com/magento/magento2/issues/5726)
 
-<!--  ENGCOM-1301 -->* The `trigger_recollect` quote attribute no longer causes a time out. *Fix submitted by Philipp Sander in pull request [14719](https://github.com/magento/magento2/pull/14719)*. [GitHub-9580](https://github.com/magento/magento2/issues/9580)
+<!--  ENGCOM-1301  -->
+*  The `trigger_recollect` quote attribute no longer causes a time out. *Fix submitted by Philipp Sander in pull request [14719](https://github.com/magento/magento2/pull/14719)*. [GitHub-9580](https://github.com/magento/magento2/issues/9580)
 
-<!-- MAGETWO-90538 -->* `Framework\Math\Random` now uses PHP 7.x features, including `random_bytes` and `random_int`.
+<!-- MAGETWO-90538  -->
+*  `Framework\Math\Random` now uses PHP 7.x features, including `random_bytes` and `random_int`.
 
-<!-- MAGETWO-91164 -->* The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
+<!-- MAGETWO-91164  -->
+*  The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
 
     * Remove   `pub/media/catalog/product/cache`. (Removing this folder frees up space.)
 
     * Run `bin/magento catalog:image:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
 
-<!-- MAGETWO-87731 -->* We've fixed a display error that occurred when both a Critical Admin Notification and Release Notification window were opened.
+<!-- MAGETWO-87731  -->
+*  We've fixed a display error that occurred when both a Critical Admin Notification and Release Notification window were opened.
 
-<!--  ENGCOM-2416 -->* Changes that were made to file permissions for  `lib/internal/Magento/Framework/View/Asset/Merged.php` and its associated test that were made in an earlier release have been reverted. *Fix submitted by Ihor Sviziev in pull request [16937](https://github.com/magento/magento2/pull/16937)*.
+<!--  ENGCOM-2416  -->
+*  Changes that were made to file permissions for  `lib/internal/Magento/Framework/View/Asset/Merged.php` and its associated test that were made in an earlier release have been reverted. *Fix submitted by Ihor Sviziev in pull request [16937](https://github.com/magento/magento2/pull/16937)*.
 
-<!--  ENGCOM-1684 -->* The constructor in `Magento\Webapi\Model\Soap\Fault.php` now assigns `$exception->getOriginator()` to `_soapFaultCode` instead of to the dynamical property `_soapCode`. *Fix submitted by Marcel Hauri in pull request [15515](https://github.com/magento/magento2/pull/15515)*.
+<!--  ENGCOM-1684  -->
+*  The constructor in `Magento\Webapi\Model\Soap\Fault.php` now assigns `$exception->getOriginator()` to `_soapFaultCode` instead of to the dynamical property `_soapCode`. *Fix submitted by Marcel Hauri in pull request [15515](https://github.com/magento/magento2/pull/15515)*.
 
-<!--  ENGCOM-1628 -->* Corrected annotation in `_toOptionArray` in `lib/internal/Magento/Framework/Data/Collection/AbstractDb.php`. *Fix submitted by Sanjay Patel in pull request [15336](https://github.com/magento/magento2/pull/15336)*.
+<!--  ENGCOM-1628  -->
+*  Corrected annotation in `_toOptionArray` in `lib/internal/Magento/Framework/Data/Collection/AbstractDb.php`. *Fix submitted by Sanjay Patel in pull request [15336](https://github.com/magento/magento2/pull/15336)*.
 
-<!--  ENGCOM-1355 -->* The invoice table now displays the correct shipping and handling for a partial items invoice. *Fix submitted by Ankur Raiyani in pull request [14795](https://github.com/magento/magento2/pull/14795)*.
+<!--  ENGCOM-1355  -->
+*  The invoice table now displays the correct shipping and handling for a partial items invoice. *Fix submitted by Ankur Raiyani in pull request [14795](https://github.com/magento/magento2/pull/14795)*.
 
-<!--  ENGCOM-1304 -->* The return values from the `usort` and `value_compare_func` function now matches  the PHP documentation for these functions. *Fix submitted by luke-denton-aligent in pull request [14726](https://github.com/magento/magento2/pull/14726)*.
+<!--  ENGCOM-1304  -->
+*  The return values from the `usort` and `value_compare_func` function now matches  the PHP documentation for these functions. *Fix submitted by luke-denton-aligent in pull request [14726](https://github.com/magento/magento2/pull/14726)*.
 
-<!--  ENGCOM-1317 -->* MySQL adapter can now reconnect successfully  when using a nonstandard port. Previously, Magento threw this error, `Port must be configured within host parameter`. *Fix submitted by Julien ANQUETIL in pull request [14753](https://github.com/magento/magento2/pull/14753)*.
+<!--  ENGCOM-1317  -->
+*  MySQL adapter can now reconnect successfully  when using a nonstandard port. Previously, Magento threw this error, `Port must be configured within host parameter`. *Fix submitted by Julien ANQUETIL in pull request [14753](https://github.com/magento/magento2/pull/14753)*.
 
 #### Application framework
 
-<!-- MAGETWO-92722 -->* You can now manually add a parameter to `app/etc/env.php: user_admin_email`. When an administrator is created, Magento sends an email  to default store's email and, if present, to the email address defined in `user_admin_email`.
+<!-- MAGETWO-92722  -->
+*  You can now manually add a parameter to `app/etc/env.php: user_admin_email`. When an administrator is created, Magento sends an email  to default store's email and, if present, to the email address defined in `user_admin_email`.
 
-<!--  ENGCOM-2240 -->* Magento now removes unneeded PDF files after generation. Previously, Magento saved a copy of every generated invoice PDF in `/var`.  *Fix submitted by Yaroslav Rogoza in pull request [16401](https://github.com/magento/magento2/pull/16401)*. [GitHub-3535](https://github.com/magento/magento2/issues/3535), [GitHub-14517](https://github.com/magento/magento2/issues/14517)
+<!--  ENGCOM-2240  -->
+*  Magento now removes unneeded PDF files after generation. Previously, Magento saved a copy of every generated invoice PDF in `/var`.  *Fix submitted by Yaroslav Rogoza in pull request [16401](https://github.com/magento/magento2/pull/16401)*. [GitHub-3535](https://github.com/magento/magento2/issues/3535), [GitHub-14517](https://github.com/magento/magento2/issues/14517)
 
-<!--  ENGCOM-2371 -->* Logs now indicate when Magento is in maintenance mode, which will help the debugging process. *Fix submitted by Ethan Yehuda in pull request [16840](https://github.com/magento/magento2/pull/16840)*.
+<!--  ENGCOM-2371  -->
+*  Logs now indicate when Magento is in maintenance mode, which will help the debugging process. *Fix submitted by Ethan Yehuda in pull request [16840](https://github.com/magento/magento2/pull/16840)*.
 
 #### JavaScript framework
 
-<!--  ENGCOM-1677 -->* `lib/web/mage/dropdowns.js` no longer fails when autoclose is set to **true**. *Fix submitted by Brian LaBelle in pull request [15499](https://github.com/magento/magento2/pull/15499)*. [GitHub-15469](https://github.com/magento/magento2/issues/15469)
+<!--  ENGCOM-1677  -->
+*  `lib/web/mage/dropdowns.js` no longer fails when autoclose is set to **true**. *Fix submitted by Brian LaBelle in pull request [15499](https://github.com/magento/magento2/pull/15499)*. [GitHub-15469](https://github.com/magento/magento2/issues/15469)
 
-<!-- MAGETWO-90193 -->* You can now view an entire zoomed product image in Fotorama fullscreen from the FireFox browser. Previously, the image jumps and the user cannot view all portions of the image. [GitHub-7978](https://github.com/magento/magento2/issues/7978)
+<!-- MAGETWO-90193  -->
+*  You can now view an entire zoomed product image in Fotorama fullscreen from the FireFox browser. Previously, the image jumps and the user cannot view all portions of the image. [GitHub-7978](https://github.com/magento/magento2/issues/7978)
 
 #### Web API framework
 
-<!--  ENGCOM-2012 -->* The `array_push` function has been added to the list of forbidden functions. *Fix submitted by Leandro F. L. in pull request [16144](https://github.com/magento/magento2/pull/16144)*.
+<!--  ENGCOM-2012  -->
+*  The `array_push` function has been added to the list of forbidden functions. *Fix submitted by Leandro F. L. in pull request [16144](https://github.com/magento/magento2/pull/16144)*.
 
-<!--  ENGCOM-1720 -->* A generated admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired. *Fix submitted by Maikel Martens in pull request [15598](https://github.com/magento/magento2/pull/15598)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
+<!--  ENGCOM-1720  -->
+*  A generated admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired. *Fix submitted by Maikel Martens in pull request [15598](https://github.com/magento/magento2/pull/15598)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
 
-<!-- MAGETWO-92122 -->* The `GET /V1/returns?searchCriteria` endpoint retrieves `tracks` arrays as expected.
+<!-- MAGETWO-92122  -->
+*  The `GET /V1/returns?searchCriteria` endpoint retrieves `tracks` arrays as expected.
 
-<!-- MAGETWO-86099 -->* The `GET /V1/returns/:id` endpoint retrieves `tracks` arrays as expected.
+<!-- MAGETWO-86099  -->
+*  The `GET /V1/returns/:id` endpoint retrieves `tracks` arrays as expected.
 
-<!-- MAGETWO-73527 -->* `catalogProductAttributeRepository` now returns the `frontend_labels` value as expected.
+<!-- MAGETWO-73527  -->
+*  `catalogProductAttributeRepository` now returns the `frontend_labels` value as expected.
 
 #### Cache framework
 
-<!-- MAGETWO-69847 -->* Magento no longer throws an exception when deploying static content on a deployment where Redis is used for cache management. See "Redis and static-content deployment" in [Redis troubleshooting]({{ page.baseurl }}/cloud/trouble/redis-troubleshooting.html) for more information. [GitHub-9287](https://github.com/magento/magento2/issues/9287)
+<!-- MAGETWO-69847  -->
+*  Magento no longer throws an exception when deploying static content on a deployment where Redis is used for cache management. See "Redis and static-content deployment" in [Redis troubleshooting]({{ page.baseurl }}/cloud/trouble/redis-troubleshooting.html) for more information. [GitHub-9287](https://github.com/magento/magento2/issues/9287)
 
-<!-- MAGETWO-84109 -->* When a layout is loaded from the cache, Magento now repopulates the list of applied layout handles to prevent any chance of a layout handle being reapplied later. *Fix submitted by Scott Buchanan in pull request [12314](https://github.com/magento/magento2/pull/12314)*.
+<!-- MAGETWO-84109  -->
+*  When a layout is loaded from the cache, Magento now repopulates the list of applied layout handles to prevent any chance of a layout handle being reapplied later. *Fix submitted by Scott Buchanan in pull request [12314](https://github.com/magento/magento2/pull/12314)*.
 
 ### Dashboard
 
-<!--  ENGCOM-1867 -->* The dashboard now displays the correct order amount on orders when deploying Magento on multiple storefronts with different currencies. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
+<!--  ENGCOM-1867  -->
+*  The dashboard now displays the correct order amount on orders when deploying Magento on multiple storefronts with different currencies. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
 
 ### Directory
 
-<!--  ENGCOM-2073 -->* Magento now supports seven-digit Israeli postal code masks. *Fix submitted by Itay Raz in pull request [16250](https://github.com/magento/magento2/pull/16250)*.
+<!--  ENGCOM-2073  -->
+*  Magento now supports seven-digit Israeli postal code masks. *Fix submitted by Itay Raz in pull request [16250](https://github.com/magento/magento2/pull/16250)*.
 
 ### General
 
-<!-- MAGETWO-90968 -->* Magento now uses the correct amounts when creating a credit memo for an order that was placed using store credit, a gift card, or reward points.
+<!-- MAGETWO-90968  -->
+*  Magento now uses the correct amounts when creating a credit memo for an order that was placed using store credit, a gift card, or reward points.
 
-<!-- MAGETWO-91411 -->* Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
+<!-- MAGETWO-91411  -->
+*  Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
 
-<!-- MAGETWO-91928 -->* You can now successfully save a product video for one store view in deployments that have several store views. Previously, when you saved a product video for one store view, Magento saved it for all store views, although customers could play the video on the original store only.
+<!-- MAGETWO-91928  -->
+*  You can now successfully save a product video for one store view in deployments that have several store views. Previously, when you saved a product video for one store view, Magento saved it for all store views, although customers could play the video on the original store only.
 
-<!-- MAGETWO-91931 -->* Customer data is now fully loaded after restarting the browser during an unexpired user session. Previously,  the `section_data_ids` section of the session cookie was not properly completed. [GitHub-14912](https://github.com/magento/magento2/issues/14912)
+<!-- MAGETWO-91931  -->
+*  Customer data is now fully loaded after restarting the browser during an unexpired user session. Previously,  the `section_data_ids` section of the session cookie was not properly completed. [GitHub-14912](https://github.com/magento/magento2/issues/14912)
 
-<!-- MAGETWO-91000 -->* We've fixed an issue with unoptimized SQL queries in customer segments. Previously, the  customer segment was not saved, and MySQL crashed.
+<!-- MAGETWO-91000  -->
+*  We've fixed an issue with unoptimized SQL queries in customer segments. Previously, the  customer segment was not saved, and MySQL crashed.
 
-<!-- MAGETWO-90246 -->* When a customer creates a product review, the link to the product from the review in the customer's **My Account** > **My Product Review** is now SEO friendly.
+<!-- MAGETWO-90246  -->
+*  When a customer creates a product review, the link to the product from the review in the customer's **My Account** > **My Product Review** is now SEO friendly.
 
-<!-- MAGETWO-87356 -->* The My Invitations page now accurately displays the reward points amount in numbers. Previously, this page displayed the special character `%` instead of numbers.
+<!-- MAGETWO-87356  -->
+*  The My Invitations page now accurately displays the reward points amount in numbers. Previously, this page displayed the special character `%` instead of numbers.
 
-<!-- MAGETWO-73512 -->* The Enterprise Reward refund logic  no longer permits administrators to grant double refunds.
+<!-- MAGETWO-73512  -->
+*  The Enterprise Reward refund logic  no longer permits administrators to grant double refunds.
 
-<!-- MAGETWO-85112 -->* We moved the `isAllowed` method from `AccessChangeQuoteControl` to a separate service to optimize the logic that supports using recurrent payments in combination with pre-ordered products. *Fix submitted by Jeroen Van Leusden in pull request [12566](https://github.com/magento/magento2/pull/12566)*.
+<!-- MAGETWO-85112  -->
+*  We moved the `isAllowed` method from `AccessChangeQuoteControl` to a separate service to optimize the logic that supports using recurrent payments in combination with pre-ordered products. *Fix submitted by Jeroen Van Leusden in pull request [12566](https://github.com/magento/magento2/pull/12566)*.
 
-<!-- MAGETWO-83551 -->* The attribute checking logic has been optimized by reducing redundant checks. *Fix submitted by Freek Vandeursen in pull request [11554](https://github.com/magento/magento2/pull/11554)*.
+<!-- MAGETWO-83551  -->
+*  The attribute checking logic has been optimized by reducing redundant checks. *Fix submitted by Freek Vandeursen in pull request [11554](https://github.com/magento/magento2/pull/11554)*.
 
-<!-- MAGETWO-86239 -->* Magento no longer validates customer address attribute value length when the minimum/maximum length fields are not displayed on the Admin.
+<!-- MAGETWO-86239  -->
+*  Magento no longer validates customer address attribute value length when the minimum/maximum length fields are not displayed on the Admin.
 
-<!-- ENGCOM-1679 -->* The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
+<!-- ENGCOM-1679  -->
+*  The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
 
-<!-- MAGETWO-87120 -->* The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
+<!-- MAGETWO-87120  -->
+*  The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
-<!-- ENGCOM-1767 -->*  `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
+<!-- ENGCOM-1767  -->
+*   `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
 
-<!-- ENGCOM-1762 -->* Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)
+<!-- ENGCOM-1762  -->
+*  Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)
 
-<!-- ENGCOM-1858 -->* An administrator can now successfully download a PDF or export data immediately after log in. Previously, an administrator could not download a PDF or export data successfully after log in, but was redirected to the Admin dashboard. *Fix submitted by Riccardo Tempesta  in pull request [15539](https://github.com/magento/magento2/pull/15539)*. [GitHub-15510](https://github.com/magento/magento2/issues/15510)
+<!-- ENGCOM-1858  -->
+*  An administrator can now successfully download a PDF or export data immediately after log in. Previously, an administrator could not download a PDF or export data successfully after log in, but was redirected to the Admin dashboard. *Fix submitted by Riccardo Tempesta  in pull request [15539](https://github.com/magento/magento2/pull/15539)*. [GitHub-15510](https://github.com/magento/magento2/issues/15510)
 
-<!-- ENGCOM-1805 -->* Merchants can now apply styling by changing LESS variables in the Luma theme as expected. *Fix submitted by hitesh-wagento in pull request [15734](https://github.com/magento/magento2/pull/15734)*. [GitHub-15608](https://github.com/magento/magento2/issues/15608)
+<!-- ENGCOM-1805  -->
+*  Merchants can now apply styling by changing LESS variables in the Luma theme as expected. *Fix submitted by hitesh-wagento in pull request [15734](https://github.com/magento/magento2/pull/15734)*. [GitHub-15608](https://github.com/magento/magento2/issues/15608)
 
-<!-- ENGCOM-1860 -->* Added a service configuration setting—Send Adminhtml and Frontend as Separate Apps—to collect and send separate data for frontend and adminhtml applications for New Relic reporting. See [New Relic Reporting]( https://docs.magento.com/m2/ce/user_guide/reports/new-relic-reporting.html?Highlight=New%20Relic%20service). *Fix submitted by Max Chadwick in pull request [12935](https://github.com/magento/magento2/pull/12935)*.
+<!-- ENGCOM-1860  -->
+*  Added a service configuration setting—Send Adminhtml and Frontend as Separate Apps—to collect and send separate data for frontend and adminhtml applications for New Relic reporting. See [New Relic Reporting]( https://docs.magento.com/m2/ce/user_guide/reports/new-relic-reporting.html?Highlight=New%20Relic%20service). *Fix submitted by Max Chadwick in pull request [12935](https://github.com/magento/magento2/pull/12935)*.
 
-<!-- ENGCOM-1864 -->*  Table alias prefixes in field mappings for customer group filter and sorting processors that were previously missing have been restored. Previous to this restoration, Magento threw this error when a merchant opened **Admin** > **Customers** > **All Customers**: `SQL Error: ambiguous column 'customer_group_id' in 'All customers' page in admin when extension attribute table is joined`. *Fix submitted by Maksim Gopey in pull request [15826](https://github.com/magento/magento2/pull/15826)*.
+<!-- ENGCOM-1864  -->
+*   Table alias prefixes in field mappings for customer group filter and sorting processors that were previously missing have been restored. Previous to this restoration, Magento threw this error when a merchant opened **Admin** > **Customers** > **All Customers**: `SQL Error: ambiguous column 'customer_group_id' in 'All customers' page in admin when extension attribute table is joined`. *Fix submitted by Maksim Gopey in pull request [15826](https://github.com/magento/magento2/pull/15826)*.
 
-<!-- ENGCOM-1883 -->* `.limiter` now has the same parent selectors as `.pages`, which prevents clashes between styles and layouts. Previously, `.limiter` float was too generic. *Fix submitted by hitesh-wagento in pull request [15878](https://github.com/magento/magento2/pull/15878)*.
+<!-- ENGCOM-1883  -->
+*  `.limiter` now has the same parent selectors as `.pages`, which prevents clashes between styles and layouts. Previously, `.limiter` float was too generic. *Fix submitted by hitesh-wagento in pull request [15878](https://github.com/magento/magento2/pull/15878)*.
 
-<!-- ENGCOM-1942 -->* The default `FormElementDependenceController` configuration is now extended by custom configuration rather than overridden.  *Fix submitted by Valerij Ivashchenko in pull request [16001](https://github.com/magento/magento2/pull/16001)*.
+<!-- ENGCOM-1942  -->
+*  The default `FormElementDependenceController` configuration is now extended by custom configuration rather than overridden.  *Fix submitted by Valerij Ivashchenko in pull request [16001](https://github.com/magento/magento2/pull/16001)*.
 
-<!-- ENGCOM-1958 -->* `inline-block` issues with space and font-size in the Name form have been resolved. *Fix submitted by Daniel Ruf in pull request [16048](https://github.com/magento/magento2/pull/16048)*.
+<!-- ENGCOM-1958  -->
+*  `inline-block` issues with space and font-size in the Name form have been resolved. *Fix submitted by Daniel Ruf in pull request [16048](https://github.com/magento/magento2/pull/16048)*.
 
-<!-- ENGCOM-1896 -->* Alignment and layout issues on  home  and category pages of the Hot Seller section have been resolved. *Fix submitted by Chirag Matholiya in pull request [15893](https://github.com/magento/magento2/pull/15893)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
+<!-- ENGCOM-1896  -->
+*  Alignment and layout issues on  home  and category pages of the Hot Seller section have been resolved. *Fix submitted by Chirag Matholiya in pull request [15893](https://github.com/magento/magento2/pull/15893)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
 
-<!-- ENGCOM-1886 -->* Updated old font formats of the default fonts (`woff` and `woff2`). *Fix submitted by Daniel Ruf in pull request [15870](https://github.com/magento/magento2/pull/15870)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
+<!-- ENGCOM-1886  -->
+*  Updated old font formats of the default fonts (`woff` and `woff2`). *Fix submitted by Daniel Ruf in pull request [15870](https://github.com/magento/magento2/pull/15870)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
 
-<!-- ENGCOM-2011 -->* We've corrected the return type of methods and  typos in `CategoriesJson.php`, `Engine.php`, `UrlRewrite.php`, and `ObserverConfig.php`. *Fix submitted by Saurabh Parekh in pull request [15993](https://github.com/magento/magento2/pull/15993)*.
+<!-- ENGCOM-2011  -->
+*  We've corrected the return type of methods and  typos in `CategoriesJson.php`, `Engine.php`, `UrlRewrite.php`, and `ObserverConfig.php`. *Fix submitted by Saurabh Parekh in pull request [15993](https://github.com/magento/magento2/pull/15993)*.
 
-<!-- ENGCOM-1991 -->* `@escapeNotVerified` annotations were replaced in `name.phtml` and `qty.phtml`. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
+<!-- ENGCOM-1991  -->
+*  `@escapeNotVerified` annotations were replaced in `name.phtml` and `qty.phtml`. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
 
-<!-- ENGCOM-1607 -->* We've removed redundant function calls in `app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml`. *Fix submitted by Saurabh Parekh in pull request [15346](https://github.com/magento/magento2/pull/15346)*. [GitHub-15355](https://github.com/magento/magento2/issues/15355)
+<!-- ENGCOM-1607  -->
+*  We've removed redundant function calls in `app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml`. *Fix submitted by Saurabh Parekh in pull request [15346](https://github.com/magento/magento2/pull/15346)*. [GitHub-15355](https://github.com/magento/magento2/issues/15355)
 
-<!-- ENGCOM-1659 -->* `magnifier.js` now works no matter which mode is set. (`magnifier.js` offers the option of setting mode to 'inside' for an in-frame zoom.) *Fix submitted by Kacper Chara in pull request [15382](https://github.com/magento/magento2/pull/15382)*. [GitHub-4977](https://github.com/magento/magento2/issues/4977)
+<!-- ENGCOM-1659  -->
+*  `magnifier.js` now works no matter which mode is set. (`magnifier.js` offers the option of setting mode to 'inside' for an in-frame zoom.) *Fix submitted by Kacper Chara in pull request [15382](https://github.com/magento/magento2/pull/15382)*. [GitHub-4977](https://github.com/magento/magento2/issues/4977)
 
-<!-- ENGCOM-2007 -->* The Change Password warning message no longer appears twice. *Fix submitted by Sanjay Patel in pull request [15774](https://github.com/magento/magento2/pull/15774)*. [GitHub-14895](https://github.com/magento/magento2/issues/14895)
+<!-- ENGCOM-2007  -->
+*  The Change Password warning message no longer appears twice. *Fix submitted by Sanjay Patel in pull request [15774](https://github.com/magento/magento2/pull/15774)*. [GitHub-14895](https://github.com/magento/magento2/issues/14895)
 
-<!-- ENGCOM-2559 -->* You can now add the `NOINDEX,NOFOLLOW` meta tag to the admin scope to instruct Google and other friendly bots to refrain from adding the Admin URL to search results. *Fix submitted by Itay Raz in pull request [17163](https://github.com/magento/magento2/pull/17163)*.
+<!-- ENGCOM-2559  -->
+*  You can now add the `NOINDEX,NOFOLLOW` meta tag to the admin scope to instruct Google and other friendly bots to refrain from adding the Admin URL to search results. *Fix submitted by Itay Raz in pull request [17163](https://github.com/magento/magento2/pull/17163)*.
 
-<!-- ENGCOM-2443 -->* The Create Account and Password Forget forms now include the required notice for relevant fields. *Fix submitted by Daniel Ruf in pull request [16965](https://github.com/magento/magento2/pull/16965)*.
+<!-- ENGCOM-2443  -->
+*  The Create Account and Password Forget forms now include the required notice for relevant fields. *Fix submitted by Daniel Ruf in pull request [16965](https://github.com/magento/magento2/pull/16965)*.
 
-<!-- ENGCOM-2437 -->* Reworked the  `addError`, `addSuccess` methods in several files. *Fix submitted by Tiago Sampaio in pull request [16921](https://github.com/magento/magento2/pull/16921)*.
+<!-- ENGCOM-2437  -->
+*  Reworked the  `addError`, `addSuccess` methods in several files. *Fix submitted by Tiago Sampaio in pull request [16921](https://github.com/magento/magento2/pull/16921)*.
 
-<!-- ENGCOM-2398 -->* Minor improvements to  `app/code/Magento/CatalogRule/Model/Rule/Job.php` and `app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16900](https://github.com/magento/magento2/pull/16900)*.
+<!-- ENGCOM-2398  -->
+*  Minor improvements to  `app/code/Magento/CatalogRule/Model/Rule/Job.php` and `app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16900](https://github.com/magento/magento2/pull/16900)*.
 
-<!-- ENGCOM-2282 -->* Refactored `app/code/Magento/User/Controller/Adminhtml/`  by removing the direct use of ObjectManager and included the dependencies using constructor dependency injection. *Fix submitted by AnshuMishra17 in pull request [16560](https://github.com/magento/magento2/pull/16560)*.
+<!-- ENGCOM-2282  -->
+*  Refactored `app/code/Magento/User/Controller/Adminhtml/`  by removing the direct use of ObjectManager and included the dependencies using constructor dependency injection. *Fix submitted by AnshuMishra17 in pull request [16560](https://github.com/magento/magento2/pull/16560)*.
 
-<!-- ENGCOM-2209 -->* `gallery.less` no longer imports `_responsive.less`. *Fix submitted by Karla Saaremäe in pull request [16579](https://github.com/magento/magento2/pull/16579)*.
+<!-- ENGCOM-2209  -->
+*  `gallery.less` no longer imports `_responsive.less`. *Fix submitted by Karla Saaremäe in pull request [16579](https://github.com/magento/magento2/pull/16579)*.
 
-<!-- ENGCOM-2384 -->* Added missing `width` property for the confirmation modal in `lib/web/css/source/components/_modals.less`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16861](https://github.com/magento/magento2/pull/16861)*.
+<!-- ENGCOM-2384  -->
+*  Added missing `width` property for the confirmation modal in `lib/web/css/source/components/_modals.less`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16861](https://github.com/magento/magento2/pull/16861)*.
 
-<!-- ENGCOM-2293 -->* Removed the redundant `font-size` attribute from the toolbar pager in  `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Karla Saaremäe in pull request [16716](https://github.com/magento/magento2/pull/16716)*.
+<!-- ENGCOM-2293  -->
+*  Removed the redundant `font-size` attribute from the toolbar pager in  `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Karla Saaremäe in pull request [16716](https://github.com/magento/magento2/pull/16716)*.
 
-<!-- ENGCOM-2284 -->* Updated the "Reporting security issues" section of `README.md` to recommend that users create a bugcrowd account.  *Fix submitted by Tommy Quissens in pull request [16685](https://github.com/magento/magento2/pull/16685)*.
+<!-- ENGCOM-2284  -->
+*  Updated the "Reporting security issues" section of `README.md` to recommend that users create a bugcrowd account.  *Fix submitted by Tommy Quissens in pull request [16685](https://github.com/magento/magento2/pull/16685)*.
 
-<!-- ENGCOM-2193 -->* The currency format that was previously broken for some locales now works as expected. Previously, broken currency formats resulted in an incorrect price amount on the product page. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11717](https://github.com/magento/magento2/issues/11717)
+<!-- ENGCOM-2193  -->
+*  The currency format that was previously broken for some locales now works as expected. Previously, broken currency formats resulted in an incorrect price amount on the product page. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11717](https://github.com/magento/magento2/issues/11717)
 
-<!-- ENGCOM-2159 -->* Changed the **My Dashboard** string to **My Account** in multiple files. *Fix submitted by Daniel Ruf in pull request [16009](https://github.com/magento/magento2/pull/16009)*.
+<!-- ENGCOM-2159  -->
+*  Changed the **My Dashboard** string to **My Account** in multiple files. *Fix submitted by Daniel Ruf in pull request [16009](https://github.com/magento/magento2/pull/16009)*.
 
-<!-- ENGCOM-1717 -->* Corrected the annotation to the `formatDateTime` function in `lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php` file. *Fix submitted by Sanjay Patel in pull request [15602](https://github.com/magento/magento2/pull/15602)*.
+<!-- ENGCOM-1717  -->
+*  Corrected the annotation to the `formatDateTime` function in `lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php` file. *Fix submitted by Sanjay Patel in pull request [15602](https://github.com/magento/magento2/pull/15602)*.
 
-<!-- ENGCOM-1658 -->* The `clickableOverlay` option now works as expected. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
+<!-- ENGCOM-1658  -->
+*  The `clickableOverlay` option now works as expected. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
 
-<!-- ENGCOM-1579 -->* The Instant Purchase module now works as expected. Previously, the `get($type)` method in `/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php` threw an exception without showing the shipping method $type as it was hardcoded as 'chooser'. *Fix submitted by Marcel Hauri in pull request [15258](https://github.com/magento/magento2/pull/15258)*.
+<!-- ENGCOM-1579  -->
+*  The Instant Purchase module now works as expected. Previously, the `get($type)` method in `/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php` threw an exception without showing the shipping method $type as it was hardcoded as 'chooser'. *Fix submitted by Marcel Hauri in pull request [15258](https://github.com/magento/magento2/pull/15258)*.
 
-<!-- ENGCOM-1618 -->* Template files now follow Magento standard coding format. *Fix submitted by Vishal Gelani in pull request [15398](https://github.com/magento/magento2/pull/15398)*.
+<!-- ENGCOM-1618  -->
+*  Template files now follow Magento standard coding format. *Fix submitted by Vishal Gelani in pull request [15398](https://github.com/magento/magento2/pull/15398)*.
 
-<!-- ENGCOM-1476 -->* Corrected `viewModel` to `view_model` where needed in `\Magento\Backend\Block\Template`. *Fix submitted by Abhishek Jakhotiya in pull request [15067](https://github.com/magento/magento2/pull/15067)*.
+<!-- ENGCOM-1476  -->
+*  Corrected `viewModel` to `view_model` where needed in `\Magento\Backend\Block\Template`. *Fix submitted by Abhishek Jakhotiya in pull request [15067](https://github.com/magento/magento2/pull/15067)*.
 
-<!-- ENGCOM-1375 -->* Non-well-formed numeric values that were encountered in `app/code/Magento/Directory/Model/Currency.php` have been resolved. *Fix submitted by Mateusz Lerczak in pull request [14833](https://github.com/magento/magento2/pull/14833)*.
+<!-- ENGCOM-1375  -->
+*  Non-well-formed numeric values that were encountered in `app/code/Magento/Directory/Model/Currency.php` have been resolved. *Fix submitted by Mateusz Lerczak in pull request [14833](https://github.com/magento/magento2/pull/14833)*.
 
-<!-- ENGCOM-1352 -->* The `README` file for the `magento2` repository now has Maintainers and Contributors sections. *Fix submitted by Stanislav Idolov in pull request [14790](https://github.com/magento/magento2/pull/14790)*.
+<!-- ENGCOM-1352  -->
+*  The `README` file for the `magento2` repository now has Maintainers and Contributors sections. *Fix submitted by Stanislav Idolov in pull request [14790](https://github.com/magento/magento2/pull/14790)*.
 
-<!-- ENGCOM-1338 -->* The documentation for `AdapterInterface::update` has been improved. *Fix submitted by Navarr Barnier in pull request [14769](https://github.com/magento/magento2/pull/14769)*.
+<!-- ENGCOM-1338  -->
+*  The documentation for `AdapterInterface::update` has been improved. *Fix submitted by Navarr Barnier in pull request [14769](https://github.com/magento/magento2/pull/14769)*.
 
-<!-- MAGETWO-93272 -->* The product video feature is now GDPR-compliant.
+<!-- MAGETWO-93272  -->
+*  The product video feature is now GDPR-compliant.
 
 ### Gift cards
 
-<!-- MAGETWO-92988 -->* Magento now displays the **Credit Memo** link  at the top of the page for orders with a total of 0 (zero). Previously, this link was missing, which prevented users from creating a credit memo for the order.
+<!-- MAGETWO-92988  -->
+*  Magento now displays the **Credit Memo** link  at the top of the page for orders with a total of 0 (zero). Previously, this link was missing, which prevented users from creating a credit memo for the order.
 
-<!-- MAGETWO-92362 -->*  You can now save gift cards without the price being changed on the Admin to an unacceptable format. Previously, Magento tried to save amounts in unacceptable formats (such as the inclusion of a comma in a four-digit price), which triggered an error.
+<!-- MAGETWO-92362  -->
+*   You can now save gift cards without the price being changed on the Admin to an unacceptable format. Previously, Magento tried to save amounts in unacceptable formats (such as the inclusion of a comma in a four-digit price), which triggered an error.
 
-<!-- MAGETWO-91925 -->* Magento no longer permits users to save a new gift card  without first completing the required values. Previously, when creating a gift card, users could save the card without having designated an amount, but the card could not be purchased. Magento also created a `report.CRITICAL: Warning` error message in the `system.log`.
+<!-- MAGETWO-91925  -->
+*  Magento no longer permits users to save a new gift card  without first completing the required values. Previously, when creating a gift card, users could save the card without having designated an amount, but the card could not be purchased. Magento also created a `report.CRITICAL: Warning` error message in the `system.log`.
 
-<!-- MAGETWO- 91867-->* Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
+<!-- MAGETWO- 91867 -->
+*  Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
 
-<!-- MAGETWO-91576 -->* Magento now maintains relationships between new gift card accounts when a customer purchases several gift cards in the same order.
+<!-- MAGETWO-91576  -->
+*  Magento now maintains relationships between new gift card accounts when a customer purchases several gift cards in the same order.
 
-<!-- MAGETWO-91400 -->* Magento now refunds only the exact amount used on a gift card if only the part of the gift card was  used. Previously, when a customer used a gift card account code to partially pay for an order,  and Magento subsequently created a credit memo for a portion of the order, the full amount of the gift card was refunded.
+<!-- MAGETWO-91400  -->
+*  Magento now refunds only the exact amount used on a gift card if only the part of the gift card was  used. Previously, when a customer used a gift card account code to partially pay for an order,  and Magento subsequently created a credit memo for a portion of the order, the full amount of the gift card was refunded.
 
-<!-- MAGETWO-86757 -->* Magento now generates the same number of gift card codes when the full order is invoiced as the customer selected when creating an order. Previously, for orders that included both physical products and multiple gift cards, the number of gift card codes  generated on an order corresponded to the quantity of the previous physical line items that the user had added to the cart before adding gift cards.
+<!-- MAGETWO-86757  -->
+*  Magento now generates the same number of gift card codes when the full order is invoiced as the customer selected when creating an order. Previously, for orders that included both physical products and multiple gift cards, the number of gift card codes  generated on an order corresponded to the quantity of the previous physical line items that the user had added to the cart before adding gift cards.
 
 ### Gift message
 
-<!-- MAGETWO-91867 -->* Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
+<!-- MAGETWO-91867  -->
+*  Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
 
 ### Google Analytics
 
-<!-- ENGCOM-1825 -->* Google analytics pageview is no longer triggered twice. *Fix submitted by Torben Höhn in pull request [15765](https://github.com/magento/magento2/pull/15765)*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
+<!-- ENGCOM-1825  -->
+*  Google analytics pageview is no longer triggered twice. *Fix submitted by Torben Höhn in pull request [15765](https://github.com/magento/magento2/pull/15765)*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
 
-<!-- ENGCOM-2537 -->* `Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver` is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17137](https://github.com/magento/magento2/pull/17137)*.
+<!-- ENGCOM-2537  -->
+*  `Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver` is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17137](https://github.com/magento/magento2/pull/17137)*.
 
 ### Google Tag Manager
 
-<!-- MAGETWO-91951 -->* The `addToCart` event triggers on the Google Task Manager console only when an item is added to the cart.  Previously, the event was triggered before the cart was updated.
+<!-- MAGETWO-91951  -->
+*  The `addToCart` event triggers on the Google Task Manager console only when an item is added to the cart.  Previously, the event was triggered before the cart was updated.
 
-<!-- MAGETWO-89532 -->* Google Analytics events are now triggered as expected. Specifically,  the  `addToCart` and `removeFromCart` events are not triggered until after a customer adds a product to the mini cart.
+<!-- MAGETWO-89532  -->
+*  Google Analytics events are now triggered as expected. Specifically,  the  `addToCart` and `removeFromCart` events are not triggered until after a customer adds a product to the mini cart.
 
-<!-- MAGETWO-87955 -->* Magento now accurately updates the mini cart when a customer removes a product while accessing a storefront using Internet Explorer 11.x. Previously, when a customer removed a product from the mini cart, Magento did not remove the product but instead threw this error, `(SCRIPT438: Object doesn't support property or method 'find'. File: sidebar.js, Line: 237, Column: 13 )`.
+<!-- MAGETWO-87955  -->
+*  Magento now accurately updates the mini cart when a customer removes a product while accessing a storefront using Internet Explorer 11.x. Previously, when a customer removed a product from the mini cart, Magento did not remove the product but instead threw this error, `(SCRIPT438: Object doesn't support property or method 'find'. File: sidebar.js, Line: 237, Column: 13 )`.
 
-<!-- MAGETWO-88806 -->* Google Tag Manager product category data is now fully reported. Previously, the Google Tag Manager product category (Enhanced Ecommerce) data did not report all information.
+<!-- MAGETWO-88806  -->
+*  Google Tag Manager product category data is now fully reported. Previously, the Google Tag Manager product category (Enhanced Ecommerce) data did not report all information.
 
 ### HTML
 
-<!-- ENGCOM-2178 -->* Responsive table headers now work as expected. Previously, when no heading was present in the `data-th` attribute on a column for a responsive table in Magento, only a colon was present. *Fix submitted by Sean Templeton in pull request [16517](https://github.com/magento/magento2/pull/16517)*.
+<!-- ENGCOM-2178  -->
+*  Responsive table headers now work as expected. Previously, when no heading was present in the `data-th` attribute on a column for a responsive table in Magento, only a colon was present. *Fix submitted by Sean Templeton in pull request [16517](https://github.com/magento/magento2/pull/16517)*.
 
-<!-- ENGCOM-1654 -->* Corrected HTML syntax in the `report.phtml` error template. *Fix submitted by abcpremium in pull request [15454](https://github.com/magento/magento2/pull/15454)*.
+<!-- ENGCOM-1654  -->
+*  Corrected HTML syntax in the `report.phtml` error template. *Fix submitted by abcpremium in pull request [15454](https://github.com/magento/magento2/pull/15454)*.
 
 ### Import/export
 
-<!-- ENGCOM-2304 -->* Product import now updates the **Enable Qty Increments** field as expected. *Fix submitted by Sergey P in pull request [14379](https://github.com/magento/magento2/pull/14379)*. [GitHub-14351](https://github.com/magento/magento2/issues/14351)
+<!-- ENGCOM-2304  -->
+*  Product import now updates the **Enable Qty Increments** field as expected. *Fix submitted by Sergey P in pull request [14379](https://github.com/magento/magento2/pull/14379)*. [GitHub-14351](https://github.com/magento/magento2/issues/14351)
 
-<!-- ENGCOM-1549 -->* `Magento_ImportExport` now supports unicode characters in column names. Previously, column names such `vitamin_a_µg` were  marked invalid. *Fix submitted by Timon de Groot in pull request [15197](https://github.com/magento/magento2/pull/15197)*.
+<!-- ENGCOM-1549  -->
+*  `Magento_ImportExport` now supports unicode characters in column names. Previously, column names such `vitamin_a_µg` were  marked invalid. *Fix submitted by Timon de Groot in pull request [15197](https://github.com/magento/magento2/pull/15197)*.
 
 ### Infrastructure
 
-<!-- MAGETWO-89442 -->* Return Merchandise Authorization (RMA) calls now return order items and comments as expected.
+<!-- MAGETWO-89442  -->
+*  Return Merchandise Authorization (RMA) calls now return order items and comments as expected.
 
-<!-- MAGETWO-92302 -->* The RMA status label now shows on the email that Magento sends to customers when the status of an RMA changes.
+<!-- MAGETWO-92302  -->
+*  The RMA status label now shows on the email that Magento sends to customers when the status of an RMA changes.
 
-<!-- MAGETWO-72090 -->* Magento now deselects only the attributes you choose to deselect when you set the **Use Default Value** setting on a store view to **no** for certain attributes. Previously, when you deselected the **Use Default Value** setting on a store view for certain attributes, Magento unselected other attributes as well.
+<!-- MAGETWO-72090  -->
+*  Magento now deselects only the attributes you choose to deselect when you set the **Use Default Value** setting on a store view to **no** for certain attributes. Previously, when you deselected the **Use Default Value** setting on a store view for certain attributes, Magento unselected other attributes as well.
 
-<!-- MAGETWO-88615 -->* Magento now deploys the translations in `js-translation.json` file when deploying static content.  *Fix submitted by Sergey Dmitruk in pull request [4814](https://github.com/magento/magento2/pull/4814)*.
+<!-- MAGETWO-88615  -->
+*  Magento now deploys the translations in `js-translation.json` file when deploying static content.  *Fix submitted by Sergey Dmitruk in pull request [4814](https://github.com/magento/magento2/pull/4814)*.
 
-<!-- ENGCOM-2304 -->* Magento now updates the `Enable Qty Increments` field as expected during product import. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
+<!-- ENGCOM-2304  -->
+*  Magento now updates the `Enable Qty Increments` field as expected during product import. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
 
-<!-- ENGCOM-1875 -->* We've expanded the  HTTP request class by adding the  `isPostRequest` method. *Fix submitted by Pavel Usachev in pull request [12626](https://github.com/magento/magento2/pull/12626)*.
+<!-- ENGCOM-1875  -->
+*  We've expanded the  HTTP request class by adding the  `isPostRequest` method. *Fix submitted by Pavel Usachev in pull request [12626](https://github.com/magento/magento2/pull/12626)*.
 
-<!-- ENGCOM-1952 -->* You can now change only the primary button `font-weight` without changing regular button `font-weight` with LESS variables. *Fix submitted by Karla Saaremäe in pull request [16012](https://github.com/magento/magento2/pull/16012)*. [GitHub-15832](https://github.com/magento/magento2/issues/15832)
+<!-- ENGCOM-1952  -->
+*  You can now change only the primary button `font-weight` without changing regular button `font-weight` with LESS variables. *Fix submitted by Karla Saaremäe in pull request [16012](https://github.com/magento/magento2/pull/16012)*. [GitHub-15832](https://github.com/magento/magento2/issues/15832)
 
-<!-- ENGCOM-1917 -->* We've added missing properties to the `Magento/Widget` component and removed a  reference to a non-existent class in the associated tests.  *Fix submitted by Marcel Hauri in pull request [15647](https://github.com/magento/magento2/pull/15647)*.
+<!-- ENGCOM-1917  -->
+*  We've added missing properties to the `Magento/Widget` component and removed a  reference to a non-existent class in the associated tests.  *Fix submitted by Marcel Hauri in pull request [15647](https://github.com/magento/magento2/pull/15647)*.
 
-<!-- ENGCOM-1960 -->* We've improved the readability of `app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php`. *Fix submitted by Valerij Ivashchenko in pull request [16010](https://github.com/magento/magento2/pull/16010)*.
+<!-- ENGCOM-1960  -->
+*  We've improved the readability of `app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php`. *Fix submitted by Valerij Ivashchenko in pull request [16010](https://github.com/magento/magento2/pull/16010)*.
 
-<!-- ENGCOM-1611 -->* Template syntax errors in `app/code/Magento/Theme/Block/Html/Breadcrumbs.php` have been corrected. *Fix submitted by Namrata in pull request [15339](https://github.com/magento/magento2/pull/15339)*. [GitHub-15345](https://github.com/magento/magento2/issues/15345)
+<!-- ENGCOM-1611  -->
+*  Template syntax errors in `app/code/Magento/Theme/Block/Html/Breadcrumbs.php` have been corrected. *Fix submitted by Namrata in pull request [15339](https://github.com/magento/magento2/pull/15339)*. [GitHub-15345](https://github.com/magento/magento2/issues/15345)
 
-<!-- ENGCOM-2107 -->* The calendar widget (`jQuery UI DatePicker`) now correctly displays more than one month. *Fix submitted by Burlacu Vasilii in pull request [16279](https://github.com/magento/magento2/pull/16279)*. [GitHub-7379](https://github.com/magento/magento2/issues/7379)
+<!-- ENGCOM-2107  -->
+*  The calendar widget (`jQuery UI DatePicker`) now correctly displays more than one month. *Fix submitted by Burlacu Vasilii in pull request [16279](https://github.com/magento/magento2/pull/16279)*. [GitHub-7379](https://github.com/magento/magento2/issues/7379)
 
-<!-- ENGCOM-2211 -->* An error with the template notation for `Magento_CatalogWidget` module has been fixed. *Fix submitted by Namrata in pull request [16530](https://github.com/magento/magento2/pull/16530)*. [GitHub-16529](https://github.com/magento/magento2/issues/16529)
+<!-- ENGCOM-2211  -->
+*  An error with the template notation for `Magento_CatalogWidget` module has been fixed. *Fix submitted by Namrata in pull request [16530](https://github.com/magento/magento2/pull/16530)*. [GitHub-16529](https://github.com/magento/magento2/issues/16529)
 
-<!-- ENGCOM-2077 -->* You can now use the `addTabAfter` method to add two or more tabs to the Admin  (for example, the Order View page) in the expected order. Previously, Magento did not preserve the correct sort order for the new tabs. *Fix submitted by Tiago Sampaio in pull request [16175](https://github.com/magento/magento2/pull/16175)*. [GitHub-16174](https://github.com/magento/magento2/issues/16174)
+<!-- ENGCOM-2077  -->
+*  You can now use the `addTabAfter` method to add two or more tabs to the Admin  (for example, the Order View page) in the expected order. Previously, Magento did not preserve the correct sort order for the new tabs. *Fix submitted by Tiago Sampaio in pull request [16175](https://github.com/magento/magento2/pull/16175)*. [GitHub-16174](https://github.com/magento/magento2/issues/16174)
 
-<!-- ENGCOM-2263 -->* The headers of the User Agent Rules table now align as expected with the content of the table's rows. *Fix submitted by Justin in pull request [16704](https://github.com/magento/magento2/pull/16704)*. [GitHub-16703](https://github.com/magento/magento2/issues/16703)
+<!-- ENGCOM-2263  -->
+*  The headers of the User Agent Rules table now align as expected with the content of the table's rows. *Fix submitted by Justin in pull request [16704](https://github.com/magento/magento2/pull/16704)*. [GitHub-16703](https://github.com/magento/magento2/issues/16703)
 
-<!-- ENGCOM-2288 -->* We've added `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by hitesh-wagento in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-15848](https://github.com/magento/magento2/issues/15848)
+<!-- ENGCOM-2288  -->
+*  We've added `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by hitesh-wagento in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-15848](https://github.com/magento/magento2/issues/15848)
 
-<!-- ENGCOM-2336 -->* Store view home pages in multistore deployments no longer display breadcrumbs. Previously, the first store view in a multistore deployment looked fine, but the other store views included unnecessary breadcrumbs on the home page.  *Fix submitted by Oleksandr Kravchuk in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-6504](https://github.com/magento/magento2/issues/6504)
+<!-- ENGCOM-2336  -->
+*  Store view home pages in multistore deployments no longer display breadcrumbs. Previously, the first store view in a multistore deployment looked fine, but the other store views included unnecessary breadcrumbs on the home page.  *Fix submitted by Oleksandr Kravchuk in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-6504](https://github.com/magento/magento2/issues/6504)
 
-<!-- ENGCOM-2412 -->* HTML minification now works as expected. *Fix submitted by Ronak Patel in pull request [16916](https://github.com/magento/magento2/pull/16916)*. [GitHub-5316](https://github.com/magento/magento2/issues/5316)
+<!-- ENGCOM-2412  -->
+*  HTML minification now works as expected. *Fix submitted by Ronak Patel in pull request [16916](https://github.com/magento/magento2/pull/16916)*. [GitHub-5316](https://github.com/magento/magento2/issues/5316)
 
-<!-- ENGCOM-2295 -->* The type of the `transport` event parameter  has been changed to `DataObject`. This change reverts a change from type `DataObject` to `Array()` made in a previous release. *Fix submitted by gwharton in pull request [16599](https://github.com/magento/magento2/pull/16599)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!-- ENGCOM-2295  -->
+*  The type of the `transport` event parameter  has been changed to `DataObject`. This change reverts a change from type `DataObject` to `Array()` made in a previous release. *Fix submitted by gwharton in pull request [16599](https://github.com/magento/magento2/pull/16599)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!-- ENGCOM-1467 -->* Transport variable can now be altered in the `email_invoice_set_template_vars_before` event. *Fix submitted by gwharton in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!-- ENGCOM-1467  -->
+*  Transport variable can now be altered in the `email_invoice_set_template_vars_before` event. *Fix submitted by gwharton in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!-- ENGCOM-2591 -->* Replaced deprecated methods in the `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php`, and `app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php`. *Fix submitted by Tiago Sampaio in pull request [17227](https://github.com/magento/magento2/pull/17227)*.
+<!-- ENGCOM-2591  -->
+*  Replaced deprecated methods in the `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php`, and `app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php`. *Fix submitted by Tiago Sampaio in pull request [17227](https://github.com/magento/magento2/pull/17227)*.
 
-<!-- ENGCOM-2553 -->* Replaced deprecated methods in 44 files. *Fix submitted by Tiago Sampaio in pull request [17035](https://github.com/magento/magento2/pull/17035)*.
+<!-- ENGCOM-2553  -->
+*  Replaced deprecated methods in 44 files. *Fix submitted by Tiago Sampaio in pull request [17035](https://github.com/magento/magento2/pull/17035)*.
 
-<!-- ENGCOM-2533 -->* The `template.js` has been updated to make the `jquery` variable consistently use `$`. Previously, JavaScript in the `template.js` sometimes used `jquery` and sometimes `$`, and Magento threw an error when running in Internet Explorer. *Fix submitted by Angelo Maragna in pull request [17129](https://github.com/magento/magento2/pull/17129)*.
+<!-- ENGCOM-2533  -->
+*  The `template.js` has been updated to make the `jquery` variable consistently use `$`. Previously, JavaScript in the `template.js` sometimes used `jquery` and sometimes `$`, and Magento threw an error when running in Internet Explorer. *Fix submitted by Angelo Maragna in pull request [17129](https://github.com/magento/magento2/pull/17129)*.
 
-<!-- ENGCOM-2522 -->* Corrected an undefined class property in the `app/code/Magento/Backend/Block/Media/Uploader.php getConfigJson()` method.  *Fix submitted by Prince Patel in pull request [17099](https://github.com/magento/magento2/pull/17099)*.
+<!-- ENGCOM-2522  -->
+*  Corrected an undefined class property in the `app/code/Magento/Backend/Block/Media/Uploader.php getConfigJson()` method.  *Fix submitted by Prince Patel in pull request [17099](https://github.com/magento/magento2/pull/17099)*.
 
-<!-- ENGCOM-2476 -->* Corrected sticky footer in `page-main` container height on mobile devices. *Fix submitted by Denis Belevtsov in pull request [17006](https://github.com/magento/magento2/pull/17006)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
+<!-- ENGCOM-2476  -->
+*  Corrected sticky footer in `page-main` container height on mobile devices. *Fix submitted by Denis Belevtsov in pull request [17006](https://github.com/magento/magento2/pull/17006)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!-- ENGCOM-2458 -->* Corrected the return type of methods in `app/code/Magento/Catalog/Controller/Category/View.php`, `app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php`, and `app/code/Magento/CatalogSearch/Model/ResourceModel/EngineInterface.php`. *Fix submitted by Pratik Oza in pull request [16988](https://github.com/magento/magento2/pull/16988)*.
+<!-- ENGCOM-2458  -->
+*  Corrected the return type of methods in `app/code/Magento/Catalog/Controller/Category/View.php`, `app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php`, and `app/code/Magento/CatalogSearch/Model/ResourceModel/EngineInterface.php`. *Fix submitted by Pratik Oza in pull request [16988](https://github.com/magento/magento2/pull/16988)*.
 
-<!-- ENGCOM-2480 -->* Style groups for mobile devices (`max-width`) are now specified in the correct order. *Fix submitted by Tejash Kumbhare in pull request [16959](https://github.com/magento/magento2/pull/16959)*. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
+<!-- ENGCOM-2480  -->
+*  Style groups for mobile devices (`max-width`) are now specified in the correct order. *Fix submitted by Tejash Kumbhare in pull request [16959](https://github.com/magento/magento2/pull/16959)*. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
 
-<!-- ENGCOM-2447 -->* Removed double occurrences of words from `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, `Magento_Sales`,  and `lib` and `dev` test function comments. *Fix submitted by Pratik Oza in pull request [16977](https://github.com/magento/magento2/pull/16977)*.
+<!-- ENGCOM-2447  -->
+*  Removed double occurrences of words from `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, `Magento_Sales`,  and `lib` and `dev` test function comments. *Fix submitted by Pratik Oza in pull request [16977](https://github.com/magento/magento2/pull/16977)*.
 
-<!-- ENGCOM-2446 -->* Corrected the namespace that is defined in `compare.phtml`. *Fix submitted by Ronak Patel in pull request [16978](https://github.com/magento/magento2/pull/16978)*.
+<!-- ENGCOM-2446  -->
+*  Corrected the namespace that is defined in `compare.phtml`. *Fix submitted by Ronak Patel in pull request [16978](https://github.com/magento/magento2/pull/16978)*.
 
-<!-- ENGCOM-2424 -->* Edited verbose code in  `app/code/Magento/Customer/Controller/Account/LoginPost.php`. *Fix submitted by Glenn Cheng in pull request [16928](https://github.com/magento/magento2/pull/16928)*.
+<!-- ENGCOM-2424  -->
+*  Edited verbose code in  `app/code/Magento/Customer/Controller/Account/LoginPost.php`. *Fix submitted by Glenn Cheng in pull request [16928](https://github.com/magento/magento2/pull/16928)*.
 
-<!-- ENGCOM-2396 -->* Fixed annotations in the following methods: `lib/internal/Magento/Framework/Acl/AclResource/Config/Converter/Dom.php`, `lib/internal/Magento/Framework/Acl/AclResource/Config/SchemaLocator.php`, and `lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php`. *Fix submitted by Tiago Sampaio in pull request [16899](https://github.com/magento/magento2/pull/16899)*.
+<!-- ENGCOM-2396  -->
+*  Fixed annotations in the following methods: `lib/internal/Magento/Framework/Acl/AclResource/Config/Converter/Dom.php`, `lib/internal/Magento/Framework/Acl/AclResource/Config/SchemaLocator.php`, and `lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php`. *Fix submitted by Tiago Sampaio in pull request [16899](https://github.com/magento/magento2/pull/16899)*.
 
 <!-- ENGCOM-2389 -->
 *  Removed or edited code comments in the following files:
@@ -947,157 +1309,224 @@ Our community contributors have made many helpful, minor corrections to spelling
 
    *  `app/code/Magento/Sales/view/adminhtml/templates/order/totals.phtml`. *Fix submitted by Pratik Oza in pull request [16891](https://github.com/magento/magento2/pull/16891)*.
 
-<!-- ENGCOM-2404 -->* Improved product gallery block helper code (`app/code/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php`). *Fix submitted by Valerij Ivashchenko in pull request [16889](https://github.com/magento/magento2/pull/16889)*.
+<!-- ENGCOM-2404  -->
+*  Improved product gallery block helper code (`app/code/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php`). *Fix submitted by Valerij Ivashchenko in pull request [16889](https://github.com/magento/magento2/pull/16889)*.
 
-<!-- ENGCOM-2388 -->* Removed duplicated string from `app/code/Magento/ProductVideo/i18n/en_US.csv`. *Fix submitted by Valerij Ivashchenko in pull request [16882](https://github.com/magento/magento2/pull/16882)*.
+<!-- ENGCOM-2388  -->
+*  Removed duplicated string from `app/code/Magento/ProductVideo/i18n/en_US.csv`. *Fix submitted by Valerij Ivashchenko in pull request [16882](https://github.com/magento/magento2/pull/16882)*.
 
-<!-- ENGCOM-2327 -->* Refactored code in `dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php` so that an undefined index warning is no longer triggered when using uppercase reserved word *Fix submitted by Freek Vandeursen in pull request [16785](https://github.com/magento/magento2/pull/16785)*.
+<!-- ENGCOM-2327  -->
+*  Refactored code in `dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php` so that an undefined index warning is no longer triggered when using uppercase reserved word *Fix submitted by Freek Vandeursen in pull request [16785](https://github.com/magento/magento2/pull/16785)*.
 
-<!-- ENGCOM-2274 -->* Regex in `ControllerAclTest::getControllerPath()` has been changed to avoid classes that are under a namespace with a controller component (such as controller plugins) being interpreted as controllers. *Fix submitted by Freek Vandeursen in pull request [16707](https://github.com/magento/magento2/pull/16707)*.
+<!-- ENGCOM-2274  -->
+*  Regex in `ControllerAclTest::getControllerPath()` has been changed to avoid classes that are under a namespace with a controller component (such as controller plugins) being interpreted as controllers. *Fix submitted by Freek Vandeursen in pull request [16707](https://github.com/magento/magento2/pull/16707)*.
 
-<!-- ENGCOM-2259 -->* Knockout template files now include a `title` attribute in the `img` tag. *Fix submitted by Namrata in pull request [16691](https://github.com/magento/magento2/pull/16691)*.
+<!-- ENGCOM-2259  -->
+*  Knockout template files now include a `title` attribute in the `img` tag. *Fix submitted by Namrata in pull request [16691](https://github.com/magento/magento2/pull/16691)*.
 
-<!-- ENGCOM-2256 -->* Added `title` attribute to links as needed for compatibility with w3c standards to these files: `app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml`,  `app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml`,  `app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml`, `app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml`,  and `app/code/Magento/Ui/view/base/web/templates/block-loader.html`. *Fix submitted by Namrata in pull request [16689](https://github.com/magento/magento2/pull/16689)*.
+<!-- ENGCOM-2256  -->
+*  Added `title` attribute to links as needed for compatibility with w3c standards to these files: `app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml`,  `app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml`,  `app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml`, `app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml`,  and `app/code/Magento/Ui/view/base/web/templates/block-loader.html`. *Fix submitted by Namrata in pull request [16689](https://github.com/magento/magento2/pull/16689)*.
 
-<!-- ENGCOM-2196 -->* Search icons are now defined by header icon variables. *Fix submitted by Karla Saaremäe in pull request [16559](https://github.com/magento/magento2/pull/16559)*.
+<!-- ENGCOM-2196  -->
+*  Search icons are now defined by header icon variables. *Fix submitted by Karla Saaremäe in pull request [16559](https://github.com/magento/magento2/pull/16559)*.
 
-<!-- ENGCOM-2202 -->* Module namespace is now defined before template path name. Previously, when we overrode any core block to any custom module, Magento threw an error because trying to find the template file in the custom module if the module namespace is not defined before the template path. *Fix submitted by Prince Patel in pull request [16576](https://github.com/magento/magento2/pull/16576)*.
+<!-- ENGCOM-2202  -->
+*  Module namespace is now defined before template path name. Previously, when we overrode any core block to any custom module, Magento threw an error because trying to find the template file in the custom module if the module namespace is not defined before the template path. *Fix submitted by Prince Patel in pull request [16576](https://github.com/magento/magento2/pull/16576)*.
 
-<!-- ENGCOM-2191 -->* Corrected the comment for the `Magento_Setup` module `includeClasses` function. *Fix submitted by Namrata in pull request [16549](https://github.com/magento/magento2/pull/16549)*.
+<!-- ENGCOM-2191  -->
+*  Corrected the comment for the `Magento_Setup` module `includeClasses` function. *Fix submitted by Namrata in pull request [16549](https://github.com/magento/magento2/pull/16549)*.
 
-<!-- ENGCOM-2162 -->* The  `module:status` command now clearly provides an easily parsed listing of all enabled and disabled modules. *Fix submitted by Jisse Reitsma in pull request [15543](https://github.com/magento/magento2/pull/15543)*.
+<!-- ENGCOM-2162  -->
+*  The  `module:status` command now clearly provides an easily parsed listing of all enabled and disabled modules. *Fix submitted by Jisse Reitsma in pull request [15543](https://github.com/magento/magento2/pull/15543)*.
 
-<!-- ENGCOM-1979 -->* Fixed the `false` value for the `cache_lifetime` argument in `Magento/Swatches/view/frontend/layout/checkout_cart_configure_type_configurable.xml`. *Fix submitted by yuriyDne in pull request [16086](https://github.com/magento/magento2/pull/16086)*.
+<!-- ENGCOM-1979  -->
+*  Fixed the `false` value for the `cache_lifetime` argument in `Magento/Swatches/view/frontend/layout/checkout_cart_configure_type_configurable.xml`. *Fix submitted by yuriyDne in pull request [16086](https://github.com/magento/magento2/pull/16086)*.
 
-<!-- ENGCOM-2143 -->* CSRF tokens are now considered sensitive strings. *Fix submitted by Robert in pull request [13509](https://github.com/magento/magento2/pull/13509)*.
+<!-- ENGCOM-2143  -->
+*  CSRF tokens are now considered sensitive strings. *Fix submitted by Robert in pull request [13509](https://github.com/magento/magento2/pull/13509)*.
 
-<!-- ENGCOM-2039 -->*  Refactored JavaScript code in `popup.phtml` and `popup.js`. *Fix submitted by IvanPletnyov in pull request [16216](https://github.com/magento/magento2/pull/16216)*.
+<!-- ENGCOM-2039  -->
+*   Refactored JavaScript code in `popup.phtml` and `popup.js`. *Fix submitted by IvanPletnyov in pull request [16216](https://github.com/magento/magento2/pull/16216)*.
 
-<!-- ENGCOM-1630 -->* Removed extraneous cursor property. *Fix submitted by Daniel Ruf in pull request [15305](https://github.com/magento/magento2/pull/15305)*.
+<!-- ENGCOM-1630  -->
+*  Removed extraneous cursor property. *Fix submitted by Daniel Ruf in pull request [15305](https://github.com/magento/magento2/pull/15305)*.
 
-<!-- ENGCOM-1688 -->* `app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml` now uses the stored value of the `getPartners` method instead of calling same method again. *Fix submitted by Saurabh Parekh in pull request [15517](https://github.com/magento/magento2/pull/15517)*.
+<!-- ENGCOM-1688  -->
+*  `app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml` now uses the stored value of the `getPartners` method instead of calling same method again. *Fix submitted by Saurabh Parekh in pull request [15517](https://github.com/magento/magento2/pull/15517)*.
 
-<!-- ENGCOM-1655 -->* Added missing lowercase conversion on grouped product assignation. *Fix submitted by Juan Alonso in pull request [15312](https://github.com/magento/magento2/pull/15312)*.
+<!-- ENGCOM-1655  -->
+*  Added missing lowercase conversion on grouped product assignation. *Fix submitted by Juan Alonso in pull request [15312](https://github.com/magento/magento2/pull/15312)*.
 
-<!-- ENGCOM-1643 -->* Removed code responsible for multiple add-to-cart initializations when Magento loads the product listing. *Fix submitted by Vova Yatsyuk in pull request [15409](https://github.com/magento/magento2/pull/15409)*.
+<!-- ENGCOM-1643  -->
+*  Removed code responsible for multiple add-to-cart initializations when Magento loads the product listing. *Fix submitted by Vova Yatsyuk in pull request [15409](https://github.com/magento/magento2/pull/15409)*.
 
-<!-- ENGCOM-1641 -->* Refactored JavaScript code from `popup.phtml` to meet Magento coding standards. *Fix submitted by Rahul Kachhadiya in pull request [15341](https://github.com/magento/magento2/pull/15341)*.
+<!-- ENGCOM-1641  -->
+*  Refactored JavaScript code from `popup.phtml` to meet Magento coding standards. *Fix submitted by Rahul Kachhadiya in pull request [15341](https://github.com/magento/magento2/pull/15341)*.
 
-<!-- ENGCOM-1577 -->* Removed redundant PHPdoc comment and deprecated private method `getSerializer` in `\Magento\Customer\Model\Customer\NotificationStorage` class. *Fix submitted by adrian-martinez-interactiv4 in pull request [15262](https://github.com/magento/magento2/pull/15262)*.
+<!-- ENGCOM-1577  -->
+*  Removed redundant PHPdoc comment and deprecated private method `getSerializer` in `\Magento\Customer\Model\Customer\NotificationStorage` class. *Fix submitted by adrian-martinez-interactiv4 in pull request [15262](https://github.com/magento/magento2/pull/15262)*.
 
-<!-- ENGCOM-1520 -->* CSS code is now automatically updated in the browser. Previously, users had to press **CTRL+F5**  to see CSS changes. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
+<!-- ENGCOM-1520  -->
+*  CSS code is now automatically updated in the browser. Previously, users had to press **CTRL+F5**  to see CSS changes. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
 
-<!-- ENGCOM-1515 -->* Concrete type hints for product and category resources have been added to `app/code/Magento/Catalog/Model/Category.php` and `app/code/Magento/Catalog/Model/Product.php` to help with static analysis and IDE autocompletion. *Fix submitted by Yaroslav Rogoza in pull request [15136](https://github.com/magento/magento2/pull/15136)*.
+<!-- ENGCOM-1515  -->
+*  Concrete type hints for product and category resources have been added to `app/code/Magento/Catalog/Model/Category.php` and `app/code/Magento/Catalog/Model/Product.php` to help with static analysis and IDE autocompletion. *Fix submitted by Yaroslav Rogoza in pull request [15136](https://github.com/magento/magento2/pull/15136)*.
 
-<!-- ENGCOM-1452 -->* Replaced `rand` with `rand_int` in several modules. *Fix submitted by Daniel Ruf in pull request [15017](https://github.com/magento/magento2/pull/15017)*.
+<!-- ENGCOM-1452  -->
+*  Replaced `rand` with `rand_int` in several modules. *Fix submitted by Daniel Ruf in pull request [15017](https://github.com/magento/magento2/pull/15017)*.
 
-<!-- ENGCOM-1446 -->* Optimized `if-condition` in `/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php`. *Fix submitted by Valerij Ivashchenko in pull request [15002](https://github.com/magento/magento2/pull/15002)*.
+<!-- ENGCOM-1446  -->
+*  Optimized `if-condition` in `/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php`. *Fix submitted by Valerij Ivashchenko in pull request [15002](https://github.com/magento/magento2/pull/15002)*.
 
-<!-- ENGCOM-1453 -->* We've upgraded to Node.js 8 from Node.js 6. *Fix submitted by Daniel Ruf in pull request [15018](https://github.com/magento/magento2/pull/15018)*.
+<!-- ENGCOM-1453  -->
+*  We've upgraded to Node.js 8 from Node.js 6. *Fix submitted by Daniel Ruf in pull request [15018](https://github.com/magento/magento2/pull/15018)*.
 
-<!-- ENGCOM-1434 -->* Replaced `template/path` with `Module_Name::template/path` in the block class to ensure extensibility of the class. Previously, if the source block classes referenced a template without specifying the module name, then block render failed with this error: `Invalid template file`. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1434  -->
+*  Replaced `template/path` with `Module_Name::template/path` in the block class to ensure extensibility of the class. Previously, if the source block classes referenced a template without specifying the module name, then block render failed with this error: `Invalid template file`. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1405 -->* Replaced the `\Magento\Backend\Helper\Data` parameter with `\Magento\Backend\Model\UrlInterface` to make them identical with the  constructor. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1405  -->
+*  Replaced the `\Magento\Backend\Helper\Data` parameter with `\Magento\Backend\Model\UrlInterface` to make them identical with the  constructor. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1403 -->* The return type of `addToCartPostParams` in `app/code/Magento/Catalog/Block/Product/ListProduct.php` has been changed to array. *Fix submitted by Sean Templeton in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1403  -->
+*  The return type of `addToCartPostParams` in `app/code/Magento/Catalog/Block/Product/ListProduct.php` has been changed to array. *Fix submitted by Sean Templeton in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1270 -->*  Datepicker now correctly converts date formats in locales other than `en-US`. *Fix submitted by Tao Sasaki in pull request [14627](https://github.com/magento/magento2/pull/14627)*.
+<!-- ENGCOM-1270  -->
+*   Datepicker now correctly converts date formats in locales other than `en-US`. *Fix submitted by Tao Sasaki in pull request [14627](https://github.com/magento/magento2/pull/14627)*.
 
-<!-- ENGCOM-1270 -->* `default_head_blocks.xml` now contains the `order` attribute for setting the load order of stylesheets. *Fix submitted by Tao Sasaki in pull request [14290](https://github.com/magento/magento2/pull/14290)*.
+<!-- ENGCOM-1270  -->
+*  `default_head_blocks.xml` now contains the `order` attribute for setting the load order of stylesheets. *Fix submitted by Tao Sasaki in pull request [14290](https://github.com/magento/magento2/pull/14290)*.
 
-<!-- ENGCOM-2455 -->* Magento now displays validation messages on the advanced search form as expected if you submit the advanced search form without entries. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
+<!-- ENGCOM-2455  -->
+*  Magento now displays validation messages on the advanced search form as expected if you submit the advanced search form without entries. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
 
-<!-- MAGETWO-84477 -->* `\Magento\Framework\Reflection\TypeProcessor` methods have been simplified.
+<!-- MAGETWO-84477  -->
+*  `\Magento\Framework\Reflection\TypeProcessor` methods have been simplified.
 
-<!-- MAGETWO-87024 -->* Magento no longer unsets the taxed shipping total information before returning the total tax.
+<!-- MAGETWO-87024  -->
+*  Magento no longer unsets the taxed shipping total information before returning the total tax.
 
 ### JavaScript
 
-<!-- ENGCOM-1640 -->* Refactored the  JavaScript code of the button split widget. *Fix submitted by amittiwari024 in pull request [15351](https://github.com/magento/magento2/pull/15351)*. [GitHub-15354](https://github.com/magento/magento2/issues/15354)
+<!-- ENGCOM-1640  -->
+*  Refactored the  JavaScript code of the button split widget. *Fix submitted by amittiwari024 in pull request [15351](https://github.com/magento/magento2/pull/15351)*. [GitHub-15354](https://github.com/magento/magento2/issues/15354)
 
 ### Klarna
 
-<!-- BUNDLE-1489 -->* Magento no longer throws multiple JavaScript errors when a customer selects Klarna from the Review & Payments page.
+<!-- BUNDLE-1489  -->
+*  Magento no longer throws multiple JavaScript errors when a customer selects Klarna from the Review & Payments page.
 
 ### Module Manager
 
-<!-- ENGCOM-1633 -->* Module Manager module grid now works as expected. *Fix submitted by Alex Gusev in pull request [15211](https://github.com/magento/magento2/pull/15211)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
+<!-- ENGCOM-1633  -->
+*  Module Manager module grid now works as expected. *Fix submitted by Alex Gusev in pull request [15211](https://github.com/magento/magento2/pull/15211)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
 
 ### Newsletter
 
-<!-- MAGETWO-88217 -->* Guest users can now sign up for newsletters for multiple stores. Previously, when a guest user signed up for a newsletter from multiple stores, Magento sent a subscription confirmation message, but did not successfully subscribe the user.
+<!-- MAGETWO-88217  -->
+*  Guest users can now sign up for newsletters for multiple stores. Previously, when a guest user signed up for a newsletter from multiple stores, Magento sent a subscription confirmation message, but did not successfully subscribe the user.
 
-<!-- MAGETWO-87969 -->* Magento now correctly updates newsletter subscriptions  when the customer is registered on two stores. Previously, when the customer tried to subscribe to the newsletter from a second store, Magento displayed this message, `You are (not) subscribed to "General Subscription"`.
+<!-- MAGETWO-87969  -->
+*  Magento now correctly updates newsletter subscriptions  when the customer is registered on two stores. Previously, when the customer tried to subscribe to the newsletter from a second store, Magento displayed this message, `You are (not) subscribed to "General Subscription"`.
 
-<!--  ENGCOM-1573 -->* The newsletter subscription confirmation message does not display after a customer clicks the link that is included in the confirmation email. *Fix submitted by Kaushik Chavda in pull request [15247](https://github.com/magento/magento2/pull/15247)*. [GitHub-14747](https://github.com/magento/magento2/issues/14747)
+<!--  ENGCOM-1573  -->
+*  The newsletter subscription confirmation message does not display after a customer clicks the link that is included in the confirmation email. *Fix submitted by Kaushik Chavda in pull request [15247](https://github.com/magento/magento2/pull/15247)*. [GitHub-14747](https://github.com/magento/magento2/issues/14747)
 
-<!-- ENGCOM-2144 -->* Magento now sends a confirmation request email to the customer when she unsubscribes to a newsletter. *Fix submitted by Lyzun Oleksandr in pull request [15464](https://github.com/magento/magento2/pull/15464)*. [GitHub-15218](https://github.com/magento/magento2/issues/15218)
+<!-- ENGCOM-2144  -->
+*  Magento now sends a confirmation request email to the customer when she unsubscribes to a newsletter. *Fix submitted by Lyzun Oleksandr in pull request [15464](https://github.com/magento/magento2/pull/15464)*. [GitHub-15218](https://github.com/magento/magento2/issues/15218)
 
-<!-- ENGCOM-2379 -->* Removed the direct use of the object manager and loaded the dependency via constructor dependency injection in `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php` and `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php`. *Fix submitted by AnshuMishra17 in pull request [16851](https://github.com/magento/magento2/pull/16851)*.
+<!-- ENGCOM-2379  -->
+*  Removed the direct use of the object manager and loaded the dependency via constructor dependency injection in `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php` and `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php`. *Fix submitted by AnshuMishra17 in pull request [16851](https://github.com/magento/magento2/pull/16851)*.
 
-<!-- ENGCOM-2272 -->* Newsletter registration now works the same when registered customers subscribe from My Account and or from the newsletter block. *Fix submitted by Lyzun Oleksandr in pull request [15479](https://github.com/magento/magento2/pull/15479)*.
+<!-- ENGCOM-2272  -->
+*  Newsletter registration now works the same when registered customers subscribe from My Account and or from the newsletter block. *Fix submitted by Lyzun Oleksandr in pull request [15479](https://github.com/magento/magento2/pull/15479)*.
 
-<!-- ENGCOM-2236 -->* Removed the redundant return statement from  `getJsTemplateName` function comment in the `Magento_Newsletter`'s block file. *Fix submitted by Namrata in pull request [16645](https://github.com/magento/magento2/pull/16645)*.
+<!-- ENGCOM-2236  -->
+*  Removed the redundant return statement from  `getJsTemplateName` function comment in the `Magento_Newsletter`'s block file. *Fix submitted by Namrata in pull request [16645](https://github.com/magento/magento2/pull/16645)*.
 
 ### Payment methods
 
 #### Braintree
 
-<!-- MAGETWO-89221 -->* You can now cancel an order that was placed with Braintree when the Braintree authorization had expired.
+<!-- MAGETWO-89221  -->
+*  You can now cancel an order that was placed with Braintree when the Braintree authorization had expired.
 
-<!-- MAGETWO-84929 -->* All invoices now have the merchant account ID set in the store configuration for the Braintree payment method. Previously, the default merchant account ID was sent to Braintree for any subsequent partial order invoices after the initial invoice is generated.
+<!-- MAGETWO-84929  -->
+*  All invoices now have the merchant account ID set in the store configuration for the Braintree payment method. Previously, the default merchant account ID was sent to Braintree for any subsequent partial order invoices after the initial invoice is generated.
 
-<!-- ENGCOM-2149 -->* Braintree configuration (`app/code/Magento/Braintree/etc/adminhtml/system.xml`) now contains `showInStore` attributes. *Fix submitted by Andreas Schrammel in pull request [16458](https://github.com/magento/magento2/pull/16458)*.
+<!-- ENGCOM-2149  -->
+*  Braintree configuration (`app/code/Magento/Braintree/etc/adminhtml/system.xml`) now contains `showInStore` attributes. *Fix submitted by Andreas Schrammel in pull request [16458](https://github.com/magento/magento2/pull/16458)*.
 
-<!-- ENGCOM-1513 -->* Magento now retains the correct address information when a customer using Braintree's **Pay with PayPal** button to complete an order navigates back to the shipping step and changes the shipping address fields. *Fix submitted by Vova Yatsyuk in pull request [15133](https://github.com/magento/magento2/pull/15133)*.
+<!-- ENGCOM-1513  -->
+*  Magento now retains the correct address information when a customer using Braintree's **Pay with PayPal** button to complete an order navigates back to the shipping step and changes the shipping address fields. *Fix submitted by Vova Yatsyuk in pull request [15133](https://github.com/magento/magento2/pull/15133)*.
 
 #### PayPal
 
-<!-- MAGETWO-92820 -->* Customers can now continue creating an order  after a PayFlow Pro payment has been declined. Previously, under these circumstances. the customer could not continue his purchase.
+<!-- MAGETWO-92820  -->
+*  Customers can now continue creating an order  after a PayFlow Pro payment has been declined. Previously, under these circumstances. the customer could not continue his purchase.
 
-<!-- MAGETWO-89995 -->* Paypal Onboarding has been configured to work for  merchants from  countries other than the United States.
+<!-- MAGETWO-89995  -->
+*  Paypal Onboarding has been configured to work for  merchants from  countries other than the United States.
 
-<!-- MAGETWO-88244 -->* Magento now accurately displays the status of PayPal orders. Previously, the status of PayPal orders was displayed only as  **Processing**.
+<!-- MAGETWO-88244  -->
+*  Magento now accurately displays the status of PayPal orders. Previously, the status of PayPal orders was displayed only as  **Processing**.
 
-<!-- ENGCOM-1372 -->* Magento no longer sends duplicate order confirmation emails when a customer uses PayPal Express to complete an order. *Fix submitted by Rocket Web in pull request [14820](https://github.com/magento/magento2/pull/14820)*.
+<!-- ENGCOM-1372  -->
+*  Magento no longer sends duplicate order confirmation emails when a customer uses PayPal Express to complete an order. *Fix submitted by Rocket Web in pull request [14820](https://github.com/magento/magento2/pull/14820)*.
 
-<!-- MAGETWO-88759 -->* Tax amount calculation for payments processed through PayPal now works as expected. Previously, Magento sent the wrong amount to PayPal when a discount was applied to an order.
+<!-- MAGETWO-88759  -->
+*  Tax amount calculation for payments processed through PayPal now works as expected. Previously, Magento sent the wrong amount to PayPal when a discount was applied to an order.
 
-<!--  ENGCOM-1462 -->* The `Allmethods config` source model now reports the full list of payment methods as expected. *Fix submitted by Manuel Schmid in pull request [15032](https://github.com/magento/magento2/pull/15032)*. [GitHub-13460](https://github.com/magento/magento2/issues/13460)
+<!--  ENGCOM-1462  -->
+*  The `Allmethods config` source model now reports the full list of payment methods as expected. *Fix submitted by Manuel Schmid in pull request [15032](https://github.com/magento/magento2/pull/15032)*. [GitHub-13460](https://github.com/magento/magento2/issues/13460)
 
-<!-- MAGETWO-85908 -->* You can now cancel an order placed through Cybersource when the fraud filters are triggered.
+<!-- MAGETWO-85908  -->
+*  You can now cancel an order placed through Cybersource when the fraud filters are triggered.
 
-<!-- MAGETWO- 92625-->* Magento now emails customer order confirmations for orders that are placed through Worldpay.
+<!-- MAGETWO- 92625 -->
+*  Magento now emails customer order confirmations for orders that are placed through Worldpay.
 
-<!-- MAGETWO-92784 -->* Magento now correctly applies free shipping to an order after the customer applied the free shipping code  during checkout.
+<!-- MAGETWO-92784  -->
+*  Magento now correctly applies free shipping to an order after the customer applied the free shipping code  during checkout.
 
-<!-- MAGETWO-90571 -->* Magento no longer sends Admin orders to Signifyd for review when Signifyd is disabled on the website on which the administrator is logged in.
+<!-- MAGETWO-90571  -->
+*  Magento no longer sends Admin orders to Signifyd for review when Signifyd is disabled on the website on which the administrator is logged in.
 
-<!-- MAGETWO-90533 -->* Magento now successfully creates shipping labels for a return merchandise authorization (RMA) when using FedEx Smart Post as the shipping option. Previously, Magento threw an error under these circumstances.
+<!-- MAGETWO-90533  -->
+*  Magento now successfully creates shipping labels for a return merchandise authorization (RMA) when using FedEx Smart Post as the shipping option. Previously, Magento threw an error under these circumstances.
 
-<!-- MAGETWO-84495 -->* Magento now sends email about payment failures to customers. Previously, Magento did not send a customer email, but instead logged an error in  `support.log`, and displayed this message on the storefront, **Transaction has been declined. Please try again later**.
+<!-- MAGETWO-84495  -->
+*  Magento now sends email about payment failures to customers. Previously, Magento did not send a customer email, but instead logged an error in  `support.log`, and displayed this message on the storefront, **Transaction has been declined. Please try again later**.
 
-<!--  ENGCOM-1648 -->* Magento no longer throws an error when multiple payment methods  are enabled. Previously, when a merchant tried to enable more than one payment method from the Admin, Magento displayed this error in the console, `Found elements with non-unique id billing-address-form`. *Fix submitted by Neeta Kangiya in pull request [15349](https://github.com/magento/magento2/pull/15349)*. [GitHub-15348](https://github.com/magento/magento2/issues/15348)
+<!--  ENGCOM-1648  -->
+*  Magento no longer throws an error when multiple payment methods  are enabled. Previously, when a merchant tried to enable more than one payment method from the Admin, Magento displayed this error in the console, `Found elements with non-unique id billing-address-form`. *Fix submitted by Neeta Kangiya in pull request [15349](https://github.com/magento/magento2/pull/15349)*. [GitHub-15348](https://github.com/magento/magento2/issues/15348)
 
-<!-- MAGETWO-92625 -->* Magento now sends order confirmation emails as expected for orders purchased with WorldPay.
+<!-- MAGETWO-92625  -->
+*  Magento now sends order confirmation emails as expected for orders purchased with WorldPay.
 
-<!-- ENGCOM-2021 -->* A type error in the payment void method of the Authorizenet module has been fixed. *Fix submitted by Oleh Kravets in pull request [16194](https://github.com/magento/magento2/pull/16194)*. [GitHub-16184](https://github.com/magento/magento2/issues/16184)
+<!-- ENGCOM-2021  -->
+*  A type error in the payment void method of the Authorizenet module has been fixed. *Fix submitted by Oleh Kravets in pull request [16194](https://github.com/magento/magento2/pull/16194)*. [GitHub-16184](https://github.com/magento/magento2/issues/16184)
 
 ### Pagecache
 
-<!-- MAGETWO-92757 -->* Full-page cache now works as expected in multistore deployments. Previously, when you opened the URL of a non-default store in a multistore deployment, full-page cache did not return the URL.
+<!-- MAGETWO-92757  -->
+*  Full-page cache now works as expected in multistore deployments. Previously, when you opened the URL of a non-default store in a multistore deployment, full-page cache did not return the URL.
 
 ### Performance
 
-<!-- MAGETWO-47320 -->* The catalog rule re-indexing operation has been optimized, and average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
+<!-- MAGETWO-47320  -->
+*  The catalog rule re-indexing operation has been optimized, and average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
 
-<!-- MAGETWO-86143 -->* Merchants can now improve store performance by disabling Magento Report functionality if business function does not require this capability. A new configuration setting  (**System Configuration**: **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
+<!-- MAGETWO-86143  -->
+*  Merchants can now improve store performance by disabling Magento Report functionality if business function does not require this capability. A new configuration setting  (**System Configuration**: **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
 
-<!-- MAGETWO-92154 -->* You can change store locale without the exporting and importing configuration process. While Magento is in Production and the `SCD_ON_DEMAND` is enabled, the Magento store and admin locale options are available. See [Change locales]({{ page.baseurl }}/cloud/live/sens-data-over.html#change-locales).
+<!-- MAGETWO-92154  -->
+*  You can change store locale without the exporting and importing configuration process. While Magento is in Production and the `SCD_ON_DEMAND` is enabled, the Magento store and admin locale options are available. See [Change locales]({{ page.baseurl }}/cloud/live/sens-data-over.html#change-locales).
 
-<!-- MAGETWO-90572 -->* The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for certain scenarios.
+<!-- MAGETWO-90572  -->
+*  The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for certain scenarios.
 
-<!-- MAGETWO-88670 -->* The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
+<!-- MAGETWO-88670  -->
+*  The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
 
 <!-- ENGCOM-1294 -->
 *  The speed of catalog price rule save operations has been improved by these changes:
@@ -1106,115 +1535,158 @@ Our community contributors have made many helpful, minor corrections to spelling
 
    *  improvement to the way that the `getMatchingProductIds` function fetches products, which has eliminated unnecessary checks of the data set. *Fix submitted by Andrey Zabara in pull request [14707](https://github.com/magento/magento2/pull/14707)*.
 
-<!-- ENGCOM-1302-->* The ID to SKU lookup process for tier prices has been optimized. Previously, with a large number of tier or group prices, each tier would separately make a database query to look up the associated SKU. *Fix submitted by Todd Christensen in pull request [14699](https://github.com/magento/magento2/pull/14699)*.
+<!-- ENGCOM-1302 -->
+*  The ID to SKU lookup process for tier prices has been optimized. Previously, with a large number of tier or group prices, each tier would separately make a database query to look up the associated SKU. *Fix submitted by Todd Christensen in pull request [14699](https://github.com/magento/magento2/pull/14699)*.
 
 ### Product video
 
-<!-- MAGETWO-93792 -->* Magento now populates the YouTube video URL and Title fields with the same values as are populated on the default store view on multisite deployments. (These fields are global scope attributes and should be the same on all storefronts.) Previously, Magento left these fields blank in multisite deployments.
+<!-- MAGETWO-93792  -->
+*  Magento now populates the YouTube video URL and Title fields with the same values as are populated on the default store view on multisite deployments. (These fields are global scope attributes and should be the same on all storefronts.) Previously, Magento left these fields blank in multisite deployments.
 
 ### Quote
 
-<!-- ENGCOM-1414 -->* Magento now displays the correct product price for an order created from the Admin in multisite deployments. Previously, when an order was created from the Admin in a multisite deployment where products were assigned different prices per store view, Magento defaulted to the product price of the primary storeview if the order was edited or updated. *Fix submitted by Riccardo Tempesta in pull request [14904](https://github.com/magento/magento2/pull/14904)*. [GitHub-14869](https://github.com/magento/magento2/issues/14869)
+<!-- ENGCOM-1414  -->
+*  Magento now displays the correct product price for an order created from the Admin in multisite deployments. Previously, when an order was created from the Admin in a multisite deployment where products were assigned different prices per store view, Magento defaulted to the product price of the primary storeview if the order was edited or updated. *Fix submitted by Riccardo Tempesta in pull request [14904](https://github.com/magento/magento2/pull/14904)*. [GitHub-14869](https://github.com/magento/magento2/issues/14869)
 
-<!-- ENGCOM-1441 -->* Magento now successfully saves the value of `REMOTE_IP` when a customer uses an IPV6 (Internet Protocol version 6) address. Previously, this value was only partially saved in the `sales_order` and `quote` tables.  *Fix submitted by George Schiopu in pull request [14976](https://github.com/magento/magento2/pull/14976)*. [GitHub-10395](https://github.com/magento/magento2/issues/10395)
+<!-- ENGCOM-1441  -->
+*  Magento now successfully saves the value of `REMOTE_IP` when a customer uses an IPV6 (Internet Protocol version 6) address. Previously, this value was only partially saved in the `sales_order` and `quote` tables.  *Fix submitted by George Schiopu in pull request [14976](https://github.com/magento/magento2/pull/14976)*. [GitHub-10395](https://github.com/magento/magento2/issues/10395)
 
-<!-- ENGCOM-1885 -->* Coupon codes now work for guest users through the web API as well as from the storefront. *Fix submitted by Marcin Dykas in pull request [15320](https://github.com/magento/magento2/pull/15320)*. [GitHub-14056](https://github.com/magento/magento2/issues/14056)
+<!-- ENGCOM-1885  -->
+*  Coupon codes now work for guest users through the web API as well as from the storefront. *Fix submitted by Marcin Dykas in pull request [15320](https://github.com/magento/magento2/pull/15320)*. [GitHub-14056](https://github.com/magento/magento2/issues/14056)
 
-<!-- ENGCOM-2254 -->* Magento no longer runs an SQL query on every item in the database when a quote is empty, which has improved the performance of the checkout process. *Fix submitted by Sean Templeton in pull request [16675](https://github.com/magento/magento2/pull/16675)*.
+<!-- ENGCOM-2254  -->
+*  Magento no longer runs an SQL query on every item in the database when a quote is empty, which has improved the performance of the checkout process. *Fix submitted by Sean Templeton in pull request [16675](https://github.com/magento/magento2/pull/16675)*.
 
 ### Reports
 
-<!-- ENGCOM-2215 -->* The timezone has been removed from the date when Magento retrieves the current month from a UTC timestamp. *Fix submitted by Prince Patel in pull request [16584](https://github.com/magento/magento2/pull/16584)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
+<!-- ENGCOM-2215  -->
+*  The timezone has been removed from the date when Magento retrieves the current month from a UTC timestamp. *Fix submitted by Prince Patel in pull request [16584](https://github.com/magento/magento2/pull/16584)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
 
 ### Review
 
-<!-- ENGCOM-1535 -->* Removed the unused class declaration from controller's index action and the unused code in the comment block from the template file in `app/code/Magento/Review/view/frontend/templates/redirect.phtml` and `app/code/Magento/Version/Controller/Index/Index.php`. *Fix submitted by Yogesh Suhagiya in pull request [15173](https://github.com/magento/magento2/pull/15173)*.
+<!-- ENGCOM-1535  -->
+*  Removed the unused class declaration from controller's index action and the unused code in the comment block from the template file in `app/code/Magento/Review/view/frontend/templates/redirect.phtml` and `app/code/Magento/Version/Controller/Index/Index.php`. *Fix submitted by Yogesh Suhagiya in pull request [15173](https://github.com/magento/magento2/pull/15173)*.
 
 ### Rule
 
-<!-- MAGETWO-89220 -->* A cart rule that uses  a `subselection` condition now works as executed. Previously, cart rules with this condition automatically granted a discount.
+<!-- MAGETWO-89220  -->
+*  A cart rule that uses  a `subselection` condition now works as executed. Previously, cart rules with this condition automatically granted a discount.
 
-<!-- ENGCOM-1961 -->* The retrieval of first array elements in the following files has been improved: `app/code/Magento/Rule/Model/Action/AbstractAction.php` and `app/code/Magento/Rule/Model/Condition/Combine.php`. *Fix submitted by Thomas Klein in pull request [16053](https://github.com/magento/magento2/pull/16053)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
+<!-- ENGCOM-1961  -->
+*  The retrieval of first array elements in the following files has been improved: `app/code/Magento/Rule/Model/Action/AbstractAction.php` and `app/code/Magento/Rule/Model/Condition/Combine.php`. *Fix submitted by Thomas Klein in pull request [16053](https://github.com/magento/magento2/pull/16053)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
 
-<!-- ENGCOM-1583 -->* The condition category chooser now handles multiple nested categories as expected. Previously,  if a cart rule contained several nested categories, no categories appeared on the page, the page  became unresponsive,  and  eventually crashed. *Fix submitted by Keith Bentrup in pull request [15265](https://github.com/magento/magento2/pull/15265)*. [GitHub-15121](https://github.com/magento/magento2/issues/15121)
+<!-- ENGCOM-1583  -->
+*  The condition category chooser now handles multiple nested categories as expected. Previously,  if a cart rule contained several nested categories, no categories appeared on the page, the page  became unresponsive,  and  eventually crashed. *Fix submitted by Keith Bentrup in pull request [15265](https://github.com/magento/magento2/pull/15265)*. [GitHub-15121](https://github.com/magento/magento2/issues/15121)
 
 ### Sales
 
-<!-- MAGETWO-93102 -->* Order status now remains in the Complete state after Magento refunds store credit on a partial credit memo. Previously, under these circumstances, Magento changed the status of the order to Closed.
+<!-- MAGETWO-93102  -->
+*  Order status now remains in the Complete state after Magento refunds store credit on a partial credit memo. Previously, under these circumstances, Magento changed the status of the order to Closed.
 
-<!-- MAGETWO-92847 -->* You can now create multiple credit memos in one session and save each successfully. Previously, Magento displayed this error when you tried to save a second credit memo after creating the first memo: `Could not save credit memo`.
+<!-- MAGETWO-92847  -->
+*  You can now create multiple credit memos in one session and save each successfully. Previously, Magento displayed this error when you tried to save a second credit memo after creating the first memo: `Could not save credit memo`.
 
-<!-- MAGETWO-92899 -->* Magento now displays any errors that occur during order creation in the browser console. Previously, Magento displayed this message: `Uncaught ReferenceError: order is not defined during order creation` instead of a specific error message.
+<!-- MAGETWO-92899  -->
+*  Magento now displays any errors that occur during order creation in the browser console. Previously, Magento displayed this message: `Uncaught ReferenceError: order is not defined during order creation` instead of a specific error message.
 
-<!-- MAGETWO-91466 -->* The `POST /V1/shipment` endpoint processes `tracks` arrays as expected.
+<!-- MAGETWO-91466  -->
+*  The `POST /V1/shipment` endpoint processes `tracks` arrays as expected.
 
-<!-- MAGETWO-90496 -->* Magento no longer reverts to the country associated with the default website when a customer edits the billing address for an order. Previously, if a customer edited the shipping address for an order, Magento would reset the billing address to the default address specified for the default website.
+<!-- MAGETWO-90496  -->
+*  Magento no longer reverts to the country associated with the default website when a customer edits the billing address for an order. Previously, if a customer edited the shipping address for an order, Magento would reset the billing address to the default address specified for the default website.
 
-<!-- ENGCOM-2148 -->* Credit memo email template file incorrect object types have been corrected. Previously, when a merchant created a credit memo and checked the **Email** checkbox, Magento threw an error. *Fix submitted by Joseph Maxwell in pull request [16438](https://github.com/magento/magento2/pull/16438)*.
+<!-- ENGCOM-2148  -->
+*  Credit memo email template file incorrect object types have been corrected. Previously, when a merchant created a credit memo and checked the **Email** checkbox, Magento threw an error. *Fix submitted by Joseph Maxwell in pull request [16438](https://github.com/magento/magento2/pull/16438)*.
 
-<!-- MAGETWO-89238 -->* Performance issues that resulted from disabling invoice emails have been resolved.
+<!-- MAGETWO-89238  -->
+*  Performance issues that resulted from disabling invoice emails have been resolved.
 
-<!-- ENGCOM-2085 -->* The Invoices grid now reflects changes in invoice state as expected. *Fix submitted by JeroenVanLeusden in pull request [16286](https://github.com/magento/magento2/pull/16286)*.
+<!-- ENGCOM-2085  -->
+*  The Invoices grid now reflects changes in invoice state as expected. *Fix submitted by JeroenVanLeusden in pull request [16286](https://github.com/magento/magento2/pull/16286)*.
 
-<!-- ENGCOM-1892 -->* You can now set the `is_visible_on_front` parameter from the `addStatusHistoryComment` of the order mode. Previously, you could set the `is_visible_on_front` parameter  from the Admin only. *Fix submitted by Mark Shust in pull request [15637](https://github.com/magento/magento2/pull/15637)*.
+<!-- ENGCOM-1892  -->
+*  You can now set the `is_visible_on_front` parameter from the `addStatusHistoryComment` of the order mode. Previously, you could set the `is_visible_on_front` parameter  from the Admin only. *Fix submitted by Mark Shust in pull request [15637](https://github.com/magento/magento2/pull/15637)*.
 
-<!-- ENGCOM-2024 -->* Module name space is now declared before the template pathname in `Magento_Sales::order/info.phtml`. *Fix submitted by Ronak Patel in pull request [16206](https://github.com/magento/magento2/pull/16206)*.
+<!-- ENGCOM-2024  -->
+*  Module name space is now declared before the template pathname in `Magento_Sales::order/info.phtml`. *Fix submitted by Ronak Patel in pull request [16206](https://github.com/magento/magento2/pull/16206)*.
 
-<!-- ENGCOM-1529 -->* The `addFieldToFilter` has been added to `addressCollection` in  `app/code/Magento/Sales/Setup/UpgradeData.php`, which optimizes the process of collecting addresses during upgrade. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1529  -->
+*  The `addFieldToFilter` has been added to `addressCollection` in  `app/code/Magento/Sales/Setup/UpgradeData.php`, which optimizes the process of collecting addresses during upgrade. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
-<!-- ENGCOM-1623 -->* Invoice prefixes now contain the correct store ID when Magento is deployed in a multistore environment. Previously, Magento always created the invoice number using the default store view ID. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*. [GitHub-14063](https://github.com/magento/magento2/issues/14063)
+<!-- ENGCOM-1623  -->
+*  Invoice prefixes now contain the correct store ID when Magento is deployed in a multistore environment. Previously, Magento always created the invoice number using the default store view ID. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*. [GitHub-14063](https://github.com/magento/magento2/issues/14063)
 
-<!-- ENGCOM-1531 -->* The `GET /V1/orders/items/{id}` request now returns `parent_item`. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1531  -->
+*  The `GET /V1/orders/items/{id}` request now returns `parent_item`. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
 ### Sales rules
 
-<!-- MAGETWO-91797 -->* Cart price rules with associated coupons are no longer affected by edits to scheduled updates.
+<!-- MAGETWO-91797  -->
+*  Cart price rules with associated coupons are no longer affected by edits to scheduled updates.
 
-<!-- ENGCOM-2122 -->* The  `discount` label in the `app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js` file is now compatible with custom module discount.  *Fix submitted by Rodrigo Santellan in pull request [16093](https://github.com/magento/magento2/pull/16093)*.
+<!-- ENGCOM-2122  -->
+*  The  `discount` label in the `app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js` file is now compatible with custom module discount.  *Fix submitted by Rodrigo Santellan in pull request [16093](https://github.com/magento/magento2/pull/16093)*.
 
 ### Search
 
-<!-- ENGCOM-1381 -->* Magento no longer throws an error when a customer uses quick search to search on a term that does not exist in the search database. Previously, Magento returned this error, `TypeError: this._getFirstVisibleElement(...).addClass is not a function`. *Fix submitted by Julien ANQUETIL in pull request [14839](https://github.com/magento/magento2/pull/14839)*. [GitHub-14274](https://github.com/magento/magento2/issues/14274)
+<!-- ENGCOM-1381  -->
+*  Magento no longer throws an error when a customer uses quick search to search on a term that does not exist in the search database. Previously, Magento returned this error, `TypeError: this._getFirstVisibleElement(...).addClass is not a function`. *Fix submitted by Julien ANQUETIL in pull request [14839](https://github.com/magento/magento2/pull/14839)*. [GitHub-14274](https://github.com/magento/magento2/issues/14274)
 
-<!-- ENGCOM-1616 -->* Customers can now use the **Enter** key to submit searches from a page header. Previously, when a customer used the **Enter** key to submit a search query, event handlers that were bound to the form submit (through jQuery) were fired twice. *Fix submitted by Amjad M in pull request [15340](https://github.com/magento/magento2/pull/15340)*. [GitHub-13793](https://github.com/magento/magento2/issues/13793)
+<!-- ENGCOM-1616  -->
+*  Customers can now use the **Enter** key to submit searches from a page header. Previously, when a customer used the **Enter** key to submit a search query, event handlers that were bound to the form submit (through jQuery) were fired twice. *Fix submitted by Amjad M in pull request [15340](https://github.com/magento/magento2/pull/15340)*. [GitHub-13793](https://github.com/magento/magento2/issues/13793)
 
-<!-- ENGCOM-1887 -->* Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Jakub in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-15322](https://github.com/magento/magento2/issues/15322)
+<!-- ENGCOM-1887  -->
+*  Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Jakub in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-15322](https://github.com/magento/magento2/issues/15322)
 
-<!--  MAGETWO-85786 -->* The Admin panel search now filters catalogs as expected. Previously, if a merchant tried to narrow a search when using the Search tool in the Admin panel, Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request [12735](https://github.com/magento/magento2/pull/12735)*. [GitHub-7861](https://github.com/magento/magento2/issues/7861)
+<!--  MAGETWO-85786  -->
+*  The Admin panel search now filters catalogs as expected. Previously, if a merchant tried to narrow a search when using the Search tool in the Admin panel, Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request [12735](https://github.com/magento/magento2/pull/12735)*. [GitHub-7861](https://github.com/magento/magento2/issues/7861)
 
-<!--  ENGCOM-1415 -->* You can now use an asterix when searching on customer names. Previously, if you used an asterix in a search query, Magento displayed this message, `Something went wrong with processing the default view and we have restored the filter to its original state.` *Fix submitted by Riccardo Tempesta  in pull request [14905](https://github.com/magento/magento2/pull/14905)*. [GitHub-14855](https://github.com/magento/magento2/issues/14855)
+<!--  ENGCOM-1415  -->
+*  You can now use an asterix when searching on customer names. Previously, if you used an asterix in a search query, Magento displayed this message, `Something went wrong with processing the default view and we have restored the filter to its original state.` *Fix submitted by Riccardo Tempesta  in pull request [14905](https://github.com/magento/magento2/pull/14905)*. [GitHub-14855](https://github.com/magento/magento2/issues/14855)
 
-<!-- ENGCOM-2455 -->* Magento now displays validation messages as needed on advanced searches. Previously, Magento did not display a message even after a customer submitted the advanced search form with no entries. *Fix submitted by Ben Robie in pull request [16952](https://github.com/magento/magento2/pull/16952)*. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
+<!-- ENGCOM-2455  -->
+*  Magento now displays validation messages as needed on advanced searches. Previously, Magento did not display a message even after a customer submitted the advanced search form with no entries. *Fix submitted by Ben Robie in pull request [16952](https://github.com/magento/magento2/pull/16952)*. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
 
-<!-- ENGCOM-2245 -->* Server load has been reduced for advanced searching.  Previously, when a customer entered text in the search suggestion box, Magento immediately sent every character to the server. The auto-complete box now delays  sending the request. *Fix submitted by Sean Templeton in pull request [16669](https://github.com/magento/magento2/pull/16669)*.
+<!-- ENGCOM-2245  -->
+*  Server load has been reduced for advanced searching.  Previously, when a customer entered text in the search suggestion box, Magento immediately sent every character to the server. The auto-complete box now delays  sending the request. *Fix submitted by Sean Templeton in pull request [16669](https://github.com/magento/magento2/pull/16669)*.
 
-<!-- ENGCOM-1672 -->* You can now successfully clone the minisearch widget. *Fix submitted by Daniel Ruf in pull request [15485](https://github.com/magento/magento2/pull/15485)*.
+<!-- ENGCOM-1672  -->
+*  You can now successfully clone the minisearch widget. *Fix submitted by Daniel Ruf in pull request [15485](https://github.com/magento/magento2/pull/15485)*.
 
 ### Shipping
 
-<!--  ENGCOM-2033 -->* The shipping and estimated tax form now display country, city, and postcode fields as expected. *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16213](https://github.com/magento/magento2/pull/16213)*. [GitHub-8222](https://github.com/magento/magento2/issues/8222)
+<!--  ENGCOM-2033  -->
+*  The shipping and estimated tax form now display country, city, and postcode fields as expected. *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16213](https://github.com/magento/magento2/pull/16213)*. [GitHub-8222](https://github.com/magento/magento2/issues/8222)
 
-<!--  ENGCOM-1675 -->* A method with a misspelled name was deprecated and the new method with correct spelling added to `app/code/Magento/Multishipping/Block/Checkout/AbstractMultishipping.php`. *Fix submitted by Anna Völkl in pull request [15514](https://github.com/magento/magento2/pull/15514)*.
+<!--  ENGCOM-1675  -->
+*  A method with a misspelled name was deprecated and the new method with correct spelling added to `app/code/Magento/Multishipping/Block/Checkout/AbstractMultishipping.php`. *Fix submitted by Anna Völkl in pull request [15514](https://github.com/magento/magento2/pull/15514)*.
 
 ### Store
 
-<!--  ENGCOM-1706 -->* Magento now adds the correct store code to product URLs in stores with more than one store view when  **Stores** > **Settings** > **Configuration** > **General** > **Web** > **Add Store Code to Urls** is set to **yes**. *Fix submitted by Elias Kotlyar in pull request [15566](https://github.com/magento/magento2/pull/15566)*. [GitHub-15565](https://github.com/magento/magento2/issues/15565)
+<!--  ENGCOM-1706  -->
+*  Magento now adds the correct store code to product URLs in stores with more than one store view when  **Stores** > **Settings** > **Configuration** > **General** > **Web** > **Add Store Code to Urls** is set to **yes**. *Fix submitted by Elias Kotlyar in pull request [15566](https://github.com/magento/magento2/pull/15566)*. [GitHub-15565](https://github.com/magento/magento2/issues/15565)
 
-<!--  ENGCOM-1249 -->* Magento now displays store views as expected when you select **Stores** > **Terms and Conditions**. *Fix submitted by afirlejczyk in pull request [14546](https://github.com/magento/magento2/pull/14546)*. [GitHub-13944](https://github.com/magento/magento2/issues/13944)
+<!--  ENGCOM-1249  -->
+*  Magento now displays store views as expected when you select **Stores** > **Terms and Conditions**. *Fix submitted by afirlejczyk in pull request [14546](https://github.com/magento/magento2/pull/14546)*. [GitHub-13944](https://github.com/magento/magento2/issues/13944)
 
 #### Elasticsearch
 
-<!-- MAGETWO-92142 -->* Bundle products are now indexed as expected in Elasticsearch.
+<!-- MAGETWO-92142  -->
+*  Bundle products are now indexed as expected in Elasticsearch.
 
-<!-- MAGETWO-86153 -->* Elasticsearch now correctly calculates the relevance of quick search results according to selected attribute search weights.
+<!-- MAGETWO-86153  -->
+*  Elasticsearch now correctly calculates the relevance of quick search results according to selected attribute search weights.
 
 #### Admin global search
 
-<!-- MAGETWO-86658 -->* Admin global search preview now works as expected. Previously, this feature worked inconsistently, and search results  differed depending on which area was being searched  (for example, Products, Categories, or Customers).
+<!-- MAGETWO-86658  -->
+*  Admin global search preview now works as expected. Previously, this feature worked inconsistently, and search results  differed depending on which area was being searched  (for example, Products, Categories, or Customers).
 
-<!-- MAGETWO-86289 -->* The Admin global search now returns results that match the keyword for all available pages, or if a user searches in  specific sections, the search feature now returns only the results that matched the key words in those specific sections. Previously, the Admin global search did not return results that matched the specified keywords and did not restrict results to specified sections.
+<!-- MAGETWO-86289  -->
+*  The Admin global search now returns results that match the keyword for all available pages, or if a user searches in  specific sections, the search feature now returns only the results that matched the key words in those specific sections. Previously, the Admin global search did not return results that matched the specified keywords and did not restrict results to specified sections.
 
-<!-- MAGETWO-85786 -->* Catalogs are now correctly filtered by the Admin search bar. Previously, if you attempted to use the Search tool in the Admin, and selected "XX in Products", Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request 12735*. [GitHub-12193](https://github.com/magento/magento2/issues/12193), [GitHub-7861](https://github.com/magento/magento2/issues/7861)
+<!-- MAGETWO-85786  -->
+*  Catalogs are now correctly filtered by the Admin search bar. Previously, if you attempted to use the Search tool in the Admin, and selected "XX in Products", Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request 12735*. [GitHub-12193](https://github.com/magento/magento2/issues/12193), [GitHub-7861](https://github.com/magento/magento2/issues/7861)
 
 ### Shipping
 
@@ -1222,23 +1694,30 @@ Our community contributors have made many helpful, minor corrections to spelling
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{page.baseurl}}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 </div>
 
-<!-- MAGETWO-92217 -->* The free shipping cart price rule now works as expected when **UPS shipping method** is enabled and **Free Shipping** is set to "For matching items only".
+<!-- MAGETWO-92217  -->
+*  The free shipping cart price rule now works as expected when **UPS shipping method** is enabled and **Free Shipping** is set to "For matching items only".
 
-<!-- MAGETWO-91035 -->* The shipping progress dates displayed in tracking popup for FedEx shipping are now accurate.
+<!-- MAGETWO-91035  -->
+*  The shipping progress dates displayed in tracking popup for FedEx shipping are now accurate.
 
 ### Sitemap
 
-<!-- MAGETWO-92781 -->* Sitemaps generated by `cron` no longer display  `/pub/` in image URLs when  `docroot` is set to `/pub`. Previously, if the `docroot` was set to `pub` and `BASE MEDIA URL` was not set, the cron-generated sitemap  generated incorrect image URLs.
+<!-- MAGETWO-92781  -->
+*  Sitemaps generated by `cron` no longer display  `/pub/` in image URLs when  `docroot` is set to `/pub`. Previously, if the `docroot` was set to `pub` and `BASE MEDIA URL` was not set, the cron-generated sitemap  generated incorrect image URLs.
 
-<!-- ENGCOM-1073 -->* Magento now generates correct product URLs for sitemaps. Previously, when the **Use Categories Path for Product URLs** attribute was set to **no**  in **Configuration** >  **Catalog** > **Search Engine Optimization**, Magento generated the wrong product URL in the sitemap.
+<!-- ENGCOM-1073  -->
+*  Magento now generates correct product URLs for sitemaps. Previously, when the **Use Categories Path for Product URLs** attribute was set to **no**  in **Configuration** >  **Catalog** > **Search Engine Optimization**, Magento generated the wrong product URL in the sitemap.
 
-<!-- ENGCOM-1866 -->* Images in XML sitemap are no longer always linked to the primary store in a multistore deployment. *Fix submitted by Steven de Jong in pull request [15689](https://github.com/magento/magento2/pull/15689)*. [GitHub-15588](https://github.com/magento/magento2/issues/15588)
+<!-- ENGCOM-1866  -->
+*  Images in XML sitemap are no longer always linked to the primary store in a multistore deployment. *Fix submitted by Steven de Jong in pull request [15689](https://github.com/magento/magento2/pull/15689)*. [GitHub-15588](https://github.com/magento/magento2/issues/15588)
 
-<!-- ENGCOM-1377 -->* Split sitemaps now use the index sitemap name as a prefix. Previously, when generating large sitemaps that result in a single index sitemap and several smaller split sitemap files, the split sitemap files did not use the same name prefix as the parent. *Fix submitted by James Halsall in pull request [14836](https://github.com/magento/magento2/pull/14836)*.
+<!-- ENGCOM-1377  -->
+*  Split sitemaps now use the index sitemap name as a prefix. Previously, when generating large sitemaps that result in a single index sitemap and several smaller split sitemap files, the split sitemap files did not use the same name prefix as the parent. *Fix submitted by James Halsall in pull request [14836](https://github.com/magento/magento2/pull/14836)*.
 
 ### Store
 
-<!--  ENGCOM-2530 -->* The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Burlacu Vasilii in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
+<!--  ENGCOM-2530  -->
+*  The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Burlacu Vasilii in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
 
 ### Swatches
 
@@ -1253,133 +1732,190 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 
 ### Tax
 
-<!--  ENGCOM-1551 -->* Redundant product tax recalculation has been reduced during the loading of category pages, which has improved page loading. *Fix submitted by JeroenVanLeusden in pull request [15089](https://github.com/magento/magento2/pull/15089)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
+<!--  ENGCOM-1551  -->
+*  Redundant product tax recalculation has been reduced during the loading of category pages, which has improved page loading. *Fix submitted by JeroenVanLeusden in pull request [15089](https://github.com/magento/magento2/pull/15089)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
 
-<!--  ENGCOM-1642 -->* JavaScript code in the `*.phtml` file of the Tax module has been refactored to meet Magento coding standards. *Fix submitted by Vishal Gelani in pull request [15343](https://github.com/magento/magento2/pull/15343)*. [GitHub-15352](https://github.com/magento/magento2/issues/15352)
+<!--  ENGCOM-1642  -->
+*  JavaScript code in the `*.phtml` file of the Tax module has been refactored to meet Magento coding standards. *Fix submitted by Vishal Gelani in pull request [15343](https://github.com/magento/magento2/pull/15343)*. [GitHub-15352](https://github.com/magento/magento2/issues/15352)
 
-<!--  ENGCOM-2386 -->* The `Invalid country code` error message that sometimes occurred during import of tax CSV files now includes the name of the country whose data is causing the error. Previously, the message did not identify which country's data caused the error. *Fix submitted by Adam Moss in pull request [16873](https://github.com/magento/magento2/pull/16873)*.
+<!--  ENGCOM-2386  -->
+*  The `Invalid country code` error message that sometimes occurred during import of tax CSV files now includes the name of the country whose data is causing the error. Previously, the message did not identify which country's data caused the error. *Fix submitted by Adam Moss in pull request [16873](https://github.com/magento/magento2/pull/16873)*.
 
 ### Testing
 
-<!--  ENGCOM-2523 -->* The `testGetIgnoresFirstSlash` method in `ObjectManagerTest` has been updated. *Fix submitted by Prince Patel in pull request [17098](https://github.com/magento/magento2/pull/17098)*.
+<!--  ENGCOM-2523  -->
+*  The `testGetIgnoresFirstSlash` method in `ObjectManagerTest` has been updated. *Fix submitted by Prince Patel in pull request [17098](https://github.com/magento/magento2/pull/17098)*.
 
-<!--  ENGCOM-2499 -->* The `\Magento\Backup\Model\Db` model is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17063](https://github.com/magento/magento2/pull/17063)*.
+<!--  ENGCOM-2499  -->
+*  The `\Magento\Backup\Model\Db` model is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17063](https://github.com/magento/magento2/pull/17063)*.
 
-<!--  ENGCOM-2239 -->* Corrected block name in the `Magento_Framework` test XML file. *Fix submitted by Namrata in pull request [16646](https://github.com/magento/magento2/pull/16646)*.
+<!--  ENGCOM-2239  -->
+*  Corrected block name in the `Magento_Framework` test XML file. *Fix submitted by Namrata in pull request [16646](https://github.com/magento/magento2/pull/16646)*.
 
-<!--  ENGCOM-2106 -->* Metadata titles in `lib/internal/Magento/Framework/View/Page/Config.php` are now covered by a unit test. *Fix submitted by Lorenzo Stramaccia in pull request [16333](https://github.com/magento/magento2/pull/16333)*.
+<!--  ENGCOM-2106  -->
+*  Metadata titles in `lib/internal/Magento/Framework/View/Page/Config.php` are now covered by a unit test. *Fix submitted by Lorenzo Stramaccia in pull request [16333](https://github.com/magento/magento2/pull/16333)*.
 
-<!-- ENGCOM-2255 -->* The `\Magento\Checkout\Model\Cart\CollectQuote` class is now covered by a unit test. *Fix submitted by Chitoraga Eduard in pull request [16271](https://github.com/magento/magento2/pull/16271)*.
+<!-- ENGCOM-2255  -->
+*  The `\Magento\Checkout\Model\Cart\CollectQuote` class is now covered by a unit test. *Fix submitted by Chitoraga Eduard in pull request [16271](https://github.com/magento/magento2/pull/16271)*.
 
 ### Theme
 
-<!--  ENGCOM-1516 -->* Merchants can now successfully change the applied theme. Previously, Magento displayed an error when a merchant tried to save changes to the applied theme on **Content** > **Design** > **Configuration**. *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-13530](https://github.com/magento/magento2/issues/13530)
+<!--  ENGCOM-1516  -->
+*  Merchants can now successfully change the applied theme. Previously, Magento displayed an error when a merchant tried to save changes to the applied theme on **Content** > **Design** > **Configuration**. *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-13530](https://github.com/magento/magento2/issues/13530)
 
-<!--  ENGCOM-1516 -->* Merchants can now successfully change the applied theme setting for a store view (**Content** > **Design** > **Configuration**). *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-14968](https://github.com/magento/magento2/issues/14968)
+<!--  ENGCOM-1516  -->
+*  Merchants can now successfully change the applied theme setting for a store view (**Content** > **Design** > **Configuration**). *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-14968](https://github.com/magento/magento2/issues/14968)
 
-<!--  ENGCOM-1922 -->* Changing the `@tab-content__border` variable in Blank theme now works as expected. *Fix submitted by hitesh-wagento in pull request [15914](https://github.com/magento/magento2/pull/15914)*. [GitHub-14999](https://github.com/magento/magento2/issues/14999)
+<!--  ENGCOM-1922  -->
+*  Changing the `@tab-content__border` variable in Blank theme now works as expected. *Fix submitted by hitesh-wagento in pull request [15914](https://github.com/magento/magento2/pull/15914)*. [GitHub-14999](https://github.com/magento/magento2/issues/14999)
 
 ### Translation
 
-<!-- MAGETWO-92210 -->* The `translation.json` file now contains translatable strings for the phrases "Store Credit" and "Gift Card". Previously, these strings were not translated for the shopping cart, one-page checkout, or order view in the customer account on the storefront.
+<!-- MAGETWO-92210  -->
+*  The `translation.json` file now contains translatable strings for the phrases "Store Credit" and "Gift Card". Previously, these strings were not translated for the shopping cart, one-page checkout, or order view in the customer account on the storefront.
 
-<!-- MAGETWO-92355 -->* We've added  client-side caching of `js-translation.js`.
+<!-- MAGETWO-92355  -->
+*  We've added  client-side caching of `js-translation.js`.
 
-<!-- ENGCOM-1965 -->* Removed the unused translation for `comment` tag from these files: `app/code/Magento/Analytics/etc/adminhtml/system.xml`, `app/code/Magento/Catalog/etc/adminhtml/system.xml`, `app/code/Magento/Swatches/etc/adminhtml/system.xml`, and `app/code/Magento/Ups/etc/adminhtml/system.xml`. *Fix submitted by Yaroslav Rogoza in pull request [15604](https://github.com/magento/magento2/pull/15604)*.
+<!-- ENGCOM-1965  -->
+*  Removed the unused translation for `comment` tag from these files: `app/code/Magento/Analytics/etc/adminhtml/system.xml`, `app/code/Magento/Catalog/etc/adminhtml/system.xml`, `app/code/Magento/Swatches/etc/adminhtml/system.xml`, and `app/code/Magento/Ups/etc/adminhtml/system.xml`. *Fix submitted by Yaroslav Rogoza in pull request [15604](https://github.com/magento/magento2/pull/15604)*.
 
-<!-- ENGCOM-1604 -->* Added language translation capability  for `comment` tags in the  `system.xml` file of the Signifyd  module. *Fix submitted by Yogesh Suhagiya in pull request [15364](https://github.com/magento/magento2/pull/15364)*. [GitHub-15361](https://github.com/magento/magento2/issues/15361)
+<!-- ENGCOM-1604  -->
+*  Added language translation capability  for `comment` tags in the  `system.xml` file of the Signifyd  module. *Fix submitted by Yogesh Suhagiya in pull request [15364](https://github.com/magento/magento2/pull/15364)*. [GitHub-15361](https://github.com/magento/magento2/issues/15361)
 
-<!-- ENGCOM-1855 -->* All previously unsupported `translate` tags in the mini cart template are now supported. *Fix submitted by VitaliyBoyko in pull request [15782](https://github.com/magento/magento2/pull/15782)*.
+<!-- ENGCOM-1855  -->
+*  All previously unsupported `translate` tags in the mini cart template are now supported. *Fix submitted by VitaliyBoyko in pull request [15782](https://github.com/magento/magento2/pull/15782)*.
 
-<!-- ENGCOM-2020 -->* The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16190](https://github.com/magento/magento2/pull/16190)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
+<!-- ENGCOM-2020  -->
+*  The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16190](https://github.com/magento/magento2/pull/16190)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
 
-<!-- ENGCOM-2257 -->*  Added language translation capability to the Braintree module's template file. *Fix submitted by Namrata in pull request [16690](https://github.com/magento/magento2/pull/16690)*.
+<!-- ENGCOM-2257  -->
+*   Added language translation capability to the Braintree module's template file. *Fix submitted by Namrata in pull request [16690](https://github.com/magento/magento2/pull/16690)*.
 
-<!-- ENGCOM-2192 -->* Added mini cart checkout-related translations that were missing from `app/code/Magento/Checkout/i18n/en_US.csv`. *Fix submitted by JeroenVanLeusden in pull request [16553](https://github.com/magento/magento2/pull/16553)*.
+<!-- ENGCOM-2192  -->
+*  Added mini cart checkout-related translations that were missing from `app/code/Magento/Checkout/i18n/en_US.csv`. *Fix submitted by JeroenVanLeusden in pull request [16553](https://github.com/magento/magento2/pull/16553)*.
 
-<!-- ENGCOM-1591 -->* Added language translation capability for labels in the Braintree, Multishipping, and PayPal modules. *Fix submitted by Rahul Kachhadiya in pull request [15371](https://github.com/magento/magento2/pull/15371)*.
+<!-- ENGCOM-1591  -->
+*  Added language translation capability for labels in the Braintree, Multishipping, and PayPal modules. *Fix submitted by Rahul Kachhadiya in pull request [15371](https://github.com/magento/magento2/pull/15371)*.
 
-<!-- ENGCOM-1609 -->* Added language translation capability for  message strings in  `app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php` and `app/code/Magento/AdminNotification/i18n/en_US.csv`. *Fix submitted by Yogesh Suhagiya in pull request [15333](https://github.com/magento/magento2/pull/15333)*.
+<!-- ENGCOM-1609  -->
+*  Added language translation capability for  message strings in  `app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php` and `app/code/Magento/AdminNotification/i18n/en_US.csv`. *Fix submitted by Yogesh Suhagiya in pull request [15333](https://github.com/magento/magento2/pull/15333)*.
 
 ### UI
 
-<!--  ENGCOM-1542 -->* The `clickableOverlay` option now works as expected, which improves the performance of modal popups. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
+<!--  ENGCOM-1542  -->
+*  The `clickableOverlay` option now works as expected, which improves the performance of modal popups. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
 
-<!--  ENGCOM-1315 -->* Customers can now place orders from grouped products where the quantity of subproducts is less than one. *Fix submitted by Valerij Ivashchenko in pull request [14752](https://github.com/magento/magento2/pull/14752)*. [GitHub-14692](https://github.com/magento/magento2/issues/14692)
+<!--  ENGCOM-1315  -->
+*  Customers can now place orders from grouped products where the quantity of subproducts is less than one. *Fix submitted by Valerij Ivashchenko in pull request [14752](https://github.com/magento/magento2/pull/14752)*. [GitHub-14692](https://github.com/magento/magento2/issues/14692)
 
-<!--  ENGCOM-1606 -->* Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Chirag Matholiya in pull request [15353](https://github.com/magento/magento2/pull/15353)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
+<!--  ENGCOM-1606  -->
+*  Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Chirag Matholiya in pull request [15353](https://github.com/magento/magento2/pull/15353)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!--  ENGCOM-1766 -->* The pagination of customer group prices in Advanced Pricing when viewed on the Admin now works as expected. *Fix submitted by Dmytro Cheshun in pull request [15614](https://github.com/magento/magento2/pull/15614)*. [GitHub-15210](https://github.com/magento/magento2/issues/15210)
+<!--  ENGCOM-1766  -->
+*  The pagination of customer group prices in Advanced Pricing when viewed on the Admin now works as expected. *Fix submitted by Dmytro Cheshun in pull request [15614](https://github.com/magento/magento2/pull/15614)*. [GitHub-15210](https://github.com/magento/magento2/issues/15210)
 
-<!--  ENGCOM-1982 -->* Magento now displays a caret icon as expected when a user hovers his mouse over a navigation category on a storefront. *Fix submitted by Tejash Kumbhare in pull request [16082](https://github.com/magento/magento2/pull/16082)*. [GitHub-15220](https://github.com/magento/magento2/issues/15220)
+<!--  ENGCOM-1982  -->
+*  Magento now displays a caret icon as expected when a user hovers his mouse over a navigation category on a storefront. *Fix submitted by Tejash Kumbhare in pull request [16082](https://github.com/magento/magento2/pull/16082)*. [GitHub-15220](https://github.com/magento/magento2/issues/15220)
 
-<!--  ENGCOM-2155 -->* Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button.  *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16477](https://github.com/magento/magento2/pull/16477)*. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
+<!--  ENGCOM-2155  -->
+*  Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button.  *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16477](https://github.com/magento/magento2/pull/16477)*. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
 
-<!--  ENGCOM-2479 -->* The alignment **Title** and **Items** on the left bar has been corrected. *Fix submitted by Rafael Corrêa Gomes in pull request [16984](https://github.com/magento/magento2/pull/16984)*.
+<!--  ENGCOM-2479  -->
+*  The alignment **Title** and **Items** on the left bar has been corrected. *Fix submitted by Rafael Corrêa Gomes in pull request [16984](https://github.com/magento/magento2/pull/16984)*.
 
-<!--  ENGCOM-2473 -->*  The black color coding standard has been changed from `color: #000;` to `color: @color-black;`. *Fix submitted by Chirag Matholiya in pull request [17019](https://github.com/magento/magento2/pull/17019)*.
+<!--  ENGCOM-2473  -->
+*   The black color coding standard has been changed from `color: #000;` to `color: @color-black;`. *Fix submitted by Chirag Matholiya in pull request [17019](https://github.com/magento/magento2/pull/17019)*.
 
-<!--  ENGCOM-2399 -->* The white color coding standard has been changed from `color: #fff;` to `color: @color-white;`. *Fix submitted by Chirag Matholiya in pull request [16903](https://github.com/magento/magento2/pull/16903)*.
+<!--  ENGCOM-2399  -->
+*  The white color coding standard has been changed from `color: #fff;` to `color: @color-white;`. *Fix submitted by Chirag Matholiya in pull request [16903](https://github.com/magento/magento2/pull/16903)*.
 
-<!--  ENGCOM-1785 -->* Minor issues with the dynamically defined ``$filter`` property and missing throws to PHPDocs for methods in the UI export converter classes have been corrected. *Fix submitted by Dmytro Cheshun in pull request [15694](https://github.com/magento/magento2/pull/15694)*.
+<!--  ENGCOM-1785  -->
+*  Minor issues with the dynamically defined ``$filter`` property and missing throws to PHPDocs for methods in the UI export converter classes have been corrected. *Fix submitted by Dmytro Cheshun in pull request [15694](https://github.com/magento/magento2/pull/15694)*.
 
-<!--  ENGCOM-1678 -->*  The `ClassMagento\Ui\Component\Control\ActionPool` constructor and `getConfiguration()` in the UI module are now invoked with the correct number of parameters. *Fix submitted by Marcel Hauri in pull request [15512](https://github.com/magento/magento2/pull/15512)*.
+<!--  ENGCOM-1678  -->
+*   The `ClassMagento\Ui\Component\Control\ActionPool` constructor and `getConfiguration()` in the UI module are now invoked with the correct number of parameters. *Fix submitted by Marcel Hauri in pull request [15512](https://github.com/magento/magento2/pull/15512)*.
 
-<!--  ENGCOM-1682 -->* Unneeded JavaScript was removed from `logout.phtml` and replaced with a new JavaScript component. *Fix submitted by Nimesh Patel in pull request [15301](https://github.com/magento/magento2/pull/15301)*
+<!--  ENGCOM-1682  -->
+*  Unneeded JavaScript was removed from `logout.phtml` and replaced with a new JavaScript component. *Fix submitted by Nimesh Patel in pull request [15301](https://github.com/magento/magento2/pull/15301)*
 
-<!--  ENGCOM-2605 -->* Page wrapper CSS has been moved from media query to `.page-wrapper`. *Fix submitted by Vishal Gelani in pull request [15416](https://github.com/magento/magento2/pull/15416)*.
+<!--  ENGCOM-2605  -->
+*  Page wrapper CSS has been moved from media query to `.page-wrapper`. *Fix submitted by Vishal Gelani in pull request [15416](https://github.com/magento/magento2/pull/15416)*.
 
-<!--  ENGCOM-1657 -->* The `font-size` variable has been updated and standardized. *Fix submitted by Vishal Gelani in pull request [15421](https://github.com/magento/magento2/pull/15421)*.
+<!--  ENGCOM-1657  -->
+*  The `font-size` variable has been updated and standardized. *Fix submitted by Vishal Gelani in pull request [15421](https://github.com/magento/magento2/pull/15421)*.
 
-<!--  ENGCOM-1473 -->* Layout arguments now support for the `const` type. *Fix submitted by Igor Vitol in pull request [15058](https://github.com/magento/magento2/pull/15058)*.
+<!--  ENGCOM-1473  -->
+*  Layout arguments now support for the `const` type. *Fix submitted by Igor Vitol in pull request [15058](https://github.com/magento/magento2/pull/15058)*.
 
-<!--  ENGCOM-1547 -->* Button definitions have been moved to the new `buttons.js` file. *Fix submitted by Jisse Reitsma in pull request [15194](https://github.com/magento/magento2/pull/15194)*.
+<!--  ENGCOM-1547  -->
+*  Button definitions have been moved to the new `buttons.js` file. *Fix submitted by Jisse Reitsma in pull request [15194](https://github.com/magento/magento2/pull/15194)*.
 
-<!--  ENGCOM-1438 -->* Overlay issues with the mini cart have been resolved. Previously, if you logged in as a customer, then clicked on the mini cart icon and then the Account menu, the mini cart overlaid the Account menu. *Fix submitted by Arthur James in pull request [14963](https://github.com/magento/magento2/pull/14963)*.
+<!--  ENGCOM-1438  -->
+*  Overlay issues with the mini cart have been resolved. Previously, if you logged in as a customer, then clicked on the mini cart icon and then the Account menu, the mini cart overlaid the Account menu. *Fix submitted by Arthur James in pull request [14963](https://github.com/magento/magento2/pull/14963)*.
 
-<!--  ENGCOM-1313 -->* Magento now supports multiple `ui_components` with layout type `tabs` on a page. Previously, the second UI component failed to render, and Magento displayed this error, `Element with ID 'tabs_nav' already exists`. *Fix submitted by Freek Vandeursen in pull request [14742](https://github.com/magento/magento2/pull/14742)*.
+<!--  ENGCOM-1313  -->
+*  Magento now supports multiple `ui_components` with layout type `tabs` on a page. Previously, the second UI component failed to render, and Magento displayed this error, `Element with ID 'tabs_nav' already exists`. *Fix submitted by Freek Vandeursen in pull request [14742](https://github.com/magento/magento2/pull/14742)*.
 
-<!--  ENGCOM-1313 -->* The order of style groups for mobile devices has been corrected. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
+<!--  ENGCOM-1313  -->
+*  The order of style groups for mobile devices has been corrected. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
 
-<!-- ENGCOM-1869 -->* Dynamic data rows no longer fail due to a read operation after a delete condition. Previously, Magento threw an undefined JavaScript error. *Fix submitted by Chirag Matholiya in pull request [15840](https://github.com/magento/magento2/pull/15840)*. [GitHub-911](https://github.com/magento-engcom/msi/issues/911)
+<!-- ENGCOM-1869  -->
+*  Dynamic data rows no longer fail due to a read operation after a delete condition. Previously, Magento threw an undefined JavaScript error. *Fix submitted by Chirag Matholiya in pull request [15840](https://github.com/magento/magento2/pull/15840)*. [GitHub-911](https://github.com/magento-engcom/msi/issues/911)
 
 ### URL rewrites
 
-<!-- MAGETWO-89905 -->* Categories of the Main menu in the different store view are now updated when Varnish is enabled.
+<!-- MAGETWO-89905  -->
+*  Categories of the Main menu in the different store view are now updated when Varnish is enabled.
 
-<!-- MAGETWO-73456 -->* URL key values are now derived from the  default value set on the default store. Previously, Magento derived the product URL key value from the product name on storeview level.
+<!-- MAGETWO-73456  -->
+*  URL key values are now derived from the  default value set on the default store. Previously, Magento derived the product URL key value from the product name on storeview level.
 
-<!-- ENGCOM-1283 -->* The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character. *Fix submitted by Vinay Shah in pull request [13397](https://github.com/magento/magento2/pull/13397)*. [GitHub-13296](https://github.com/magento/magento2/issues/13296)
+<!-- ENGCOM-1283  -->
+*  The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character. *Fix submitted by Vinay Shah in pull request [13397](https://github.com/magento/magento2/pull/13397)*. [GitHub-13296](https://github.com/magento/magento2/issues/13296)
 
-<!-- ENGCOM-1916 -->* An unnecessary parameter has been removed from `_addProductLinkBlock()`.  *Fix submitted by Saurabh Parekh in pull request [15891](https://github.com/magento/magento2/pull/15891)*.
+<!-- ENGCOM-1916  -->
+*  An unnecessary parameter has been removed from `_addProductLinkBlock()`.  *Fix submitted by Saurabh Parekh in pull request [15891](https://github.com/magento/magento2/pull/15891)*.
 
-<!-- ENGCOM-1656 -->* Template files have been refactored to follow Magento coding standards. *Fix submitted by Nimesh Patel in pull request [15422](https://github.com/magento/magento2/pull/15422)*. [GitHub-15356](https://github.com/magento/magento2/issues/15356)
+<!-- ENGCOM-1656  -->
+*  Template files have been refactored to follow Magento coding standards. *Fix submitted by Nimesh Patel in pull request [15422](https://github.com/magento/magento2/pull/15422)*. [GitHub-15356](https://github.com/magento/magento2/issues/15356)
 
-<!-- ENGCOM-2524 -->* Undefined mixin parameters are now defined and variable scope has been improved in `lib/web/css/source/lib/_icons.less`, `lib/web/css/source/lib/_pages.less`, and `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Prince Patel in pull request [17097](https://github.com/magento/magento2/pull/17097)*.
+<!-- ENGCOM-2524  -->
+*  Undefined mixin parameters are now defined and variable scope has been improved in `lib/web/css/source/lib/_icons.less`, `lib/web/css/source/lib/_pages.less`, and `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Prince Patel in pull request [17097](https://github.com/magento/magento2/pull/17097)*.
 
-<!-- ENGCOM-1314 -->* Magento now removes URL rewrites as expected after you delete a CMS page through the API or in the `crontab` area. *Fix submitted by Roman in pull request [14751](https://github.com/magento/magento2/pull/14751)*.
+<!-- ENGCOM-1314  -->
+*  Magento now removes URL rewrites as expected after you delete a CMS page through the API or in the `crontab` area. *Fix submitted by Roman in pull request [14751](https://github.com/magento/magento2/pull/14751)*.
 
-<!-- MAGETWO-89905 -->* Main menu categories  in  different store views are now updated as expected when Varnish is enabled.
+<!-- MAGETWO-89905  -->
+*  Main menu categories  in  different store views are now updated as expected when Varnish is enabled.
 
 ### Vertex
 
-<!-- BUNDLE-1399 -->*  The Gross Amount and Tax Amount columns in the Transaction Details Report file  now include price and tax for products as expected.
+<!-- BUNDLE-1399  -->
+*   The Gross Amount and Tax Amount columns in the Transaction Details Report file  now include price and tax for products as expected.
 
 ### Wishlist
 
-<!--  ENGCOM-1878 -->* Incorrect return type hinting in DocBlocks has been corrected for several methods in the Wishlist module. *Fix submitted by Yaroslav Rogoza in pull request [15854](https://github.com/magento/magento2/pull/15854)*.
+<!--  ENGCOM-1878  -->
+*  Incorrect return type hinting in DocBlocks has been corrected for several methods in the Wishlist module. *Fix submitted by Yaroslav Rogoza in pull request [15854](https://github.com/magento/magento2/pull/15854)*.
 
-<!--  ENGCOM-1949 -->* Removed an unnecessary parameter from the `toHtml()` method in `Wishlist/view/frontend/templates/item/list.phtml`. *Fix submitted by Yaroslav Rogoza in pull request [16023](https://github.com/magento/magento2/pull/16023)*.
+<!--  ENGCOM-1949  -->
+*  Removed an unnecessary parameter from the `toHtml()` method in `Wishlist/view/frontend/templates/item/list.phtml`. *Fix submitted by Yaroslav Rogoza in pull request [16023](https://github.com/magento/magento2/pull/16023)*.
 
-<!--  ENGCOM-2133 -->* Magento no longer thows errors when you log in using the wishlist URL. *Fix submitted by Oleksandr Kravchuk in pull request [16386](https://github.com/magento/magento2/pull/16386)*.
+<!--  ENGCOM-2133  -->
+*  Magento no longer thows errors when you log in using the wishlist URL. *Fix submitted by Oleksandr Kravchuk in pull request [16386](https://github.com/magento/magento2/pull/16386)*.
 
-<!--  ENGCOM-2128 -->* Magento no longer removes a product from the wishlist when you update a wishlist item. *Fix submitted by Chitoraga Eduard in pull request [16372](https://github.com/magento/magento2/pull/16372)*.
+<!--  ENGCOM-2128  -->
+*  Magento no longer removes a product from the wishlist when you update a wishlist item. *Fix submitted by Chitoraga Eduard in pull request [16372](https://github.com/magento/magento2/pull/16372)*.
 
-<!--  ENGCOM-2035 -->* Magento now passes empty arrays (instead of null values) into the DataObject constructor. Previously, a null value was passed, which caused a fatal error. *Fix submitted by Abhishek Jakhotiya in pull request [16220](https://github.com/magento/magento2/pull/16220)*.
+<!--  ENGCOM-2035  -->
+*  Magento now passes empty arrays (instead of null values) into the DataObject constructor. Previously, a null value was passed, which caused a fatal error. *Fix submitted by Abhishek Jakhotiya in pull request [16220](https://github.com/magento/magento2/pull/16220)*.
 
-<!--  ENGCOM-1800 -->* The `\Magento\Wishlist\CustomerData\Wishlist::getImageData()` method DocBlock now correctly indicates that the method returns an array. *Fix submitted by Yaroslav Rogoza in pull request [15718](https://github.com/magento/magento2/pull/15718)*.
+<!--  ENGCOM-1800  -->
+*  The `\Magento\Wishlist\CustomerData\Wishlist::getImageData()` method DocBlock now correctly indicates that the method returns an array. *Fix submitted by Yaroslav Rogoza in pull request [15718](https://github.com/magento/magento2/pull/15718)*.
 
-<!--  ENGCOM-1668 -->* Magento now displays the correct product image for the selected configurable product variant in the  My Wishlist sidebar. Previously, Magento always displayed the image associated with the default configurable product in the  My Wishlist sidebar. *Fix submitted by kishanpatadia in pull request [15477](https://github.com/magento/magento2/pull/15477)*.
+<!--  ENGCOM-1668  -->
+*  Magento now displays the correct product image for the selected configurable product variant in the  My Wishlist sidebar. Previously, Magento always displayed the image associated with the default configurable product in the  My Wishlist sidebar. *Fix submitted by kishanpatadia in pull request [15477](https://github.com/magento/magento2/pull/15477)*.
 
 <!-- not needed- 72024 ENGCOM-1665 1454 72051 93668 93674 93239 93320 90029 86243 87525 88658 91372 88667 92175 93204 83975 91412 86480 87966 88005 92178 86104 73638 93066 92165 82785 93042 93093 84387 93067 92162 81926 92983 92693 92200 92751 83992 92312 90837 92197 73967 90570 88655 92468 88592 74766 91989 81470 91894 89726 9057589342 84209 72982 86471 88604 88598 89746 89744 91791 93960 92191 93182 84093 82025 89301 92012 89988 92400 92747 87418 93799 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.6EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.6EE.md
@@ -24,37 +24,49 @@ This release includes significant performance improvements to the core Magento c
 
 Performance-tuning enhancements focus on catalog indexing and include:
 
-<!-- MAGETWO-87430 -->* Category product indexer logic has been optimized, and re-indexing time has decreased up to 98%, from 40 minutes to one minute for 100,000 categories.  Previously, when your store contained many categories (100,0000), Magento could take up to 40 minutes to re-index product catalogs.
+<!-- MAGETWO-87430  -->
+*  Category product indexer logic has been optimized, and re-indexing time has decreased up to 98%, from 40 minutes to one minute for 100,000 categories.  Previously, when your store contained many categories (100,0000), Magento could take up to 40 minutes to re-index product catalogs.
 
-<!-- MAGETWO-91164 -->* The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
+<!-- MAGETWO-91164  -->
+*  The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
 
     * Remove   `pub/media/catalog/product/cache` . (Removing this folder frees up space.)
 
     * Run `bin/magento catalog:image:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
 
-<!-- MAGETWO-47320 -->* The catalog rule re-indexing operation has been optimized, and the average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
+<!-- MAGETWO-47320  -->
+*  The catalog rule re-indexing operation has been optimized, and the average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
 
-<!-- MAGETWO-92447 -->* The catalog price indexer is now scoped and multithreaded, which improves the performance of layered navigation, search, and indexing actions for Magento instances with multiple websites and stores. This makes it possible to parallelize catalog price indexing by websites and customer groups. To re-index in parallel mode, add the `MAGE_INDEXER_THREADS_COUNT` environment variable to `env.php`.
+<!-- MAGETWO-92447  -->
+*  The catalog price indexer is now scoped and multithreaded, which improves the performance of layered navigation, search, and indexing actions for Magento instances with multiple websites and stores. This makes it possible to parallelize catalog price indexing by websites and customer groups. To re-index in parallel mode, add the `MAGE_INDEXER_THREADS_COUNT` environment variable to `env.php`.
 
-<!-- MAGETWO-90572 -->* The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for scenarios with a large number of product attribute sets. (Performance will not noticeably improve for deployments with only one attribute set configured with 500 attributes. However, deployments with many attribute sets that contain only a few attributes will show significant performance improvement. For example, a deployment with 100 attribute sets, each of which contains 50 attributes, might see a 40-90% reduction in load time.)
+<!-- MAGETWO-90572  -->
+*  The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for scenarios with a large number of product attribute sets. (Performance will not noticeably improve for deployments with only one attribute set configured with 500 attributes. However, deployments with many attribute sets that contain only a few attributes will show significant performance improvement. For example, a deployment with 100 attribute sets, each of which contains 50 attributes, might see a 40-90% reduction in load time.)
 
-<!-- MAGETWO-88670 -->* The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
+<!-- MAGETWO-88670  -->
+*  The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
 
-<!-- MAGETWO-86143 -->* Merchants can now improve store performance by disabling Magento Report functionality. A new configuration setting  (**System Configuration:** **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
+<!-- MAGETWO-86143  -->
+*  Merchants can now improve store performance by disabling Magento Report functionality. A new configuration setting  (**System Configuration:** **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
 
 #### **Improvements to the reliability and ease of the checkout process**
 
-<!-- MAGETWO-86490 -->* A shopping cart’s contents remain constant even when the checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart, and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
+<!-- MAGETWO-86490  -->
+*  A shopping cart’s contents remain constant even when the checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart, and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
 
-<!-- MAGETWO-90053-->* Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout page affected information entered into form fields for a guest checkout.
+<!-- MAGETWO-90053 -->
+*  Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout page affected information entered into form fields for a guest checkout.
 
-<!-- MAGETWO-89222-->* The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
+<!-- MAGETWO-89222 -->
+*  The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
 
 #### **Additional enhancements**
 
-<!-- MAGETWO-86125-->* Configurable products are now sorted by visible prices as expected. Previously, sorting a catalog by price produced  sort results that included the prices of out-of-stock products and disabled child products.
+<!-- MAGETWO-86125 -->
+*  Configurable products are now sorted by visible prices as expected. Previously, sorting a catalog by price produced  sort results that included the prices of out-of-stock products and disabled child products.
 
-<!-- MAGETWO-91411 -->*  Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
+<!-- MAGETWO-91411  -->
+*   Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
 
 ### **Magento Cloud highlights**
 
@@ -150,31 +162,44 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- ENGCOM-1537 -->* You can now use the `app:config:status` command to check whether configuration propagation is up-to-date. (This fix restores this command, which was inadvertently deleted in a previous release.)  *Fix submitted by Pieter Hoste in pull request [15174](https://github.com/magento/magento2/pull/15174)*. [GitHub-14104](https://github.com/magento/magento2/issues/14104)
+<!-- ENGCOM-1537  -->
+*  You can now use the `app:config:status` command to check whether configuration propagation is up-to-date. (This fix restores this command, which was inadvertently deleted in a previous release.)  *Fix submitted by Pieter Hoste in pull request [15174](https://github.com/magento/magento2/pull/15174)*. [GitHub-14104](https://github.com/magento/magento2/issues/14104)
 
-<!-- MAGETWO-84651 -->* The `app:config:dump` command now has an argument that supports dumping only the specified settings that are required to prepare static content on a build system, not all system settings. This new option (`config-types`) makes it possible to dump scopes and themes automatically (which are needed for a build system) while managing system settings manually using `config:set --lock-config`. *Fix submitted by Juan Alonso in pull request [12410](https://github.com/magento/magento2/pull/12410)*. [GitHub-11396](https://github.com/magento/magento2/issues/11396)
+<!-- MAGETWO-84651  -->
+*  The `app:config:dump` command now has an argument that supports dumping only the specified settings that are required to prepare static content on a build system, not all system settings. This new option (`config-types`) makes it possible to dump scopes and themes automatically (which are needed for a build system) while managing system settings manually using `config:set --lock-config`. *Fix submitted by Juan Alonso in pull request [12410](https://github.com/magento/magento2/pull/12410)*. [GitHub-11396](https://github.com/magento/magento2/issues/11396)
 
-<!-- MAGETWO-93192 -->* Configuration backend models are now populated as expected with all fieldset data, which makes it possible to access all configured values from a current group. [GitHub-16712](https://github.com/magento/magento2/issues/16712)
+<!-- MAGETWO-93192  -->
+*  Configuration backend models are now populated as expected with all fieldset data, which makes it possible to access all configured values from a current group. [GitHub-16712](https://github.com/magento/magento2/issues/16712)
 
-<!-- MAGETWO-90860 -->* The `magento-deploy-ignore` setting in `composer.json` now works as expected. Previously, files specified in this setting were overwritten during deployment.
+<!-- MAGETWO-90860  -->
+*  The `magento-deploy-ignore` setting in `composer.json` now works as expected. Previously, files specified in this setting were overwritten during deployment.
 
-<!-- MAGETWO-87120 -->* The `timestamp` fields in `oauth_nonce` now include indexes to avoid deadlocks while erasing old records. *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
+<!-- MAGETWO-87120  -->
+*  The `timestamp` fields in `oauth_nonce` now include indexes to avoid deadlocks while erasing old records. *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
-<!-- ENGCOM-1972 -->* Sorting has been disabled in the  `glob` and `scandir` functions to improve performance. *Fix submitted by Leandro F. L. in pull request [16052](https://github.com/magento/magento2/pull/16052)*.
+<!-- ENGCOM-1972  -->
+*  Sorting has been disabled in the  `glob` and `scandir` functions to improve performance. *Fix submitted by Leandro F. L. in pull request [16052](https://github.com/magento/magento2/pull/16052)*.
 
-<!-- ENGCOM-2407 -->* The `nginx.config.sample` file no longer includes an option for PHP 5.x. (Magento 2.2.x is not compatible with PHP 5.x.) *Fix submitted by Sean Breeden in pull request [16883](https://github.com/magento/magento2/pull/16883)*.
+<!-- ENGCOM-2407  -->
+*  The `nginx.config.sample` file no longer includes an option for PHP 5.x. (Magento 2.2.x is not compatible with PHP 5.x.) *Fix submitted by Sean Breeden in pull request [16883](https://github.com/magento/magento2/pull/16883)*.
 
-<!-- ENGCOM-2315 -->* Autoloading performance has improved on production environments as a result of the reduction in `file_exists` calls. *Fix submitted by Pieter Hoste in pull request [16435](https://github.com/magento/magento2/pull/16435)*.
+<!-- ENGCOM-2315  -->
+*  Autoloading performance has improved on production environments as a result of the reduction in `file_exists` calls. *Fix submitted by Pieter Hoste in pull request [16435](https://github.com/magento/magento2/pull/16435)*.
 
-<!-- ENGCOM-2029 -->* Setting deploy mode to production mode by  using the `--skip-compilation` flag no longer clears generated code in `generated/code/` and `generated/metadata/`. *Fix submitted by platformvaimo in pull request [16211](https://github.com/magento/magento2/pull/16211)*.
+<!-- ENGCOM-2029  -->
+*  Setting deploy mode to production mode by  using the `--skip-compilation` flag no longer clears generated code in `generated/code/` and `generated/metadata/`. *Fix submitted by platformvaimo in pull request [16211](https://github.com/magento/magento2/pull/16211)*.
 
-<!-- ENGCOM-1673 -->* We've made two changes to `Magento/Config` module: `Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php::testGetElementHtmlWithValue()` method no longer references a invalid backend model, and  the anonymous function no longer has an unused `$data` in `Magento/Config/Model/Config/Importer.php`. *Fix submitted by Marcel Hauri in pull request [15511](https://github.com/magento/magento2/pull/15511)*.
+<!-- ENGCOM-1673  -->
+*  We've made two changes to `Magento/Config` module: `Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php::testGetElementHtmlWithValue()` method no longer references a invalid backend model, and  the anonymous function no longer has an unused `$data` in `Magento/Config/Model/Config/Importer.php`. *Fix submitted by Marcel Hauri in pull request [15511](https://github.com/magento/magento2/pull/15511)*.
 
-<!-- ENGCOM-1448 -->* The upgrade check implemented during setup now indicates success if the latest version of Magento is already installed. Previously, the message indicated that the latest product version was already installed was presented as error. *Fix submitted by Daniel Ruf in pull request [15012](https://github.com/magento/magento2/pull/15012)*.
+<!-- ENGCOM-1448  -->
+*  The upgrade check implemented during setup now indicates success if the latest version of Magento is already installed. Previously, the message indicated that the latest product version was already installed was presented as error. *Fix submitted by Daniel Ruf in pull request [15012](https://github.com/magento/magento2/pull/15012)*.
 
-<!-- ENGCOM-1431 -->* The **Add Block Names to Hints** configuration setting has been renamed to **Add Block Class Type to Hints**. *Fix submitted by Chris Pook in pull request [14939](https://github.com/magento/magento2/pull/14939)*.
+<!-- ENGCOM-1431  -->
+*  The **Add Block Names to Hints** configuration setting has been renamed to **Add Block Class Type to Hints**. *Fix submitted by Chris Pook in pull request [14939](https://github.com/magento/magento2/pull/14939)*.
 
-<!-- MAGETWO-93758 -->* The `cron:run` command now reads `cron/enabled` configuration setting and if this value is set to **1** (the default value), then the `cron:run` command will execute. A value of **0** determines that `cron:run` will not be executed, and prompts Magento to send the customer email indicating that `cron` is disabled.
+<!-- MAGETWO-93758  -->
+*  The `cron:run` command now reads `cron/enabled` configuration setting and if this value is set to **1** (the default value), then the `cron:run` command will execute. A value of **0** determines that `cron:run` will not be executed, and prompts Magento to send the customer email indicating that `cron` is disabled.
 
 <!-- MAGETWO-93981 -->
 *  New command-line interface (CLI) commands support setting and showing indexer dimension modes:
@@ -185,242 +210,355 @@ In addition to security enhancements, this release contains the following functi
 
 ### Amazon Pay
 
-<!-- BUNDLE-1453 -->* Amazon Pay no longer appears as an option during checkout when a customer selects  **Check Out with Multiple Addresses**. Previously, Magento displayed Amazon Pay as an option, even though Amazon Pay does not support multishipping.
+<!-- BUNDLE-1453  -->
+*  Amazon Pay no longer appears as an option during checkout when a customer selects  **Check Out with Multiple Addresses**. Previously, Magento displayed Amazon Pay as an option, even though Amazon Pay does not support multishipping.
 
-<!-- BUNDLE-1324 -->*  You can now change and save Amazon Pay configuration settings from **Configuration**  > **Sales** > **Payment Methods**  > **Amazon Pay** when deploying Magento in a Cloud environment. Previously, Magento did not save changed settings.
+<!-- BUNDLE-1324  -->
+*   You can now change and save Amazon Pay configuration settings from **Configuration**  > **Sales** > **Payment Methods**  > **Amazon Pay** when deploying Magento in a Cloud environment. Previously, Magento did not save changed settings.
 
 ### B2B
 
-<!-- MAGETWO-92388 -->* Company blocked warnings are no longer included in the source code. Previously, source code included these warning strings, which search indexers detected and treated as text.
+<!-- MAGETWO-92388  -->
+*  Company blocked warnings are no longer included in the source code. Previously, source code included these warning strings, which search indexers detected and treated as text.
 
-<!-- MAGETWO-92375 -->* Category pages now display as expected all products whose SKUs contain either single or double quotation marks. Previously, Magento threw an error when trying to set pricing and structure on a shared catalog when product SKUs contained these characters.
+<!-- MAGETWO-92375  -->
+*  Category pages now display as expected all products whose SKUs contain either single or double quotation marks. Previously, Magento threw an error when trying to set pricing and structure on a shared catalog when product SKUs contained these characters.
 
-<!-- MAGETWO-92040 -->* In multisite environments, you can now save the address of a company that is allowed only on the non-primary website. Previously, if a merchant tried to save a company address from the default website, Magento displayed this error, `Invalid value of "UA" provided for the 'country_id' field`.
+<!-- MAGETWO-92040  -->
+*  In multisite environments, you can now save the address of a company that is allowed only on the non-primary website. Previously, if a merchant tried to save a company address from the default website, Magento displayed this error, `Invalid value of "UA" provided for the 'country_id' field`.
 
-<!-- MAGETWO-90824 -->* Access to the Companies resource can now be explicitly set on the Roles Resources page in Admin. Previously, this resource was available only to top-level administrators with all resources selected.
+<!-- MAGETWO-90824  -->
+*  Access to the Companies resource can now be explicitly set on the Roles Resources page in Admin. Previously, this resource was available only to top-level administrators with all resources selected.
 
-<!-- MAGETWO-89971 -->* Magento now displays the correct product total price value on all websites in a B2B deployment. Previously, Magento did not apply cart price rules for product prices on non-primary websites, but instead displayed the product price assigned to products on the primary website to all websites.
+<!-- MAGETWO-89971  -->
+*  Magento now displays the correct product total price value on all websites in a B2B deployment. Previously, Magento did not apply cart price rules for product prices on non-primary websites, but instead displayed the product price assigned to products on the primary website to all websites.
 
-<!-- MAGETWO-89888 -->* When **Website Restrictions** are set to **Private Sales: Login Only**, access to the storefront is now restricted to customers who log in, and merchants can still create new companies in the Admin. Previously, when a merchant tried to create a company when this setting was enabled, Magento threw this error, `Can not register new customer due to restrictions are enabled`.
+<!-- MAGETWO-89888  -->
+*  When **Website Restrictions** are set to **Private Sales: Login Only**, access to the storefront is now restricted to customers who log in, and merchants can still create new companies in the Admin. Previously, when a merchant tried to create a company when this setting was enabled, Magento threw this error, `Can not register new customer due to restrictions are enabled`.
 
-<!-- MAGETWO-87349 -->* Configurable products can now be added to the requisition list directly from the Category page.
+<!-- MAGETWO-87349  -->
+*  Configurable products can now be added to the requisition list directly from the Category page.
 
-<!-- ENGCOM-1373 -->* The `beforeSave` method on Braintree `CountryCreditCard` class now has a statement that supports `app:config:import`. Previously, Magento threw an exception during  import if it encountered an empty field in the Braintree configuration file.  *Fix submitted by Mateusz Lerczak in pull request [14829](https://github.com/magento/magento2/pull/14829)*.
+<!-- ENGCOM-1373  -->
+*  The `beforeSave` method on Braintree `CountryCreditCard` class now has a statement that supports `app:config:import`. Previously, Magento threw an exception during  import if it encountered an empty field in the Braintree configuration file.  *Fix submitted by Mateusz Lerczak in pull request [14829](https://github.com/magento/magento2/pull/14829)*.
 
-<!-- MAGETWO-92748 -->* Guests can now view products as expected when shared catalogs are enabled. Previously, if a merchant added a product when shared catalogs were enabled, guest users could not view the product, even when shared catalogs were later disabled.
+<!-- MAGETWO-92748  -->
+*  Guests can now view products as expected when shared catalogs are enabled. Previously, if a merchant added a product when shared catalogs were enabled, guest users could not view the product, even when shared catalogs were later disabled.
 
-<!-- MAGETWO-92823 -->* Company administrators can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
+<!-- MAGETWO-92823  -->
+*  Company administrators can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
 
-<!-- MAGETWO-92653 -->* You can now successfully search for products  when the **Shared Catalog** setting is enabled.
+<!-- MAGETWO-92653  -->
+*  You can now successfully search for products  when the **Shared Catalog** setting is enabled.
 
 ### Bundle products
 
-<!-- MAGETWO-90999 -->* Magento now successfully imports bundle products. Previously, bundle products were not visible in the product catalog, and were listed as out-of-stock on the storefront.
+<!-- MAGETWO-90999  -->
+*  Magento now successfully imports bundle products. Previously, bundle products were not visible in the product catalog, and were listed as out-of-stock on the storefront.
 
-<!--  ENGCOM-1863-->* The `Magento_Bundle` module name has been added to the relevant template files to meet Magento standard coding format. *Fix submitted by Namrata in pull request [15825](https://github.com/magento/magento2/pull/15825)*.
+<!--  ENGCOM-1863 -->
+*  The `Magento_Bundle` module name has been added to the relevant template files to meet Magento standard coding format. *Fix submitted by Namrata in pull request [15825](https://github.com/magento/magento2/pull/15825)*.
 
-<!--  ENGCOM-2176-->* The `option` variable has been renamed to `quoteItemOption` to improve code readability in `app/code/Magento/Bundle/Model/Product/Type.php`. *Fix submitted by Leandro F. L. in pull request [16143](https://github.com/magento/magento2/pull/16143)*.
+<!--  ENGCOM-2176 -->
+*  The `option` variable has been renamed to `quoteItemOption` to improve code readability in `app/code/Magento/Bundle/Model/Product/Type.php`. *Fix submitted by Leandro F. L. in pull request [16143](https://github.com/magento/magento2/pull/16143)*.
 
-<!-- MAGETWO-86218-->* Magento now accurately displays the status of bundle product stock when **Add to Cart** is enabled for bundle products. Previously, bundle products with the **User Defined** field unchecked could not be back ordered as expected.
+<!-- MAGETWO-86218 -->
+*  Magento now accurately displays the status of bundle product stock when **Add to Cart** is enabled for bundle products. Previously, bundle products with the **User Defined** field unchecked could not be back ordered as expected.
 [GitHub-10061](https://github.com/magento/magento2/issues/10061)
 
 ### Catalog
 
-<!-- ENGCOM-1539 -->* The breadcrumbs component no longer relies on the `mageMenu` widget. *Fix submitted by Vova Yatsyuk in pull request [15178](https://github.com/magento/magento2/pull/15178)*. [GitHub-14987](https://github.com/magento/magento2/issues/14987)
+<!-- ENGCOM-1539  -->
+*  The breadcrumbs component no longer relies on the `mageMenu` widget. *Fix submitted by Vova Yatsyuk in pull request [15178](https://github.com/magento/magento2/pull/15178)*. [GitHub-14987](https://github.com/magento/magento2/issues/14987)
 
-<!-- ENGCOM-1622 -->* The `data-container` class name is now based on view mode. *Fix submitted by sunilit42 in pull request [15350](https://github.com/magento/magento2/pull/15350)*. [GitHub-15319](https://github.com/magento/magento2/issues/15319)
+<!-- ENGCOM-1622  -->
+*  The `data-container` class name is now based on view mode. *Fix submitted by sunilit42 in pull request [15350](https://github.com/magento/magento2/pull/15350)*. [GitHub-15319](https://github.com/magento/magento2/issues/15319)
 
-<!-- ENGCOM-1617 -->* Breadcrumbs now work as expected when a product name contains quotation marks. Previously, the breadcrumbs on the product details page caused this syntax error to be thrown, `SyntaxError: Unexpected token x in JSON`. *Fix submitted by Jignesh Baldha in pull request [15347](https://github.com/magento/magento2/pull/15347)*. [GitHub-15037](https://github.com/magento/magento2/issues/15037)
+<!-- ENGCOM-1617  -->
+*  Breadcrumbs now work as expected when a product name contains quotation marks. Previously, the breadcrumbs on the product details page caused this syntax error to be thrown, `SyntaxError: Unexpected token x in JSON`. *Fix submitted by Jignesh Baldha in pull request [15347](https://github.com/magento/magento2/pull/15347)*. [GitHub-15037](https://github.com/magento/magento2/issues/15037)
 
-<!-- ENGCOM-1463 -->* Disabling a product now removes it from the flat index as expected. *Fix submitted by Mr. Lewis in pull request [15019](https://github.com/magento/magento2/pull/15019)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
+<!-- ENGCOM-1463  -->
+*  Disabling a product now removes it from the flat index as expected. *Fix submitted by Mr. Lewis in pull request [15019](https://github.com/magento/magento2/pull/15019)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
 
-<!-- ENGCOM-1051 -->* The success message that Magento displays when a customer adds a product to the compare list now contains a link to the comparison list. *Fix submitted by Andreas von Studnitz in pull request [13862](https://github.com/magento/magento2/pull/13862)*.
+<!-- ENGCOM-1051  -->
+*  The success message that Magento displays when a customer adds a product to the compare list now contains a link to the comparison list. *Fix submitted by Andreas von Studnitz in pull request [13862](https://github.com/magento/magento2/pull/13862)*.
 
-<!-- ENGCOM-1953 -->* Cache problems no longer occur when currencies are used without a currency symbol. *Fix submitted by Dmytro Cheshun in pull request [15902](https://github.com/magento/magento2/pull/15902)*.
+<!-- ENGCOM-1953  -->
+*  Cache problems no longer occur when currencies are used without a currency symbol. *Fix submitted by Dmytro Cheshun in pull request [15902](https://github.com/magento/magento2/pull/15902)*.
 
-<!-- ENGCOM-1927 -->* Catalog component blocks now contain correct return type suggestions, and typos have been corrected where needed in the PHPDocs. *Fix submitted by Dmytro Cheshun in pull request [15913](https://github.com/magento/magento2/pull/15913)*.
+<!-- ENGCOM-1927  -->
+*  Catalog component blocks now contain correct return type suggestions, and typos have been corrected where needed in the PHPDocs. *Fix submitted by Dmytro Cheshun in pull request [15913](https://github.com/magento/magento2/pull/15913)*.
 
-<!-- ENGCOM-1287 -->* Widget cache errors that resulted in one widget being loaded twice on the storefront have been resolved. *Fix submitted by Alexandr Kozyr in pull request [12764](https://github.com/magento/magento2/pull/12764)*. [GitHub-4389](https://github.com/magento/magento2/issues/4389)
+<!-- ENGCOM-1287  -->
+*  Widget cache errors that resulted in one widget being loaded twice on the storefront have been resolved. *Fix submitted by Alexandr Kozyr in pull request [12764](https://github.com/magento/magento2/pull/12764)*. [GitHub-4389](https://github.com/magento/magento2/issues/4389)
 
-<!-- ENGCOM-1059 -->* Magento no longer makes redundant requests on the 'customer data' on the checkout  page. *Fix submitted by Andrey Bezyazychnyy in pull request [14314](https://github.com/magento/magento2/pull/14314)*. [GitHub-13765](https://github.com/magento/magento2/issues/13765)
+<!-- ENGCOM-1059  -->
+*  Magento no longer makes redundant requests on the 'customer data' on the checkout  page. *Fix submitted by Andrey Bezyazychnyy in pull request [14314](https://github.com/magento/magento2/pull/14314)*. [GitHub-13765](https://github.com/magento/magento2/issues/13765)
 
-<!-- MAGETWO-93196 -->* Administrators with permission to change product names on one website only cannot change product names on any other sites. Previously, an administrator with permission to change a product name on one site only could change product names on all websites in a multisite deployment.
+<!-- MAGETWO-93196  -->
+*  Administrators with permission to change product names on one website only cannot change product names on any other sites. Previously, an administrator with permission to change a product name on one site only could change product names on all websites in a multisite deployment.
 
-<!-- MAGETWO-93103 -->* Administrators with limited privileges can now save products as expected.
+<!-- MAGETWO-93103  -->
+*  Administrators with limited privileges can now save products as expected.
 
-<!-- MAGETWO-93071 -->* Magento now uses the current date as expected when setting the start date for a special price. Previously, Magento set the start date for a special price a few years in the future, which prevented the special price for being active.
+<!-- MAGETWO-93071  -->
+*  Magento now uses the current date as expected when setting the start date for a special price. Previously, Magento set the start date for a special price a few years in the future, which prevented the special price for being active.
 
-<!-- MAGETWO-92907 -->* Magento now reliably displays category images on the custom store view level.  Previously, the category image on custom store view level alternately disappeared and appeared after every save operation.
+<!-- MAGETWO-92907  -->
+*  Magento now reliably displays category images on the custom store view level.  Previously, the category image on custom store view level alternately disappeared and appeared after every save operation.
 
-<!-- MAGETWO-92574 -->* Magento no longer removes downloadable product links after an attribute is updated.
+<!-- MAGETWO-92574  -->
+*  Magento no longer removes downloadable product links after an attribute is updated.
 
-<!-- MAGETWO-92502 -->* Extra POST requests are no longer sent if the  **Synchronize widget products with backend storage** option is set to **yes**.
+<!-- MAGETWO-92502  -->
+*  Extra POST requests are no longer sent if the  **Synchronize widget products with backend storage** option is set to **yes**.
 
-<!-- MAGETWO-92389 -->* You can now create a product date attribute that contains a day value than exceeds 12 (in the format dd/mm/yyyy). Previously, when you created a product attribute with a default date specifying a day greater than 12, Magento did not save the attribute, but instead displayed this error, `Invalid default date`.
+<!-- MAGETWO-92389  -->
+*  You can now create a product date attribute that contains a day value than exceeds 12 (in the format dd/mm/yyyy). Previously, when you created a product attribute with a default date specifying a day greater than 12, Magento did not save the attribute, but instead displayed this error, `Invalid default date`.
 
-<!-- MAGETWO-91402 -->* You can now use the `Magento\Catalog\Model\ProductRepository` class to assign a product to one website as expected. Previously, using this class to save a product assigned the product to all existing websites, not just the specified one.
+<!-- MAGETWO-91402  -->
+*  You can now use the `Magento\Catalog\Model\ProductRepository` class to assign a product to one website as expected. Previously, using this class to save a product assigned the product to all existing websites, not just the specified one.
 
-<!-- MAGETWO-91163 -->* Images now load as expected on the product display page (PDP) when the image name contains double quotation marks.
+<!-- MAGETWO-91163  -->
+*  Images now load as expected on the product display page (PDP) when the image name contains double quotation marks.
 
-<!-- MAGETWO-90940 -->* The SEO-friendly URL for the Category page now works as expected.
+<!-- MAGETWO-90940  -->
+*  The SEO-friendly URL for the Category page now works as expected.
 
-<!-- MAGETWO-90768 -->* The **Use Default Value** checkboxes in the design section of the category page are now enabled by default as expected.
+<!-- MAGETWO-90768  -->
+*  The **Use Default Value** checkboxes in the design section of the category page are now enabled by default as expected.
 
-<!-- MAGETWO-92280 -->* Customers can now use the **Add Product By SKU** button to add configurable products to a sales order.
+<!-- MAGETWO-92280  -->
+*  Customers can now use the **Add Product By SKU** button to add configurable products to a sales order.
 
-<!-- MAGETWO-90569 -->* Empty dropdown or swatch type product attributes are no longer visible on the product page.
+<!-- MAGETWO-90569  -->
+*  Empty dropdown or swatch type product attributes are no longer visible on the product page.
 
-<!-- MAGETWO-90367 -->* Attributes that have empty values across all products being compared are not displayed as rows in the comparison table. Previously, Magento displayed these attributes  with an N/A value on the  Compare Products page.
+<!-- MAGETWO-90367  -->
+*  Attributes that have empty values across all products being compared are not displayed as rows in the comparison table. Previously, Magento displayed these attributes  with an N/A value on the  Compare Products page.
 
-<!-- MAGETWO-89732 -->* The Catalog page now displays breadcrumbs as expected.
+<!-- MAGETWO-89732  -->
+*  The Catalog page now displays breadcrumbs as expected.
 
-<!-- MAGETWO-88504 -->* Tiered pricing and quantity increments now work as expected with decimal-based inventories.
+<!-- MAGETWO-88504  -->
+*  Tiered pricing and quantity increments now work as expected with decimal-based inventories.
 
-<!-- MAGETWO-88102 -->* Magento now updates the `catalog_category_product_index` table as expected after a category is deleted.
+<!-- MAGETWO-88102  -->
+*  Magento now updates the `catalog_category_product_index` table as expected after a category is deleted.
 
-<!-- MAGETWO-87721 -->* Customizable options are now configured the same for all websites to which a product is added. Previously, when a merchant added a product with customizable options to an additional site, the options were corrupted.
+<!-- MAGETWO-87721  -->
+*  Customizable options are now configured the same for all websites to which a product is added. Previously, when a merchant added a product with customizable options to an additional site, the options were corrupted.
 
-<!-- MAGETWO-87589 -->* The **Use default value** option is no longer unchecked unless the user overrides the value of the attribute in the store view scope. Previously, after creating an item, if the user changed to store view scope and did not make any modifications to the item's attributes and only clicked **Save**, most of the attributes that were set as **Use default value** became unchecked.
+<!-- MAGETWO-87589  -->
+*  The **Use default value** option is no longer unchecked unless the user overrides the value of the attribute in the store view scope. Previously, after creating an item, if the user changed to store view scope and did not make any modifications to the item's attributes and only clicked **Save**, most of the attributes that were set as **Use default value** became unchecked.
 
-<!-- MAGETWO-87430 -->* Category product indexer logic has been optimized, and re-indexing time has been noticeably reduced.  Previously, when you had many categories (100,000), Magento could take up to 40 minutes to re-index product catalogs.
+<!-- MAGETWO-87430  -->
+*  Category product indexer logic has been optimized, and re-indexing time has been noticeably reduced.  Previously, when you had many categories (100,000), Magento could take up to 40 minutes to re-index product catalogs.
 
-<!-- MAGETWO-86710 -->* Widget selection by Enabled Products no longer causes a fatal error on a storefront when the **Flat Product** is configured.
+<!-- MAGETWO-86710  -->
+*  Widget selection by Enabled Products no longer causes a fatal error on a storefront when the **Flat Product** is configured.
 
-<!-- MAGETWO-86295 -->* Merchants can now change the `status` and `update` attributes from the product page. Previously, Magento returned a 404 page when bulk enabling or disabling products in the Admin with a restricted user role that is limited to a specific website.
+<!-- MAGETWO-86295  -->
+*  Merchants can now change the `status` and `update` attributes from the product page. Previously, Magento returned a 404 page when bulk enabling or disabling products in the Admin with a restricted user role that is limited to a specific website.
 
-<!-- MAGETWO-85682 -->* Magento now maintains the default setting for a product's `status` attribute when you create a new product. Previously, when creating a new product after changing the default option from Enabled to Disabled for this attribute, the status is incorrectly set to enabled by default.
+<!-- MAGETWO-85682  -->
+*  Magento now maintains the default setting for a product's `status` attribute when you create a new product. Previously, when creating a new product after changing the default option from Enabled to Disabled for this attribute, the status is incorrectly set to enabled by default.
 
-<!-- MAGETWO-84891 -->* The print preview of product comparison results (that is, the page of results that Magento produces when you click **Compare** after selecting two or more products) now  displays as expected. Previously, only a subset of page elements was displayed.
+<!-- MAGETWO-84891  -->
+*  The print preview of product comparison results (that is, the page of results that Magento produces when you click **Compare** after selecting two or more products) now  displays as expected. Previously, only a subset of page elements was displayed.
 
-<!-- MAGETWO-82116 -->* Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date.  [GitHub-11517](https://github.com/magento/magento2/issues/11517)
+<!-- MAGETWO-82116  -->
+*  Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date.  [GitHub-11517](https://github.com/magento/magento2/issues/11517)
 
-<!-- MAGETWO-75427 -->* As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
+<!-- MAGETWO-75427  -->
+*  As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
 
-<!-- MAGETWO-60573 -->* Merchants can now set custom option fixed prices with  negative values in the Admin. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
+<!-- MAGETWO-60573  -->
+*  Merchants can now set custom option fixed prices with  negative values in the Admin. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
 
-<!-- MAGETWO-73739 -->* You can now unset a category image on the store-view level when the image is defined on all store views.
+<!-- MAGETWO-73739  -->
+*  You can now unset a category image on the store-view level when the image is defined on all store views.
 
-<!-- MAGETWO-74021 -->* The Catalog Products List widget can now display products on the storefront that have specific attributes.
+<!-- MAGETWO-74021  -->
+*  The Catalog Products List widget can now display products on the storefront that have specific attributes.
 
-<!--  ENGCOM-2383 -->* The shopping cart now correctly displays images of configurable products that have only size options (that is, no color options). Previously, when a customer added a configurable product that had only size options to her shopping cart, the shopping cart did not display the expected product image. *Fix submitted by Ronak Patel in pull request [16863](https://github.com/magento/magento2/pull/16863)*. [GitHub-16843](https://github.com/magento/magento2/issues/16843)
+<!--  ENGCOM-2383  -->
+*  The shopping cart now correctly displays images of configurable products that have only size options (that is, no color options). Previously, when a customer added a configurable product that had only size options to her shopping cart, the shopping cart did not display the expected product image. *Fix submitted by Ronak Patel in pull request [16863](https://github.com/magento/magento2/pull/16863)*. [GitHub-16843](https://github.com/magento/magento2/issues/16843)
 
-<!--  ENGCOM-2313 -->* Magento now throws an exception as expected  when a user tries to submit a product review without selecting a star rating. Previously, if a user submitted a product review without selecting a star rating, Magento assigned a one-star rating.
+<!--  ENGCOM-2313  -->
+*  Magento now throws an exception as expected  when a user tries to submit a product review without selecting a star rating. Previously, if a user submitted a product review without selecting a star rating, Magento assigned a one-star rating.
 
-<!--  ENGCOM-2213 -->* Magento now successfully displays product prices in currencies without minor units if the price amount is less then the number group size.  [GitHub-11711](https://github.com/magento/magento2/issues/11711)
+<!--  ENGCOM-2213  -->
+*  Magento now successfully displays product prices in currencies without minor units if the price amount is less then the number group size.  [GitHub-11711](https://github.com/magento/magento2/issues/11711)
 
-<!-- ENGCOM-2193 -->* Magento now displays the correct  price on the product page for storefronts running Japanese locales. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11711](https://github.com/magento/magento2/issues/11711)
+<!-- ENGCOM-2193  -->
+*  Magento now displays the correct  price on the product page for storefronts running Japanese locales. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11711](https://github.com/magento/magento2/issues/11711)
 
-<!-- ENGCOM-1106 -->* Magento now correctly saves the value of a product's custom options. Previously, Magento saved all objects by using the same value object for all values. *Fix submitted by Jeroen Van Leusden in pull request [13569](https://github.com/magento/magento2/pull/13569)*. [GitHub-5067](https://github.com/magento/magento2/issues/5067)
+<!-- ENGCOM-1106  -->
+*  Magento now correctly saves the value of a product's custom options. Previously, Magento saved all objects by using the same value object for all values. *Fix submitted by Jeroen Van Leusden in pull request [13569](https://github.com/magento/magento2/pull/13569)*. [GitHub-5067](https://github.com/magento/magento2/issues/5067)
 
-<!-- ENGCOM-1911 -->* Magento now displays the product name as browser title as expected. Previously, the meta title tag was missing, which prevented Magento from displaying the product name. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
+<!-- ENGCOM-1911  -->
+*  Magento now displays the product name as browser title as expected. Previously, the meta title tag was missing, which prevented Magento from displaying the product name. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
 
-<!-- ENGCOM-2042 -->* Magento now maintains the default products sort order of “newest first” when you upgrade your Magento deployment to 2.2.4. Previously, after upgrade, the default products order in categories changed from “newest first” to “oldest first”. *Fix submitted by Danny Verkade in pull request [15629](https://github.com/magento/magento2/pull/15629)*. [GitHub-15627](https://github.com/magento/magento2/issues/15627)
+<!-- ENGCOM-2042  -->
+*  Magento now maintains the default products sort order of “newest first” when you upgrade your Magento deployment to 2.2.4. Previously, after upgrade, the default products order in categories changed from “newest first” to “oldest first”. *Fix submitted by Danny Verkade in pull request [15629](https://github.com/magento/magento2/pull/15629)*. [GitHub-15627](https://github.com/magento/magento2/issues/15627)
 
-<!-- ENGCOM-1909-->* Links on product pages are now linkable as expected. Previously, when Magento displayed a product page, none of the provided links were clickable. *Fix submitted by simonjanguapa in pull request [15687](https://github.com/magento/magento2/pull/15687)*. [GitHub-15393](https://github.com/magento/magento2/issues/15393)
+<!-- ENGCOM-1909 -->
+*  Links on product pages are now linkable as expected. Previously, when Magento displayed a product page, none of the provided links were clickable. *Fix submitted by simonjanguapa in pull request [15687](https://github.com/magento/magento2/pull/15687)*. [GitHub-15393](https://github.com/magento/magento2/issues/15393)
 
-<!-- ENGCOM-2408-->* Deprecated methods in Message Manager have been replaced with valid methods. *Fix submitted by Tiago Sampaio in pull request [16924](https://github.com/magento/magento2/pull/16924)*.
+<!-- ENGCOM-2408 -->
+*  Deprecated methods in Message Manager have been replaced with valid methods. *Fix submitted by Tiago Sampaio in pull request [16924](https://github.com/magento/magento2/pull/16924)*.
 
-<!-- ENGCOM-2390-->* Array short syntax usage has been standardized in these files: `app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php`, `app/code/Magento/GroupedProduct/Test/Unit/Model/ProductTest.php`, and `setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php`. *Fix submitted by Leandro F. L. in pull request [16880](https://github.com/magento/magento2/pull/16880)*.
+<!-- ENGCOM-2390 -->
+*  Array short syntax usage has been standardized in these files: `app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php`, `app/code/Magento/GroupedProduct/Test/Unit/Model/ProductTest.php`, and `setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php`. *Fix submitted by Leandro F. L. in pull request [16880](https://github.com/magento/magento2/pull/16880)*.
 
-<!-- ENGCOM-2132-->* The error message that Magento displayed when a duplicate error key occurred during product import has been improved. *Fix submitted by Vishal Gelani in pull request [16389](https://github.com/magento/magento2/pull/16389)*.
+<!-- ENGCOM-2132 -->
+*  The error message that Magento displayed when a duplicate error key occurred during product import has been improved. *Fix submitted by Vishal Gelani in pull request [16389](https://github.com/magento/magento2/pull/16389)*.
 
-<!-- ENGCOM-2093-->* We've removed the direct use of the object manager when saving Admin attribute sets. *Fix submitted by AnshuMishra17 in pull request [16217](https://github.com/magento/magento2/pull/16217)*.
+<!-- ENGCOM-2093 -->
+*  We've removed the direct use of the object manager when saving Admin attribute sets. *Fix submitted by AnshuMishra17 in pull request [16217](https://github.com/magento/magento2/pull/16217)*.
 
-<!-- ENGCOM-1703-->* Breadcrumb JSON configuration has been moved to the view model and serialized using the Magento JSON serializer. *Fix submitted by Diederick Bruin in pull request [15521](https://github.com/magento/magento2/pull/15521)*.
+<!-- ENGCOM-1703 -->
+*  Breadcrumb JSON configuration has been moved to the view model and serialized using the Magento JSON serializer. *Fix submitted by Diederick Bruin in pull request [15521](https://github.com/magento/magento2/pull/15521)*.
 
-<!-- ENGCOM-1464-->* `row_id` has been added to the flat action indexer,  ensuring that index values are not set to `0` for new products when using index on save. Previously, if you used `\Magento\Framework\Api\SearchCriteriaBuilder`, and the flat `product row_id` is set to `0`, Magento did not show the product in the `getList` of the `ProductRepository`. *Fix submitted by Mr. Lewis in pull request [15010](https://github.com/magento/magento2/pull/15010)*.
+<!-- ENGCOM-1464 -->
+*  `row_id` has been added to the flat action indexer,  ensuring that index values are not set to `0` for new products when using index on save. Previously, if you used `\Magento\Framework\Api\SearchCriteriaBuilder`, and the flat `product row_id` is set to `0`, Magento did not show the product in the `getList` of the `ProductRepository`. *Fix submitted by Mr. Lewis in pull request [15010](https://github.com/magento/magento2/pull/15010)*.
 
-<!-- ENGCOM-1444-->* Magento no longer inserts redundant links to the homepage  into breadcrumbs on the product page. *Fix submitted by Vova Yatsyuk in pull request [14994](https://github.com/magento/magento2/pull/14994)*.
+<!-- ENGCOM-1444 -->
+*  Magento no longer inserts redundant links to the homepage  into breadcrumbs on the product page. *Fix submitted by Vova Yatsyuk in pull request [14994](https://github.com/magento/magento2/pull/14994)*.
 
-<!-- ENGCOM-1553-->* Magento now correctly displays product information for products that have a negative price as a custom option.  *Fix submitted by Danny Verkade in pull request [15202](https://github.com/magento/magento2/pull/15202)*.
+<!-- ENGCOM-1553 -->
+*  Magento now correctly displays product information for products that have a negative price as a custom option.  *Fix submitted by Danny Verkade in pull request [15202](https://github.com/magento/magento2/pull/15202)*.
 
-<!-- ENGCOM-1530-->* Product names can now contain a double quotation mark character (`"`). Previously, when a product name contained this character, Magento threw a JavaScript error. *Fix submitted by Vova Yatsyuk in pull request [15162](https://github.com/magento/magento2/pull/15162)*.
+<!-- ENGCOM-1530 -->
+*  Product names can now contain a double quotation mark character (`"`). Previously, when a product name contained this character, Magento threw a JavaScript error. *Fix submitted by Vova Yatsyuk in pull request [15162](https://github.com/magento/magento2/pull/15162)*.
 
-<!-- ENGCOM-1404-->* Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page. *Fix submitted by Neos2007 in pull request [14886](https://github.com/magento/magento2/pull/14886)*.
+<!-- ENGCOM-1404 -->
+*  Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page. *Fix submitted by Neos2007 in pull request [14886](https://github.com/magento/magento2/pull/14886)*.
 
-<!-- ENGCOM-1336-->* Magento now updates product options and quantity by checking the item ID when updating a cart that contains configurable products with different options. *Fix submitted by Nitin Khalasi in pull request [14765](https://github.com/magento/magento2/pull/14765)*.
+<!-- ENGCOM-1336 -->
+*  Magento now updates product options and quantity by checking the item ID when updating a cart that contains configurable products with different options. *Fix submitted by Nitin Khalasi in pull request [14765](https://github.com/magento/magento2/pull/14765)*.
 
-<!-- ENGCOM-1239-->* Product meta descriptions no longer contain unnecessary HTML tags. *Fix submitted by David Windell in pull request [14538](https://github.com/magento/magento2/pull/14538)*.
+<!-- ENGCOM-1239 -->
+*  Product meta descriptions no longer contain unnecessary HTML tags. *Fix submitted by David Windell in pull request [14538](https://github.com/magento/magento2/pull/14538)*.
 
-<!-- MAGETWO-90367-->* Attributes that have empty values across all products being compared are not displayed on the Compare Products page as rows in the comparison table. Previously, these attributes were displayed with a value of **N/A**.
+<!-- MAGETWO-90367 -->
+*  Attributes that have empty values across all products being compared are not displayed on the Compare Products page as rows in the comparison table. Previously, these attributes were displayed with a value of **N/A**.
 
-<!-- MAGETWO-82116-->* Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date. [GitHub-11517](https://github.com/magento/magento2/issues/11517)
+<!-- MAGETWO-82116 -->
+*  Magento now maintains the correct dates in the results of filtering the Admin Product Grid Filter: Set Product as New from Date. [GitHub-11517](https://github.com/magento/magento2/issues/11517)
 
-<!-- MAGETWO-92823-->* Company Admin can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
+<!-- MAGETWO-92823 -->
+*  Company Admin can now use Quick Order to buy products. Previously, when a company administator tried to use Quick Order to buy products, Magento displayed this error: `The SKU was not found in the catalog`.
 
 ### CAPTCHA
 
-<!-- MAGETWO-91840 -->* Customers can now successfully log in when guest checkout is disabled and CAPTCHA is enabled. Previously, Magento threw the `Provided form does not exist` error when a customer tried to log in under these conditions.
+<!-- MAGETWO-91840  -->
+*  Customers can now successfully log in when guest checkout is disabled and CAPTCHA is enabled. Previously, Magento threw the `Provided form does not exist` error when a customer tried to log in under these conditions.
 
-<!-- MAGETWO-89615 -->* CAPTCHA validation now works when the **Website Restrictions** setting is enabled.
+<!-- MAGETWO-89615  -->
+*  CAPTCHA validation now works when the **Website Restrictions** setting is enabled.
 
-<!-- ENGCOM-1973 -->* The `\Magento\Captcha\Observer\CaptchaStringResolver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16065](https://github.com/magento/magento2/pull/16065)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
+<!-- ENGCOM-1973  -->
+*  The `\Magento\Captcha\Observer\CaptchaStringResolver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16065](https://github.com/magento/magento2/pull/16065)*. [GitHub-14966](https://github.com/magento/magento2/issues/14966)
 
-<!-- ENGCOM-2013 -->* The `CheckRegisterCheckoutObserver` class  is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16160](https://github.com/magento/magento2/pull/16160)*.
+<!-- ENGCOM-2013  -->
+*  The `CheckRegisterCheckoutObserver` class  is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16160](https://github.com/magento/magento2/pull/16160)*.
 
-<!-- ENGCOM-2268 -->* The `\Magento\Captcha\Observer\CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
+<!-- ENGCOM-2268  -->
+*  The `\Magento\Captcha\Observer\CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
 
-<!-- ENGCOM-2531 -->* Autocomplete for CAPTCHA inputs has been disabled. *Fix submitted by Denis Belevtsov in pull request [17114](https://github.com/magento/magento2/pull/17114)*.
+<!-- ENGCOM-2531  -->
+*  Autocomplete for CAPTCHA inputs has been disabled. *Fix submitted by Denis Belevtsov in pull request [17114](https://github.com/magento/magento2/pull/17114)*.
 
-<!-- ENGCOM-2090 -->* Integration tests now check that customer login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16306](https://github.com/magento/magento2/pull/16306)*.
+<!-- ENGCOM-2090  -->
+*  Integration tests now check that customer login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16306](https://github.com/magento/magento2/pull/16306)*.
 
-<!-- ENGCOM-2087 -->* Integration tests now check that administrator login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16300](https://github.com/magento/magento2/pull/16300)*.
+<!-- ENGCOM-2087  -->
+*  Integration tests now check that administrator login attempts are removed after a successful login or account details edit. *Fix submitted by Yaroslav Rogoza in pull request [16300](https://github.com/magento/magento2/pull/16300)*.
 
-<!-- ENGCOM-2268 -->* The `CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
+<!-- ENGCOM-2268  -->
+*  The `CheckGuestCheckoutObserver` class is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [16680](https://github.com/magento/magento2/pull/16680)*.
 
 ### Cart and checkout
 
-<!-- ENGCOM-2126 -->* Placeholders for the password field  no longer suggest that a password is optional. Previously, the placeholder for the password field in the checkout page suggested that the password was optional, but after validation, Magento indicated that the password field  was mandatory. *Fix submitted by hitesh-wagento in pull request [16379](https://github.com/magento/magento2/pull/16379)*. [GitHub-16378](https://github.com/magento/magento2/issues/16378)
+<!-- ENGCOM-2126  -->
+*  Placeholders for the password field  no longer suggest that a password is optional. Previously, the placeholder for the password field in the checkout page suggested that the password was optional, but after validation, Magento indicated that the password field  was mandatory. *Fix submitted by hitesh-wagento in pull request [16379](https://github.com/magento/magento2/pull/16379)*. [GitHub-16378](https://github.com/magento/magento2/issues/16378)
 
-<!-- ENGCOM-1941 -->* The dropdown toggle icon on the shopping cart now works as expected. Previously, the arrow did not change direction as expected when you toggled the Discount or Tax options. *Fix submitted by Karla Saaremäe in pull request [15991](https://github.com/magento/magento2/pull/15991)*.
+<!-- ENGCOM-1941  -->
+*  The dropdown toggle icon on the shopping cart now works as expected. Previously, the arrow did not change direction as expected when you toggled the Discount or Tax options. *Fix submitted by Karla Saaremäe in pull request [15991](https://github.com/magento/magento2/pull/15991)*.
 
-<!-- ENGCOM-1951 -->* The shopping cart icon on the checkout page on mobile screens now displays hover color and regular color as expected. *Fix submitted by Karla Saaremäe in pull request [16002](https://github.com/magento/magento2/pull/16002)*.
+<!-- ENGCOM-1951  -->
+*  The shopping cart icon on the checkout page on mobile screens now displays hover color and regular color as expected. *Fix submitted by Karla Saaremäe in pull request [16002](https://github.com/magento/magento2/pull/16002)*.
 
-<!-- ENGCOM-1154 -->* Customers are not unexpectedly logged out if the customers hits the F5 key twice during checkout. *Fix submitted by adrian-martinez-interactiv4 in pull request [14428](https://github.com/magento/magento2/pull/14428)*. [GitHub-4301](https://github.com/magento/magento2/issues/4301), [GitHub-12362](https://github.com/magento/magento2/issues/12362), [GitHub-13427](https://github.com/magento/magento2/issues/13427)
+<!-- ENGCOM-1154  -->
+*  Customers are not unexpectedly logged out if the customers hits the F5 key twice during checkout. *Fix submitted by adrian-martinez-interactiv4 in pull request [14428](https://github.com/magento/magento2/pull/14428)*. [GitHub-4301](https://github.com/magento/magento2/issues/4301), [GitHub-12362](https://github.com/magento/magento2/issues/12362), [GitHub-13427](https://github.com/magento/magento2/issues/13427)
 
-<!-- ENGCOM-1646 -->* The **Purchased Order Form** button is now correctly aligned. *Fix submitted by Neeta Kangiya in pull request [15331](https://github.com/magento/magento2/pull/15331)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
+<!-- ENGCOM-1646  -->
+*  The **Purchased Order Form** button is now correctly aligned. *Fix submitted by Neeta Kangiya in pull request [15331](https://github.com/magento/magento2/pull/15331)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
 
-<!-- ENGCOM-1634-->* The **Purchased Order Form** button is now visible. *Fix submitted by hitesh-wagento in pull request [15372](https://github.com/magento/magento2/pull/15372)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
+<!-- ENGCOM-1634 -->
+*  The **Purchased Order Form** button is now visible. *Fix submitted by hitesh-wagento in pull request [15372](https://github.com/magento/magento2/pull/15372)*. [GitHub-15334](https://github.com/magento/magento2/issues/15334)
 
-<!-- ENGCOM-1713 -->* Magento no longer displays duplicate element IDs on the Checkout page. *Fix submitted by Julien ANQUETIL in pull request [15585](https://github.com/magento/magento2/pull/15585)*. [GitHub-13415](https://github.com/magento/magento2/issues/13415)
+<!-- ENGCOM-1713  -->
+*  Magento no longer displays duplicate element IDs on the Checkout page. *Fix submitted by Julien ANQUETIL in pull request [15585](https://github.com/magento/magento2/pull/15585)*. [GitHub-13415](https://github.com/magento/magento2/issues/13415)
 
-<!-- ENGCOM-1988 -->* During the payment step of checkout, a customer can now successfully deselect the **Billing save-in address book** checkbox in a selected payment method other than the default method.  *Fix submitted by Rakesh Gangani in pull request [15344](https://github.com/magento/magento2/pull/15344)*. [GitHub-13692](https://github.com/magento/magento2/issues/13692)
+<!-- ENGCOM-1988  -->
+*  During the payment step of checkout, a customer can now successfully deselect the **Billing save-in address book** checkbox in a selected payment method other than the default method.  *Fix submitted by Rakesh Gangani in pull request [15344](https://github.com/magento/magento2/pull/15344)*. [GitHub-13692](https://github.com/magento/magento2/issues/13692)
 
-<!-- ENGCOM-1298 -->* The `.block-minicart` element on the mini cart dropdown menu no longer has an empty class. *Fix submitted by Karla Saaremäe in pull request [14715](https://github.com/magento/magento2/pull/14715)*. [GitHub-14669](https://github.com/magento/magento2/issues/14669)
+<!-- ENGCOM-1298  -->
+*  The `.block-minicart` element on the mini cart dropdown menu no longer has an empty class. *Fix submitted by Karla Saaremäe in pull request [14715](https://github.com/magento/magento2/pull/14715)*. [GitHub-14669](https://github.com/magento/magento2/issues/14669)
 
-<!-- MAGETWO-92573 -->* Customers can now add configurable products to their shopping cart when Magento is running on Internet Explorer 11.x.
+<!-- MAGETWO-92573  -->
+*  Customers can now add configurable products to their shopping cart when Magento is running on Internet Explorer 11.x.
 
-<!--MAGETWO-87872 -->* The free shipping cart price rule now works as expected when the UPS shipping method is enabled. Previously, UPS Ground shipping method was not available for free shipping at checkout when the UPS shipping method was enabled.
+<!--MAGETWO-87872  -->
+*  The free shipping cart price rule now works as expected when the UPS shipping method is enabled. Previously, UPS Ground shipping method was not available for free shipping at checkout when the UPS shipping method was enabled.
 
-<!-- MAGETWO-82132 -->* Cart price rule condition values now handle commas as expected.
+<!-- MAGETWO-82132  -->
+*  Cart price rule condition values now handle commas as expected.
 
-<!-- MAGETWO-69940 -->* Free shipping coupons now work as expected with Table Rates shipping. Previously, Magento displayed this message when a customer tried to use a free shipping coupon: `Sorry, no quotes are available for this order`.  [GitHub-8172](https://github.com/magento/magento2/issues/8172)
+<!-- MAGETWO-69940  -->
+*  Free shipping coupons now work as expected with Table Rates shipping. Previously, Magento displayed this message when a customer tried to use a free shipping coupon: `Sorry, no quotes are available for this order`.  [GitHub-8172](https://github.com/magento/magento2/issues/8172)
 
-<!-- MAGETWO-91112 -->* Magento now displays correct store view prices for cases when a merchant uses a CSV file to add products by SKU  from the Admin.
+<!-- MAGETWO-91112  -->
+*  Magento now displays correct store view prices for cases when a merchant uses a CSV file to add products by SKU  from the Admin.
 
-<!-- MAGETWO-90190 -->* A merchant can successfully use SKU values that contain capital letters to  add a product  to a cart from the Admin.
+<!-- MAGETWO-90190  -->
+*  A merchant can successfully use SKU values that contain capital letters to  add a product  to a cart from the Admin.
 
-<!-- MAGETWO-90053 -->* Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout out page affected information entered into form fields for a guest checkout.
+<!-- MAGETWO-90053  -->
+*  Refreshing the checkout page no longer deletes the shipping address when a guest checks out. Previously, when the persistent shopping cart was enabled, refreshing the checkout out page affected information entered into form fields for a guest checkout.
 
-<!-- MAGETWO-89222 -->* The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
+<!-- MAGETWO-89222  -->
+*  The speed at which Magento places an order is no longer affected by how many shipping methods are available. Previously, when a customer placed an order for which multiple shipping methods were available, Magento took more than 20 seconds to place the order.
 
-<!-- MAGETWO-73537 -->* Magento now maintains browser history as expected when a user navigates from the checkout contact information page to the checkout payment information page.  Previously, when a user tried to retrace her steps after landing on the payment information page, Magento did not return them to the checkout contact information page, but instead landed on a product page.
+<!-- MAGETWO-73537  -->
+*  Magento now maintains browser history as expected when a user navigates from the checkout contact information page to the checkout payment information page.  Previously, when a user tried to retrace her steps after landing on the payment information page, Magento did not return them to the checkout contact information page, but instead landed on a product page.
 
-<!-- MAGETWO-73736 -->* Magento now displays a message  when a gift card  card is removed during checkout.
+<!-- MAGETWO-73736  -->
+*  Magento now displays a message  when a gift card  card is removed during checkout.
 
-<!-- MAGETWO-86470 -->* Guest orders placed with gift cards can now be canceled.
+<!-- MAGETWO-86470  -->
+*  Guest orders placed with gift cards can now be canceled.
 
-<!-- MAGETWO-86490 -->* A shopping cart’s contents remains constant even when the Checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
+<!-- MAGETWO-86490  -->
+*  A shopping cart’s contents remains constant even when the Checkout page is repeatedly reloaded. Previously, if a customer reloaded the checkout page several times, Magento emptied the shopping cart and the customer could not place the order. (This problem primarily affected stores running on HTTPS.)
 
-<!-- ENGCOM-840 -->* The message that Magento displays when a customer has successfully added a product to his shopping cart now contains a link to the cart.  *Fix submitted by Andreas von Studnitz in pull request [13904](https://github.com/magento/magento2/pull/13904)*.
+<!-- ENGCOM-840  -->
+*  The message that Magento displays when a customer has successfully added a product to his shopping cart now contains a link to the cart.  *Fix submitted by Andreas von Studnitz in pull request [13904](https://github.com/magento/magento2/pull/13904)*.
 
-<!-- ENGCOM-1430 -->* The Update button now behaves the same whether product quantity is manually edited or changed by JavaScript. *Fix submitted by Valerij Ivashchenko in pull request [14935](https://github.com/magento/magento2/pull/14935)*.
+<!-- ENGCOM-1430  -->
+*  The Update button now behaves the same whether product quantity is manually edited or changed by JavaScript. *Fix submitted by Valerij Ivashchenko in pull request [14935](https://github.com/magento/magento2/pull/14935)*.
 
-<!-- ENGCOM-1399 -->* Magento no longer displays the infinite checkout loader when a module that is loading  makes a `require` call, but the dependency is not returned (typically due to network error). *Fix submitted by Vova Yatsyuk in pull request [14874](https://github.com/magento/magento2/pull/14874)*.
+<!-- ENGCOM-1399  -->
+*  Magento no longer displays the infinite checkout loader when a module that is loading  makes a `require` call, but the dependency is not returned (typically due to network error). *Fix submitted by Vova Yatsyuk in pull request [14874](https://github.com/magento/magento2/pull/14874)*.
 
-<!-- ENGCOM-1299 -->* The minicart quantity label no longer has a fixed length. *Fix submitted by Karla Saaremäe in pull request [14716](https://github.com/magento/magento2/pull/14716)*.
+<!-- ENGCOM-1299  -->
+*  The minicart quantity label no longer has a fixed length. *Fix submitted by Karla Saaremäe in pull request [14716](https://github.com/magento/magento2/pull/14716)*.
 
-<!-- MAGETWO-93347 -->* Double-clicking on the **Proceed to checkout** button from the minicart no longer returns an empty shopping cart.
+<!-- MAGETWO-93347  -->
+*  Double-clicking on the **Proceed to checkout** button from the minicart no longer returns an empty shopping cart.
 
 ### Cleanup
 
@@ -428,227 +566,332 @@ Our community contributors have made many helpful, minor corrections to spelling
 
 #### Spelling corrections
 
-<!-- ENGCOM-2290 -->* Corrected misspelling of `formatedPrice` throughout the code base. *Fix submitted by Arnoud Beekman in pull request [16726](https://github.com/magento/magento2/pull/16726)*.
+<!-- ENGCOM-2290  -->
+*  Corrected misspelling of `formatedPrice` throughout the code base. *Fix submitted by Arnoud Beekman in pull request [16726](https://github.com/magento/magento2/pull/16726)*.
 
-<!-- ENGCOM-2280 -->* Corrected return message from `ProductRuleTest.php`. *Fix submitted by Namrata in pull request [16721](https://github.com/magento/magento2/pull/16721)*.
+<!-- ENGCOM-2280  -->
+*  Corrected return message from `ProductRuleTest.php`. *Fix submitted by Namrata in pull request [16721](https://github.com/magento/magento2/pull/16721)*.
 
-<!-- ENGCOM-2297 -->* Replaced the `proccessAdditionalValidation` method with `processAdditionalValidation`. *Fix submitted by Tiago Sampaio in pull request [16414](https://github.com/magento/magento2/pull/16414)*.
+<!-- ENGCOM-2297  -->
+*  Replaced the `proccessAdditionalValidation` method with `processAdditionalValidation`. *Fix submitted by Tiago Sampaio in pull request [16414](https://github.com/magento/magento2/pull/16414)*.
 
-<!-- ENGCOM-2276 -->* Corrected misspelling in `SynonymGroupRepositoryInterface`. *Fix submitted by AnshuMishra17 in pull request [16711](https://github.com/magento/magento2/pull/16711)*.
+<!-- ENGCOM-2276  -->
+*  Corrected misspelling in `SynonymGroupRepositoryInterface`. *Fix submitted by AnshuMishra17 in pull request [16711](https://github.com/magento/magento2/pull/16711)*.
 
-<!-- ENGCOM-2170 -->* Corrected misspelling in  library file. *Fix submitted by Namrata in pull request [16495](https://github.com/magento/magento2/pull/16495)*.
+<!-- ENGCOM-2170  -->
+*  Corrected misspelling in  library file. *Fix submitted by Namrata in pull request [16495](https://github.com/magento/magento2/pull/16495)*.
 
-<!-- ENGCOM-2165 -->* Corrected punctuation in the message displayed on **CONTENT** > **Design** > **Configuration**. *Fix submitted by Erik Hansen in pull request [16489](https://github.com/magento/magento2/pull/16489)*.
+<!-- ENGCOM-2165  -->
+*  Corrected punctuation in the message displayed on **CONTENT** > **Design** > **Configuration**. *Fix submitted by Erik Hansen in pull request [16489](https://github.com/magento/magento2/pull/16489)*.
 
-<!-- ENGCOM-2040 -->* Correct misspellings in Model and library files. *Fix submitted by Namarata in pull request [16230](https://github.com/magento/magento2/pull/16230)*.
+<!-- ENGCOM-2040  -->
+*  Correct misspellings in Model and library files. *Fix submitted by Namarata in pull request [16230](https://github.com/magento/magento2/pull/16230)*.
 
-<!-- ENGCOM-1581 -->* Corrected misspelling in  `_exportAddressses` method name. *Fix submitted by Marcel Hauri in pull request [15275](https://github.com/magento/magento2/pull/15275)*.
+<!-- ENGCOM-1581  -->
+*  Corrected misspelling in  `_exportAddressses` method name. *Fix submitted by Marcel Hauri in pull request [15275](https://github.com/magento/magento2/pull/15275)*.
 
-<!-- ENGCOM-1647 -->* Corrected misspelling in comments for `addTaxPercents()` in `app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php`. *Fix submitted by AnshuMishra17 in pull request [15431](https://github.com/magento/magento2/pull/15431)*.
+<!-- ENGCOM-1647  -->
+*  Corrected misspelling in comments for `addTaxPercents()` in `app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php`. *Fix submitted by AnshuMishra17 in pull request [15431](https://github.com/magento/magento2/pull/15431)*.
 
-<!-- ENGCOM-1637 -->* Corrected misspelling in `abstract.js`. *Fix submitted by VitaliyBoyko in pull request [15411](https://github.com/magento/magento2/pull/15411)*.
+<!-- ENGCOM-1637  -->
+*  Corrected misspelling in `abstract.js`. *Fix submitted by VitaliyBoyko in pull request [15411](https://github.com/magento/magento2/pull/15411)*.
 
-<!-- ENGCOM-1797 -->* Corrected misspellings in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebar.php`, `app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js`, `app/code/Magento/Ui/view/base/web/js/form/components/group.js`,  `setup/pub/angular-sanitize/angular-sanitize.js`, and `setup/pub/angular-sanitize/angular-sanitize.min.js.map`.  *Fix submitted by Danny Verkade in pull request [15715](https://github.com/magento/magento2/pull/15715)*.
+<!-- ENGCOM-1797  -->
+*  Corrected misspellings in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebar.php`, `app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js`, `app/code/Magento/Ui/view/base/web/js/form/components/group.js`,  `setup/pub/angular-sanitize/angular-sanitize.js`, and `setup/pub/angular-sanitize/angular-sanitize.min.js.map`.  *Fix submitted by Danny Verkade in pull request [15715](https://github.com/magento/magento2/pull/15715)*.
 
-<!-- ENGCOM-1692 -->* Corrected misspelling in `app/code/Magento/Catalog/Model/Product/Type/AbstractType.php`. *Fix submitted by Saurabh Parekh in pull request [15519](https://github.com/magento/magento2/pull/15519)*.
+<!-- ENGCOM-1692  -->
+*  Corrected misspelling in `app/code/Magento/Catalog/Model/Product/Type/AbstractType.php`. *Fix submitted by Saurabh Parekh in pull request [15519](https://github.com/magento/magento2/pull/15519)*.
 
-<!-- ENGCOM-1676 -->* Corrected misspellings in Multishipping and User modules. *Fix submitted by Anna Völkl in pull request [15513](https://github.com/magento/magento2/pull/15513)*.
+<!-- ENGCOM-1676  -->
+*  Corrected misspellings in Multishipping and User modules. *Fix submitted by Anna Völkl in pull request [15513](https://github.com/magento/magento2/pull/15513)*.
 
-<!-- ENGCOM-1599-->* Corrected a misspelling in function comment in `app/code/Magento/Paypal/Model/Api/Nvp.php` *Fix submitted by Namrata in pull request [15302](https://github.com/magento/magento2/pull/15302)*.
+<!-- ENGCOM-1599 -->
+*  Corrected a misspelling in function comment in `app/code/Magento/Paypal/Model/Api/Nvp.php` *Fix submitted by Namrata in pull request [15302](https://github.com/magento/magento2/pull/15302)*.
 
-<!-- ENGCOM-1588-->*  Corrected misspellings in PHPDocs and comments. *Fix submitted by Dmytro Cheshun in pull request [15293](https://github.com/magento/magento2/pull/15293)*.
+<!-- ENGCOM-1588 -->
+*   Corrected misspellings in PHPDocs and comments. *Fix submitted by Dmytro Cheshun in pull request [15293](https://github.com/magento/magento2/pull/15293)*.
 
-<!-- ENGCOM-1580-->* Corrected typo in method name `_getCharg[e]ableOptionPrice`. *Fix submitted by Marcel Hauri in pull request [15276](https://github.com/magento/magento2/pull/15276)*.
+<!-- ENGCOM-1580 -->
+*  Corrected typo in method name `_getCharg[e]ableOptionPrice`. *Fix submitted by Marcel Hauri in pull request [15276](https://github.com/magento/magento2/pull/15276)*.
 
-<!-- ENGCOM-1586-->* Corrected typo in database column comment in `app/code/Magento/Catalog/Setup/InstallSchema.php`. *Fix submitted by VitaliyBoyko in pull request [15291](https://github.com/magento/magento2/pull/15291)*.
+<!-- ENGCOM-1586 -->
+*  Corrected typo in database column comment in `app/code/Magento/Catalog/Setup/InstallSchema.php`. *Fix submitted by VitaliyBoyko in pull request [15291](https://github.com/magento/magento2/pull/15291)*.
 
-<!-- ENGCOM-1584-->* Corrected misspelling in the name of private method `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniq[ue]ImageIndex`. *Fix submitted by Marcel Hauri in pull request [15282](https://github.com/magento/magento2/pull/15282)*.
+<!-- ENGCOM-1584 -->
+*  Corrected misspelling in the name of private method `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniq[ue]ImageIndex`. *Fix submitted by Marcel Hauri in pull request [15282](https://github.com/magento/magento2/pull/15282)*.
 
-<!-- ENGCOM-1582-->* Corrected typo in the `\Magento\Framework\Image::open` exception message. *Fix submitted by Tom Richards in pull request [15269](https://github.com/magento/magento2/pull/15269)*.
+<!-- ENGCOM-1582 -->
+*  Corrected typo in the `\Magento\Framework\Image::open` exception message. *Fix submitted by Tom Richards in pull request [15269](https://github.com/magento/magento2/pull/15269)*.
 
-<!-- ENGCOM-1406-->* Corrected misspelling in `ResourceModel\Coupon.php:updateSpecificCoupons`. *Fix submitted by Stephen Biston in pull request [14891](https://github.com/magento/magento2/pull/14891)*.
+<!-- ENGCOM-1406 -->
+*  Corrected misspelling in `ResourceModel\Coupon.php:updateSpecificCoupons`. *Fix submitted by Stephen Biston in pull request [14891](https://github.com/magento/magento2/pull/14891)*.
 
-<!-- ENGCOM-1575-->* Corrected typo in the name of the `\Magento\Framework\App\Request\Http::removeRepitedSlashes` method. *Fix submitted by Igor Tripolskiy in pull request [15256](https://github.com/magento/magento2/pull/15256)*.
+<!-- ENGCOM-1575 -->
+*  Corrected typo in the name of the `\Magento\Framework\App\Request\Http::removeRepitedSlashes` method. *Fix submitted by Igor Tripolskiy in pull request [15256](https://github.com/magento/magento2/pull/15256)*.
 
-<!-- ENGCOM-1470-->* Corrected misspelling in `app/code/Magento/CatalogSearch/Block/Advanced/Form.php`. *Fix submitted by Jeevan M R in pull request [15053](https://github.com/magento/magento2/pull/15053)*.
+<!-- ENGCOM-1470 -->
+*  Corrected misspelling in `app/code/Magento/CatalogSearch/Block/Advanced/Form.php`. *Fix submitted by Jeevan M R in pull request [15053](https://github.com/magento/magento2/pull/15053)*.
 
-<!-- ENGCOM-1458-->* Corrected misspelling in `.less` files. *Fix submitted by Kalpesh Mehta in pull request [15023](https://github.com/magento/magento2/pull/15023)*.
+<!-- ENGCOM-1458 -->
+*  Corrected misspelling in `.less` files. *Fix submitted by Kalpesh Mehta in pull request [15023](https://github.com/magento/magento2/pull/15023)*.
 
-<!-- ENGCOM-2057 -->* Removed double occurrence of 'it' from sentences and corrected minor grammar error. *Fix submitted by Namrata in pull request [16240](https://github.com/magento/magento2/pull/16240)*.
+<!-- ENGCOM-2057  -->
+*  Removed double occurrence of 'it' from sentences and corrected minor grammar error. *Fix submitted by Namrata in pull request [16240](https://github.com/magento/magento2/pull/16240)*.
 
-<!-- ENGCOM-2097 -->* Fixed typo in `app/code/Magento/Checkout/etc/webapi.xml`. *Fix submitted by Markus Haack in pull request [15845](https://github.com/magento/magento2/pull/15845)*.
+<!-- ENGCOM-2097  -->
+*  Fixed typo in `app/code/Magento/Checkout/etc/webapi.xml`. *Fix submitted by Markus Haack in pull request [15845](https://github.com/magento/magento2/pull/15845)*.
 
-<!-- ENGCOM-1897 -->* Corrected misspelling in `file-uploader.js` and `storage-manager.js`. *Fix submitted by Saurabh Parekh in pull request [15888](https://github.com/magento/magento2/pull/15888)*.
+<!-- ENGCOM-1897  -->
+*  Corrected misspelling in `file-uploader.js` and `storage-manager.js`. *Fix submitted by Saurabh Parekh in pull request [15888](https://github.com/magento/magento2/pull/15888)*.
 
-<!-- ENGCOM-1925 -->* Corrected misspelling in `scripts.js`. *Fix submitted by Ledian Hymetllari in pull request [15878](https://github.com/magento/magento2/pull/15907)*.
+<!-- ENGCOM-1925  -->
+*  Corrected misspelling in `scripts.js`. *Fix submitted by Ledian Hymetllari in pull request [15878](https://github.com/magento/magento2/pull/15907)*.
 
-<!-- ENGCOM-2545 -->* Corrected grammar error in the "What is this" tooltip for the Braintree vault tool tip. *Fix submitted by kreativedev in pull request [17151](https://github.com/magento/magento2/pull/17151)*.
+<!-- ENGCOM-2545  -->
+*  Corrected grammar error in the "What is this" tooltip for the Braintree vault tool tip. *Fix submitted by kreativedev in pull request [17151](https://github.com/magento/magento2/pull/17151)*.
 
-<!-- ENGCOM-2456 -->* Renamed `_requesetd` to `_requested` in  `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`. *Fix submitted by Valerij Ivashchenko in pull request [16971](https://github.com/magento/magento2/pull/16971)*.
+<!-- ENGCOM-2456  -->
+*  Renamed `_requesetd` to `_requested` in  `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`. *Fix submitted by Valerij Ivashchenko in pull request [16971](https://github.com/magento/magento2/pull/16971)*.
 
-<!-- ENGCOM-2447 -->* Removed double occurrences of words from `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, `Magento_Sales`,  and `lib` and `dev` test function comments. *Fix submitted by Pratik Oza in pull request [16977](https://github.com/magento/magento2/pull/16977)*.
+<!-- ENGCOM-2447  -->
+*  Removed double occurrences of words from `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, `Magento_Sales`,  and `lib` and `dev` test function comments. *Fix submitted by Pratik Oza in pull request [16977](https://github.com/magento/magento2/pull/16977)*.
 
-<!--  ENGCOM-1589 -->* Correct misspelling in method name and result in these files: `dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Onepage/Shipping/Method.php` and `dev/tests/functional/tests/app/Magento/Shipping/Test/Constraint/AssertCityBasedShippingRateChanged.php`. *Fix submitted by Dmytro Cheshun in pull request [15297](https://github.com/magento/magento2/pull/15297)*.
+<!--  ENGCOM-1589  -->
+*  Correct misspelling in method name and result in these files: `dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Onepage/Shipping/Method.php` and `dev/tests/functional/tests/app/Magento/Shipping/Test/Constraint/AssertCityBasedShippingRateChanged.php`. *Fix submitted by Dmytro Cheshun in pull request [15297](https://github.com/magento/magento2/pull/15297)*.
 
 #### Minor corrections to code and code formatting
 
-<!-- ENGCOM-2385 -->* Removed extra spaces from `Magento/Ui`. *Fix submitted by Ronak Patel in pull request [16872](https://github.com/magento/magento2/pull/16872)*.
+<!-- ENGCOM-2385  -->
+*  Removed extra spaces from `Magento/Ui`. *Fix submitted by Ronak Patel in pull request [16872](https://github.com/magento/magento2/pull/16872)*.
 
-<!-- ENGCOM-2354 -->* Improved code formatting. *Fix submitted by Pratik Oza in pull request [16821](https://github.com/magento/magento2/pull/16821)*.
+<!-- ENGCOM-2354  -->
+*  Improved code formatting. *Fix submitted by Pratik Oza in pull request [16821](https://github.com/magento/magento2/pull/16821)*.
 
-<!-- ENGCOM-2305 -->* Removed comments and unnecessary spaces. *Fix submitted by Ronak Patel in pull request [16748](https://github.com/magento/magento2/pull/16748)*.
+<!-- ENGCOM-2305  -->
+*  Removed comments and unnecessary spaces. *Fix submitted by Ronak Patel in pull request [16748](https://github.com/magento/magento2/pull/16748)*.
 
-<!-- ENGCOM-2283 -->* Removed space before ending sentence throughout code base. *Fix submitted by Namrata in pull request [16717](https://github.com/magento/magento2/pull/16717)*.
+<!-- ENGCOM-2283  -->
+*  Removed space before ending sentence throughout code base. *Fix submitted by Namrata in pull request [16717](https://github.com/magento/magento2/pull/16717)*.
 
-<!-- ENGCOM-2249 -->* Removed unnecessary spaces in `app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php`. *Fix submitted by Ronak Patel in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
+<!-- ENGCOM-2249  -->
+*  Removed unnecessary spaces in `app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php`. *Fix submitted by Ronak Patel in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
 
-<!-- ENGCOM-2238 -->* Removed double occurrences of words from the lib and dev test function comments and from these modules: `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, and `Magento_Sales`. *Fix submitted by Namrata in pull request [16644](https://github.com/magento/magento2/pull/16644)*.
+<!-- ENGCOM-2238  -->
+*  Removed double occurrences of words from the lib and dev test function comments and from these modules: `Magento_Catalog`, `Magento_Customer`, `Magento_Downloadable`, and `Magento_Sales`. *Fix submitted by Namrata in pull request [16644](https://github.com/magento/magento2/pull/16644)*.
 
-<!-- ENGCOM-2206 -->* Removed double occurrences from `jQuery`, Angular JS files and the `Magento_Setup` module's scan function's comment. *Fix submitted by Namrata in pull request [16581](https://github.com/magento/magento2/pull/16581)*.
+<!-- ENGCOM-2206  -->
+*  Removed double occurrences from `jQuery`, Angular JS files and the `Magento_Setup` module's scan function's comment. *Fix submitted by Namrata in pull request [16581](https://github.com/magento/magento2/pull/16581)*.
 
-<!-- ENGCOM-2195 -->* Removed extra space from the value of the `is_required` XML node in `SynonymGroup.xml`. *Fix submitted by Namrata in pull request [16557](https://github.com/magento/magento2/pull/16557)*.
+<!-- ENGCOM-2195  -->
+*  Removed extra space from the value of the `is_required` XML node in `SynonymGroup.xml`. *Fix submitted by Namrata in pull request [16557](https://github.com/magento/magento2/pull/16557)*.
 
-<!--  ENGCOM-2366 -->* Minor corrections to code throughout the code base. *Fix submitted by GraysonChiang in pull request [16841](https://github.com/magento/magento2/pull/16841)*.
+<!--  ENGCOM-2366  -->
+*  Minor corrections to code throughout the code base. *Fix submitted by GraysonChiang in pull request [16841](https://github.com/magento/magento2/pull/16841)*.
 
-<!-- ENGCOM-2186 -->* Removed unused data from `app/code/Magento/Ui/Model/Export/ConvertToCsv.php` and `app/code/Magento/Ui/Model/Export/ConvertToXml.php`. *Fix submitted by Vishal Gelani in pull request [16524](https://github.com/magento/magento2/pull/16524)*.
+<!-- ENGCOM-2186  -->
+*  Removed unused data from `app/code/Magento/Ui/Model/Export/ConvertToCsv.php` and `app/code/Magento/Ui/Model/Export/ConvertToXml.php`. *Fix submitted by Vishal Gelani in pull request [16524](https://github.com/magento/magento2/pull/16524)*.
 
-<!-- ENGCOM-2086 -->* Removed unnecessary translations for label and comment tags and added missing translation strings. *Fix submitted by Yogesh Suhagiya in pull request [16090](https://github.com/magento/magento2/pull/16090)*.
+<!-- ENGCOM-2086  -->
+*  Removed unnecessary translations for label and comment tags and added missing translation strings. *Fix submitted by Yogesh Suhagiya in pull request [16090](https://github.com/magento/magento2/pull/16090)*.
 
-<!-- ENGCOM-2177 -->* Removed redundant plug-in information (`dev:di:info`). *Fix submitted by Alexander Shkurko in pull request [16474](https://github.com/magento/magento2/pull/16474)*.
+<!-- ENGCOM-2177  -->
+*  Removed redundant plug-in information (`dev:di:info`). *Fix submitted by Alexander Shkurko in pull request [16474](https://github.com/magento/magento2/pull/16474)*.
 
-<!-- ENGCOM-1711 -->* Removed redundant semicolon from these files: `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.phpMagento/Multishipping/Test/Unit/Block/Checkout/SuccessTest.php` and  `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php`. *Fix submitted by Saurabh Parekh in pull request [15594](https://github.com/magento/magento2/pull/15594)*.
+<!-- ENGCOM-1711  -->
+*  Removed redundant semicolon from these files: `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.phpMagento/Multishipping/Test/Unit/Block/Checkout/SuccessTest.php` and  `app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php`. *Fix submitted by Saurabh Parekh in pull request [15594](https://github.com/magento/magento2/pull/15594)*.
 
-<!-- ENGCOM-1700 -->* Corrected errors in method description in `app/code/Magento/Config/Block/System/Config/Form.php`,  `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`, and  `app/code/Magento/Customer/Model/Session.php`. *Fix submitted by Vishal Gelani in pull request [15549](https://github.com/magento/magento2/pull/15549)*.
+<!-- ENGCOM-1700  -->
+*  Corrected errors in method description in `app/code/Magento/Config/Block/System/Config/Form.php`,  `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`, and  `app/code/Magento/Customer/Model/Session.php`. *Fix submitted by Vishal Gelani in pull request [15549](https://github.com/magento/magento2/pull/15549)*.
 
-<!-- ENGCOM-1697 -->* Removed extra space and formatted the code in `app/code/Magento/Captcha/i18n/en_US.csv`. *Fix submitted by Saurabh Parekh in pull request [15552](https://github.com/magento/magento2/pull/15552)*.
+<!-- ENGCOM-1697  -->
+*  Removed extra space and formatted the code in `app/code/Magento/Captcha/i18n/en_US.csv`. *Fix submitted by Saurabh Parekh in pull request [15552](https://github.com/magento/magento2/pull/15552)*.
 
-<!-- ENGCOM-1651 -->* Removed the redundant `else` statement in `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`. *Fix submitted by Yaroslav Rogoza in pull request [15435](https://github.com/magento/magento2/pull/15435)*.
+<!-- ENGCOM-1651  -->
+*  Removed the redundant `else` statement in `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php`. *Fix submitted by Yaroslav Rogoza in pull request [15435](https://github.com/magento/magento2/pull/15435)*.
 
-<!-- ENGCOM-2270-->* Fixed misplaced bracket in `Option/Type/Text.php`. *Fix submitted by Valerij Ivashchenko in pull request [16566](https://github.com/magento/magento2/pull/16566)*.
+<!-- ENGCOM-2270 -->
+*  Fixed misplaced bracket in `Option/Type/Text.php`. *Fix submitted by Valerij Ivashchenko in pull request [16566](https://github.com/magento/magento2/pull/16566)*.
 
-<!-- ENGCOM-1592 -->* Removed a duplicate line and added comment in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Discount.php`. *Fix submitted by Vishal Gelani in pull request [15362](https://github.com/magento/magento2/pull/15362)*.
+<!-- ENGCOM-1592  -->
+*  Removed a duplicate line and added comment in `app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Discount.php`. *Fix submitted by Vishal Gelani in pull request [15362](https://github.com/magento/magento2/pull/15362)*.
 
-<!-- ENGCOM-1593 -->* Removed unused variable in `lib/web/css/source/lib/variables/_typography.less`. *Fix submitted by VitaliyBoyko in pull request [15386](https://github.com/magento/magento2/pull/15386)*.
+<!-- ENGCOM-1593  -->
+*  Removed unused variable in `lib/web/css/source/lib/variables/_typography.less`. *Fix submitted by VitaliyBoyko in pull request [15386](https://github.com/magento/magento2/pull/15386)*.
 
-<!-- ENGCOM-1602-->* Corrected variable names in `LockAdminUserWhenEditingIntegrationTest` and `AssertCityBasedShippingRateChanged`, among others. *Fix submitted by Dmytro Cheshun in pull request [15294](https://github.com/magento/magento2/pull/15294)*.
+<!-- ENGCOM-1602 -->
+*  Corrected variable names in `LockAdminUserWhenEditingIntegrationTest` and `AssertCityBasedShippingRateChanged`, among others. *Fix submitted by Dmytro Cheshun in pull request [15294](https://github.com/magento/magento2/pull/15294)*.
 
-<!-- ENGCOM-1587-->* Corrected property name in  `dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php`. *Fix submitted by Dmytro Cheshun in pull request [15292](https://github.com/magento/magento2/pull/15292)*.
+<!-- ENGCOM-1587 -->
+*  Corrected property name in  `dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php`. *Fix submitted by Dmytro Cheshun in pull request [15292](https://github.com/magento/magento2/pull/15292)*.
 
-<!-- ENGCOM-1572-->* Removed non-existing argument from the constructor's comment block in  `app/code/Magento/Translation/Block/Html/Head/Config.php` and added space where needed in  `app/code/Magento/Translation/Model/Json/PreProcessor.php`. *Fix submitted by Yogesh Suhagiya in pull request [15249](https://github.com/magento/magento2/pull/15249)*.
+<!-- ENGCOM-1572 -->
+*  Removed non-existing argument from the constructor's comment block in  `app/code/Magento/Translation/Block/Html/Head/Config.php` and added space where needed in  `app/code/Magento/Translation/Model/Json/PreProcessor.php`. *Fix submitted by Yogesh Suhagiya in pull request [15249](https://github.com/magento/magento2/pull/15249)*.
 
-<!-- ENGCOM-1427-->* Removed redundant close tag from `app/code/Magento/Review/view/frontend/templates/view.phtml`. *Fix submitted by Yogesh Suhagiya in pull request [14928](https://github.com/magento/magento2/pull/14928)*.
+<!-- ENGCOM-1427 -->
+*  Removed redundant close tag from `app/code/Magento/Review/view/frontend/templates/view.phtml`. *Fix submitted by Yogesh Suhagiya in pull request [14928](https://github.com/magento/magento2/pull/14928)*.
 
-<!-- ENGCOM-1409-->* Removed extra spaces from a key-value pair in the `en_US.csv`language file. *Fix submitted by Yogesh Suhagiya in pull request [14896](https://github.com/magento/magento2/pull/14896)*.
+<!-- ENGCOM-1409 -->
+*  Removed extra spaces from a key-value pair in the `en_US.csv`language file. *Fix submitted by Yogesh Suhagiya in pull request [14896](https://github.com/magento/magento2/pull/14896)*.
 
-<!-- ENGCOM-1306-->* Cleaned up `foreach` and `break` statements in `app/code/Magento/Rule/Model/Condition/AbstractCondition.php`. *Fix submitted by Thomas Klein in pull request [14609](https://github.com/magento/magento2/pull/14609)*.
+<!-- ENGCOM-1306 -->
+*  Cleaned up `foreach` and `break` statements in `app/code/Magento/Rule/Model/Condition/AbstractCondition.php`. *Fix submitted by Thomas Klein in pull request [14609](https://github.com/magento/magento2/pull/14609)*.
 
-<!--  ENGCOM-1384 -->* Corrected grammar in `README.md`. *Fix submitted by Stanislav Idolov in pull request [14844](https://github.com/magento/magento2/pull/14844)*.
+<!--  ENGCOM-1384  -->
+*  Corrected grammar in `README.md`. *Fix submitted by Stanislav Idolov in pull request [14844](https://github.com/magento/magento2/pull/14844)*.
 
-<!--  ENGCOM-2218 -->* Corrected type hints in `Webapi/Controller/Soap/Request/Handler.php` and `Webapi/Model/Plugin/GuestAuthorization.php`. Also corrected case in property annotation  in `Soap\Server.php` and added undefined property `_appState` in `Controller\Soap.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
+<!--  ENGCOM-2218  -->
+*  Corrected type hints in `Webapi/Controller/Soap/Request/Handler.php` and `Webapi/Model/Plugin/GuestAuthorization.php`. Also corrected case in property annotation  in `Soap\Server.php` and added undefined property `_appState` in `Controller\Soap.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
 
-<!--  ENGCOM-2218 -->* Corrected `Magento\Webapi\Model\Soap\Fault::toXml()` method invocation in `Soap\FaultTest.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
+<!--  ENGCOM-2218  -->
+*  Corrected `Magento\Webapi\Model\Soap\Fault::toXml()` method invocation in `Soap\FaultTest.php`. *Fix submitted by Prince Patel in pull request [16626](https://github.com/magento/magento2/pull/16626)*.
 
-<!-- ENGCOM-1853 -->* We've removed an unused class from the `lib/_forms.less` file. *Fix submitted by Chirag Matholiya in pull request [15791](https://github.com/magento/magento2/pull/15791)*.
+<!-- ENGCOM-1853  -->
+*  We've removed an unused class from the `lib/_forms.less` file. *Fix submitted by Chirag Matholiya in pull request [15791](https://github.com/magento/magento2/pull/15791)*.
 
-<!-- ENGCOM-1861 -->* We've removed unnecessary CSS code from  `_actions-toolbar.less`. *Fix submitted by Chirag Matholiya in pull request [15789](https://github.com/magento/magento2/pull/15789)*.
+<!-- ENGCOM-1861  -->
+*  We've removed unnecessary CSS code from  `_actions-toolbar.less`. *Fix submitted by Chirag Matholiya in pull request [15789](https://github.com/magento/magento2/pull/15789)*.
 
-<!-- ENGCOM-1850 -->* We've removed the unnecessary double semicolon from the style sheets. *Fix submitted by Namrata in pull request [15795](https://github.com/magento/magento2/pull/15795)*.
+<!-- ENGCOM-1850  -->
+*  We've removed the unnecessary double semicolon from the style sheets. *Fix submitted by Namrata in pull request [15795](https://github.com/magento/magento2/pull/15795)*.
 
-<!-- ENGCOM-1880 -->* We've removed the unused code from `docs.less`. *Fix submitted by Daniel Ruf in pull request [15871](https://github.com/magento/magento2/pull/15871)*.
+<!-- ENGCOM-1880  -->
+*  We've removed the unused code from `docs.less`. *Fix submitted by Daniel Ruf in pull request [15871](https://github.com/magento/magento2/pull/15871)*.
 
-<!-- ENGCOM-1923 -->* Removed extraneous negative margin on product list and product list items. *Fix submitted by Steven de Jong in pull request [15936](https://github.com/magento/magento2/pull/15936)*. [GitHub-15308](https://github.com/magento/magento2/issues/15308)
+<!-- ENGCOM-1923  -->
+*  Removed extraneous negative margin on product list and product list items. *Fix submitted by Steven de Jong in pull request [15936](https://github.com/magento/magento2/pull/15936)*. [GitHub-15308](https://github.com/magento/magento2/issues/15308)
 
-<!-- ENGCOM-1959 -->* Indentation issues with LESS files have been resolved. *Fix submitted by hitesh-wagento in pull request [15811](https://github.com/magento/magento2/pull/15811)*.
+<!-- ENGCOM-1959  -->
+*  Indentation issues with LESS files have been resolved. *Fix submitted by hitesh-wagento in pull request [15811](https://github.com/magento/magento2/pull/15811)*.
 
-<!-- ENGCOM-2016 -->* The syntax for before-after operators in LESS files has been corrected. *Fix submitted by Namrata in pull request [16181](https://github.com/magento/magento2/pull/16181)*.
+<!-- ENGCOM-2016  -->
+*  The syntax for before-after operators in LESS files has been corrected. *Fix submitted by Namrata in pull request [16181](https://github.com/magento/magento2/pull/16181)*.
 
-<!-- ENGCOM-2018 -->* Redundant keywords have been removed from miscellaneous files. *Fix submitted by Namrata in pull request [16182](https://github.com/magento/magento2/pull/16182)*.
+<!-- ENGCOM-2018  -->
+*  Redundant keywords have been removed from miscellaneous files. *Fix submitted by Namrata in pull request [16182](https://github.com/magento/magento2/pull/16182)*.
 
-<!-- ENGCOM-2019 -->* We've corrected misspellings in the  comment section of `OrderFixture.php`.  *Fix submitted by Namrata in pull request [16183](https://github.com/magento/magento2/pull/16183)*.
+<!-- ENGCOM-2019  -->
+*  We've corrected misspellings in the  comment section of `OrderFixture.php`.  *Fix submitted by Namrata in pull request [16183](https://github.com/magento/magento2/pull/16183)*.
 
-<!-- ENGCOM-1680 -->* Unnecessary leading and trailing spaces have been removed from the customer account login page email field. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-1680  -->
+*  Unnecessary leading and trailing spaces have been removed from the customer account login page email field. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2023 -->* Unnecessary leading and trailing spaces have been removed from fields in the customer account create and login forms. *Fix submitted by Piyush Dankhara in pull request [16192](https://github.com/magento/magento2/pull/16192)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2023  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in the customer account create and login forms. *Fix submitted by Piyush Dankhara in pull request [16192](https://github.com/magento/magento2/pull/16192)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2198 -->* Unnecessary leading and trailing spaces have been removed from fields in newsletter, forgot password, checkout login and email to a friend forms. *Fix submitted by Piyush Dankhara in pull request [16564](https://github.com/magento/magento2/pull/16564)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2198  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in newsletter, forgot password, checkout login and email to a friend forms. *Fix submitted by Piyush Dankhara in pull request [16564](https://github.com/magento/magento2/pull/16564)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2381 -->* Unnecessary leading and trailing spaces have been removed from fields in the customer confirmation form. *Fix submitted by Vishal Gelani in pull request [16595](https://github.com/magento/magento2/pull/16595)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!-- ENGCOM-2381  -->
+*  Unnecessary leading and trailing spaces have been removed from fields in the customer confirmation form. *Fix submitted by Vishal Gelani in pull request [16595](https://github.com/magento/magento2/pull/16595)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!-- ENGCOM-2507 -->* Removed unnecessary commented code from these files: `app/code/Magento/Review/Model/ResourceModel/Rating/Collection.php`, `app/code/Magento/Sales/Model/Order/Creditmemo.php`, `lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php`, and `lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php`. *Fix submitted by Pratik Oza in pull request [17077](https://github.com/magento/magento2/pull/17077)*.
+<!-- ENGCOM-2507  -->
+*  Removed unnecessary commented code from these files: `app/code/Magento/Review/Model/ResourceModel/Rating/Collection.php`, `app/code/Magento/Sales/Model/Order/Creditmemo.php`, `lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php`, and `lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php`. *Fix submitted by Pratik Oza in pull request [17077](https://github.com/magento/magento2/pull/17077)*.
 
-<!-- ENGCOM-2485 -->* Removed unnecessary spaces from the price value in `app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml`. *Fix submitted by Valerij Ivashchenko in pull request [17027](https://github.com/magento/magento2/pull/17027)*.
+<!-- ENGCOM-2485  -->
+*  Removed unnecessary spaces from the price value in `app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml`. *Fix submitted by Valerij Ivashchenko in pull request [17027](https://github.com/magento/magento2/pull/17027)*.
 
-<!-- ENGCOM-2461 -->* Remove unused comments from `_initDiscount()` function. *Fix submitted by Prince Patel in pull request [17002](https://github.com/magento/magento2/pull/17002)*.
+<!-- ENGCOM-2461  -->
+*  Remove unused comments from `_initDiscount()` function. *Fix submitted by Prince Patel in pull request [17002](https://github.com/magento/magento2/pull/17002)*.
 
-<!-- ENGCOM-2451 -->* Corrected misspellings in multiple files, including `app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php`, `app/code/Magento/Catalog/view/adminhtml/web/js/product/weight-handler.js`, `app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php`, `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`, and `dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php`. *Fix submitted by Pratik Oza in pull request [16980](https://github.com/magento/magento2/pull/16980)*.
+<!-- ENGCOM-2451  -->
+*  Corrected misspellings in multiple files, including `app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php`, `app/code/Magento/Catalog/view/adminhtml/web/js/product/weight-handler.js`, `app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php`, `app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js`, and `dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php`. *Fix submitted by Pratik Oza in pull request [16980](https://github.com/magento/magento2/pull/16980)*.
 
-<!-- ENGCOM-1439 -->* Corrected formatting of the JavaScript code in the `app/code/Magento/Ui/view/base/templates/control/button/split.phtml` and `app/code/Magento/Ui/view/base/web/js/grid/controls/button/split.jstemplate` files. *Fix submitted by Yogesh Suhagiya in pull request [14967](https://github.com/magento/magento2/pull/14967)*.
+<!-- ENGCOM-1439  -->
+*  Corrected formatting of the JavaScript code in the `app/code/Magento/Ui/view/base/templates/control/button/split.phtml` and `app/code/Magento/Ui/view/base/web/js/grid/controls/button/split.jstemplate` files. *Fix submitted by Yogesh Suhagiya in pull request [14967](https://github.com/magento/magento2/pull/14967)*.
 
-<!-- ENGCOM-2071 -->* Removed redundant `@throws` hinting and unused import for `AdvancedPricingImportExport` module classes. *Fix submitted by Dmytro Cheshun in pull request [15872](https://github.com/magento/magento2/pull/15872)*.
+<!-- ENGCOM-2071  -->
+*  Removed redundant `@throws` hinting and unused import for `AdvancedPricingImportExport` module classes. *Fix submitted by Dmytro Cheshun in pull request [15872](https://github.com/magento/magento2/pull/15872)*.
 
-<!-- ENGCOM-2034 -->* Added missing PHPDoc to methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [16215](https://github.com/magento/magento2/pull/16215)*.
+<!-- ENGCOM-2034  -->
+*  Added missing PHPDoc to methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [16215](https://github.com/magento/magento2/pull/16215)*.
 
-<!-- ENGCOM-2045 -->* Fixed mismatches in case between class and method name spellings. *Fix submitted by Leandro F. L. in pull request [16141](https://github.com/magento/magento2/pull/16141)*.
+<!-- ENGCOM-2045  -->
+*  Fixed mismatches in case between class and method name spellings. *Fix submitted by Leandro F. L. in pull request [16141](https://github.com/magento/magento2/pull/16141)*.
 
-<!-- ENGCOM-1760 -->* Removed an unnecessary comma from the `translate` attribute in `app/code/Magento/Sales/etc/adminhtml/system.xml`. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1760  -->
+*  Removed an unnecessary comma from the `translate` attribute in `app/code/Magento/Sales/etc/adminhtml/system.xml`. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
 ### CMS content
 
-<!-- MAGETWO-92611-->* Page layout issues that resulted from incorrect module sequence have been corrected. Previously, the  `Magento_theme` module was loaded too late, which resulted in unexpected display issues.
+<!-- MAGETWO-92611 -->
+*  Page layout issues that resulted from incorrect module sequence have been corrected. Previously, the  `Magento_theme` module was loaded too late, which resulted in unexpected display issues.
 
-<!-- ENGCOM-1407-->* Corrected use statements and return values in `AggregationInterface`. *Fix submitted by Yaroslav Rogoza in pull request [14893](https://github.com/magento/magento2/pull/14893)*.
+<!-- ENGCOM-1407 -->
+*  Corrected use statements and return values in `AggregationInterface`. *Fix submitted by Yaroslav Rogoza in pull request [14893](https://github.com/magento/magento2/pull/14893)*.
 
 ### Configurable products
 
-<!-- ENGCOM-1686 -->* Customers can now successfully complete checkout when their order contains a configurable product with a configurable option. Previously, customers could not check out when there is a configurable product in the cart with a configurable option, which is now deleted, shopping cart could not be loaded. *Fix submitted by jonshipman in pull request [15468](https://github.com/magento/magento2/pull/15468)*. [GitHub-15467](https://github.com/magento/magento2/issues/15467)
+<!-- ENGCOM-1686  -->
+*  Customers can now successfully complete checkout when their order contains a configurable product with a configurable option. Previously, customers could not check out when there is a configurable product in the cart with a configurable option, which is now deleted, shopping cart could not be loaded. *Fix submitted by jonshipman in pull request [15468](https://github.com/magento/magento2/pull/15468)*. [GitHub-15467](https://github.com/magento/magento2/issues/15467)
 
-<!-- MAGETWO-87047 -->* Magento now displays the manufacturer attribute on the Admin on the Catalog page for configurable products. Previously, Magento displayed these attributes on the simple products catalog page, but not on the configurable products catalog page.
+<!-- MAGETWO-87047  -->
+*  Magento now displays the manufacturer attribute on the Admin on the Catalog page for configurable products. Previously, Magento displayed these attributes on the simple products catalog page, but not on the configurable products catalog page.
 
-<!-- MAGETWO-86125 -->* Configurable products are now sorted by only visible prices as expected. Previously, sorting a catalog by price resulted in sort results that included the prices of out-of-stock products and disabled child products.
+<!-- MAGETWO-86125  -->
+*  Configurable products are now sorted by only visible prices as expected. Previously, sorting a catalog by price resulted in sort results that included the prices of out-of-stock products and disabled child products.
 
-<!-- ENGCOM-2188 -->* When two simple products of a configurable product have different prices, Magento now uses the lowest price as the default price on the product detail page. Previously, if one of the simple products had price=0, Magento did not use it as the default. *Fix submitted by Torrey Tsui in pull request [16540](https://github.com/magento/magento2/pull/16540)*.
+<!-- ENGCOM-2188  -->
+*  When two simple products of a configurable product have different prices, Magento now uses the lowest price as the default price on the product detail page. Previously, if one of the simple products had price=0, Magento did not use it as the default. *Fix submitted by Torrey Tsui in pull request [16540](https://github.com/magento/magento2/pull/16540)*.
 
-<!-- ENGCOM-1512 -->* The missing check for a `false` value has been added  to  `ConfiguredRegularPrice`. Previously, when the parent method returned false, Magento threw this fatal error: `NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24`. *Fix submitted by Tibor Kotosz in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
+<!-- ENGCOM-1512  -->
+*  The missing check for a `false` value has been added  to  `ConfiguredRegularPrice`. Previously, when the parent method returned false, Magento threw this fatal error: `NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24`. *Fix submitted by Tibor Kotosz in pull request [15129](https://github.com/magento/magento2/pull/15129)*.
 
-<!-- ENGCOM-2194 -->* Fixed the DocBlock for `hasInvoices()`, `hasShipments()`, and `hasCreditmemos()` in `app/code/Magento/Sales/Model/Order.php`. *Fix submitted by Lyzun Oleksandr in pull request [16554](https://github.com/magento/magento2/pull/16554)*.
+<!-- ENGCOM-2194  -->
+*  Fixed the DocBlock for `hasInvoices()`, `hasShipments()`, and `hasCreditmemos()` in `app/code/Magento/Sales/Model/Order.php`. *Fix submitted by Lyzun Oleksandr in pull request [16554](https://github.com/magento/magento2/pull/16554)*.
 
-<!-- ENGCOM-2145 -->* Fixed type hints and docs for the Downloadable Samples block. *Fix submitted by Björn Kraus in pull request [16408](https://github.com/magento/magento2/pull/16408)*.
+<!-- ENGCOM-2145  -->
+*  Fixed type hints and docs for the Downloadable Samples block. *Fix submitted by Björn Kraus in pull request [16408](https://github.com/magento/magento2/pull/16408)*.
 
 ### Cookies
 
-<!-- ENGCOM-2403 -->* Magento now responds to a customer accepting a cookie notice by simply hiding the notice. Previously, Magento reloaded the entire site when a user accepted the cookie notice. *Fix submitted by Torben Höhn in pull request [16890](https://github.com/magento/magento2/pull/16890)*.
+<!-- ENGCOM-2403  -->
+*  Magento now responds to a customer accepting a cookie notice by simply hiding the notice. Previously, Magento reloaded the entire site when a user accepted the cookie notice. *Fix submitted by Torben Höhn in pull request [16890](https://github.com/magento/magento2/pull/16890)*.
 
 ### Customer account
 
-<!-- MAGETWO-92989 -->* Magento no longer logs out a customer after a successful password change.
+<!-- MAGETWO-92989  -->
+*  Magento no longer logs out a customer after a successful password change.
 
-<!-- MAGETWO-92507 -->* Magento no longer displays the State/Province instead of the State field on U.S. customer address forms.
+<!-- MAGETWO-92507  -->
+*  Magento no longer displays the State/Province instead of the State field on U.S. customer address forms.
 
-<!-- MAGETWO-91327 -->* Customer attributes are now correctly validated on the Admin Order form. Previously, Magento validated attributes\length  after an order has been submitted, but not on the Admin Order form.
+<!-- MAGETWO-91327  -->
+*  Customer attributes are now correctly validated on the Admin Order form. Previously, Magento validated attributes\length  after an order has been submitted, but not on the Admin Order form.
 
-<!-- MAGETWO-89624 -->* Customers no longer lose their session when they switch stores on different domains.
+<!-- MAGETWO-89624  -->
+*  Customers no longer lose their session when they switch stores on different domains.
 
-<!-- MAGETWO-89849 -->* Non-U.S. and non-Canadian addresses that are displayed in the  **Address Book summary**  field now display the State/Province values as expected if that information was provided.
+<!-- MAGETWO-89849  -->
+*  Non-U.S. and non-Canadian addresses that are displayed in the  **Address Book summary**  field now display the State/Province values as expected if that information was provided.
 
-<!-- MAGETWO-89034 -->* The checkout page no longer displays custom address attributes when **Show on frontend** is set to **no**.
+<!-- MAGETWO-89034  -->
+*  The checkout page no longer displays custom address attributes when **Show on frontend** is set to **no**.
 
-<!-- MAGETWO-88411 -->* Magento now displays the default value for a new Customer attribute that is created from the Admin. Previously, Magento set this value to **no** by default.
+<!-- MAGETWO-88411  -->
+*  Magento now displays the default value for a new Customer attribute that is created from the Admin. Previously, Magento set this value to **no** by default.
 
-<!-- MAGETWO-73827 -->* Administrators can see all customers when the **Share Customer Accounts** value is set to Global.
+<!-- MAGETWO-73827  -->
+*  Administrators can see all customers when the **Share Customer Accounts** value is set to Global.
 
-<!--  ENGCOM-1680 -->* User login email validation no longer fails if the field contains a leading or trailing space on Internet Explorer 11.x. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
+<!--  ENGCOM-1680  -->
+*  User login email validation no longer fails if the field contains a leading or trailing space on Internet Explorer 11.x. *Fix submitted by Piyush Dankhara in pull request [15365](https://github.com/magento/magento2/pull/15365)*. [GitHub-6058](https://github.com/magento/magento2/issues/6058)
 
-<!--  ENGCOM-1987 -->* Customer accounts are now unlocked as expected after a password reset. *Fix submitted by Andrea Gaspardo in pull request [15255](https://github.com/magento/magento2/pull/15255)*. [GitHub-15534](https://github.com/magento/magento2/issues/15534)
+<!--  ENGCOM-1987  -->
+*  Customer accounts are now unlocked as expected after a password reset. *Fix submitted by Andrea Gaspardo in pull request [15255](https://github.com/magento/magento2/pull/15255)*. [GitHub-15534](https://github.com/magento/magento2/issues/15534)
 
-<!--  ENGCOM-1625 -->* Magento no longer changes the format of Date of Birth information when this field is enabled on the Create New Customer Account page, and an existing customer tries to re-register. *Fix submitted by KaushikChavda in pull request [15272](https://github.com/magento/magento2/pull/15272)*.
+<!--  ENGCOM-1625  -->
+*  Magento no longer changes the format of Date of Birth information when this field is enabled on the Create New Customer Account page, and an existing customer tries to re-register. *Fix submitted by KaushikChavda in pull request [15272](https://github.com/magento/magento2/pull/15272)*.
 
-<!--  ENGCOM-2089 -->*  When saving a customer group, Magento now copies extension attributes to the new data model that is returned. Previously, this action was not completed, and Magento behaved unpredictably. *Fix submitted by Joseph Maxwell in pull request [16254](https://github.com/magento/magento2/pull/16254)*.
+<!--  ENGCOM-2089  -->
+*   When saving a customer group, Magento now copies extension attributes to the new data model that is returned. Previously, this action was not completed, and Magento behaved unpredictably. *Fix submitted by Joseph Maxwell in pull request [16254](https://github.com/magento/magento2/pull/16254)*.
 
-<!--  ENGCOM-1432 -->* The `customer.account.dashboard.info.extra` block has been moved to contact information from the newsletter section in `app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml`. *Fix submitted by JeroenVanLeusden in pull request [14923](https://github.com/magento/magento2/pull/14923)*.
+<!--  ENGCOM-1432  -->
+*  The `customer.account.dashboard.info.extra` block has been moved to contact information from the newsletter section in `app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml`. *Fix submitted by JeroenVanLeusden in pull request [14923](https://github.com/magento/magento2/pull/14923)*.
 
 ### Directory
 
-<!--  ENGCOM-2281 -->* You can now configure different Allowed Countries for default and store scopes. *Fix submitted by Oleksandr Kravchuk in pull request [16693](https://github.com/magento/magento2/pull/16693)*.
+<!--  ENGCOM-2281  -->
+*  You can now configure different Allowed Countries for default and store scopes. *Fix submitted by Oleksandr Kravchuk in pull request [16693](https://github.com/magento/magento2/pull/16693)*.
 
 ### dotmailer
 
@@ -662,303 +905,434 @@ Our community contributors have made many helpful, minor corrections to spelling
 
 * Unexpected errors during subscriber or customer creation no longer occur.
 
-<!-- BUNDLE-526 -->* A merchant can now successfully create a new user and displays the appropriate welcome message. Previously, Magento threw an error during the creation of a customer or subscriber, although the new user/subscriber was created.
+<!-- BUNDLE-526  -->
+*  A merchant can now successfully create a new user and displays the appropriate welcome message. Previously, Magento threw an error during the creation of a customer or subscriber, although the new user/subscriber was created.
 
 ### EAV
 
-<!-- MAGETWO-73062-->* Magento now displays the fixed product tax attribute label as expected according to the specified store view.
+<!-- MAGETWO-73062 -->
+*  Magento now displays the fixed product tax attribute label as expected according to the specified store view.
 
-<!-- MAGETWO-90576-->* Magento now correctly renders multiselect product attributes with a custom source model in  `adminhtml`. Previously, the selected value was saved the first time in the `catalog_product_entity_varchar` table, and the attribute was added to the `eav_attribute` table, but the selected options were not highlighted against the attribute.
+<!-- MAGETWO-90576 -->
+*  Magento now correctly renders multiselect product attributes with a custom source model in  `adminhtml`. Previously, the selected value was saved the first time in the `catalog_product_entity_varchar` table, and the attribute was added to the `eav_attribute` table, but the selected options were not highlighted against the attribute.
 
 ### Frameworks
 
-<!-- ENGCOM-2370 -->* `@api` annotation has been added to the `magento/framework` component of the Filter Group and Sort Order classes. *Fix submitted by Ronak Patel in pull request [16845](https://github.com/magento/magento2/pull/16845)*.
+<!-- ENGCOM-2370  -->
+*  `@api` annotation has been added to the `magento/framework` component of the Filter Group and Sort Order classes. *Fix submitted by Ronak Patel in pull request [16845](https://github.com/magento/magento2/pull/16845)*.
 
-<!--  ENGCOM-2532 -->* `app/code/Magento/Theme/etc/di.xml` now uses `Translate` instead of `TranslateInterface`. *Fix submitted by Wouter Samaey in pull request [17124](https://github.com/magento/magento2/pull/17124)*.
+<!--  ENGCOM-2532  -->
+*  `app/code/Magento/Theme/etc/di.xml` now uses `Translate` instead of `TranslateInterface`. *Fix submitted by Wouter Samaey in pull request [17124](https://github.com/magento/magento2/pull/17124)*.
 
-<!--  ENGCOM-1981 -->* Classes with methods that contain variadic arguments can be also used in proxy classes. *Fix submitted by Vishal Gelani in pull request [16080](https://github.com/magento/magento2/pull/16080)*.
+<!--  ENGCOM-1981  -->
+*  Classes with methods that contain variadic arguments can be also used in proxy classes. *Fix submitted by Vishal Gelani in pull request [16080](https://github.com/magento/magento2/pull/16080)*.
 
-<!--  ENGCOM-1915 -->* The annotation in  `_toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php` has been corrected. *Fix submitted by Namrata in pull request [15892](https://github.com/magento/magento2/pull/15892)*.
+<!--  ENGCOM-1915  -->
+*  The annotation in  `_toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php` has been corrected. *Fix submitted by Namrata in pull request [15892](https://github.com/magento/magento2/pull/15892)*.
 
-<!--  ENGCOM-1374 -->* Scheduled XML sitemap generation now works as expected. Previously, you could schedule sitemap generation (**Admin** > **Store** > **Configuration** > **Catalog** > **XML sitemap**), but Magento would not generate the sitemap. *Fix submitted by James Halsall in pull request [14822](https://github.com/magento/magento2/pull/14822)*. [GitHub-5768](https://github.com/magento/magento2/issues/5768)
+<!--  ENGCOM-1374  -->
+*  Scheduled XML sitemap generation now works as expected. Previously, you could schedule sitemap generation (**Admin** > **Store** > **Configuration** > **Catalog** > **XML sitemap**), but Magento would not generate the sitemap. *Fix submitted by James Halsall in pull request [14822](https://github.com/magento/magento2/pull/14822)*. [GitHub-5768](https://github.com/magento/magento2/issues/5768)
 
-<!--  ENGCOM-1356 -->* In multi-site deployments, a customer requesting a password reset on a non-default store should receive the password reset email from the non-default, not the primary, store. Previously, this password reset email was sent from the default store. *Fix submitted by Rodrigo Mourão in pull request [14800](https://github.com/magento/magento2/pull/14800)*. [GitHub-5726](https://github.com/magento/magento2/issues/5726)
+<!--  ENGCOM-1356  -->
+*  In multi-site deployments, a customer requesting a password reset on a non-default store should receive the password reset email from the non-default, not the primary, store. Previously, this password reset email was sent from the default store. *Fix submitted by Rodrigo Mourão in pull request [14800](https://github.com/magento/magento2/pull/14800)*. [GitHub-5726](https://github.com/magento/magento2/issues/5726)
 
-<!--  ENGCOM-1301 -->* The `trigger_recollect` quote attribute no longer causes a time out. *Fix submitted by Philipp Sander in pull request [14719](https://github.com/magento/magento2/pull/14719)*. [GitHub-9580](https://github.com/magento/magento2/issues/9580)
+<!--  ENGCOM-1301  -->
+*  The `trigger_recollect` quote attribute no longer causes a time out. *Fix submitted by Philipp Sander in pull request [14719](https://github.com/magento/magento2/pull/14719)*. [GitHub-9580](https://github.com/magento/magento2/issues/9580)
 
-<!-- MAGETWO-90538 -->* `Framework\Math\Random` now uses PHP 7.x features, including `random_bytes` and `random_int`.
+<!-- MAGETWO-90538  -->
+*  `Framework\Math\Random` now uses PHP 7.x features, including `random_bytes` and `random_int`.
 
-<!-- MAGETWO-91164 -->* The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
+<!-- MAGETWO-91164  -->
+*  The `catalog:image:resize` command execution time has been reduced by up to 90% in the release. However, this improvement necessitates these additional steps after upgrading your Magento instance to 2.2.6:
 
     * Remove   `pub/media/catalog/product/cache`. (Removing this folder frees up space.)
 
     * Run `bin/magento catalog:image:resize`  to generate a new image cache.  (This step is necessary because we’ve changed the path to cached images and must remove the previously cached images.)
 
-<!-- MAGETWO-87731 -->* We've fixed a display error that occurred when both a Critical Admin Notification and Release Notification window were opened.
+<!-- MAGETWO-87731  -->
+*  We've fixed a display error that occurred when both a Critical Admin Notification and Release Notification window were opened.
 
-<!--  ENGCOM-2416 -->* Changes that were made to file permissions for  `lib/internal/Magento/Framework/View/Asset/Merged.php` and its associated test that were made in an earlier release have been reverted. *Fix submitted by Ihor Sviziev in pull request [16937](https://github.com/magento/magento2/pull/16937)*.
+<!--  ENGCOM-2416  -->
+*  Changes that were made to file permissions for  `lib/internal/Magento/Framework/View/Asset/Merged.php` and its associated test that were made in an earlier release have been reverted. *Fix submitted by Ihor Sviziev in pull request [16937](https://github.com/magento/magento2/pull/16937)*.
 
-<!--  ENGCOM-1684 -->* The constructor in `Magento\Webapi\Model\Soap\Fault.php` now assigns `$exception->getOriginator()` to `_soapFaultCode` instead of to the dynamical property `_soapCode`. *Fix submitted by Marcel Hauri in pull request [15515](https://github.com/magento/magento2/pull/15515)*.
+<!--  ENGCOM-1684  -->
+*  The constructor in `Magento\Webapi\Model\Soap\Fault.php` now assigns `$exception->getOriginator()` to `_soapFaultCode` instead of to the dynamical property `_soapCode`. *Fix submitted by Marcel Hauri in pull request [15515](https://github.com/magento/magento2/pull/15515)*.
 
-<!--  ENGCOM-1628 -->* Corrected annotation in `_toOptionArray` in `lib/internal/Magento/Framework/Data/Collection/AbstractDb.php`. *Fix submitted by Sanjay Patel in pull request [15336](https://github.com/magento/magento2/pull/15336)*.
+<!--  ENGCOM-1628  -->
+*  Corrected annotation in `_toOptionArray` in `lib/internal/Magento/Framework/Data/Collection/AbstractDb.php`. *Fix submitted by Sanjay Patel in pull request [15336](https://github.com/magento/magento2/pull/15336)*.
 
-<!--  ENGCOM-1355 -->* The invoice table now displays the correct shipping and handling for a partial items invoice. *Fix submitted by Ankur Raiyani in pull request [14795](https://github.com/magento/magento2/pull/14795)*.
+<!--  ENGCOM-1355  -->
+*  The invoice table now displays the correct shipping and handling for a partial items invoice. *Fix submitted by Ankur Raiyani in pull request [14795](https://github.com/magento/magento2/pull/14795)*.
 
-<!--  ENGCOM-1304 -->* The return values from the `usort` and `value_compare_func` function now matches  the PHP documentation for these functions. *Fix submitted by luke-denton-aligent in pull request [14726](https://github.com/magento/magento2/pull/14726)*.
+<!--  ENGCOM-1304  -->
+*  The return values from the `usort` and `value_compare_func` function now matches  the PHP documentation for these functions. *Fix submitted by luke-denton-aligent in pull request [14726](https://github.com/magento/magento2/pull/14726)*.
 
-<!--  ENGCOM-1317 -->* MySQL adapter can now reconnect successfully  when using a nonstandard port. Previously, Magento threw this error, `Port must be configured within host parameter`. *Fix submitted by Julien ANQUETIL in pull request [14753](https://github.com/magento/magento2/pull/14753)*.
+<!--  ENGCOM-1317  -->
+*  MySQL adapter can now reconnect successfully  when using a nonstandard port. Previously, Magento threw this error, `Port must be configured within host parameter`. *Fix submitted by Julien ANQUETIL in pull request [14753](https://github.com/magento/magento2/pull/14753)*.
 
 #### Application framework
 
-<!-- MAGETWO-92722 -->* You can now manually add a parameter to `app/etc/env.php: user_admin_email`. When an administrator is created, Magento sends an email  to default store's email and, if present, to the email address defined in `user_admin_email`.
+<!-- MAGETWO-92722  -->
+*  You can now manually add a parameter to `app/etc/env.php: user_admin_email`. When an administrator is created, Magento sends an email  to default store's email and, if present, to the email address defined in `user_admin_email`.
 
-<!--  ENGCOM-2240 -->* Magento now removes unneeded PDF files after generation. Previously, Magento saved a copy of every generated invoice PDF in `/var`.  *Fix submitted by Yaroslav Rogoza in pull request [16401](https://github.com/magento/magento2/pull/16401)*. [GitHub-3535](https://github.com/magento/magento2/issues/3535), [GitHub-14517](https://github.com/magento/magento2/issues/14517)
+<!--  ENGCOM-2240  -->
+*  Magento now removes unneeded PDF files after generation. Previously, Magento saved a copy of every generated invoice PDF in `/var`.  *Fix submitted by Yaroslav Rogoza in pull request [16401](https://github.com/magento/magento2/pull/16401)*. [GitHub-3535](https://github.com/magento/magento2/issues/3535), [GitHub-14517](https://github.com/magento/magento2/issues/14517)
 
-<!--  ENGCOM-2371 -->* Logs now indicate when Magento is in maintenance mode, which will help the debugging process. *Fix submitted by Ethan Yehuda in pull request [16840](https://github.com/magento/magento2/pull/16840)*.
+<!--  ENGCOM-2371  -->
+*  Logs now indicate when Magento is in maintenance mode, which will help the debugging process. *Fix submitted by Ethan Yehuda in pull request [16840](https://github.com/magento/magento2/pull/16840)*.
 
 #### JavaScript framework
 
-<!--  ENGCOM-1677 -->* `lib/web/mage/dropdowns.js` no longer fails when autoclose is set to **true**. *Fix submitted by Brian LaBelle in pull request [15499](https://github.com/magento/magento2/pull/15499)*. [GitHub-15469](https://github.com/magento/magento2/issues/15469)
+<!--  ENGCOM-1677  -->
+*  `lib/web/mage/dropdowns.js` no longer fails when autoclose is set to **true**. *Fix submitted by Brian LaBelle in pull request [15499](https://github.com/magento/magento2/pull/15499)*. [GitHub-15469](https://github.com/magento/magento2/issues/15469)
 
-<!-- MAGETWO-90193 -->* You can now view an entire zoomed product image in Fotorama fullscreen from the FireFox browser. Previously, the image jumps and the user cannot view all portions of the image. [GitHub-7978](https://github.com/magento/magento2/issues/7978)
+<!-- MAGETWO-90193  -->
+*  You can now view an entire zoomed product image in Fotorama fullscreen from the FireFox browser. Previously, the image jumps and the user cannot view all portions of the image. [GitHub-7978](https://github.com/magento/magento2/issues/7978)
 
 #### Web API framework
 
-<!--  ENGCOM-2012 -->* The `array_push` function has been added to the list of forbidden functions. *Fix submitted by Leandro F. L. in pull request [16144](https://github.com/magento/magento2/pull/16144)*.
+<!--  ENGCOM-2012  -->
+*  The `array_push` function has been added to the list of forbidden functions. *Fix submitted by Leandro F. L. in pull request [16144](https://github.com/magento/magento2/pull/16144)*.
 
-<!--  ENGCOM-1720 -->* A generated admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired. *Fix submitted by Maikel Martens in pull request [15598](https://github.com/magento/magento2/pull/15598)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
+<!--  ENGCOM-1720  -->
+*  A generated admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired. *Fix submitted by Maikel Martens in pull request [15598](https://github.com/magento/magento2/pull/15598)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
 
-<!-- MAGETWO-92122 -->* The `GET /V1/returns?searchCriteria` endpoint retrieves `tracks` arrays as expected.
+<!-- MAGETWO-92122  -->
+*  The `GET /V1/returns?searchCriteria` endpoint retrieves `tracks` arrays as expected.
 
-<!-- MAGETWO-86099 -->* The `GET /V1/returns/:id` endpoint retrieves `tracks` arrays as expected.
+<!-- MAGETWO-86099  -->
+*  The `GET /V1/returns/:id` endpoint retrieves `tracks` arrays as expected.
 
-<!-- MAGETWO-73527 -->* `catalogProductAttributeRepository` now returns the `frontend_labels` value as expected.
+<!-- MAGETWO-73527  -->
+*  `catalogProductAttributeRepository` now returns the `frontend_labels` value as expected.
 
 #### Cache framework
 
-<!-- MAGETWO-69847 -->* Magento no longer throws an exception when deploying static content on a deployment where Redis is used for cache management. See "Redis and static-content deployment" in [Redis troubleshooting]({{ page.baseurl }}/cloud/trouble/redis-troubleshooting.html) for more information. [GitHub-9287](https://github.com/magento/magento2/issues/9287)
+<!-- MAGETWO-69847  -->
+*  Magento no longer throws an exception when deploying static content on a deployment where Redis is used for cache management. See "Redis and static-content deployment" in [Redis troubleshooting]({{ page.baseurl }}/cloud/trouble/redis-troubleshooting.html) for more information. [GitHub-9287](https://github.com/magento/magento2/issues/9287)
 
-<!-- MAGETWO-84109 -->* When a layout is loaded from the cache, Magento now repopulates the list of applied layout handles to prevent any chance of a layout handle being reapplied later. *Fix submitted by Scott Buchanan in pull request [12314](https://github.com/magento/magento2/pull/12314)*.
+<!-- MAGETWO-84109  -->
+*  When a layout is loaded from the cache, Magento now repopulates the list of applied layout handles to prevent any chance of a layout handle being reapplied later. *Fix submitted by Scott Buchanan in pull request [12314](https://github.com/magento/magento2/pull/12314)*.
 
 ### Dashboard
 
-<!--  ENGCOM-1867 -->* The dashboard now displays the correct order amount on orders when deploying Magento on multiple storefronts with different currencies. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
+<!--  ENGCOM-1867  -->
+*  The dashboard now displays the correct order amount on orders when deploying Magento on multiple storefronts with different currencies. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
 
 ### Directory
 
-<!--  ENGCOM-2073 -->* Magento now supports seven-digit Israeli postal code masks. *Fix submitted by Itay Raz in pull request [16250](https://github.com/magento/magento2/pull/16250)*.
+<!--  ENGCOM-2073  -->
+*  Magento now supports seven-digit Israeli postal code masks. *Fix submitted by Itay Raz in pull request [16250](https://github.com/magento/magento2/pull/16250)*.
 
 ### General
 
-<!-- MAGETWO-90968 -->* Magento now uses the correct amounts when creating a credit memo for an order that was placed using store credit, a gift card, or reward points.
+<!-- MAGETWO-90968  -->
+*  Magento now uses the correct amounts when creating a credit memo for an order that was placed using store credit, a gift card, or reward points.
 
-<!-- MAGETWO-91411 -->* Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
+<!-- MAGETWO-91411  -->
+*  Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
 
-<!-- MAGETWO-91928 -->* You can now successfully save a product video for one store view in deployments that have several store views. Previously, when you saved a product video for one store view, Magento saved it for all store views, although customers could play the video on the original store only.
+<!-- MAGETWO-91928  -->
+*  You can now successfully save a product video for one store view in deployments that have several store views. Previously, when you saved a product video for one store view, Magento saved it for all store views, although customers could play the video on the original store only.
 
-<!-- MAGETWO-91931 -->* Customer data is now fully loaded after restarting the browser during an unexpired user session. Previously,  the `section_data_ids` section of the session cookie was not properly completed. [GitHub-14912](https://github.com/magento/magento2/issues/14912)
+<!-- MAGETWO-91931  -->
+*  Customer data is now fully loaded after restarting the browser during an unexpired user session. Previously,  the `section_data_ids` section of the session cookie was not properly completed. [GitHub-14912](https://github.com/magento/magento2/issues/14912)
 
-<!-- MAGETWO-91000 -->* We've fixed an issue with unoptimized SQL queries in customer segments. Previously, the  customer segment was not saved, and MySQL crashed.
+<!-- MAGETWO-91000  -->
+*  We've fixed an issue with unoptimized SQL queries in customer segments. Previously, the  customer segment was not saved, and MySQL crashed.
 
-<!-- MAGETWO-90246 -->* When a customer creates a product review, the link to the product from the review in the customer's **My Account** > **My Product Review** is now SEO friendly.
+<!-- MAGETWO-90246  -->
+*  When a customer creates a product review, the link to the product from the review in the customer's **My Account** > **My Product Review** is now SEO friendly.
 
-<!-- MAGETWO-87356 -->* The My Invitations page now accurately displays the reward points amount in numbers. Previously, this page displayed the special character `%` instead of numbers.
+<!-- MAGETWO-87356  -->
+*  The My Invitations page now accurately displays the reward points amount in numbers. Previously, this page displayed the special character `%` instead of numbers.
 
-<!-- MAGETWO-73512 -->* The Enterprise Reward refund logic  no longer permits administrators to grant double refunds.
+<!-- MAGETWO-73512  -->
+*  The Enterprise Reward refund logic  no longer permits administrators to grant double refunds.
 
-<!-- MAGETWO-85112 -->* We moved the `isAllowed` method from `AccessChangeQuoteControl` to a separate service to optimize the logic that supports using recurrent payments in combination with pre-ordered products. *Fix submitted by Jeroen Van Leusden in pull request [12566](https://github.com/magento/magento2/pull/12566)*.
+<!-- MAGETWO-85112  -->
+*  We moved the `isAllowed` method from `AccessChangeQuoteControl` to a separate service to optimize the logic that supports using recurrent payments in combination with pre-ordered products. *Fix submitted by Jeroen Van Leusden in pull request [12566](https://github.com/magento/magento2/pull/12566)*.
 
-<!-- MAGETWO-83551 -->* The attribute checking logic has been optimized by reducing redundant checks. *Fix submitted by Freek Vandeursen in pull request [11554](https://github.com/magento/magento2/pull/11554)*.
+<!-- MAGETWO-83551  -->
+*  The attribute checking logic has been optimized by reducing redundant checks. *Fix submitted by Freek Vandeursen in pull request [11554](https://github.com/magento/magento2/pull/11554)*.
 
-<!-- MAGETWO-86239 -->* Magento no longer validates customer address attribute value length when the minimum/maximum length fields are not displayed on the Admin.
+<!-- MAGETWO-86239  -->
+*  Magento no longer validates customer address attribute value length when the minimum/maximum length fields are not displayed on the Admin.
 
-<!-- ENGCOM-1679 -->* The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
+<!-- ENGCOM-1679  -->
+*  The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Ankur Raiyani in pull request [15661](https://github.com/magento/magento2/pull/15661)*. [GitHub-15660](https://github.com/magento/magento2/issues/15660)
 
-<!-- MAGETWO-87120 -->* The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
+<!-- MAGETWO-87120  -->
+*  The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
-<!-- ENGCOM-1767 -->*  `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
+<!-- ENGCOM-1767  -->
+*   `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
 
-<!-- ENGCOM-1762 -->* Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)
+<!-- ENGCOM-1762  -->
+*  Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)
 
-<!-- ENGCOM-1858 -->* An administrator can now successfully download a PDF or export data immediately after log in. Previously, an administrator could not download a PDF or export data successfully after log in, but was redirected to the Admin dashboard. *Fix submitted by Riccardo Tempesta  in pull request [15539](https://github.com/magento/magento2/pull/15539)*. [GitHub-15510](https://github.com/magento/magento2/issues/15510)
+<!-- ENGCOM-1858  -->
+*  An administrator can now successfully download a PDF or export data immediately after log in. Previously, an administrator could not download a PDF or export data successfully after log in, but was redirected to the Admin dashboard. *Fix submitted by Riccardo Tempesta  in pull request [15539](https://github.com/magento/magento2/pull/15539)*. [GitHub-15510](https://github.com/magento/magento2/issues/15510)
 
-<!-- ENGCOM-1805 -->* Merchants can now apply styling by changing LESS variables in the Luma theme as expected. *Fix submitted by hitesh-wagento in pull request [15734](https://github.com/magento/magento2/pull/15734)*. [GitHub-15608](https://github.com/magento/magento2/issues/15608)
+<!-- ENGCOM-1805  -->
+*  Merchants can now apply styling by changing LESS variables in the Luma theme as expected. *Fix submitted by hitesh-wagento in pull request [15734](https://github.com/magento/magento2/pull/15734)*. [GitHub-15608](https://github.com/magento/magento2/issues/15608)
 
-<!-- ENGCOM-1860 -->* Added a service configuration setting—Send Adminhtml and Frontend as Separate Apps—to collect and send separate data for frontend and adminhtml applications for New Relic reporting. See [New Relic Reporting]( https://docs.magento.com/m2/ce/user_guide/reports/new-relic-reporting.html?Highlight=New%20Relic%20service). *Fix submitted by Max Chadwick in pull request [12935](https://github.com/magento/magento2/pull/12935)*.
+<!-- ENGCOM-1860  -->
+*  Added a service configuration setting—Send Adminhtml and Frontend as Separate Apps—to collect and send separate data for frontend and adminhtml applications for New Relic reporting. See [New Relic Reporting]( https://docs.magento.com/m2/ce/user_guide/reports/new-relic-reporting.html?Highlight=New%20Relic%20service). *Fix submitted by Max Chadwick in pull request [12935](https://github.com/magento/magento2/pull/12935)*.
 
-<!-- ENGCOM-1864 -->*  Table alias prefixes in field mappings for customer group filter and sorting processors that were previously missing have been restored. Previous to this restoration, Magento threw this error when a merchant opened **Admin** > **Customers** > **All Customers**: `SQL Error: ambiguous column 'customer_group_id' in 'All customers' page in admin when extension attribute table is joined`. *Fix submitted by Maksim Gopey in pull request [15826](https://github.com/magento/magento2/pull/15826)*.
+<!-- ENGCOM-1864  -->
+*   Table alias prefixes in field mappings for customer group filter and sorting processors that were previously missing have been restored. Previous to this restoration, Magento threw this error when a merchant opened **Admin** > **Customers** > **All Customers**: `SQL Error: ambiguous column 'customer_group_id' in 'All customers' page in admin when extension attribute table is joined`. *Fix submitted by Maksim Gopey in pull request [15826](https://github.com/magento/magento2/pull/15826)*.
 
-<!-- ENGCOM-1883 -->* `.limiter` now has the same parent selectors as `.pages`, which prevents clashes between styles and layouts. Previously, `.limiter` float was too generic. *Fix submitted by hitesh-wagento in pull request [15878](https://github.com/magento/magento2/pull/15878)*.
+<!-- ENGCOM-1883  -->
+*  `.limiter` now has the same parent selectors as `.pages`, which prevents clashes between styles and layouts. Previously, `.limiter` float was too generic. *Fix submitted by hitesh-wagento in pull request [15878](https://github.com/magento/magento2/pull/15878)*.
 
-<!-- ENGCOM-1942 -->* The default `FormElementDependenceController` configuration is now extended by custom configuration rather than overridden.  *Fix submitted by Valerij Ivashchenko in pull request [16001](https://github.com/magento/magento2/pull/16001)*.
+<!-- ENGCOM-1942  -->
+*  The default `FormElementDependenceController` configuration is now extended by custom configuration rather than overridden.  *Fix submitted by Valerij Ivashchenko in pull request [16001](https://github.com/magento/magento2/pull/16001)*.
 
-<!-- ENGCOM-1958 -->* `inline-block` issues with space and font-size in the Name form have been resolved. *Fix submitted by Daniel Ruf in pull request [16048](https://github.com/magento/magento2/pull/16048)*.
+<!-- ENGCOM-1958  -->
+*  `inline-block` issues with space and font-size in the Name form have been resolved. *Fix submitted by Daniel Ruf in pull request [16048](https://github.com/magento/magento2/pull/16048)*.
 
-<!-- ENGCOM-1896 -->* Alignment and layout issues on  home  and category pages of the Hot Seller section have been resolved. *Fix submitted by Chirag Matholiya in pull request [15893](https://github.com/magento/magento2/pull/15893)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
+<!-- ENGCOM-1896  -->
+*  Alignment and layout issues on  home  and category pages of the Hot Seller section have been resolved. *Fix submitted by Chirag Matholiya in pull request [15893](https://github.com/magento/magento2/pull/15893)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
 
-<!-- ENGCOM-1886 -->* Updated old font formats of the default fonts (`woff` and `woff2`). *Fix submitted by Daniel Ruf in pull request [15870](https://github.com/magento/magento2/pull/15870)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
+<!-- ENGCOM-1886  -->
+*  Updated old font formats of the default fonts (`woff` and `woff2`). *Fix submitted by Daniel Ruf in pull request [15870](https://github.com/magento/magento2/pull/15870)*. [GitHub-15213](https://github.com/magento/magento2/issues/15213)
 
-<!-- ENGCOM-2011 -->* We've corrected the return type of methods and  typos in `CategoriesJson.php`, `Engine.php`, `UrlRewrite.php`, and `ObserverConfig.php`. *Fix submitted by Saurabh Parekh in pull request [15993](https://github.com/magento/magento2/pull/15993)*.
+<!-- ENGCOM-2011  -->
+*  We've corrected the return type of methods and  typos in `CategoriesJson.php`, `Engine.php`, `UrlRewrite.php`, and `ObserverConfig.php`. *Fix submitted by Saurabh Parekh in pull request [15993](https://github.com/magento/magento2/pull/15993)*.
 
-<!-- ENGCOM-1991 -->* `@escapeNotVerified` annotations were replaced in `name.phtml` and `qty.phtml`. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
+<!-- ENGCOM-1991  -->
+*  `@escapeNotVerified` annotations were replaced in `name.phtml` and `qty.phtml`. *Fix submitted by Riccardo Tempesta in pull request [15532](https://github.com/magento/magento2/pull/15532)*. [GitHub-15501](https://github.com/magento/magento2/issues/15501)
 
-<!-- ENGCOM-1607 -->* We've removed redundant function calls in `app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml`. *Fix submitted by Saurabh Parekh in pull request [15346](https://github.com/magento/magento2/pull/15346)*. [GitHub-15355](https://github.com/magento/magento2/issues/15355)
+<!-- ENGCOM-1607  -->
+*  We've removed redundant function calls in `app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml`. *Fix submitted by Saurabh Parekh in pull request [15346](https://github.com/magento/magento2/pull/15346)*. [GitHub-15355](https://github.com/magento/magento2/issues/15355)
 
-<!-- ENGCOM-1659 -->* `magnifier.js` now works no matter which mode is set. (`magnifier.js` offers the option of setting mode to 'inside' for an in-frame zoom.) *Fix submitted by Kacper Chara in pull request [15382](https://github.com/magento/magento2/pull/15382)*. [GitHub-4977](https://github.com/magento/magento2/issues/4977)
+<!-- ENGCOM-1659  -->
+*  `magnifier.js` now works no matter which mode is set. (`magnifier.js` offers the option of setting mode to 'inside' for an in-frame zoom.) *Fix submitted by Kacper Chara in pull request [15382](https://github.com/magento/magento2/pull/15382)*. [GitHub-4977](https://github.com/magento/magento2/issues/4977)
 
-<!-- ENGCOM-2007 -->* The Change Password warning message no longer appears twice. *Fix submitted by Sanjay Patel in pull request [15774](https://github.com/magento/magento2/pull/15774)*. [GitHub-14895](https://github.com/magento/magento2/issues/14895)
+<!-- ENGCOM-2007  -->
+*  The Change Password warning message no longer appears twice. *Fix submitted by Sanjay Patel in pull request [15774](https://github.com/magento/magento2/pull/15774)*. [GitHub-14895](https://github.com/magento/magento2/issues/14895)
 
-<!-- ENGCOM-2559 -->* You can now add the `NOINDEX,NOFOLLOW` meta tag to the admin scope to instruct Google and other friendly bots to refrain from adding the Admin URL to search results. *Fix submitted by Itay Raz in pull request [17163](https://github.com/magento/magento2/pull/17163)*.
+<!-- ENGCOM-2559  -->
+*  You can now add the `NOINDEX,NOFOLLOW` meta tag to the admin scope to instruct Google and other friendly bots to refrain from adding the Admin URL to search results. *Fix submitted by Itay Raz in pull request [17163](https://github.com/magento/magento2/pull/17163)*.
 
-<!-- ENGCOM-2443 -->* The Create Account and Password Forget forms now include the required notice for relevant fields. *Fix submitted by Daniel Ruf in pull request [16965](https://github.com/magento/magento2/pull/16965)*.
+<!-- ENGCOM-2443  -->
+*  The Create Account and Password Forget forms now include the required notice for relevant fields. *Fix submitted by Daniel Ruf in pull request [16965](https://github.com/magento/magento2/pull/16965)*.
 
-<!-- ENGCOM-2437 -->* Reworked the  `addError`, `addSuccess` methods in several files. *Fix submitted by Tiago Sampaio in pull request [16921](https://github.com/magento/magento2/pull/16921)*.
+<!-- ENGCOM-2437  -->
+*  Reworked the  `addError`, `addSuccess` methods in several files. *Fix submitted by Tiago Sampaio in pull request [16921](https://github.com/magento/magento2/pull/16921)*.
 
-<!-- ENGCOM-2398 -->* Minor improvements to  `app/code/Magento/CatalogRule/Model/Rule/Job.php` and `app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16900](https://github.com/magento/magento2/pull/16900)*.
+<!-- ENGCOM-2398  -->
+*  Minor improvements to  `app/code/Magento/CatalogRule/Model/Rule/Job.php` and `app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16900](https://github.com/magento/magento2/pull/16900)*.
 
-<!-- ENGCOM-2282 -->* Refactored `app/code/Magento/User/Controller/Adminhtml/`  by removing the direct use of ObjectManager and included the dependencies using constructor dependency injection. *Fix submitted by AnshuMishra17 in pull request [16560](https://github.com/magento/magento2/pull/16560)*.
+<!-- ENGCOM-2282  -->
+*  Refactored `app/code/Magento/User/Controller/Adminhtml/`  by removing the direct use of ObjectManager and included the dependencies using constructor dependency injection. *Fix submitted by AnshuMishra17 in pull request [16560](https://github.com/magento/magento2/pull/16560)*.
 
-<!-- ENGCOM-2209 -->* `gallery.less` no longer imports `_responsive.less`. *Fix submitted by Karla Saaremäe in pull request [16579](https://github.com/magento/magento2/pull/16579)*.
+<!-- ENGCOM-2209  -->
+*  `gallery.less` no longer imports `_responsive.less`. *Fix submitted by Karla Saaremäe in pull request [16579](https://github.com/magento/magento2/pull/16579)*.
 
-<!-- ENGCOM-2384 -->* Added missing `width` property for the confirmation modal in `lib/web/css/source/components/_modals.less`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16861](https://github.com/magento/magento2/pull/16861)*.
+<!-- ENGCOM-2384  -->
+*  Added missing `width` property for the confirmation modal in `lib/web/css/source/components/_modals.less`. *Fix submitted by Vladymyr Hrivinskyi in pull request [16861](https://github.com/magento/magento2/pull/16861)*.
 
-<!-- ENGCOM-2293 -->* Removed the redundant `font-size` attribute from the toolbar pager in  `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Karla Saaremäe in pull request [16716](https://github.com/magento/magento2/pull/16716)*.
+<!-- ENGCOM-2293  -->
+*  Removed the redundant `font-size` attribute from the toolbar pager in  `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Karla Saaremäe in pull request [16716](https://github.com/magento/magento2/pull/16716)*.
 
-<!-- ENGCOM-2284 -->* Updated the "Reporting security issues" section of `README.md` to recommend that users create a bugcrowd account.  *Fix submitted by Tommy Quissens in pull request [16685](https://github.com/magento/magento2/pull/16685)*.
+<!-- ENGCOM-2284  -->
+*  Updated the "Reporting security issues" section of `README.md` to recommend that users create a bugcrowd account.  *Fix submitted by Tommy Quissens in pull request [16685](https://github.com/magento/magento2/pull/16685)*.
 
-<!-- ENGCOM-2193 -->* The currency format that was previously broken for some locales now works as expected. Previously, broken currency formats resulted in an incorrect price amount on the product page. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11717](https://github.com/magento/magento2/issues/11717)
+<!-- ENGCOM-2193  -->
+*  The currency format that was previously broken for some locales now works as expected. Previously, broken currency formats resulted in an incorrect price amount on the product page. *Fix submitted by Vishal Gelani in pull request [15909](https://github.com/magento/magento2/pull/15909)*. [GitHub-11717](https://github.com/magento/magento2/issues/11717)
 
-<!-- ENGCOM-2159 -->* Changed the **My Dashboard** string to **My Account** in multiple files. *Fix submitted by Daniel Ruf in pull request [16009](https://github.com/magento/magento2/pull/16009)*.
+<!-- ENGCOM-2159  -->
+*  Changed the **My Dashboard** string to **My Account** in multiple files. *Fix submitted by Daniel Ruf in pull request [16009](https://github.com/magento/magento2/pull/16009)*.
 
-<!-- ENGCOM-1717 -->* Corrected the annotation to the `formatDateTime` function in `lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php` file. *Fix submitted by Sanjay Patel in pull request [15602](https://github.com/magento/magento2/pull/15602)*.
+<!-- ENGCOM-1717  -->
+*  Corrected the annotation to the `formatDateTime` function in `lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php` file. *Fix submitted by Sanjay Patel in pull request [15602](https://github.com/magento/magento2/pull/15602)*.
 
-<!-- ENGCOM-1658 -->* The `clickableOverlay` option now works as expected. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
+<!-- ENGCOM-1658  -->
+*  The `clickableOverlay` option now works as expected. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
 
-<!-- ENGCOM-1579 -->* The Instant Purchase module now works as expected. Previously, the `get($type)` method in `/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php` threw an exception without showing the shipping method $type as it was hardcoded as 'chooser'. *Fix submitted by Marcel Hauri in pull request [15258](https://github.com/magento/magento2/pull/15258)*.
+<!-- ENGCOM-1579  -->
+*  The Instant Purchase module now works as expected. Previously, the `get($type)` method in `/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php` threw an exception without showing the shipping method $type as it was hardcoded as 'chooser'. *Fix submitted by Marcel Hauri in pull request [15258](https://github.com/magento/magento2/pull/15258)*.
 
-<!-- ENGCOM-1618 -->* Template files now follow Magento standard coding format. *Fix submitted by Vishal Gelani in pull request [15398](https://github.com/magento/magento2/pull/15398)*.
+<!-- ENGCOM-1618  -->
+*  Template files now follow Magento standard coding format. *Fix submitted by Vishal Gelani in pull request [15398](https://github.com/magento/magento2/pull/15398)*.
 
-<!-- ENGCOM-1476 -->* Corrected `viewModel` to `view_model` where needed in `\Magento\Backend\Block\Template`. *Fix submitted by Abhishek Jakhotiya in pull request [15067](https://github.com/magento/magento2/pull/15067)*.
+<!-- ENGCOM-1476  -->
+*  Corrected `viewModel` to `view_model` where needed in `\Magento\Backend\Block\Template`. *Fix submitted by Abhishek Jakhotiya in pull request [15067](https://github.com/magento/magento2/pull/15067)*.
 
-<!-- ENGCOM-1375 -->* Non-well-formed numeric values that were encountered in `app/code/Magento/Directory/Model/Currency.php` have been resolved. *Fix submitted by Mateusz Lerczak in pull request [14833](https://github.com/magento/magento2/pull/14833)*.
+<!-- ENGCOM-1375  -->
+*  Non-well-formed numeric values that were encountered in `app/code/Magento/Directory/Model/Currency.php` have been resolved. *Fix submitted by Mateusz Lerczak in pull request [14833](https://github.com/magento/magento2/pull/14833)*.
 
-<!-- ENGCOM-1352 -->* The `README` file for the `magento2` repository now has Maintainers and Contributors sections. *Fix submitted by Stanislav Idolov in pull request [14790](https://github.com/magento/magento2/pull/14790)*.
+<!-- ENGCOM-1352  -->
+*  The `README` file for the `magento2` repository now has Maintainers and Contributors sections. *Fix submitted by Stanislav Idolov in pull request [14790](https://github.com/magento/magento2/pull/14790)*.
 
-<!-- ENGCOM-1338 -->* The documentation for `AdapterInterface::update` has been improved. *Fix submitted by Navarr Barnier in pull request [14769](https://github.com/magento/magento2/pull/14769)*.
+<!-- ENGCOM-1338  -->
+*  The documentation for `AdapterInterface::update` has been improved. *Fix submitted by Navarr Barnier in pull request [14769](https://github.com/magento/magento2/pull/14769)*.
 
-<!-- MAGETWO-93272 -->* The product video feature is now GDPR-compliant.
+<!-- MAGETWO-93272  -->
+*  The product video feature is now GDPR-compliant.
 
 ### Gift cards
 
-<!-- MAGETWO-92988 -->* Magento now displays the **Credit Memo** link  at the top of the page for orders with a total of 0 (zero). Previously, this link was missing, which prevented users from creating a credit memo for the order.
+<!-- MAGETWO-92988  -->
+*  Magento now displays the **Credit Memo** link  at the top of the page for orders with a total of 0 (zero). Previously, this link was missing, which prevented users from creating a credit memo for the order.
 
-<!-- MAGETWO-92362 -->*  You can now save gift cards without the price being changed on the Admin to an unacceptable format. Previously, Magento tried to save amounts in unacceptable formats (such as the inclusion of a comma in a four-digit price), which triggered an error.
+<!-- MAGETWO-92362  -->
+*   You can now save gift cards without the price being changed on the Admin to an unacceptable format. Previously, Magento tried to save amounts in unacceptable formats (such as the inclusion of a comma in a four-digit price), which triggered an error.
 
-<!-- MAGETWO-91925 -->* Magento no longer permits users to save a new gift card  without first completing the required values. Previously, when creating a gift card, users could save the card without having designated an amount, but the card could not be purchased. Magento also created a `report.CRITICAL: Warning` error message in the `system.log`.
+<!-- MAGETWO-91925  -->
+*  Magento no longer permits users to save a new gift card  without first completing the required values. Previously, when creating a gift card, users could save the card without having designated an amount, but the card could not be purchased. Magento also created a `report.CRITICAL: Warning` error message in the `system.log`.
 
-<!-- MAGETWO- 91867-->* Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
+<!-- MAGETWO- 91867 -->
+*  Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
 
-<!-- MAGETWO-91576 -->* Magento now maintains relationships between new gift card accounts when a customer purchases several gift cards in the same order.
+<!-- MAGETWO-91576  -->
+*  Magento now maintains relationships between new gift card accounts when a customer purchases several gift cards in the same order.
 
-<!-- MAGETWO-91400 -->* Magento now refunds only the exact amount used on a gift card if only the part of the gift card was  used. Previously, when a customer used a gift card account code to partially pay for an order,  and Magento subsequently created a credit memo for a portion of the order, the full amount of the gift card was refunded.
+<!-- MAGETWO-91400  -->
+*  Magento now refunds only the exact amount used on a gift card if only the part of the gift card was  used. Previously, when a customer used a gift card account code to partially pay for an order,  and Magento subsequently created a credit memo for a portion of the order, the full amount of the gift card was refunded.
 
-<!-- MAGETWO-86757 -->* Magento now generates the same number of gift card codes when the full order is invoiced as the customer selected when creating an order. Previously, for orders that included both physical products and multiple gift cards, the number of gift card codes  generated on an order corresponded to the quantity of the previous physical line items that the user had added to the cart before adding gift cards.
+<!-- MAGETWO-86757  -->
+*  Magento now generates the same number of gift card codes when the full order is invoiced as the customer selected when creating an order. Previously, for orders that included both physical products and multiple gift cards, the number of gift card codes  generated on an order corresponded to the quantity of the previous physical line items that the user had added to the cart before adding gift cards.
 
 ### Gift message
 
-<!-- MAGETWO-91867 -->* Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
+<!-- MAGETWO-91867  -->
+*  Orders now retain gift message information on both item and order level. Previously, gift messages disappeared from an order when a customer logged into his account during checkout.
 
 ### Google Analytics
 
-<!-- ENGCOM-1825 -->* Google analytics pageview is no longer triggered twice. *Fix submitted by Torben Höhn in pull request [15765](https://github.com/magento/magento2/pull/15765)*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
+<!-- ENGCOM-1825  -->
+*  Google analytics pageview is no longer triggered twice. *Fix submitted by Torben Höhn in pull request [15765](https://github.com/magento/magento2/pull/15765)*. [GitHub-12221](https://github.com/magento/magento2/issues/12221)
 
-<!-- ENGCOM-2537 -->* `Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver` is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17137](https://github.com/magento/magento2/pull/17137)*.
+<!-- ENGCOM-2537  -->
+*  `Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver` is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17137](https://github.com/magento/magento2/pull/17137)*.
 
 ### Google Tag Manager
 
-<!-- MAGETWO-91951 -->* The `addToCart` event triggers on the Google Task Manager console only when an item is added to the cart.  Previously, the event was triggered before the cart was updated.
+<!-- MAGETWO-91951  -->
+*  The `addToCart` event triggers on the Google Task Manager console only when an item is added to the cart.  Previously, the event was triggered before the cart was updated.
 
-<!-- MAGETWO-89532 -->* Google Analytics events are now triggered as expected. Specifically,  the  `addToCart` and `removeFromCart` events are not triggered until after a customer adds a product to the mini cart.
+<!-- MAGETWO-89532  -->
+*  Google Analytics events are now triggered as expected. Specifically,  the  `addToCart` and `removeFromCart` events are not triggered until after a customer adds a product to the mini cart.
 
-<!-- MAGETWO-87955 -->* Magento now accurately updates the mini cart when a customer removes a product while accessing a storefront using Internet Explorer 11.x. Previously, when a customer removed a product from the mini cart, Magento did not remove the product but instead threw this error, `(SCRIPT438: Object doesn't support property or method 'find'. File: sidebar.js, Line: 237, Column: 13 )`.
+<!-- MAGETWO-87955  -->
+*  Magento now accurately updates the mini cart when a customer removes a product while accessing a storefront using Internet Explorer 11.x. Previously, when a customer removed a product from the mini cart, Magento did not remove the product but instead threw this error, `(SCRIPT438: Object doesn't support property or method 'find'. File: sidebar.js, Line: 237, Column: 13 )`.
 
-<!-- MAGETWO-88806 -->* Google Tag Manager product category data is now fully reported. Previously, the Google Tag Manager product category (Enhanced Ecommerce) data did not report all information.
+<!-- MAGETWO-88806  -->
+*  Google Tag Manager product category data is now fully reported. Previously, the Google Tag Manager product category (Enhanced Ecommerce) data did not report all information.
 
 ### HTML
 
-<!-- ENGCOM-2178 -->* Responsive table headers now work as expected. Previously, when no heading was present in the `data-th` attribute on a column for a responsive table in Magento, only a colon was present. *Fix submitted by Sean Templeton in pull request [16517](https://github.com/magento/magento2/pull/16517)*.
+<!-- ENGCOM-2178  -->
+*  Responsive table headers now work as expected. Previously, when no heading was present in the `data-th` attribute on a column for a responsive table in Magento, only a colon was present. *Fix submitted by Sean Templeton in pull request [16517](https://github.com/magento/magento2/pull/16517)*.
 
-<!-- ENGCOM-1654 -->* Corrected HTML syntax in the `report.phtml` error template. *Fix submitted by abcpremium in pull request [15454](https://github.com/magento/magento2/pull/15454)*.
+<!-- ENGCOM-1654  -->
+*  Corrected HTML syntax in the `report.phtml` error template. *Fix submitted by abcpremium in pull request [15454](https://github.com/magento/magento2/pull/15454)*.
 
 ### Import/export
 
-<!-- ENGCOM-2304 -->* Product import now updates the **Enable Qty Increments** field as expected. *Fix submitted by Sergey P in pull request [14379](https://github.com/magento/magento2/pull/14379)*. [GitHub-14351](https://github.com/magento/magento2/issues/14351)
+<!-- ENGCOM-2304  -->
+*  Product import now updates the **Enable Qty Increments** field as expected. *Fix submitted by Sergey P in pull request [14379](https://github.com/magento/magento2/pull/14379)*. [GitHub-14351](https://github.com/magento/magento2/issues/14351)
 
-<!-- ENGCOM-1549 -->* `Magento_ImportExport` now supports unicode characters in column names. Previously, column names such `vitamin_a_µg` were  marked invalid. *Fix submitted by Timon de Groot in pull request [15197](https://github.com/magento/magento2/pull/15197)*.
+<!-- ENGCOM-1549  -->
+*  `Magento_ImportExport` now supports unicode characters in column names. Previously, column names such `vitamin_a_µg` were  marked invalid. *Fix submitted by Timon de Groot in pull request [15197](https://github.com/magento/magento2/pull/15197)*.
 
 ### Infrastructure
 
-<!-- MAGETWO-92303 -->* Magento now sends email when the status of a Return Merchandise Authorization (RMA) changes to Return Received, Approved, or Rejected. Previously, no email was sent to the customer who created the order.
+<!-- MAGETWO-92303  -->
+*  Magento now sends email when the status of a Return Merchandise Authorization (RMA) changes to Return Received, Approved, or Rejected. Previously, no email was sent to the customer who created the order.
 
-<!-- MAGETWO-89442 -->* Return Merchandise Authorization (RMA) calls now return order items and comments as expected.
+<!-- MAGETWO-89442  -->
+*  Return Merchandise Authorization (RMA) calls now return order items and comments as expected.
 
-<!-- MAGETWO-92302 -->* The RMA status label now shows on the email that Magento sends to customers when the status of an RMA changes.
+<!-- MAGETWO-92302  -->
+*  The RMA status label now shows on the email that Magento sends to customers when the status of an RMA changes.
 
-<!-- MAGETWO-72090 -->* Magento now deselects only the attributes you choose to deselect when you set the **Use Default Value** setting on a store view to **no** for certain attributes. Previously, when you deselected the **Use Default Value** setting on a store view for certain attributes, Magento unselected other attributes as well.
+<!-- MAGETWO-72090  -->
+*  Magento now deselects only the attributes you choose to deselect when you set the **Use Default Value** setting on a store view to **no** for certain attributes. Previously, when you deselected the **Use Default Value** setting on a store view for certain attributes, Magento unselected other attributes as well.
 
-<!-- MAGETWO-88615 -->* Magento now deploys the translations in `js-translation.json` file when deploying static content.  *Fix submitted by Sergey Dmitruk in pull request [4814](https://github.com/magento/magento2/pull/4814)*.
+<!-- MAGETWO-88615  -->
+*  Magento now deploys the translations in `js-translation.json` file when deploying static content.  *Fix submitted by Sergey Dmitruk in pull request [4814](https://github.com/magento/magento2/pull/4814)*.
 
-<!-- ENGCOM-2304 -->* Magento now updates the `Enable Qty Increments` field as expected during product import. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
+<!-- ENGCOM-2304  -->
+*  Magento now updates the `Enable Qty Increments` field as expected during product import. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
 
-<!-- ENGCOM-1875 -->* We've expanded the  HTTP request class by adding the  `isPostRequest` method. *Fix submitted by Pavel Usachev in pull request [12626](https://github.com/magento/magento2/pull/12626)*.
+<!-- ENGCOM-1875  -->
+*  We've expanded the  HTTP request class by adding the  `isPostRequest` method. *Fix submitted by Pavel Usachev in pull request [12626](https://github.com/magento/magento2/pull/12626)*.
 
-<!-- ENGCOM-1952 -->* You can now change only the primary button `font-weight` without changing regular button `font-weight` with LESS variables. *Fix submitted by Karla Saaremäe in pull request [16012](https://github.com/magento/magento2/pull/16012)*. [GitHub-15832](https://github.com/magento/magento2/issues/15832)
+<!-- ENGCOM-1952  -->
+*  You can now change only the primary button `font-weight` without changing regular button `font-weight` with LESS variables. *Fix submitted by Karla Saaremäe in pull request [16012](https://github.com/magento/magento2/pull/16012)*. [GitHub-15832](https://github.com/magento/magento2/issues/15832)
 
-<!-- ENGCOM-1917 -->* We've added missing properties to the `Magento/Widget` component and removed a  reference to a non-existent class in the associated tests.  *Fix submitted by Marcel Hauri in pull request [15647](https://github.com/magento/magento2/pull/15647)*.
+<!-- ENGCOM-1917  -->
+*  We've added missing properties to the `Magento/Widget` component and removed a  reference to a non-existent class in the associated tests.  *Fix submitted by Marcel Hauri in pull request [15647](https://github.com/magento/magento2/pull/15647)*.
 
-<!-- ENGCOM-1960 -->* We've improved the readability of `app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php`. *Fix submitted by Valerij Ivashchenko in pull request [16010](https://github.com/magento/magento2/pull/16010)*.
+<!-- ENGCOM-1960  -->
+*  We've improved the readability of `app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php`. *Fix submitted by Valerij Ivashchenko in pull request [16010](https://github.com/magento/magento2/pull/16010)*.
 
-<!-- ENGCOM-1611 -->* Template syntax errors in `app/code/Magento/Theme/Block/Html/Breadcrumbs.php` have been corrected. *Fix submitted by Namrata in pull request [15339](https://github.com/magento/magento2/pull/15339)*. [GitHub-15345](https://github.com/magento/magento2/issues/15345)
+<!-- ENGCOM-1611  -->
+*  Template syntax errors in `app/code/Magento/Theme/Block/Html/Breadcrumbs.php` have been corrected. *Fix submitted by Namrata in pull request [15339](https://github.com/magento/magento2/pull/15339)*. [GitHub-15345](https://github.com/magento/magento2/issues/15345)
 
-<!-- ENGCOM-2107 -->* The calendar widget (`jQuery UI DatePicker`) now correctly displays more than one month. *Fix submitted by Burlacu Vasilii in pull request [16279](https://github.com/magento/magento2/pull/16279)*. [GitHub-7379](https://github.com/magento/magento2/issues/7379)
+<!-- ENGCOM-2107  -->
+*  The calendar widget (`jQuery UI DatePicker`) now correctly displays more than one month. *Fix submitted by Burlacu Vasilii in pull request [16279](https://github.com/magento/magento2/pull/16279)*. [GitHub-7379](https://github.com/magento/magento2/issues/7379)
 
-<!-- ENGCOM-2211 -->* An error with the template notation for `Magento_CatalogWidget` module has been fixed. *Fix submitted by Namrata in pull request [16530](https://github.com/magento/magento2/pull/16530)*. [GitHub-16529](https://github.com/magento/magento2/issues/16529)
+<!-- ENGCOM-2211  -->
+*  An error with the template notation for `Magento_CatalogWidget` module has been fixed. *Fix submitted by Namrata in pull request [16530](https://github.com/magento/magento2/pull/16530)*. [GitHub-16529](https://github.com/magento/magento2/issues/16529)
 
-<!-- ENGCOM-2077 -->* You can now use the `addTabAfter` method to add two or more tabs to the Admin  (for example, the Order View page) in the expected order. Previously, Magento did not preserve the correct sort order for the new tabs. *Fix submitted by Tiago Sampaio in pull request [16175](https://github.com/magento/magento2/pull/16175)*. [GitHub-16174](https://github.com/magento/magento2/issues/16174)
+<!-- ENGCOM-2077  -->
+*  You can now use the `addTabAfter` method to add two or more tabs to the Admin  (for example, the Order View page) in the expected order. Previously, Magento did not preserve the correct sort order for the new tabs. *Fix submitted by Tiago Sampaio in pull request [16175](https://github.com/magento/magento2/pull/16175)*. [GitHub-16174](https://github.com/magento/magento2/issues/16174)
 
-<!-- ENGCOM-2263 -->* The headers of the User Agent Rules table now align as expected with the content of the table's rows. *Fix submitted by Justin in pull request [16704](https://github.com/magento/magento2/pull/16704)*. [GitHub-16703](https://github.com/magento/magento2/issues/16703)
+<!-- ENGCOM-2263  -->
+*  The headers of the User Agent Rules table now align as expected with the content of the table's rows. *Fix submitted by Justin in pull request [16704](https://github.com/magento/magento2/pull/16704)*. [GitHub-16703](https://github.com/magento/magento2/issues/16703)
 
-<!-- ENGCOM-2288 -->* We've added `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by hitesh-wagento in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-15848](https://github.com/magento/magento2/issues/15848)
+<!-- ENGCOM-2288  -->
+*  We've added `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by hitesh-wagento in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-15848](https://github.com/magento/magento2/issues/15848)
 
-<!-- ENGCOM-2336 -->* Store view home pages in multistore deployments no longer display breadcrumbs. Previously, the first store view in a multistore deployment looked fine, but the other store views included unnecessary breadcrumbs on the home page.  *Fix submitted by Oleksandr Kravchuk in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-6504](https://github.com/magento/magento2/issues/6504)
+<!-- ENGCOM-2336  -->
+*  Store view home pages in multistore deployments no longer display breadcrumbs. Previously, the first store view in a multistore deployment looked fine, but the other store views included unnecessary breadcrumbs on the home page.  *Fix submitted by Oleksandr Kravchuk in pull request [16732](https://github.com/magento/magento2/pull/16732)*. [GitHub-6504](https://github.com/magento/magento2/issues/6504)
 
-<!-- ENGCOM-2412 -->* HTML minification now works as expected. *Fix submitted by Ronak Patel in pull request [16916](https://github.com/magento/magento2/pull/16916)*. [GitHub-5316](https://github.com/magento/magento2/issues/5316)
+<!-- ENGCOM-2412  -->
+*  HTML minification now works as expected. *Fix submitted by Ronak Patel in pull request [16916](https://github.com/magento/magento2/pull/16916)*. [GitHub-5316](https://github.com/magento/magento2/issues/5316)
 
-<!-- ENGCOM-2295 -->* The type of the `transport` event parameter  has been changed to `DataObject`. This change reverts a change from type `DataObject` to `Array()` made in a previous release. *Fix submitted by gwharton in pull request [16599](https://github.com/magento/magento2/pull/16599)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!-- ENGCOM-2295  -->
+*  The type of the `transport` event parameter  has been changed to `DataObject`. This change reverts a change from type `DataObject` to `Array()` made in a previous release. *Fix submitted by gwharton in pull request [16599](https://github.com/magento/magento2/pull/16599)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!-- ENGCOM-1467 -->* Transport variable can now be altered in the `email_invoice_set_template_vars_before` event. *Fix submitted by gwharton in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
+<!-- ENGCOM-1467  -->
+*  Transport variable can now be altered in the `email_invoice_set_template_vars_before` event. *Fix submitted by gwharton in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-10210](https://github.com/magento/magento2/issues/10210)
 
-<!-- ENGCOM-2591 -->* Replaced deprecated methods in the `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php`, and `app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php`. *Fix submitted by Tiago Sampaio in pull request [17227](https://github.com/magento/magento2/pull/17227)*.
+<!-- ENGCOM-2591  -->
+*  Replaced deprecated methods in the `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php`, `app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php`, and `app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php`. *Fix submitted by Tiago Sampaio in pull request [17227](https://github.com/magento/magento2/pull/17227)*.
 
-<!-- ENGCOM-2553 -->* Replaced deprecated methods in 44 files. *Fix submitted by Tiago Sampaio in pull request [17035](https://github.com/magento/magento2/pull/17035)*.
+<!-- ENGCOM-2553  -->
+*  Replaced deprecated methods in 44 files. *Fix submitted by Tiago Sampaio in pull request [17035](https://github.com/magento/magento2/pull/17035)*.
 
-<!-- ENGCOM-2533 -->* The `template.js` has been updated to make the `jquery` variable consistently use `$`. Previously, JavaScript in the `template.js` sometimes used `jquery` and sometimes `$`, and Magento threw an error when running in Internet Explorer. *Fix submitted by Angelo Maragna in pull request [17129](https://github.com/magento/magento2/pull/17129)*.
+<!-- ENGCOM-2533  -->
+*  The `template.js` has been updated to make the `jquery` variable consistently use `$`. Previously, JavaScript in the `template.js` sometimes used `jquery` and sometimes `$`, and Magento threw an error when running in Internet Explorer. *Fix submitted by Angelo Maragna in pull request [17129](https://github.com/magento/magento2/pull/17129)*.
 
-<!-- ENGCOM-2522 -->* Corrected an undefined class property in the `app/code/Magento/Backend/Block/Media/Uploader.php getConfigJson()` method.  *Fix submitted by Prince Patel in pull request [17099](https://github.com/magento/magento2/pull/17099)*.
+<!-- ENGCOM-2522  -->
+*  Corrected an undefined class property in the `app/code/Magento/Backend/Block/Media/Uploader.php getConfigJson()` method.  *Fix submitted by Prince Patel in pull request [17099](https://github.com/magento/magento2/pull/17099)*.
 
-<!-- ENGCOM-2476 -->* Corrected sticky footer in `page-main` container height on mobile devices. *Fix submitted by Denis Belevtsov in pull request [17006](https://github.com/magento/magento2/pull/17006)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
+<!-- ENGCOM-2476  -->
+*  Corrected sticky footer in `page-main` container height on mobile devices. *Fix submitted by Denis Belevtsov in pull request [17006](https://github.com/magento/magento2/pull/17006)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!-- ENGCOM-2458 -->* Corrected the return type of methods in `app/code/Magento/Catalog/Controller/Category/View.php`, `app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php`, and `app/code/Magento/CatalogSearch/Model/ResourceModel/EngineInterface.php`. *Fix submitted by Pratik Oza in pull request [16988](https://github.com/magento/magento2/pull/16988)*.
+<!-- ENGCOM-2458  -->
+*  Corrected the return type of methods in `app/code/Magento/Catalog/Controller/Category/View.php`, `app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php`, and `app/code/Magento/CatalogSearch/Model/ResourceModel/EngineInterface.php`. *Fix submitted by Pratik Oza in pull request [16988](https://github.com/magento/magento2/pull/16988)*.
 
-<!-- ENGCOM-2480 -->* Style groups for mobile devices (`max-width`) are now specified in the correct order. *Fix submitted by Tejash Kumbhare in pull request [16959](https://github.com/magento/magento2/pull/16959)*. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
+<!-- ENGCOM-2480  -->
+*  Style groups for mobile devices (`max-width`) are now specified in the correct order. *Fix submitted by Tejash Kumbhare in pull request [16959](https://github.com/magento/magento2/pull/16959)*. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
 
-<!-- ENGCOM-2446 -->* Corrected the namespace that is defined in `compare.phtml`. *Fix submitted by Ronak Patel in pull request [16978](https://github.com/magento/magento2/pull/16978)*.
+<!-- ENGCOM-2446  -->
+*  Corrected the namespace that is defined in `compare.phtml`. *Fix submitted by Ronak Patel in pull request [16978](https://github.com/magento/magento2/pull/16978)*.
 
-<!-- ENGCOM-2424 -->* Edited verbose code in  `app/code/Magento/Customer/Controller/Account/LoginPost.php`. *Fix submitted by Glenn Cheng in pull request [16928](https://github.com/magento/magento2/pull/16928)*.
+<!-- ENGCOM-2424  -->
+*  Edited verbose code in  `app/code/Magento/Customer/Controller/Account/LoginPost.php`. *Fix submitted by Glenn Cheng in pull request [16928](https://github.com/magento/magento2/pull/16928)*.
 
-<!-- ENGCOM-2396 -->* Fixed annotations in the following methods: `lib/internal/Magento/Framework/Acl/AclResource/Config/Converter/Dom.php`, `lib/internal/Magento/Framework/Acl/AclResource/Config/SchemaLocator.php`, and `lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php`. *Fix submitted by Tiago Sampaio in pull request [16899](https://github.com/magento/magento2/pull/16899)*.
+<!-- ENGCOM-2396  -->
+*  Fixed annotations in the following methods: `lib/internal/Magento/Framework/Acl/AclResource/Config/Converter/Dom.php`, `lib/internal/Magento/Framework/Acl/AclResource/Config/SchemaLocator.php`, and `lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php`. *Fix submitted by Tiago Sampaio in pull request [16899](https://github.com/magento/magento2/pull/16899)*.
 
-<!-- ENGCOM-2389 -->* Removed or edited code comments in the following files:
+<!-- ENGCOM-2389  -->
+*  Removed or edited code comments in the following files:
 
    *  `app/code/Magento/Backend/Block/Dashboard/Bar.php`
 
@@ -972,157 +1346,224 @@ Our community contributors have made many helpful, minor corrections to spelling
 
    *  `app/code/Magento/Sales/view/adminhtml/templates/order/totals.phtml`. *Fix submitted by Pratik Oza in pull request [16891](https://github.com/magento/magento2/pull/16891)*.
 
-<!-- ENGCOM-2404 -->* Improved product gallery block helper code (`app/code/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php`). *Fix submitted by Valerij Ivashchenko in pull request [16889](https://github.com/magento/magento2/pull/16889)*.
+<!-- ENGCOM-2404  -->
+*  Improved product gallery block helper code (`app/code/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php`). *Fix submitted by Valerij Ivashchenko in pull request [16889](https://github.com/magento/magento2/pull/16889)*.
 
-<!-- ENGCOM-2388 -->* Removed duplicated string from `app/code/Magento/ProductVideo/i18n/en_US.csv`. *Fix submitted by Valerij Ivashchenko in pull request [16882](https://github.com/magento/magento2/pull/16882)*.
+<!-- ENGCOM-2388  -->
+*  Removed duplicated string from `app/code/Magento/ProductVideo/i18n/en_US.csv`. *Fix submitted by Valerij Ivashchenko in pull request [16882](https://github.com/magento/magento2/pull/16882)*.
 
-<!-- ENGCOM-2327 -->* Refactored code in `dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php` so that an undefined index warning is no longer triggered when using uppercase reserved word *Fix submitted by Freek Vandeursen in pull request [16785](https://github.com/magento/magento2/pull/16785)*.
+<!-- ENGCOM-2327  -->
+*  Refactored code in `dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php` so that an undefined index warning is no longer triggered when using uppercase reserved word *Fix submitted by Freek Vandeursen in pull request [16785](https://github.com/magento/magento2/pull/16785)*.
 
-<!-- ENGCOM-2274 -->* Regex in `ControllerAclTest::getControllerPath()` has been changed to avoid classes that are under a namespace with a controller component (such as controller plugins) being interpreted as controllers. *Fix submitted by Freek Vandeursen in pull request [16707](https://github.com/magento/magento2/pull/16707)*.
+<!-- ENGCOM-2274  -->
+*  Regex in `ControllerAclTest::getControllerPath()` has been changed to avoid classes that are under a namespace with a controller component (such as controller plugins) being interpreted as controllers. *Fix submitted by Freek Vandeursen in pull request [16707](https://github.com/magento/magento2/pull/16707)*.
 
-<!-- ENGCOM-2259 -->* Knockout template files now include a `title` attribute in the `img` tag. *Fix submitted by Namrata in pull request [16691](https://github.com/magento/magento2/pull/16691)*.
+<!-- ENGCOM-2259  -->
+*  Knockout template files now include a `title` attribute in the `img` tag. *Fix submitted by Namrata in pull request [16691](https://github.com/magento/magento2/pull/16691)*.
 
-<!-- ENGCOM-2256 -->* Added `title` attribute to links as needed for compatibility with w3c standards to these files: `app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml`,  `app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml`,  `app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml`, `app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml`,  and `app/code/Magento/Ui/view/base/web/templates/block-loader.html`. *Fix submitted by Namrata in pull request [16689](https://github.com/magento/magento2/pull/16689)*.
+<!-- ENGCOM-2256  -->
+*  Added `title` attribute to links as needed for compatibility with w3c standards to these files: `app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml`,  `app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml`,  `app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml`, `app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml`,  and `app/code/Magento/Ui/view/base/web/templates/block-loader.html`. *Fix submitted by Namrata in pull request [16689](https://github.com/magento/magento2/pull/16689)*.
 
-<!-- ENGCOM-2196 -->* Search icons are now defined by header icon variables. *Fix submitted by Karla Saaremäe in pull request [16559](https://github.com/magento/magento2/pull/16559)*.
+<!-- ENGCOM-2196  -->
+*  Search icons are now defined by header icon variables. *Fix submitted by Karla Saaremäe in pull request [16559](https://github.com/magento/magento2/pull/16559)*.
 
-<!-- ENGCOM-2202 -->* Module namespace is now defined before template path name. Previously, when we overrode any core block to any custom module, Magento threw an error because trying to find the template file in the custom module if the module namespace is not defined before the template path. *Fix submitted by Prince Patel in pull request [16576](https://github.com/magento/magento2/pull/16576)*.
+<!-- ENGCOM-2202  -->
+*  Module namespace is now defined before template path name. Previously, when we overrode any core block to any custom module, Magento threw an error because trying to find the template file in the custom module if the module namespace is not defined before the template path. *Fix submitted by Prince Patel in pull request [16576](https://github.com/magento/magento2/pull/16576)*.
 
-<!-- ENGCOM-2191 -->* Corrected the comment for the `Magento_Setup` module `includeClasses` function. *Fix submitted by Namrata in pull request [16549](https://github.com/magento/magento2/pull/16549)*.
+<!-- ENGCOM-2191  -->
+*  Corrected the comment for the `Magento_Setup` module `includeClasses` function. *Fix submitted by Namrata in pull request [16549](https://github.com/magento/magento2/pull/16549)*.
 
-<!-- ENGCOM-2162 -->* The  `module:status` command now clearly provides an easily parsed listing of all enabled and disabled modules. *Fix submitted by Jisse Reitsma in pull request [15543](https://github.com/magento/magento2/pull/15543)*.
+<!-- ENGCOM-2162  -->
+*  The  `module:status` command now clearly provides an easily parsed listing of all enabled and disabled modules. *Fix submitted by Jisse Reitsma in pull request [15543](https://github.com/magento/magento2/pull/15543)*.
 
-<!-- ENGCOM-1979 -->* Fixed the `false` value for the `cache_lifetime` argument in `Magento/Swatches/view/frontend/layout/checkout_cart_configure_type_configurable.xml`. *Fix submitted by yuriyDne in pull request [16086](https://github.com/magento/magento2/pull/16086)*.
+<!-- ENGCOM-1979  -->
+*  Fixed the `false` value for the `cache_lifetime` argument in `Magento/Swatches/view/frontend/layout/checkout_cart_configure_type_configurable.xml`. *Fix submitted by yuriyDne in pull request [16086](https://github.com/magento/magento2/pull/16086)*.
 
-<!-- ENGCOM-2143 -->* CSRF tokens are now considered sensitive strings. *Fix submitted by Robert in pull request [13509](https://github.com/magento/magento2/pull/13509)*.
+<!-- ENGCOM-2143  -->
+*  CSRF tokens are now considered sensitive strings. *Fix submitted by Robert in pull request [13509](https://github.com/magento/magento2/pull/13509)*.
 
-<!-- ENGCOM-2039 -->*  Refactored JavaScript code in `popup.phtml` and `popup.js`. *Fix submitted by IvanPletnyov in pull request [16216](https://github.com/magento/magento2/pull/16216)*.
+<!-- ENGCOM-2039  -->
+*   Refactored JavaScript code in `popup.phtml` and `popup.js`. *Fix submitted by IvanPletnyov in pull request [16216](https://github.com/magento/magento2/pull/16216)*.
 
-<!-- ENGCOM-1630 -->* Removed extraneous cursor property. *Fix submitted by Daniel Ruf in pull request [15305](https://github.com/magento/magento2/pull/15305)*.
+<!-- ENGCOM-1630  -->
+*  Removed extraneous cursor property. *Fix submitted by Daniel Ruf in pull request [15305](https://github.com/magento/magento2/pull/15305)*.
 
-<!-- ENGCOM-1688 -->* `app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml` now uses the stored value of the `getPartners` method instead of calling same method again. *Fix submitted by Saurabh Parekh in pull request [15517](https://github.com/magento/magento2/pull/15517)*.
+<!-- ENGCOM-1688  -->
+*  `app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml` now uses the stored value of the `getPartners` method instead of calling same method again. *Fix submitted by Saurabh Parekh in pull request [15517](https://github.com/magento/magento2/pull/15517)*.
 
-<!-- ENGCOM-1655 -->* Added missing lowercase conversion on grouped product assignation. *Fix submitted by Juan Alonso in pull request [15312](https://github.com/magento/magento2/pull/15312)*.
+<!-- ENGCOM-1655  -->
+*  Added missing lowercase conversion on grouped product assignation. *Fix submitted by Juan Alonso in pull request [15312](https://github.com/magento/magento2/pull/15312)*.
 
-<!-- ENGCOM-1643 -->* Removed code responsible for multiple add-to-cart initializations when Magento loads the product listing. *Fix submitted by Vova Yatsyuk in pull request [15409](https://github.com/magento/magento2/pull/15409)*.
+<!-- ENGCOM-1643  -->
+*  Removed code responsible for multiple add-to-cart initializations when Magento loads the product listing. *Fix submitted by Vova Yatsyuk in pull request [15409](https://github.com/magento/magento2/pull/15409)*.
 
-<!-- ENGCOM-1641 -->* Refactored JavaScript code from `popup.phtml` to meet Magento coding standards. *Fix submitted by Rahul Kachhadiya in pull request [15341](https://github.com/magento/magento2/pull/15341)*.
+<!-- ENGCOM-1641  -->
+*  Refactored JavaScript code from `popup.phtml` to meet Magento coding standards. *Fix submitted by Rahul Kachhadiya in pull request [15341](https://github.com/magento/magento2/pull/15341)*.
 
-<!-- ENGCOM-1577 -->* Removed redundant PHPdoc comment and deprecated private method `getSerializer` in `\Magento\Customer\Model\Customer\NotificationStorage` class. *Fix submitted by adrian-martinez-interactiv4 in pull request [15262](https://github.com/magento/magento2/pull/15262)*.
+<!-- ENGCOM-1577  -->
+*  Removed redundant PHPdoc comment and deprecated private method `getSerializer` in `\Magento\Customer\Model\Customer\NotificationStorage` class. *Fix submitted by adrian-martinez-interactiv4 in pull request [15262](https://github.com/magento/magento2/pull/15262)*.
 
-<!-- ENGCOM-1520 -->* CSS code is now automatically updated in the browser. Previously, users had to press **CTRL+F5**  to see CSS changes. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
+<!-- ENGCOM-1520  -->
+*  CSS code is now automatically updated in the browser. Previously, users had to press **CTRL+F5**  to see CSS changes. *Fix submitted by Alexander Lukyanov in pull request [15144](https://github.com/magento/magento2/pull/15144)*. [GitHub-11354](https://github.com/magento/magento2/issues/11354)
 
-<!-- ENGCOM-1515 -->* Concrete type hints for product and category resources have been added to `app/code/Magento/Catalog/Model/Category.php` and `app/code/Magento/Catalog/Model/Product.php` to help with static analysis and IDE autocompletion. *Fix submitted by Yaroslav Rogoza in pull request [15136](https://github.com/magento/magento2/pull/15136)*.
+<!-- ENGCOM-1515  -->
+*  Concrete type hints for product and category resources have been added to `app/code/Magento/Catalog/Model/Category.php` and `app/code/Magento/Catalog/Model/Product.php` to help with static analysis and IDE autocompletion. *Fix submitted by Yaroslav Rogoza in pull request [15136](https://github.com/magento/magento2/pull/15136)*.
 
-<!-- ENGCOM-1452 -->* Replaced `rand` with `rand_int` in several modules. *Fix submitted by Daniel Ruf in pull request [15017](https://github.com/magento/magento2/pull/15017)*.
+<!-- ENGCOM-1452  -->
+*  Replaced `rand` with `rand_int` in several modules. *Fix submitted by Daniel Ruf in pull request [15017](https://github.com/magento/magento2/pull/15017)*.
 
-<!-- ENGCOM-1446 -->* Optimized `if-condition` in `/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php`. *Fix submitted by Valerij Ivashchenko in pull request [15002](https://github.com/magento/magento2/pull/15002)*.
+<!-- ENGCOM-1446  -->
+*  Optimized `if-condition` in `/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php`. *Fix submitted by Valerij Ivashchenko in pull request [15002](https://github.com/magento/magento2/pull/15002)*.
 
-<!-- ENGCOM-1453 -->* We've upgraded to Node.js 8 from Node.js 6. *Fix submitted by Daniel Ruf in pull request [15018](https://github.com/magento/magento2/pull/15018)*.
+<!-- ENGCOM-1453  -->
+*  We've upgraded to Node.js 8 from Node.js 6. *Fix submitted by Daniel Ruf in pull request [15018](https://github.com/magento/magento2/pull/15018)*.
 
-<!-- ENGCOM-1434 -->* Replaced `template/path` with `Module_Name::template/path` in the block class to ensure extensibility of the class. Previously, if the source block classes referenced a template without specifying the module name, then block render failed with this error: `Invalid template file`. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1434  -->
+*  Replaced `template/path` with `Module_Name::template/path` in the block class to ensure extensibility of the class. Previously, if the source block classes referenced a template without specifying the module name, then block render failed with this error: `Invalid template file`. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1405 -->* Replaced the `\Magento\Backend\Helper\Data` parameter with `\Magento\Backend\Model\UrlInterface` to make them identical with the  constructor. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1405  -->
+*  Replaced the `\Magento\Backend\Helper\Data` parameter with `\Magento\Backend\Model\UrlInterface` to make them identical with the  constructor. *Fix submitted by Abhishek Jakhotiya in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1403 -->* The return type of `addToCartPostParams` in `app/code/Magento/Catalog/Block/Product/ListProduct.php` has been changed to array. *Fix submitted by Sean Templeton in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
+<!-- ENGCOM-1403  -->
+*  The return type of `addToCartPostParams` in `app/code/Magento/Catalog/Block/Product/ListProduct.php` has been changed to array. *Fix submitted by Sean Templeton in pull request [14946](https://github.com/magento/magento2/pull/14946)*.
 
-<!-- ENGCOM-1270 -->*  Datepicker now correctly converts date formats in locales other than `en-US`. *Fix submitted by Tao Sasaki in pull request [14627](https://github.com/magento/magento2/pull/14627)*.
+<!-- ENGCOM-1270  -->
+*   Datepicker now correctly converts date formats in locales other than `en-US`. *Fix submitted by Tao Sasaki in pull request [14627](https://github.com/magento/magento2/pull/14627)*.
 
-<!-- ENGCOM-1270 -->* `default_head_blocks.xml` now contains the `order` attribute for setting the load order of stylesheets. *Fix submitted by Tao Sasaki in pull request [14290](https://github.com/magento/magento2/pull/14290)*.
+<!-- ENGCOM-1270  -->
+*  `default_head_blocks.xml` now contains the `order` attribute for setting the load order of stylesheets. *Fix submitted by Tao Sasaki in pull request [14290](https://github.com/magento/magento2/pull/14290)*.
 
-<!-- ENGCOM-2455 -->* Magento now displays validation messages on the advanced search form as expected if you submit the advanced search form without entries. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
+<!-- ENGCOM-2455  -->
+*  Magento now displays validation messages on the advanced search form as expected if you submit the advanced search form without entries. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
 
-<!-- MAGETWO-84477 -->* `\Magento\Framework\Reflection\TypeProcessor` methods have been simplified.
+<!-- MAGETWO-84477  -->
+*  `\Magento\Framework\Reflection\TypeProcessor` methods have been simplified.
 
-<!-- MAGETWO-87024 -->* Magento no longer unsets the taxed shipping total information before returning the total tax.
+<!-- MAGETWO-87024  -->
+*  Magento no longer unsets the taxed shipping total information before returning the total tax.
 
 ### JavaScript
 
-<!-- ENGCOM-1640 -->* Refactored the  JavaScript code of the button split widget. *Fix submitted by amittiwari024 in pull request [15351](https://github.com/magento/magento2/pull/15351)*. [GitHub-15354](https://github.com/magento/magento2/issues/15354)
+<!-- ENGCOM-1640  -->
+*  Refactored the  JavaScript code of the button split widget. *Fix submitted by amittiwari024 in pull request [15351](https://github.com/magento/magento2/pull/15351)*. [GitHub-15354](https://github.com/magento/magento2/issues/15354)
 
 ### Klarna
 
-<!-- BUNDLE-1489 -->* Magento no longer throws multiple JavaScript errors when a customer selects Klarna from the Review & Payments page.
+<!-- BUNDLE-1489  -->
+*  Magento no longer throws multiple JavaScript errors when a customer selects Klarna from the Review & Payments page.
 
 ### Module Manager
 
-<!-- ENGCOM-1633 -->* Module Manager module grid now works as expected. *Fix submitted by Alex Gusev in pull request [15211](https://github.com/magento/magento2/pull/15211)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
+<!-- ENGCOM-1633  -->
+*  Module Manager module grid now works as expected. *Fix submitted by Alex Gusev in pull request [15211](https://github.com/magento/magento2/pull/15211)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
 
 ### Newsletter
 
-<!-- MAGETWO-88217 -->* Guest users can now sign up for newsletters for multiple stores. Previously, when a guest user signed up for a newsletter from multiple stores, Magento sent a subscription confirmation message, but did not successfully subscribe the user.
+<!-- MAGETWO-88217  -->
+*  Guest users can now sign up for newsletters for multiple stores. Previously, when a guest user signed up for a newsletter from multiple stores, Magento sent a subscription confirmation message, but did not successfully subscribe the user.
 
-<!-- MAGETWO-87969 -->* Magento now correctly updates newsletter subscriptions  when the customer is registered on two stores. Previously, when the customer tried to subscribe to the newsletter from a second store, Magento displayed this message, `You are (not) subscribed to "General Subscription"`.
+<!-- MAGETWO-87969  -->
+*  Magento now correctly updates newsletter subscriptions  when the customer is registered on two stores. Previously, when the customer tried to subscribe to the newsletter from a second store, Magento displayed this message, `You are (not) subscribed to "General Subscription"`.
 
-<!--  ENGCOM-1573 -->* The newsletter subscription confirmation message does not display after a customer clicks the link that is included in the confirmation email. *Fix submitted by Kaushik Chavda in pull request [15247](https://github.com/magento/magento2/pull/15247)*. [GitHub-14747](https://github.com/magento/magento2/issues/14747)
+<!--  ENGCOM-1573  -->
+*  The newsletter subscription confirmation message does not display after a customer clicks the link that is included in the confirmation email. *Fix submitted by Kaushik Chavda in pull request [15247](https://github.com/magento/magento2/pull/15247)*. [GitHub-14747](https://github.com/magento/magento2/issues/14747)
 
-<!-- ENGCOM-2144 -->* Magento now sends a confirmation request email to the customer when she unsubscribes to a newsletter. *Fix submitted by Lyzun Oleksandr in pull request [15464](https://github.com/magento/magento2/pull/15464)*. [GitHub-15218](https://github.com/magento/magento2/issues/15218)
+<!-- ENGCOM-2144  -->
+*  Magento now sends a confirmation request email to the customer when she unsubscribes to a newsletter. *Fix submitted by Lyzun Oleksandr in pull request [15464](https://github.com/magento/magento2/pull/15464)*. [GitHub-15218](https://github.com/magento/magento2/issues/15218)
 
-<!-- ENGCOM-2379 -->* Removed the direct use of the object manager and loaded the dependency via constructor dependency injection in `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php` and `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php`. *Fix submitted by AnshuMishra17 in pull request [16851](https://github.com/magento/magento2/pull/16851)*.
+<!-- ENGCOM-2379  -->
+*  Removed the direct use of the object manager and loaded the dependency via constructor dependency injection in `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php` and `app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php`. *Fix submitted by AnshuMishra17 in pull request [16851](https://github.com/magento/magento2/pull/16851)*.
 
-<!-- ENGCOM-2272 -->* Newsletter registration now works the same when registered customers subscribe from My Account and or from the newsletter block. *Fix submitted by Lyzun Oleksandr in pull request [15479](https://github.com/magento/magento2/pull/15479)*.
+<!-- ENGCOM-2272  -->
+*  Newsletter registration now works the same when registered customers subscribe from My Account and or from the newsletter block. *Fix submitted by Lyzun Oleksandr in pull request [15479](https://github.com/magento/magento2/pull/15479)*.
 
-<!-- ENGCOM-2236 -->* Removed the redundant return statement from  `getJsTemplateName` function comment in the `Magento_Newsletter`'s block file. *Fix submitted by Namrata in pull request [16645](https://github.com/magento/magento2/pull/16645)*.
+<!-- ENGCOM-2236  -->
+*  Removed the redundant return statement from  `getJsTemplateName` function comment in the `Magento_Newsletter`'s block file. *Fix submitted by Namrata in pull request [16645](https://github.com/magento/magento2/pull/16645)*.
 
 ### Payment methods
 
 #### Braintree
 
-<!-- MAGETWO-89221 -->* You can now cancel an order that was placed with Braintree when the Braintree authorization had expired.
+<!-- MAGETWO-89221  -->
+*  You can now cancel an order that was placed with Braintree when the Braintree authorization had expired.
 
-<!-- MAGETWO-84929 -->* All invoices now have the merchant account ID set in the store configuration for the Braintree payment method. Previously, the default merchant account ID was sent to Braintree for any subsequent partial order invoices after the initial invoice is generated.
+<!-- MAGETWO-84929  -->
+*  All invoices now have the merchant account ID set in the store configuration for the Braintree payment method. Previously, the default merchant account ID was sent to Braintree for any subsequent partial order invoices after the initial invoice is generated.
 
-<!-- ENGCOM-2149 -->* Braintree configuration (`app/code/Magento/Braintree/etc/adminhtml/system.xml`) now contains `showInStore` attributes. *Fix submitted by Andreas Schrammel in pull request [16458](https://github.com/magento/magento2/pull/16458)*.
+<!-- ENGCOM-2149  -->
+*  Braintree configuration (`app/code/Magento/Braintree/etc/adminhtml/system.xml`) now contains `showInStore` attributes. *Fix submitted by Andreas Schrammel in pull request [16458](https://github.com/magento/magento2/pull/16458)*.
 
-<!-- ENGCOM-1513 -->* Magento now retains the correct address information when a customer using Braintree's **Pay with PayPal** button to complete an order navigates back to the shipping step and changes the shipping address fields. *Fix submitted by Vova Yatsyuk in pull request [15133](https://github.com/magento/magento2/pull/15133)*.
+<!-- ENGCOM-1513  -->
+*  Magento now retains the correct address information when a customer using Braintree's **Pay with PayPal** button to complete an order navigates back to the shipping step and changes the shipping address fields. *Fix submitted by Vova Yatsyuk in pull request [15133](https://github.com/magento/magento2/pull/15133)*.
 
 #### PayPal
 
-<!-- MAGETWO-92820 -->* Customers can now continue creating an order  after a PayFlow Pro payment has been declined. Previously, under these circumstances. the customer could not continue his purchase.
+<!-- MAGETWO-92820  -->
+*  Customers can now continue creating an order  after a PayFlow Pro payment has been declined. Previously, under these circumstances. the customer could not continue his purchase.
 
-<!-- MAGETWO-89995 -->* Paypal Onboarding has been configured to work for  merchants from  countries other than the United States.
+<!-- MAGETWO-89995  -->
+*  Paypal Onboarding has been configured to work for  merchants from  countries other than the United States.
 
-<!-- MAGETWO-88244 -->* Magento now accurately displays the status of PayPal orders. Previously, the status of PayPal orders was displayed only as  **Processing**.
+<!-- MAGETWO-88244  -->
+*  Magento now accurately displays the status of PayPal orders. Previously, the status of PayPal orders was displayed only as  **Processing**.
 
-<!-- ENGCOM-1372 -->* Magento no longer sends duplicate order confirmation emails when a customer uses PayPal Express to complete an order. *Fix submitted by Rocket Web in pull request [14820](https://github.com/magento/magento2/pull/14820)*.
+<!-- ENGCOM-1372  -->
+*  Magento no longer sends duplicate order confirmation emails when a customer uses PayPal Express to complete an order. *Fix submitted by Rocket Web in pull request [14820](https://github.com/magento/magento2/pull/14820)*.
 
-<!-- MAGETWO-88759 -->* Tax amount calculation for payments processed through PayPal now works as expected. Previously, Magento sent the wrong amount to PayPal when a discount was applied to an order.
+<!-- MAGETWO-88759  -->
+*  Tax amount calculation for payments processed through PayPal now works as expected. Previously, Magento sent the wrong amount to PayPal when a discount was applied to an order.
 
-<!--  ENGCOM-1462 -->* The `Allmethods config` source model now reports the full list of payment methods as expected. *Fix submitted by Manuel Schmid in pull request [15032](https://github.com/magento/magento2/pull/15032)*. [GitHub-13460](https://github.com/magento/magento2/issues/13460)
+<!--  ENGCOM-1462  -->
+*  The `Allmethods config` source model now reports the full list of payment methods as expected. *Fix submitted by Manuel Schmid in pull request [15032](https://github.com/magento/magento2/pull/15032)*. [GitHub-13460](https://github.com/magento/magento2/issues/13460)
 
-<!-- MAGETWO-85908 -->* You can now cancel an order placed through Cybersource when the fraud filters are triggered.
+<!-- MAGETWO-85908  -->
+*  You can now cancel an order placed through Cybersource when the fraud filters are triggered.
 
-<!-- MAGETWO- 92625-->* Magento now emails customer order confirmations for orders that are placed through Worldpay.
+<!-- MAGETWO- 92625 -->
+*  Magento now emails customer order confirmations for orders that are placed through Worldpay.
 
-<!-- MAGETWO-92784 -->* Magento now correctly applies free shipping to an order after the customer applied the free shipping code  during checkout.
+<!-- MAGETWO-92784  -->
+*  Magento now correctly applies free shipping to an order after the customer applied the free shipping code  during checkout.
 
-<!-- MAGETWO-90571 -->* Magento no longer sends Admin orders to Signifyd for review when Signifyd is disabled on the website on which the administrator is logged in.
+<!-- MAGETWO-90571  -->
+*  Magento no longer sends Admin orders to Signifyd for review when Signifyd is disabled on the website on which the administrator is logged in.
 
-<!-- MAGETWO-90533 -->* Magento now successfully creates shipping labels for a return merchandise authorization (RMA) when using FedEx Smart Post as the shipping option. Previously, Magento threw an error under these circumstances.
+<!-- MAGETWO-90533  -->
+*  Magento now successfully creates shipping labels for a return merchandise authorization (RMA) when using FedEx Smart Post as the shipping option. Previously, Magento threw an error under these circumstances.
 
-<!-- MAGETWO-84495 -->* Magento now sends email about payment failures to customers. Previously, Magento did not send a customer email, but instead logged an error in  `support.log`, and displayed this message on the storefront, **Transaction has been declined. Please try again later**.
+<!-- MAGETWO-84495  -->
+*  Magento now sends email about payment failures to customers. Previously, Magento did not send a customer email, but instead logged an error in  `support.log`, and displayed this message on the storefront, **Transaction has been declined. Please try again later**.
 
-<!--  ENGCOM-1648 -->* Magento no longer throws an error when multiple payment methods  are enabled. Previously, when a merchant tried to enable more than one payment method from the Admin, Magento displayed this error in the console, `Found elements with non-unique id billing-address-form`. *Fix submitted by Neeta Kangiya in pull request [15349](https://github.com/magento/magento2/pull/15349)*. [GitHub-15348](https://github.com/magento/magento2/issues/15348)
+<!--  ENGCOM-1648  -->
+*  Magento no longer throws an error when multiple payment methods  are enabled. Previously, when a merchant tried to enable more than one payment method from the Admin, Magento displayed this error in the console, `Found elements with non-unique id billing-address-form`. *Fix submitted by Neeta Kangiya in pull request [15349](https://github.com/magento/magento2/pull/15349)*. [GitHub-15348](https://github.com/magento/magento2/issues/15348)
 
-<!-- MAGETWO-92625 -->* Magento now sends order confirmation emails as expected for orders purchased with WorldPay.
+<!-- MAGETWO-92625  -->
+*  Magento now sends order confirmation emails as expected for orders purchased with WorldPay.
 
-<!-- ENGCOM-2021 -->* A type error in the payment void method of the Authorizenet module has been fixed. *Fix submitted by Oleh Kravets in pull request [16194](https://github.com/magento/magento2/pull/16194)*. [GitHub-16184](https://github.com/magento/magento2/issues/16184)
+<!-- ENGCOM-2021  -->
+*  A type error in the payment void method of the Authorizenet module has been fixed. *Fix submitted by Oleh Kravets in pull request [16194](https://github.com/magento/magento2/pull/16194)*. [GitHub-16184](https://github.com/magento/magento2/issues/16184)
 
 ### Pagecache
 
-<!-- MAGETWO-92757 -->* Full-page cache now works as expected in multistore deployments. Previously, when you opened the URL of a non-default store in a multistore deployment, full-page cache did not return the URL.
+<!-- MAGETWO-92757  -->
+*  Full-page cache now works as expected in multistore deployments. Previously, when you opened the URL of a non-default store in a multistore deployment, full-page cache did not return the URL.
 
 ### Performance
 
-<!-- MAGETWO-47320 -->* The catalog rule re-indexing operation has been optimized, and average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
+<!-- MAGETWO-47320  -->
+*  The catalog rule re-indexing operation has been optimized, and average re-indexing time (which depends on rule conditions) has improved by more than  80%.  Previously, a full catalog rule re-index operation on a medium B2C store took more than 20 minutes.
 
-<!-- MAGETWO-86143 -->* Merchants can now improve store performance by disabling Magento Report functionality if business function does not require this capability. A new configuration setting  (**System Configuration**: **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
+<!-- MAGETWO-86143  -->
+*  Merchants can now improve store performance by disabling Magento Report functionality if business function does not require this capability. A new configuration setting  (**System Configuration**: **General** > **Reports** > **General Options**) allows merchants to disable Magento Reports, which is recommended practice  if a merchant's business function does not require this capability.
 
-<!-- MAGETWO-92154 -->* You can change store locale without the exporting and importing configuration process. While Magento is in Production and the `SCD_ON_DEMAND` is enabled, the Magento store and admin locale options are available. See [Change locales]({{ page.baseurl }}/cloud/live/sens-data-over.html#change-locales).
+<!-- MAGETWO-92154  -->
+*  You can change store locale without the exporting and importing configuration process. While Magento is in Production and the `SCD_ON_DEMAND` is enabled, the Magento store and admin locale options are available. See [Change locales]({{ page.baseurl }}/cloud/live/sens-data-over.html#change-locales).
 
-<!-- MAGETWO-90572 -->* The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for certain scenarios.
+<!-- MAGETWO-90572  -->
+*  The time required to load category or product pages for products that are configured with many attributes (more than 500) has been significantly reduced. Refactoring the logic for product attribute retrieval has resulted in a reduction of load time of almost 90% for certain scenarios.
 
-<!-- MAGETWO-88670 -->* The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
+<!-- MAGETWO-88670  -->
+*  The time required to load a store’s home page has been reduced noticeably when the top menu contains many categories.  (Load time is still affected by the number of categories and the structure of the top menu.)
 
 <!-- ENGCOM-1294 -->
 *  The speed of catalog price rule save operations has been improved by these changes:
@@ -1131,115 +1572,158 @@ Our community contributors have made many helpful, minor corrections to spelling
 
    *  improvement to the way that the `getMatchingProductIds` function fetches products, which has eliminated unnecessary checks of the data set. *Fix submitted by Andrey Zabara in pull request [14707](https://github.com/magento/magento2/pull/14707)*.
 
-<!-- ENGCOM-1302-->* The ID to SKU lookup process for tier prices has been optimized. Previously, with a large number of tier or group prices, each tier would separately make a database query to look up the associated SKU. *Fix submitted by Todd Christensen in pull request [14699](https://github.com/magento/magento2/pull/14699)*.
+<!-- ENGCOM-1302 -->
+*  The ID to SKU lookup process for tier prices has been optimized. Previously, with a large number of tier or group prices, each tier would separately make a database query to look up the associated SKU. *Fix submitted by Todd Christensen in pull request [14699](https://github.com/magento/magento2/pull/14699)*.
 
 ### Product video
 
-<!-- MAGETWO-93792 -->* Magento now populates the YouTube video URL and Title fields with the same values as are populated on the default store view on multisite deployments. (These fields are global scope attributes and should be the same on all storefronts.) Previously, Magento left these fields blank in multisite deployments.
+<!-- MAGETWO-93792  -->
+*  Magento now populates the YouTube video URL and Title fields with the same values as are populated on the default store view on multisite deployments. (These fields are global scope attributes and should be the same on all storefronts.) Previously, Magento left these fields blank in multisite deployments.
 
 ### Quote
 
-<!-- ENGCOM-1414 -->* Magento now displays the correct product price for an order created from the Admin in multisite deployments. Previously, when an order was created from the Admin in a multisite deployment where products were assigned different prices per store view, Magento defaulted to the product price of the primary storeview if the order was edited or updated. *Fix submitted by Riccardo Tempesta in pull request [14904](https://github.com/magento/magento2/pull/14904)*. [GitHub-14869](https://github.com/magento/magento2/issues/14869)
+<!-- ENGCOM-1414  -->
+*  Magento now displays the correct product price for an order created from the Admin in multisite deployments. Previously, when an order was created from the Admin in a multisite deployment where products were assigned different prices per store view, Magento defaulted to the product price of the primary storeview if the order was edited or updated. *Fix submitted by Riccardo Tempesta in pull request [14904](https://github.com/magento/magento2/pull/14904)*. [GitHub-14869](https://github.com/magento/magento2/issues/14869)
 
-<!-- ENGCOM-1441 -->* Magento now successfully saves the value of `REMOTE_IP` when a customer uses an IPV6 (Internet Protocol version 6) address. Previously, this value was only partially saved in the `sales_order` and `quote` tables.  *Fix submitted by George Schiopu in pull request [14976](https://github.com/magento/magento2/pull/14976)*. [GitHub-10395](https://github.com/magento/magento2/issues/10395)
+<!-- ENGCOM-1441  -->
+*  Magento now successfully saves the value of `REMOTE_IP` when a customer uses an IPV6 (Internet Protocol version 6) address. Previously, this value was only partially saved in the `sales_order` and `quote` tables.  *Fix submitted by George Schiopu in pull request [14976](https://github.com/magento/magento2/pull/14976)*. [GitHub-10395](https://github.com/magento/magento2/issues/10395)
 
-<!-- ENGCOM-1885 -->* Coupon codes now work for guest users through the web API as well as from the storefront. *Fix submitted by Marcin Dykas in pull request [15320](https://github.com/magento/magento2/pull/15320)*. [GitHub-14056](https://github.com/magento/magento2/issues/14056)
+<!-- ENGCOM-1885  -->
+*  Coupon codes now work for guest users through the web API as well as from the storefront. *Fix submitted by Marcin Dykas in pull request [15320](https://github.com/magento/magento2/pull/15320)*. [GitHub-14056](https://github.com/magento/magento2/issues/14056)
 
-<!-- ENGCOM-2254 -->* Magento no longer runs an SQL query on every item in the database when a quote is empty, which has improved the performance of the checkout process. *Fix submitted by Sean Templeton in pull request [16675](https://github.com/magento/magento2/pull/16675)*.
+<!-- ENGCOM-2254  -->
+*  Magento no longer runs an SQL query on every item in the database when a quote is empty, which has improved the performance of the checkout process. *Fix submitted by Sean Templeton in pull request [16675](https://github.com/magento/magento2/pull/16675)*.
 
 ### Reports
 
-<!-- ENGCOM-2215 -->* The timezone has been removed from the date when Magento retrieves the current month from a UTC timestamp. *Fix submitted by Prince Patel in pull request [16584](https://github.com/magento/magento2/pull/16584)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
+<!-- ENGCOM-2215  -->
+*  The timezone has been removed from the date when Magento retrieves the current month from a UTC timestamp. *Fix submitted by Prince Patel in pull request [16584](https://github.com/magento/magento2/pull/16584)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
 
 ### Review
 
-<!-- ENGCOM-1535 -->* Removed the unused class declaration from controller's index action and the unused code in the comment block from the template file in `app/code/Magento/Review/view/frontend/templates/redirect.phtml` and `app/code/Magento/Version/Controller/Index/Index.php`. *Fix submitted by Yogesh Suhagiya in pull request [15173](https://github.com/magento/magento2/pull/15173)*.
+<!-- ENGCOM-1535  -->
+*  Removed the unused class declaration from controller's index action and the unused code in the comment block from the template file in `app/code/Magento/Review/view/frontend/templates/redirect.phtml` and `app/code/Magento/Version/Controller/Index/Index.php`. *Fix submitted by Yogesh Suhagiya in pull request [15173](https://github.com/magento/magento2/pull/15173)*.
 
 ### Rule
 
-<!-- MAGETWO-89220 -->* A cart rule that uses  a `subselection` condition now works as executed. Previously, cart rules with this condition automatically granted a discount.
+<!-- MAGETWO-89220  -->
+*  A cart rule that uses  a `subselection` condition now works as executed. Previously, cart rules with this condition automatically granted a discount.
 
-<!-- ENGCOM-1961 -->* The retrieval of first array elements in the following files has been improved: `app/code/Magento/Rule/Model/Action/AbstractAction.php` and `app/code/Magento/Rule/Model/Condition/Combine.php`. *Fix submitted by Thomas Klein in pull request [16053](https://github.com/magento/magento2/pull/16053)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
+<!-- ENGCOM-1961  -->
+*  The retrieval of first array elements in the following files has been improved: `app/code/Magento/Rule/Model/Action/AbstractAction.php` and `app/code/Magento/Rule/Model/Condition/Combine.php`. *Fix submitted by Thomas Klein in pull request [16053](https://github.com/magento/magento2/pull/16053)*. [GitHub-15940](https://github.com/magento/magento2/issues/15940)
 
-<!-- ENGCOM-1583 -->* The condition category chooser now handles multiple nested categories as expected. Previously,  if a cart rule contained several nested categories, no categories appeared on the page, the page  became unresponsive,  and  eventually crashed. *Fix submitted by Keith Bentrup in pull request [15265](https://github.com/magento/magento2/pull/15265)*. [GitHub-15121](https://github.com/magento/magento2/issues/15121)
+<!-- ENGCOM-1583  -->
+*  The condition category chooser now handles multiple nested categories as expected. Previously,  if a cart rule contained several nested categories, no categories appeared on the page, the page  became unresponsive,  and  eventually crashed. *Fix submitted by Keith Bentrup in pull request [15265](https://github.com/magento/magento2/pull/15265)*. [GitHub-15121](https://github.com/magento/magento2/issues/15121)
 
 ### Sales
 
-<!-- MAGETWO-93102 -->* Order status now remains in the Complete state after Magento refunds store credit on a partial credit memo. Previously, under these circumstances, Magento changed the status of the order to Closed.
+<!-- MAGETWO-93102  -->
+*  Order status now remains in the Complete state after Magento refunds store credit on a partial credit memo. Previously, under these circumstances, Magento changed the status of the order to Closed.
 
-<!-- MAGETWO-92847 -->* You can now create multiple credit memos in one session and save each successfully. Previously, Magento displayed this error when you tried to save a second credit memo after creating the first memo: `Could not save credit memo`.
+<!-- MAGETWO-92847  -->
+*  You can now create multiple credit memos in one session and save each successfully. Previously, Magento displayed this error when you tried to save a second credit memo after creating the first memo: `Could not save credit memo`.
 
-<!-- MAGETWO-92899 -->* Magento now displays any errors that occur during order creation in the browser console. Previously, Magento displayed this message: `Uncaught ReferenceError: order is not defined during order creation` instead of a specific error message.
+<!-- MAGETWO-92899  -->
+*  Magento now displays any errors that occur during order creation in the browser console. Previously, Magento displayed this message: `Uncaught ReferenceError: order is not defined during order creation` instead of a specific error message.
 
-<!-- MAGETWO-91466 -->* The `POST /V1/shipment` endpoint processes `tracks` arrays as expected.
+<!-- MAGETWO-91466  -->
+*  The `POST /V1/shipment` endpoint processes `tracks` arrays as expected.
 
-<!-- MAGETWO-90496 -->* Magento no longer reverts to the country associated with the default website when a customer edits the billing address for an order. Previously, if a customer edited the shipping address for an order, Magento would reset the billing address to the default address specified for the default website.
+<!-- MAGETWO-90496  -->
+*  Magento no longer reverts to the country associated with the default website when a customer edits the billing address for an order. Previously, if a customer edited the shipping address for an order, Magento would reset the billing address to the default address specified for the default website.
 
-<!-- ENGCOM-2148 -->* Credit memo email template file incorrect object types have been corrected. Previously, when a merchant created a credit memo and checked the **Email** checkbox, Magento threw an error. *Fix submitted by Joseph Maxwell in pull request [16438](https://github.com/magento/magento2/pull/16438)*.
+<!-- ENGCOM-2148  -->
+*  Credit memo email template file incorrect object types have been corrected. Previously, when a merchant created a credit memo and checked the **Email** checkbox, Magento threw an error. *Fix submitted by Joseph Maxwell in pull request [16438](https://github.com/magento/magento2/pull/16438)*.
 
-<!-- MAGETWO-89238 -->* Performance issues that resulted from disabling invoice emails have been resolved.
+<!-- MAGETWO-89238  -->
+*  Performance issues that resulted from disabling invoice emails have been resolved.
 
-<!-- ENGCOM-2085 -->* The Invoices grid now reflects changes in invoice state as expected. *Fix submitted by JeroenVanLeusden in pull request [16286](https://github.com/magento/magento2/pull/16286)*.
+<!-- ENGCOM-2085  -->
+*  The Invoices grid now reflects changes in invoice state as expected. *Fix submitted by JeroenVanLeusden in pull request [16286](https://github.com/magento/magento2/pull/16286)*.
 
-<!-- ENGCOM-1892 -->* You can now set the `is_visible_on_front` parameter from the `addStatusHistoryComment` of the order mode. Previously, you could set the `is_visible_on_front` parameter  from the Admin only. *Fix submitted by Mark Shust in pull request [15637](https://github.com/magento/magento2/pull/15637)*.
+<!-- ENGCOM-1892  -->
+*  You can now set the `is_visible_on_front` parameter from the `addStatusHistoryComment` of the order mode. Previously, you could set the `is_visible_on_front` parameter  from the Admin only. *Fix submitted by Mark Shust in pull request [15637](https://github.com/magento/magento2/pull/15637)*.
 
-<!-- ENGCOM-2024 -->* Module name space is now declared before the template pathname in `Magento_Sales::order/info.phtml`. *Fix submitted by Ronak Patel in pull request [16206](https://github.com/magento/magento2/pull/16206)*.
+<!-- ENGCOM-2024  -->
+*  Module name space is now declared before the template pathname in `Magento_Sales::order/info.phtml`. *Fix submitted by Ronak Patel in pull request [16206](https://github.com/magento/magento2/pull/16206)*.
 
-<!-- ENGCOM-1529 -->* The `addFieldToFilter` has been added to `addressCollection` in  `app/code/Magento/Sales/Setup/UpgradeData.php`, which optimizes the process of collecting addresses during upgrade. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1529  -->
+*  The `addFieldToFilter` has been added to `addressCollection` in  `app/code/Magento/Sales/Setup/UpgradeData.php`, which optimizes the process of collecting addresses during upgrade. *Fix submitted by Dmytro Cheshun in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
-<!-- ENGCOM-1623 -->* Invoice prefixes now contain the correct store ID when Magento is deployed in a multistore environment. Previously, Magento always created the invoice number using the default store view ID. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*. [GitHub-14063](https://github.com/magento/magento2/issues/14063)
+<!-- ENGCOM-1623  -->
+*  Invoice prefixes now contain the correct store ID when Magento is deployed in a multistore environment. Previously, Magento always created the invoice number using the default store view ID. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*. [GitHub-14063](https://github.com/magento/magento2/issues/14063)
 
-<!-- ENGCOM-1531 -->* The `GET /V1/orders/items/{id}` request now returns `parent_item`. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
+<!-- ENGCOM-1531  -->
+*  The `GET /V1/orders/items/{id}` request now returns `parent_item`. *Fix submitted by Sanjay Patel in pull request [15615](https://github.com/magento/magento2/pull/15615)*.
 
 ### Sales rules
 
-<!-- MAGETWO-91797 -->* Cart price rules with associated coupons are no longer affected by edits to scheduled updates.
+<!-- MAGETWO-91797  -->
+*  Cart price rules with associated coupons are no longer affected by edits to scheduled updates.
 
-<!-- ENGCOM-2122 -->* The  `discount` label in the `app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js` file is now compatible with custom module discount.  *Fix submitted by Rodrigo Santellan in pull request [16093](https://github.com/magento/magento2/pull/16093)*.
+<!-- ENGCOM-2122  -->
+*  The  `discount` label in the `app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js` file is now compatible with custom module discount.  *Fix submitted by Rodrigo Santellan in pull request [16093](https://github.com/magento/magento2/pull/16093)*.
 
 ### Search
 
-<!-- ENGCOM-1381 -->* Magento no longer throws an error when a customer uses quick search to search on a term that does not exist in the search database. Previously, Magento returned this error, `TypeError: this._getFirstVisibleElement(...).addClass is not a function`. *Fix submitted by Julien ANQUETIL in pull request [14839](https://github.com/magento/magento2/pull/14839)*. [GitHub-14274](https://github.com/magento/magento2/issues/14274)
+<!-- ENGCOM-1381  -->
+*  Magento no longer throws an error when a customer uses quick search to search on a term that does not exist in the search database. Previously, Magento returned this error, `TypeError: this._getFirstVisibleElement(...).addClass is not a function`. *Fix submitted by Julien ANQUETIL in pull request [14839](https://github.com/magento/magento2/pull/14839)*. [GitHub-14274](https://github.com/magento/magento2/issues/14274)
 
-<!-- ENGCOM-1616 -->* Customers can now use the **Enter** key to submit searches from a page header. Previously, when a customer used the **Enter** key to submit a search query, event handlers that were bound to the form submit (through jQuery) were fired twice. *Fix submitted by Amjad M in pull request [15340](https://github.com/magento/magento2/pull/15340)*. [GitHub-13793](https://github.com/magento/magento2/issues/13793)
+<!-- ENGCOM-1616  -->
+*  Customers can now use the **Enter** key to submit searches from a page header. Previously, when a customer used the **Enter** key to submit a search query, event handlers that were bound to the form submit (through jQuery) were fired twice. *Fix submitted by Amjad M in pull request [15340](https://github.com/magento/magento2/pull/15340)*. [GitHub-13793](https://github.com/magento/magento2/issues/13793)
 
-<!-- ENGCOM-1887 -->* Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Jakub in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-15322](https://github.com/magento/magento2/issues/15322)
+<!-- ENGCOM-1887  -->
+*  Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Jakub in pull request [15040](https://github.com/magento/magento2/pull/15040)*. [GitHub-15322](https://github.com/magento/magento2/issues/15322)
 
-<!--  MAGETWO-85786 -->* The Admin panel search now filters catalogs as expected. Previously, if a merchant tried to narrow a search when using the Search tool in the Admin panel, Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request [12735](https://github.com/magento/magento2/pull/12735)*. [GitHub-7861](https://github.com/magento/magento2/issues/7861)
+<!--  MAGETWO-85786  -->
+*  The Admin panel search now filters catalogs as expected. Previously, if a merchant tried to narrow a search when using the Search tool in the Admin panel, Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request [12735](https://github.com/magento/magento2/pull/12735)*. [GitHub-7861](https://github.com/magento/magento2/issues/7861)
 
-<!--  ENGCOM-1415 -->* You can now use an asterix when searching on customer names. Previously, if you used an asterix in a search query, Magento displayed this message, `Something went wrong with processing the default view and we have restored the filter to its original state.` *Fix submitted by Riccardo Tempesta  in pull request [14905](https://github.com/magento/magento2/pull/14905)*. [GitHub-14855](https://github.com/magento/magento2/issues/14855)
+<!--  ENGCOM-1415  -->
+*  You can now use an asterix when searching on customer names. Previously, if you used an asterix in a search query, Magento displayed this message, `Something went wrong with processing the default view and we have restored the filter to its original state.` *Fix submitted by Riccardo Tempesta  in pull request [14905](https://github.com/magento/magento2/pull/14905)*. [GitHub-14855](https://github.com/magento/magento2/issues/14855)
 
-<!-- ENGCOM-2455 -->* Magento now displays validation messages as needed on advanced searches. Previously, Magento did not display a message even after a customer submitted the advanced search form with no entries. *Fix submitted by Ben Robie in pull request [16952](https://github.com/magento/magento2/pull/16952)*. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
+<!-- ENGCOM-2455  -->
+*  Magento now displays validation messages as needed on advanced searches. Previously, Magento did not display a message even after a customer submitted the advanced search form with no entries. *Fix submitted by Ben Robie in pull request [16952](https://github.com/magento/magento2/pull/16952)*. [GitHub-8131](https://github.com/magento/magento2/issues/8131)
 
-<!-- ENGCOM-2245 -->* Server load has been reduced for advanced searching.  Previously, when a customer entered text in the search suggestion box, Magento immediately sent every character to the server. The auto-complete box now delays  sending the request. *Fix submitted by Sean Templeton in pull request [16669](https://github.com/magento/magento2/pull/16669)*.
+<!-- ENGCOM-2245  -->
+*  Server load has been reduced for advanced searching.  Previously, when a customer entered text in the search suggestion box, Magento immediately sent every character to the server. The auto-complete box now delays  sending the request. *Fix submitted by Sean Templeton in pull request [16669](https://github.com/magento/magento2/pull/16669)*.
 
-<!-- ENGCOM-1672 -->* You can now successfully clone the minisearch widget. *Fix submitted by Daniel Ruf in pull request [15485](https://github.com/magento/magento2/pull/15485)*.
+<!-- ENGCOM-1672  -->
+*  You can now successfully clone the minisearch widget. *Fix submitted by Daniel Ruf in pull request [15485](https://github.com/magento/magento2/pull/15485)*.
 
 ### Shipping
 
-<!--  ENGCOM-2033 -->* The shipping and estimated tax form now display country, city, and postcode fields as expected. *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16213](https://github.com/magento/magento2/pull/16213)*. [GitHub-8222](https://github.com/magento/magento2/issues/8222)
+<!--  ENGCOM-2033  -->
+*  The shipping and estimated tax form now display country, city, and postcode fields as expected. *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16213](https://github.com/magento/magento2/pull/16213)*. [GitHub-8222](https://github.com/magento/magento2/issues/8222)
 
-<!--  ENGCOM-1675 -->* A method with a misspelled name was deprecated and the new method with correct spelling added to `app/code/Magento/Multishipping/Block/Checkout/AbstractMultishipping.php`. *Fix submitted by Anna Völkl in pull request [15514](https://github.com/magento/magento2/pull/15514)*.
+<!--  ENGCOM-1675  -->
+*  A method with a misspelled name was deprecated and the new method with correct spelling added to `app/code/Magento/Multishipping/Block/Checkout/AbstractMultishipping.php`. *Fix submitted by Anna Völkl in pull request [15514](https://github.com/magento/magento2/pull/15514)*.
 
 ### Store
 
-<!--  ENGCOM-1706 -->* Magento now adds the correct store code to product URLs in stores with more than one store view when  **Stores** > **Settings** > **Configuration** > **General** > **Web** > **Add Store Code to Urls** is set to **yes**. *Fix submitted by Elias Kotlyar in pull request [15566](https://github.com/magento/magento2/pull/15566)*. [GitHub-15565](https://github.com/magento/magento2/issues/15565)
+<!--  ENGCOM-1706  -->
+*  Magento now adds the correct store code to product URLs in stores with more than one store view when  **Stores** > **Settings** > **Configuration** > **General** > **Web** > **Add Store Code to Urls** is set to **yes**. *Fix submitted by Elias Kotlyar in pull request [15566](https://github.com/magento/magento2/pull/15566)*. [GitHub-15565](https://github.com/magento/magento2/issues/15565)
 
-<!--  ENGCOM-1249 -->* Magento now displays store views as expected when you select **Stores** > **Terms and Conditions**. *Fix submitted by afirlejczyk in pull request [14546](https://github.com/magento/magento2/pull/14546)*. [GitHub-13944](https://github.com/magento/magento2/issues/13944)
+<!--  ENGCOM-1249  -->
+*  Magento now displays store views as expected when you select **Stores** > **Terms and Conditions**. *Fix submitted by afirlejczyk in pull request [14546](https://github.com/magento/magento2/pull/14546)*. [GitHub-13944](https://github.com/magento/magento2/issues/13944)
 
 #### Elasticsearch
 
-<!-- MAGETWO-92142 -->* Bundle products are now indexed as expected in Elasticsearch.
+<!-- MAGETWO-92142  -->
+*  Bundle products are now indexed as expected in Elasticsearch.
 
-<!-- MAGETWO-86153 -->* Elasticsearch now correctly calculates the relevance of quick search results according to selected attribute search weights.
+<!-- MAGETWO-86153  -->
+*  Elasticsearch now correctly calculates the relevance of quick search results according to selected attribute search weights.
 
 #### Admin global search
 
-<!-- MAGETWO-86658 -->* Admin global search preview now works as expected. Previously, this feature worked inconsistently, and search results  differed depending on which area was being searched  (for example, Products, Categories, or Customers).
+<!-- MAGETWO-86658  -->
+*  Admin global search preview now works as expected. Previously, this feature worked inconsistently, and search results  differed depending on which area was being searched  (for example, Products, Categories, or Customers).
 
-<!-- MAGETWO-86289 -->* The Admin global search now returns results that match the keyword for all available pages, or if a user searches in  specific sections, the search feature now returns only the results that matched the key words in those specific sections. Previously, the Admin global search did not return results that matched the specified keywords and did not restrict results to specified sections.
+<!-- MAGETWO-86289  -->
+*  The Admin global search now returns results that match the keyword for all available pages, or if a user searches in  specific sections, the search feature now returns only the results that matched the key words in those specific sections. Previously, the Admin global search did not return results that matched the specified keywords and did not restrict results to specified sections.
 
-<!-- MAGETWO-85786 -->* Catalogs are now correctly filtered by the Admin search bar. Previously, if you attempted to use the Search tool in the Admin, and selected "XX in Products", Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request 12735*. [GitHub-12193](https://github.com/magento/magento2/issues/12193), [GitHub-7861](https://github.com/magento/magento2/issues/7861)
+<!-- MAGETWO-85786  -->
+*  Catalogs are now correctly filtered by the Admin search bar. Previously, if you attempted to use the Search tool in the Admin, and selected "XX in Products", Magento displayed the full catalog view without narrowing down the list. *Fix submitted by Pavel in pull request 12735*. [GitHub-12193](https://github.com/magento/magento2/issues/12193), [GitHub-7861](https://github.com/magento/magento2/issues/7861)
 
 ### Shipping
 
@@ -1247,41 +1731,56 @@ Our community contributors have made many helpful, minor corrections to spelling
 You can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{page.baseurl}}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).
 </div>
 
-<!-- MAGETWO-92217 -->* The free shipping cart price rule now works as expected when **UPS shipping method** is enabled and **Free Shipping** is set to "For matching items only".
+<!-- MAGETWO-92217  -->
+*  The free shipping cart price rule now works as expected when **UPS shipping method** is enabled and **Free Shipping** is set to "For matching items only".
 
-<!-- MAGETWO-91035 -->* The shipping progress dates displayed in tracking popup for FedEx shipping are now accurate.
+<!-- MAGETWO-91035  -->
+*  The shipping progress dates displayed in tracking popup for FedEx shipping are now accurate.
 
 ### Sitemap
 
-<!-- MAGETWO-92781 -->* Sitemaps generated by `cron` no longer display  `/pub/` in image URLs when  `docroot` is set to `/pub`. Previously, if the `docroot` was set to `pub` and `BASE MEDIA URL` was not set, the cron-generated sitemap  generated incorrect image URLs.
+<!-- MAGETWO-92781  -->
+*  Sitemaps generated by `cron` no longer display  `/pub/` in image URLs when  `docroot` is set to `/pub`. Previously, if the `docroot` was set to `pub` and `BASE MEDIA URL` was not set, the cron-generated sitemap  generated incorrect image URLs.
 
-<!-- ENGCOM-1073 -->* Magento now generates correct product URLs for sitemaps. Previously, when the **Use Categories Path for Product URLs** attribute was set to **no**  in **Configuration** >  **Catalog** > **Search Engine Optimization**, Magento generated the wrong product URL in the sitemap.
+<!-- ENGCOM-1073  -->
+*  Magento now generates correct product URLs for sitemaps. Previously, when the **Use Categories Path for Product URLs** attribute was set to **no**  in **Configuration** >  **Catalog** > **Search Engine Optimization**, Magento generated the wrong product URL in the sitemap.
 
-<!-- ENGCOM-1866 -->* Images in XML sitemap are no longer always linked to the primary store in a multistore deployment. *Fix submitted by Steven de Jong in pull request [15689](https://github.com/magento/magento2/pull/15689)*. [GitHub-15588](https://github.com/magento/magento2/issues/15588)
+<!-- ENGCOM-1866  -->
+*  Images in XML sitemap are no longer always linked to the primary store in a multistore deployment. *Fix submitted by Steven de Jong in pull request [15689](https://github.com/magento/magento2/pull/15689)*. [GitHub-15588](https://github.com/magento/magento2/issues/15588)
 
-<!-- ENGCOM-1377 -->* Split sitemaps now use the index sitemap name as a prefix. Previously, when generating large sitemaps that result in a single index sitemap and several smaller split sitemap files, the split sitemap files did not use the same name prefix as the parent. *Fix submitted by James Halsall in pull request [14836](https://github.com/magento/magento2/pull/14836)*.
+<!-- ENGCOM-1377  -->
+*  Split sitemaps now use the index sitemap name as a prefix. Previously, when generating large sitemaps that result in a single index sitemap and several smaller split sitemap files, the split sitemap files did not use the same name prefix as the parent. *Fix submitted by James Halsall in pull request [14836](https://github.com/magento/magento2/pull/14836)*.
 
 ### Staging
 
-<!-- MAGETWO-90682 -->* Banners remain assigned to a cart rule after a staging Update is applied. Previously, a banner was unassigned from the cart rule after a staging update was applied.
+<!-- MAGETWO-90682  -->
+*  Banners remain assigned to a cart rule after a staging Update is applied. Previously, a banner was unassigned from the cart rule after a staging update was applied.
 
-<!-- MAGETWO-91889 -->* Magento now rolls  back updated changes to their pre-update state  when a merchant deletes an active Scheduled Update. Previously, some products were removed from their assigned categories (and categories were removed from the Admin) when an active product update was deleted.
+<!-- MAGETWO-91889  -->
+*  Magento now rolls  back updated changes to their pre-update state  when a merchant deletes an active Scheduled Update. Previously, some products were removed from their assigned categories (and categories were removed from the Admin) when an active product update was deleted.
 
-<!-- MAGETWO-92509 -->* You can now successfully re-order a configurable product. Previously, a schedule update for one configurable product affected other ordered configurable products.
+<!-- MAGETWO-92509  -->
+*  You can now successfully re-order a configurable product. Previously, a schedule update for one configurable product affected other ordered configurable products.
 
-<!-- MAGETWO-89779 -->* Magento no longer unexpectedly locks up CMS pages when a merchant changes a scheduler end date. Previously, when a merchant updated the end date for a CMS page after the current scheduler ended, Magento generated an error, and the merchant could no longer access any CMS page from the Admin.
+<!-- MAGETWO-89779  -->
+*  Magento no longer unexpectedly locks up CMS pages when a merchant changes a scheduler end date. Previously, when a merchant updated the end date for a CMS page after the current scheduler ended, Magento generated an error, and the merchant could no longer access any CMS page from the Admin.
 
-<!-- MAGETWO-72815 -->* Merchants can now edit a schedule update as expected. Previously, updating schedule data removed the  product from the Admin product list.
+<!-- MAGETWO-72815  -->
+*  Merchants can now edit a schedule update as expected. Previously, updating schedule data removed the  product from the Admin product list.
 
-<!-- MAGETWO-86032 -->* Magento no longer deletes products from the Admin product list after a merchant deletes its active schedule update. This deletion only appeared after the scheduled update time.
+<!-- MAGETWO-86032  -->
+*  Magento no longer deletes products from the Admin product list after a merchant deletes its active schedule update. This deletion only appeared after the scheduled update time.
 
-<!--  ENGCOM-2335 -->* Magento no longer throws an error when a merchant edits a product from the Admin when reviews are disabled. *Fix submitted by Oleksandr Kravchuk in pull request [70](https://github.com/magento/magento2/pull/70)*. [GitHub-6264](https://github.com/magento/magento2/issues/6264)
+<!--  ENGCOM-2335  -->
+*  Magento no longer throws an error when a merchant edits a product from the Admin when reviews are disabled. *Fix submitted by Oleksandr Kravchuk in pull request [70](https://github.com/magento/magento2/pull/70)*. [GitHub-6264](https://github.com/magento/magento2/issues/6264)
 
-<!-- MAGETWO-83706 -->* Scheduled updates to an existing group price or special price no longer remove the previously configured price. Previously, Magento removed the configured price or reverted the price to its original value after the scheduled update expired.
+<!-- MAGETWO-83706  -->
+*  Scheduled updates to an existing group price or special price no longer remove the previously configured price. Previously, Magento removed the configured price or reverted the price to its original value after the scheduled update expired.
 
 ### Store
 
-<!--  ENGCOM-2530 -->* The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Burlacu Vasilii in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
+<!--  ENGCOM-2530  -->
+*  The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Burlacu Vasilii in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
 
 ### Swatches
 
@@ -1296,139 +1795,198 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 
 ### Tax
 
-<!--  ENGCOM-1551 -->* Redundant product tax recalculation has been reduced during the loading of category pages, which has improved page loading. *Fix submitted by JeroenVanLeusden in pull request [15089](https://github.com/magento/magento2/pull/15089)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
+<!--  ENGCOM-1551  -->
+*  Redundant product tax recalculation has been reduced during the loading of category pages, which has improved page loading. *Fix submitted by JeroenVanLeusden in pull request [15089](https://github.com/magento/magento2/pull/15089)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
 
-<!--  ENGCOM-1642 -->* JavaScript code in the `*.phtml` file of the Tax module has been refactored to meet Magento coding standards. *Fix submitted by Vishal Gelani in pull request [15343](https://github.com/magento/magento2/pull/15343)*. [GitHub-15352](https://github.com/magento/magento2/issues/15352)
+<!--  ENGCOM-1642  -->
+*  JavaScript code in the `*.phtml` file of the Tax module has been refactored to meet Magento coding standards. *Fix submitted by Vishal Gelani in pull request [15343](https://github.com/magento/magento2/pull/15343)*. [GitHub-15352](https://github.com/magento/magento2/issues/15352)
 
-<!--  ENGCOM-2386 -->* The `Invalid country code` error message that sometimes occurred during import of tax CSV files now includes the name of the country whose data is causing the error. Previously, the message did not identify which country's data caused the error. *Fix submitted by Adam Moss in pull request [16873](https://github.com/magento/magento2/pull/16873)*.
+<!--  ENGCOM-2386  -->
+*  The `Invalid country code` error message that sometimes occurred during import of tax CSV files now includes the name of the country whose data is causing the error. Previously, the message did not identify which country's data caused the error. *Fix submitted by Adam Moss in pull request [16873](https://github.com/magento/magento2/pull/16873)*.
 
 ### Testing
 
-<!--  ENGCOM-2523 -->* The `testGetIgnoresFirstSlash` method in `ObjectManagerTest` has been updated. *Fix submitted by Prince Patel in pull request [17098](https://github.com/magento/magento2/pull/17098)*.
+<!--  ENGCOM-2523  -->
+*  The `testGetIgnoresFirstSlash` method in `ObjectManagerTest` has been updated. *Fix submitted by Prince Patel in pull request [17098](https://github.com/magento/magento2/pull/17098)*.
 
-<!--  ENGCOM-2499 -->* The `\Magento\Backup\Model\Db` model is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17063](https://github.com/magento/magento2/pull/17063)*.
+<!--  ENGCOM-2499  -->
+*  The `\Magento\Backup\Model\Db` model is now covered by unit tests. *Fix submitted by Yaroslav Rogoza in pull request [17063](https://github.com/magento/magento2/pull/17063)*.
 
-<!--  ENGCOM-2239 -->* Corrected block name in the `Magento_Framework` test XML file. *Fix submitted by Namrata in pull request [16646](https://github.com/magento/magento2/pull/16646)*.
+<!--  ENGCOM-2239  -->
+*  Corrected block name in the `Magento_Framework` test XML file. *Fix submitted by Namrata in pull request [16646](https://github.com/magento/magento2/pull/16646)*.
 
-<!--  ENGCOM-2106 -->* Metadata titles in `lib/internal/Magento/Framework/View/Page/Config.php` are now covered by a unit test. *Fix submitted by Lorenzo Stramaccia in pull request [16333](https://github.com/magento/magento2/pull/16333)*.
+<!--  ENGCOM-2106  -->
+*  Metadata titles in `lib/internal/Magento/Framework/View/Page/Config.php` are now covered by a unit test. *Fix submitted by Lorenzo Stramaccia in pull request [16333](https://github.com/magento/magento2/pull/16333)*.
 
-<!-- ENGCOM-2255 -->* The `\Magento\Checkout\Model\Cart\CollectQuote` class is now covered by a unit test. *Fix submitted by Chitoraga Eduard in pull request [16271](https://github.com/magento/magento2/pull/16271)*.
+<!-- ENGCOM-2255  -->
+*  The `\Magento\Checkout\Model\Cart\CollectQuote` class is now covered by a unit test. *Fix submitted by Chitoraga Eduard in pull request [16271](https://github.com/magento/magento2/pull/16271)*.
 
 ### Theme
 
-<!--  ENGCOM-1516 -->* Merchants can now successfully change the applied theme. Previously, Magento displayed an error when a merchant tried to save changes to the applied theme on **Content** > **Design** > **Configuration**. *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-13530](https://github.com/magento/magento2/issues/13530)
+<!--  ENGCOM-1516  -->
+*  Merchants can now successfully change the applied theme. Previously, Magento displayed an error when a merchant tried to save changes to the applied theme on **Content** > **Design** > **Configuration**. *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-13530](https://github.com/magento/magento2/issues/13530)
 
-<!--  ENGCOM-1516 -->* Merchants can now successfully change the applied theme setting for a store view (**Content** > **Design** > **Configuration**). *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-14968](https://github.com/magento/magento2/issues/14968)
+<!--  ENGCOM-1516  -->
+*  Merchants can now successfully change the applied theme setting for a store view (**Content** > **Design** > **Configuration**). *Fix submitted by Daniel Ruf in pull request [15137](https://github.com/magento/magento2/pull/15137)*. [GitHub-14968](https://github.com/magento/magento2/issues/14968)
 
-<!--  ENGCOM-1922 -->* Changing the `@tab-content__border` variable in Blank theme now works as expected. *Fix submitted by hitesh-wagento in pull request [15914](https://github.com/magento/magento2/pull/15914)*. [GitHub-14999](https://github.com/magento/magento2/issues/14999)
+<!--  ENGCOM-1922  -->
+*  Changing the `@tab-content__border` variable in Blank theme now works as expected. *Fix submitted by hitesh-wagento in pull request [15914](https://github.com/magento/magento2/pull/15914)*. [GitHub-14999](https://github.com/magento/magento2/issues/14999)
 
 ### Translation
 
-<!-- MAGETWO-92210 -->* The `translation.json` file now contains translatable strings for the phrases "Store Credit" and "Gift Card". Previously, these strings were not translated for the shopping cart, one-page checkout, or order view in the customer account on the storefront.
+<!-- MAGETWO-92210  -->
+*  The `translation.json` file now contains translatable strings for the phrases "Store Credit" and "Gift Card". Previously, these strings were not translated for the shopping cart, one-page checkout, or order view in the customer account on the storefront.
 
-<!-- MAGETWO-92355 -->* We've added  client-side caching of `js-translation.js`.
+<!-- MAGETWO-92355  -->
+*  We've added  client-side caching of `js-translation.js`.
 
-<!-- ENGCOM-1965 -->* Removed the unused translation for `comment` tag from these files: `app/code/Magento/Analytics/etc/adminhtml/system.xml`, `app/code/Magento/Catalog/etc/adminhtml/system.xml`, `app/code/Magento/Swatches/etc/adminhtml/system.xml`, and `app/code/Magento/Ups/etc/adminhtml/system.xml`. *Fix submitted by Yaroslav Rogoza in pull request [15604](https://github.com/magento/magento2/pull/15604)*.
+<!-- ENGCOM-1965  -->
+*  Removed the unused translation for `comment` tag from these files: `app/code/Magento/Analytics/etc/adminhtml/system.xml`, `app/code/Magento/Catalog/etc/adminhtml/system.xml`, `app/code/Magento/Swatches/etc/adminhtml/system.xml`, and `app/code/Magento/Ups/etc/adminhtml/system.xml`. *Fix submitted by Yaroslav Rogoza in pull request [15604](https://github.com/magento/magento2/pull/15604)*.
 
-<!-- ENGCOM-1604 -->* Added language translation capability  for `comment` tags in the  `system.xml` file of the Signifyd  module. *Fix submitted by Yogesh Suhagiya in pull request [15364](https://github.com/magento/magento2/pull/15364)*. [GitHub-15361](https://github.com/magento/magento2/issues/15361)
+<!-- ENGCOM-1604  -->
+*  Added language translation capability  for `comment` tags in the  `system.xml` file of the Signifyd  module. *Fix submitted by Yogesh Suhagiya in pull request [15364](https://github.com/magento/magento2/pull/15364)*. [GitHub-15361](https://github.com/magento/magento2/issues/15361)
 
-<!-- ENGCOM-1855 -->* All previously unsupported `translate` tags in the mini cart template are now supported. *Fix submitted by VitaliyBoyko in pull request [15782](https://github.com/magento/magento2/pull/15782)*.
+<!-- ENGCOM-1855  -->
+*  All previously unsupported `translate` tags in the mini cart template are now supported. *Fix submitted by VitaliyBoyko in pull request [15782](https://github.com/magento/magento2/pull/15782)*.
 
-<!-- ENGCOM-2020 -->* The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16190](https://github.com/magento/magento2/pull/16190)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
+<!-- ENGCOM-2020  -->
+*  The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16190](https://github.com/magento/magento2/pull/16190)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
 
-<!-- ENGCOM-2257 -->*  Added language translation capability to the Braintree module's template file. *Fix submitted by Namrata in pull request [16690](https://github.com/magento/magento2/pull/16690)*.
+<!-- ENGCOM-2257  -->
+*   Added language translation capability to the Braintree module's template file. *Fix submitted by Namrata in pull request [16690](https://github.com/magento/magento2/pull/16690)*.
 
-<!-- ENGCOM-2192 -->* Added mini cart checkout-related translations that were missing from `app/code/Magento/Checkout/i18n/en_US.csv`. *Fix submitted by JeroenVanLeusden in pull request [16553](https://github.com/magento/magento2/pull/16553)*.
+<!-- ENGCOM-2192  -->
+*  Added mini cart checkout-related translations that were missing from `app/code/Magento/Checkout/i18n/en_US.csv`. *Fix submitted by JeroenVanLeusden in pull request [16553](https://github.com/magento/magento2/pull/16553)*.
 
-<!-- ENGCOM-1591 -->* Added language translation capability for labels in the Braintree, Multishipping, and PayPal modules. *Fix submitted by Rahul Kachhadiya in pull request [15371](https://github.com/magento/magento2/pull/15371)*.
+<!-- ENGCOM-1591  -->
+*  Added language translation capability for labels in the Braintree, Multishipping, and PayPal modules. *Fix submitted by Rahul Kachhadiya in pull request [15371](https://github.com/magento/magento2/pull/15371)*.
 
-<!-- ENGCOM-1609 -->* Added language translation capability for  message strings in  `app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php` and `app/code/Magento/AdminNotification/i18n/en_US.csv`. *Fix submitted by Yogesh Suhagiya in pull request [15333](https://github.com/magento/magento2/pull/15333)*.
+<!-- ENGCOM-1609  -->
+*  Added language translation capability for  message strings in  `app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php` and `app/code/Magento/AdminNotification/i18n/en_US.csv`. *Fix submitted by Yogesh Suhagiya in pull request [15333](https://github.com/magento/magento2/pull/15333)*.
 
 ### UI
 
-<!--  ENGCOM-1542 -->* The `clickableOverlay` option now works as expected, which improves the performance of modal popups. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
+<!--  ENGCOM-1542  -->
+*  The `clickableOverlay` option now works as expected, which improves the performance of modal popups. *Fix submitted by virtua-pmakowski in pull request [15172](https://github.com/magento/magento2/pull/15172)*. [GitHub-7399](https://github.com/magento/magento2/issues/7399)
 
-<!--  ENGCOM-1315 -->* Customers can now place orders from grouped products where the quantity of subproducts is less than one. *Fix submitted by Valerij Ivashchenko in pull request [14752](https://github.com/magento/magento2/pull/14752)*. [GitHub-14692](https://github.com/magento/magento2/issues/14692)
+<!--  ENGCOM-1315  -->
+*  Customers can now place orders from grouped products where the quantity of subproducts is less than one. *Fix submitted by Valerij Ivashchenko in pull request [14752](https://github.com/magento/magento2/pull/14752)*. [GitHub-14692](https://github.com/magento/magento2/issues/14692)
 
-<!--  ENGCOM-1606 -->* Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Chirag Matholiya in pull request [15353](https://github.com/magento/magento2/pull/15353)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
+<!--  ENGCOM-1606  -->
+*  Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Chirag Matholiya in pull request [15353](https://github.com/magento/magento2/pull/15353)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!--  ENGCOM-1766 -->* The pagination of customer group prices in Advanced Pricing when viewed on the Admin now works as expected. *Fix submitted by Dmytro Cheshun in pull request [15614](https://github.com/magento/magento2/pull/15614)*. [GitHub-15210](https://github.com/magento/magento2/issues/15210)
+<!--  ENGCOM-1766  -->
+*  The pagination of customer group prices in Advanced Pricing when viewed on the Admin now works as expected. *Fix submitted by Dmytro Cheshun in pull request [15614](https://github.com/magento/magento2/pull/15614)*. [GitHub-15210](https://github.com/magento/magento2/issues/15210)
 
-<!--  ENGCOM-1982 -->* Magento now displays a caret icon as expected when a user hovers his mouse over a navigation category on a storefront. *Fix submitted by Tejash Kumbhare in pull request [16082](https://github.com/magento/magento2/pull/16082)*. [GitHub-15220](https://github.com/magento/magento2/issues/15220)
+<!--  ENGCOM-1982  -->
+*  Magento now displays a caret icon as expected when a user hovers his mouse over a navigation category on a storefront. *Fix submitted by Tejash Kumbhare in pull request [16082](https://github.com/magento/magento2/pull/16082)*. [GitHub-15220](https://github.com/magento/magento2/issues/15220)
 
-<!--  ENGCOM-2155 -->* Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button.  *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16477](https://github.com/magento/magento2/pull/16477)*. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
+<!--  ENGCOM-2155  -->
+*  Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button.  *Fix submitted by [Alexander Kras'ko](https://github.com/0m3r) in pull request [16477](https://github.com/magento/magento2/pull/16477)*. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
 
-<!--  ENGCOM-2479 -->* The alignment **Title** and **Items** on the left bar has been corrected. *Fix submitted by Rafael Corrêa Gomes in pull request [16984](https://github.com/magento/magento2/pull/16984)*.
+<!--  ENGCOM-2479  -->
+*  The alignment **Title** and **Items** on the left bar has been corrected. *Fix submitted by Rafael Corrêa Gomes in pull request [16984](https://github.com/magento/magento2/pull/16984)*.
 
-<!--  ENGCOM-2473 -->*  The black color coding standard has been changed from `color: #000;` to `color: @color-black;`. *Fix submitted by Chirag Matholiya in pull request [17019](https://github.com/magento/magento2/pull/17019)*.
+<!--  ENGCOM-2473  -->
+*   The black color coding standard has been changed from `color: #000;` to `color: @color-black;`. *Fix submitted by Chirag Matholiya in pull request [17019](https://github.com/magento/magento2/pull/17019)*.
 
-<!--  ENGCOM-2399 -->* The white color coding standard has been changed from `color: #fff;` to `color: @color-white;`. *Fix submitted by Chirag Matholiya in pull request [16903](https://github.com/magento/magento2/pull/16903)*.
+<!--  ENGCOM-2399  -->
+*  The white color coding standard has been changed from `color: #fff;` to `color: @color-white;`. *Fix submitted by Chirag Matholiya in pull request [16903](https://github.com/magento/magento2/pull/16903)*.
 
-<!--  ENGCOM-1785 -->* Minor issues with the dynamically defined ``$filter`` property and missing throws to PHPDocs for methods in the UI export converter classes have been corrected. *Fix submitted by Dmytro Cheshun in pull request [15694](https://github.com/magento/magento2/pull/15694)*.
+<!--  ENGCOM-1785  -->
+*  Minor issues with the dynamically defined ``$filter`` property and missing throws to PHPDocs for methods in the UI export converter classes have been corrected. *Fix submitted by Dmytro Cheshun in pull request [15694](https://github.com/magento/magento2/pull/15694)*.
 
-<!--  ENGCOM-1678 -->*  The `ClassMagento\Ui\Component\Control\ActionPool` constructor and `getConfiguration()` in the UI module are now invoked with the correct number of parameters. *Fix submitted by Marcel Hauri in pull request [15512](https://github.com/magento/magento2/pull/15512)*.
+<!--  ENGCOM-1678  -->
+*   The `ClassMagento\Ui\Component\Control\ActionPool` constructor and `getConfiguration()` in the UI module are now invoked with the correct number of parameters. *Fix submitted by Marcel Hauri in pull request [15512](https://github.com/magento/magento2/pull/15512)*.
 
-<!--  ENGCOM-1682 -->* Unneeded JavaScript was removed from `logout.phtml` and replaced with a new JavaScript component. *Fix submitted by Nimesh Patel in pull request [15301](https://github.com/magento/magento2/pull/15301)*
+<!--  ENGCOM-1682  -->
+*  Unneeded JavaScript was removed from `logout.phtml` and replaced with a new JavaScript component. *Fix submitted by Nimesh Patel in pull request [15301](https://github.com/magento/magento2/pull/15301)*
 
-<!--  ENGCOM-2605 -->* Page wrapper CSS has been moved from media query to `.page-wrapper`. *Fix submitted by Vishal Gelani in pull request [15416](https://github.com/magento/magento2/pull/15416)*.
+<!--  ENGCOM-2605  -->
+*  Page wrapper CSS has been moved from media query to `.page-wrapper`. *Fix submitted by Vishal Gelani in pull request [15416](https://github.com/magento/magento2/pull/15416)*.
 
-<!--  ENGCOM-1657 -->* The `font-size` variable has been updated and standardized. *Fix submitted by Vishal Gelani in pull request [15421](https://github.com/magento/magento2/pull/15421)*.
+<!--  ENGCOM-1657  -->
+*  The `font-size` variable has been updated and standardized. *Fix submitted by Vishal Gelani in pull request [15421](https://github.com/magento/magento2/pull/15421)*.
 
-<!--  ENGCOM-1473 -->* Layout arguments now  support for the `const` type. *Fix submitted by Igor Vitol in pull request [15058](https://github.com/magento/magento2/pull/15058)*.
+<!--  ENGCOM-1473  -->
+*  Layout arguments now  support for the `const` type. *Fix submitted by Igor Vitol in pull request [15058](https://github.com/magento/magento2/pull/15058)*.
 
-<!--  ENGCOM-1547 -->* Button definitions have been moved to the new `buttons.js` file. *Fix submitted by Jisse Reitsma in pull request [15194](https://github.com/magento/magento2/pull/15194)*.
+<!--  ENGCOM-1547  -->
+*  Button definitions have been moved to the new `buttons.js` file. *Fix submitted by Jisse Reitsma in pull request [15194](https://github.com/magento/magento2/pull/15194)*.
 
-<!--  ENGCOM-1438 -->* Overlay issues with the mini cart have been resolved. Previously, if you logged in as a customer, then clicked on the mini cart icon and then the Account menu, the mini cart overlaid the Account menu. *Fix submitted by Arthur James in pull request [14963](https://github.com/magento/magento2/pull/14963)*.
+<!--  ENGCOM-1438  -->
+*  Overlay issues with the mini cart have been resolved. Previously, if you logged in as a customer, then clicked on the mini cart icon and then the Account menu, the mini cart overlaid the Account menu. *Fix submitted by Arthur James in pull request [14963](https://github.com/magento/magento2/pull/14963)*.
 
-<!--  ENGCOM-1313 -->* Magento now supports multiple `ui_components` with layout type `tabs` on a page. Previously, the second UI component failed to render, and Magento displayed this error, `Element with ID 'tabs_nav' already exists`. *Fix submitted by Freek Vandeursen in pull request [14742](https://github.com/magento/magento2/pull/14742)*.
+<!--  ENGCOM-1313  -->
+*  Magento now supports multiple `ui_components` with layout type `tabs` on a page. Previously, the second UI component failed to render, and Magento displayed this error, `Element with ID 'tabs_nav' already exists`. *Fix submitted by Freek Vandeursen in pull request [14742](https://github.com/magento/magento2/pull/14742)*.
 
-<!--  ENGCOM-1313 -->* The order of style groups for mobile devices has been corrected. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
+<!--  ENGCOM-1313  -->
+*  The order of style groups for mobile devices has been corrected. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
 
-<!-- ENGCOM-1869 -->* Dynamic data rows no longer fail due to a read operation after a delete condition. Previously, Magento threw an undefined JavaScript error. *Fix submitted by Chirag Matholiya in pull request [15840](https://github.com/magento/magento2/pull/15840)*. [GitHub-911](https://github.com/magento-engcom/msi/issues/911)
+<!-- ENGCOM-1869  -->
+*  Dynamic data rows no longer fail due to a read operation after a delete condition. Previously, Magento threw an undefined JavaScript error. *Fix submitted by Chirag Matholiya in pull request [15840](https://github.com/magento/magento2/pull/15840)*. [GitHub-911](https://github.com/magento-engcom/msi/issues/911)
 
 ### URL rewrites
 
-<!-- MAGETWO-89905 -->* Categories of the Main menu in the different store view are now updated when Varnish is enabled.
+<!-- MAGETWO-89905  -->
+*  Categories of the Main menu in the different store view are now updated when Varnish is enabled.
 
-<!-- MAGETWO-73456 -->* URL key values are now derived from the  default value set on the default store. Previously, Magento derived the product URL key value from the product name on storeview level.
+<!-- MAGETWO-73456  -->
+*  URL key values are now derived from the  default value set on the default store. Previously, Magento derived the product URL key value from the product name on storeview level.
 
-<!-- ENGCOM-1283 -->* The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character. *Fix submitted by Vinay Shah in pull request [13397](https://github.com/magento/magento2/pull/13397)*. [GitHub-13296](https://github.com/magento/magento2/issues/13296)
+<!-- ENGCOM-1283  -->
+*  The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character. *Fix submitted by Vinay Shah in pull request [13397](https://github.com/magento/magento2/pull/13397)*. [GitHub-13296](https://github.com/magento/magento2/issues/13296)
 
-<!-- ENGCOM-1916 -->* An unnecessary parameter has been removed from `_addProductLinkBlock()`.  *Fix submitted by Saurabh Parekh in pull request [15891](https://github.com/magento/magento2/pull/15891)*.
+<!-- ENGCOM-1916  -->
+*  An unnecessary parameter has been removed from `_addProductLinkBlock()`.  *Fix submitted by Saurabh Parekh in pull request [15891](https://github.com/magento/magento2/pull/15891)*.
 
-<!-- ENGCOM-1656 -->* Template files have been refactored to follow Magento coding standards. *Fix submitted by Nimesh Patel in pull request [15422](https://github.com/magento/magento2/pull/15422)*. [GitHub-15356](https://github.com/magento/magento2/issues/15356)
+<!-- ENGCOM-1656  -->
+*  Template files have been refactored to follow Magento coding standards. *Fix submitted by Nimesh Patel in pull request [15422](https://github.com/magento/magento2/pull/15422)*. [GitHub-15356](https://github.com/magento/magento2/issues/15356)
 
-<!-- ENGCOM-2524 -->* Undefined mixin parameters are now defined and variable scope has been improved in `lib/web/css/source/lib/_icons.less`, `lib/web/css/source/lib/_pages.less`, and `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Prince Patel in pull request [17097](https://github.com/magento/magento2/pull/17097)*.
+<!-- ENGCOM-2524  -->
+*  Undefined mixin parameters are now defined and variable scope has been improved in `lib/web/css/source/lib/_icons.less`, `lib/web/css/source/lib/_pages.less`, and `lib/web/css/source/lib/_utilities.less`. *Fix submitted by Prince Patel in pull request [17097](https://github.com/magento/magento2/pull/17097)*.
 
-<!-- ENGCOM-1314 -->* Magento now removes URL rewrites as expected after you delete a CMS page through the API or in the `crontab` area. *Fix submitted by Roman in pull request [14751](https://github.com/magento/magento2/pull/14751)*.
+<!-- ENGCOM-1314  -->
+*  Magento now removes URL rewrites as expected after you delete a CMS page through the API or in the `crontab` area. *Fix submitted by Roman in pull request [14751](https://github.com/magento/magento2/pull/14751)*.
 
-<!-- MAGETWO-89905 -->* Main menu categories  in  different store views are now updated as expected when Varnish is enabled.
+<!-- MAGETWO-89905  -->
+*  Main menu categories  in  different store views are now updated as expected when Varnish is enabled.
 
 ### Visual Merchandiser
 
-<!-- MAGETWO-90599 -->* Magento now maintains manual sort order and adds newly assigned products to the top of the products list. Previously, Magento reset the manual sort order and sorted products by ID.
+<!-- MAGETWO-90599  -->
+*  Magento now maintains manual sort order and adds newly assigned products to the top of the products list. Previously, Magento reset the manual sort order and sorted products by ID.
 
-<!-- MAGETWO-92504 -->* Saving a product no longer reverts the selected sort order for a category. Previously, after a merchant saved a product, Magento reverted the sort order that defined the display of products in that category from the defined  sort order to an order defined by product ID.
+<!-- MAGETWO-92504  -->
+*  Saving a product no longer reverts the selected sort order for a category. Previously, after a merchant saved a product, Magento reverted the sort order that defined the display of products in that category from the defined  sort order to an order defined by product ID.
 
 ### Vertex
 
-<!-- BUNDLE-1399 -->*  The Gross Amount and Tax Amount columns in the Transaction Details Report file  now include price and tax for products as expected.
+<!-- BUNDLE-1399  -->
+*   The Gross Amount and Tax Amount columns in the Transaction Details Report file  now include price and tax for products as expected.
 
 ### Wishlist
 
-<!--  ENGCOM-1878 -->* Incorrect return type hinting in DocBlocks has been corrected for several methods in the Wishlist module. *Fix submitted by Yaroslav Rogoza in pull request [15854](https://github.com/magento/magento2/pull/15854)*.
+<!--  ENGCOM-1878  -->
+*  Incorrect return type hinting in DocBlocks has been corrected for several methods in the Wishlist module. *Fix submitted by Yaroslav Rogoza in pull request [15854](https://github.com/magento/magento2/pull/15854)*.
 
-<!--  ENGCOM-1949 -->* Removed an unnecessary parameter from the `toHtml()` method in `Wishlist/view/frontend/templates/item/list.phtml`. *Fix submitted by Yaroslav Rogoza in pull request [16023](https://github.com/magento/magento2/pull/16023)*.
+<!--  ENGCOM-1949  -->
+*  Removed an unnecessary parameter from the `toHtml()` method in `Wishlist/view/frontend/templates/item/list.phtml`. *Fix submitted by Yaroslav Rogoza in pull request [16023](https://github.com/magento/magento2/pull/16023)*.
 
-<!--  ENGCOM-2133 -->* Magento no longer thows errors when you log in using the wishlist URL. *Fix submitted by Oleksandr Kravchuk in pull request [16386](https://github.com/magento/magento2/pull/16386)*.
+<!--  ENGCOM-2133  -->
+*  Magento no longer thows errors when you log in using the wishlist URL. *Fix submitted by Oleksandr Kravchuk in pull request [16386](https://github.com/magento/magento2/pull/16386)*.
 
-<!--  ENGCOM-2128 -->* Magento no longer removes a product from the wishlist when you update a wishlist item. *Fix submitted by Chitoraga Eduard in pull request [16372](https://github.com/magento/magento2/pull/16372)*.
+<!--  ENGCOM-2128  -->
+*  Magento no longer removes a product from the wishlist when you update a wishlist item. *Fix submitted by Chitoraga Eduard in pull request [16372](https://github.com/magento/magento2/pull/16372)*.
 
-<!--  ENGCOM-2035 -->* Magento now passes empty arrays (instead of null values) into the DataObject constructor. Previously, a null value was passed, which caused a fatal error. *Fix submitted by Abhishek Jakhotiya in pull request [16220](https://github.com/magento/magento2/pull/16220)*.
+<!--  ENGCOM-2035  -->
+*  Magento now passes empty arrays (instead of null values) into the DataObject constructor. Previously, a null value was passed, which caused a fatal error. *Fix submitted by Abhishek Jakhotiya in pull request [16220](https://github.com/magento/magento2/pull/16220)*.
 
-<!--  ENGCOM-1800 -->* The `\Magento\Wishlist\CustomerData\Wishlist::getImageData()` method DocBlock now correctly indicates that the method returns an array. *Fix submitted by Yaroslav Rogoza in pull request [15718](https://github.com/magento/magento2/pull/15718)*.
+<!--  ENGCOM-1800  -->
+*  The `\Magento\Wishlist\CustomerData\Wishlist::getImageData()` method DocBlock now correctly indicates that the method returns an array. *Fix submitted by Yaroslav Rogoza in pull request [15718](https://github.com/magento/magento2/pull/15718)*.
 
-<!--  ENGCOM-1668 -->* Magento now displays the correct product image for the selected configurable product variant in the  My Wishlist sidebar. Previously, Magento always displayed the image associated with the default configurable product in the  My Wishlist sidebar. *Fix submitted by kishanpatadia in pull request [15477](https://github.com/magento/magento2/pull/15477)*.
+<!--  ENGCOM-1668  -->
+*  Magento now displays the correct product image for the selected configurable product variant in the  My Wishlist sidebar. Previously, Magento always displayed the image associated with the default configurable product in the  My Wishlist sidebar. *Fix submitted by kishanpatadia in pull request [15477](https://github.com/magento/magento2/pull/15477)*.
 
 <!-- not needed- 72024 ENGCOM-1665 1454 72051 93668 93674 93239 93320 90029 86243 87525 88658 91372 88667 92175 93204 83975 91412 86480 87966 88005 92178 86104 73638 93066 92165 82785 93042 93093 84387 93067 92162 81926 92983 92693 92200 92751 83992 92312 90837 92197 73967 90570 88655 92468 88592 74766 91989 81470 91894 89726 9057589342 84209 72982 86471 88604 88598 89746 89744 91791 93960 92191 93182 84093 82025 89301 92012 89988 92400 92747 87418 93799 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
@@ -46,21 +46,27 @@ This release includes improvements to general usability of the core code plus en
 
 #### General improvements
 
-<!-- MAGETWO-87437 -->* All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing from the Google Tag Manager.
+<!-- MAGETWO-87437  -->
+*  All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing from the Google Tag Manager.
 
 #### Wishlist
 
-<!-- MAGETWO-74289 -->* Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
+<!-- MAGETWO-74289  -->
+*  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
 
-<!-- MAGETWO-86609 -->* Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+<!-- MAGETWO-86609  -->
+*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
-<!-- MAGETWO-89234 -->* Magento now displays a success message when a customer successfully updates a wishlist.
+<!-- MAGETWO-89234  -->
+*  Magento now displays a success message when a customer successfully updates a wishlist.
 
-<!-- MAGETWO-75086 -->* Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options. ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!-- MAGETWO-75086  -->
+*  Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options. ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
 ### Shipping
 
-<!-- MAGETWO-94434 -->* The Magento UPS module has been updated to support new UPS API endpoints.
+<!-- MAGETWO-94434  -->
+*  The Magento UPS module has been updated to support new UPS API endpoints.
 
 ### Magento Functional Test Framework (MFTF)
 
@@ -70,11 +76,14 @@ This release includes improvements to general usability of the core code plus en
 
 Highlights of community contributions include these fixes:
 
-<!-- MAGETWO-86712 -->* The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. Thanks to community member [Jason Woods](https://github.com/driskell)!
+<!-- MAGETWO-86712  -->
+*  The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. Thanks to community member [Jason Woods](https://github.com/driskell)!
 
-<!-- ENGCOM-2671 -->* You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. Thanks to community member [zamboten](https://github.com/zamboten)! [GitHub-15028](https://github.com/magento/magento2/issues/15028)
+<!-- ENGCOM-2671  -->
+*  You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. Thanks to community member [zamboten](https://github.com/zamboten)! [GitHub-15028](https://github.com/magento/magento2/issues/15028)
 
-<!-- ENGCOM-1832 -->* The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. Thanks to community member [Riccardo Tempesta](https://github.com/phoenix128)! [GitHub-15457](https://github.com/magento/magento2/issues/15457)
+<!-- ENGCOM-1832  -->
+*  The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. Thanks to community member [Riccardo Tempesta](https://github.com/phoenix128)! [GitHub-15457](https://github.com/magento/magento2/issues/15457)
 
 ## Fixes
 
@@ -82,382 +91,533 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!---MAGETWO-94174 -->* Magento backup functionality is no longer enabled by default, and the code has been deprecated. See [Back up and roll back the file system, media, and database]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) for more information on backup strategies.
+<!---MAGETWO-94174  -->
+*  Magento backup functionality is no longer enabled by default, and the code has been deprecated. See [Back up and roll back the file system, media, and database]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) for more information on backup strategies.
 
-<!-- MAGETWO-95591 -->* Customer attribute management issues that merchants  experienced after upgrading to Magento 2.2.6 have been resolved. Previously, after upgrading their stores to Magento 2.2.6, merchants could not create and save a new multiselect or dropdown customer custom attribute, and  existing customer attributes  no longer appeared for editing within the customer's account on the storefront.
+<!-- MAGETWO-95591  -->
+*  Customer attribute management issues that merchants  experienced after upgrading to Magento 2.2.6 have been resolved. Previously, after upgrading their stores to Magento 2.2.6, merchants could not create and save a new multiselect or dropdown customer custom attribute, and  existing customer attributes  no longer appeared for editing within the customer's account on the storefront.
 
-<!-- MAGETWO-94764 -->* Fixed an issue with the shared configuration settings in `app/etc/config.php` that caused `recursion detected` errors during deployment.
+<!-- MAGETWO-94764  -->
+*  Fixed an issue with the shared configuration settings in `app/etc/config.php` that caused `recursion detected` errors during deployment.
 
-<!-- ENGCOM-2673 -->* You can now enable logs as expected (through the use of **Stores** > **Settings** > **Configuration** > **Advanced** > **Developer** > **Debug** > **Log to file**) when switching from production mode to developer mode. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [15335](https://github.com/magento/magento2/pull/15335)*. [GitHub-13480](https://github.com/magento/magento2/issues/13480)
+<!-- ENGCOM-2673  -->
+*  You can now enable logs as expected (through the use of **Stores** > **Settings** > **Configuration** > **Advanced** > **Developer** > **Debug** > **Log to file**) when switching from production mode to developer mode. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [15335](https://github.com/magento/magento2/pull/15335)*. [GitHub-13480](https://github.com/magento/magento2/issues/13480)
 
-<!-- ENGCOM-2920 -->* You can now filter the customer grid without inadvertently triggering a next-page Ajax call. Previously, when you created an order from the Orders page and tried to filter the customer list, Magento did not filter the list, and displayed the next page of customer entries. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17870](https://github.com/magento/magento2/pull/17870)*. [GitHub-17789](https://github.com/magento/magento2/issues/17789)
+<!-- ENGCOM-2920  -->
+*  You can now filter the customer grid without inadvertently triggering a next-page Ajax call. Previously, when you created an order from the Orders page and tried to filter the customer list, Magento did not filter the list, and displayed the next page of customer entries. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17870](https://github.com/magento/magento2/pull/17870)*. [GitHub-17789](https://github.com/magento/magento2/issues/17789)
 
-<!-- MAGETWO-94475 -->* The `bin/magento` command now works as expected when Magento is not installed. Previously, Magento displayed this error, `Command line user does not have read and write permissions on generated directory. Please address this issue before using Magento command line.`
+<!-- MAGETWO-94475  -->
+*  The `bin/magento` command now works as expected when Magento is not installed. Previously, Magento displayed this error, `Command line user does not have read and write permissions on generated directory. Please address this issue before using Magento command line.`
 
-<!-- ENGCOM-2740 -->* Magento no longer throws an error when loading configuration data while running the `setup:di:compile` command. Previously, Magento threw an error when loading configuration data before Magento was installed because no  store-specific or website-specific configuration data was available. (Store and website data is available only after Magento is installed.) *Fix submitted by [Marcel](https://github.com/mimarcel) in pull request [13649](https://github.com/magento/magento2/pull/13649)*.
+<!-- ENGCOM-2740  -->
+*  Magento no longer throws an error when loading configuration data while running the `setup:di:compile` command. Previously, Magento threw an error when loading configuration data before Magento was installed because no  store-specific or website-specific configuration data was available. (Store and website data is available only after Magento is installed.) *Fix submitted by [Marcel](https://github.com/mimarcel) in pull request [13649](https://github.com/magento/magento2/pull/13649)*.
 
-<!-- ENGCOM-2674 -->* You can now set a custom `frontend_model` value in `system.xml` if the name of the module you're using contains an underscore. *Fix submitted by [Ben Tideswell](https://github.com/bentideswell) in pull request [14397](https://github.com/magento/magento2/pull/14397)*.
+<!-- ENGCOM-2674  -->
+*  You can now set a custom `frontend_model` value in `system.xml` if the name of the module you're using contains an underscore. *Fix submitted by [Ben Tideswell](https://github.com/bentideswell) in pull request [14397](https://github.com/magento/magento2/pull/14397)*.
 
-<!-- ENGCOM-2596 -->* Performance of the `setup:upgrade` step  of the update process has been improved for installations containing many orders (greater than 100,000). *Fix submitted by [Aurélien Lavorel](https://github.com/AurelienLavorel) in pull request [16570](https://github.com/magento/magento2/pull/16570)*.
+<!-- ENGCOM-2596  -->
+*  Performance of the `setup:upgrade` step  of the update process has been improved for installations containing many orders (greater than 100,000). *Fix submitted by [Aurélien Lavorel](https://github.com/AurelienLavorel) in pull request [16570](https://github.com/magento/magento2/pull/16570)*.
 
-<!-- ENGCOM-2646 -->* You can now complete `setup:install` for installations running  an authenticated Redis instance for cache configuration. Previously, Magento did not read the Redis cache options in `env.php` as expected, although the Redis session password configuration worked as expected.  *Fix submitted by [Guillaume Giordana](https://github.com/guillaumegiordana) in pull request [17078](https://github.com/magento/magento2/pull/17078)*.
+<!-- ENGCOM-2646  -->
+*  You can now complete `setup:install` for installations running  an authenticated Redis instance for cache configuration. Previously, Magento did not read the Redis cache options in `env.php` as expected, although the Redis session password configuration worked as expected.  *Fix submitted by [Guillaume Giordana](https://github.com/guillaumegiordana) in pull request [17078](https://github.com/magento/magento2/pull/17078)*.
 
-<!-- ENGCOM-2721 -->* You can now replace the transaction trace driver for the Profiler (`app/bootstrap.php`). For example, with this change you could replace  the default profiler with the OpenTracing API, which can then use its own exporters to express the code to the CNCF Jaeger project. This in turn supports a more granular view of application transactions. *Fix submitted by [Andrew Howden](https://github.com/andrewhowdencom) in pull request [15171](https://github.com/magento/magento2/pull/15171)*.
+<!-- ENGCOM-2721  -->
+*  You can now replace the transaction trace driver for the Profiler (`app/bootstrap.php`). For example, with this change you could replace  the default profiler with the OpenTracing API, which can then use its own exporters to express the code to the CNCF Jaeger project. This in turn supports a more granular view of application transactions. *Fix submitted by [Andrew Howden](https://github.com/andrewhowdencom) in pull request [15171](https://github.com/magento/magento2/pull/15171)*.
 
 ### Bundle products
 
-<!-- MAGETWO-93145 -->* Magento now sorts bundle summaries according to the criteria set in the Admin.
+<!-- MAGETWO-93145  -->
+*  Magento now sorts bundle summaries according to the criteria set in the Admin.
 
-<!-- ENGCOM-1832 -->* The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [15535](https://github.com/magento/magento2/pull/15535)*. [GitHub-15457](https://github.com/magento/magento2/issues/15457)
+<!-- ENGCOM-1832  -->
+*  The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [15535](https://github.com/magento/magento2/pull/15535)*. [GitHub-15457](https://github.com/magento/magento2/issues/15457)
 
 ### CAPTCHA
 
-<!-- ENGCOM-2576 -->* CAPTCHA code has been refactored to eliminate unnecessary multiple conditions. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17203](https://github.com/magento/magento2/pull/17203)*.
+<!-- ENGCOM-2576  -->
+*  CAPTCHA code has been refactored to eliminate unnecessary multiple conditions. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17203](https://github.com/magento/magento2/pull/17203)*.
 
 ### Cart and checkout
 
-<!-- MAGETWO-93037 -->* Customers can no longer place orders for out-of-stock products.
+<!-- MAGETWO-93037  -->
+*  Customers can no longer place orders for out-of-stock products.
 
-<!-- ENGCOM-2743 -->* Magento no longer displays an undefined string on the Order Summary page. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17526](https://github.com/magento/magento2/pull/17526)*. [GitHub-17492](https://github.com/magento/magento2/issues/17492)
+<!-- ENGCOM-2743  -->
+*  Magento no longer displays an undefined string on the Order Summary page. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17526](https://github.com/magento/magento2/pull/17526)*. [GitHub-17492](https://github.com/magento/magento2/issues/17492)
 
-<!-- ENGCOM-2901 -->* Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [17877](https://github.com/magento/magento2/pull/17877)*. [GitHub-17851](https://github.com/magento/magento2/issues/17851)
+<!-- ENGCOM-2901  -->
+*  Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [17877](https://github.com/magento/magento2/pull/17877)*. [GitHub-17851](https://github.com/magento/magento2/issues/17851)
 
-<!-- ENGCOM-2789 -->* Magento no longer unchecks **My billing and shipping address are the same** checkbox when a customer uses an offline custom payment method for an order. Previously, when a customer used an offline custom payment method for an order, Magento unchecked this checkbox on the payment step if the shipping address was updated. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17593](https://github.com/magento/magento2/pull/17593)*. [GitHub-14819](https://github.com/magento/magento2/issues/14819)
+<!-- ENGCOM-2789  -->
+*  Magento no longer unchecks **My billing and shipping address are the same** checkbox when a customer uses an offline custom payment method for an order. Previously, when a customer used an offline custom payment method for an order, Magento unchecked this checkbox on the payment step if the shipping address was updated. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17593](https://github.com/magento/magento2/pull/17593)*. [GitHub-14819](https://github.com/magento/magento2/issues/14819)
 
-<!-- MAGETWO-93038 -->* You can now see category changes on the storefront as expected after the changes have been saved. Previously, Magento did not display changes to product categories on the storefront until reindexing occurred even if **update on schedule** was set and the cache had been cleaned.
+<!-- MAGETWO-93038  -->
+*  You can now see category changes on the storefront as expected after the changes have been saved. Previously, Magento did not display changes to product categories on the storefront until reindexing occurred even if **update on schedule** was set and the cache had been cleaned.
 
-<!-- MAGETWO-73604 -->* Magento now populates the **Default Billing** address field with the shipping address when a customer selects **Save in address book** during checkout. Previously, Magento saved the address, but did not populate the default billing address field as expected.
+<!-- MAGETWO-73604  -->
+*  Magento now populates the **Default Billing** address field with the shipping address when a customer selects **Save in address book** during checkout. Previously, Magento saved the address, but did not populate the default billing address field as expected.
 
-<!-- ENGCOM-2534 -->* Third-party modules can now perform actions after `totals` calculation. (Modules can perform additional actions by adding `.done`, `.fail`, or `.always` tasks to the request promise by creating a JavaScript mixin for the totals processor.) *Fix submitted by [Navarr Barnier](https://github.com/navarr) in pull request [17127](https://github.com/magento/magento2/pull/17127)*.
+<!-- ENGCOM-2534  -->
+*  Third-party modules can now perform actions after `totals` calculation. (Modules can perform additional actions by adding `.done`, `.fail`, or `.always` tasks to the request promise by creating a JavaScript mixin for the totals processor.) *Fix submitted by [Navarr Barnier](https://github.com/navarr) in pull request [17127](https://github.com/magento/magento2/pull/17127)*.
 
-<!-- ENGCOM-2645 -->* Magento no longer adds an empty method to the cart summary. Previously, when the method html was empty, an empty list item resulted, which subsequently  resulted in an extra margin of 20px because of default styling. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17189](https://github.com/magento/magento2/pull/17189)*.
+<!-- ENGCOM-2645  -->
+*  Magento no longer adds an empty method to the cart summary. Previously, when the method html was empty, an empty list item resulted, which subsequently  resulted in an extra margin of 20px because of default styling. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17189](https://github.com/magento/magento2/pull/17189)*.
 
-<!-- ENGCOM-2636 -->* The sidebars for the wishlist on the catalog, my account, and checkout pages now render special characters correctly. Previously, the browser displayed `&trade;` instead of rendered special characters on these pages. *Fix submitted by [deepjoshi94](https://github.com/deepjoshi94) in pull request [17070](https://github.com/magento/magento2/pull/17070)*.
+<!-- ENGCOM-2636  -->
+*  The sidebars for the wishlist on the catalog, my account, and checkout pages now render special characters correctly. Previously, the browser displayed `&trade;` instead of rendered special characters on these pages. *Fix submitted by [deepjoshi94](https://github.com/deepjoshi94) in pull request [17070](https://github.com/magento/magento2/pull/17070)*.
 
-<!-- ENGCOM-2665 -->* The `disabled attribute` has been removed from the region list. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [16955](https://github.com/magento/magento2/pull/16955)*.
+<!-- ENGCOM-2665  -->
+*  The `disabled attribute` has been removed from the region list. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [16955](https://github.com/magento/magento2/pull/16955)*.
 
-<!-- ENGCOM-2210 -->* The Admin checkout agreement controllers have been refactored to remove the use of `ObjectManager`. *Fix submitted by [AnshuMishra17](https://github.com/AnshuMishra17) in pull request [16505](https://github.com/magento/magento2/pull/16505)*.
+<!-- ENGCOM-2210  -->
+*  The Admin checkout agreement controllers have been refactored to remove the use of `ObjectManager`. *Fix submitted by [AnshuMishra17](https://github.com/AnshuMishra17) in pull request [16505](https://github.com/magento/magento2/pull/16505)*.
 
 ### Catalog
 
-<!-- MAGETWO-93198 -->* Magento now displays the product name  under the product image on the product page.
+<!-- MAGETWO-93198  -->
+*  Magento now displays the product name  under the product image on the product page.
 
-<!-- MAGETWO-92036 -->* Magento now alerts you to an error when a merchant tries to save a product without completed required fields.
+<!-- MAGETWO-92036  -->
+*  Magento now alerts you to an error when a merchant tries to save a product without completed required fields.
 
-<!-- ENGCOM-2555 -->* A previous fix for a gallery template issue that was inadvertently reverted has been restored. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [16594](https://github.com/magento/magento2/pull/16594)*. [GitHub-15009](https://github.com/magento/magento2/issues/15009)
+<!-- ENGCOM-2555  -->
+*  A previous fix for a gallery template issue that was inadvertently reverted has been restored. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [16594](https://github.com/magento/magento2/pull/16594)*. [GitHub-15009](https://github.com/magento/magento2/issues/15009)
 
-<!-- ENGCOM-2650 -->* Parent theme image height settings (specified in `view.xml`) no longer override the height settings assigned to individual images. *Fix submitted by [Tommy Quissens](https://github.com/quisse) in pull request [14537](https://github.com/magento/magento2/pull/14537)*. [GitHub-12250](https://github.com/magento/magento2/issues/12250)
+<!-- ENGCOM-2650  -->
+*  Parent theme image height settings (specified in `view.xml`) no longer override the height settings assigned to individual images. *Fix submitted by [Tommy Quissens](https://github.com/quisse) in pull request [14537](https://github.com/magento/magento2/pull/14537)*. [GitHub-12250](https://github.com/magento/magento2/issues/12250)
 
-<!-- ENGCOM-2672 -->* Magento now maintains product image roles as expected after upgrade. Previously, image roles randomly disappeared from product pages after upgrade. *Fix submitted by [Sam Butler Thompson](https://github.com/Scarraban) in pull request [15606](https://github.com/magento/magento2/pull/15606)*. [GitHub-10687](https://github.com/magento/magento2/issues/10687)
+<!-- ENGCOM-2672  -->
+*  Magento now maintains product image roles as expected after upgrade. Previously, image roles randomly disappeared from product pages after upgrade. *Fix submitted by [Sam Butler Thompson](https://github.com/Scarraban) in pull request [15606](https://github.com/magento/magento2/pull/15606)*. [GitHub-10687](https://github.com/magento/magento2/issues/10687)
 
-<!-- ENGCOM-2670 -->* You can now save attributes for a configurable product after a validation error occurs. Previously, when you added a new product with an image, if a validation error occurred during the product save, Magento removed the images  from the **Images and Videos** section. If you subsequently fixed the validation conflict and attempted to save the product again, Magento threw a descriptive error. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16597](https://github.com/magento/magento2/pull/16597)*. [GitHub-7372](https://github.com/magento/magento2/issues/7372), [GitHub-13177](https://github.com/magento/magento2/issues/13177)
+<!-- ENGCOM-2670  -->
+*  You can now save attributes for a configurable product after a validation error occurs. Previously, when you added a new product with an image, if a validation error occurred during the product save, Magento removed the images  from the **Images and Videos** section. If you subsequently fixed the validation conflict and attempted to save the product again, Magento threw a descriptive error. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16597](https://github.com/magento/magento2/pull/16597)*. [GitHub-7372](https://github.com/magento/magento2/issues/7372), [GitHub-13177](https://github.com/magento/magento2/issues/13177)
 
-<!-- ENGCOM-2675 -->* You can now add a product with a price of zero (0) to a wishlist. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [17395](https://github.com/magento/magento2/pull/17395)*. [GitHub-16479](https://github.com/magento/magento2/issues/16479)
+<!-- ENGCOM-2675  -->
+*  You can now add a product with a price of zero (0) to a wishlist. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [17395](https://github.com/magento/magento2/pull/17395)*. [GitHub-16479](https://github.com/magento/magento2/issues/16479)
 
-<!-- ENGCOM-1605 -->* You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
+<!-- ENGCOM-1605  -->
+*  You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
 
-<!-- ENGCOM-2758 -->*  You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
+<!-- ENGCOM-2758  -->
+*   You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
 
-<!-- MAGETWO-94080 -->* The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
+<!-- MAGETWO-94080  -->
+*  The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
 
-<!-- MAGETWO-94062 -->* Magento now displays a descriptive error message  when a customer tries to order a product in increments that are not allowed.
+<!-- MAGETWO-94062  -->
+*  Magento now displays a descriptive error message  when a customer tries to order a product in increments that are not allowed.
 
-<!-- MAGETWO-88641 -->* Magento now applies tier prices as expected after a customer logs into their shopping cart. [GitHub-14255](https://github.com/magento/magento2/issues/14255)
+<!-- MAGETWO-88641  -->
+*  Magento now applies tier prices as expected after a customer logs into their shopping cart. [GitHub-14255](https://github.com/magento/magento2/issues/14255)
 
-<!-- MAGETWO-84894 -->* Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
+<!-- MAGETWO-84894  -->
+*  Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
 
-<!-- MAGETWO-73443 -->*  Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
+<!-- MAGETWO-73443  -->
+*   Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
 product, and hung indefinitely while trying to add the product.
 
-<!-- MAGETWO-73245 -->* A merchant can now successfully create and save configurable products from the Admin in a multisite deployment. Previously, when a merchant created a configurable product with customizable options, Magento set its `has_options` and `required_options`  (in the `catalog_product_entity` table) to 0, and the merchant needed to click **Save** again to correctly add the product.
+<!-- MAGETWO-73245  -->
+*  A merchant can now successfully create and save configurable products from the Admin in a multisite deployment. Previously, when a merchant created a configurable product with customizable options, Magento set its `has_options` and `required_options`  (in the `catalog_product_entity` table) to 0, and the merchant needed to click **Save** again to correctly add the product.
 
-<!-- MAGETWO-93047 -->* The `PUT rest/all/V1/categories/:categoryId` endpoint now requires the `name` field.
+<!-- MAGETWO-93047  -->
+*  The `PUT rest/all/V1/categories/:categoryId` endpoint now requires the `name` field.
 
-<!-- ENGCOM-2622 -->* Special price expressions now work as expected. Previously, `catalog_product_price` did not generate correct price data. *Fix submitted by Dmitry Chukhnov in pull request [16510](https://github.com/magento/magento2/pull/16510)*.
+<!-- ENGCOM-2622  -->
+*  Special price expressions now work as expected. Previously, `catalog_product_price` did not generate correct price data. *Fix submitted by Dmitry Chukhnov in pull request [16510](https://github.com/magento/magento2/pull/16510)*.
 
 ### Catalog rule
 
-<!-- ENGCOM-2718 -->* `date` can now be used as a condition for Catalog Price rules. *Fix submitted by [Glenn Cheng](https://github.com/GlennCheng) in pull request [16855](https://github.com/magento/magento2/pull/16855)*.
+<!-- ENGCOM-2718  -->
+*  `date` can now be used as a condition for Catalog Price rules. *Fix submitted by [Glenn Cheng](https://github.com/GlennCheng) in pull request [16855](https://github.com/magento/magento2/pull/16855)*.
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-2580 -->* Problems with the responsive layout  `app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less` have been resolved. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17217](https://github.com/magento/magento2/pull/17217)*.
+<!-- ENGCOM-2580  -->
+*  Problems with the responsive layout  `app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less` have been resolved. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17217](https://github.com/magento/magento2/pull/17217)*.
 
-<!-- ENGCOM-2549 -->* The `text-align` for the `<th>` element of the Subtotal column in the creditmemo email has been corrected. *Fix submitted by [Tomash Khamlai](https://github.com/TomashKhamlai) in pull request [17153](https://github.com/magento/magento2/pull/17153)*.
+<!-- ENGCOM-2549  -->
+*  The `text-align` for the `<th>` element of the Subtotal column in the creditmemo email has been corrected. *Fix submitted by [Tomash Khamlai](https://github.com/TomashKhamlai) in pull request [17153](https://github.com/magento/magento2/pull/17153)*.
 
-<!-- ENGCOM-2568 -->* The  invalid `knockoutjs` data binding in Braintree PayPal has been fixed. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17236](https://github.com/magento/magento2/pull/17236)*.
+<!-- ENGCOM-2568  -->
+*  The  invalid `knockoutjs` data binding in Braintree PayPal has been fixed. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17236](https://github.com/magento/magento2/pull/17236)*.
 
-<!-- ENGCOM-2613 -->* The overall readability of Shipping Methods sorting has been improved by replacing sort callbacks. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [16788](https://github.com/magento/magento2/pull/16788)*.
+<!-- ENGCOM-2613  -->
+*  The overall readability of Shipping Methods sorting has been improved by replacing sort callbacks. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [16788](https://github.com/magento/magento2/pull/16788)*.
 
-<!-- ENGCOM-2594 -->* Files in `/lib` have been cleaned up. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17103](https://github.com/magento/magento2/pull/17103)*.
+<!-- ENGCOM-2594  -->
+*  Files in `/lib` have been cleaned up. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17103](https://github.com/magento/magento2/pull/17103)*.
 
-<!-- ENGCOM-2619 -->* Unused IDs in `app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html` and `app/code/Magento/Checkout/Test/Mftf/Section/CheckoutPaymentSection.xml` have been removed. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
+<!-- ENGCOM-2619  -->
+*  Unused IDs in `app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html` and `app/code/Magento/Checkout/Test/Mftf/Section/CheckoutPaymentSection.xml` have been removed. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
 
-<!-- ENGCOM-2118 -->* Removed unnecessary translation of HTML tags in `app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php` and `app/code/Magento/Catalog/i18n/en_US.csv`. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
+<!-- ENGCOM-2118  -->
+*  Removed unnecessary translation of HTML tags in `app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php` and `app/code/Magento/Catalog/i18n/en_US.csv`. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
 
-<!-- ENGCOM-2651 -->* Minor CSS issues in `lib/internal/Magento/Framework/View/Test/Unit/Url/_files/sourceImport.css` have been fixed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17365](https://github.com/magento/magento2/pull/17365)*.
+<!-- ENGCOM-2651  -->
+*  Minor CSS issues in `lib/internal/Magento/Framework/View/Test/Unit/Url/_files/sourceImport.css` have been fixed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17365](https://github.com/magento/magento2/pull/17365)*.
 
-<!-- ENGCOM-2762 -->* Duplicate code in `app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js` has been removed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17505](https://github.com/magento/magento2/pull/17505)*.
+<!-- ENGCOM-2762  -->
+*  Duplicate code in `app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js` has been removed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17505](https://github.com/magento/magento2/pull/17505)*.
 
-<!-- ENGCOM-2776 -->* The code generator for Proxy is no longer missing `returnType` in the method information definition. *Fix submitted by [adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request [17552](https://github.com/magento/magento2/pull/17552)*.
+<!-- ENGCOM-2776  -->
+*  The code generator for Proxy is no longer missing `returnType` in the method information definition. *Fix submitted by [adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request [17552](https://github.com/magento/magento2/pull/17552)*.
 
-<!-- ENGCOM-2748 -->* The `<script/>` tag has been replaced with `<script type="text/x-magento-init" />` in  `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml` and `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml`. Also, a new JavaScript component with the callback function has been created. *Fix submitted by [Yogesh Suhagiya](https://github.com/swnsma) in pull request [17527](https://github.com/magento/magento2/pull/17527)*.
+<!-- ENGCOM-2748  -->
+*  The `<script/>` tag has been replaced with `<script type="text/x-magento-init" />` in  `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml` and `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml`. Also, a new JavaScript component with the callback function has been created. *Fix submitted by [Yogesh Suhagiya](https://github.com/swnsma) in pull request [17527](https://github.com/magento/magento2/pull/17527)*.
 
-<!-- ENGCOM-2632 -->* The `$outputHelper` property declaration has been added to `app/code/Magento/Catalog/CustomerData/CompareProducts.php`. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
+<!-- ENGCOM-2632  -->
+*  The `$outputHelper` property declaration has been added to `app/code/Magento/Catalog/CustomerData/CompareProducts.php`. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
 
-<!-- ENGCOM-2632 -->* The `Magento_Backend` module  has been refactored. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17101](https://github.com/magento/magento2/pull/17101)*.
+<!-- ENGCOM-2632  -->
+*  The `Magento_Backend` module  has been refactored. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17101](https://github.com/magento/magento2/pull/17101)*.
 
-<!-- ENGCOM-1666 -->* The usage of the `count()` function in for loops has been refactored to improve the performance of the loops that were running `count()` in every iteration throughout the code base. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [15507](https://github.com/magento/magento2/pull/15507)*.
+<!-- ENGCOM-1666  -->
+*  The usage of the `count()` function in for loops has been refactored to improve the performance of the loops that were running `count()` in every iteration throughout the code base. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [15507](https://github.com/magento/magento2/pull/15507)*.
 
 ### CMS content
 
-<!-- ENGCOM-2734 -->* A new `OptionSource` of blocks has been added. *Fix submitted by Thomas Klein in pull request [16021](https://github.com/magento/magento2/pull/16021)*.
+<!-- ENGCOM-2734  -->
+*  A new `OptionSource` of blocks has been added. *Fix submitted by Thomas Klein in pull request [16021](https://github.com/magento/magento2/pull/16021)*.
 
-<!-- MAGETWO-73359 -->* You can successfully save a CMS page with the same URL key as another store on a different website but with the same hierarchy.
+<!-- MAGETWO-73359  -->
+*  You can successfully save a CMS page with the same URL key as another store on a different website but with the same hierarchy.
 
-<!-- ENGCOM-2655 -->* The CMS page index has been refactored to remove the Object Manager, and  dependency injection has been added  to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
+<!-- ENGCOM-2655  -->
+*  The CMS page index has been refactored to remove the Object Manager, and  dependency injection has been added  to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
 
 ### Configurable products
 
-<!-- ENGCOM-2671 -->* You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. *Fix submitted by [zamboten](https://github.com/zamboten) in pull request [15720](https://github.com/magento/magento2/pull/15720)*. [GitHub-15028](https://github.com/magento/magento2/issues/15028)
+<!-- ENGCOM-2671  -->
+*  You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. *Fix submitted by [zamboten](https://github.com/zamboten) in pull request [15720](https://github.com/magento/magento2/pull/15720)*. [GitHub-15028](https://github.com/magento/magento2/issues/15028)
 
-<!-- MAGETWO-77742 -->* Magento now displays a descriptive error message when you try to upload a file in an unsupported format. Previously, Magento displayed an error that did not relate to the specific upload problem.
+<!-- MAGETWO-77742  -->
+*  Magento now displays a descriptive error message when you try to upload a file in an unsupported format. Previously, Magento displayed an error that did not relate to the specific upload problem.
 
-<!-- MAGETWO-75086 -->* Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options.  ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!-- MAGETWO-75086  -->
+*  Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options.  ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
 ### Customer
 
-<!-- ENGCOM-2746 -->* When editing an Admin user role, Magento now displays the Customer Groups section under the Customers section as expected. Previously, Magento displayed the Customer Groups section under the **Stores** > **Other settings** section. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [17515](https://github.com/magento/magento2/pull/17515)*. [GitHub-16499](https://github.com/magento/magento2/issues/16499)
+<!-- ENGCOM-2746  -->
+*  When editing an Admin user role, Magento now displays the Customer Groups section under the Customers section as expected. Previously, Magento displayed the Customer Groups section under the **Stores** > **Other settings** section. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [17515](https://github.com/magento/magento2/pull/17515)*. [GitHub-16499](https://github.com/magento/magento2/issues/16499)
 
 ### Directory
 
-<!-- MAGETWO-92831 -->* Currency conversion rate services now work as expected in the Admin.
+<!-- MAGETWO-92831  -->
+*  Currency conversion rate services now work as expected in the Admin.
 
 ### EAV
 
-<!-- ENGCOM-2642 -->*  The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
+<!-- ENGCOM-2642  -->
+*   The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
 
 ### Email
 
-<!-- MAGETWO-92786 -->* Magento now displays the correct width for the welcome email when viewed on a mobile device.
+<!-- MAGETWO-92786  -->
+*  Magento now displays the correct width for the welcome email when viewed on a mobile device.
 
-<!-- ENGCOM-2787 -->* Magento can no longer send more than 50 emails per cronjob, which will reduce duplicate emails.  *Fix submitted by [iGerchak](https://github.com/iGerchak) in pull request [17484](https://github.com/magento/magento2/pull/15942)*.
+<!-- ENGCOM-2787  -->
+*  Magento can no longer send more than 50 emails per cronjob, which will reduce duplicate emails.  *Fix submitted by [iGerchak](https://github.com/iGerchak) in pull request [17484](https://github.com/magento/magento2/pull/15942)*.
 
 ### Frameworks
 
-<!-- ENGCOM-2070 -->* You can now set values for `MAX_IMAGE_WIDTH` and `MAX_IMAGE_HEIGHT` in **Stores** > **Settings** > **Configuration** > **Advanced** > **System** > **Images Configuration**, which supports the upload of larger images. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [15942](https://github.com/magento/magento2/pull/15942)*. [GitHub-13747](https://github.com/magento/magento2/issues/13747)
+<!-- ENGCOM-2070  -->
+*  You can now set values for `MAX_IMAGE_WIDTH` and `MAX_IMAGE_HEIGHT` in **Stores** > **Settings** > **Configuration** > **Advanced** > **System** > **Images Configuration**, which supports the upload of larger images. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [15942](https://github.com/magento/magento2/pull/15942)*. [GitHub-13747](https://github.com/magento/magento2/issues/13747)
 
-<!-- ENGCOM-2915 -->* `functions.php`  now resides in the Framework module. *Fix submitted by [Kristof, Fooman](https://github.com/fooman) in pull request [16800](https://github.com/magento/magento2/pull/16800)*.
+<!-- ENGCOM-2915  -->
+*  `functions.php`  now resides in the Framework module. *Fix submitted by [Kristof, Fooman](https://github.com/fooman) in pull request [16800](https://github.com/magento/magento2/pull/16800)*.
 
-<!-- ENGCOM-2570 -->* FTP connections can  now use user or password strings with special characters (for example, @ or #). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17246](https://github.com/magento/magento2/pull/17246)*.
+<!-- ENGCOM-2570  -->
+*  FTP connections can  now use user or password strings with special characters (for example, @ or #). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17246](https://github.com/magento/magento2/pull/17246)*.
 
 #### Application framework
 
-<!-- ENGCOM-2382 -->* Magento now validates that the required **Purchase Order Number** field is  set as expected during checkout. *Fix submitted by [Pablo](https://github.com/centerax) in pull request [14393](https://github.com/magento/magento2/pull/14393)*. [GitHub-6585](https://github.com/magento/magento2/issues/6585)
+<!-- ENGCOM-2382  -->
+*  Magento now validates that the required **Purchase Order Number** field is  set as expected during checkout. *Fix submitted by [Pablo](https://github.com/centerax) in pull request [14393](https://github.com/magento/magento2/pull/14393)*. [GitHub-6585](https://github.com/magento/magento2/issues/6585)
 
 #### Database framework
 
-<!-- MAGETWO-83918 -->* The `getSize` function now reflects item and page count totals for filtered product collections on the category page.
+<!-- MAGETWO-83918  -->
+*  The `getSize` function now reflects item and page count totals for filtered product collections on the category page.
 
 #### JavaScript framework
 
-<!-- ENGCOM-2291 -->* JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed. *Fix submitted by [Vitaliy Boyko](https://github.com/VitaliyBoyko) in pull request [16724](https://github.com/magento/magento2/pull/16724)*. [GitHub-16544](https://github.com/magento/magento2/issues/16544)
+<!-- ENGCOM-2291  -->
+*  JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed. *Fix submitted by [Vitaliy Boyko](https://github.com/VitaliyBoyko) in pull request [16724](https://github.com/magento/magento2/pull/16724)*. [GitHub-16544](https://github.com/magento/magento2/issues/16544)
 
-<!-- ENGCOM-1967 -->* You can disable the **Use system value** checkboxes on the Admin as expected. *Fix submitted by [Valerij Ivashchenko](https://github.com/likemusic) in pull request [16000](https://github.com/magento/magento2/pull/16000)*.
+<!-- ENGCOM-1967  -->
+*  You can disable the **Use system value** checkboxes on the Admin as expected. *Fix submitted by [Valerij Ivashchenko](https://github.com/likemusic) in pull request [16000](https://github.com/magento/magento2/pull/16000)*.
 
 #### Session framework
 
-<!-- ENGCOM-1440 -->* Magento no longer unexpectedly empties a customer's shopping cart during checkout when concurrent requests occur. *Fix submitted by [Elio Ermini](https://github.com/elioermini) in pull request [14973](https://github.com/magento/magento2/pull/14973)*. [GitHub-12362](https://github.com/magento/magento2/issues/12362)
+<!-- ENGCOM-1440  -->
+*  Magento no longer unexpectedly empties a customer's shopping cart during checkout when concurrent requests occur. *Fix submitted by [Elio Ermini](https://github.com/elioermini) in pull request [14973](https://github.com/magento/magento2/pull/14973)*. [GitHub-12362](https://github.com/magento/magento2/issues/12362)
 
 ### General
 
-<!-- MAGETWO-93152 -->* Magento now processes zero (0) in email filter fields correctly.
+<!-- MAGETWO-93152  -->
+*  Magento now processes zero (0) in email filter fields correctly.
 
-<!-- MAGETWO-93939 -->* You can now clear the **Date of Birth** field in the customer edit page when accessed from the Admin.
+<!-- MAGETWO-93939  -->
+*  You can now clear the **Date of Birth** field in the customer edit page when accessed from the Admin.
 
-<!-- ENGCOM-2737 -->* Product image zoom now works as expected in stores running on Safari. *Fix submitted by [Danny Nimmo](https://github.com/dannynimmo) in pull request [17491](https://github.com/magento/magento2/pull/17491)*. [GitHub-17416](https://github.com/magento/magento2/issues/17416)
+<!-- ENGCOM-2737  -->
+*  Product image zoom now works as expected in stores running on Safari. *Fix submitted by [Danny Nimmo](https://github.com/dannynimmo) in pull request [17491](https://github.com/magento/magento2/pull/17491)*. [GitHub-17416](https://github.com/magento/magento2/issues/17416)
 
-<!-- ENGCOM-2785 -->* Magento now displays the background of transparent product image watermarks correctly. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17013](https://github.com/magento/magento2/pull/17013)*. [GitHub-16929](https://github.com/magento/magento2/issues/16929)
+<!-- ENGCOM-2785  -->
+*  Magento now displays the background of transparent product image watermarks correctly. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17013](https://github.com/magento/magento2/pull/17013)*. [GitHub-16929](https://github.com/magento/magento2/issues/16929)
 
-<!-- ENGCOM-2855 -->* The WYSIWYG editor now displays the backgrounds of .png thumbnail images as expected. Previously, transparent backgrounds were displayed as black.  *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
+<!-- ENGCOM-2855  -->
+*  The WYSIWYG editor now displays the backgrounds of .png thumbnail images as expected. Previously, transparent backgrounds were displayed as black.  *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
 
-<!-- ENGCOM-2860 -->*  Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
+<!-- ENGCOM-2860  -->
+*   Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
 
-<!-- ENGCOM-2322 -->* Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
+<!-- ENGCOM-2322  -->
+*  Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
 
-<!-- ENGCOM-2628 -->* Magento now disables the **Shop By** button on the search page when a customer sets additional search filters. *Fix submitted by [Andrea Rivadossi](https://github.com/AndreaRivadossi) in pull request [15650](https://github.com/magento/magento2/pull/15650)*. [GitHub-13445](https://github.com/magento/magento2/issues/13445)
+<!-- ENGCOM-2628  -->
+*  Magento now disables the **Shop By** button on the search page when a customer sets additional search filters. *Fix submitted by [Andrea Rivadossi](https://github.com/AndreaRivadossi) in pull request [15650](https://github.com/magento/magento2/pull/15650)*. [GitHub-13445](https://github.com/magento/magento2/issues/13445)
 
-<!-- ENGCOM-2875 -->* The `setterName` method is now correctly set. *Fix submitted by [insanityinside](https://github.com/insanityinside) in pull request [17773](https://github.com/magento/magento2/pull/17773)*.
+<!-- ENGCOM-2875  -->
+*  The `setterName` method is now correctly set. *Fix submitted by [insanityinside](https://github.com/insanityinside) in pull request [17773](https://github.com/magento/magento2/pull/17773)*.
 
-<!-- ENGCOM-2896 -->* New templates have been added to the GitHub Issue Reporting section. These templates target a broad scope of possible problems, and the proposed descriptions are aimed at simplifying future fixes. *Fix submitted by [Eugene Shakhsuvarov](https://github.com/ishakhsuvarov) in pull request [17817](https://github.com/magento/magento2/pull/17817)*.
+<!-- ENGCOM-2896  -->
+*  New templates have been added to the GitHub Issue Reporting section. These templates target a broad scope of possible problems, and the proposed descriptions are aimed at simplifying future fixes. *Fix submitted by [Eugene Shakhsuvarov](https://github.com/ishakhsuvarov) in pull request [17817](https://github.com/magento/magento2/pull/17817)*.
 
 ### Google Tag Manager
 
-<!-- MAGETWO-87437 -->* All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing in the Google Tag Manager.
+<!-- MAGETWO-87437  -->
+*  All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing in the Google Tag Manager.
 
 ### Import/export
 
-<!-- MAGETWO-93223 -->* Magento now displays the correct execution time for an import operation on the **System** > **Import History** page.
+<!-- MAGETWO-93223  -->
+*  Magento now displays the correct execution time for an import operation on the **System** > **Import History** page.
 
 ### Infrastructure
 
-<!-- ENGCOM-2783 -->* The Web Setup wizard icon sidebar shortcut on the Admin now links as expected to the wizard. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17543](https://github.com/magento/magento2/pull/17543)*. [GitHub-13948](https://github.com/magento/magento2/issues/13948)
+<!-- ENGCOM-2783  -->
+*  The Web Setup wizard icon sidebar shortcut on the Admin now links as expected to the wizard. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17543](https://github.com/magento/magento2/pull/17543)*. [GitHub-13948](https://github.com/magento/magento2/issues/13948)
 
-<!-- ENGCOM-2872 -->* The `$keepRation` parameter in the `Magento\Cms\Model\Wysiwyg\Images\Storage` class has been renamed to `$keepRatio`. *Fix submitted by [Martin Aarts](https://github.com/MartinAarts) in pull request [17776](https://github.com/magento/magento2/pull/17776)*. [GitHub-17587](https://github.com/magento/magento2/issues/17587)
+<!-- ENGCOM-2872  -->
+*  The `$keepRation` parameter in the `Magento\Cms\Model\Wysiwyg\Images\Storage` class has been renamed to `$keepRatio`. *Fix submitted by [Martin Aarts](https://github.com/MartinAarts) in pull request [17776](https://github.com/magento/magento2/pull/17776)*. [GitHub-17587](https://github.com/magento/magento2/issues/17587)
 
-<!-- ENGCOM-2736 -->* Outdated LESS lib docs have been updated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17479](https://github.com/magento/magento2/pull/17479)*.
+<!-- ENGCOM-2736  -->
+*  Outdated LESS lib docs have been updated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17479](https://github.com/magento/magento2/pull/17479)*.
 
-<!-- ENGCOM-2643 -->* The `floatval()` function has been replaced by the use of direct type casting to `(float)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16848](https://github.com/magento/magento2/pull/16848)*.
+<!-- ENGCOM-2643  -->
+*  The `floatval()` function has been replaced by the use of direct type casting to `(float)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16848](https://github.com/magento/magento2/pull/16848)*.
 
-<!-- ENGCOM-2644 -->* The `strval()` function has been replaced by the use of direct type casting to `(string)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16849](https://github.com/magento/magento2/pull/16849)*.
+<!-- ENGCOM-2644  -->
+*  The `strval()` function has been replaced by the use of direct type casting to `(string)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16849](https://github.com/magento/magento2/pull/16849)*.
 
-<!-- ENGCOM-2668 -->* The EU-VAT-Numbers `Countrycode`  prefixes have been removed for validation purposes. *Fix submitted by [Drischie](https://github.com/Drischie) in pull request [17385](https://github.com/magento/magento2/pull/17385)*.
+<!-- ENGCOM-2668  -->
+*  The EU-VAT-Numbers `Countrycode`  prefixes have been removed for validation purposes. *Fix submitted by [Drischie](https://github.com/Drischie) in pull request [17385](https://github.com/magento/magento2/pull/17385)*.
 
-<!-- ENGCOM-2634 -->* Missing `data-th` selectors have been added to tables. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17327](https://github.com/magento/magento2/pull/17327)*.
+<!-- ENGCOM-2634  -->
+*  Missing `data-th` selectors have been added to tables. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17327](https://github.com/magento/magento2/pull/17327)*.
 
 ### Locale
 
-<!-- MAGETWO-94075 -->* The DatePicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
+<!-- MAGETWO-94075  -->
+*  The DatePicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
 
 ### Payment methods
 
-<!-- MAGETWO-93299 -->* Magento no longer throws an error when you try to add a new shipping address to an order placed using Braintree from the Admin.
+<!-- MAGETWO-93299  -->
+*  Magento no longer throws an error when you try to add a new shipping address to an order placed using Braintree from the Admin.
 
-<!-- MAGETWO-86712 -->* The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. *Fix submitted by [Jason Woods](https://github.com/driskell) in pull request [13133](https://github.com/magento/magento2/pull/13133)*.
+<!-- MAGETWO-86712  -->
+*  The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. *Fix submitted by [Jason Woods](https://github.com/driskell) in pull request [13133](https://github.com/magento/magento2/pull/13133)*.
 
 ### Reports
 
-<!-- MAGETWO-93729 -->* The scope selector for reports now works as expected. Previously, when a merchant set the scope to **All Websites**, the generated report showed  sales from only a subset of websites.
+<!-- MAGETWO-93729  -->
+*  The scope selector for reports now works as expected. Previously, when a merchant set the scope to **All Websites**, the generated report showed  sales from only a subset of websites.
 
-<!-- MAGETWO-93345 -->* The `.csv` export of Coupon reports now shows the correct total for  selected coupons. Previously, the total line in the `.csv` file showed the totals for all coupons in the selected time period, rather than just the selected coupons.
+<!-- MAGETWO-93345  -->
+*  The `.csv` export of Coupon reports now shows the correct total for  selected coupons. Previously, the total line in the `.csv` file showed the totals for all coupons in the selected time period, rather than just the selected coupons.
 
-<!-- MAGETWO-86650 -->* The `.csv` export of the Abandoned Cart report now contains information about all abandoned carts as expected. Previously, this `.csv` file contained only  the first 20 rows of the report.
+<!-- MAGETWO-86650  -->
+*  The `.csv` export of the Abandoned Cart report now contains information about all abandoned carts as expected. Previously, this `.csv` file contained only  the first 20 rows of the report.
 
-<!-- ENGCOM-2724 -->* The **Year-to-date** dropdown accessed from **Stores** > **Settings** > **Configuration** > **General** > **Reports** > **Dashboard** now displays a numerical list that ranges from 01 to 12 as expected. *Fix submitted by [teddysie](https://github.com/teddysie) in pull request [17383](https://github.com/magento/magento2/pull/17383)*. [GitHub-17289](https://github.com/magento/magento2/issues/17289)
+<!-- ENGCOM-2724  -->
+*  The **Year-to-date** dropdown accessed from **Stores** > **Settings** > **Configuration** > **General** > **Reports** > **Dashboard** now displays a numerical list that ranges from 01 to 12 as expected. *Fix submitted by [teddysie](https://github.com/teddysie) in pull request [17383](https://github.com/magento/magento2/pull/17383)*. [GitHub-17289](https://github.com/magento/magento2/issues/17289)
 
-<!-- MAGETWO- 73585-->* Wishlist reports are available on the Admin as expected.
+<!-- MAGETWO- 73585 -->
+*  Wishlist reports are available on the Admin as expected.
 
 ### Review
 
-<!-- ENGCOM-2720-->* Magento now displays a `404 page not found` error when a customer tries to navigate to a product review that is not accessible. Previously. Magento displayed a PHP error code. *Fix submitted by Ananth in pull request [15369](https://github.com/magento/magento2/pull/15369)*. [GitHub-13102](https://github.com/magento/magento2/issues/13102)
+<!-- ENGCOM-2720 -->
+*  Magento now displays a `404 page not found` error when a customer tries to navigate to a product review that is not accessible. Previously. Magento displayed a PHP error code. *Fix submitted by Ananth in pull request [15369](https://github.com/magento/magento2/pull/15369)*. [GitHub-13102](https://github.com/magento/magento2/issues/13102)
 
 ### Sales
 
-<!-- ENGCOM-2623 -->* The `Magento\Sales\Block\Adminhtml\Order\Totalbar` class and totalbar template files  have been deprecated.  These components were formerly included but never implemented in the invoice create and credit memo create layout files. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [16656](https://github.com/magento/magento2/pull/16656)*. [GitHub-16653](https://github.com/magento/magento2/issues/16653)
+<!-- ENGCOM-2623  -->
+*  The `Magento\Sales\Block\Adminhtml\Order\Totalbar` class and totalbar template files  have been deprecated.  These components were formerly included but never implemented in the invoice create and credit memo create layout files. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [16656](https://github.com/magento/magento2/pull/16656)*. [GitHub-16653](https://github.com/magento/magento2/issues/16653)
 
-<!-- MAGETWO-94291 -->* Magento now displays product price and shipping costs in the default currency that was configured for that  specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
+<!-- MAGETWO-94291  -->
+*  Magento now displays product price and shipping costs in the default currency that was configured for that  specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
 
-<!-- MAGETWO-94163 -->* Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
+<!-- MAGETWO-94163  -->
+*  Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
 
-<!-- MAGETWO-88858 -->* Admin orders are no longer restricted by a minimum order amount. Previously, Magento required this minimum for both Admin and storefront users.
+<!-- MAGETWO-88858  -->
+*  Admin orders are no longer restricted by a minimum order amount. Previously, Magento required this minimum for both Admin and storefront users.
 
 ### Sales rule
 
-<!-- MAGETWO-93209 -->* You can now use wildcard values in coupon codes.
+<!-- MAGETWO-93209  -->
+*  You can now use wildcard values in coupon codes.
 
 ### Search
 
-<!-- ENGCOM-2415 -->* JavaScript files are now located inside the `web/js` directory. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16582](https://github.com/magento/magento2/pull/16582)*. [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!-- ENGCOM-2415  -->
+*  JavaScript files are now located inside the `web/js` directory. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16582](https://github.com/magento/magento2/pull/16582)*. [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!-- MAGETWO-91063 -->* Search synonyms are now available for all search engines deployed in your Magento store. Previously, search synonyms did not appear in the Admin menu when Elasticsearch 5.0+ was deployed.
+<!-- MAGETWO-91063  -->
+*  Search synonyms are now available for all search engines deployed in your Magento store. Previously, search synonyms did not appear in the Admin menu when Elasticsearch 5.0+ was deployed.
 
-<!-- MAGETWO-92652 -->* Product attribute are now displayed as expected in layered navigation with Elasticsearch 5.0+.
+<!-- MAGETWO-92652  -->
+*  Product attribute are now displayed as expected in layered navigation with Elasticsearch 5.0+.
 
 ### Shipping
 
-<!-- MAGETWO-86179 -->* Customers can now add a new address to an order during checkout of an order being shipped to multiple addresses.
+<!-- MAGETWO-86179  -->
+*  Customers can now add a new address to an order during checkout of an order being shipped to multiple addresses.
 
-<!-- ENGCOM-2704 -->* Multishipping checkout now works as expected. Previously, Magento displayed the `Shipping address is not set` error message  when checking out an order with multiple addresses. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [16753](https://github.com/magento/magento2/pull/16753)*. [GitHub-16555](https://github.com/magento/magento2/issues/16555)
+<!-- ENGCOM-2704  -->
+*  Multishipping checkout now works as expected. Previously, Magento displayed the `Shipping address is not set` error message  when checking out an order with multiple addresses. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [16753](https://github.com/magento/magento2/pull/16753)*. [GitHub-16555](https://github.com/magento/magento2/issues/16555)
 
-<!-- MAGETWO-94434 -->* The Magento UPS module has been updated to support new UPS API endpoints.
+<!-- MAGETWO-94434  -->
+*  The Magento UPS module has been updated to support new UPS API endpoints.
 
-<!-- MAGETWO-93810 -->* Customers can now view their completed order from the success page for orders that will be shipped to multiple addresses. Previously, when a customer took a link from the order success page to view their just-completed order, Magento displayed this error, **There has been an error processing your request**.
+<!-- MAGETWO-93810  -->
+*  Customers can now view their completed order from the success page for orders that will be shipped to multiple addresses. Previously, when a customer took a link from the order success page to view their just-completed order, Magento displayed this error, **There has been an error processing your request**.
 
-<!-- MAGETWO-92144 -->* The Shipment grid now displays the status of completed orders correctly. Previously, the Order Status column of the Shipment grid indicated that a completed order was being processed.
+<!-- MAGETWO-92144  -->
+*  The Shipment grid now displays the status of completed orders correctly. Previously, the Order Status column of the Shipment grid indicated that a completed order was being processed.
 
 ### Store
 
-<!--  ENGCOM-2530 -->* The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
+<!--  ENGCOM-2530  -->
+*  The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
 
 ### Swagger
 
-<!-- ENGCOM-2837, MAGETWO-93748 -->* Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the `swagger-ui-bundle.js` became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17626](https://github.com/magento/magento2/pull/17626)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
+<!-- ENGCOM-2837, MAGETWO-93748  -->
+*  Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the `swagger-ui-bundle.js` became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17626](https://github.com/magento/magento2/pull/17626)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
 
 ### Testing
 
-<!-- ENGCOM-2616 -->* The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17191](https://github.com/magento/magento2/pull/17191)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
+<!-- ENGCOM-2616  -->
+*  The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17191](https://github.com/magento/magento2/pull/17191)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
 
-<!-- ENGCOM-2900 -->* Deprecated methods throughout the test suite have been replaced. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17872](https://github.com/magento/magento2/pull/17872)*.
+<!-- ENGCOM-2900  -->
+*  Deprecated methods throughout the test suite have been replaced. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17872](https://github.com/magento/magento2/pull/17872)*.
 
-<!-- ENGCOM-2899 -->* An API functional test  for the `/V1/search` (searchV1) resource has been added. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17840](https://github.com/magento/magento2/pull/17840)*.
+<!-- ENGCOM-2899  -->
+*  An API functional test  for the `/V1/search` (searchV1) resource has been added. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17840](https://github.com/magento/magento2/pull/17840)*.
 
-<!-- ENGCOM-2907 -->* The `\Magento\Sales\Model\Validator` class is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17876](https://github.com/magento/magento2/pull/17876)*.
+<!-- ENGCOM-2907  -->
+*  The `\Magento\Sales\Model\Validator` class is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17876](https://github.com/magento/magento2/pull/17876)*.
 
-<!-- ENGCOM-2908 -->* The `\Magento\Search\Model\PopularSearchTerms` is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17739](https://github.com/magento/magento2/pull/17739)*.
+<!-- ENGCOM-2908  -->
+*  The `\Magento\Search\Model\PopularSearchTerms` is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17739](https://github.com/magento/magento2/pull/17739)*.
 
-<!-- ENGCOM-2876 -->* The `\Magento\Search\Model\SynonymAnalyzer` class  is now covered by a unit test. *Fix submitted by [Zebra](https://github.com/furseyev) in pull request [17801](https://github.com/magento/magento2/pull/17801)*.
+<!-- ENGCOM-2876  -->
+*  The `\Magento\Search\Model\SynonymAnalyzer` class  is now covered by a unit test. *Fix submitted by [Zebra](https://github.com/furseyev) in pull request [17801](https://github.com/magento/magento2/pull/17801)*.
 
-<!-- ENGCOM-2843 -->* The Sales Rule model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17710](https://github.com/magento/magento2/pull/17710)*.
+<!-- ENGCOM-2843  -->
+*  The Sales Rule model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17710](https://github.com/magento/magento2/pull/17710)*.
 
-<!-- ENGCOM-2830 -->* The `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17693](https://github.com/magento/magento2/pull/17693)*.
+<!-- ENGCOM-2830  -->
+*  The `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17693](https://github.com/magento/magento2/pull/17693)*.
 
-<!-- ENGCOM-2823 -->* The CMS model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17678](https://github.com/magento/magento2/pull/17678)*.
+<!-- ENGCOM-2823  -->
+*  The CMS model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17678](https://github.com/magento/magento2/pull/17678)*.
 
-<!-- ENGCOM-2807 -->* The `\Magento\Newsletter\Model\Problem` class is now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17633](https://github.com/magento/magento2/pull/17633)*.
+<!-- ENGCOM-2807  -->
+*  The `\Magento\Newsletter\Model\Problem` class is now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17633](https://github.com/magento/magento2/pull/17633)*.
 
-<!-- ENGCOM-2780 -->* The `\Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter` class is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17590](https://github.com/magento/magento2/pull/17590)*.
+<!-- ENGCOM-2780  -->
+*  The `\Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter` class is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17590](https://github.com/magento/magento2/pull/17590)*.
 
-<!-- ENGCOM-2772 -->* The `\Magento\Catalog\Test\Unit\Cron\AvailabilityCheckerTest ` and `\Magento\Catalog\Test\Unit\Cron\DeleteOutdatedPriceValuesTest` classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17561](https://github.com/magento/magento2/pull/17561)*.
+<!-- ENGCOM-2772  -->
+*  The `\Magento\Catalog\Test\Unit\Cron\AvailabilityCheckerTest ` and `\Magento\Catalog\Test\Unit\Cron\DeleteOutdatedPriceValuesTest` classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17561](https://github.com/magento/magento2/pull/17561)*.
 
-<!-- ENGCOM-2715 -->* The `Magento\Braintree\Model\InstantPurchase\CreditCard\AvailabilityChecker` class is now covered by a unit test. [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17454](https://github.com/magento/magento2/pull/17454)*
+<!-- ENGCOM-2715  -->
+*  The `Magento\Braintree\Model\InstantPurchase\CreditCard\AvailabilityChecker` class is now covered by a unit test. [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17454](https://github.com/magento/magento2/pull/17454)*
 
-<!-- ENGCOM-2680 -->* The instant purchase PayPal token formatter is now covered by a unit test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17405](https://github.com/magento/magento2/pull/17405)*.
+<!-- ENGCOM-2680  -->
+*  The instant purchase PayPal token formatter is now covered by a unit test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17405](https://github.com/magento/magento2/pull/17405)*.
 
-<!-- ENGCOM-2657 -->* The `\Magento\Braintree\Gateway\Http\Client\TransactionVoid` and `\Magento\Braintree\Gateway\Http\Client\TransactionRefund` classes are now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17368](https://github.com/magento/magento2/pull/17368)*.
+<!-- ENGCOM-2657  -->
+*  The `\Magento\Braintree\Gateway\Http\Client\TransactionVoid` and `\Magento\Braintree\Gateway\Http\Client\TransactionRefund` classes are now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17368](https://github.com/magento/magento2/pull/17368)*.
 
-<!-- ENGCOM-2632 -->* The `\Magento\Catalog\CustomerData\CompareProducts` class is now covered by unit tests. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
+<!-- ENGCOM-2632  -->
+*  The `\Magento\Catalog\CustomerData\CompareProducts` class is now covered by unit tests. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
 
-<!-- ENGCOM-2828 -->* `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by an integration test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17690](https://github.com/magento/magento2/pull/17690)*.
+<!-- ENGCOM-2828  -->
+*  `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by an integration test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17690](https://github.com/magento/magento2/pull/17690)*.
 
 ### Translation
 
-<!-- ENGCOM-2863 -->* Errors in  `app/code/Magento/Sales/i18n/en_US.csv` have been corrected. *Fix submitted by [Jignesh Baldha](https://github.com/jignesh-baldha) in pull request [17735](https://github.com/magento/magento2/pull/17735)*.
+<!-- ENGCOM-2863  -->
+*  Errors in  `app/code/Magento/Sales/i18n/en_US.csv` have been corrected. *Fix submitted by [Jignesh Baldha](https://github.com/jignesh-baldha) in pull request [17735](https://github.com/magento/magento2/pull/17735)*.
 
-<!-- ENGCOM-2817 -->* `translate="title"`  has been added to Admin menus. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17521](https://github.com/magento/magento2/pull/17521)*.
+<!-- ENGCOM-2817  -->
+*  `translate="title"`  has been added to Admin menus. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17521](https://github.com/magento/magento2/pull/17521)*.
 
-<!-- ENGCOM-2799 -->* The custom attribute group name on customer and product pages can now be translated. *Fix submitted by [Grayson](https://github.com/GraysonChiang) in pull request [17602](https://github.com/magento/magento2/pull/17602)*.
+<!-- ENGCOM-2799  -->
+*  The custom attribute group name on customer and product pages can now be translated. *Fix submitted by [Grayson](https://github.com/GraysonChiang) in pull request [17602](https://github.com/magento/magento2/pull/17602)*.
 
-<!-- ENGCOM-2781 -->* Validation error messages can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17575](https://github.com/magento/magento2/pull/17575)*.
+<!-- ENGCOM-2781  -->
+*  Validation error messages can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17575](https://github.com/magento/magento2/pull/17575)*.
 
-<!-- ENGCOM-2677 -->* Error messages in the shopping cart page can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [16777](https://github.com/magento/magento2/pull/16777)*.
+<!-- ENGCOM-2677  -->
+*  Error messages in the shopping cart page can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [16777](https://github.com/magento/magento2/pull/16777)*.
 
 ### UI
 
-<!-- ENGCOM-2812 -->* The JavaScript  validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified. *Fix submitted by Mark Shust in pull request [17652](https://github.com/magento/magento2/pull/17652)*. [GitHub-17648](https://github.com/magento/magento2/issues/17648)
+<!-- ENGCOM-2812  -->
+*  The JavaScript  validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified. *Fix submitted by Mark Shust in pull request [17652](https://github.com/magento/magento2/pull/17652)*. [GitHub-17648](https://github.com/magento/magento2/issues/17648)
 
-<!-- ENGCOM-2834 -->* The message list component message type now has a message type of `success`. Previously, this type was always `error` when the `parameters` property was specified. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17701](https://github.com/magento/magento2/pull/17701)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
+<!-- ENGCOM-2834  -->
+*  The message list component message type now has a message type of `success`. Previously, this type was always `error` when the `parameters` property was specified. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17701](https://github.com/magento/magento2/pull/17701)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
 
-<!-- ENGCOM-2607 -->* The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17275](https://github.com/magento/magento2/pull/17275)*. [GitHub-17193](https://github.com/magento/magento2/issues/17193)
+<!-- ENGCOM-2607  -->
+*  The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17275](https://github.com/magento/magento2/pull/17275)*. [GitHub-17193](https://github.com/magento/magento2/issues/17193)
 
 ### User
 
-<!-- MAGETWO-93003 -->* Magento no longer displays stores to which an administrator does not have access when the administrator creates a product and assigns it to a store view. Previously, an administrator with permissions set on one website only could view the **All Store Views** scope for a product.
+<!-- MAGETWO-93003  -->
+*  Magento no longer displays stores to which an administrator does not have access when the administrator creates a product and assigns it to a store view. Previously, an administrator with permissions set on one website only could view the **All Store Views** scope for a product.
 
 ### Wishlist
 
-<!-- MAGETWO-86609 -->*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+<!-- MAGETWO-86609  -->
+*   Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
-<!-- MAGETWO-74289 -->* Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
+<!-- MAGETWO-74289  -->
+*  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
 
-<!-- MAGETWO-89234 -->* Magento now displays a success message when a customer successfully updates a wishlist.
+<!-- MAGETWO-89234  -->
+*  Magento now displays a success message when a customer successfully updates a wishlist.
 
 ## Known issues
 
-<!-- BUNDLE-1731 -->* Magento  currently does not display the requested quote information when you select Get Quotes for an order from a storefront that supports collection point delivery.
+<!-- BUNDLE-1731  -->
+*  Magento  currently does not display the requested quote information when you select Get Quotes for an order from a storefront that supports collection point delivery.
 
-<!-- BUNDLE-1840 -->* The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
+<!-- BUNDLE-1840  -->
+*  The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
 
-<!-- BUNDLE-1835 -->*  Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
+<!-- BUNDLE-1835  -->
+*   Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
 
 <!-- not needed --  MAGETWO-93800 MAGETWO-94468 MAGETWO-94236 MAGETWO-94213 MAGETWO-94174 MAGETWO-94098 MAGETWO-93725 MAGETWO-93105 MAGETWO-92654 MAGETWO-92187 MAGETWO-92169 MAGETWO-91477 MAGETWO-91358 MAGETWO-91288 MAGETWO-89892 MAGETWO-89309 MAGETWO-88233 MAGETWO-86482 MAGETWO-85420 MAGETWO-82084 MAGETWO-73357 MAGETWO-72067 MAGETWO-71157 MAGETWO-95529 MAGETWO-95424 MAGETWO-94762 MAGETWO-94409 MAGETWO-94331 MAGETWO-94300 MAGETWO-94475 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
@@ -49,33 +49,44 @@ This release includes improvements to general usability of the core code plus en
 
 #### General improvements
 
-<!-- MAGETWO-93990 -->* An administrator with permissions on one website only can no longer access the All Store Views scope for a product that is assigned to multiple websites.
+<!-- MAGETWO-93990  -->
+*  An administrator with permissions on one website only can no longer access the All Store Views scope for a product that is assigned to multiple websites.
 
-<!-- MAGETWO-87437 -->* All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing from the Google Tag Manager.
+<!-- MAGETWO-87437  -->
+*  All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing from the Google Tag Manager.
 
 #### Wishlist
 
-<!-- MAGETWO-74289 -->* Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
+<!-- MAGETWO-74289  -->
+*  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
 
-<!-- MAGETWO-86609 -->* Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+<!-- MAGETWO-86609  -->
+*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
-<!-- MAGETWO-89234 -->* Magento now displays a success message when a customer successfully updates a wishlist.
+<!-- MAGETWO-89234  -->
+*  Magento now displays a success message when a customer successfully updates a wishlist.
 
-<!-- MAGETWO-75086 -->* Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options. ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!-- MAGETWO-75086  -->
+*  Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options. ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
 #### B2B
 
-<!-- MAGETWO-94163 -->* Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
+<!-- MAGETWO-94163  -->
+*  Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
 
-<!-- MAGETWO-89654 -->* Merchants can now create a Company with an optional regional setting. Previously, Magento displayed this message, `Error message: Invalid value of "" provided for the region_id field.`
+<!-- MAGETWO-89654  -->
+*  Merchants can now create a Company with an optional regional setting. Previously, Magento displayed this message, `Error message: Invalid value of "" provided for the region_id field.`
 
-<!-- MAGETWO-92400 -->* Magento now removes information from all fields when you click **Reset** when creating a new Company from the Admin. Previously, Magento cleared all fields except for the **admin email** field.
+<!-- MAGETWO-92400  -->
+*  Magento now removes information from all fields when you click **Reset** when creating a new Company from the Admin. Previously, Magento cleared all fields except for the **admin email** field.
 
-<!-- MAGETWO-93050 -->* Magento no longer permits merchants to open a new tab to edit Company users from the Company Users tab. Previously, when a merchant  tried to open a new tab to edit users,  Magento threw an error.
+<!-- MAGETWO-93050  -->
+*  Magento no longer permits merchants to open a new tab to edit Company users from the Company Users tab. Previously, when a merchant  tried to open a new tab to edit users,  Magento threw an error.
 
 ### Shipping
 
-<!-- MAGETWO-94434 -->* The Magento UPS module has been updated to support new UPS API endpoints.
+<!-- MAGETWO-94434  -->
+*  The Magento UPS module has been updated to support new UPS API endpoints.
 
 ### Magento Functional Test Framework (MFTF)
 
@@ -87,11 +98,14 @@ Highlights of community contributions include these fixes:
 
 * **Bulk Web APIs**  allow all existing REST APIs to accept payloads with multiple entities. These community-contributed bulk APIs support more efficient and scalable implementations that eliminate round-trip network overhead. Like asynchronous APIs, bulk web APIs can be used in conjunction with queues that have also been migrated to {{site.data.var.ce}}. [See Bulk endpoints]({{ page.baseurl }}/rest/bulk-endpoints.html) for more information.
 
-<!-- MAGETWO-86712 -->* The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. Thanks to community member [Jason Woods](https://github.com/driskell)!
+<!-- MAGETWO-86712  -->
+*  The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. Thanks to community member [Jason Woods](https://github.com/driskell)!
 
-<!-- ENGCOM-2671 -->* You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. Thanks to community member [zamboten](https://github.com/zamboten)! [GitHub-15028](https://github.com/magento/magento2/issues/15028)
+<!-- ENGCOM-2671  -->
+*  You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. Thanks to community member [zamboten](https://github.com/zamboten)! [GitHub-15028](https://github.com/magento/magento2/issues/15028)
 
-<!-- ENGCOM-1832 -->* The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. Thanks to community member [Riccardo Tempesta](https://github.com/phoenix128)! [GitHub-15457](https://github.com/magento/magento2/issues/15457)
+<!-- ENGCOM-1832  -->
+*  The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. Thanks to community member [Riccardo Tempesta](https://github.com/phoenix128)! [GitHub-15457](https://github.com/magento/magento2/issues/15457)
 
 Looking for more information on these new features as well as many others? Check out [Magento Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Commerce User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html).
 
@@ -101,428 +115,596 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!---MAGETWO-94174 -->* Magento backup functionality is no longer enabled by default, and the code has been deprecated. See [Back up and roll back the file system, media, and database]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) for more information on backup strategies.
+<!---MAGETWO-94174  -->
+*  Magento backup functionality is no longer enabled by default, and the code has been deprecated. See [Back up and roll back the file system, media, and database]({{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html) for more information on backup strategies.
 
-<!-- MAGETWO-95591 -->* Customer attribute management issues that merchants  experienced after upgrading to Magento 2.2.6 have been resolved. Previously, after upgrading their stores to Magento 2.2.6, merchants could not create and save a new multiselect or dropdown customer custom attribute, and  existing customer attributes  no longer appeared for editing within the customer's account on the storefront.
+<!-- MAGETWO-95591  -->
+*  Customer attribute management issues that merchants  experienced after upgrading to Magento 2.2.6 have been resolved. Previously, after upgrading their stores to Magento 2.2.6, merchants could not create and save a new multiselect or dropdown customer custom attribute, and  existing customer attributes  no longer appeared for editing within the customer's account on the storefront.
 
-<!-- MAGETWO-94764 -->* Fixed an issue with the shared configuration settings in `app/etc/config.php` that caused `recursion detected` errors during deployment.
+<!-- MAGETWO-94764  -->
+*  Fixed an issue with the shared configuration settings in `app/etc/config.php` that caused `recursion detected` errors during deployment.
 
-<!-- ENGCOM-2673 -->* You can now enable logs as expected (through the use of **Stores** > **Settings** > **Configuration** > **Advanced** > **Developer** > **Debug** > **Log to file**) when switching from production mode to developer mode. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [15335](https://github.com/magento/magento2/pull/15335)*. [GitHub-13480](https://github.com/magento/magento2/issues/13480)
+<!-- ENGCOM-2673  -->
+*  You can now enable logs as expected (through the use of **Stores** > **Settings** > **Configuration** > **Advanced** > **Developer** > **Debug** > **Log to file**) when switching from production mode to developer mode. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [15335](https://github.com/magento/magento2/pull/15335)*. [GitHub-13480](https://github.com/magento/magento2/issues/13480)
 
-<!-- ENGCOM-2920 -->* You can now filter the customer grid without inadvertently triggering a next-page Ajax call. Previously, when you created an order from the Orders page and tried to filter the customer list, Magento did not filter the list, and displayed the next page of customer entries. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17870](https://github.com/magento/magento2/pull/17870)*. [GitHub-17789](https://github.com/magento/magento2/issues/17789)
+<!-- ENGCOM-2920  -->
+*  You can now filter the customer grid without inadvertently triggering a next-page Ajax call. Previously, when you created an order from the Orders page and tried to filter the customer list, Magento did not filter the list, and displayed the next page of customer entries. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17870](https://github.com/magento/magento2/pull/17870)*. [GitHub-17789](https://github.com/magento/magento2/issues/17789)
 
-<!-- MAGETWO-94475 -->* The `bin/magento` command now works as expected when Magento is not installed. Previously, Magento displayed this error, `Command line user does not have read and write permissions on generated directory. Please address this issue before using Magento command line.`
+<!-- MAGETWO-94475  -->
+*  The `bin/magento` command now works as expected when Magento is not installed. Previously, Magento displayed this error, `Command line user does not have read and write permissions on generated directory. Please address this issue before using Magento command line.`
 
-<!-- ENGCOM-2740 -->* Magento no longer throws an error when loading configuration data while running the `setup:di:compile` command. Previously, Magento threw an error when loading configuration data before Magento was installed because no  store-specific or website-specific configuration data was available. (Store and website data is available only after Magento is installed.) *Fix submitted by [Marcel](https://github.com/mimarcel) in pull request [13649](https://github.com/magento/magento2/pull/13649)*.
+<!-- ENGCOM-2740  -->
+*  Magento no longer throws an error when loading configuration data while running the `setup:di:compile` command. Previously, Magento threw an error when loading configuration data before Magento was installed because no  store-specific or website-specific configuration data was available. (Store and website data is available only after Magento is installed.) *Fix submitted by [Marcel](https://github.com/mimarcel) in pull request [13649](https://github.com/magento/magento2/pull/13649)*.
 
-<!-- ENGCOM-2674 -->* You can now set a custom `frontend_model` value in `system.xml` if the name of the module you're using contains an underscore. *Fix submitted by [Ben Tideswell](https://github.com/bentideswell) in pull request [14397](https://github.com/magento/magento2/pull/14397)*.
+<!-- ENGCOM-2674  -->
+*  You can now set a custom `frontend_model` value in `system.xml` if the name of the module you're using contains an underscore. *Fix submitted by [Ben Tideswell](https://github.com/bentideswell) in pull request [14397](https://github.com/magento/magento2/pull/14397)*.
 
-<!-- ENGCOM-2596 -->* Performance of the `setup:upgrade` step  of the update process has been improved for installations containing many orders (greater than 100,000). *Fix submitted by [Aurélien Lavorel](https://github.com/AurelienLavorel) in pull request [16570](https://github.com/magento/magento2/pull/16570)*.
+<!-- ENGCOM-2596  -->
+*  Performance of the `setup:upgrade` step  of the update process has been improved for installations containing many orders (greater than 100,000). *Fix submitted by [Aurélien Lavorel](https://github.com/AurelienLavorel) in pull request [16570](https://github.com/magento/magento2/pull/16570)*.
 
-<!-- ENGCOM-2646 -->* You can now complete `setup:install` for installations running  an authenticated Redis instance for cache configuration. Previously, Magento did not read the Redis cache options in `env.php` as expected, although  the Redis session password configuration worked as expected.  *Fix submitted by [Guillaume Giordana](https://github.com/guillaumegiordana) in pull request [17078](https://github.com/magento/magento2/pull/17078)*.
+<!-- ENGCOM-2646  -->
+*  You can now complete `setup:install` for installations running  an authenticated Redis instance for cache configuration. Previously, Magento did not read the Redis cache options in `env.php` as expected, although  the Redis session password configuration worked as expected.  *Fix submitted by [Guillaume Giordana](https://github.com/guillaumegiordana) in pull request [17078](https://github.com/magento/magento2/pull/17078)*.
 
-<!-- ENGCOM-2721 -->* You can now replace the transaction trace driver for the Profiler (`app/bootstrap.php`). For example, with this change you could replace  the default profiler with the OpenTracing API, which can then use its own exporters to express the code to the CNCF Jaeger project. This in turn supports a more granular view of application transactions. *Fix submitted by [Andrew Howden](https://github.com/andrewhowdencom) in pull request [15171](https://github.com/magento/magento2/pull/15171)*.
+<!-- ENGCOM-2721  -->
+*  You can now replace the transaction trace driver for the Profiler (`app/bootstrap.php`). For example, with this change you could replace  the default profiler with the OpenTracing API, which can then use its own exporters to express the code to the CNCF Jaeger project. This in turn supports a more granular view of application transactions. *Fix submitted by [Andrew Howden](https://github.com/andrewhowdencom) in pull request [15171](https://github.com/magento/magento2/pull/15171)*.
 
 ### AdminGWS
 
-<!-- MAGETWO-93990 -->* An administrator with permissions on one website only can no longer access the All Store Views scope for a product that is assigned to multiple websites.
+<!-- MAGETWO-93990  -->
+*  An administrator with permissions on one website only can no longer access the All Store Views scope for a product that is assigned to multiple websites.
 
-<!-- MAGETWO-90765 -->* Administrators with restricted privileges can now edit and create CMS blocks as expected. Previously, Magento threw an  error like this when an administrator tried to edit or create a block: `Warning: array_intersect(): Argument #1 is not an array in /var/www/html/magento2ee/app/code/Magento/AdminGws/Model/Models.php on line 1075 `.￼
+<!-- MAGETWO-90765  -->
+*  Administrators with restricted privileges can now edit and create CMS blocks as expected. Previously, Magento threw an  error like this when an administrator tried to edit or create a block: `Warning: array_intersect(): Argument #1 is not an array in /var/www/html/magento2ee/app/code/Magento/AdminGws/Model/Models.php on line 1075 `.￼
 
 ### B2B
 
-<!-- MAGETWO-93050 -->* Magento no longer permits merchants to open a new tab to edit company users from the company users tabs. Previously, a merchant would try to open a new tab to edit users, and Magento threw an error.
+<!-- MAGETWO-93050  -->
+*  Magento no longer permits merchants to open a new tab to edit company users from the company users tabs. Previously, a merchant would try to open a new tab to edit users, and Magento threw an error.
 
-<!-- MAGETWO-92400 -->* Magento now removes information from all fields when you click **Reset** when creating a new company from the Admin. Previously, Magento cleared all fields except for the **admin email** field.
+<!-- MAGETWO-92400  -->
+*  Magento now removes information from all fields when you click **Reset** when creating a new company from the Admin. Previously, Magento cleared all fields except for the **admin email** field.
 
-<!-- MAGETWO-89654 -->* Merchants can now create a company with an optional regional setting. Previously, Magento displayed this message, `Error message: Invalid value of "" provided for the region_id field`.
+<!-- MAGETWO-89654  -->
+*  Merchants can now create a company with an optional regional setting. Previously, Magento displayed this message, `Error message: Invalid value of "" provided for the region_id field`.
 
-<!-- MAGETWO-93081 -->* Administrators with appropriate permissions can now change the status of a company  to **Rejected**. Previously, Magento did not save the change in status, and threw an error.
+<!-- MAGETWO-93081  -->
+*  Administrators with appropriate permissions can now change the status of a company  to **Rejected**. Previously, Magento did not save the change in status, and threw an error.
 
-<!-- MAGETWO-93050 -->*  Magento now opens a new window for edit purposes when a merchant selects **Edit User in New Tab** from the company Users page. Previously, when a merchant tried to edit company users from the storefront by selecting  **Edit User in New Tab**, Magento threw a JSON error.
+<!-- MAGETWO-93050  -->
+*   Magento now opens a new window for edit purposes when a merchant selects **Edit User in New Tab** from the company Users page. Previously, when a merchant tried to edit company users from the storefront by selecting  **Edit User in New Tab**, Magento threw a JSON error.
 
 ### Bundle products
 
-<!-- MAGETWO-93145 -->* Magento now sorts bundle summaries according to the criteria set in the Admin.
+<!-- MAGETWO-93145  -->
+*  Magento now sorts bundle summaries according to the criteria set in the Admin.
 
-<!-- ENGCOM-1832 -->* The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [15535](https://github.com/magento/magento2/pull/15535)*. [GitHub-15457](https://github.com/magento/magento2/issues/15457)
+<!-- ENGCOM-1832  -->
+*  The price range displayed for bundle products now shows only valid prices. Previously, Magento displayed special prices that had expired, even though the price in the customization and summary area was correct. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [15535](https://github.com/magento/magento2/pull/15535)*. [GitHub-15457](https://github.com/magento/magento2/issues/15457)
 
-<!-- MAGETWO-89006 -->* Merchants can now create a return merchandise authorization (RMA)  for a bundled product from a customer's account. Previously, Magento did not create the RMA, and the store returned an error.
+<!-- MAGETWO-89006  -->
+*  Merchants can now create a return merchandise authorization (RMA)  for a bundled product from a customer's account. Previously, Magento did not create the RMA, and the store returned an error.
 
 ### CAPTCHA
 
-<!-- ENGCOM-2576 -->* CAPTCHA code has been refactored to eliminate unnecessary multiple conditions. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17203](https://github.com/magento/magento2/pull/17203)*.
+<!-- ENGCOM-2576  -->
+*  CAPTCHA code has been refactored to eliminate unnecessary multiple conditions. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17203](https://github.com/magento/magento2/pull/17203)*.
 
 ### Catalog
 
-<!-- MAGETWO-93198 -->* Magento now displays the product name  under the product image on the product page.
+<!-- MAGETWO-93198  -->
+*  Magento now displays the product name  under the product image on the product page.
 
-<!-- MAGETWO-92036 -->* Magento now alerts you to an error when a merchant tries to save a product without completed required fields.
+<!-- MAGETWO-92036  -->
+*  Magento now alerts you to an error when a merchant tries to save a product without completed required fields.
 
-<!-- ENGCOM-2555 -->* A previous fix for a gallery template issue that was inadvertently reverted has been restored. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [16594](https://github.com/magento/magento2/pull/16594)*. [GitHub-15009](https://github.com/magento/magento2/issues/15009)
+<!-- ENGCOM-2555  -->
+*  A previous fix for a gallery template issue that was inadvertently reverted has been restored. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [16594](https://github.com/magento/magento2/pull/16594)*. [GitHub-15009](https://github.com/magento/magento2/issues/15009)
 
-<!-- ENGCOM-2650 -->* Parent theme image height settings (specified in `view.xml`) no longer override the height settings assigned to individual images. *Fix submitted by [Tommy Quissens](https://github.com/quisse) in pull request [14537](https://github.com/magento/magento2/pull/14537)*. [GitHub-12250](https://github.com/magento/magento2/issues/12250)
+<!-- ENGCOM-2650  -->
+*  Parent theme image height settings (specified in `view.xml`) no longer override the height settings assigned to individual images. *Fix submitted by [Tommy Quissens](https://github.com/quisse) in pull request [14537](https://github.com/magento/magento2/pull/14537)*. [GitHub-12250](https://github.com/magento/magento2/issues/12250)
 
-<!-- ENGCOM-2672 -->* Magento now maintains product image roles as expected after upgrade. Previously, image roles randomly disappeared from product pages after upgrade. *Fix submitted by [Sam Butler Thompson](https://github.com/Scarraban) in pull request [15606](https://github.com/magento/magento2/pull/15606)*. [GitHub-10687](https://github.com/magento/magento2/issues/10687)
+<!-- ENGCOM-2672  -->
+*  Magento now maintains product image roles as expected after upgrade. Previously, image roles randomly disappeared from product pages after upgrade. *Fix submitted by [Sam Butler Thompson](https://github.com/Scarraban) in pull request [15606](https://github.com/magento/magento2/pull/15606)*. [GitHub-10687](https://github.com/magento/magento2/issues/10687)
 
-<!-- ENGCOM-2670 -->* You can now save attributes for a configurable product after a validation error occurs. Previously, when you added a new product with an image, if a validation error occurred during the product save, Magento removed the images  from the **Images and Videos** section. If you subsequently fixed the validation conflict and attempted to save the product again, Magento threw a descriptive error. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16597](https://github.com/magento/magento2/pull/16597)*. [GitHub-7372](https://github.com/magento/magento2/issues/7372), [GitHub-13177](https://github.com/magento/magento2/issues/13177)
+<!-- ENGCOM-2670  -->
+*  You can now save attributes for a configurable product after a validation error occurs. Previously, when you added a new product with an image, if a validation error occurred during the product save, Magento removed the images  from the **Images and Videos** section. If you subsequently fixed the validation conflict and attempted to save the product again, Magento threw a descriptive error. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16597](https://github.com/magento/magento2/pull/16597)*. [GitHub-7372](https://github.com/magento/magento2/issues/7372), [GitHub-13177](https://github.com/magento/magento2/issues/13177)
 
-<!-- ENGCOM-2675 -->* You can now add a product with a price of zero (0) to a wishlist. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [17395](https://github.com/magento/magento2/pull/17395)*. [GitHub-16479](https://github.com/magento/magento2/issues/16479)
+<!-- ENGCOM-2675  -->
+*  You can now add a product with a price of zero (0) to a wishlist. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [17395](https://github.com/magento/magento2/pull/17395)*. [GitHub-16479](https://github.com/magento/magento2/issues/16479)
 
-<!-- ENGCOM-1605 -->* You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
+<!-- ENGCOM-1605  -->
+*  You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
 
-<!-- ENGCOM-2758 -->*  You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
+<!-- ENGCOM-2758  -->
+*   You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
 
-<!-- MAGETWO-94080 -->* The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
+<!-- MAGETWO-94080  -->
+*  The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
 
-<!-- MAGETWO-94062 -->* Magento now displays a descriptive error message  when a customer tries to order a product in increments that are not allowed.
+<!-- MAGETWO-94062  -->
+*  Magento now displays a descriptive error message  when a customer tries to order a product in increments that are not allowed.
 
-<!-- MAGETWO-92682 -->* The Catalog Staging module no longer overrides trigger settings in scheduled indexed operations. Previously, when Magento indexes were configured to run on schedule, Magento  created the appropriate INSERT/UPDATE/DELETE triggers. Consequently, the UPDATE trigger script contained a condition to check if any values were  changed, and only then inserted a record into the changelog table of subscribed indexers. The Catalog Staging module prevented the inclusion of trigger conditions.
+<!-- MAGETWO-92682  -->
+*  The Catalog Staging module no longer overrides trigger settings in scheduled indexed operations. Previously, when Magento indexes were configured to run on schedule, Magento  created the appropriate INSERT/UPDATE/DELETE triggers. Consequently, the UPDATE trigger script contained a condition to check if any values were  changed, and only then inserted a record into the changelog table of subscribed indexers. The Catalog Staging module prevented the inclusion of trigger conditions.
 
-<!-- MAGETWO-88641 -->* Magento now applies tier prices as expected after a customer logs into their shopping cart. [GitHub-14255](https://github.com/magento/magento2/issues/14255)
+<!-- MAGETWO-88641  -->
+*  Magento now applies tier prices as expected after a customer logs into their shopping cart. [GitHub-14255](https://github.com/magento/magento2/issues/14255)
 
-<!-- MAGETWO-84894 -->* Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
+<!-- MAGETWO-84894  -->
+*  Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
 
-<!-- MAGETWO-73443 -->*  Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
+<!-- MAGETWO-73443  -->
+*   Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
 product, and hung indefinitely while trying to add the product.
 
-<!-- MAGETWO-73245 -->* A merchant can now successfully create and save configurable products from the Admin in a multisite deployment. Previously, when a merchant created a configurable product with customizable options, Magento set its `has_options` and `required_options`  (in the `catalog_product_entity` table) to 0, and the merchant needed to click **Save** again to correctly add the product.
+<!-- MAGETWO-73245  -->
+*  A merchant can now successfully create and save configurable products from the Admin in a multisite deployment. Previously, when a merchant created a configurable product with customizable options, Magento set its `has_options` and `required_options`  (in the `catalog_product_entity` table) to 0, and the merchant needed to click **Save** again to correctly add the product.
 
-<!-- MAGETWO-93047 -->* The `PUT rest/all/V1/categories/:categoryId` endpoint now requires the `name` field.
+<!-- MAGETWO-93047  -->
+*  The `PUT rest/all/V1/categories/:categoryId` endpoint now requires the `name` field.
 
-<!-- ENGCOM-2622 -->* Special price expressions now work as expected. Previously, `catalog_product_price` did not generate correct price data. *Fix submitted by Dmitry Chukhnov in pull request [16510](https://github.com/magento/magento2/pull/16510)*.
+<!-- ENGCOM-2622  -->
+*  Special price expressions now work as expected. Previously, `catalog_product_price` did not generate correct price data. *Fix submitted by Dmitry Chukhnov in pull request [16510](https://github.com/magento/magento2/pull/16510)*.
 
 ### Catalog rule
 
-<!-- ENGCOM-2718 -->* `date` can now be used as a condition for Catalog Price rules. *Fix submitted by [Glenn Cheng](https://github.com/GlennCheng) in pull request [16855](https://github.com/magento/magento2/pull/16855)*.
+<!-- ENGCOM-2718  -->
+*  `date` can now be used as a condition for Catalog Price rules. *Fix submitted by [Glenn Cheng](https://github.com/GlennCheng) in pull request [16855](https://github.com/magento/magento2/pull/16855)*.
 
 ### Cart and checkout
 
-<!-- MAGETWO-93037 -->* Customers can no longer place orders for out-of-stock products.
+<!-- MAGETWO-93037  -->
+*  Customers can no longer place orders for out-of-stock products.
 
-<!-- ENGCOM-2743 -->* Magento no longer displays an undefined string on the Order Summary page. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17526](https://github.com/magento/magento2/pull/17526)*. [GitHub-17492](https://github.com/magento/magento2/issues/17492)
+<!-- ENGCOM-2743  -->
+*  Magento no longer displays an undefined string on the Order Summary page. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17526](https://github.com/magento/magento2/pull/17526)*. [GitHub-17492](https://github.com/magento/magento2/issues/17492)
 
-<!-- ENGCOM-2901 -->* Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [17877](https://github.com/magento/magento2/pull/17877)*. [GitHub-17851](https://github.com/magento/magento2/issues/17851)
+<!-- ENGCOM-2901  -->
+*  Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [17877](https://github.com/magento/magento2/pull/17877)*. [GitHub-17851](https://github.com/magento/magento2/issues/17851)
 
-<!-- ENGCOM-2789 -->* Magento no longer unchecks **My billing and shipping address are the same** checkbox when a customer uses an offline custom payment method for an order. Previously, when a customer used an offline custom payment method for an order, Magento unchecked this  checkbox on the payment step if the shipping address was updated. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17593](https://github.com/magento/magento2/pull/17593)*. [GitHub-14819](https://github.com/magento/magento2/issues/14819)
+<!-- ENGCOM-2789  -->
+*  Magento no longer unchecks **My billing and shipping address are the same** checkbox when a customer uses an offline custom payment method for an order. Previously, when a customer used an offline custom payment method for an order, Magento unchecked this  checkbox on the payment step if the shipping address was updated. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17593](https://github.com/magento/magento2/pull/17593)*. [GitHub-14819](https://github.com/magento/magento2/issues/14819)
 
-<!-- MAGETWO-93038 -->* You can now see category changes on the storefront as expected after the changes have been saved. Previously, Magento did not display changes to product categories on the storefront until reindexing occurred even if **update on schedule** was set and the cache had been cleaned.
+<!-- MAGETWO-93038  -->
+*  You can now see category changes on the storefront as expected after the changes have been saved. Previously, Magento did not display changes to product categories on the storefront until reindexing occurred even if **update on schedule** was set and the cache had been cleaned.
 
-<!-- MAGETWO-73604 -->* Magento now populates the **Default Billing** address field with the shipping address when a customer selects **Save in address book** during checkout. Previously, Magento saved the address, but did not populate the default billing address field as expected.
+<!-- MAGETWO-73604  -->
+*  Magento now populates the **Default Billing** address field with the shipping address when a customer selects **Save in address book** during checkout. Previously, Magento saved the address, but did not populate the default billing address field as expected.
 
-<!-- ENGCOM-2534 -->* Third-party modules can now perform actions after `totals` calculation. (Modules can perform additional actions by adding `.done`, `.fail`, or `.always` tasks to the request promise by creating a JavaScript mixin for the totals processor.) *Fix submitted by [Navarr Barnier](https://github.com/navarr) in pull request [17127](https://github.com/magento/magento2/pull/17127)*.
+<!-- ENGCOM-2534  -->
+*  Third-party modules can now perform actions after `totals` calculation. (Modules can perform additional actions by adding `.done`, `.fail`, or `.always` tasks to the request promise by creating a JavaScript mixin for the totals processor.) *Fix submitted by [Navarr Barnier](https://github.com/navarr) in pull request [17127](https://github.com/magento/magento2/pull/17127)*.
 
-<!-- ENGCOM-2645 -->* Magento no longer adds an empty method to the cart summary. Previously, when the method html was empty, an empty list item resulted, which subsequently  resulted in an extra margin of 20px because of default styling. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17189](https://github.com/magento/magento2/pull/17189)*.
+<!-- ENGCOM-2645  -->
+*  Magento no longer adds an empty method to the cart summary. Previously, when the method html was empty, an empty list item resulted, which subsequently  resulted in an extra margin of 20px because of default styling. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17189](https://github.com/magento/magento2/pull/17189)*.
 
-<!-- ENGCOM-2636 -->* The sidebars for the wishlist on the catalog, my account, and checkout pages now render special characters correctly. Previously, the browser displayed `&trade;` instead of rendered special characters on these pages. *Fix submitted by [deepjoshi94](https://github.com/deepjoshi94) in pull request [17070](https://github.com/magento/magento2/pull/17070)*.
+<!-- ENGCOM-2636  -->
+*  The sidebars for the wishlist on the catalog, my account, and checkout pages now render special characters correctly. Previously, the browser displayed `&trade;` instead of rendered special characters on these pages. *Fix submitted by [deepjoshi94](https://github.com/deepjoshi94) in pull request [17070](https://github.com/magento/magento2/pull/17070)*.
 
-<!-- ENGCOM-2665 -->* The `disabled attribute` has been removed from the region list. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [16955](https://github.com/magento/magento2/pull/16955)*.
+<!-- ENGCOM-2665  -->
+*  The `disabled attribute` has been removed from the region list. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [16955](https://github.com/magento/magento2/pull/16955)*.
 
-<!-- ENGCOM-2210 -->* The Admin checkout agreement controllers have been refactored to remove the use of `ObjectManager`. *Fix submitted by [AnshuMishra17](https://github.com/AnshuMishra17) in pull request [16505](https://github.com/magento/magento2/pull/16505)*.
+<!-- ENGCOM-2210  -->
+*  The Admin checkout agreement controllers have been refactored to remove the use of `ObjectManager`. *Fix submitted by [AnshuMishra17](https://github.com/AnshuMishra17) in pull request [16505](https://github.com/magento/magento2/pull/16505)*.
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-2580 -->* Problems with the responsive layout  `app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less` have been resolved. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17217](https://github.com/magento/magento2/pull/17217)*.
+<!-- ENGCOM-2580  -->
+*  Problems with the responsive layout  `app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less` have been resolved. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17217](https://github.com/magento/magento2/pull/17217)*.
 
-<!-- ENGCOM-2549 -->* The `text-align` for the `<th>` element of the Subtotal column in the creditmemo email has been corrected. *Fix submitted by [Tomash Khamlai](https://github.com/TomashKhamlai) in pull request [17153](https://github.com/magento/magento2/pull/17153)*.
+<!-- ENGCOM-2549  -->
+*  The `text-align` for the `<th>` element of the Subtotal column in the creditmemo email has been corrected. *Fix submitted by [Tomash Khamlai](https://github.com/TomashKhamlai) in pull request [17153](https://github.com/magento/magento2/pull/17153)*.
 
-<!-- ENGCOM-2568 -->* The  invalid `knockoutjs` data binding in Braintree PayPal has been fixed. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17236](https://github.com/magento/magento2/pull/17236)*.
+<!-- ENGCOM-2568  -->
+*  The  invalid `knockoutjs` data binding in Braintree PayPal has been fixed. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17236](https://github.com/magento/magento2/pull/17236)*.
 
-<!-- ENGCOM-2613 -->* The overall readability of Shipping Methods sorting has been improved by replacing sort callbacks. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [16788](https://github.com/magento/magento2/pull/16788)*.
+<!-- ENGCOM-2613  -->
+*  The overall readability of Shipping Methods sorting has been improved by replacing sort callbacks. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [16788](https://github.com/magento/magento2/pull/16788)*.
 
-<!-- ENGCOM-2594 -->* Files in `/lib` have been cleaned up. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17103](https://github.com/magento/magento2/pull/17103)*.
+<!-- ENGCOM-2594  -->
+*  Files in `/lib` have been cleaned up. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17103](https://github.com/magento/magento2/pull/17103)*.
 
-<!-- ENGCOM-2619 -->* Unused IDs in `app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html` and `app/code/Magento/Checkout/Test/Mftf/Section/CheckoutPaymentSection.xml` have been removed. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
+<!-- ENGCOM-2619  -->
+*  Unused IDs in `app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html` and `app/code/Magento/Checkout/Test/Mftf/Section/CheckoutPaymentSection.xml` have been removed. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
 
-<!-- ENGCOM-2118 -->* Removed unnecessary translation of HTML tags in `app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php` and `app/code/Magento/Catalog/i18n/en_US.csv`. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
+<!-- ENGCOM-2118  -->
+*  Removed unnecessary translation of HTML tags in `app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php` and `app/code/Magento/Catalog/i18n/en_US.csv`. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17291](https://github.com/magento/magento2/pull/17291)*.
 
-<!-- ENGCOM-2651 -->* Minor CSS issues in `lib/internal/Magento/Framework/View/Test/Unit/Url/_files/sourceImport.css` have been fixed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17365](https://github.com/magento/magento2/pull/17365)*.
+<!-- ENGCOM-2651  -->
+*  Minor CSS issues in `lib/internal/Magento/Framework/View/Test/Unit/Url/_files/sourceImport.css` have been fixed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17365](https://github.com/magento/magento2/pull/17365)*.
 
-<!-- ENGCOM-2762 -->* Duplicate code in `app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js` has been removed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17505](https://github.com/magento/magento2/pull/17505)*.
+<!-- ENGCOM-2762  -->
+*  Duplicate code in `app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js` has been removed. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17505](https://github.com/magento/magento2/pull/17505)*.
 
-<!-- ENGCOM-2776 -->* The code generator for Proxy is no longer missing `returnType` in the method information definition. *Fix submitted by [adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request [17552](https://github.com/magento/magento2/pull/17552)*.
+<!-- ENGCOM-2776  -->
+*  The code generator for Proxy is no longer missing `returnType` in the method information definition. *Fix submitted by [adrian-martinez-interactiv4](https://github.com/adrian-martinez-interactiv4) in pull request [17552](https://github.com/magento/magento2/pull/17552)*.
 
-<!-- ENGCOM-2748 -->* The `<script/>` tag has been replaced with `<script type="text/x-magento-init" />` in  `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml` and `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml`. Also,  a new JavaScript component with the callback function has been created.  *Fix submitted by [Yogesh Suhagiya](https://github.com/swnsma) in pull request [17527](https://github.com/magento/magento2/pull/17527)*.
+<!-- ENGCOM-2748  -->
+*  The `<script/>` tag has been replaced with `<script type="text/x-magento-init" />` in  `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml` and `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml`. Also,  a new JavaScript component with the callback function has been created.  *Fix submitted by [Yogesh Suhagiya](https://github.com/swnsma) in pull request [17527](https://github.com/magento/magento2/pull/17527)*.
 
-<!-- ENGCOM-2632 -->* The `$outputHelper` property declaration has been added to `app/code/Magento/Catalog/CustomerData/CompareProducts.php`. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
+<!-- ENGCOM-2632  -->
+*  The `$outputHelper` property declaration has been added to `app/code/Magento/Catalog/CustomerData/CompareProducts.php`. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
 
-<!-- ENGCOM-2632 -->* The `Magento_Backend` module  has been refactored. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17101](https://github.com/magento/magento2/pull/17101)*.
+<!-- ENGCOM-2632  -->
+*  The `Magento_Backend` module  has been refactored. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17101](https://github.com/magento/magento2/pull/17101)*.
 
-<!-- ENGCOM-1666 -->* The usage of the `count()` function in for loops has been refactored to improve the performance of the loops that were running `count()` in every iteration throughout the code base. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [15507](https://github.com/magento/magento2/pull/15507)*.
+<!-- ENGCOM-1666  -->
+*  The usage of the `count()` function in for loops has been refactored to improve the performance of the loops that were running `count()` in every iteration throughout the code base. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [15507](https://github.com/magento/magento2/pull/15507)*.
 
 ### CMS content
 
-<!-- ENGCOM-2734 -->* A new `OptionSource` of blocks has been added. *Fix submitted by Thomas Klein in pull request [16021](https://github.com/magento/magento2/pull/16021)*.
+<!-- ENGCOM-2734  -->
+*  A new `OptionSource` of blocks has been added. *Fix submitted by Thomas Klein in pull request [16021](https://github.com/magento/magento2/pull/16021)*.
 
-<!-- MAGETWO-73359 -->* You can successfully save a CMS page with the same URL key as another store on a different website but with the same hierarchy.
+<!-- MAGETWO-73359  -->
+*  You can successfully save a CMS page with the same URL key as another store on a different website but with the same hierarchy.
 
-<!-- ENGCOM-2655 -->* The CMS page index has been refactored to remove the Object Manager, and  dependency injection has been added  to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
+<!-- ENGCOM-2655  -->
+*  The CMS page index has been refactored to remove the Object Manager, and  dependency injection has been added  to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
 
 ### Configurable products
 
-<!-- ENGCOM-2671 -->* You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. *Fix submitted by [zamboten](https://github.com/zamboten) in pull request [15720](https://github.com/magento/magento2/pull/15720)*. [GitHub-15028](https://github.com/magento/magento2/issues/15028)
+<!-- ENGCOM-2671  -->
+*  You can now use REST to add a configurable product to a shopping cart without creating a duplicate product entry. *Fix submitted by [zamboten](https://github.com/zamboten) in pull request [15720](https://github.com/magento/magento2/pull/15720)*. [GitHub-15028](https://github.com/magento/magento2/issues/15028)
 
-<!-- MAGETWO-77742 -->* Magento now displays a descriptive error message when you try to upload a file in an unsupported format. Previously, Magento displayed an error that did not relate to the specific upload problem.
+<!-- MAGETWO-77742  -->
+*  Magento now displays a descriptive error message when you try to upload a file in an unsupported format. Previously, Magento displayed an error that did not relate to the specific upload problem.
 
-<!-- MAGETWO-75086 -->* Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options.  ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
+<!-- MAGETWO-75086  -->
+*  Magento now displays the correct  options when you click  on  **View Details** for a  product with configurable options.  ￼Previously, Magento displayed the image for the parent product. [GitHub-8168](https://github.com/magento/magento2/issues/8168)
 
 ### CMS
 
-<!-- MAGETWO-73359 -->* You can successfully save a CMS page with same URL key as another store on a different website but with the same hierarchy.
+<!-- MAGETWO-73359  -->
+*  You can successfully save a CMS page with same URL key as another store on a different website but with the same hierarchy.
 
-<!-- ENGCOM-2655 -->* The CMS page index has been refactored to remove the Object Manager and added dependency injection to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
+<!-- ENGCOM-2655  -->
+*  The CMS page index has been refactored to remove the Object Manager and added dependency injection to the constructor. *Fix submitted by [Vladymyr Hrivinskyi](https://github.com/hryvinskyi) in pull request [17066](https://github.com/magento/magento2/pull/17066)*.
 
 ### Customer
 
-<!-- ENGCOM-2746 -->* When editing an Admin user role, Magento now displays the Customer Groups section under the Customers section as expected. Previously, Magento displayed the Customer Groups section under the **Stores** > **Other settings** section. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [17515](https://github.com/magento/magento2/pull/17515)*. [GitHub-16499](https://github.com/magento/magento2/issues/16499)
+<!-- ENGCOM-2746  -->
+*  When editing an Admin user role, Magento now displays the Customer Groups section under the Customers section as expected. Previously, Magento displayed the Customer Groups section under the **Stores** > **Other settings** section. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [17515](https://github.com/magento/magento2/pull/17515)*. [GitHub-16499](https://github.com/magento/magento2/issues/16499)
 
 ### Directory
 
-<!-- MAGETWO-92831 -->* Currency conversion rate services now work as expected in the Admin.
+<!-- MAGETWO-92831  -->
+*  Currency conversion rate services now work as expected in the Admin.
 
 ### EAV
 
-<!-- ENGCOM-2642 -->*  The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
+<!-- ENGCOM-2642  -->
+*   The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
 
 ### Email
 
-<!-- MAGETWO-92786 -->* Magento now displays the correct width for the welcome email when viewed on a mobile device.
+<!-- MAGETWO-92786  -->
+*  Magento now displays the correct width for the welcome email when viewed on a mobile device.
 
-<!-- ENGCOM-2787 -->* Magento can no longer send more than 50 emails per cronjob, which will reduce duplicate emails.  *Fix submitted by [iGerchak](https://github.com/iGerchak) in pull request [17484](https://github.com/magento/magento2/pull/15942)*.
+<!-- ENGCOM-2787  -->
+*  Magento can no longer send more than 50 emails per cronjob, which will reduce duplicate emails.  *Fix submitted by [iGerchak](https://github.com/iGerchak) in pull request [17484](https://github.com/magento/magento2/pull/15942)*.
 
 ### Frameworks
 
-<!-- ENGCOM-2070 -->* You can now set values for `MAX_IMAGE_WIDTH` and `MAX_IMAGE_HEIGHT` in **Stores** > **Settings** > **Configuration** > **Advanced** > **System** > **Images Configuration**, which supports the upload of larger images. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [15942](https://github.com/magento/magento2/pull/15942)*. [GitHub-13747](https://github.com/magento/magento2/issues/13747)
+<!-- ENGCOM-2070  -->
+*  You can now set values for `MAX_IMAGE_WIDTH` and `MAX_IMAGE_HEIGHT` in **Stores** > **Settings** > **Configuration** > **Advanced** > **System** > **Images Configuration**, which supports the upload of larger images. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [15942](https://github.com/magento/magento2/pull/15942)*. [GitHub-13747](https://github.com/magento/magento2/issues/13747)
 
-<!-- ENGCOM-2915 -->* `functions.php`  now resides in the Framework module. *Fix submitted by [Kristof, Fooman](https://github.com/fooman) in pull request [16800](https://github.com/magento/magento2/pull/16800)*.
+<!-- ENGCOM-2915  -->
+*  `functions.php`  now resides in the Framework module. *Fix submitted by [Kristof, Fooman](https://github.com/fooman) in pull request [16800](https://github.com/magento/magento2/pull/16800)*.
 
-<!-- ENGCOM-2570 -->* FTP connections can  now use user or password strings with special characters (for example, @ or #). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17246](https://github.com/magento/magento2/pull/17246)*.
+<!-- ENGCOM-2570  -->
+*  FTP connections can  now use user or password strings with special characters (for example, @ or #). *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [17246](https://github.com/magento/magento2/pull/17246)*.
 
 #### Application framework
 
-<!-- ENGCOM-2382 -->* Magento now validates that the required **Purchase Order Number** field is  set as expected during checkout. *Fix submitted by [Pablo](https://github.com/centerax) in pull request [14393](https://github.com/magento/magento2/pull/14393)*. [GitHub-6585](https://github.com/magento/magento2/issues/6585)
+<!-- ENGCOM-2382  -->
+*  Magento now validates that the required **Purchase Order Number** field is  set as expected during checkout. *Fix submitted by [Pablo](https://github.com/centerax) in pull request [14393](https://github.com/magento/magento2/pull/14393)*. [GitHub-6585](https://github.com/magento/magento2/issues/6585)
 
 #### Database framework
 
-<!-- MAGETWO-83918 -->* The `getSize` function now reflects item and page count totals for filtered product collections on the category page.
+<!-- MAGETWO-83918  -->
+*  The `getSize` function now reflects item and page count totals for filtered product collections on the category page.
 
 #### JavaScript framework
 
-<!-- ENGCOM-2291 -->* JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed. *Fix submitted by [Vitaliy Boyko](https://github.com/VitaliyBoyko) in pull request [16724](https://github.com/magento/magento2/pull/16724)*. [GitHub-16544](https://github.com/magento/magento2/issues/16544)
+<!-- ENGCOM-2291  -->
+*  JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed. *Fix submitted by [Vitaliy Boyko](https://github.com/VitaliyBoyko) in pull request [16724](https://github.com/magento/magento2/pull/16724)*. [GitHub-16544](https://github.com/magento/magento2/issues/16544)
 
-<!-- ENGCOM-1967 -->* You can disable the **Use system value** checkboxes on the Admin as expected. *Fix submitted by [Valerij Ivashchenko](https://github.com/likemusic) in pull request [16000](https://github.com/magento/magento2/pull/16000)*.
+<!-- ENGCOM-1967  -->
+*  You can disable the **Use system value** checkboxes on the Admin as expected. *Fix submitted by [Valerij Ivashchenko](https://github.com/likemusic) in pull request [16000](https://github.com/magento/magento2/pull/16000)*.
 
 #### Session framework
 
-<!-- ENGCOM-1440 -->* Magento no longer unexpectedly empties a customer's shopping cart during checkout when concurrent requests occur. *Fix submitted by [Elio Ermini](https://github.com/elioermini) in pull request [14973](https://github.com/magento/magento2/pull/14973)*. [GitHub-12362](https://github.com/magento/magento2/issues/12362)
+<!-- ENGCOM-1440  -->
+*  Magento no longer unexpectedly empties a customer's shopping cart during checkout when concurrent requests occur. *Fix submitted by [Elio Ermini](https://github.com/elioermini) in pull request [14973](https://github.com/magento/magento2/pull/14973)*. [GitHub-12362](https://github.com/magento/magento2/issues/12362)
 
 ### General
 
-<!-- MAGETWO-93152 -->* Magento now processes zero (0) in email filter fields correctly.
+<!-- MAGETWO-93152  -->
+*  Magento now processes zero (0) in email filter fields correctly.
 
-<!-- MAGETWO-93939 -->* You can now clear the **Date of Birth** field in the customer edit page when accessed from the Admin.
+<!-- MAGETWO-93939  -->
+*  You can now clear the **Date of Birth** field in the customer edit page when accessed from the Admin.
 
-<!-- ENGCOM-2737 -->* Product image zoom now works as expected in stores running on Safari. *Fix submitted by [Danny Nimmo](https://github.com/dannynimmo) in pull request [17491](https://github.com/magento/magento2/pull/17491)*. [GitHub-17416](https://github.com/magento/magento2/issues/17416)
+<!-- ENGCOM-2737  -->
+*  Product image zoom now works as expected in stores running on Safari. *Fix submitted by [Danny Nimmo](https://github.com/dannynimmo) in pull request [17491](https://github.com/magento/magento2/pull/17491)*. [GitHub-17416](https://github.com/magento/magento2/issues/17416)
 
-<!-- ENGCOM-2785 -->* Magento now displays the background of transparent product image watermarks correctly. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17013](https://github.com/magento/magento2/pull/17013)*. [GitHub-16929](https://github.com/magento/magento2/issues/16929)
+<!-- ENGCOM-2785  -->
+*  Magento now displays the background of transparent product image watermarks correctly. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [17013](https://github.com/magento/magento2/pull/17013)*. [GitHub-16929](https://github.com/magento/magento2/issues/16929)
 
-<!-- ENGCOM-2855 -->* `.png` images from the GD2 image library that have transparent backgrounds now retain their  transparent backgrounds after upload. Previously, these transparent backgrounds were rendered black when you displayed these images after upload. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
+<!-- ENGCOM-2855  -->
+*  `.png` images from the GD2 image library that have transparent backgrounds now retain their  transparent backgrounds after upload. Previously, these transparent backgrounds were rendered black when you displayed these images after upload. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
 
-<!-- ENGCOM-2860 -->*  Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
+<!-- ENGCOM-2860  -->
+*   Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
 
-<!-- ENGCOM-2322 -->* Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
+<!-- ENGCOM-2322  -->
+*  Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
 
-<!-- ENGCOM-2628 -->* Magento now disables the **Shop By** button on the search page when a customer sets additional search filters. *Fix submitted by [Andrea Rivadossi](https://github.com/AndreaRivadossi) in pull request [15650](https://github.com/magento/magento2/pull/15650)*. [GitHub-13445](https://github.com/magento/magento2/issues/13445)
+<!-- ENGCOM-2628  -->
+*  Magento now disables the **Shop By** button on the search page when a customer sets additional search filters. *Fix submitted by [Andrea Rivadossi](https://github.com/AndreaRivadossi) in pull request [15650](https://github.com/magento/magento2/pull/15650)*. [GitHub-13445](https://github.com/magento/magento2/issues/13445)
 
-<!-- MAGETWO-83984-->* Magento now processes the oldest message queue entries first instead of last.
+<!-- MAGETWO-83984 -->
+*  Magento now processes the oldest message queue entries first instead of last.
 
-<!-- ENGCOM-2875 -->* The `setterName` method is now correctly set. *Fix submitted by [insanityinside](https://github.com/insanityinside) in pull request [17773](https://github.com/magento/magento2/pull/17773)*.
+<!-- ENGCOM-2875  -->
+*  The `setterName` method is now correctly set. *Fix submitted by [insanityinside](https://github.com/insanityinside) in pull request [17773](https://github.com/magento/magento2/pull/17773)*.
 
-<!-- ENGCOM-2896 -->* New templates have been added to the GitHub Issue Reporting section. These templates target a broad scope of possible problems, and the proposed descriptions are aimed at simplifying future fixes. *Fix submitted by [Eugene Shakhsuvarov](https://github.com/ishakhsuvarov) in pull request [17817](https://github.com/magento/magento2/pull/17817)*.
+<!-- ENGCOM-2896  -->
+*  New templates have been added to the GitHub Issue Reporting section. These templates target a broad scope of possible problems, and the proposed descriptions are aimed at simplifying future fixes. *Fix submitted by [Eugene Shakhsuvarov](https://github.com/ishakhsuvarov) in pull request [17817](https://github.com/magento/magento2/pull/17817)*.
 
 ### Google Tag Manager
 
-<!-- MAGETWO-87437 -->* All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing in the Google Tag Manager.
+<!-- MAGETWO-87437  -->
+*  All relevant attributes are now populated in the Google Tag Manager when a customer adds a product to their shopping cart. Previously, grouped, bundle,  and configurable  product attributes were missing in the Google Tag Manager.
 
 ### Import/export
 
-<!-- MAGETWO-93223 -->* Magento now displays the correct execution time for an import operation on the **System** > **Import History** page.
+<!-- MAGETWO-93223  -->
+*  Magento now displays the correct execution time for an import operation on the **System** > **Import History** page.
 
 ### Infrastructure
 
-<!-- ENGCOM-2783 -->* The Web Setup wizard icon sidebar shortcut on the Admin now links as expected to the wizard. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17543](https://github.com/magento/magento2/pull/17543)*. [GitHub-13948](https://github.com/magento/magento2/issues/13948)
+<!-- ENGCOM-2783  -->
+*  The Web Setup wizard icon sidebar shortcut on the Admin now links as expected to the wizard. *Fix submitted by [Arnoud Beekman](https://github.com/arnoudhgz) in pull request [17543](https://github.com/magento/magento2/pull/17543)*. [GitHub-13948](https://github.com/magento/magento2/issues/13948)
 
-<!-- ENGCOM-2872 -->* The `$keepRation` parameter in the `Magento\Cms\Model\Wysiwyg\Images\Storage` class has been renamed to `$keepRatio`. *Fix submitted by [Martin Aarts](https://github.com/MartinAarts) in pull request [17776](https://github.com/magento/magento2/pull/17776)*. [GitHub-17587](https://github.com/magento/magento2/issues/17587)
+<!-- ENGCOM-2872  -->
+*  The `$keepRation` parameter in the `Magento\Cms\Model\Wysiwyg\Images\Storage` class has been renamed to `$keepRatio`. *Fix submitted by [Martin Aarts](https://github.com/MartinAarts) in pull request [17776](https://github.com/magento/magento2/pull/17776)*. [GitHub-17587](https://github.com/magento/magento2/issues/17587)
 
-<!-- MAGETWO-73342 -->* Customers can now change product status by clicking on either the toggle element or label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
+<!-- MAGETWO-73342  -->
+*  Customers can now change product status by clicking on either the toggle element or label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
 
-<!-- ENGCOM-2736 -->* Outdated LESS lib docs have been updated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17479](https://github.com/magento/magento2/pull/17479)*.
+<!-- ENGCOM-2736  -->
+*  Outdated LESS lib docs have been updated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17479](https://github.com/magento/magento2/pull/17479)*.
 
-<!-- ENGCOM-2643 -->* The `floatval()` function has been replaced by the use of direct type casting to `(float)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16848](https://github.com/magento/magento2/pull/16848)*.
+<!-- ENGCOM-2643  -->
+*  The `floatval()` function has been replaced by the use of direct type casting to `(float)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16848](https://github.com/magento/magento2/pull/16848)*.
 
-<!-- ENGCOM-2644 -->* The `strval()` function has been replaced by the use of direct type casting to `(string)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16849](https://github.com/magento/magento2/pull/16849)*.
+<!-- ENGCOM-2644  -->
+*  The `strval()` function has been replaced by the use of direct type casting to `(string)` throughout the code base. *Fix submitted by [Marcel Hauri](https://github.com/mhauri) in pull request [16849](https://github.com/magento/magento2/pull/16849)*.
 
-<!-- ENGCOM-2668 -->* The EU-VAT-Numbers `Countrycode`  prefixes have been removed for validation purposes. *Fix submitted by [Drischie](https://github.com/Drischie) in pull request [17385](https://github.com/magento/magento2/pull/17385)*.
+<!-- ENGCOM-2668  -->
+*  The EU-VAT-Numbers `Countrycode`  prefixes have been removed for validation purposes. *Fix submitted by [Drischie](https://github.com/Drischie) in pull request [17385](https://github.com/magento/magento2/pull/17385)*.
 
-<!-- ENGCOM-2634 -->* Missing `data-th` selectors have been added to tables. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17327](https://github.com/magento/magento2/pull/17327)*.
+<!-- ENGCOM-2634  -->
+*  Missing `data-th` selectors have been added to tables. *Fix submitted by [Daniel Ruf](https://github.com/DanielRuf) in pull request [17327](https://github.com/magento/magento2/pull/17327)*.
 
 ### Locale
 
-<!-- MAGETWO-94075 -->* The DatePicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
+<!-- MAGETWO-94075  -->
+*  The DatePicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
 
 ### Logging
 
-<!-- MAGETWO-93054 -->* Admin action logs now list changes to product quantity as expected.
+<!-- MAGETWO-93054  -->
+*  Admin action logs now list changes to product quantity as expected.
 
 ### Payment methods
 
-<!-- MAGETWO-93299 -->* Magento no longer throws an error when you try to add a new shipping address to an order placed with Braintree from the Admin.
+<!-- MAGETWO-93299  -->
+*  Magento no longer throws an error when you try to add a new shipping address to an order placed with Braintree from the Admin.
 
-<!-- MAGETWO-86712 -->* The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. *Fix submitted by [Jason Woods](https://github.com/driskell) in pull request [13133](https://github.com/magento/magento2/pull/13133)*.
+<!-- MAGETWO-86712  -->
+*  The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. *Fix submitted by [Jason Woods](https://github.com/driskell) in pull request [13133](https://github.com/magento/magento2/pull/13133)*.
 
 ### Reports
 
-<!-- MAGETWO-93729 -->* The scope selector for reports now works as expected. Previously, when a merchant set the scope to **All Websites** , the generated report showed  sales from only a subset of websites.
+<!-- MAGETWO-93729  -->
+*  The scope selector for reports now works as expected. Previously, when a merchant set the scope to **All Websites** , the generated report showed  sales from only a subset of websites.
 
-<!-- MAGETWO-93345 -->* The `.csv` export of Coupon reports now shows the correct total for  selected coupons. Previously, the total line in the `.csv` file showed the totals for all coupons in the selected time period, rather than just the selected coupons.
+<!-- MAGETWO-93345  -->
+*  The `.csv` export of Coupon reports now shows the correct total for  selected coupons. Previously, the total line in the `.csv` file showed the totals for all coupons in the selected time period, rather than just the selected coupons.
 
-<!-- MAGETWO-86650 -->* The `.csv` export of the Abandoned Cart report now contains information about all abandoned carts as expected. Previously, this `.csv` file contained  only the first 20 rows of the report.
+<!-- MAGETWO-86650  -->
+*  The `.csv` export of the Abandoned Cart report now contains information about all abandoned carts as expected. Previously, this `.csv` file contained  only the first 20 rows of the report.
 
-<!-- ENGCOM-2724 -->* The **Year-to-date** dropdown accessed from **Stores** > **Settings** > **Configuration** > **General** > **Reports** > **Dashboard** now displays a numerical list that ranges from 01 to 12 as expected. *Fix submitted by [teddysie](https://github.com/teddysie) in pull request [17383](https://github.com/magento/magento2/pull/17383)*. [GitHub-17289](https://github.com/magento/magento2/issues/17289)
+<!-- ENGCOM-2724  -->
+*  The **Year-to-date** dropdown accessed from **Stores** > **Settings** > **Configuration** > **General** > **Reports** > **Dashboard** now displays a numerical list that ranges from 01 to 12 as expected. *Fix submitted by [teddysie](https://github.com/teddysie) in pull request [17383](https://github.com/magento/magento2/pull/17383)*. [GitHub-17289](https://github.com/magento/magento2/issues/17289)
 
-<!-- MAGETWO- 73585-->* Wishlist reports are available on the Admin as expected.
+<!-- MAGETWO- 73585 -->
+*  Wishlist reports are available on the Admin as expected.
 
 ### Review
 
-<!-- ENGCOM-2720-->* Magento now displays a `404 page not found` error when a customer tries to navigate to a product review that is not accessible. Previously. Magento displayed a PHP error code. *Fix submitted by Ananth in pull request [15369](https://github.com/magento/magento2/pull/15369)*. [GitHub-13102](https://github.com/magento/magento2/issues/13102)
+<!-- ENGCOM-2720 -->
+*  Magento now displays a `404 page not found` error when a customer tries to navigate to a product review that is not accessible. Previously. Magento displayed a PHP error code. *Fix submitted by Ananth in pull request [15369](https://github.com/magento/magento2/pull/15369)*. [GitHub-13102](https://github.com/magento/magento2/issues/13102)
 
 ### Reward
 
-<!-- MAGETWO-93060 -->* Magento now throws a descriptive error as expected when using a negative value that contains an invalid minus symbol to update reward points on a customer account.
+<!-- MAGETWO-93060  -->
+*  Magento now throws a descriptive error as expected when using a negative value that contains an invalid minus symbol to update reward points on a customer account.
 
 ### Sales
 
-<!-- ENGCOM-2623 -->* The `Magento\Sales\Block\Adminhtml\Order\Totalbar` class and totalbar template files  have been deprecated.  These components were formerly included but never implemented in the invoice create and credit memo create layout files. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [16656](https://github.com/magento/magento2/pull/16656)*. [GitHub-16653](https://github.com/magento/magento2/issues/16653)
+<!-- ENGCOM-2623  -->
+*  The `Magento\Sales\Block\Adminhtml\Order\Totalbar` class and totalbar template files  have been deprecated.  These components were formerly included but never implemented in the invoice create and credit memo create layout files. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [16656](https://github.com/magento/magento2/pull/16656)*. [GitHub-16653](https://github.com/magento/magento2/issues/16653)
 
-<!-- MAGETWO-94291 -->* Magento now displays product price and shipping costs in the default currency that was configured for that  specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an Admin order are incorrect.
+<!-- MAGETWO-94291  -->
+*  Magento now displays product price and shipping costs in the default currency that was configured for that  specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an Admin order are incorrect.
 
-<!-- MAGETWO-94163 -->* Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
+<!-- MAGETWO-94163  -->
+*  Merchants can now successfully update product prices and currencies using **Admin** > **Stores** > **Settings** > **Configuration** > **Currency Setup**.
 
-<!-- MAGETWO-88858 -->* Admin orders are no longer restricted by a minimum order amount. Previously, Magento required this minimum for both Admin and storefront users.
+<!-- MAGETWO-88858  -->
+*  Admin orders are no longer restricted by a minimum order amount. Previously, Magento required this minimum for both Admin and storefront users.
 
 ### Sales rule
 
-<!-- MAGETWO-93209 -->* You can now use wildcard values in coupon codes.
+<!-- MAGETWO-93209  -->
+*  You can now use wildcard values in coupon codes.
 
 ### Search
 
-<!-- ENGCOM-2415 -->* JavaScript files are now located inside the `web/js` directory. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16582](https://github.com/magento/magento2/pull/16582)*. [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!-- ENGCOM-2415  -->
+*  JavaScript files are now located inside the `web/js` directory. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16582](https://github.com/magento/magento2/pull/16582)*. [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!-- MAGETWO-91063 -->* Search synonyms are now available for all search engines deployed in your Magento store. Previously, search synonyms did not appear in the Admin menu when Elasticsearch 5.0+ was deployed.
+<!-- MAGETWO-91063  -->
+*  Search synonyms are now available for all search engines deployed in your Magento store. Previously, search synonyms did not appear in the Admin menu when Elasticsearch 5.0+ was deployed.
 
-<!-- MAGETWO-92652 -->* Product attribute are now displayed as expected in layered navigation with Elasticsearch 5.0+.
+<!-- MAGETWO-92652  -->
+*  Product attribute are now displayed as expected in layered navigation with Elasticsearch 5.0+.
 
-<!-- MAGETWO-90497 -->* Elasticsearch now works as expected for Chinese locales.
+<!-- MAGETWO-90497  -->
+*  Elasticsearch now works as expected for Chinese locales.
 
 ### Shipping
 
-<!-- MAGETWO-86179 -->* Customers can now add a new address to an order during checkout of an order being shipped to multiple addresses.
+<!-- MAGETWO-86179  -->
+*  Customers can now add a new address to an order during checkout of an order being shipped to multiple addresses.
 
-<!-- ENGCOM-2704 -->* Multishipping checkout now works as expected. Previously, Magento displayed the `Shipping address is not set` error message  when checking out an order with multiple addresses. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [16753](https://github.com/magento/magento2/pull/16753)*. [GitHub-16555](https://github.com/magento/magento2/issues/16555)
+<!-- ENGCOM-2704  -->
+*  Multishipping checkout now works as expected. Previously, Magento displayed the `Shipping address is not set` error message  when checking out an order with multiple addresses. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [16753](https://github.com/magento/magento2/pull/16753)*. [GitHub-16555](https://github.com/magento/magento2/issues/16555)
 
-<!-- MAGETWO-94434 -->* The Magento UPS module has been updated to support new UPS API endpoints.
+<!-- MAGETWO-94434  -->
+*  The Magento UPS module has been updated to support new UPS API endpoints.
 
-<!-- MAGETWO-93810 -->* Customers can now view their completed order from the success page for orders that will be shipped to multiple addresses. Previously, when a customer took a link from the order success page to view their just-completed order, Magento displayed this error, **There has been an error processing your request**.
+<!-- MAGETWO-93810  -->
+*  Customers can now view their completed order from the success page for orders that will be shipped to multiple addresses. Previously, when a customer took a link from the order success page to view their just-completed order, Magento displayed this error, **There has been an error processing your request**.
 
-<!-- MAGETWO-92144 -->* The Shipment grid now displays the status of completed orders correctly. Previously, the Order Status column of the Shipment grid indicated that a completed order was being processed.
+<!-- MAGETWO-92144  -->
+*  The Shipment grid now displays the status of completed orders correctly. Previously, the Order Status column of the Shipment grid indicated that a completed order was being processed.
 
 #### Magento Shipping
 
-<!-- BUNDLE-1663 -->* Magento Shipping return merchandise authorization (RMA) can no longer be enabled when Magento Shipping is disabled.
+<!-- BUNDLE-1663  -->
+*  Magento Shipping return merchandise authorization (RMA) can no longer be enabled when Magento Shipping is disabled.
 
 ### Store
 
-<!--  ENGCOM-2530 -->* The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
+<!--  ENGCOM-2530  -->
+*  The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [16468](https://github.com/magento/magento2/pull/16468)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
 
 ### Swagger
 
-<!-- ENGCOM-2837, MAGETWO-93748 -->* Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the `swagger-ui-bundle.js` became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17626](https://github.com/magento/magento2/pull/17626)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
+<!-- ENGCOM-2837, MAGETWO-93748  -->
+*  Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the `swagger-ui-bundle.js` became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17626](https://github.com/magento/magento2/pull/17626)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
 
 ### Testing
 
-<!-- ENGCOM-2616 -->* The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17191](https://github.com/magento/magento2/pull/17191)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
+<!-- ENGCOM-2616  -->
+*  The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [17191](https://github.com/magento/magento2/pull/17191)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
 
-<!-- ENGCOM-2900 -->* Deprecated methods throughout the test suite have been replaced. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17872](https://github.com/magento/magento2/pull/17872)*.
+<!-- ENGCOM-2900  -->
+*  Deprecated methods throughout the test suite have been replaced. *Fix submitted by [Tiago Sampaio](https://github.com/tiagosampaio) in pull request [17872](https://github.com/magento/magento2/pull/17872)*.
 
-<!-- ENGCOM-2899 -->* An API functional test  for the `/V1/search` (searchV1) resource has been added. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17840](https://github.com/magento/magento2/pull/17840)*.
+<!-- ENGCOM-2899  -->
+*  An API functional test  for the `/V1/search` (searchV1) resource has been added. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17840](https://github.com/magento/magento2/pull/17840)*.
 
-<!-- ENGCOM-2907 -->* The `\Magento\Sales\Model\Validator` class is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17876](https://github.com/magento/magento2/pull/17876)*.
+<!-- ENGCOM-2907  -->
+*  The `\Magento\Sales\Model\Validator` class is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17876](https://github.com/magento/magento2/pull/17876)*.
 
-<!-- ENGCOM-2908 -->* The `\Magento\Search\Model\PopularSearchTerms` is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17739](https://github.com/magento/magento2/pull/17739)*.
+<!-- ENGCOM-2908  -->
+*  The `\Magento\Search\Model\PopularSearchTerms` is now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17739](https://github.com/magento/magento2/pull/17739)*.
 
-<!-- ENGCOM-2876 -->* The `\Magento\Search\Model\SynonymAnalyzer` class  is now covered by a unit test. *Fix submitted by [Zebra](https://github.com/furseyev) in pull request [17801](https://github.com/magento/magento2/pull/17801)*.
+<!-- ENGCOM-2876  -->
+*  The `\Magento\Search\Model\SynonymAnalyzer` class  is now covered by a unit test. *Fix submitted by [Zebra](https://github.com/furseyev) in pull request [17801](https://github.com/magento/magento2/pull/17801)*.
 
-<!-- ENGCOM-2843 -->* The Sales Rule model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17710](https://github.com/magento/magento2/pull/17710)*.
+<!-- ENGCOM-2843  -->
+*  The Sales Rule model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17710](https://github.com/magento/magento2/pull/17710)*.
 
-<!-- ENGCOM-2830 -->* The `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17693](https://github.com/magento/magento2/pull/17693)*.
+<!-- ENGCOM-2830  -->
+*  The `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17693](https://github.com/magento/magento2/pull/17693)*.
 
-<!-- ENGCOM-2823 -->* The CMS model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17678](https://github.com/magento/magento2/pull/17678)*.
+<!-- ENGCOM-2823  -->
+*  The CMS model classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17678](https://github.com/magento/magento2/pull/17678)*.
 
-<!-- ENGCOM-2807 -->* The `\Magento\Newsletter\Model\Problem` class is now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17633](https://github.com/magento/magento2/pull/17633)*.
+<!-- ENGCOM-2807  -->
+*  The `\Magento\Newsletter\Model\Problem` class is now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17633](https://github.com/magento/magento2/pull/17633)*.
 
-<!-- ENGCOM-2780 -->* The `\Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter` class is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17590](https://github.com/magento/magento2/pull/17590)*.
+<!-- ENGCOM-2780  -->
+*  The `\Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter` class is now covered by unit tests. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [17590](https://github.com/magento/magento2/pull/17590)*.
 
-<!-- ENGCOM-2772 -->* The `\Magento\Catalog\Test\Unit\Cron\AvailabilityCheckerTest ` and `\Magento\Catalog\Test\Unit\Cron\DeleteOutdatedPriceValuesTest` classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17561](https://github.com/magento/magento2/pull/17561)*.
+<!-- ENGCOM-2772  -->
+*  The `\Magento\Catalog\Test\Unit\Cron\AvailabilityCheckerTest ` and `\Magento\Catalog\Test\Unit\Cron\DeleteOutdatedPriceValuesTest` classes are now covered by unit tests. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17561](https://github.com/magento/magento2/pull/17561)*.
 
-<!-- ENGCOM-2715 -->* The `Magento\Braintree\Model\InstantPurchase\CreditCard\AvailabilityChecker` class is now covered by a unit test. [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17454](https://github.com/magento/magento2/pull/17454)*
+<!-- ENGCOM-2715  -->
+*  The `Magento\Braintree\Model\InstantPurchase\CreditCard\AvailabilityChecker` class is now covered by a unit test. [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17454](https://github.com/magento/magento2/pull/17454)*
 
-<!-- ENGCOM-2680 -->* The instant purchase PayPal token formatter is now covered by a unit test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17405](https://github.com/magento/magento2/pull/17405)*.
+<!-- ENGCOM-2680  -->
+*  The instant purchase PayPal token formatter is now covered by a unit test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17405](https://github.com/magento/magento2/pull/17405)*.
 
-<!-- ENGCOM-2657 -->* The `\Magento\Braintree\Gateway\Http\Client\TransactionVoid` and `\Magento\Braintree\Gateway\Http\Client\TransactionRefund` classes are now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17368](https://github.com/magento/magento2/pull/17368)*.
+<!-- ENGCOM-2657  -->
+*  The `\Magento\Braintree\Gateway\Http\Client\TransactionVoid` and `\Magento\Braintree\Gateway\Http\Client\TransactionRefund` classes are now covered by unit tests. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17368](https://github.com/magento/magento2/pull/17368)*.
 
-<!-- ENGCOM-2632 -->* The `\Magento\Catalog\CustomerData\CompareProducts` class is now covered by unit tests. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
+<!-- ENGCOM-2632  -->
+*  The `\Magento\Catalog\CustomerData\CompareProducts` class is now covered by unit tests. *Fix submitted by [Oleksandr Kravchuk](https://github.com/Yogeshks) in pull request [17250](https://github.com/magento/magento2/pull/17250)*.
 
-<!-- ENGCOM-2828 -->* `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by an integration test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17690](https://github.com/magento/magento2/pull/17690)*.
+<!-- ENGCOM-2828  -->
+*  `\Magento\Review\Observer\ProcessProductAfterDeleteEventObserver` is now covered by an integration test. *Fix submitted by [Yaroslav Rogoza](https://github.com/rogyar) in pull request [17690](https://github.com/magento/magento2/pull/17690)*.
 
 ### Translation
 
-<!-- ENGCOM-2863 -->* Errors in  `app/code/Magento/Sales/i18n/en_US.csv` have been corrected. *Fix submitted by [Jignesh Baldha](https://github.com/jignesh-baldha) in pull request [17735](https://github.com/magento/magento2/pull/17735)*.
+<!-- ENGCOM-2863  -->
+*  Errors in  `app/code/Magento/Sales/i18n/en_US.csv` have been corrected. *Fix submitted by [Jignesh Baldha](https://github.com/jignesh-baldha) in pull request [17735](https://github.com/magento/magento2/pull/17735)*.
 
-<!-- ENGCOM-2817 -->* `translate="title"`  has been added to Admin menus. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17521](https://github.com/magento/magento2/pull/17521)*.
+<!-- ENGCOM-2817  -->
+*  `translate="title"`  has been added to Admin menus. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17521](https://github.com/magento/magento2/pull/17521)*.
 
-<!-- ENGCOM-2799 -->* The custom attribute group name on customer and product pages can now be translated. *Fix submitted by [Grayson](https://github.com/GraysonChiang) in pull request [17602](https://github.com/magento/magento2/pull/17602)*.
+<!-- ENGCOM-2799  -->
+*  The custom attribute group name on customer and product pages can now be translated. *Fix submitted by [Grayson](https://github.com/GraysonChiang) in pull request [17602](https://github.com/magento/magento2/pull/17602)*.
 
-<!-- ENGCOM-2781 -->* Validation error messages can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17575](https://github.com/magento/magento2/pull/17575)*.
+<!-- ENGCOM-2781  -->
+*  Validation error messages can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [17575](https://github.com/magento/magento2/pull/17575)*.
 
-<!-- ENGCOM-2677 -->* Error messages in the shopping cart page can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [16777](https://github.com/magento/magento2/pull/16777)*.
+<!-- ENGCOM-2677  -->
+*  Error messages in the shopping cart page can now be translated. *Fix submitted by [Yogesh Suhagiya](https://github.com/Yogeshks) in pull request [16777](https://github.com/magento/magento2/pull/16777)*.
 
 ### UI
 
-<!-- ENGCOM-2812 -->* The JavaScript  validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified. *Fix submitted by Mark Shust in pull request [17652](https://github.com/magento/magento2/pull/17652)*. [GitHub-17648](https://github.com/magento/magento2/issues/17648)
+<!-- ENGCOM-2812  -->
+*  The JavaScript  validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified. *Fix submitted by Mark Shust in pull request [17652](https://github.com/magento/magento2/pull/17652)*. [GitHub-17648](https://github.com/magento/magento2/issues/17648)
 
-<!-- ENGCOM-2834 -->* The message list component message type now has a message type of `success`. Previously, this type was always `error` when the `parameters` property was specified. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17701](https://github.com/magento/magento2/pull/17701)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
+<!-- ENGCOM-2834  -->
+*  The message list component message type now has a message type of `success`. Previously, this type was always `error` when the `parameters` property was specified. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [17701](https://github.com/magento/magento2/pull/17701)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
 
-<!-- ENGCOM-2607 -->* The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17275](https://github.com/magento/magento2/pull/17275)*. [GitHub-17193](https://github.com/magento/magento2/issues/17193)
+<!-- ENGCOM-2607  -->
+*  The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [17275](https://github.com/magento/magento2/pull/17275)*. [GitHub-17193](https://github.com/magento/magento2/issues/17193)
 
 ### User
 
-<!-- MAGETWO-93003 -->* Magento no longer displays stores to which an administrator does not have access when the administrator creates a product and assigns it to a store view. Previously, an administrator with permissions set on one website only could view the **All Store Views** scope for a product.
+<!-- MAGETWO-93003  -->
+*  Magento no longer displays stores to which an administrator does not have access when the administrator creates a product and assigns it to a store view. Previously, an administrator with permissions set on one website only could view the **All Store Views** scope for a product.
 
 ### Wishlist
 
-<!-- MAGETWO-86609 -->*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+<!-- MAGETWO-86609  -->
+*   Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
-<!-- MAGETWO-74289 -->* Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
+<!-- MAGETWO-74289  -->
+*  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
 
-<!-- MAGETWO-89234 -->* Magento now displays a success message when a customer successfully updates a wishlist.
+<!-- MAGETWO-89234  -->
+*  Magento now displays a success message when a customer successfully updates a wishlist.
 
 ## Known issues
 
-<!-- BUNDLE-1731 -->* Magento  currently does not display the requested quote information when you select Get Quotes for an order from a storefront that supports collection point delivery.
+<!-- BUNDLE-1731  -->
+*  Magento  currently does not display the requested quote information when you select Get Quotes for an order from a storefront that supports collection point delivery.
 
-<!-- BUNDLE-1840 -->* The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
+<!-- BUNDLE-1840  -->
+*  The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
 
-<!-- BUNDLE-1835 -->*  Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
+<!-- BUNDLE-1835  -->
+*   Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
 
 <!-- not needed --  MAGETWO-93800 MAGETWO-94468 MAGETWO-94236 MAGETWO-94213 MAGETWO-94174 MAGETWO-94098 MAGETWO-93725 MAGETWO-93105 MAGETWO-92654 MAGETWO-92187 MAGETWO-92169 MAGETWO-91477 MAGETWO-91358 MAGETWO-91288 MAGETWO-89892 MAGETWO-89309 MAGETWO-88233 MAGETWO-86482 MAGETWO-85420 MAGETWO-82084 MAGETWO-73357 MAGETWO-72067 MAGETWO-71157 MAGETWO-95529 MAGETWO-95424 MAGETWO-94762 MAGETWO-94409 MAGETWO-94331 MAGETWO-94300 MAGETWO-94475 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
@@ -100,459 +100,658 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- MC-5926 -->* The `bin/magento setup:config:set --enable-syslog-logging=true|false` command now provides the functionality that Magento previously provided in .  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
+<!-- MC-5926  -->
+*  The `bin/magento setup:config:set --enable-syslog-logging=true|false` command now provides the functionality that Magento previously provided in .  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
 
-<!-- MAGETWO-83474 -->* The storefront now  uses HTTPS exclusively and the Admin  uses HTTP without resulting in excessive redirects.
+<!-- MAGETWO-83474  -->
+*  The storefront now  uses HTTPS exclusively and the Admin  uses HTTP without resulting in excessive redirects.
 
-<!-- ENGCOM-2958-->* Controllers with different route IDs and front names  no longer redirect users  to the dashboard when a user clicks on a menu link. *Fix submitted by [Laura Folco](https://github.com/lfolco) in pull request [18018](https://github.com/magento/magento2/pull/18018)*. [GitHub-7557](https://github.com/magento/magento2/issues/7557)
+<!-- ENGCOM-2958 -->
+*  Controllers with different route IDs and front names  no longer redirect users  to the dashboard when a user clicks on a menu link. *Fix submitted by [Laura Folco](https://github.com/lfolco) in pull request [18018](https://github.com/magento/magento2/pull/18018)*. [GitHub-7557](https://github.com/magento/magento2/issues/7557)
 
-<!-- ENGCOM-2723 -->* Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
+<!-- ENGCOM-2723  -->
+*  Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
 
-<!-- ENGCOM-3001 -->* The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by [Keyur Shah](https://github.com/keyurshah070) in pull request [17993](https://github.com/magento/magento2/pull/17993)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
+<!-- ENGCOM-3001  -->
+*  The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by [Keyur Shah](https://github.com/keyurshah070) in pull request [17993](https://github.com/magento/magento2/pull/17993)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
 
-<!-- ENGCOM-3104 -->* A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18389](https://github.com/magento/magento2/pull/18389)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
+<!-- ENGCOM-3104  -->
+*  A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18389](https://github.com/magento/magento2/pull/18389)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
 
-<!-- ENGCOM-3207 -->* The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18659](https://github.com/magento/magento2/pull/18659)*. [GitHub-12969](https://github.com/magento/magento2/issues/12969)
+<!-- ENGCOM-3207  -->
+*  The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18659](https://github.com/magento/magento2/pull/18659)*. [GitHub-12969](https://github.com/magento/magento2/issues/12969)
 
-<!-- MAGETWO-95411 -->* You can now install Magento without first creating an administrator account.
+<!-- MAGETWO-95411  -->
+*  You can now install Magento without first creating an administrator account.
 
-<!-- ENGCOM-3756-->* Magento now skips disabled modules  when compiling static content. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19989](https://github.com/magento/magento2/pull/19989)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
+<!-- ENGCOM-3756 -->
+*  Magento now skips disabled modules  when compiling static content. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19989](https://github.com/magento/magento2/pull/19989)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
 
-<!-- ENGCOM-3881 -->* The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, admin users were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20322](https://github.com/magento/magento2/pull/20322)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
+<!-- ENGCOM-3881  -->
+*  The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, admin users were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20322](https://github.com/magento/magento2/pull/20322)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
 
 ### Backend
 
-<!-- MAGETWO-96174 -->* The address form in the Admin order creation workflow has been refactored to improve performance.
+<!-- MAGETWO-96174  -->
+*  The address form in the Admin order creation workflow has been refactored to improve performance.
 
-<!-- ENGCOM-3777-->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19910](https://github.com/magento/magento2/pull/19910)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
+<!-- ENGCOM-3777 -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19910](https://github.com/magento/magento2/pull/19910)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
 
-<!-- ENGCOM-3868 -->* `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20284](https://github.com/magento/magento2/pull/20284)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
+<!-- ENGCOM-3868  -->
+*  `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20284](https://github.com/magento/magento2/pull/20284)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
 
 ### Bundle products
 
-<!-- MAGETWO-88810 -->* Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product.
+<!-- MAGETWO-88810  -->
+*  Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product.
 
-<!-- ENGCOM-2997 -->* Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by [Joseph Maxwell](https://github.com/JosephMaxwell) in pull request [15905](https://github.com/magento/magento2/pull/15905)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
+<!-- ENGCOM-2997  -->
+*  Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by [Joseph Maxwell](https://github.com/JosephMaxwell) in pull request [15905](https://github.com/magento/magento2/pull/15905)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
 
-<!-- ENGCOM-3275 -->* Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by [magently](https://github.com/magently) in pull request [17971](https://github.com/magento/magento2/pull/17971)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!-- ENGCOM-3275  -->
+*  Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by [magently](https://github.com/magently) in pull request [17971](https://github.com/magento/magento2/pull/17971)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!-- MAGETWO-90381 -->* Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
+<!-- MAGETWO-90381  -->
+*  Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
 
 ### CAPTCHA
 
-<!-- MAGETWO-93780 -->* CAPTCHA now appears as expected in the Log in popup window.
+<!-- MAGETWO-93780  -->
+*  CAPTCHA now appears as expected in the Log in popup window.
 
 ### Catalog
 
-<!-- ENGCOM-3392 -->* Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18743](https://github.com/magento/magento2/pull/18743)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
+<!-- ENGCOM-3392  -->
+*  Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18743](https://github.com/magento/magento2/pull/18743)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
 
-<!-- MAGETWO-69650 -->* Products no longer display discounted prices in the shopping cart unless discounts have been applied or special or tiered prices are in effect.
+<!-- MAGETWO-69650  -->
+*  Products no longer display discounted prices in the shopping cart unless discounts have been applied or special or tiered prices are in effect.
 
-<!-- MAGETWO-73140 -->* Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
+<!-- MAGETWO-73140  -->
+*  Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
 
-<!-- MAGETWO-96288 -->* You can now use REST to update category positions.
+<!-- MAGETWO-96288  -->
+*  You can now use REST to update category positions.
 
-<!-- MAGETWO-95556 -->* Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
+<!-- MAGETWO-95556  -->
+*  Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
 
-<!-- MAGETWO-95461 -->* You can now save products with at least one tier price.
+<!-- MAGETWO-95461  -->
+*  You can now save products with at least one tier price.
 
-<!-- MAGETWO-95122 -->* Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
+<!-- MAGETWO-95122  -->
+*  Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
 
-<!-- MAGETWO-73687 -->* Magento now retains across categories any value you set for the number of categories displayed per page.
+<!-- MAGETWO-73687  -->
+*  Magento now retains across categories any value you set for the number of categories displayed per page.
 
-<!-- MAGETWO-73449 -->* Changes to product images made under the All Stores scope now affect product images at the store-view level.
+<!-- MAGETWO-73449  -->
+*  Changes to product images made under the All Stores scope now affect product images at the store-view level.
 
-<!-- MAGETWO-93149 -->* You can now successfully change and save product order when you use a rule that implements a `contains` condition operator in Virtual Merchandiser. Previously, Magento did not save product position as expected.
+<!-- MAGETWO-93149  -->
+*  You can now successfully change and save product order when you use a rule that implements a `contains` condition operator in Virtual Merchandiser. Previously, Magento did not save product position as expected.
 
-<!-- MAGETWO-91070 -->* Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
+<!-- MAGETWO-91070  -->
+*  Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
 
-<!-- ENGCOM-4089 -->*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+<!-- ENGCOM-4089  -->
+*   Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
-<!-- MAGETWO-73342 -->* Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
+<!-- MAGETWO-73342  -->
+*  Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
 
-<!-- ENGCOM-2930 -->*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*   Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-2943 -->* You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
+<!-- ENGCOM-2943  -->
+*  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
 
-<!-- ENGCOM-3047 -->* `getStoreId()` now consistently returns `int`. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [18086](https://github.com/magento/magento2/pull/18086)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!-- ENGCOM-3047  -->
+*  `getStoreId()` now consistently returns `int`. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [18086](https://github.com/magento/magento2/pull/18086)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!-- ENGCOM-3097 -->* You can now set a Boolean attribute to `is_filterable`, which allows them to be included in layered navigation. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [17823](https://github.com/magento/magento2/pull/17823)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
+<!-- ENGCOM-3097  -->
+*  You can now set a Boolean attribute to `is_filterable`, which allows them to be included in layered navigation. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [17823](https://github.com/magento/magento2/pull/17823)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
 
-<!-- ENGCOM-3050 -->* If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
+<!-- ENGCOM-3050  -->
+*  If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
 Previously, when you reopened these categories, no checkboxes were checked.  *Fix submitted by [magently](https://github.com/magently) in pull request [18175](https://github.com/magento/magento2/pull/18175)*. [GitHub-17493](https://github.com/magento/magento2/issues/17493)
 
-<!-- ENGCOM-3133 -->* An incorrect return type in the `StockRegistryInterface` API has been corrected. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18427](https://github.com/magento/magento2/pull/18427)*. [GitHub-15085](https://github.com/magento/magento2/issues/15085)
+<!-- ENGCOM-3133  -->
+*  An incorrect return type in the `StockRegistryInterface` API has been corrected. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18427](https://github.com/magento/magento2/pull/18427)*. [GitHub-15085](https://github.com/magento/magento2/issues/15085)
 
-<!-- ENGCOM-3158 -->* Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by [Bartosz Kubicki](https://github.com/bartoszkubicki) in pull request [18196](https://github.com/magento/magento2/pull/18196)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
+<!-- ENGCOM-3158  -->
+*  Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by [Bartosz Kubicki](https://github.com/bartoszkubicki) in pull request [18196](https://github.com/magento/magento2/pull/18196)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
 
-<!-- ENGCOM-3171 -->* Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18552](https://github.com/magento/magento2/pull/18552)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
+<!-- ENGCOM-3171  -->
+*  Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18552](https://github.com/magento/magento2/pull/18552)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
 
-<!-- ENGCOM-3193 -->* When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
+<!-- ENGCOM-3193  -->
+*  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
-<!-- ENGCOM-3230 -->*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+<!-- ENGCOM-3230  -->
+*   `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
-<!-- ENGCOM-3254 -->* Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
+<!-- ENGCOM-3254  -->
+*  Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
 
-<!-- ENGCOM-3261 -->* The **order by price** option for product listings on category pages now works as expected. *Fix submitted by [Giel Berkers](https://github.com/kanduvisla) in pull request [18737](https://github.com/magento/magento2/pull/18737)*. [GitHub-18264](https://github.com/magento/magento2/issues/18264)
+<!-- ENGCOM-3261  -->
+*  The **order by price** option for product listings on category pages now works as expected. *Fix submitted by [Giel Berkers](https://github.com/kanduvisla) in pull request [18737](https://github.com/magento/magento2/pull/18737)*. [GitHub-18264](https://github.com/magento/magento2/issues/18264)
 
-<!-- ENGCOM-2930 -->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-3317 -->* Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
+<!-- ENGCOM-3317  -->
+*  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
-<!-- MAGETWO-93673 -->*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+<!-- MAGETWO-93673  -->
+*   You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
-<!-- MAGETWO-96258 -->*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+<!-- MAGETWO-96258  -->
+*   **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
-<!-- MAGETWO-96374 -->* In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
+<!-- MAGETWO-96374  -->
+*  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
 
-<!-- MAGETWO-90930 -->* Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
+<!-- MAGETWO-90930  -->
+*  Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
 
-<!-- ENGCOM-3312 -->* You can now insert multiple catalog product list widgets in a CMS page.
+<!-- ENGCOM-3312  -->
+*  You can now insert multiple catalog product list widgets in a CMS page.
 
-<!-- ENGCOM-3373 -->* Performance has improved for sessions where  customers browse many product pages. (This performance boost is a result of replacing the jQuery `localStorage` API  with native `localStorage` in `app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js` and  `app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage.js`.) *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [19014](https://github.com/magento/magento2/pull/19014)*. [GitHub-17813](https://github.com/magento/magento2/issues/17813)
+<!-- ENGCOM-3373  -->
+*  Performance has improved for sessions where  customers browse many product pages. (This performance boost is a result of replacing the jQuery `localStorage` API  with native `localStorage` in `app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js` and  `app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage.js`.) *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [19014](https://github.com/magento/magento2/pull/19014)*. [GitHub-17813](https://github.com/magento/magento2/issues/17813)
 
-<!-- ENGCOM-3790 -->* Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.
+<!-- ENGCOM-3790  -->
+*  Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.
 
-<!-- ENGCOM-3800 -->* Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
+<!-- ENGCOM-3800  -->
+*  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
 
-<!-- ENGCOM-4004 -->*  The `bin/magento catalog:images:resize` command now processes all specified images.
+<!-- ENGCOM-4004  -->
+*   The `bin/magento catalog:images:resize` command now processes all specified images.
 
-<!-- ENGCOM-4003 -->*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
+<!-- ENGCOM-4003  -->
+*   The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
 
-<!-- ENGCOM-3859 -->*  `getProductUrl` no longer returns the wrong URL when the current category has no products.
+<!-- ENGCOM-3859  -->
+*   `getProductUrl` no longer returns the wrong URL when the current category has no products.
 
-<!-- ENGCOM-3978 -->* Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
+<!-- ENGCOM-3978  -->
+*  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
 
-<!-- ENGCOM-3832 -->* Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value.
+<!-- ENGCOM-3832  -->
+*  Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value.
 
-<!-- ENGCOM-3826 -->* Deleting an image from **Admin** > **Catalog** > **Categories** now deletes the image as expected. Previously, the deleted image remained in `pub\media\catalog\category`. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20178](https://github.com/magento/magento2/pull/20178)*. [GitHub-16198](https://github.com/magento/magento2/issues/16198)
+<!-- ENGCOM-3826  -->
+*  Deleting an image from **Admin** > **Catalog** > **Categories** now deletes the image as expected. Previously, the deleted image remained in `pub\media\catalog\category`. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20178](https://github.com/magento/magento2/pull/20178)*. [GitHub-16198](https://github.com/magento/magento2/issues/16198)
 
-<!-- MAGETWO-95898 -->* Magento now successfully updates product quantities in the mini-shopping cart for a product that has **Qty Uses Decimals** and **Enable Qty Increments** are enabled. Previously, Magento did not update the product quantity, but displayed this error, `You can buy this product only in quantities of 1.1 at a time`.
+<!-- MAGETWO-95898  -->
+*  Magento now successfully updates product quantities in the mini-shopping cart for a product that has **Qty Uses Decimals** and **Enable Qty Increments** are enabled. Previously, Magento did not update the product quantity, but displayed this error, `You can buy this product only in quantities of 1.1 at a time`.
 
-<!-- MAGETWO-94988 -->* Product images on the storefront are now identical in size, width, height, and DPI to the  image as specified for upload in the Admin.
+<!-- MAGETWO-94988  -->
+*  Product images on the storefront are now identical in size, width, height, and DPI to the  image as specified for upload in the Admin.
 
 ### Catalog rule
 
-<!-- ENGCOM-3396 -->* Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English.
+<!-- ENGCOM-3396  -->
+*  Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English.
 
 ### Cart and checkout
 
-<!-- MAGETWO-95938 -->* Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
+<!-- MAGETWO-95938  -->
+*  Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
 
-<!-- MAGETWO-95846 -->* Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
+<!-- MAGETWO-95846  -->
+*  Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
 
-<!-- MAGETWO-95067 -->* Checkout information now persists after a cart update. Information previously entered by a customer during check out (such as shipping address) now persists after the customer updates their shopping cart. Previously, when a customer updated their shopping cart, all information previously entered during check out (such as shipping address) was deleted
+<!-- MAGETWO-95067  -->
+*  Checkout information now persists after a cart update. Information previously entered by a customer during check out (such as shipping address) now persists after the customer updates their shopping cart. Previously, when a customer updated their shopping cart, all information previously entered during check out (such as shipping address) was deleted
 
-<!-- MAGETWO-94425 -->* Magento now updates the minicart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
+<!-- MAGETWO-94425  -->
+*  Magento now updates the minicart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
 
-<!-- MAGETWO-91932 -->* Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
+<!-- MAGETWO-91932  -->
+*  Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
 
-<!-- MAGETWO-91138 -->* You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
+<!-- MAGETWO-91138  -->
+*  You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
-<!-- MAGETWO-90056 -->*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+<!-- MAGETWO-90056  -->
+*   Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
-<!-- MAGETWO-89397 -->* Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
+<!-- MAGETWO-89397  -->
+*  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
 
-<!-- MAGETWO-87971 -->* Magento  no  longer displays any Top destinations in the shopping cart's Country drop-down menu after a customer  removes unneeded destinations.
+<!-- MAGETWO-87971  -->
+*  Magento  no  longer displays any Top destinations in the shopping cart's Country drop-down menu after a customer  removes unneeded destinations.
 
-<!-- MAGETWO-87016 -->* Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
+<!-- MAGETWO-87016  -->
+*  Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
 
-<!-- MAGETWO-87016 -->* Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
+<!-- MAGETWO-87016  -->
+*  Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
 
-<!-- MAGETWO-72877 -->* Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
+<!-- MAGETWO-72877  -->
+*  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
-<!-- MAGETWO-62841 -->*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+<!-- MAGETWO-62841  -->
+*   Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
-<!-- MAGETWO-86477 -->* Magento now displays informative error messages when an order paid for with Authorize.Net fails.
+<!-- MAGETWO-86477  -->
+*  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
 
-<!-- ENGCOM-3649 -->* `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed.
+<!-- ENGCOM-3649  -->
+*  `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed.
 
-<!-- ENGCOM-3348 -->* You can now select a payment method during check for an order placed in a deployment where different payment methods are configured for different countries. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18908](https://github.com/magento/magento2/pull/18908)*. [GitHub-18907](https://github.com/magento/magento2/issues/18907)
+<!-- ENGCOM-3348  -->
+*  You can now select a payment method during check for an order placed in a deployment where different payment methods are configured for different countries. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18908](https://github.com/magento/magento2/pull/18908)*. [GitHub-18907](https://github.com/magento/magento2/issues/18907)
 
-<!-- ENGCOM-3315 -->* Custom shipping methods in custom carrier code can now include underscores.
+<!-- ENGCOM-3315  -->
+*  Custom shipping methods in custom carrier code can now include underscores.
 
-<!-- ENGCOM-3322 -->* The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!-- ENGCOM-3322  -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!-- ENGCOM-3088 -->* Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18369](https://github.com/magento/magento2/pull/18369)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
+<!-- ENGCOM-3088  -->
+*  Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18369](https://github.com/magento/magento2/pull/18369)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
 
-<!-- ENGCOM-3154 -->* One-step checkout now works as expected. Previously, Magento displayed this console error when you tried to complete an order using one-step checkout, `Uncaught TypeError: Cannot read property 'code' of undefined at UiClass.initialize (/en_US/Magento_Checkout/js/view/progress-bar.js:31:93)`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18495](https://github.com/magento/magento2/pull/18495)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
+<!-- ENGCOM-3154  -->
+*  One-step checkout now works as expected. Previously, Magento displayed this console error when you tried to complete an order using one-step checkout, `Uncaught TypeError: Cannot read property 'code' of undefined at UiClass.initialize (/en_US/Magento_Checkout/js/view/progress-bar.js:31:93)`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18495](https://github.com/magento/magento2/pull/18495)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
 
-<!-- ENGCOM-3251 -->* The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18597](https://github.com/magento/magento2/pull/18597)*.
+<!-- ENGCOM-3251  -->
+*  The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18597](https://github.com/magento/magento2/pull/18597)*.
 
-<!-- ENGCOM-3195 -->* Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
+<!-- ENGCOM-3195  -->
+*  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
-<!-- MAGETWO-86120 -->*  You can now add gift wrapping to the shopping cart to an already added product without having to add to additional product.
+<!-- MAGETWO-86120  -->
+*   You can now add gift wrapping to the shopping cart to an already added product without having to add to additional product.
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-3738 -->* Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`.
+<!-- ENGCOM-3738  -->
+*  Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`.
 
-<!-- ENGCOM-3766 -->* Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page.
+<!-- ENGCOM-3766  -->
+*  Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page.
 
-<!-- ENGCOM-3903 -->* Corrected alignment of the **Detailed Rating** field on the Edit Review page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20272](https://github.com/magento/magento2/pull/20272)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
+<!-- ENGCOM-3903  -->
+*  Corrected alignment of the **Detailed Rating** field on the Edit Review page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20272](https://github.com/magento/magento2/pull/20272)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
 
-<!-- ENGCOM-3540 -->* Corrected the logic in JavaScript for the **Add to cart** button  and `last-order-items.js`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19357](https://github.com/magento/magento2/pull/19357)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
+<!-- ENGCOM-3540  -->
+*  Corrected the logic in JavaScript for the **Add to cart** button  and `last-order-items.js`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19357](https://github.com/magento/magento2/pull/19357)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
 
-<!-- ENGCOM-4014 -->* Fixed misalignment of logo on the Admin home page. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20544](https://github.com/magento/magento2/pull/20544)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
+<!-- ENGCOM-4014  -->
+*  Fixed misalignment of logo on the Admin home page. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20544](https://github.com/magento/magento2/pull/20544)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
 
-<!-- ENGCOM-3933 -->* Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
+<!-- ENGCOM-3933  -->
+*  Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
-<!-- ENGCOM-3853 -->*  Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+<!-- ENGCOM-3853  -->
+*   Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
-<!-- ENGCOM-3895 -->*  Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+<!-- ENGCOM-3895  -->
+*   Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
-<!-- ENGCOM-3970 -->* The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
+<!-- ENGCOM-3970  -->
+*  The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
 
-<!-- ENGCOM-3322 -->* The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!-- ENGCOM-3322  -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!-- ENGCOM-3324 -->* Removed redundant asterix on **Admin** > **Catalog** > **Display Settings**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [18922](https://github.com/magento/magento2/pull/18922)*. [GitHub-18918](https://github.com/magento/magento2/issues/18918)
+<!-- ENGCOM-3324  -->
+*  Removed redundant asterix on **Admin** > **Catalog** > **Display Settings**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [18922](https://github.com/magento/magento2/pull/18922)*. [GitHub-18918](https://github.com/magento/magento2/issues/18918)
 
-<!-- ENGCOM-3327 -->* Corrected typo in  name of event (`catalogsearch_searchable_attributes_load_after`) dispatched by `Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::getSearchableAttributes`. *Fix submitted by [Neeta Kangiya](https://github.com/neeta-wagento) in pull request [18372](https://github.com/magento/magento2/pull/18372)*. [GitHub-18355](https://github.com/magento/magento2/issues/18355)
+<!-- ENGCOM-3327  -->
+*  Corrected typo in  name of event (`catalogsearch_searchable_attributes_load_after`) dispatched by `Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::getSearchableAttributes`. *Fix submitted by [Neeta Kangiya](https://github.com/neeta-wagento) in pull request [18372](https://github.com/magento/magento2/pull/18372)*. [GitHub-18355](https://github.com/magento/magento2/issues/18355)
 
-<!-- ENGCOM-3534 -->* Content in  confirmation popups on the Admin no longer overlap the **Close** button. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19340](https://github.com/magento/magento2/pull/19340)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
+<!-- ENGCOM-3534  -->
+*  Content in  confirmation popups on the Admin no longer overlap the **Close** button. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19340](https://github.com/magento/magento2/pull/19340)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
 
-<!-- ENGCOM-3527 -->* The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19023](https://github.com/magento/magento2/pull/19023)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
+<!-- ENGCOM-3527  -->
+*  The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19023](https://github.com/magento/magento2/pull/19023)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
 
-<!-- ENGCOM-3541 -->* Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19356](https://github.com/magento/magento2/pull/19356)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!-- ENGCOM-3541  -->
+*  Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19356](https://github.com/magento/magento2/pull/19356)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!-- ENGCOM-3618 -->* You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would  appear in the newsletter. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!-- ENGCOM-3618  -->
+*  You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would  appear in the newsletter. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!-- ENGCOM-3748 -->* Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
+<!-- ENGCOM-3748  -->
+*  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
-<!-- ENGCOM-4010 -->*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+<!-- ENGCOM-4010  -->
+*   Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
-<!-- ENGCOM-4040 -->*  Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+<!-- ENGCOM-4040  -->
+*   Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
-<!-- ENGCOM-4058 -->*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+<!-- ENGCOM-4058  -->
+*   Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
-<!-- ENGCOM-4090 -->*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+<!-- ENGCOM-4090  -->
+*   Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
-<!-- ENGCOM-3935 -->* Fixed checkbox alignment on the account information page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
+<!-- ENGCOM-3935  -->
+*  Fixed checkbox alignment on the account information page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
 
-<!-- ENGCOM-3882 -->* Corrected alignment of the store switcher in Tab view. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20325](https://github.com/magento/magento2/pull/20325)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
+<!-- ENGCOM-3882  -->
+*  Corrected alignment of the store switcher in Tab view. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20325](https://github.com/magento/magento2/pull/20325)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
 
-<!-- ENGCOM-3934 -->* Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20455](https://github.com/magento/magento2/pull/20455)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
+<!-- ENGCOM-3934  -->
+*  Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20455](https://github.com/magento/magento2/pull/20455)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
 
-<!-- ENGCOM-3185 -->* Fixed the misalignment of the calendar icon on the advanced pricing page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18593](https://github.com/magento/magento2/pull/18593)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
+<!-- ENGCOM-3185  -->
+*  Fixed the misalignment of the calendar icon on the advanced pricing page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18593](https://github.com/magento/magento2/pull/18593)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
 
-<!-- ENGCOM-3734 -->* Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
+<!-- ENGCOM-3734  -->
+*  Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
-<!-- ENGCOM-4017 -->*  Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+<!-- ENGCOM-4017  -->
+*   Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
 ### Configurable products
 
-<!-- ENGCOM-3554 -->* Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by [Oleksii Gorbulin](https://github.com/agorbulin) in pull request [19377](https://github.com/magento/magento2/pull/19377)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
+<!-- ENGCOM-3554  -->
+*  Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by [Oleksii Gorbulin](https://github.com/agorbulin) in pull request [19377](https://github.com/magento/magento2/pull/19377)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
 
-<!-- MAGETWO-89230 -->* You can now add a configurable product with no options  to a gift registry from a wishlist.
+<!-- MAGETWO-89230  -->
+*  You can now add a configurable product with no options  to a gift registry from a wishlist.
 
-<!-- ENGCOM-3135 -->* Magento no longer throws a fatal error when you try to save a configurable product with an SKU equal to or less than 64 digits. *Fix submitted by [Thiago](https://github.com/thiagolima-bm) in pull request [18461](https://github.com/magento/magento2/pull/18461)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!-- ENGCOM-3135  -->
+*  Magento no longer throws a fatal error when you try to save a configurable product with an SKU equal to or less than 64 digits. *Fix submitted by [Thiago](https://github.com/thiagolima-bm) in pull request [18461](https://github.com/magento/magento2/pull/18461)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
 ### CMS
 
-<!-- MAGETWO-94154 -->* Files and folders that are symlinked in `pub/media` can now be deleted from the media gallery browser. Previously, these symlinked files or folders inside of the `pub/media` directory could not be deleted because a validation check  uses `realpath` to test whether a file is outside of the media directory base path.
+<!-- MAGETWO-94154  -->
+*  Files and folders that are symlinked in `pub/media` can now be deleted from the media gallery browser. Previously, these symlinked files or folders inside of the `pub/media` directory could not be deleted because a validation check  uses `realpath` to test whether a file is outside of the media directory base path.
 
-<!-- MAGETWO-91122 -->* The WYSIWYG editor no longer arbitrarily removes `aria-role` attributes from  `div` in CMS pages or blocks.
+<!-- MAGETWO-91122  -->
+*  The WYSIWYG editor no longer arbitrarily removes `aria-role` attributes from  `div` in CMS pages or blocks.
 
 ### Customer
 
-<!-- MAGETWO-97151 -->* Order creation page in Admin was fixed and now works without any performance issues and slowdowns for customer accounts with 3000 addresses.
+<!-- MAGETWO-97151  -->
+*  Order creation page in Admin was fixed and now works without any performance issues and slowdowns for customer accounts with 3000 addresses.
 
-<!-- MAGETWO-95990 -->* Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
+<!-- MAGETWO-95990  -->
+*  Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
 
-<!-- MAGETWO-89847 -->* Customers can now be matched in customer segments based on the number of orders in a multi-site deployment
+<!-- MAGETWO-89847  -->
+*  Customers can now be matched in customer segments based on the number of orders in a multi-site deployment
 
-<!-- MAGETWO-87214 -->* When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
+<!-- MAGETWO-87214  -->
+*  When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
-<!-- MAGETWO-81818 -->*  Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
+<!-- MAGETWO-81818  -->
+*   Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
 
-<!-- ENGCOM-3052 -->* Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
+<!-- ENGCOM-3052  -->
+*  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
 
-<!-- ENGCOM-3107 -->* Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18414](https://github.com/magento/magento2/pull/18414)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
+<!-- ENGCOM-3107  -->
+*  Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18414](https://github.com/magento/magento2/pull/18414)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
 
-<!-- ENGCOM-3082 -->* Magento now saves customer custom attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [17968](https://github.com/magento/magento2/pull/17968)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
+<!-- ENGCOM-3082  -->
+*  Magento now saves customer custom attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [17968](https://github.com/magento/magento2/pull/17968)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
 
-<!-- MAGETWO-96079 -->* You can now successfully update your password from the link provided in the email sent when you click **Reset Password** on the Admin.  Previously, Magento did not update the password and displayed this message, `Something went wrong while saving the new password`.
+<!-- MAGETWO-96079  -->
+*  You can now successfully update your password from the link provided in the email sent when you click **Reset Password** on the Admin.  Previously, Magento did not update the password and displayed this message, `Something went wrong while saving the new password`.
 
-<!-- MAGETWO-87853 -->* You can now change payment methods after selecting store credit when creating an order from the Admin.
+<!-- MAGETWO-87853  -->
+*  You can now change payment methods after selecting store credit when creating an order from the Admin.
 
-<!-- ENGCOM-3812 -->* Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password.
+<!-- ENGCOM-3812  -->
+*  Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password.
 
-<!-- MAGETWO-93072 -->* Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
+<!-- MAGETWO-93072  -->
+*  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
-<!-- MAGETWO-74169 -->*  Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
+<!-- MAGETWO-74169  -->
+*   Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
 
 ### Customer custom attributes
 
-<!-- MAGETWO-89039 -->* Customer address attribute validation during checkout now permits spaces.
+<!-- MAGETWO-89039  -->
+*  Customer address attribute validation during checkout now permits spaces.
 
-<!-- MAGETWO-95059 -->* Merchants can now create attributes  for customer addresses (**Stores** > **Attributes** > **Customer Address**) as expected. Previously, a merchant could create an attribute, but Magento did not save or display it.
+<!-- MAGETWO-95059  -->
+*  Merchants can now create attributes  for customer addresses (**Stores** > **Attributes** > **Customer Address**) as expected. Previously, a merchant could create an attribute, but Magento did not save or display it.
 
-<!-- MAGETWO-86686 -->* Magento now adds the address entered during checkout to a new account when a custom address attribute is required when creating a user account after checkout.
+<!-- MAGETWO-86686  -->
+*  Magento now adds the address entered during checkout to a new account when a custom address attribute is required when creating a user account after checkout.
 
 ### Developer
 
-<!-- ENGCOM-2940 -->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!-- ENGCOM-2940  -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Directory
 
-<!-- ENGCOM-2747 -->* Australian country regions are now available from the drop-down menu that Magento displays during the checkout address population steps. *Fix submitted by [Maxim Baibakov](https://github.com/maximbaibakov) in pull request [17516](https://github.com/magento/magento2/pull/17516)*. [GitHub-17514](https://github.com/magento/magento2/issues/17514)
+<!-- ENGCOM-2747  -->
+*  Australian country regions are now available from the drop-down menu that Magento displays during the checkout address population steps. *Fix submitted by [Maxim Baibakov](https://github.com/maximbaibakov) in pull request [17516](https://github.com/magento/magento2/pull/17516)*. [GitHub-17514](https://github.com/magento/magento2/issues/17514)
 
 ### Downloadable
 
-<!-- ENGCOM-3385 -->* The order confirmation email sent to the customer during  guest checkout now includes download links for purchased downloadable products as expected. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19036](https://github.com/magento/magento2/pull/19036)*. [GitHub-10934](https://github.com/magento/magento2/issues/10934),
+<!-- ENGCOM-3385  -->
+*  The order confirmation email sent to the customer during  guest checkout now includes download links for purchased downloadable products as expected. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19036](https://github.com/magento/magento2/pull/19036)*. [GitHub-10934](https://github.com/magento/magento2/issues/10934),
  [GitHub-19003](https://github.com/magento/magento2/issues/19003),  [GitHub-18323](https://github.com/magento/magento2/issues/18323)
 
-<!-- ENGCOM-3584 -->* You can now delete a sample link from a downloadable product. Previously, Magento restored a deleted link after you saved the downloadable product. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [19431](https://github.com/magento/magento2/pull/19431)*. [GitHub-19344](https://github.com/magento/magento2/issues/19344)
+<!-- ENGCOM-3584  -->
+*  You can now delete a sample link from a downloadable product. Previously, Magento restored a deleted link after you saved the downloadable product. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [19431](https://github.com/magento/magento2/pull/19431)*. [GitHub-19344](https://github.com/magento/magento2/issues/19344)
 
 ### EAV
 
-<!-- ENGCOM-3128 -->* Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18390](https://github.com/magento/magento2/pull/18390)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
+<!-- ENGCOM-3128  -->
+*  Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18390](https://github.com/magento/magento2/pull/18390)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
 
-<!-- ENGCOM-3215 -->* Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532)
+<!-- ENGCOM-3215  -->
+*  Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532)
 
-<!-- ENGCOM-3732 -->* You can now retrieve the  product attribute value for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19911](https://github.com/magento/magento2/pull/19911)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
+<!-- ENGCOM-3732  -->
+*  You can now retrieve the  product attribute value for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19911](https://github.com/magento/magento2/pull/19911)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
 
 ### Email
 
-<!-- MAGETWO-95057 -->* The return path e-mail variable `system/smtp/return_path_email` now works as expected.
+<!-- MAGETWO-95057  -->
+*  The return path e-mail variable `system/smtp/return_path_email` now works as expected.
 
 ### Frameworks
 
-<!-- ENGCOM-3921 -->* Fixed icon behavior on product customization page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19400](https://github.com/magento/magento2/pull/19400)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
+<!-- ENGCOM-3921  -->
+*  Fixed icon behavior on product customization page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19400](https://github.com/magento/magento2/pull/19400)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
 
-<!-- ENGCOM-3740 -->* Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19927](https://github.com/magento/magento2/pull/19927)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
+<!-- ENGCOM-3740  -->
+*  Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19927](https://github.com/magento/magento2/pull/19927)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
 
-<!-- ENGCOM-3359 -->* Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [18985](https://github.com/magento/magento2/pull/18985)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
+<!-- ENGCOM-3359  -->
+*  Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [18985](https://github.com/magento/magento2/pull/18985)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
 
-<!-- ENGCOM-2942 -->* The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18002](https://github.com/magento/magento2/pull/18002)*. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
+<!-- ENGCOM-2942  -->
+*  The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18002](https://github.com/magento/magento2/pull/18002)*. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
 
-<!-- ENGCOM-3172 -->* Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18554](https://github.com/magento/magento2/pull/18554)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
+<!-- ENGCOM-3172  -->
+*  Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18554](https://github.com/magento/magento2/pull/18554)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
 
-<!-- MAGETWO-87297 -->* Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
+<!-- MAGETWO-87297  -->
+*  Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
 
-<!-- MAGETWO-95779 -->* Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
+<!-- MAGETWO-95779  -->
+*  Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
 
-<!-- MAGETWO-93183 -->* You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
+<!-- MAGETWO-93183  -->
+*  You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
 
-<!-- ENGCOM-3528 -->* Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded.
+<!-- ENGCOM-3528  -->
+*  Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded.
 
-<!-- ENGCOM-3568 -->* Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
+<!-- ENGCOM-3568  -->
+*  Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
 
-<!-- ENGCOM-3479 -->*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+<!-- ENGCOM-3479  -->
+*   Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
-<!-- ENGCOM-3424 -->* The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
+<!-- ENGCOM-3424  -->
+*  The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
 
 #### Cache framework
 
-<!-- MAGETWO-73528 -->* Problems with cache-cleaning for product pages for simple  products associated with configurable products  have been resolved. and as a result, product pages now now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
+<!-- MAGETWO-73528  -->
+*  Problems with cache-cleaning for product pages for simple  products associated with configurable products  have been resolved. and as a result, product pages now now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
 
-<!-- MAGETWO-69766 -->* The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
+<!-- MAGETWO-69766  -->
+*  The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
 
 ### General
 
-<!-- MAGETWO-89377 -->* You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
+<!-- MAGETWO-89377  -->
+*  You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
 
-<!-- ENGCOM-3507 -->* Resolved issues with pager style. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19296](https://github.com/magento/magento2/pull/19296)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
+<!-- ENGCOM-3507  -->
+*  Resolved issues with pager style. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19296](https://github.com/magento/magento2/pull/19296)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
 
-<!-- ENGCOM-3301 -->* Removed use of `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18886](https://github.com/magento/magento2/pull/18886)*. [GitHub-18779](https://github.com/magento/magento2/issues/18779)
+<!-- ENGCOM-3301  -->
+*  Removed use of `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18886](https://github.com/magento/magento2/pull/18886)*. [GitHub-18779](https://github.com/magento/magento2/issues/18779)
 
-<!-- ENGCOM-2937 -->* Merchants can now change the currency symbol back to its default value from the Admin in Single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by [magently](https://github.com/magently) in pull request [17966](https://github.com/magento/magento2/pull/17966)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
+<!-- ENGCOM-2937  -->
+*  Merchants can now change the currency symbol back to its default value from the Admin in Single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by [magently](https://github.com/magently) in pull request [17966](https://github.com/magento/magento2/pull/17966)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
 
-<!-- ENGCOM-2938 -->* The menu on category pages accessed from the Admin now work as expected when you change from mobile to desktop view. *Fix submitted by [Emanuel Arcos](https://github.com/emanuelarcos) in pull request [17990](https://github.com/magento/magento2/pull/17990)*. [GitHub-5402](https://github.com/magento/magento2/issues/5402)
+<!-- ENGCOM-2938  -->
+*  The menu on category pages accessed from the Admin now work as expected when you change from mobile to desktop view. *Fix submitted by [Emanuel Arcos](https://github.com/emanuelarcos) in pull request [17990](https://github.com/magento/magento2/pull/17990)*. [GitHub-5402](https://github.com/magento/magento2/issues/5402)
 
-<!-- ENGCOM-3054 -->* The WYSIWYG editor now correctly parses directives of files that contain special characters in their URLs. Previously, the editor did not decode base64 special chars. *Fix submitted by [adammada](https://github.com/adammada) in pull request [18215](https://github.com/magento/magento2/pull/18215)*. [GitHub-18138](https://github.com/magento/magento2/issues/18138)
+<!-- ENGCOM-3054  -->
+*  The WYSIWYG editor now correctly parses directives of files that contain special characters in their URLs. Previously, the editor did not decode base64 special chars. *Fix submitted by [adammada](https://github.com/adammada) in pull request [18215](https://github.com/magento/magento2/pull/18215)*. [GitHub-18138](https://github.com/magento/magento2/issues/18138)
 
-<!-- ENGCOM-3200 -->* Navigation arrows in the fotorama zoom now work as expected. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18595](https://github.com/magento/magento2/pull/18595)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
+<!-- ENGCOM-3200  -->
+*  Navigation arrows in the fotorama zoom now work as expected. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18595](https://github.com/magento/magento2/pull/18595)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
 
-<!-- ENGCOM-3311 -->* You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18875](https://github.com/magento/magento2/pull/18875)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
+<!-- ENGCOM-3311  -->
+*  You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18875](https://github.com/magento/magento2/pull/18875)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
 
-<!-- MAGETWO-87734 -->* You can now pause product videos on YouTube on storefronts that are running on Internet Explorer 11.x.
+<!-- MAGETWO-87734  -->
+*  You can now pause product videos on YouTube on storefronts that are running on Internet Explorer 11.x.
 
-<!-- MAGETWO-90189 -->* You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
+<!-- MAGETWO-90189  -->
+*  You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
 
-<!-- MAGETWO-85932 -->* Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
+<!-- MAGETWO-85932  -->
+*  Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
 
-<!-- MAGETWO-86549 -->* After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the minicart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
+<!-- MAGETWO-86549  -->
+*  After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the minicart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
 
-<!-- MAGETWO-94423 -->* You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
+<!-- MAGETWO-94423  -->
+*  You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
 
-<!-- MAGETWO-89487 -->* Fixed  error message overlapping on the  **Quick Search Form Types** field on **Admin** > **Content** > **Elements** > **Widgets** > **Add Widget**.
+<!-- MAGETWO-89487  -->
+*  Fixed  error message overlapping on the  **Quick Search Form Types** field on **Admin** > **Content** > **Elements** > **Widgets** > **Add Widget**.
 
-<!-- MAGETWO-89438 -->* Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
+<!-- MAGETWO-89438  -->
+*  Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
 
 ### Gift card
 
-<!-- MAGETWO-90920 -->* Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
+<!-- MAGETWO-90920  -->
+*  Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
 
-<!-- MAGETWO-87985 -->* Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
+<!-- MAGETWO-87985  -->
+*  Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
 
 ### Gift registry
 
-<!-- MAGETWO-95738 -->* Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
+<!-- MAGETWO-95738  -->
+*  Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
 
-<!-- MAGETWO-73447 -->* You can now successfully preview a Registry Update email template. Previously, Magento threw a fatal error when you tried to preview this template.
+<!-- MAGETWO-73447  -->
+*  You can now successfully preview a Registry Update email template. Previously, Magento threw a fatal error when you tried to preview this template.
 
 ### Google Analytics
 
-<!-- ENGCOM-3091 -->* Google Analytics JavaScript is now loaded correctly on the frontend. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18375](https://github.com/magento/magento2/pull/18375)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
+<!-- ENGCOM-3091  -->
+*  Google Analytics JavaScript is now loaded correctly on the frontend. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18375](https://github.com/magento/magento2/pull/18375)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
 
-<!-- ENGCOM-2271 -->* You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by [Sunil](https://github.com/sunilit42) in pull request [15366](https://github.com/magento/magento2/pull/15366)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
+<!-- ENGCOM-2271  -->
+*  You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by [Sunil](https://github.com/sunilit42) in pull request [15366](https://github.com/magento/magento2/pull/15366)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
 
 ### Image
 
-<!-- MAGETWO-93985 -->* Magnifier now works as expected on any supported operating system and browser. Previously, Magnifier did not hover correctly on devices running Windows Chrome or FireFox.
+<!-- MAGETWO-93985  -->
+*  Magnifier now works as expected on any supported operating system and browser. Previously, Magnifier did not hover correctly on devices running Windows Chrome or FireFox.
 
-<!-- MAGETWO-94235 -->* Images added to a product attribute using the WYSIWYG editor now display as expected on the storefront. Previously, the URL for these images included the Admin CMS directive path in their URL.
+<!-- MAGETWO-94235  -->
+*  Images added to a product attribute using the WYSIWYG editor now display as expected on the storefront. Previously, the URL for these images included the Admin CMS directive path in their URL.
 
 ### Import/export
 
-<!-- ENGCOM-3877 -->* We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.
+<!-- ENGCOM-3877  -->
+*  We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.
 
-<!-- ENGCOM-3827 -->* Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20177](https://github.com/magento/magento2/pull/20177)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
+<!-- ENGCOM-3827  -->
+*  Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20177](https://github.com/magento/magento2/pull/20177)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
 
-<!-- ENGCOM-2930 -->* Magento now correctly displays all linked products in the correct order in the Admin tables. Previously, Magento displayed all products correctly on the storefront, but products were missing from the Admin display. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*  Magento now correctly displays all linked products in the correct order in the Admin tables. Previously, Magento displayed all products correctly on the storefront, but products were missing from the Admin display. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-2916 -->* Magento does not change or overwrite  `url_key` values when updating product data during import if no values are provided in the import data.  *Fix submitted by [Joseph McDermott](https://github.com/josephmcdermott) in pull request [17882](https://github.com/magento/magento2/pull/17882)*. [GitHub-17023](https://github.com/magento/magento2/issues/17023)
+<!-- ENGCOM-2916  -->
+*  Magento does not change or overwrite  `url_key` values when updating product data during import if no values are provided in the import data.  *Fix submitted by [Joseph McDermott](https://github.com/josephmcdermott) in pull request [17882](https://github.com/magento/magento2/pull/17882)*. [GitHub-17023](https://github.com/magento/magento2/issues/17023)
 
-<!-- ENGCOM-3321 -->* Magento now displays an error message after you run check data when importing new products with SKUs that exceed the maximum permitted length. *Fix submitted by [Ravi Chandra](https://github.com/ravi-chandra3197) in pull request [18591](https://github.com/magento/magento2/pull/18591)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
+<!-- ENGCOM-3321  -->
+*  Magento now displays an error message after you run check data when importing new products with SKUs that exceed the maximum permitted length. *Fix submitted by [Ravi Chandra](https://github.com/ravi-chandra3197) in pull request [18591](https://github.com/magento/magento2/pull/18591)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
 
-<!-- MAGETWO-93222 -->* Magento no longer deletes  `url-key` values for existing products when updating these products with imported data that does not contain `url-key` values.
+<!-- MAGETWO-93222  -->
+*  Magento no longer deletes  `url-key` values for existing products when updating these products with imported data that does not contain `url-key` values.
 
-<!-- MAGETWO-86048 -->* Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
+<!-- MAGETWO-86048  -->
+*  Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
 
-<!-- MAGETWO-73922 -->* You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
+<!-- MAGETWO-73922  -->
+*  You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
 
-<!-- MAGETWO-95101 -->* URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
+<!-- MAGETWO-95101  -->
+*  URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
 
-<!-- MAGETWO-94432 -->* You can now hide an image as expected by using the `hide_from_product_page` attribute during import.
+<!-- MAGETWO-94432  -->
+*  You can now hide an image as expected by using the `hide_from_product_page` attribute during import.
 
-<!-- MAGETWO-91283 -->* Import now completes successfully when a product’s CSV entry is split over two import bunches.  Previously, Magento threw this error, `Cannot add or update a child row: a foreign key constraint fails`, and import failed.
+<!-- MAGETWO-91283  -->
+*  Import now completes successfully when a product’s CSV entry is split over two import bunches.  Previously, Magento threw this error, `Cannot add or update a child row: a foreign key constraint fails`, and import failed.
 
-<!-- MAGETWO-95653 -->* Magento now retains product order within a category after import.
+<!-- MAGETWO-95653  -->
+*  Magento now retains product order within a category after import.
 
-<!-- MAGETWO-74012 -->* You can now provide your own sample data file for a custom module in `your_module/Files/Sample/your_sample.csv`. Previously, this custom sample file had to be placed in the ImportExport module. [GitHub-6553](https://github.com/magento/magento2/issues/6553)
+<!-- MAGETWO-74012  -->
+*  You can now provide your own sample data file for a custom module in `your_module/Files/Sample/your_sample.csv`. Previously, this custom sample file had to be placed in the ImportExport module. [GitHub-6553](https://github.com/magento/magento2/issues/6553)
 
-<!-- MAGETWO-95535 -->* Imported images of all sizes no longer revert to the default placeholder size after import.
+<!-- MAGETWO-95535  -->
+*  Imported images of all sizes no longer revert to the default placeholder size after import.
 
-<!-- MAGETWO-95535 -->* Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
+<!-- MAGETWO-95535  -->
+*  Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
 
-<!-- ENGCOM-4075 -->*  The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+<!-- ENGCOM-4075  -->
+*   The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
-<!-- MAGETWO-74044 -->* The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
+<!-- MAGETWO-74044  -->
+*  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
 
-<!-- MAGETWO-94072 -->* Configurable products based on swatches are now exported with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
+<!-- MAGETWO-94072  -->
+*  Configurable products based on swatches are now exported with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
 
 ### Infrastructure
 
-<!-- ENGCOM-3025 -->* Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!-- ENGCOM-3025  -->
+*  Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Integration
 
-<!-- ENGCOM-3102 -->* The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by [Prakash](https://github.com/prakashpatel07) in pull request [17978](https://github.com/magento/magento2/pull/17978)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
+<!-- ENGCOM-3102  -->
+*  The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by [Prakash](https://github.com/prakashpatel07) in pull request [17978](https://github.com/magento/magento2/pull/17978)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
 
 ### Layered navigation
 
-<!-- ENGCOM-3388 -->* The code comment that describes the `Use in Layered Navigation: Filterable (no results)` property for the price filter has been made more informative. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19044](https://github.com/magento/magento2/pull/19044)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!-- ENGCOM-3388  -->
+*  The code comment that describes the `Use in Layered Navigation: Filterable (no results)` property for the price filter has been made more informative. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19044](https://github.com/magento/magento2/pull/19044)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
 <!-- MAGETWO-97000 -->
 *  Layered navigation for Elasticsearch now includes all product sizes. If the **Filterable (with results)** option is set for a product attribute, then:
@@ -563,7 +762,8 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 
    *  Attribute values with a count of zero (0) product matches are omitted from the list of available filters.
 
-<!-- MAGETWO-85162 -->* You can now filter products based on color.
+<!-- MAGETWO-85162  -->
+*  You can now filter products based on color.
 
 ### Magento Shipping
 
@@ -573,285 +773,400 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 
 ### Newsletter
 
-<!-- ENGCOM-3253 -->* Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [18643](https://github.com/magento/magento2/pull/18643)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
+<!-- ENGCOM-3253  -->
+*  Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [18643](https://github.com/magento/magento2/pull/18643)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
 
-<!-- MAGETWO-88736 -->* Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
+<!-- MAGETWO-88736  -->
+*  Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
 
-<!-- MAGETWO-82530 -->* Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
+<!-- MAGETWO-82530  -->
+*  Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
 
-<!-- ENGCOM-3680 -->*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+<!-- ENGCOM-3680  -->
+*   A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
 ### Offline shipping
 
-<!-- ENGCOM-3079 -->*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+<!-- ENGCOM-3079  -->
+*   Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
-<!-- ENGCOM-3057 -->* The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
+<!-- ENGCOM-3057  -->
+*  The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
 
 ### Payment methods
 
-<!-- MAGETWO-93750 -->* Customers are now billed in the appropriate currency for orders that have been paid with using PayPal Payflow Pro. Previously, customers were billed in U.S. dollars even when another currency has been set.
+<!-- MAGETWO-93750  -->
+*  Customers are now billed in the appropriate currency for orders that have been paid with using PayPal Payflow Pro. Previously, customers were billed in U.S. dollars even when another currency has been set.
 
-<!-- MAGETWO-94260 -->* Magento now displays the correct billing address in the order confirmation email when  **Paypal Express Checkout** is enabled. Previously, Magento displayed the shipping address instead of the billing address.
+<!-- MAGETWO-94260  -->
+*  Magento now displays the correct billing address in the order confirmation email when  **Paypal Express Checkout** is enabled. Previously, Magento displayed the shipping address instead of the billing address.
 
-<!-- MAGETWO-96587 -->* When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
+<!-- MAGETWO-96587  -->
+*  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
 
-<!-- ENGCOM-3997 -->*  Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+<!-- ENGCOM-3997  -->
+*   Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
-<!-- ENGCOM-3691 -->*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+<!-- ENGCOM-3691  -->
+*   Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
-<!-- ENGCOM-3316 -->* Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
+<!-- ENGCOM-3316  -->
+*  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
 
-<!-- ENGCOM-2629 -->* You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by [Michiel Gerritsen](https://github.com/michielgerritsen) in pull request [15683](https://github.com/magento/magento2/pull/15683)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
+<!-- ENGCOM-2629  -->
+*  You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by [Michiel Gerritsen](https://github.com/michielgerritsen) in pull request [15683](https://github.com/magento/magento2/pull/15683)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
 
-<!-- MAGETWO-96289 -->* A popup no longer blocks completion of check out using Braintree PayPal on a mobile device.
+<!-- MAGETWO-96289  -->
+*  A popup no longer blocks completion of check out using Braintree PayPal on a mobile device.
 
-<!-- MAGETWO-90929 -->* Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
+<!-- MAGETWO-90929  -->
+*  Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
 
-<!-- MAGETWO-94857 -->*  Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
+<!-- MAGETWO-94857  -->
+*   Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
 
-<!-- MAGETWO-95218 -->* When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
+<!-- MAGETWO-95218  -->
+*  When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
 
 ### Pricing
 
-<!-- MAGETWO-95721 -->* Sorting by price now works as expected. Previously, when a merchant removed a special price or a simple product, the `final_price`, `min_price` and `max_price` attributes of the `catalog_product_index_price` table was changed to 0.0000 instead of reverting back to the original price.
+<!-- MAGETWO-95721  -->
+*  Sorting by price now works as expected. Previously, when a merchant removed a special price or a simple product, the `final_price`, `min_price` and `max_price` attributes of the `catalog_product_index_price` table was changed to 0.0000 instead of reverting back to the original price.
 
 ### Quote
 
-<!-- MAGETWO-91332 -->* You can now request a quote on a storefront running on iOS 11.3.1.
+<!-- MAGETWO-91332  -->
+*  You can now request a quote on a storefront running on iOS 11.3.1.
 
-<!-- MAGETWO-95180 -->* Merchants can now create new user roles that do not have  access to quotes.
+<!-- MAGETWO-95180  -->
+*  Merchants can now create new user roles that do not have  access to quotes.
 
-<!-- ENGCOM-3314 -->* You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18872](https://github.com/magento/magento2/pull/18872)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
+<!-- ENGCOM-3314  -->
+*  You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18872](https://github.com/magento/magento2/pull/18872)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
 
-<!-- ENGCOM-3839 -->* You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20208](https://github.com/magento/magento2/pull/20208)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
+<!-- ENGCOM-3839  -->
+*  You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20208](https://github.com/magento/magento2/pull/20208)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
 
-<!-- ENGCOM-3975 -->* We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20638](https://github.com/magento/magento2/pull/20638)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
+<!-- ENGCOM-3975  -->
+*  We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20638](https://github.com/magento/magento2/pull/20638)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
 
 ### Reports
 
-<!-- MAGETWO-90727 -->* Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
+<!-- MAGETWO-90727  -->
+*  Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
 
 ### Review
 
-<!-- ENGCOM-3833 -->* Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20183](https://github.com/magento/magento2/pull/20183)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
+<!-- ENGCOM-3833  -->
+*  Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20183](https://github.com/magento/magento2/pull/20183)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
 
-<!-- MAGETWO-93988 -->* The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
+<!-- MAGETWO-93988  -->
+*  The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
 
 ### Reward
 
-<!-- MAGETWO-89737 -->* Customers are now subscribed as expected to email notifications about reward points.
+<!-- MAGETWO-89737  -->
+*  Customers are now subscribed as expected to email notifications about reward points.
 
-<!-- MAGETWO-88674 -->* `/V1/orders/{id}` now retrieves information about used reward points.
+<!-- MAGETWO-88674  -->
+*  `/V1/orders/{id}` now retrieves information about used reward points.
 
 ### RMA
 
-<!-- MAGETWO-96664 -->* Magento now displays newly created RMA attributes on the storefront when the **Enable RMA on Storefront** RMA attribute is enabled.
+<!-- MAGETWO-96664  -->
+*  Magento now displays newly created RMA attributes on the storefront when the **Enable RMA on Storefront** RMA attribute is enabled.
 
-<!-- MAGETWO-94019 -->* The **Show/Hide** details button now works as expected on the Returns (RMA) page.
+<!-- MAGETWO-94019  -->
+*  The **Show/Hide** details button now works as expected on the Returns (RMA) page.
 
-<!-- MAGETWO-94232 -->* Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
+<!-- MAGETWO-94232  -->
+*  Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
 
-<!-- MAGETWO-72953 -->* Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
+<!-- MAGETWO-72953  -->
+*  Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
 
-<!-- MAGETWO-97009 -->* Administrators can now process returns when an RMA request includes a required image attribute.
+<!-- MAGETWO-97009  -->
+*  Administrators can now process returns when an RMA request includes a required image attribute.
 
 ### Sales
 
-<!-- ENGCOM-1429 -->*  The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+<!-- ENGCOM-1429  -->
+*   The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
-<!-- MAGETWO-93155 -->* You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
+<!-- MAGETWO-93155  -->
+*  You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
 
-<!-- ENGCOM-3791 -->* Fixed an incorrect class name on orders and returns pages on the Admin. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20080](https://github.com/magento/magento2/pull/20080)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
+<!-- ENGCOM-3791  -->
+*  Fixed an incorrect class name on orders and returns pages on the Admin. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20080](https://github.com/magento/magento2/pull/20080)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
 
-<!-- ENGCOM-3494 -->* The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by [Ian cassidy](https://github.com/iancassidyweb) in pull request [18621](https://github.com/magento/magento2/pull/18621)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
+<!-- ENGCOM-3494  -->
+*  The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by [Ian cassidy](https://github.com/iancassidyweb) in pull request [18621](https://github.com/magento/magento2/pull/18621)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
 
-<!-- ENGCOM-2940 -->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [MateuszChrapek](https://github.com/MateuszChrapek) in pull request [17998](https://github.com/magento/magento2/pull/17998)*. [GitHub-9830](https://github.com/magento/magento2/issues/9830) [GitHub-10530](https://github.com/magento/magento2/issues/10530)
+<!-- ENGCOM-2940  -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [MateuszChrapek](https://github.com/MateuszChrapek) in pull request [17998](https://github.com/magento/magento2/pull/17998)*. [GitHub-9830](https://github.com/magento/magento2/issues/9830) [GitHub-10530](https://github.com/magento/magento2/issues/10530)
 
-<!-- ENGCOM-3092 -->* Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18376](https://github.com/magento/magento2/pull/18376)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
+<!-- ENGCOM-3092  -->
+*  Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18376](https://github.com/magento/magento2/pull/18376)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
 
-<!-- MAGETWO-96976 -->* Magento no longer adds gift wrap tax to the credit memo twice.
+<!-- MAGETWO-96976  -->
+*  Magento no longer adds gift wrap tax to the credit memo twice.
 
-<!-- MAGETWO-94295 -->* The **State/province** field that Magento displays for Admin orders that will be shipped to the U.S. is now a drop-down as expected. Previously, the **state/province** field  was not a drop-down menu with states but a text field.
+<!-- MAGETWO-94295  -->
+*  The **State/province** field that Magento displays for Admin orders that will be shipped to the U.S. is now a drop-down as expected. Previously, the **state/province** field  was not a drop-down menu with states but a text field.
 
-<!-- MAGETWO-94181 -->* You can now issue a partial refund to store credit for an order made with an online payment method.
+<!-- MAGETWO-94181  -->
+*  You can now issue a partial refund to store credit for an order made with an online payment method.
 
-<!-- MAGETWO-73570 -->* Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
+<!-- MAGETWO-73570  -->
+*  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
-<!-- MAGETWO-93393 -->*  Magento now uses  the correct table rate shipment when  a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
+<!-- MAGETWO-93393  -->
+*   Magento now uses  the correct table rate shipment when  a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
 
-<!-- MAGETWO-94458 -->* You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
+<!-- MAGETWO-94458  -->
+*  You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
 
-<!-- MAGETWO-86292 -->* You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
+<!-- MAGETWO-86292  -->
+*  You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
 
-<!-- MAGETWO-73039 -->* Orders exported to a CSV file now display dates in a consistent format.
+<!-- MAGETWO-73039  -->
+*  Orders exported to a CSV file now display dates in a consistent format.
 
-<!-- MAGETWO-86121 -->* Merchants can now ship the remaining items in an order in which some items require a credit memo.
+<!-- MAGETWO-86121  -->
+*  Merchants can now ship the remaining items in an order in which some items require a credit memo.
 
-<!-- MAGETWO-96394 -->* Orders for bundle products created from the Admin now display  correct product prices.
+<!-- MAGETWO-96394  -->
+*  Orders for bundle products created from the Admin now display  correct product prices.
 
-<!-- MAGETWO-96141 -->* You can now remove a custom price from a product during order creation from the Admin.
+<!-- MAGETWO-96141  -->
+*  You can now remove a custom price from a product during order creation from the Admin.
 
-<!-- ENGCOM-3998 -->*  The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+<!-- ENGCOM-3998  -->
+*   The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
-<!-- ENGCOM-3999 -->* Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
+<!-- ENGCOM-3999  -->
+*  Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
 
-<!-- ENGCOM-3939 -->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20508](https://github.com/magento/magento2/pull/20508)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
+<!-- ENGCOM-3939  -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20508](https://github.com/magento/magento2/pull/20508)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
 
-<!-- ENGCOM-3874 -->* The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20184](https://github.com/magento/magento2/pull/20184)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
+<!-- ENGCOM-3874  -->
+*  The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20184](https://github.com/magento/magento2/pull/20184)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
 
-<!-- ENGCOM-3880 -->* Product option values are now rendered correctly as links when  you view an order that contains a product with a file type option. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20353](https://github.com/magento/magento2/pull/20353)*. [GitHub-20352](https://github.com/magento/magento2/issues/20352)
+<!-- ENGCOM-3880  -->
+*  Product option values are now rendered correctly as links when  you view an order that contains a product with a file type option. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20353](https://github.com/magento/magento2/pull/20353)*. [GitHub-20352](https://github.com/magento/magento2/issues/20352)
 
-<!-- MAGETWO-73883 -->* The Items Ordered list now updates as expected when the user clicks **OK** when changing the options of a configurable product during creation of an order from the Admin. Previously, the update did not occur until the user clicked **Update Items and Quantities**.
+<!-- MAGETWO-73883  -->
+*  The Items Ordered list now updates as expected when the user clicks **OK** when changing the options of a configurable product during creation of an order from the Admin. Previously, the update did not occur until the user clicked **Update Items and Quantities**.
 
 ### Sales rule
 
-<!-- MAGETWO-86098 -->* The cart price rule now uses specified conditions correctly when applying discounts on configurable products.
+<!-- MAGETWO-86098  -->
+*  The cart price rule now uses specified conditions correctly when applying discounts on configurable products.
 
-<!-- MAGETWO-86637 -->* The sales rule indexer now runs without error. Previously, the sales rule indexer returned an error during reindexing because of the Magento_AdvancedSalesRule module.
+<!-- MAGETWO-86637  -->
+*  The sales rule indexer now runs without error. Previously, the sales rule indexer returned an error during reindexing because of the Magento_AdvancedSalesRule module.
 
-<!-- ENGCOM-3784 -->* Magento no longer throws an exception upon cancelation of an order that was placed with a coupon by a guest who, after checkout, created a customer account. *Fix submitted by [Andriy Kravets](https://github.com/Winfle) in pull request [19423](https://github.com/magento/magento2/pull/19423)*. [GitHub-19230](https://github.com/magento/magento2/issues/19230)
+<!-- ENGCOM-3784  -->
+*  Magento no longer throws an exception upon cancelation of an order that was placed with a coupon by a guest who, after checkout, created a customer account. *Fix submitted by [Andriy Kravets](https://github.com/Winfle) in pull request [19423](https://github.com/magento/magento2/pull/19423)*. [GitHub-19230](https://github.com/magento/magento2/issues/19230)
 
-<!-- MAGETWO-95993 -->* Archived orders no longer reappear in the Order Management table after cron runs.
+<!-- MAGETWO-95993  -->
+*  Archived orders no longer reappear in the Order Management table after cron runs.
 
 ### Search
 
-<!-- MAGETWO-73351 -->* Full text search for Elasticsearch no longer includes the `date` attribute.
+<!-- MAGETWO-73351  -->
+*  Full text search for Elasticsearch no longer includes the `date` attribute.
 
-<!-- MAGETWO-86052 -->* The default sort order field now works as expected on the Catalog Search results page.
+<!-- MAGETWO-86052  -->
+*  The default sort order field now works as expected on the Catalog Search results page.
 
-<!-- MAGETWO-86396 -->* Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group
+<!-- MAGETWO-86396  -->
+*  Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group
 
-<!-- ENGCOM-3811 -->* A mistyped `saveHandler` has been removed from the CatalogSearch indexer declaration. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [19984](https://github.com/magento/magento2/pull/19984)*. [GitHub-19982](https://github.com/magento/magento2/issues/19982)
+<!-- ENGCOM-3811  -->
+*  A mistyped `saveHandler` has been removed from the CatalogSearch indexer declaration. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [19984](https://github.com/magento/magento2/pull/19984)*. [GitHub-19982](https://github.com/magento/magento2/issues/19982)
 
 ### Shipping
 
-<!-- MAGETWO-c -->* Magento now uses the  shipping table rate from the correct store in multistore deployments.
+<!-- MAGETWO-c  -->
+*  Magento now uses the  shipping table rate from the correct store in multistore deployments.
 
-<!-- MAGETWO-73894 -->* You can now use `GET .V1/shipments` to search for shipments that contain a shipping label. Previously, using this call  caused Magento to throw an exception. [GitHub-6668](https://github.com/magento/magento2/issues/6668)
+<!-- MAGETWO-73894  -->
+*  You can now use `GET .V1/shipments` to search for shipments that contain a shipping label. Previously, using this call  caused Magento to throw an exception. [GitHub-6668](https://github.com/magento/magento2/issues/6668)
 
-<!-- MAGETWO-91105 -->* Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
+<!-- MAGETWO-91105  -->
+*  Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
 
-<!-- MAGETWO-96156 -->* Shipments that are created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when shipment was created using REST.
+<!-- MAGETWO-96156  -->
+*  Shipments that are created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when shipment was created using REST.
 
-<!-- MAGETWO-95497 -->* Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
+<!-- MAGETWO-95497  -->
+*  Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
 
-<!-- ENGCOM-4042 -->*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!-- ENGCOM-4042  -->
+*   Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!-- ENGCOM-3008 -->*  Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+<!-- ENGCOM-3008  -->
+*   Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Store
 
-<!-- ENGCOM-3737 -->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Nazar](https://github.com/Nazar65) in pull request [19945](https://github.com/magento/magento2/pull/19945)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941)
+<!-- ENGCOM-3737  -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Nazar](https://github.com/Nazar65) in pull request [19945](https://github.com/magento/magento2/pull/19945)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941)
 
 ### Swatches
 
-<!-- ENGCOM-3383 -->* An administrator with appropriate permissions  can now change a product's default swatch option from the Admin. *Fix submitted by [Rostislav Sabischenko](https://github.com/RostislavS) in pull request [19012](https://github.com/magento/magento2/pull/19012)*. [GitHub-8348](https://github.com/magento/magento2/issues/8348)
+<!-- ENGCOM-3383  -->
+*  An administrator with appropriate permissions  can now change a product's default swatch option from the Admin. *Fix submitted by [Rostislav Sabischenko](https://github.com/RostislavS) in pull request [19012](https://github.com/magento/magento2/pull/19012)*. [GitHub-8348](https://github.com/magento/magento2/issues/8348)
 
-<!-- ENGCOM-2912 -->* Store views now show the correct swatch values. *Fix submitted by [Misha Medzhytov](https://github.com/magicaner) in pull request [17891](https://github.com/magento/magento2/pull/17891)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
+<!-- ENGCOM-2912  -->
+*  Store views now show the correct swatch values. *Fix submitted by [Misha Medzhytov](https://github.com/magicaner) in pull request [17891](https://github.com/magento/magento2/pull/17891)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
 
-<!-- MAGETWO-73862 -->* You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
+<!-- MAGETWO-73862  -->
+*  You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
 
 ### TargetRule
 
-<!-- MAGETWO-95420 -->* Magento no longer throws a fatal error when price is used in a Target Rule for actions.
+<!-- MAGETWO-95420  -->
+*  Magento no longer throws a fatal error when price is used in a Target Rule for actions.
 
-<!-- MAGETWO-87678 -->* Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configurations** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
+<!-- MAGETWO-87678  -->
+*  Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configurations** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
 
 ### Tax
 
-<!-- MAGETWO-94179 -->* Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
+<!-- MAGETWO-94179  -->
+*  Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
 
-<!-- ENGCOM-3319 -->* Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data.  *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [18857](https://github.com/magento/magento2/pull/18857)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
+<!-- ENGCOM-3319  -->
+*  Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data.  *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [18857](https://github.com/magento/magento2/pull/18857)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
 
 ### Testing
 
-<!-- ENGCOM-3410 -->* Unit test annotations now assert exception messages correctly. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19105](https://github.com/magento/magento2/pull/19105)*. [GitHub-18840](https://github.com/magento/magento2/issues/18840)
+<!-- ENGCOM-3410  -->
+*  Unit test annotations now assert exception messages correctly. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19105](https://github.com/magento/magento2/pull/19105)*. [GitHub-18840](https://github.com/magento/magento2/issues/18840)
 
-<!-- ENGCOM-3875 -->* `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
+<!-- ENGCOM-3875  -->
+*  `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
 
-<!-- ENGCOM-3021 -->*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+<!-- ENGCOM-3021  -->
+*   Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
 ### Theme
 
-<!-- MAGETWO-74208 -->* Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
+<!-- MAGETWO-74208  -->
+*  Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
 
-<!-- MAGETWO-85037 -->* Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
+<!-- MAGETWO-85037  -->
+*  Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
 
-<!-- MAGETWO-89546 -->* We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
+<!-- MAGETWO-89546  -->
+*  We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
 
-<!-- MAGETWO-94455 -->* The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
+<!-- MAGETWO-94455  -->
+*  The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
 
-<!-- MAGETWO-87027 -->* The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
+<!-- MAGETWO-87027  -->
+*  The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
 
-<!-- MAGETWO-94462 -->* All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
+<!-- MAGETWO-94462  -->
+*  All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
 
-<!-- ENGCOM-3672 -->* Clicking on the store logo on the home page now reloads the page. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19199](https://github.com/magento/magento2/pull/19199)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
+<!-- ENGCOM-3672  -->
+*  Clicking on the store logo on the home page now reloads the page. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19199](https://github.com/magento/magento2/pull/19199)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
 
 ### UI
 
-<!-- ENGCOM-3973 -->* Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
+<!-- ENGCOM-3973  -->
+*  Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
-<!-- ENGCOM-4012 -->*  Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+<!-- ENGCOM-4012  -->
+*   Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
-<!-- ENGCOM-3308 -->* Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
+<!-- ENGCOM-3308  -->
+*  Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
 
-<!-- ENGCOM-3306 -->* The delete product confirmation popup now closes only when you click the **OK** button. *Fix submitted by [Shubham Sharma](https://github.com/Shubham-Webkul) in pull request [18865](https://github.com/magento/magento2/pull/18865)*. [GitHub-18458](https://github.com/magento/magento2/issues/18458)
+<!-- ENGCOM-3306  -->
+*  The delete product confirmation popup now closes only when you click the **OK** button. *Fix submitted by [Shubham Sharma](https://github.com/Shubham-Webkul) in pull request [18865](https://github.com/magento/magento2/pull/18865)*. [GitHub-18458](https://github.com/magento/magento2/issues/18458)
 
-<!-- ENGCOM-3174 -->* Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
+<!-- ENGCOM-3174  -->
+*  Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
-<!-- ENGCOM-3177 -->*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!-- ENGCOM-3177  -->
+*   Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!-- ENGCOM-3313 -->* You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
+<!-- ENGCOM-3313  -->
+*  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
 
-<!-- MAGETWO-91403 -->* WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
+<!-- MAGETWO-91403  -->
+*  WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
 
 ### URL rewrite
 
-<!-- MAGETWO-86419 -->* Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
+<!-- MAGETWO-86419  -->
+*  Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
 
-<!-- MAGETWO-94860 -->* The storefront now properly displays the order of categories when you move categories in the Admin.
+<!-- MAGETWO-94860  -->
+*  The storefront now properly displays the order of categories when you move categories in the Admin.
 
-<!-- MAGETWO-93424 -->* Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
+<!-- MAGETWO-93424  -->
+*  Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
 
-<!-- MAGETWO-89619 -->* Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
+<!-- MAGETWO-89619  -->
+*  Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
 
-<!-- MAGETWO-86303 -->* Magento now correctly updates existing product URLs during import. Previously, Magento updated existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
+<!-- MAGETWO-86303  -->
+*  Magento now correctly updates existing product URLs during import. Previously, Magento updated existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
 
-<!-- ENGCOM-3175 -->* The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18563](https://github.com/magento/magento2/pull/18563)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
+<!-- ENGCOM-3175  -->
+*  The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18563](https://github.com/magento/magento2/pull/18563)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
 
 ### Visual Merchandiser
 
-<!-- MAGETWO-91019 -->* Visual Merchandiser now correctly sorts configurable product prices in Tile view.
+<!-- MAGETWO-91019  -->
+*  Visual Merchandiser now correctly sorts configurable product prices in Tile view.
 
 ### Web API framework
 
-<!-- MAGETWO-73526 -->* You can now create products with same name. Previously, Magento did not create the second  product and displayed this error, `Error "URL key for specified store already exists`.
+<!-- MAGETWO-73526  -->
+*  You can now create products with same name. Previously, Magento did not create the second  product and displayed this error, `Error "URL key for specified store already exists`.
 
-<!-- MAGETWO-86344 -->* Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
+<!-- MAGETWO-86344  -->
+*  Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
 
-<!-- MAGETWO-73061 -->* The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
+<!-- MAGETWO-73061  -->
+*  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
-<!-- ENGCOM-3929 -->*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+<!-- ENGCOM-3929  -->
+*   `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
 ### Widget
 
-<!-- MAGETWO-85683 -->* Magento now correctly renders apostrophes as entered in text fields.
+<!-- MAGETWO-85683  -->
+*  Magento now correctly renders apostrophes as entered in text fields.
 
-<!-- MAGETWO-93947 -->* The product page's Recently Viewed section no longer displays the name of the current product.
+<!-- MAGETWO-93947  -->
+*  The product page's Recently Viewed section no longer displays the name of the current product.
 
-<!-- ENGCOM-4037 -->* Fixed alignment of options on the Admin edit widget page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20270](https://github.com/magento/magento2/pull/20270)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!-- ENGCOM-4037  -->
+*  Fixed alignment of options on the Admin edit widget page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20270](https://github.com/magento/magento2/pull/20270)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
 ### Wishlist
 
-<!-- ENGCOM-3344 -->* Default configured values are now rendering on the wishlist product edit page. *Fix submitted by [Ratnesh Kumar](https://github.com/webkul-ratnesh) in pull request [18967](https://github.com/magento/magento2/pull/18967)*. [GitHub-18555](https://github.com/magento/magento2/issues/18555)
+<!-- ENGCOM-3344  -->
+*  Default configured values are now rendering on the wishlist product edit page. *Fix submitted by [Ratnesh Kumar](https://github.com/webkul-ratnesh) in pull request [18967](https://github.com/magento/magento2/pull/18967)*. [GitHub-18555](https://github.com/magento/magento2/issues/18555)
 
-<!-- MAGETWO-90812 -->* Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
+<!-- MAGETWO-90812  -->
+*  Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
 
-<!-- MAGETWO-93035 -->* Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
+<!-- MAGETWO-93035  -->
+*  Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
 
 ### WYSIWG
 
-<!-- ENGCOM-3291 -->* The `id_prefix` option for the cache frontend, which is used to prefix cache keys, is now set when Magento is installed. Previously, the performance of all websites in multisite deployments was uneven due to the previous mechanism used to prefix cache keys. *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
+<!-- ENGCOM-3291  -->
+*  The `id_prefix` option for the cache frontend, which is used to prefix cache keys, is now set when Magento is installed. Previously, the performance of all websites in multisite deployments was uneven due to the previous mechanism used to prefix cache keys. *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 
 ## Known issues
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
@@ -101,479 +101,686 @@ In addition to security enhancements, this release contains the following functi
 
 ### Installation, setup, and deployment
 
-<!-- MC-5926 -->* The `bin/magento setup:config:set --enable-syslog-logging=true|false` command now provides the functionality that Magento previously provided in .  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
+<!-- MC-5926  -->
+*  The `bin/magento setup:config:set --enable-syslog-logging=true|false` command now provides the functionality that Magento previously provided in .  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
 
-<!-- MAGETWO-83474 -->* The storefront now  uses HTTPS exclusively and the Admin  uses HTTP without resulting in excessive redirects.
+<!-- MAGETWO-83474  -->
+*  The storefront now  uses HTTPS exclusively and the Admin  uses HTTP without resulting in excessive redirects.
 
-<!-- ENGCOM-2958-->* Controllers with different route IDs and front names  no longer redirect users  to the dashboard when a user clicks on a menu link. *Fix submitted by [Laura Folco](https://github.com/lfolco) in pull request [18018](https://github.com/magento/magento2/pull/18018)*. [GitHub-7557](https://github.com/magento/magento2/issues/7557)
+<!-- ENGCOM-2958 -->
+*  Controllers with different route IDs and front names  no longer redirect users  to the dashboard when a user clicks on a menu link. *Fix submitted by [Laura Folco](https://github.com/lfolco) in pull request [18018](https://github.com/magento/magento2/pull/18018)*. [GitHub-7557](https://github.com/magento/magento2/issues/7557)
 
-<!-- ENGCOM-2723 -->* Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
+<!-- ENGCOM-2723  -->
+*  Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
 
-<!-- ENGCOM-3001 -->* The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by [Keyur Shah](https://github.com/keyurshah070) in pull request [17993](https://github.com/magento/magento2/pull/17993)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
+<!-- ENGCOM-3001  -->
+*  The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by [Keyur Shah](https://github.com/keyurshah070) in pull request [17993](https://github.com/magento/magento2/pull/17993)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
 
-<!-- ENGCOM-3104 -->* A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18389](https://github.com/magento/magento2/pull/18389)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
+<!-- ENGCOM-3104  -->
+*  A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18389](https://github.com/magento/magento2/pull/18389)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
 
-<!-- ENGCOM-3207 -->* The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18659](https://github.com/magento/magento2/pull/18659)*. [GitHub-12969](https://github.com/magento/magento2/issues/12969)
+<!-- ENGCOM-3207  -->
+*  The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18659](https://github.com/magento/magento2/pull/18659)*. [GitHub-12969](https://github.com/magento/magento2/issues/12969)
 
-<!-- MAGETWO-95411 -->* You can now install Magento without first creating an administrator account.
+<!-- MAGETWO-95411  -->
+*  You can now install Magento without first creating an administrator account.
 
-<!-- ENGCOM-3756-->* Magento now skips disabled modules  when compiling static content. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19989](https://github.com/magento/magento2/pull/19989)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
+<!-- ENGCOM-3756 -->
+*  Magento now skips disabled modules  when compiling static content. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19989](https://github.com/magento/magento2/pull/19989)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
 
-<!-- ENGCOM-3881 -->* The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, admin users were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20322](https://github.com/magento/magento2/pull/20322)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
+<!-- ENGCOM-3881  -->
+*  The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, admin users were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20322](https://github.com/magento/magento2/pull/20322)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
 
 ### Backend
 
-<!-- MAGETWO-96174 -->* The address form in the Admin order creation workflow has been refactored to improve performance.
+<!-- MAGETWO-96174  -->
+*  The address form in the Admin order creation workflow has been refactored to improve performance.
 
-<!-- ENGCOM-3777-->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19910](https://github.com/magento/magento2/pull/19910)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
+<!-- ENGCOM-3777 -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19910](https://github.com/magento/magento2/pull/19910)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
 
-<!-- ENGCOM-3868 -->* `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20284](https://github.com/magento/magento2/pull/20284)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
+<!-- ENGCOM-3868  -->
+*  `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20284](https://github.com/magento/magento2/pull/20284)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
 
 ### B2B
 
-<!-- MAGETWO-96442 -->*  Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
+<!-- MAGETWO-96442  -->
+*   Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
 
-<!-- MAGETWO-94884 -->* Magento no longer displays a duplicate **Add product** button when you change currency from the Order currency dropdown while creating an order from the Admin.
+<!-- MAGETWO-94884  -->
+*  Magento no longer displays a duplicate **Add product** button when you change currency from the Order currency dropdown while creating an order from the Admin.
 
-<!-- MAGETWO-94820 -->* Magento no longer deletes custom shared catalogs  when the user that created it is deleted.
+<!-- MAGETWO-94820  -->
+*  Magento no longer deletes custom shared catalogs  when the user that created it is deleted.
 
-<!-- MAGETWO-85125 -->* Magento now loads the company profile, roles, and permissions sections of a company account when **Enable Reward Points Functionality** is set to **no** in the Admin, and you flush cache storage.
+<!-- MAGETWO-85125  -->
+*  Magento now loads the company profile, roles, and permissions sections of a company account when **Enable Reward Points Functionality** is set to **no** in the Admin, and you flush cache storage.
 
-<!-- MAGETWO-88254 -->* Tier pricing remains in effect when you add a product with tier pricing  to an order from the Admin. Previously, Magento converted tier prices to non-discounted product prices when you added more products to the order, applied a custom price to one of the products, or applied a coupon code to the order.
+<!-- MAGETWO-88254  -->
+*  Tier pricing remains in effect when you add a product with tier pricing  to an order from the Admin. Previously, Magento converted tier prices to non-discounted product prices when you added more products to the order, applied a custom price to one of the products, or applied a coupon code to the order.
 
-<!-- MAGETWO-90835 -->* You can now filter customers by status. Previously, Magento threw an SQL ERROR when you clicked on **Apply Filters** after setting the filter to status.
+<!-- MAGETWO-90835  -->
+*  You can now filter customers by status. Previously, Magento threw an SQL ERROR when you clicked on **Apply Filters** after setting the filter to status.
 
-<!-- MAGETWO-94431 -->* Magento now displays products that merchants have added to the public catalog through **Product** > **Edit page** > **Shared Catalog**. Previously, these items appeared if added  through **Catalog** > **Shared Catalog**, but not through **Product** > **Edit page** > **Shared Catalog**.
+<!-- MAGETWO-94431  -->
+*  Magento now displays products that merchants have added to the public catalog through **Product** > **Edit page** > **Shared Catalog**. Previously, these items appeared if added  through **Catalog** > **Shared Catalog**, but not through **Product** > **Edit page** > **Shared Catalog**.
 
-<!-- MAGETWO-89296 -->* Menus now close as expected from the Quick Order page in mobile view.
+<!-- MAGETWO-89296  -->
+*  Menus now close as expected from the Quick Order page in mobile view.
 
 ### Bundle products
 
-<!-- MAGETWO-88810 -->* Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product.
+<!-- MAGETWO-88810  -->
+*  Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product.
 
-<!-- ENGCOM-2997 -->* Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by [Joseph Maxwell](https://github.com/JosephMaxwell) in pull request [15905](https://github.com/magento/magento2/pull/15905)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
+<!-- ENGCOM-2997  -->
+*  Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by [Joseph Maxwell](https://github.com/JosephMaxwell) in pull request [15905](https://github.com/magento/magento2/pull/15905)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
 
-<!-- ENGCOM-3275 -->* Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by [magently](https://github.com/magently) in pull request [17971](https://github.com/magento/magento2/pull/17971)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!-- ENGCOM-3275  -->
+*  Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by [magently](https://github.com/magently) in pull request [17971](https://github.com/magento/magento2/pull/17971)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!-- MAGETWO-90381 -->* Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
+<!-- MAGETWO-90381  -->
+*  Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
 
 ### CAPTCHA
 
-<!-- MAGETWO-93780 -->* CAPTCHA now appears as expected in the Log in popup window.
+<!-- MAGETWO-93780  -->
+*  CAPTCHA now appears as expected in the Log in popup window.
 
 ### Catalog
 
-<!-- ENGCOM-3392 -->* Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18743](https://github.com/magento/magento2/pull/18743)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
+<!-- ENGCOM-3392  -->
+*  Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18743](https://github.com/magento/magento2/pull/18743)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
 
-<!-- MAGETWO-69650 -->* Products no longer display discounted prices in the shopping cart unless discounts have been applied or special or tiered prices are in effect.
+<!-- MAGETWO-69650  -->
+*  Products no longer display discounted prices in the shopping cart unless discounts have been applied or special or tiered prices are in effect.
 
-<!-- MAGETWO-73140 -->* Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
+<!-- MAGETWO-73140  -->
+*  Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
 
-<!-- MAGETWO-96288 -->* You can now use REST to update category positions.
+<!-- MAGETWO-96288  -->
+*  You can now use REST to update category positions.
 
-<!-- MAGETWO-95556 -->* Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
+<!-- MAGETWO-95556  -->
+*  Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
 
-<!-- MAGETWO-95461 -->* You can now save products with at least one tier price.
+<!-- MAGETWO-95461  -->
+*  You can now save products with at least one tier price.
 
-<!-- MAGETWO-95122 -->* Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
+<!-- MAGETWO-95122  -->
+*  Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
 
-<!-- MAGETWO-73687 -->* Magento now retains across categories any value you set for the number of categories displayed per page.
+<!-- MAGETWO-73687  -->
+*  Magento now retains across categories any value you set for the number of categories displayed per page.
 
-<!-- MAGETWO-73449 -->* Changes to product images made under the All Stores scope now affect product images at the store-view level.
+<!-- MAGETWO-73449  -->
+*  Changes to product images made under the All Stores scope now affect product images at the store-view level.
 
-<!-- MAGETWO-93149 -->* You can now successfully change and save product order when you use a rule that implements a `contains` condition operator in Virtual Merchandiser. Previously, Magento did not save product position as expected.
+<!-- MAGETWO-93149  -->
+*  You can now successfully change and save product order when you use a rule that implements a `contains` condition operator in Virtual Merchandiser. Previously, Magento did not save product position as expected.
 
-<!-- MAGETWO-91070 -->* Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
+<!-- MAGETWO-91070  -->
+*  Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
 
-<!-- ENGCOM-4089 -->*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+<!-- ENGCOM-4089  -->
+*   Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
-<!-- MAGETWO-73342 -->* Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
+<!-- MAGETWO-73342  -->
+*  Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
 
-<!-- ENGCOM-2930 -->*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*   Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-2943 -->* You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
+<!-- ENGCOM-2943  -->
+*  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
 
-<!-- ENGCOM-3047 -->* `getStoreId()` now consistently returns `int`. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [18086](https://github.com/magento/magento2/pull/18086)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!-- ENGCOM-3047  -->
+*  `getStoreId()` now consistently returns `int`. *Fix submitted by [sv3n](https://github.com/sreichel) in pull request [18086](https://github.com/magento/magento2/pull/18086)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!-- ENGCOM-3097 -->* You can now set a Boolean attribute to `is_filterable`, which allows them to be included in layered navigation. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [17823](https://github.com/magento/magento2/pull/17823)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
+<!-- ENGCOM-3097  -->
+*  You can now set a Boolean attribute to `is_filterable`, which allows them to be included in layered navigation. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [17823](https://github.com/magento/magento2/pull/17823)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
 
-<!-- ENGCOM-3050 -->* If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
+<!-- ENGCOM-3050  -->
+*  If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
 Previously, when you reopened these categories, no checkboxes were checked.  *Fix submitted by [magently](https://github.com/magently) in pull request [18175](https://github.com/magento/magento2/pull/18175)*. [GitHub-17493](https://github.com/magento/magento2/issues/17493)
 
-<!-- ENGCOM-3133 -->* An incorrect return type in the `StockRegistryInterface` API has been corrected. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18427](https://github.com/magento/magento2/pull/18427)*. [GitHub-15085](https://github.com/magento/magento2/issues/15085)
+<!-- ENGCOM-3133  -->
+*  An incorrect return type in the `StockRegistryInterface` API has been corrected. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18427](https://github.com/magento/magento2/pull/18427)*. [GitHub-15085](https://github.com/magento/magento2/issues/15085)
 
-<!-- ENGCOM-3158 -->* Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by [Bartosz Kubicki](https://github.com/bartoszkubicki) in pull request [18196](https://github.com/magento/magento2/pull/18196)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
+<!-- ENGCOM-3158  -->
+*  Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by [Bartosz Kubicki](https://github.com/bartoszkubicki) in pull request [18196](https://github.com/magento/magento2/pull/18196)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
 
-<!-- ENGCOM-3171 -->* Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18552](https://github.com/magento/magento2/pull/18552)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
+<!-- ENGCOM-3171  -->
+*  Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18552](https://github.com/magento/magento2/pull/18552)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
 
-<!-- ENGCOM-3193 -->* When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
+<!-- ENGCOM-3193  -->
+*  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
-<!-- ENGCOM-3230 -->*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+<!-- ENGCOM-3230  -->
+*   `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
-<!-- ENGCOM-3254 -->* Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
+<!-- ENGCOM-3254  -->
+*  Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
 
-<!-- ENGCOM-3261 -->* The **order by price** option for product listings on category pages now works as expected. *Fix submitted by [Giel Berkers](https://github.com/kanduvisla) in pull request [18737](https://github.com/magento/magento2/pull/18737)*. [GitHub-18264](https://github.com/magento/magento2/issues/18264)
+<!-- ENGCOM-3261  -->
+*  The **order by price** option for product listings on category pages now works as expected. *Fix submitted by [Giel Berkers](https://github.com/kanduvisla) in pull request [18737](https://github.com/magento/magento2/pull/18737)*. [GitHub-18264](https://github.com/magento/magento2/issues/18264)
 
-<!-- ENGCOM-2930 -->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-3317 -->* Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
+<!-- ENGCOM-3317  -->
+*  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
-<!-- MAGETWO-93673 -->*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+<!-- MAGETWO-93673  -->
+*   You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
-<!-- MAGETWO-96258 -->*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+<!-- MAGETWO-96258  -->
+*   **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
-<!-- MAGETWO-96374 -->* In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
+<!-- MAGETWO-96374  -->
+*  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
 
-<!-- MAGETWO-90930 -->* Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
+<!-- MAGETWO-90930  -->
+*  Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
 
-<!-- ENGCOM-3312 -->* You can now insert multiple catalog product list widgets in a CMS page.
+<!-- ENGCOM-3312  -->
+*  You can now insert multiple catalog product list widgets in a CMS page.
 
-<!-- ENGCOM-3373 -->* Performance has improved for sessions where  customers browse many product pages. (This performance boost is a result of replacing the jQuery `localStorage` API  with native `localStorage` in `app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js` and  `app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage.js`.) *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [19014](https://github.com/magento/magento2/pull/19014)*. [GitHub-17813](https://github.com/magento/magento2/issues/17813)
+<!-- ENGCOM-3373  -->
+*  Performance has improved for sessions where  customers browse many product pages. (This performance boost is a result of replacing the jQuery `localStorage` API  with native `localStorage` in `app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js` and  `app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage.js`.) *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [19014](https://github.com/magento/magento2/pull/19014)*. [GitHub-17813](https://github.com/magento/magento2/issues/17813)
 
-<!-- ENGCOM-3790 -->* Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.
+<!-- ENGCOM-3790  -->
+*  Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.
 
-<!-- ENGCOM-3800 -->* Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
+<!-- ENGCOM-3800  -->
+*  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
 
-<!-- ENGCOM-4004 -->*  The `bin/magento catalog:images:resize` command now processes all specified images.
+<!-- ENGCOM-4004  -->
+*   The `bin/magento catalog:images:resize` command now processes all specified images.
 
-<!-- ENGCOM-4003 -->*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
+<!-- ENGCOM-4003  -->
+*   The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
 
-<!-- ENGCOM-3859 -->*  `getProductUrl` no longer returns the wrong URL when the current category has no products.
+<!-- ENGCOM-3859  -->
+*   `getProductUrl` no longer returns the wrong URL when the current category has no products.
 
-<!-- ENGCOM-3978 -->* Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
+<!-- ENGCOM-3978  -->
+*  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
 
-<!-- ENGCOM-3832 -->* Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value.
+<!-- ENGCOM-3832  -->
+*  Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value.
 
-<!-- ENGCOM-3826 -->* Deleting an image from **Admin** > **Catalog** > **Categories** now deletes the image as expected. Previously, the deleted image remained in `pub\media\catalog\category`. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20178](https://github.com/magento/magento2/pull/20178)*. [GitHub-16198](https://github.com/magento/magento2/issues/16198)
+<!-- ENGCOM-3826  -->
+*  Deleting an image from **Admin** > **Catalog** > **Categories** now deletes the image as expected. Previously, the deleted image remained in `pub\media\catalog\category`. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20178](https://github.com/magento/magento2/pull/20178)*. [GitHub-16198](https://github.com/magento/magento2/issues/16198)
 
-<!-- MAGETWO-95898 -->* Magento now successfully updates product quantities in the mini-shopping cart for a product that has **Qty Uses Decimals** and **Enable Qty Increments** are enabled. Previously, Magento did not update the product quantity, but displayed this error, `You can buy this product only in quantities of 1.1 at a time`.
+<!-- MAGETWO-95898  -->
+*  Magento now successfully updates product quantities in the mini-shopping cart for a product that has **Qty Uses Decimals** and **Enable Qty Increments** are enabled. Previously, Magento did not update the product quantity, but displayed this error, `You can buy this product only in quantities of 1.1 at a time`.
 
-<!-- MAGETWO-94988 -->* Product images on the storefront are now identical in size, width, height, and DPI to the  image as specified for upload in the Admin.
+<!-- MAGETWO-94988  -->
+*  Product images on the storefront are now identical in size, width, height, and DPI to the  image as specified for upload in the Admin.
 
 ### Catalog rule
 
-<!-- ENGCOM-3396 -->* Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English.
+<!-- ENGCOM-3396  -->
+*  Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English.
 
 ### Cart and checkout
 
-<!-- MAGETWO-95938 -->* Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
+<!-- MAGETWO-95938  -->
+*  Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
 
-<!-- MAGETWO-95846 -->* Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
+<!-- MAGETWO-95846  -->
+*  Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
 
-<!-- MAGETWO-95067 -->* Checkout information now persists after a cart update. Information previously entered by a customer during check out (such as shipping address) now persists after the customer updates their shopping cart. Previously, when a customer updated their shopping cart, all information previously entered during check out (such as shipping address) was deleted
+<!-- MAGETWO-95067  -->
+*  Checkout information now persists after a cart update. Information previously entered by a customer during check out (such as shipping address) now persists after the customer updates their shopping cart. Previously, when a customer updated their shopping cart, all information previously entered during check out (such as shipping address) was deleted
 
-<!-- MAGETWO-94425 -->* Magento now updates the minicart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
+<!-- MAGETWO-94425  -->
+*  Magento now updates the minicart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
 
-<!-- MAGETWO-91932 -->* Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
+<!-- MAGETWO-91932  -->
+*  Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
 
-<!-- MAGETWO-91138 -->* You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
+<!-- MAGETWO-91138  -->
+*  You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
-<!-- MAGETWO-90056 -->*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+<!-- MAGETWO-90056  -->
+*   Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
-<!-- MAGETWO-89397 -->* Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
+<!-- MAGETWO-89397  -->
+*  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
 
-<!-- MAGETWO-87971 -->* Magento  no  longer displays any Top destinations in the shopping cart's Country drop-down menu after a customer  removes unneeded destinations.
+<!-- MAGETWO-87971  -->
+*  Magento  no  longer displays any Top destinations in the shopping cart's Country drop-down menu after a customer  removes unneeded destinations.
 
-<!-- MAGETWO-87016 -->* Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
+<!-- MAGETWO-87016  -->
+*  Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
 
-<!-- MAGETWO-87016 -->* Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
+<!-- MAGETWO-87016  -->
+*  Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
 
-<!-- MAGETWO-72877 -->* Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
+<!-- MAGETWO-72877  -->
+*  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
-<!-- MAGETWO-62841 -->*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+<!-- MAGETWO-62841  -->
+*   Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
-<!-- MAGETWO-86477 -->* Magento now displays informative error messages when an order paid for with Authorize.Net fails.
+<!-- MAGETWO-86477  -->
+*  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
 
-<!-- ENGCOM-3649 -->* `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed.
+<!-- ENGCOM-3649  -->
+*  `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed.
 
-<!-- ENGCOM-3348 -->* You can now select a payment method during check for an order placed in a deployment where different payment methods are configured for different countries. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18908](https://github.com/magento/magento2/pull/18908)*. [GitHub-18907](https://github.com/magento/magento2/issues/18907)
+<!-- ENGCOM-3348  -->
+*  You can now select a payment method during check for an order placed in a deployment where different payment methods are configured for different countries. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18908](https://github.com/magento/magento2/pull/18908)*. [GitHub-18907](https://github.com/magento/magento2/issues/18907)
 
-<!-- ENGCOM-3315 -->* Custom shipping methods in custom carrier code can now include underscores.
+<!-- ENGCOM-3315  -->
+*  Custom shipping methods in custom carrier code can now include underscores.
 
-<!-- ENGCOM-3322 -->* The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!-- ENGCOM-3322  -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!-- ENGCOM-3088 -->* Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18369](https://github.com/magento/magento2/pull/18369)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
+<!-- ENGCOM-3088  -->
+*  Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18369](https://github.com/magento/magento2/pull/18369)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
 
-<!-- ENGCOM-3154 -->* One-step checkout now works as expected. Previously, Magento displayed this console error when you tried to complete an order using one-step checkout, `Uncaught TypeError: Cannot read property 'code' of undefined at UiClass.initialize (/en_US/Magento_Checkout/js/view/progress-bar.js:31:93)`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18495](https://github.com/magento/magento2/pull/18495)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
+<!-- ENGCOM-3154  -->
+*  One-step checkout now works as expected. Previously, Magento displayed this console error when you tried to complete an order using one-step checkout, `Uncaught TypeError: Cannot read property 'code' of undefined at UiClass.initialize (/en_US/Magento_Checkout/js/view/progress-bar.js:31:93)`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18495](https://github.com/magento/magento2/pull/18495)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
 
-<!-- ENGCOM-3251 -->* The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18597](https://github.com/magento/magento2/pull/18597)*.
+<!-- ENGCOM-3251  -->
+*  The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18597](https://github.com/magento/magento2/pull/18597)*.
 
-<!-- ENGCOM-3195 -->* Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
+<!-- ENGCOM-3195  -->
+*  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
-<!-- MAGETWO-86120 -->*  You can now add gift wrapping to the shopping cart to an already  added product without having to add to additional product.
+<!-- MAGETWO-86120  -->
+*   You can now add gift wrapping to the shopping cart to an already  added product without having to add to additional product.
 
 ### Clean up and minor refactoring
 
-<!-- ENGCOM-3935 -->* Fixed checkbox alignment on the account information page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
+<!-- ENGCOM-3935  -->
+*  Fixed checkbox alignment on the account information page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
 
-<!-- ENGCOM-3738 -->* Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`.
+<!-- ENGCOM-3738  -->
+*  Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`.
 
-<!-- ENGCOM-3766 -->* Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page.
+<!-- ENGCOM-3766  -->
+*  Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page.
 
-<!-- ENGCOM-3903 -->* Corrected alignment of the **Detailed Rating** field on the Edit Review page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20272](https://github.com/magento/magento2/pull/20272)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
+<!-- ENGCOM-3903  -->
+*  Corrected alignment of the **Detailed Rating** field on the Edit Review page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20272](https://github.com/magento/magento2/pull/20272)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
 
-<!-- ENGCOM-3540 -->* Corrected the logic in JavaScript for the **Add to cart** button  and `last-order-items.js`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19357](https://github.com/magento/magento2/pull/19357)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
+<!-- ENGCOM-3540  -->
+*  Corrected the logic in JavaScript for the **Add to cart** button  and `last-order-items.js`. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19357](https://github.com/magento/magento2/pull/19357)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
 
-<!-- ENGCOM-4014 -->* Fixed misalignment of logo on the Admin home page. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20544](https://github.com/magento/magento2/pull/20544)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
+<!-- ENGCOM-4014  -->
+*  Fixed misalignment of logo on the Admin home page. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20544](https://github.com/magento/magento2/pull/20544)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
 
-<!-- ENGCOM-3933 -->* Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
+<!-- ENGCOM-3933  -->
+*  Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
-<!-- ENGCOM-3853 -->*  Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+<!-- ENGCOM-3853  -->
+*   Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
-<!-- ENGCOM-3895 -->*  Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+<!-- ENGCOM-3895  -->
+*   Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
-<!-- ENGCOM-3970 -->* The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
+<!-- ENGCOM-3970  -->
+*  The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
 
-<!-- ENGCOM-3322 -->* The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!-- ENGCOM-3322  -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [18917](https://github.com/magento/magento2/pull/18917)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!-- ENGCOM-3324 -->* Removed redundant asterix on **Admin** > **Catalog** > **Display Settings**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [18922](https://github.com/magento/magento2/pull/18922)*. [GitHub-18918](https://github.com/magento/magento2/issues/18918)
+<!-- ENGCOM-3324  -->
+*  Removed redundant asterix on **Admin** > **Catalog** > **Display Settings**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [18922](https://github.com/magento/magento2/pull/18922)*. [GitHub-18918](https://github.com/magento/magento2/issues/18918)
 
-<!-- ENGCOM-3327 -->* Corrected typo in  name of event (`catalogsearch_searchable_attributes_load_after`) dispatched by `Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::getSearchableAttributes`. *Fix submitted by [Neeta Kangiya](https://github.com/neeta-wagento) in pull request [18372](https://github.com/magento/magento2/pull/18372)*. [GitHub-18355](https://github.com/magento/magento2/issues/18355)
+<!-- ENGCOM-3327  -->
+*  Corrected typo in  name of event (`catalogsearch_searchable_attributes_load_after`) dispatched by `Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::getSearchableAttributes`. *Fix submitted by [Neeta Kangiya](https://github.com/neeta-wagento) in pull request [18372](https://github.com/magento/magento2/pull/18372)*. [GitHub-18355](https://github.com/magento/magento2/issues/18355)
 
-<!-- ENGCOM-3534 -->* Content in  confirmation popups on the Admin no longer overlap the **Close** button. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19340](https://github.com/magento/magento2/pull/19340)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
+<!-- ENGCOM-3534  -->
+*  Content in  confirmation popups on the Admin no longer overlap the **Close** button. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19340](https://github.com/magento/magento2/pull/19340)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
 
-<!-- ENGCOM-3527 -->* The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19023](https://github.com/magento/magento2/pull/19023)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
+<!-- ENGCOM-3527  -->
+*  The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19023](https://github.com/magento/magento2/pull/19023)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
 
-<!-- ENGCOM-3541 -->* Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19356](https://github.com/magento/magento2/pull/19356)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!-- ENGCOM-3541  -->
+*  Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19356](https://github.com/magento/magento2/pull/19356)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!-- ENGCOM-3618 -->* You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!-- ENGCOM-3618  -->
+*  You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!-- ENGCOM-3748 -->* Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
+<!-- ENGCOM-3748  -->
+*  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
-<!-- ENGCOM-4010 -->*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+<!-- ENGCOM-4010  -->
+*   Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
-<!-- ENGCOM-4040 -->*  Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+<!-- ENGCOM-4040  -->
+*   Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
-<!-- ENGCOM-4058 -->*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+<!-- ENGCOM-4058  -->
+*   Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
-<!-- ENGCOM-4090 -->*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+<!-- ENGCOM-4090  -->
+*   Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
-<!-- ENGCOM-3882 -->* Corrected alignment of the store switcher in Tab view. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20325](https://github.com/magento/magento2/pull/20325)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
+<!-- ENGCOM-3882  -->
+*  Corrected alignment of the store switcher in Tab view. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20325](https://github.com/magento/magento2/pull/20325)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
 
-<!-- ENGCOM-3934 -->* Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20455](https://github.com/magento/magento2/pull/20455)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
+<!-- ENGCOM-3934  -->
+*  Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20455](https://github.com/magento/magento2/pull/20455)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
 
-<!-- ENGCOM-3734 -->* Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
+<!-- ENGCOM-3734  -->
+*  Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
-<!-- ENGCOM-4017 -->*  Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+<!-- ENGCOM-4017  -->
+*   Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
 ### Configurable products
 
-<!-- ENGCOM-3554 -->* Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by [Oleksii Gorbulin](https://github.com/agorbulin) in pull request [19377](https://github.com/magento/magento2/pull/19377)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
+<!-- ENGCOM-3554  -->
+*  Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by [Oleksii Gorbulin](https://github.com/agorbulin) in pull request [19377](https://github.com/magento/magento2/pull/19377)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
 
-<!-- MAGETWO-89230 -->* You can now add a configurable product with no options  to a gift registry from a wishlist.
+<!-- MAGETWO-89230  -->
+*  You can now add a configurable product with no options  to a gift registry from a wishlist.
 
-<!-- ENGCOM-3135 -->* Magento no longer throws a fatal error when you try to save a configurable product with an SKU equal to or less than 64 digits. *Fix submitted by [Thiago](https://github.com/thiagolima-bm) in pull request [18461](https://github.com/magento/magento2/pull/18461)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!-- ENGCOM-3135  -->
+*  Magento no longer throws a fatal error when you try to save a configurable product with an SKU equal to or less than 64 digits. *Fix submitted by [Thiago](https://github.com/thiagolima-bm) in pull request [18461](https://github.com/magento/magento2/pull/18461)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
 ### CMS
 
-<!-- MAGETWO-94154 -->* Files and folders that are symlinked in `pub/media` can now be deleted from the media gallery browser. Previously, these symlinked files or folders inside of the `pub/media` directory could not be deleted because a validation check  uses `realpath` to test whether a file is outside of the media directory base path.
+<!-- MAGETWO-94154  -->
+*  Files and folders that are symlinked in `pub/media` can now be deleted from the media gallery browser. Previously, these symlinked files or folders inside of the `pub/media` directory could not be deleted because a validation check  uses `realpath` to test whether a file is outside of the media directory base path.
 
-<!-- MAGETWO-91122 -->* The WYSIWYG editor no longer arbitrarily removes `aria-role` attributes from  `div` in CMS pages or blocks.
+<!-- MAGETWO-91122  -->
+*  The WYSIWYG editor no longer arbitrarily removes `aria-role` attributes from  `div` in CMS pages or blocks.
 
 ### Customer
 
-<!-- MAGETWO-97151 -->* Order creation page in Admin was fixed and now works without any performance issues and slowdowns for customer accounts with 3000 addresses.
+<!-- MAGETWO-97151  -->
+*  Order creation page in Admin was fixed and now works without any performance issues and slowdowns for customer accounts with 3000 addresses.
 
-<!-- MAGETWO-95990 -->* Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
+<!-- MAGETWO-95990  -->
+*  Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
 
-<!-- MAGETWO-89847 -->* Customers can now be matched in customer segments based on the number of orders in a multi-site deployment
+<!-- MAGETWO-89847  -->
+*  Customers can now be matched in customer segments based on the number of orders in a multi-site deployment
 
-<!-- MAGETWO-87214 -->* When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
+<!-- MAGETWO-87214  -->
+*  When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
-<!-- MAGETWO-81818 -->*  Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
+<!-- MAGETWO-81818  -->
+*   Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
 
-<!-- ENGCOM-3052 -->* Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
+<!-- ENGCOM-3052  -->
+*  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
 
-<!-- ENGCOM-3107 -->* Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18414](https://github.com/magento/magento2/pull/18414)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
+<!-- ENGCOM-3107  -->
+*  Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18414](https://github.com/magento/magento2/pull/18414)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
 
-<!-- ENGCOM-3082 -->* Magento now saves customer custom attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [17968](https://github.com/magento/magento2/pull/17968)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
+<!-- ENGCOM-3082  -->
+*  Magento now saves customer custom attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [17968](https://github.com/magento/magento2/pull/17968)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
 
-<!-- MAGETWO-96079 -->* You can now successfully update your password from the link provided in the email sent when you click **Reset Password** on the Admin.  Previously, Magento did not update the password and displayed this message, `Something went wrong while saving the new password`.
+<!-- MAGETWO-96079  -->
+*  You can now successfully update your password from the link provided in the email sent when you click **Reset Password** on the Admin.  Previously, Magento did not update the password and displayed this message, `Something went wrong while saving the new password`.
 
-<!-- MAGETWO-87853 -->* You can now change payment methods after selecting store credit when creating an order from the Admin.
+<!-- MAGETWO-87853  -->
+*  You can now change payment methods after selecting store credit when creating an order from the Admin.
 
-<!-- ENGCOM-3812 -->* Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password.
+<!-- ENGCOM-3812  -->
+*  Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password.
 
-<!-- MAGETWO-93072 -->* Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
+<!-- MAGETWO-93072  -->
+*  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
-<!-- MAGETWO-74169 -->*  Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
+<!-- MAGETWO-74169  -->
+*   Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
 
 ### Customer custom attributes
 
-<!-- MAGETWO-89039 -->* Customer address attribute validation during checkout now permits spaces.
+<!-- MAGETWO-89039  -->
+*  Customer address attribute validation during checkout now permits spaces.
 
-<!-- MAGETWO-95059 -->* Merchants can now create attributes  for customer addresses (**Stores** > **Attributes** > **Customer Address**) as expected. Previously, a merchant could create an attribute, but Magento did not save or display it.
+<!-- MAGETWO-95059  -->
+*  Merchants can now create attributes  for customer addresses (**Stores** > **Attributes** > **Customer Address**) as expected. Previously, a merchant could create an attribute, but Magento did not save or display it.
 
-<!-- MAGETWO-86686 -->* Magento now adds the address entered during checkout to a new account when a custom address attribute is required when creating a user account after checkout.
+<!-- MAGETWO-86686  -->
+*  Magento now adds the address entered during checkout to a new account when a custom address attribute is required when creating a user account after checkout.
 
 ### Developer
 
-<!-- ENGCOM-2940 -->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!-- ENGCOM-2940  -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Directory
 
-<!-- ENGCOM-2747 -->* Australian country regions are now available from the drop-down menu that Magento displays during the checkout address population steps. *Fix submitted by [Maxim Baibakov](https://github.com/maximbaibakov) in pull request [17516](https://github.com/magento/magento2/pull/17516)*. [GitHub-17514](https://github.com/magento/magento2/issues/17514)
+<!-- ENGCOM-2747  -->
+*  Australian country regions are now available from the drop-down menu that Magento displays during the checkout address population steps. *Fix submitted by [Maxim Baibakov](https://github.com/maximbaibakov) in pull request [17516](https://github.com/magento/magento2/pull/17516)*. [GitHub-17514](https://github.com/magento/magento2/issues/17514)
 
 ### Downloadable
 
-<!-- ENGCOM-3385 -->* The order confirmation email sent to the customer during  guest checkout now includes download links for purchased downloadable products as expected. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19036](https://github.com/magento/magento2/pull/19036)*. [GitHub-10934](https://github.com/magento/magento2/issues/10934),
+<!-- ENGCOM-3385  -->
+*  The order confirmation email sent to the customer during  guest checkout now includes download links for purchased downloadable products as expected. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19036](https://github.com/magento/magento2/pull/19036)*. [GitHub-10934](https://github.com/magento/magento2/issues/10934),
  [GitHub-19003](https://github.com/magento/magento2/issues/19003),  [GitHub-18323](https://github.com/magento/magento2/issues/18323)
 
-<!-- ENGCOM-3584 -->* You can now delete a sample link from a downloadable product. Previously, Magento restored a deleted link after you saved the downloadable product. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [19431](https://github.com/magento/magento2/pull/19431)*. [GitHub-19344](https://github.com/magento/magento2/issues/19344)
+<!-- ENGCOM-3584  -->
+*  You can now delete a sample link from a downloadable product. Previously, Magento restored a deleted link after you saved the downloadable product. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [19431](https://github.com/magento/magento2/pull/19431)*. [GitHub-19344](https://github.com/magento/magento2/issues/19344)
 
 ### EAV
 
-<!-- ENGCOM-3128 -->* Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18390](https://github.com/magento/magento2/pull/18390)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
+<!-- ENGCOM-3128  -->
+*  Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [18390](https://github.com/magento/magento2/pull/18390)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
 
-<!-- ENGCOM-3215 -->* Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532)
+<!-- ENGCOM-3215  -->
+*  Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532)
 
-<!-- ENGCOM-3732 -->* You can now retrieve the  product attribute value for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19911](https://github.com/magento/magento2/pull/19911)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
+<!-- ENGCOM-3732  -->
+*  You can now retrieve the  product attribute value for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19911](https://github.com/magento/magento2/pull/19911)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
 
 ### Email
 
-<!-- MAGETWO-95057 -->* The return path e-mail variable `system/smtp/return_path_email` now works as expected.
+<!-- MAGETWO-95057  -->
+*  The return path e-mail variable `system/smtp/return_path_email` now works as expected.
 
 ### Frameworks
 
-<!-- ENGCOM-3921 -->* Fixed icon behavior on product customization page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19400](https://github.com/magento/magento2/pull/19400)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
+<!-- ENGCOM-3921  -->
+*  Fixed icon behavior on product customization page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19400](https://github.com/magento/magento2/pull/19400)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
 
-<!-- ENGCOM-3740 -->* Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19927](https://github.com/magento/magento2/pull/19927)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
+<!-- ENGCOM-3740  -->
+*  Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19927](https://github.com/magento/magento2/pull/19927)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
 
-<!-- ENGCOM-3359 -->* Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [18985](https://github.com/magento/magento2/pull/18985)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
+<!-- ENGCOM-3359  -->
+*  Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [18985](https://github.com/magento/magento2/pull/18985)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
 
-<!-- ENGCOM-2942 -->* The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18002](https://github.com/magento/magento2/pull/18002)*. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
+<!-- ENGCOM-2942  -->
+*  The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18002](https://github.com/magento/magento2/pull/18002)*. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
 
-<!-- ENGCOM-3172 -->* Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18554](https://github.com/magento/magento2/pull/18554)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
+<!-- ENGCOM-3172  -->
+*  Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18554](https://github.com/magento/magento2/pull/18554)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
 
-<!-- MAGETWO-87297 -->* Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
+<!-- MAGETWO-87297  -->
+*  Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
 
-<!-- MAGETWO-95779 -->* Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
+<!-- MAGETWO-95779  -->
+*  Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
 
-<!-- MAGETWO-93183 -->* You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
+<!-- MAGETWO-93183  -->
+*  You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
 
-<!-- ENGCOM-3528 -->* Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded.
+<!-- ENGCOM-3528  -->
+*  Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded.
 
-<!-- ENGCOM-3568 -->* Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
+<!-- ENGCOM-3568  -->
+*  Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
 
-<!-- ENGCOM-3479 -->*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+<!-- ENGCOM-3479  -->
+*   Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
-<!-- ENGCOM-3424 -->* The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
+<!-- ENGCOM-3424  -->
+*  The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
 
 #### Cache framework
 
-<!-- MAGETWO-73528 -->* Problems with cache-cleaning for product pages for simple  products associated with configurable products  have been resolved. and as a result, product pages now now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
+<!-- MAGETWO-73528  -->
+*  Problems with cache-cleaning for product pages for simple  products associated with configurable products  have been resolved. and as a result, product pages now now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
 
-<!-- MAGETWO-69766 -->* The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
+<!-- MAGETWO-69766  -->
+*  The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
 
 #### JavaScript framework
 
-<!-- MAGETWO-74160 -->* Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
+<!-- MAGETWO-74160  -->
+*  Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
 
 ### General
 
-<!-- MAGETWO-89377 -->* You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
+<!-- MAGETWO-89377  -->
+*  You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
 
-<!-- ENGCOM-3507 -->* Resolved issues with pager style. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19296](https://github.com/magento/magento2/pull/19296)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
+<!-- ENGCOM-3507  -->
+*  Resolved issues with pager style. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19296](https://github.com/magento/magento2/pull/19296)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
 
-<!-- ENGCOM-3301 -->* Removed use of `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18886](https://github.com/magento/magento2/pull/18886)*. [GitHub-18779](https://github.com/magento/magento2/issues/18779)
+<!-- ENGCOM-3301  -->
+*  Removed use of `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by [Rahul Mahto](https://github.com/rahulwebkul) in pull request [18886](https://github.com/magento/magento2/pull/18886)*. [GitHub-18779](https://github.com/magento/magento2/issues/18779)
 
-<!-- ENGCOM-2937 -->* Merchants can now change the currency symbol back to its default value from the Admin in Single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by [magently](https://github.com/magently) in pull request [17966](https://github.com/magento/magento2/pull/17966)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
+<!-- ENGCOM-2937  -->
+*  Merchants can now change the currency symbol back to its default value from the Admin in Single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by [magently](https://github.com/magently) in pull request [17966](https://github.com/magento/magento2/pull/17966)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
 
-<!-- ENGCOM-2938 -->* The menu on category pages accessed from the Admin now work as expected when you change from mobile to desktop view. *Fix submitted by [Emanuel Arcos](https://github.com/emanuelarcos) in pull request [17990](https://github.com/magento/magento2/pull/17990)*. [GitHub-5402](https://github.com/magento/magento2/issues/5402)
+<!-- ENGCOM-2938  -->
+*  The menu on category pages accessed from the Admin now work as expected when you change from mobile to desktop view. *Fix submitted by [Emanuel Arcos](https://github.com/emanuelarcos) in pull request [17990](https://github.com/magento/magento2/pull/17990)*. [GitHub-5402](https://github.com/magento/magento2/issues/5402)
 
-<!-- ENGCOM-3054 -->* The WYSIWYG editor now correctly parses directives of files that contain special characters in their URLs. Previously, the editor did not decode base64 special chars. *Fix submitted by [adammada](https://github.com/adammada) in pull request [18215](https://github.com/magento/magento2/pull/18215)*. [GitHub-18138](https://github.com/magento/magento2/issues/18138)
+<!-- ENGCOM-3054  -->
+*  The WYSIWYG editor now correctly parses directives of files that contain special characters in their URLs. Previously, the editor did not decode base64 special chars. *Fix submitted by [adammada](https://github.com/adammada) in pull request [18215](https://github.com/magento/magento2/pull/18215)*. [GitHub-18138](https://github.com/magento/magento2/issues/18138)
 
-<!-- ENGCOM-3200 -->* Navigation arrows in the fotorama zoom now work as expected. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18595](https://github.com/magento/magento2/pull/18595)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
+<!-- ENGCOM-3200  -->
+*  Navigation arrows in the fotorama zoom now work as expected. *Fix submitted by [Luuk Schakenraad](https://github.com/luukschakenraad) in pull request [18595](https://github.com/magento/magento2/pull/18595)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
 
-<!-- ENGCOM-3311 -->* You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18875](https://github.com/magento/magento2/pull/18875)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
+<!-- ENGCOM-3311  -->
+*  You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18875](https://github.com/magento/magento2/pull/18875)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
 
-<!-- MAGETWO-87734 -->* You can now pause product videos on YouTube on storefronts that are running on Internet Explorer 11.x.
+<!-- MAGETWO-87734  -->
+*  You can now pause product videos on YouTube on storefronts that are running on Internet Explorer 11.x.
 
-<!-- MAGETWO-90189 -->* You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
+<!-- MAGETWO-90189  -->
+*  You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
 
-<!-- MAGETWO-85932 -->* Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
+<!-- MAGETWO-85932  -->
+*  Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
 
-<!-- MAGETWO-86549 -->* After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the minicart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
+<!-- MAGETWO-86549  -->
+*  After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the minicart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
 
-<!-- MAGETWO-94423 -->* You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
+<!-- MAGETWO-94423  -->
+*  You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
 
-<!-- MAGETWO-89487 -->* Fixed  error message overlapping on the  **Quick Search Form Types** field on **Admin** > **Content** > **Elements** > **Widgets** > **Add Widget**.
+<!-- MAGETWO-89487  -->
+*  Fixed  error message overlapping on the  **Quick Search Form Types** field on **Admin** > **Content** > **Elements** > **Widgets** > **Add Widget**.
 
-<!-- MAGETWO-89438 -->* Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
+<!-- MAGETWO-89438  -->
+*  Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
 
 ### Gift card
 
-<!-- MAGETWO-90920 -->* Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
+<!-- MAGETWO-90920  -->
+*  Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
 
-<!-- MAGETWO-87985 -->* Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
+<!-- MAGETWO-87985  -->
+*  Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
 
 ### Gift registry
 
-<!-- MAGETWO-95738 -->* Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
+<!-- MAGETWO-95738  -->
+*  Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
 
-<!-- MAGETWO-73447 -->* You can now successfully preview a Registry Update email template. Previously, Magento threw a fatal error when you tried to preview this template.
+<!-- MAGETWO-73447  -->
+*  You can now successfully preview a Registry Update email template. Previously, Magento threw a fatal error when you tried to preview this template.
 
 ### Google Analytics
 
-<!-- ENGCOM-3091 -->* Google Analytics JavaScript is now loaded correctly on the frontend. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18375](https://github.com/magento/magento2/pull/18375)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
+<!-- ENGCOM-3091  -->
+*  Google Analytics JavaScript is now loaded correctly on the frontend. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18375](https://github.com/magento/magento2/pull/18375)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
 
-<!-- ENGCOM-2271 -->* You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by [Sunil](https://github.com/sunilit42) in pull request [15366](https://github.com/magento/magento2/pull/15366)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
+<!-- ENGCOM-2271  -->
+*  You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by [Sunil](https://github.com/sunilit42) in pull request [15366](https://github.com/magento/magento2/pull/15366)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
 
 ### Image
 
-<!-- MAGETWO-93985 -->* Magnifier now works as expected on any supported operating system and browser. Previously, Magnifier did not hover correctly on devices running Windows Chrome or FireFox.
+<!-- MAGETWO-93985  -->
+*  Magnifier now works as expected on any supported operating system and browser. Previously, Magnifier did not hover correctly on devices running Windows Chrome or FireFox.
 
-<!-- MAGETWO-94235 -->* Images added to a product attribute using the WYSIWYG editor now display as expected on the storefront. Previously, the URL for these images included the Admin CMS directive path in their URL.
+<!-- MAGETWO-94235  -->
+*  Images added to a product attribute using the WYSIWYG editor now display as expected on the storefront. Previously, the URL for these images included the Admin CMS directive path in their URL.
 
 ### Import/export
 
-<!-- ENGCOM-3877 -->* We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.
+<!-- ENGCOM-3877  -->
+*  We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.
 
-<!-- ENGCOM-3827 -->* Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20177](https://github.com/magento/magento2/pull/20177)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
+<!-- ENGCOM-3827  -->
+*  Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20177](https://github.com/magento/magento2/pull/20177)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
 
-<!-- ENGCOM-2930 -->* Magento now correctly displays all linked products in the correct order in the Admin tables. Previously, Magento displayed all products correctly on the storefront, but products were missing from the Admin display. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+<!-- ENGCOM-2930  -->
+*  Magento now correctly displays all linked products in the correct order in the Admin tables. Previously, Magento displayed all products correctly on the storefront, but products were missing from the Admin display. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720), [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
-<!-- ENGCOM-2916 -->* Magento does not change or overwrite  `url_key` values when updating product data during import if no values are provided in the import data.  *Fix submitted by [Joseph McDermott](https://github.com/josephmcdermott) in pull request [17882](https://github.com/magento/magento2/pull/17882)*. [GitHub-17023](https://github.com/magento/magento2/issues/17023)
+<!-- ENGCOM-2916  -->
+*  Magento does not change or overwrite  `url_key` values when updating product data during import if no values are provided in the import data.  *Fix submitted by [Joseph McDermott](https://github.com/josephmcdermott) in pull request [17882](https://github.com/magento/magento2/pull/17882)*. [GitHub-17023](https://github.com/magento/magento2/issues/17023)
 
-<!-- ENGCOM-3321 -->* Magento now displays an error message after you run check data when importing new products with SKUs that exceed the maximum permitted length. *Fix submitted by [Ravi Chandra](https://github.com/ravi-chandra3197) in pull request [18591](https://github.com/magento/magento2/pull/18591)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
+<!-- ENGCOM-3321  -->
+*  Magento now displays an error message after you run check data when importing new products with SKUs that exceed the maximum permitted length. *Fix submitted by [Ravi Chandra](https://github.com/ravi-chandra3197) in pull request [18591](https://github.com/magento/magento2/pull/18591)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
 
-<!-- MAGETWO-93222 -->* Magento no longer deletes  `url-key` values for existing products when updating these products with imported data that does not contain `url-key` values.
+<!-- MAGETWO-93222  -->
+*  Magento no longer deletes  `url-key` values for existing products when updating these products with imported data that does not contain `url-key` values.
 
-<!-- MAGETWO-86048 -->* Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
+<!-- MAGETWO-86048  -->
+*  Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
 
-<!-- MAGETWO-73922 -->* You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
+<!-- MAGETWO-73922  -->
+*  You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
 
-<!-- MAGETWO-95101 -->* URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
+<!-- MAGETWO-95101  -->
+*  URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
 
-<!-- MAGETWO-94432 -->* You can now hide an image as expected by using the `hide_from_product_page` attribute during import.
+<!-- MAGETWO-94432  -->
+*  You can now hide an image as expected by using the `hide_from_product_page` attribute during import.
 
-<!-- MAGETWO-91283 -->* Import now completes successfully when a product’s CSV entry is split over two import bunches.  Previously, Magento threw this error, `Cannot add or update a child row: a foreign key constraint fails`, and import failed.
+<!-- MAGETWO-91283  -->
+*  Import now completes successfully when a product’s CSV entry is split over two import bunches.  Previously, Magento threw this error, `Cannot add or update a child row: a foreign key constraint fails`, and import failed.
 
-<!-- MAGETWO-95653 -->* Magento now retains product order within a category after import.
+<!-- MAGETWO-95653  -->
+*  Magento now retains product order within a category after import.
 
-<!-- MAGETWO-74012 -->* You can now provide your own sample data file for a custom module in `your_module/Files/Sample/your_sample.csv`. Previously, this custom sample file had to be placed in the ImportExport module. [GitHub-6553](https://github.com/magento/magento2/issues/6553)
+<!-- MAGETWO-74012  -->
+*  You can now provide your own sample data file for a custom module in `your_module/Files/Sample/your_sample.csv`. Previously, this custom sample file had to be placed in the ImportExport module. [GitHub-6553](https://github.com/magento/magento2/issues/6553)
 
-<!-- MAGETWO-95535 -->* Imported images of all sizes no longer revert to the default placeholder size after import.
+<!-- MAGETWO-95535  -->
+*  Imported images of all sizes no longer revert to the default placeholder size after import.
 
-<!-- MAGETWO-95535 -->* Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
+<!-- MAGETWO-95535  -->
+*  Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
 
-<!-- ENGCOM-4075 -->*  The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+<!-- ENGCOM-4075  -->
+*   The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
-<!-- MAGETWO-74044 -->* The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
+<!-- MAGETWO-74044  -->
+*  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
 
-<!-- MAGETWO-94072 -->* Configurable products based on swatches are now exported with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
+<!-- MAGETWO-94072  -->
+*  Configurable products based on swatches are now exported with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
 
 ### Infrastructure
 
-<!-- ENGCOM-3025 -->* Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!-- ENGCOM-3025  -->
+*  Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by [passtet](https://github.com/passtet) in pull request [17984](https://github.com/magento/magento2/pull/17984)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Integration
 
-<!-- ENGCOM-3102 -->* The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by [Prakash](https://github.com/prakashpatel07) in pull request [17978](https://github.com/magento/magento2/pull/17978)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
+<!-- ENGCOM-3102  -->
+*  The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by [Prakash](https://github.com/prakashpatel07) in pull request [17978](https://github.com/magento/magento2/pull/17978)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
 
 ### Layered navigation
 
-<!-- ENGCOM-3388 -->* The code comment that describes the `Use in Layered Navigation: Filterable (no results)` property for the price filter has been made more informative. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19044](https://github.com/magento/magento2/pull/19044)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!-- ENGCOM-3388  -->
+*  The code comment that describes the `Use in Layered Navigation: Filterable (no results)` property for the price filter has been made more informative. *Fix submitted by [Vladyslav Podorozhnyi](https://github.com/vpodorozh) in pull request [19044](https://github.com/magento/magento2/pull/19044)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
 <!-- MAGETWO-97000 -->
 *  Layered navigation for Elasticsearch now includes all product sizes. If the **Filterable (with results)** option is set for a product attribute, then:
@@ -584,7 +791,8 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 
    *  Attribute values with a count of zero (0) product matches are omitted from the list of available filters.
 
-<!-- MAGETWO-85162 -->* You can now filter products based on color.
+<!-- MAGETWO-85162  -->
+*  You can now filter products based on color.
 
 ### Magento Shipping
 
@@ -594,295 +802,414 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 
 ### Newsletter
 
-<!-- ENGCOM-3253 -->* Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [18643](https://github.com/magento/magento2/pull/18643)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
+<!-- ENGCOM-3253  -->
+*  Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by [Janak Bhimani](https://github.com/janakbhimani) in pull request [18643](https://github.com/magento/magento2/pull/18643)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
 
-<!-- MAGETWO-88736 -->* Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
+<!-- MAGETWO-88736  -->
+*  Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
 
-<!-- MAGETWO-82530 -->* Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
+<!-- MAGETWO-82530  -->
+*  Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
 
-<!-- ENGCOM-3680 -->*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+<!-- ENGCOM-3680  -->
+*   A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
 ### Offline shipping
 
-<!-- ENGCOM-3079 -->*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+<!-- ENGCOM-3079  -->
+*   Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
-<!-- ENGCOM-3057 -->* The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
+<!-- ENGCOM-3057  -->
+*  The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
 
 ### Payment methods
 
-<!-- MAGETWO-93750 -->* Customers are now billed in the appropriate currency for orders that have been paid with using PayPal Payflow Pro. Previously, customers were billed in U.S. dollars even when another currency had been set.
+<!-- MAGETWO-93750  -->
+*  Customers are now billed in the appropriate currency for orders that have been paid with using PayPal Payflow Pro. Previously, customers were billed in U.S. dollars even when another currency had been set.
 
-<!-- MAGETWO-94260 -->* Magento now displays the correct billing address in the order confirmation email when  **Paypal Express Checkout** is enabled. Previously, Magento displayed the shipping address instead of the billing address.
+<!-- MAGETWO-94260  -->
+*  Magento now displays the correct billing address in the order confirmation email when  **Paypal Express Checkout** is enabled. Previously, Magento displayed the shipping address instead of the billing address.
 
-<!-- MAGETWO-96587 -->* When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
+<!-- MAGETWO-96587  -->
+*  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
 
-<!-- ENGCOM-3997 -->*  Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+<!-- ENGCOM-3997  -->
+*   Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
-<!-- ENGCOM-3691 -->*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+<!-- ENGCOM-3691  -->
+*   Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
-<!-- ENGCOM-3316 -->* Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
+<!-- ENGCOM-3316  -->
+*  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
 
-<!-- ENGCOM-2629 -->* You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by [Michiel Gerritsen](https://github.com/michielgerritsen) in pull request [15683](https://github.com/magento/magento2/pull/15683)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
+<!-- ENGCOM-2629  -->
+*  You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by [Michiel Gerritsen](https://github.com/michielgerritsen) in pull request [15683](https://github.com/magento/magento2/pull/15683)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
 
-<!-- MAGETWO-96289 -->* A popup no longer blocks completion of check out using Braintree PayPal on a mobile device.
+<!-- MAGETWO-96289  -->
+*  A popup no longer blocks completion of check out using Braintree PayPal on a mobile device.
 
-<!-- MAGETWO-90929 -->* Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
+<!-- MAGETWO-90929  -->
+*  Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
 
-<!-- MAGETWO-94857 -->*  Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
+<!-- MAGETWO-94857  -->
+*   Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
 
-<!-- MAGETWO-95218 -->* When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
+<!-- MAGETWO-95218  -->
+*  When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
 
 ### Pricing
 
-<!-- MAGETWO-95721 -->* Sorting by price now works as expected. Previously, when a merchant removed a special price or a simple product, the `final_price`, `min_price` and `max_price` attributes of the `catalog_product_index_price` table was changed to 0.0000 instead of reverting back to the original price.
+<!-- MAGETWO-95721  -->
+*  Sorting by price now works as expected. Previously, when a merchant removed a special price or a simple product, the `final_price`, `min_price` and `max_price` attributes of the `catalog_product_index_price` table was changed to 0.0000 instead of reverting back to the original price.
 
 ### Quote
 
-<!-- MAGETWO-91332 -->* You can now request a quote on a storefront running on iOS 11.3.1.
+<!-- MAGETWO-91332  -->
+*  You can now request a quote on a storefront running on iOS 11.3.1.
 
-<!-- MAGETWO-95180 -->* Merchants can now create new user roles that do not have  access to quotes.
+<!-- MAGETWO-95180  -->
+*  Merchants can now create new user roles that do not have  access to quotes.
 
-<!-- ENGCOM-3314 -->* You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18872](https://github.com/magento/magento2/pull/18872)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
+<!-- ENGCOM-3314  -->
+*  You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18872](https://github.com/magento/magento2/pull/18872)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
 
-<!-- ENGCOM-3839 -->* You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20208](https://github.com/magento/magento2/pull/20208)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
+<!-- ENGCOM-3839  -->
+*  You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20208](https://github.com/magento/magento2/pull/20208)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
 
-<!-- ENGCOM-3975 -->* We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20638](https://github.com/magento/magento2/pull/20638)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
+<!-- ENGCOM-3975  -->
+*  We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20638](https://github.com/magento/magento2/pull/20638)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
 
 ### Reports
 
-<!-- MAGETWO-90727 -->* Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
+<!-- MAGETWO-90727  -->
+*  Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
 
 ### Review
 
-<!-- ENGCOM-3833 -->* Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20183](https://github.com/magento/magento2/pull/20183)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
+<!-- ENGCOM-3833  -->
+*  Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by [Saphal Jha](https://github.com/saphaljha) in pull request [20183](https://github.com/magento/magento2/pull/20183)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
 
-<!-- MAGETWO-93988 -->* The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
+<!-- MAGETWO-93988  -->
+*  The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
 
 ### Reward
 
-<!-- MAGETWO-89737 -->* Customers are now subscribed as expected to email notifications about reward points.
+<!-- MAGETWO-89737  -->
+*  Customers are now subscribed as expected to email notifications about reward points.
 
-<!-- MAGETWO-88674 -->* `/V1/orders/{id}` now retrieves information about used reward points.
+<!-- MAGETWO-88674  -->
+*  `/V1/orders/{id}` now retrieves information about used reward points.
 
 ### RMA
 
-<!-- MAGETWO-96664 -->* Magento now displays newly created RMA attributes on the storefront when the **Enable RMA on Storefront** RMA attribute is enabled.
+<!-- MAGETWO-96664  -->
+*  Magento now displays newly created RMA attributes on the storefront when the **Enable RMA on Storefront** RMA attribute is enabled.
 
-<!-- MAGETWO-94019 -->* The **Show/Hide** details button now works as expected on the Returns (RMA) page.
+<!-- MAGETWO-94019  -->
+*  The **Show/Hide** details button now works as expected on the Returns (RMA) page.
 
-<!-- MAGETWO-94232 -->* Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
+<!-- MAGETWO-94232  -->
+*  Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
 
-<!-- MAGETWO-72953 -->* Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
+<!-- MAGETWO-72953  -->
+*  Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
 
-<!-- MAGETWO-97009 -->* Administrators can now process returns when an RMA request includes a required image attribute.
+<!-- MAGETWO-97009  -->
+*  Administrators can now process returns when an RMA request includes a required image attribute.
 
 ### Sales
 
-<!-- ENGCOM-1429 -->*  The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+<!-- ENGCOM-1429  -->
+*   The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
-<!-- MAGETWO-93155 -->* You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
+<!-- MAGETWO-93155  -->
+*  You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
 
-<!-- ENGCOM-3791 -->* Fixed an incorrect class name on orders and returns pages on the Admin. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20080](https://github.com/magento/magento2/pull/20080)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
+<!-- ENGCOM-3791  -->
+*  Fixed an incorrect class name on orders and returns pages on the Admin. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20080](https://github.com/magento/magento2/pull/20080)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
 
-<!-- ENGCOM-3494 -->* The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by [Ian cassidy](https://github.com/iancassidyweb) in pull request [18621](https://github.com/magento/magento2/pull/18621)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
+<!-- ENGCOM-3494  -->
+*  The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by [Ian cassidy](https://github.com/iancassidyweb) in pull request [18621](https://github.com/magento/magento2/pull/18621)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
 
-<!-- ENGCOM-2940 -->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [MateuszChrapek](https://github.com/MateuszChrapek) in pull request [17998](https://github.com/magento/magento2/pull/17998)*. [GitHub-9830](https://github.com/magento/magento2/issues/9830) [GitHub-10530](https://github.com/magento/magento2/issues/10530)
+<!-- ENGCOM-2940  -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by [MateuszChrapek](https://github.com/MateuszChrapek) in pull request [17998](https://github.com/magento/magento2/pull/17998)*. [GitHub-9830](https://github.com/magento/magento2/issues/9830) [GitHub-10530](https://github.com/magento/magento2/issues/10530)
 
-<!-- ENGCOM-3092 -->* Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18376](https://github.com/magento/magento2/pull/18376)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
+<!-- ENGCOM-3092  -->
+*  Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by [Petar Sambolek](https://github.com/sambolek) in pull request [18376](https://github.com/magento/magento2/pull/18376)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
 
-<!-- MAGETWO-96976 -->* Magento no longer adds gift wrap tax to the credit memo twice.
+<!-- MAGETWO-96976  -->
+*  Magento no longer adds gift wrap tax to the credit memo twice.
 
-<!-- MAGETWO-94295 -->* The **State/province** field that Magento displays for Admin orders that will be shipped to the U.S. is now a drop-down as expected. Previously, the **state/province** field  was not a drop-down menu with states but a text field.
+<!-- MAGETWO-94295  -->
+*  The **State/province** field that Magento displays for Admin orders that will be shipped to the U.S. is now a drop-down as expected. Previously, the **state/province** field  was not a drop-down menu with states but a text field.
 
-<!-- MAGETWO-94181 -->* You can now issue a partial refund to store credit for an order made with an online payment method.
+<!-- MAGETWO-94181  -->
+*  You can now issue a partial refund to store credit for an order made with an online payment method.
 
-<!-- MAGETWO-73570 -->* Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
+<!-- MAGETWO-73570  -->
+*  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
-<!-- MAGETWO-93393 -->*  Magento now uses  the correct table rate shipment when a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
+<!-- MAGETWO-93393  -->
+*   Magento now uses  the correct table rate shipment when a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
 
-<!-- MAGETWO-94458 -->* You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
+<!-- MAGETWO-94458  -->
+*  You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
 
-<!-- MAGETWO-86292 -->* You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
+<!-- MAGETWO-86292  -->
+*  You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
 
-<!-- MAGETWO-73039 -->* Orders exported to a CSV file now display dates in a consistent format.
+<!-- MAGETWO-73039  -->
+*  Orders exported to a CSV file now display dates in a consistent format.
 
-<!-- MAGETWO-86121 -->* Merchants can now ship the remaining items in an order in which some items require a credit memo.
+<!-- MAGETWO-86121  -->
+*  Merchants can now ship the remaining items in an order in which some items require a credit memo.
 
-<!-- MAGETWO-96394 -->* Orders for bundle products created from the Admin now display  correct product prices.
+<!-- MAGETWO-96394  -->
+*  Orders for bundle products created from the Admin now display  correct product prices.
 
-<!-- MAGETWO-96141 -->* You can now remove a custom price from a product during order creation from the Admin.
+<!-- MAGETWO-96141  -->
+*  You can now remove a custom price from a product during order creation from the Admin.
 
-<!-- ENGCOM-3998 -->*  The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+<!-- ENGCOM-3998  -->
+*   The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
-<!-- ENGCOM-3999 -->* Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
+<!-- ENGCOM-3999  -->
+*  Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
 
-<!-- ENGCOM-3939 -->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20508](https://github.com/magento/magento2/pull/20508)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
+<!-- ENGCOM-3939  -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [20508](https://github.com/magento/magento2/pull/20508)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
 
-<!-- ENGCOM-3874 -->* The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20184](https://github.com/magento/magento2/pull/20184)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
+<!-- ENGCOM-3874  -->
+*  The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20184](https://github.com/magento/magento2/pull/20184)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
 
-<!-- ENGCOM-3880 -->* Product option values are now rendered correctly as links when  you view an order that contains a product with a file type option. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20353](https://github.com/magento/magento2/pull/20353)*. [GitHub-20352](https://github.com/magento/magento2/issues/20352)
+<!-- ENGCOM-3880  -->
+*  Product option values are now rendered correctly as links when  you view an order that contains a product with a file type option. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20353](https://github.com/magento/magento2/pull/20353)*. [GitHub-20352](https://github.com/magento/magento2/issues/20352)
 
-<!-- MAGETWO-73883 -->* The Items Ordered list now updates as expected when the user clicks **OK** when changing the options of a configurable product during creation of an order from the Admin. Previously, the update did not occur until the user clicked **Update Items and Quantities**.
+<!-- MAGETWO-73883  -->
+*  The Items Ordered list now updates as expected when the user clicks **OK** when changing the options of a configurable product during creation of an order from the Admin. Previously, the update did not occur until the user clicked **Update Items and Quantities**.
 
 ### Sales rule
 
-<!-- MAGETWO-86098 -->* The cart price rule now uses specified conditions correctly when applying discounts on configurable products.
+<!-- MAGETWO-86098  -->
+*  The cart price rule now uses specified conditions correctly when applying discounts on configurable products.
 
-<!-- MAGETWO-86637 -->* The sales rule indexer now runs without error. Previously, the sales rule indexer returned an error during reindexing because of the Magento_AdvancedSalesRule module.
+<!-- MAGETWO-86637  -->
+*  The sales rule indexer now runs without error. Previously, the sales rule indexer returned an error during reindexing because of the Magento_AdvancedSalesRule module.
 
-<!-- ENGCOM-3784 -->* Magento no longer throws an exception upon cancelation of an order that was placed with a coupon by a guest who, after checkout, created a customer account. *Fix submitted by [Andriy Kravets](https://github.com/Winfle) in pull request [19423](https://github.com/magento/magento2/pull/19423)*. [GitHub-19230](https://github.com/magento/magento2/issues/19230)
+<!-- ENGCOM-3784  -->
+*  Magento no longer throws an exception upon cancelation of an order that was placed with a coupon by a guest who, after checkout, created a customer account. *Fix submitted by [Andriy Kravets](https://github.com/Winfle) in pull request [19423](https://github.com/magento/magento2/pull/19423)*. [GitHub-19230](https://github.com/magento/magento2/issues/19230)
 
-<!-- MAGETWO-95993 -->* Archived orders no longer reappear in the Order Management table after cron runs.
+<!-- MAGETWO-95993  -->
+*  Archived orders no longer reappear in the Order Management table after cron runs.
 
 ### Search
 
-<!-- MAGETWO-73351 -->* Full text search for Elasticsearch no longer includes the `date` attribute.
+<!-- MAGETWO-73351  -->
+*  Full text search for Elasticsearch no longer includes the `date` attribute.
 
-<!-- MAGETWO-86052 -->* The default sort order field now works as expected on the Catalog Search results page.
+<!-- MAGETWO-86052  -->
+*  The default sort order field now works as expected on the Catalog Search results page.
 
-<!-- MAGETWO-86396 -->* Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group
+<!-- MAGETWO-86396  -->
+*  Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group
 
-<!-- ENGCOM-3811 -->* A mistyped `saveHandler` has been removed from the CatalogSearch indexer declaration. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [19984](https://github.com/magento/magento2/pull/19984)*. [GitHub-19982](https://github.com/magento/magento2/issues/19982)
+<!-- ENGCOM-3811  -->
+*  A mistyped `saveHandler` has been removed from the CatalogSearch indexer declaration. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [19984](https://github.com/magento/magento2/pull/19984)*. [GitHub-19982](https://github.com/magento/magento2/issues/19982)
 
 ### Shipping
 
-<!-- MAGETWO-c -->* Magento now uses the  shipping table rate from the correct store in multistore deployments.
+<!-- MAGETWO-c  -->
+*  Magento now uses the  shipping table rate from the correct store in multistore deployments.
 
-<!-- MAGETWO-73894 -->* You can now use `GET .V1/shipments` to search for shipments that contain a shipping label. Previously, using this call  caused Magento to throw an exception. [GitHub-6668](https://github.com/magento/magento2/issues/6668)
+<!-- MAGETWO-73894  -->
+*  You can now use `GET .V1/shipments` to search for shipments that contain a shipping label. Previously, using this call  caused Magento to throw an exception. [GitHub-6668](https://github.com/magento/magento2/issues/6668)
 
-<!-- MAGETWO-91105 -->* Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
+<!-- MAGETWO-91105  -->
+*  Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
 
-<!-- MAGETWO-96156 -->* Shipments that are created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when shipment was created using REST.
+<!-- MAGETWO-96156  -->
+*  Shipments that are created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when shipment was created using REST.
 
-<!-- MAGETWO-95497 -->* Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
+<!-- MAGETWO-95497  -->
+*  Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
 
-<!-- ENGCOM-4042 -->*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!-- ENGCOM-4042  -->
+*   Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!-- ENGCOM-3008 -->*  Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+<!-- ENGCOM-3008  -->
+*   Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Staging
 
-<!-- MAGETWO-86541 -->* Updates containing zero objects are now removed as expected from the dashboard. Previously, Magento did not remove updates with zero objects.
+<!-- MAGETWO-86541  -->
+*  Updates containing zero objects are now removed as expected from the dashboard. Previously, Magento did not remove updates with zero objects.
 
-<!-- MAGETWO-73332 -->* The staging dashboard now loads without freezing.
+<!-- MAGETWO-73332  -->
+*  The staging dashboard now loads without freezing.
 
-<!-- MAGETWO-67135 -->* An administrator  with a custom (limited) role can now edit and schedule  updates to CMS content pages.
+<!-- MAGETWO-67135  -->
+*  An administrator  with a custom (limited) role can now edit and schedule  updates to CMS content pages.
 
-<!-- MAGETWO-86102 -->* Restricted users with access to specified sections can now save a scheduled update. Previously, Magento threw a `forbidden` error.
+<!-- MAGETWO-86102  -->
+*  Restricted users with access to specified sections can now save a scheduled update. Previously, Magento threw a `forbidden` error.
 
 ### Store
 
-<!-- ENGCOM-3737 -->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Nazar](https://github.com/Nazar65) in pull request [19945](https://github.com/magento/magento2/pull/19945)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941)
+<!-- ENGCOM-3737  -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by [Nazar](https://github.com/Nazar65) in pull request [19945](https://github.com/magento/magento2/pull/19945)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941)
 
 ### Swatches
 
-<!-- ENGCOM-3383 -->* An administrator with appropriate permissions  can now change a product's default swatch option from the Admin. *Fix submitted by [Rostislav Sabischenko](https://github.com/RostislavS) in pull request [19012](https://github.com/magento/magento2/pull/19012)*. [GitHub-8348](https://github.com/magento/magento2/issues/8348)
+<!-- ENGCOM-3383  -->
+*  An administrator with appropriate permissions  can now change a product's default swatch option from the Admin. *Fix submitted by [Rostislav Sabischenko](https://github.com/RostislavS) in pull request [19012](https://github.com/magento/magento2/pull/19012)*. [GitHub-8348](https://github.com/magento/magento2/issues/8348)
 
-<!-- ENGCOM-2912 -->* Store views now show the correct swatch values. *Fix submitted by [Misha Medzhytov](https://github.com/magicaner) in pull request [17891](https://github.com/magento/magento2/pull/17891)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
+<!-- ENGCOM-2912  -->
+*  Store views now show the correct swatch values. *Fix submitted by [Misha Medzhytov](https://github.com/magicaner) in pull request [17891](https://github.com/magento/magento2/pull/17891)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
 
-<!-- MAGETWO-73862 -->* You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
+<!-- MAGETWO-73862  -->
+*  You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
 
 ### TargetRule
 
-<!-- MAGETWO-95420 -->* Magento no longer throws a fatal error when price is used in a Target Rule for actions.
+<!-- MAGETWO-95420  -->
+*  Magento no longer throws a fatal error when price is used in a Target Rule for actions.
 
-<!-- MAGETWO-87678 -->* Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configurations** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
+<!-- MAGETWO-87678  -->
+*  Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configurations** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
 
 ### Tax
 
-<!-- MAGETWO-94179 -->* Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
+<!-- MAGETWO-94179  -->
+*  Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
 
-<!-- ENGCOM-3319 -->* Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data.  *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [18857](https://github.com/magento/magento2/pull/18857)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
+<!-- ENGCOM-3319  -->
+*  Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data.  *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [18857](https://github.com/magento/magento2/pull/18857)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
 
 ### Testing
 
-<!-- ENGCOM-3410 -->* Unit test annotations now assert exception messages correctly. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19105](https://github.com/magento/magento2/pull/19105)*. [GitHub-18840](https://github.com/magento/magento2/issues/18840)
+<!-- ENGCOM-3410  -->
+*  Unit test annotations now assert exception messages correctly. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19105](https://github.com/magento/magento2/pull/19105)*. [GitHub-18840](https://github.com/magento/magento2/issues/18840)
 
-<!-- ENGCOM-3875 -->* `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
+<!-- ENGCOM-3875  -->
+*  `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
 
-<!-- ENGCOM-3021 -->*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+<!-- ENGCOM-3021  -->
+*   Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
 ### Theme
 
-<!-- MAGETWO-74208 -->* Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
+<!-- MAGETWO-74208  -->
+*  Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
 
-<!-- MAGETWO-85037 -->* Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
+<!-- MAGETWO-85037  -->
+*  Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
 
-<!-- MAGETWO-89546 -->* We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
+<!-- MAGETWO-89546  -->
+*  We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
 
-<!-- MAGETWO-94455 -->* The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
+<!-- MAGETWO-94455  -->
+*  The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
 
-<!-- MAGETWO-87027 -->* The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
+<!-- MAGETWO-87027  -->
+*  The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
 
-<!-- MAGETWO-94462 -->* All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
+<!-- MAGETWO-94462  -->
+*  All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
 
-<!-- ENGCOM-3672 -->* Clicking on the store logo on the home page now reloads the page. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19199](https://github.com/magento/magento2/pull/19199)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
+<!-- ENGCOM-3672  -->
+*  Clicking on the store logo on the home page now reloads the page. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19199](https://github.com/magento/magento2/pull/19199)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
 
 ### UI
 
-<!-- ENGCOM-3973 -->* Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
+<!-- ENGCOM-3973  -->
+*  Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
-<!-- ENGCOM-4012 -->*  Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+<!-- ENGCOM-4012  -->
+*   Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
-<!-- ENGCOM-3308 -->* Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
+<!-- ENGCOM-3308  -->
+*  Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
 
-<!-- ENGCOM-3306 -->* The delete product confirmation popup now closes only when you click the **OK** button. *Fix submitted by [Shubham Sharma](https://github.com/Shubham-Webkul) in pull request [18865](https://github.com/magento/magento2/pull/18865)*. [GitHub-18458](https://github.com/magento/magento2/issues/18458)
+<!-- ENGCOM-3306  -->
+*  The delete product confirmation popup now closes only when you click the **OK** button. *Fix submitted by [Shubham Sharma](https://github.com/Shubham-Webkul) in pull request [18865](https://github.com/magento/magento2/pull/18865)*. [GitHub-18458](https://github.com/magento/magento2/issues/18458)
 
-<!-- ENGCOM-3174 -->* Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
+<!-- ENGCOM-3174  -->
+*  Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
-<!-- ENGCOM-3177 -->*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!-- ENGCOM-3177  -->
+*   Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!-- ENGCOM-3313 -->* You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
+<!-- ENGCOM-3313  -->
+*  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
 
-<!-- MAGETWO-91403 -->* WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
+<!-- MAGETWO-91403  -->
+*  WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
 
 ### URL rewrite
 
-<!-- MAGETWO-86419 -->* Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
+<!-- MAGETWO-86419  -->
+*  Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
 
-<!-- MAGETWO-94860 -->* The storefront now properly displays the order of categories when you move categories in the Admin.
+<!-- MAGETWO-94860  -->
+*  The storefront now properly displays the order of categories when you move categories in the Admin.
 
-<!-- MAGETWO-93424 -->* Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
+<!-- MAGETWO-93424  -->
+*  Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
 
-<!-- MAGETWO-89619 -->* Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
+<!-- MAGETWO-89619  -->
+*  Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
 
-<!-- MAGETWO-86303 -->* Magento now correctly updates existing product URLs during import. Previously, Magento updated existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
+<!-- MAGETWO-86303  -->
+*  Magento now correctly updates existing product URLs during import. Previously, Magento updated existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
 
-<!-- ENGCOM-3175 -->* The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18563](https://github.com/magento/magento2/pull/18563)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
+<!-- ENGCOM-3175  -->
+*  The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18563](https://github.com/magento/magento2/pull/18563)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
 
 ### Visual Merchandiser
 
-<!-- MAGETWO-91019 -->* Visual Merchandiser now correctly sorts configurable product prices in Tile view.
+<!-- MAGETWO-91019  -->
+*  Visual Merchandiser now correctly sorts configurable product prices in Tile view.
 
 ### Web API framework
 
-<!-- MAGETWO-73526 -->* You can now create products with same name. Previously, Magento did not create the second  product and displayed this error, `Error "URL key for specified store already exists`.
+<!-- MAGETWO-73526  -->
+*  You can now create products with same name. Previously, Magento did not create the second  product and displayed this error, `Error "URL key for specified store already exists`.
 
-<!-- MAGETWO-86344 -->* Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
+<!-- MAGETWO-86344  -->
+*  Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
 
-<!-- MAGETWO-73061 -->* The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
+<!-- MAGETWO-73061  -->
+*  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
-<!-- ENGCOM-3929 -->*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+<!-- ENGCOM-3929  -->
+*   `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
 ### Widget
 
-<!-- MAGETWO-85683 -->* Magento now correctly renders apostrophes as entered in text fields.
+<!-- MAGETWO-85683  -->
+*  Magento now correctly renders apostrophes as entered in text fields.
 
-<!-- MAGETWO-93947 -->* The product page's Recently Viewed section no longer displays the name of the current product.
+<!-- MAGETWO-93947  -->
+*  The product page's Recently Viewed section no longer displays the name of the current product.
 
-<!-- ENGCOM-4037 -->* Fixed alignment of options on the Admin edit widget page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20270](https://github.com/magento/magento2/pull/20270)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!-- ENGCOM-4037  -->
+*  Fixed alignment of options on the Admin edit widget page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20270](https://github.com/magento/magento2/pull/20270)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
 ### Wishlist
 
-<!-- ENGCOM-3344 -->* Default configured values are now rendering on the wishlist product edit page. *Fix submitted by [Ratnesh Kumar](https://github.com/webkul-ratnesh) in pull request [18967](https://github.com/magento/magento2/pull/18967)*. [GitHub-18555](https://github.com/magento/magento2/issues/18555)
+<!-- ENGCOM-3344  -->
+*  Default configured values are now rendering on the wishlist product edit page. *Fix submitted by [Ratnesh Kumar](https://github.com/webkul-ratnesh) in pull request [18967](https://github.com/magento/magento2/pull/18967)*. [GitHub-18555](https://github.com/magento/magento2/issues/18555)
 
-<!-- MAGETWO-90812 -->* Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
+<!-- MAGETWO-90812  -->
+*  Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
 
-<!-- MAGETWO-93035 -->* Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
+<!-- MAGETWO-93035  -->
+*  Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
 
 ### WYSIWG
 
-<!-- ENGCOM-3291 -->* The `id_prefix` option for the cache frontend, which is used to prefix cache keys, is now set when Magento is installed. Previously, the performance of all websites in multisite deployments was uneven due to the previous mechanism used to prefix cache keys. *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
+<!-- ENGCOM-3291  -->
+*  The `id_prefix` option for the cache frontend, which is used to prefix cache keys, is now set when Magento is installed. Previously, the performance of all websites in multisite deployments was uneven due to the previous mechanism used to prefix cache keys. *Fix submitted by [Fabian Schmengler](https://github.com/schmengler) in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 
 ## Known issues
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -113,7 +113,8 @@ In addition to security enhancements, this release contains the following functi
 
 * Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
 
-<!-- MAGETWO-74081 -->* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+<!-- MAGETWO-74081  -->
+*  You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
 <!-- MAGETWO-98626 -->
 
@@ -155,7 +156,8 @@ In addition to security enhancements, this release contains the following functi
 
 * Magento no longer permits you to change an attribute set if the new set does not have equivalent attributes as the original set. Previously, Magento sometimes threw this exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.`
 
-<!-- MAGETWO-97380 -->* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
+<!-- MAGETWO-97380  -->
+*  You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
 <!-- MAGETWO-97425 -->
 
@@ -177,7 +179,8 @@ In addition to security enhancements, this release contains the following functi
 
 * Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
-<!-- ENGCOM-4030 -->* Fixed misalignment of product page tab content in mobile view. *Fix submitted by Amol Chaudhari in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+<!-- ENGCOM-4030  -->
+*  Fixed misalignment of product page tab content in mobile view. *Fix submitted by Amol Chaudhari in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
 <!-- ENGCOM-4254 -->
 
@@ -275,7 +278,8 @@ In addition to security enhancements, this release contains the following functi
 
 * Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by Prince Patel in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
-<!-- ENGCOM-4436 -->* The **Cancel** button on the checkout page now works as expected. *Fix submitted by Pratik Oza in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+<!-- ENGCOM-4436  -->
+*  The **Cancel** button on the checkout page now works as expected. *Fix submitted by Pratik Oza in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
 <!-- ENGCOM-4479 -->
 
@@ -417,7 +421,8 @@ In addition to security enhancements, this release contains the following functi
 
 * Magento now uses the value of the  default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
-<!-- MAGETWO-93521 -->* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+<!-- MAGETWO-93521  -->
+*  Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 <!-- ENGCOM-4132 -->
 
@@ -873,7 +878,8 @@ In addition to security enhancements, this release contains the following functi
 
 * The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by Amol Chaudhari in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
-<!-- ENGCOM-4088 -->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Amol Chaudhari in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+<!-- ENGCOM-4088  -->
+*  Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Amol Chaudhari in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
 <!-- ENGCOM-4011 -->
 
@@ -951,9 +957,11 @@ In addition to security enhancements, this release contains the following functi
 
 ### Wishlist
 
-<!-- MAGETWO-73613 -->* The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesirable and inaccurate changes in quantity
+<!-- MAGETWO-73613  -->
+*  The quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesirable and inaccurate changes in quantity
 
-<!-- ENGCOM-4513 -->* Customer wishlists now include review summaries for included products. *Fix submitted by Amol Chaudhari in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
+<!-- ENGCOM-4513  -->
+*  Customer wishlists now include review summaries for included products. *Fix submitted by Amol Chaudhari in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 ## Known issue
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
@@ -3593,39 +3593,55 @@ We've fixed hundreds of issues in the Magento 2.3.0 core code.
 
 ### Web API
 
-<!--- MAGETWO-82315 -->* When you use REST to update an existing product, Magento assigns the update only to the websites that they were assigned to before the update. Previously, updating a product using the REST API (`PUT /rest/all/V1/products/example_sku`) assigned the product update to all websites automatically. *Fix submitted by adrian-martinez-interactiv4 in pull request [11443](https://github.com/magento/magento2/pull/11443)*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82315  -->
+*  When you use REST to update an existing product, Magento assigns the update only to the websites that they were assigned to before the update. Previously, updating a product using the REST API (`PUT /rest/all/V1/products/example_sku`) assigned the product update to all websites automatically. *Fix submitted by adrian-martinez-interactiv4 in pull request [11443](https://github.com/magento/magento2/pull/11443)*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- MAGETWO-90147 -->* When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
+<!--- MAGETWO-90147  -->
+*  When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
 
-<!--- MAGETWO-84319 -->* Magento no longer creates duplicate shipments for orders created via API. Previously, Magento created duplicate shipments when a merchant created a shipment via the API under certain conditions (mainly with bundled products).
+<!--- MAGETWO-84319  -->
+*  Magento no longer creates duplicate shipments for orders created via API. Previously, Magento created duplicate shipments when a merchant created a shipment via the API under certain conditions (mainly with bundled products).
 
-<!--- MAGETWO-91540 -->*  Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
+<!--- MAGETWO-91540  -->
+*   Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
 
-<!--- MAGETWO-91568 -->*  You can now include custom attributes when filtering the responses of REST calls.
+<!--- MAGETWO-91568  -->
+*   You can now include custom attributes when filtering the responses of REST calls.
 
-<!--- MAGETWO-94207 -->*  Magento now returns a 404 error and includes a descriptive error message when a  REST search is performed on a non-existent cart.
+<!--- MAGETWO-94207  -->
+*   Magento now returns a 404 error and includes a descriptive error message when a  REST search is performed on a non-existent cart.
 
-<!--- MAGETWO-81910 -->*   Magento now includes the filter groups and the sort order of the `$searchCriteria` parameter in the `searchCriteria` object that is provided for the EAV set repository. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
+<!--- MAGETWO-81910  -->
+*    Magento now includes the filter groups and the sort order of the `$searchCriteria` parameter in the `searchCriteria` object that is provided for the EAV set repository. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
 
-<!--- MAGETWO-82315 -->* Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82315  -->
+*  Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- ENGCOM-2066 -->* A generated Admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired.  *Fix submitted by Vijay Golani in pull request [15564](https://github.com/magento/magento2/pull/15564)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
+<!--- ENGCOM-2066  -->
+*  A generated Admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired.  *Fix submitted by Vijay Golani in pull request [15564](https://github.com/magento/magento2/pull/15564)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
 
-<!-- MAGETWO-87057 -->* Magento now checks for the uniqueness of attribute option values for attributes created via REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
+<!-- MAGETWO-87057  -->
+*  Magento now checks for the uniqueness of attribute option values for attributes created via REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
 
-<!--- MAGETWO-87152 -->*  `salesRefundInvoiceV1` now saves the invoice ID as expected for a credit memo. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
+<!--- MAGETWO-87152  -->
+*   `salesRefundInvoiceV1` now saves the invoice ID as expected for a credit memo. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
 
 ### Wishlist
 
-<!--- MAGETWO-85627 -->* Magento now displays an error message if you try to add products to a wishlist without first logging in. *Fix submitted by Pieter Cappelle in pull request [12681](https://github.com/magento/magento2/pull/12681)*.
+<!--- MAGETWO-85627  -->
+*  Magento now displays an error message if you try to add products to a wishlist without first logging in. *Fix submitted by Pieter Cappelle in pull request [12681](https://github.com/magento/magento2/pull/12681)*.
 
-<!--- MAGETWO-86101 -->* Magento now stores product IDs and SKUs to locally stored customer data for wishlists. *Fix submitted by James Halsall in pull request [12896](https://github.com/magento/magento2/pull/12896)*.
+<!--- MAGETWO-86101  -->
+*  Magento now stores product IDs and SKUs to locally stored customer data for wishlists. *Fix submitted by James Halsall in pull request [12896](https://github.com/magento/magento2/pull/12896)*.
 
-<!--- MAGETWO-90297 -->* `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built the wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
+<!--- MAGETWO-90297  -->
+*  `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built the wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
 
-<!--- MAGETWO-91615 -->*  Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
+<!--- MAGETWO-91615  -->
+*   Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
 
-<!--- MAGETWO-91433 -->*  Magento no longer changes the grid view to list view on the product list page when a customer adds a product from the wishlist section to the cart, and now displays the appropriate success message.
+<!--- MAGETWO-91433  -->
+*   Magento no longer changes the grid view to list view on the product list page when a customer adds a product from the wishlist section to the cart, and now displays the appropriate success message.
 
 ## Known issues
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
@@ -1038,7 +1038,8 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.7
 
 * A typo in `gallery.php` has been fixed. *Fix submitted by Daniël van der Linden in pull request [17659](https://github.com/magento/magento2/pull/17659)*.
 
-<!---ENGCOM-2859 -->* The delete operation `entity_manager_delete_before`  transaction event  is no longer dispatched twice unnecessarily. *Fix submitted by p-bystritsky in pull request [17720](https://github.com/magento/magento2/pull/17720)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
+<!---ENGCOM-2859  -->
+*  The delete operation `entity_manager_delete_before`  transaction event  is no longer dispatched twice unnecessarily. *Fix submitted by p-bystritsky in pull request [17720](https://github.com/magento/magento2/pull/17720)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
 
 <!---ENGCOM-2231 -->
 
@@ -1886,7 +1887,8 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.7
 
 * The `404 forbidden` error message has been corrected for accuracy to `404 not found` in `/app/code/Magento/Backend/Controller/Adminhtml/Noroute/Index.php`. [GitHub-10775](https://github.com/magento/magento2/issues/10775)
 
-<!--- ENGCOM-1857 -->* The Module Manager module grid list is now displayed correctly (**System** > **Tools** > **Web Setup Wizard**  >  **Module Manager**).  *Fix submitted by [Vijay Golani](https://github.com/vijay-wagento) in pull request [15755](https://github.com/magento/magento2/pull/15755)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
+<!--- ENGCOM-1857  -->
+*  The Module Manager module grid list is now displayed correctly (**System** > **Tools** > **Web Setup Wizard**  >  **Module Manager**).  *Fix submitted by [Vijay Golani](https://github.com/vijay-wagento) in pull request [15755](https://github.com/magento/magento2/pull/15755)*. [GitHub-15192](https://github.com/magento/magento2/issues/15192)
 
 <!--- MAGETWO-87176 -->
 
@@ -2218,7 +2220,8 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.7
 
 * Corrected sticky footer in `page-main` container height on mobile devices. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!---ENGCOM-2604 -->* Style groups for mobile devices (`max-width`) are now specified in the correct order. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
+<!---ENGCOM-2604  -->
+*  Style groups for mobile devices (`max-width`) are now specified in the correct order. [GitHub-14476](https://github.com/magento/magento2/issues/14476)
 
 <!---ENGCOM-2796 -->
 
@@ -2692,7 +2695,8 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.7
 
 * Magento now successfully saves the value of `REMOTE_IP` when a customer uses an IPV6 (Internet Protocol version 6) address. Previously, this value was only partially saved in the `sales_order` and `quote` tables. *Fix submitted by Dmytro Cheshun in pull request [15142](https://github.com/magento/magento2/pull/15142)*. [GitHub-10395](https://github.com/magento/magento2/issues/10395)
 
-<!--- ENGCOM-2801 -->* A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
+<!--- ENGCOM-2801  -->
+*  A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
 
 <!--- ENGCOM-2482 -->
 
@@ -3064,233 +3068,336 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.7
 
 *  Returns from REST endpoint  `/V1/store/storeViews` calls now include  `is_active` values for stores. [GitHub-10922](https://github.com/magento/magento2/issues/10922)
 
-<!---ENGCOM-2606 -->* The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Pratik Oza in pull request [17261](https://github.com/magento/magento2/pull/17261)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
+<!---ENGCOM-2606  -->
+*  The `getUrlInStore()` method no longer returns URLs that contain the store code, which has shortened the extremely long URLs it previously returned. *Fix submitted by Pratik Oza in pull request [17261](https://github.com/magento/magento2/pull/17261)*. [GitHub-16273](https://github.com/magento/magento2/issues/16273)
 
-<!--- MAGETWO-87615 -->*  You can now use an `admin_system_config_changed_section` event to subscribe to changes for all sections in **Stores** > **Settings** > **Configuration**. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
+<!--- MAGETWO-87615  -->
+*   You can now use an `admin_system_config_changed_section` event to subscribe to changes for all sections in **Stores** > **Settings** > **Configuration**. [GitHub-5035](https://github.com/magento/magento2/issues/5035)
 
-<!--- MAGETWO-87938 -->*  TinyMCE now loads successfully due to a refactoring of  the use of  `minify_exclude` configuration. *Fix submitted by Pieter Hoste in pull request [13687](https://github.com/magento/magento2/pull/13687)*. [GitHub-11577](https://github.com/magento/magento2/issues/11577)
+<!--- MAGETWO-87938  -->
+*   TinyMCE now loads successfully due to a refactoring of  the use of  `minify_exclude` configuration. *Fix submitted by Pieter Hoste in pull request [13687](https://github.com/magento/magento2/pull/13687)*. [GitHub-11577](https://github.com/magento/magento2/issues/11577)
 
 ### Swagger
 
-<!--- MAGETWO-90787-->* Swagger now correctly renders POST/PUT operations. Previously, in Swagger, the text area that contained the payload structure of some POST and PUT operations was not displayed.
+<!--- MAGETWO-90787 -->
+*  Swagger now correctly renders POST/PUT operations. Previously, in Swagger, the text area that contained the payload structure of some POST and PUT operations was not displayed.
 
-<!---ENGCOM-2811 -->* Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the swagger-ui-bundle.js became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by Pieter Hoste in pull request [17627](https://github.com/magento/magento2/pull/17627)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
+<!---ENGCOM-2811  -->
+*  Swagger now works as expected when JavaScript minification is enabled. Previously, when JavaScript minification was enabled, the swagger-ui-bundle.js became corrupted, although Swagger worked fine when minification was subsequently disabled, and the files were redeployed. *Fix submitted by Pieter Hoste in pull request [17627](https://github.com/magento/magento2/pull/17627)*. [GitHub-16927](https://github.com/magento/magento2/issues/16927)
 
-<!---ENGCOM-1934 -->* Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Vishal Gelani in pull request [15946](https://github.com/magento/magento2/pull/15946)*. [GitHub-11477](https://github.com/magento/magento2/issues/11477)
+<!---ENGCOM-1934  -->
+*  Swagger now handles `searchCriteria`-related requests as expected. *Fix submitted by Vishal Gelani in pull request [15946](https://github.com/magento/magento2/pull/15946)*. [GitHub-11477](https://github.com/magento/magento2/issues/11477)
 
-<!--- MAGETWO-94046-->*  Swagger now works as expected when JavaScript minification and merging are enabled.
+<!--- MAGETWO-94046 -->
+*   Swagger now works as expected when JavaScript minification and merging are enabled.
 
 ### Swatches
 
-<!-- MAGETWO-87155 -->* Visual swatches now display  swatch color in the Admin as expected. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
+<!-- MAGETWO-87155  -->
+*  Visual swatches now display  swatch color in the Admin as expected. [GitHub-11828](https://github.com/magento/magento2/issues/11828)
 
-<!-- MAGETWO-82558 -->* The dropdown menu that Magento displays when a user clicks on the **Add Swatch** button on the Manage Swatch tab now displays all possible options. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
+<!-- MAGETWO-82558  -->
+*  The dropdown menu that Magento displays when a user clicks on the **Add Swatch** button on the Manage Swatch tab now displays all possible options. [GitHub-11534](https://github.com/magento/magento2/issues/11534)
 
-<!-- MAGETWO-87151 -->* Color attribute swatches are now visible when sorting is enabled. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
+<!-- MAGETWO-87151  -->
+*  Color attribute swatches are now visible when sorting is enabled. [GitHub-10628](https://github.com/magento/magento2/issues/10628)
 
-<!--- MAGETWO-83292-->* You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute. *Fix submitted by gonzalopelon in pull request [12044](https://github.com/magento/magento2/pull/12044)*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
+<!--- MAGETWO-83292 -->
+*  You can now use REST to import visual swatch attribute options. Previously, you could not add swatch options using service contracts unless a swatch option already existed for the attribute. *Fix submitted by gonzalopelon in pull request [12044](https://github.com/magento/magento2/pull/12044)*. [GitHub-9410](https://github.com/magento/magento2/issues/9410), [GitHub-10707](https://github.com/magento/magento2/issues/10707), [GitHub-10737](https://github.com/magento/magento2/issues/10737), [GitHub-11032](https://github.com/magento/magento2/issues/11032)
 
-<!--- MAGETWO-87869-->* The load and merge order of `view.xml` configuration in `\Magento\Swatches\Helper\Media` now matches `\Magento\Catalog\Helper\Image.` *Fix submitted by Patrick McLain in pull request [13506](https://github.com/magento/magento2/pull/13506)*. [GitHub-12647](https://github.com/magento/magento2/issues/12647)
+<!--- MAGETWO-87869 -->
+*  The load and merge order of `view.xml` configuration in `\Magento\Swatches\Helper\Media` now matches `\Magento\Catalog\Helper\Image.` *Fix submitted by Patrick McLain in pull request [13506](https://github.com/magento/magento2/pull/13506)*. [GitHub-12647](https://github.com/magento/magento2/issues/12647)
 
-<!--- MAGETWO-87935-->* We've replaced `.size()` with `.length` to be compatible with jQuery 3.*. *Fix submitted by Kirill Morozov in pull request [13686](https://github.com/magento/magento2/pull/13686)*.
+<!--- MAGETWO-87935 -->
+*  We've replaced `.size()` with `.length` to be compatible with jQuery 3.*. *Fix submitted by Kirill Morozov in pull request [13686](https://github.com/magento/magento2/pull/13686)*.
 
-<!--- ENGCOM-1128 -->* Swatch functionality that has been extended using JavaScript mixins now works as expected in Safari and Microsoft Edge. *Fix submitted by Rostyslav in pull request [14247](https://github.com/magento/magento2/pull/14247)*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- ENGCOM-1128  -->
+*  Swatch functionality that has been extended using JavaScript mixins now works as expected in Safari and Microsoft Edge. *Fix submitted by Rostyslav in pull request [14247](https://github.com/magento/magento2/pull/14247)*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
-<!--- ENGCOM-1017 -->* You can now save a swatch attribute that has an empty option. *Fix submitted by enriquei4 in pull request [13220](https://github.com/magento/magento2/pull/13220)*. [GitHub-13117](https://github.com/magento/magento2/issues/13117)
+<!--- ENGCOM-1017  -->
+*  You can now save a swatch attribute that has an empty option. *Fix submitted by enriquei4 in pull request [13220](https://github.com/magento/magento2/pull/13220)*. [GitHub-13117](https://github.com/magento/magento2/issues/13117)
 
-<!--- ENGCOM-2870 -->* You can now change attribute type from `swatch` to `dropdown`. *Fix submitted by Malyovanets Nickolas in pull request [17750](https://github.com/magento/magento2/pull/17750)*. [GitHub-12695](https://github.com/magento/magento2/issues/12695), [GitHub-11703](https://github.com/magento/magento2/issues/11703), [GitHub-9307](https://github.com/magento/magento2/issues/9307), [GitHub-11403](https://github.com/magento/magento2/issues/11403), [GitHub-9923](https://github.com/magento/magento2/issues/9923)
+<!--- ENGCOM-2870  -->
+*  You can now change attribute type from `swatch` to `dropdown`. *Fix submitted by Malyovanets Nickolas in pull request [17750](https://github.com/magento/magento2/pull/17750)*. [GitHub-12695](https://github.com/magento/magento2/issues/12695), [GitHub-11703](https://github.com/magento/magento2/issues/11703), [GitHub-9307](https://github.com/magento/magento2/issues/9307), [GitHub-11403](https://github.com/magento/magento2/issues/11403), [GitHub-9923](https://github.com/magento/magento2/issues/9923)
 
 ### Tax
 
-<!--- MAGETWO-83405 -->* Tax total amount is now equal to the sum of the tax details amounts. Previously, Magento displayed the wrong order tax amounts when using specific tax configurations. *Fix submitted by Pieter Cappelle in pull request [11594](https://github.com/magento/magento2/pull/11594)*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
+<!--- MAGETWO-83405  -->
+*  Tax total amount is now equal to the sum of the tax details amounts. Previously, Magento displayed the wrong order tax amounts when using specific tax configurations. *Fix submitted by Pieter Cappelle in pull request [11594](https://github.com/magento/magento2/pull/11594)*. [GitHub-10347](https://github.com/magento/magento2/issues/10347)
 
-<!---MAGETWO-87511 -->*  `\Magento\Framework\Data\OptionSourceInterface::getAllOptions()` and `\Magento\Framework\Data\OptionSourceInterface::toOptionArray()` are now compatible with parent classes. *Fix submitted by Yevhen Sentiabov in pull request [34](https://github.com/magento-engcom/php-7.2-support/pull/34)*.
+<!---MAGETWO-87511  -->
+*   `\Magento\Framework\Data\OptionSourceInterface::getAllOptions()` and `\Magento\Framework\Data\OptionSourceInterface::toOptionArray()` are now compatible with parent classes. *Fix submitted by Yevhen Sentiabov in pull request [34](https://github.com/magento-engcom/php-7.2-support/pull/34)*.
 
-<!---MAGETWO-75865 -->* Double tags have been removed from the `config.xml` of the `Magento_Tax` module.
+<!---MAGETWO-75865  -->
+*  Double tags have been removed from the `config.xml` of the `Magento_Tax` module.
 
-<!---ENGCOM-1555 -->* Magento no longer performs redundant tax calculations  for every price on category page, which has improved product performance. *Fix submitted by Jeroen in pull request [15200](https://github.com/magento/magento2/pull/15200)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
+<!---ENGCOM-1555  -->
+*  Magento no longer performs redundant tax calculations  for every price on category page, which has improved product performance. *Fix submitted by Jeroen in pull request [15200](https://github.com/magento/magento2/pull/15200)*. [GitHub-14941](https://github.com/magento/magento2/issues/14941)
 
-<!---MAGETWO-93394 -->* Magento now uses  the correct table rate shipment when creating a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
+<!---MAGETWO-93394  -->
+*  Magento now uses  the correct table rate shipment when creating a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
 
 ### Testing
 
-<!-- MAGETWO-87154 -->*  Integrations tests no longer throw `Cannot instantiate interface Magento\Framework\Interception\ObjectManager\ConfigInterface` errors. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
+<!-- MAGETWO-87154  -->
+*   Integrations tests no longer throw `Cannot instantiate interface Magento\Framework\Interception\ObjectManager\ConfigInterface` errors. [GitHub-12844](https://github.com/magento/magento2/issues/12844)
 
-<!-- MAGETWO-87064 -->* Integration tests now reset the integration test database as expected.  [GitHub-10025](https://github.com/magento/magento2/issues/10025)
+<!-- MAGETWO-87064  -->
+*  Integration tests now reset the integration test database as expected.  [GitHub-10025](https://github.com/magento/magento2/issues/10025)
 
-<!---MAGETWO-82550 -->* A typo in `dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+<!---MAGETWO-82550  -->
+*  A typo in `dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
-<!---MAGETWO-87317 -->* Static tests now check for the deprecated `each()` function. *Fix submitted by Yevhen Sentiabov in pull request 31*.
+<!---MAGETWO-87317  -->
+*  Static tests now check for the deprecated `each()` function. *Fix submitted by Yevhen Sentiabov in pull request 31*.
 
-<!---MAGETWO-85993 -->*  The `functional.suite.dist.yml` has been updated to handle custom backend names. (This value was previously hard-coded.) *Fix submitted by scribam in pull request [12848](https://github.com/magento/magento2/pull/12848)*.
+<!---MAGETWO-85993  -->
+*   The `functional.suite.dist.yml` has been updated to handle custom backend names. (This value was previously hard-coded.) *Fix submitted by scribam in pull request [12848](https://github.com/magento/magento2/pull/12848)*.
 
-<!---MAGETWO-85817 -->*  THe `validate_image_info_rollback.php` test suite has been updated. *Fix submitted by Harry Mumford-Turner in pull request [12800](https://github.com/magento/magento2/pull/12800)*.
+<!---MAGETWO-85817  -->
+*   THe `validate_image_info_rollback.php` test suite has been updated. *Fix submitted by Harry Mumford-Turner in pull request [12800](https://github.com/magento/magento2/pull/12800)*.
 
-<!---MAGETWO-90803 -->*  `phpunit.xml` is now blacklisted during schema validation static tests, particularly `Magento/Test/Integrity/Xml/SchemaTest.php`.
+<!---MAGETWO-90803  -->
+*   `phpunit.xml` is now blacklisted during schema validation static tests, particularly `Magento/Test/Integrity/Xml/SchemaTest.php`.
 
-<!--- MAGETWO-81646 -->* The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request [11376](https://github.com/magento/magento2/pull/11376)*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+<!--- MAGETWO-81646  -->
+*  The `\Magento\Test\Php\LiveCodeTest::testCodeStyle`  method now uses whitelist files. *Fix submitted by Adrian Martinez in pull request [11376](https://github.com/magento/magento2/pull/11376)*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
-<!--- ENGCOM-1257 -->*  Integration test coverage for the new extension point for New Shipment Controller has been added. *Fix submitted by Malyovanets Nickolas in pull request [14634](https://github.com/magento/magento2/pull/14634)*. [GitHub-788](https://github.com/magento/magento2/issues/788)
+<!--- ENGCOM-1257  -->
+*   Integration test coverage for the new extension point for New Shipment Controller has been added. *Fix submitted by Malyovanets Nickolas in pull request [14634](https://github.com/magento/magento2/pull/14634)*. [GitHub-788](https://github.com/magento/magento2/issues/788)
 
-<!--- ENGCOM-1093 -->* `sjparkinson/static-review` and other obsolete tools  (including `dev/tools/Magento/Tools/Layout`, `dev/tools/Magento/Tools/StaticReview/pre-commit`, and `dev/tools/Magento/Tools/psr/phpcs_precommit_hook.sh`) have been removed from the test code base. *Fix submitted by Rostyslav in pull request [14368](https://github.com/magento/magento2/pull/14368)*. [GitHub-14138](https://github.com/magento/magento2/issues/14138)
+<!--- ENGCOM-1093  -->
+*  `sjparkinson/static-review` and other obsolete tools  (including `dev/tools/Magento/Tools/Layout`, `dev/tools/Magento/Tools/StaticReview/pre-commit`, and `dev/tools/Magento/Tools/psr/phpcs_precommit_hook.sh`) have been removed from the test code base. *Fix submitted by Rostyslav in pull request [14368](https://github.com/magento/magento2/pull/14368)*. [GitHub-14138](https://github.com/magento/magento2/issues/14138)
 
-<!--- ENGCOM-1031 -->* Integration tests for product URL rewrite generation have been added.  *Fix submitted by Rostyslav in pull request [14252](https://github.com/magento/magento2/pull/14252)*.
+<!--- ENGCOM-1031  -->
+*  Integration tests for product URL rewrite generation have been added.  *Fix submitted by Rostyslav in pull request [14252](https://github.com/magento/magento2/pull/14252)*.
 
-<!--- ENGCOM-2138 -->* The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by Eino Keskitalo in pull request [16253](https://github.com/magento/magento2/pull/16253)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
+<!--- ENGCOM-2138  -->
+*  The `ProcessCronQueueObserverTest.php` integration test now works correctly. *Fix submitted by Eino Keskitalo in pull request [16253](https://github.com/magento/magento2/pull/16253)*. [GitHub-16243](https://github.com/magento/magento2/issues/16243)
 
-<!--- ENGCOM-2409 -->* `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites.  *Fix submitted by Pratik Oza in pull request [16926](https://github.com/magento/magento2/pull/16926)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
+<!--- ENGCOM-2409  -->
+*  `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites.  *Fix submitted by Pratik Oza in pull request [16926](https://github.com/magento/magento2/pull/16926)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
 
-<!--- ENGCOM-1968 -->*  CreateOrderBackendTest has been refactored to support the  **Reorder** button when Inventory Management is enabled. *Fix submitted by Malyovanets Nickolas in pull request [16006](https://github.com/magento/magento2/pull/16006)*. [GitHub-680](https://github.com/magento/magento2/issues/680)
+<!--- ENGCOM-1968  -->
+*   CreateOrderBackendTest has been refactored to support the  **Reorder** button when Inventory Management is enabled. *Fix submitted by Malyovanets Nickolas in pull request [16006](https://github.com/magento/magento2/pull/16006)*. [GitHub-680](https://github.com/magento/magento2/issues/680)
 
-<!---MAGETWO-87058 -->*  Unit tests have been refactored to no longer check for deleted file `app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php`. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
+<!---MAGETWO-87058  -->
+*   Unit tests have been refactored to no longer check for deleted file `app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php`. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
 
-<!--- ENGCOM-2028 -->*  `CreateCreditMemoEntityTest` has been refactored to support the Inventory Management reservation mechanism.  *Fix submitted by Malyovanets Nickolas in pull request [16170](https://github.com/magento/magento2/pull/16170)*.
+<!--- ENGCOM-2028  -->
+*   `CreateCreditMemoEntityTest` has been refactored to support the Inventory Management reservation mechanism.  *Fix submitted by Malyovanets Nickolas in pull request [16170](https://github.com/magento/magento2/pull/16170)*.
 
-<!--- ENGCOM-2026 -->*  `CreateOrderBackendPartOneTest` has been refactored to support the Inventory Management reservation mechanism. *Fix submitted by Malyovanets Nickolas in pull request [16153](https://github.com/magento/magento2/pull/16153)*.
+<!--- ENGCOM-2026  -->
+*   `CreateOrderBackendPartOneTest` has been refactored to support the Inventory Management reservation mechanism. *Fix submitted by Malyovanets Nickolas in pull request [16153](https://github.com/magento/magento2/pull/16153)*.
 
 ### Theme
 
-<!--- MAGETWO-88973 -->* Customers can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full-screen zoom for any product image, he could not close the full-screen zoom.
+<!--- MAGETWO-88973  -->
+*  Customers can now successfully close full-screen zoomed product images displayed on an iPhone 4s, 5s, 6, or 6s with the Safari browser. Previously, if a customer chose full-screen zoom for any product image, he could not close the full-screen zoom.
 
-<!--- MAGETWO-88264 -->* The forced setting of `cache_lifetime` to `false`  has been changed to a default `cache_lifetime` value of 3600 for `Magento\Theme\Block\Html\Footer`. [GitHub-13595](https://github.com/magento/magento2/issues/13595)
+<!--- MAGETWO-88264  -->
+*  The forced setting of `cache_lifetime` to `false`  has been changed to a default `cache_lifetime` value of 3600 for `Magento\Theme\Block\Html\Footer`. [GitHub-13595](https://github.com/magento/magento2/issues/13595)
 
-<!--- ENGCOM-959 -->* The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled.  *Fix submitted by Dmytro Paidych in pull request [14177](https://github.com/magento/magento2/pull/14177)*.  [GitHub-12711](https://github.com/magento/magento2/issues/12711)
+<!--- ENGCOM-959  -->
+*  The default storefront welcome message now works as expected when the **Translate Inline**  (**Stores > Settings > Configuration > Advanced > Developer >**) setting is enabled.  *Fix submitted by Dmytro Paidych in pull request [14177](https://github.com/magento/magento2/pull/14177)*.  [GitHub-12711](https://github.com/magento/magento2/issues/12711)
 
-<!--- ENGCOM-775 -->* We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced.  *Fix submitted by Marcin Kwiatkowski in pull request [13979](https://github.com/magento/magento2/pull/13979)*. [GitHub-13315](https://github.com/magento/magento2/issues/13315)
+<!--- ENGCOM-775  -->
+*  We've improved the display of the Payment Methods section of the checkout page on mobile devices. Previously, the layout of page elements was not correctly spaced.  *Fix submitted by Marcin Kwiatkowski in pull request [13979](https://github.com/magento/magento2/pull/13979)*. [GitHub-13315](https://github.com/magento/magento2/issues/13315)
 
 ### Translation and locales
 
-<!---MAGETWO-82650 -->* The `<![CDATA[]]>` statement in `system.xml` now works as expected. *Fix submitted by Nickolas Malyovanets in pull request [11679](https://github.com/magento/magento2/pull/11679)*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
+<!---MAGETWO-82650  -->
+*  The `<![CDATA[]]>` statement in `system.xml` now works as expected. *Fix submitted by Nickolas Malyovanets in pull request [11679](https://github.com/magento/magento2/pull/11679)*. [GitHub-7767](https://github.com/magento/magento2/issues/7767)
 
-<!---MAGETWO-71380 -->* The JavaScript translation for validation messages now works for customer account pages. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-5820](https://github.com/magento/magento2/issues/5820)
+<!---MAGETWO-71380  -->
+*  The JavaScript translation for validation messages now works for customer account pages. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-5820](https://github.com/magento/magento2/issues/5820)
 
-<!--- MAGETWO-71380-->* Messages on password strength are now translatable. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-5509](https://github.com/magento/magento2/issues/5509)
+<!--- MAGETWO-71380 -->
+*  Messages on password strength are now translatable. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-5509](https://github.com/magento/magento2/issues/5509)
 
-<!--- 71380-->* The JavaScript translation regex no longer leads to unexpected results and untranslatable strings. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-7403](https://github.com/magento/magento2/issues/7403)
+<!--- 71380 -->
+*  The JavaScript translation regex no longer leads to unexpected results and untranslatable strings. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-7403](https://github.com/magento/magento2/issues/7403)
 
-<!--- MAGETWO-71380-->* All messages in Customer Account Create are now translatable. Previously, warning messages about password validation appeared in locale language only. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-9967](https://github.com/magento/magento2/issues/9967)
+<!--- MAGETWO-71380 -->
+*  All messages in Customer Account Create are now translatable. Previously, warning messages about password validation appeared in locale language only. *Fix submitted by Anton Evers in pull request [10445](https://github.com/magento/magento2/pull/10445)*. [GitHub-9967](https://github.com/magento/magento2/issues/9967)
 
-<!-- MAGETWO-93708 -->* We've added  client-side caching of `js-translation.js`.
+<!-- MAGETWO-93708  -->
+*  We've added  client-side caching of `js-translation.js`.
 
-<!-- MAGETWO-94119 -->* The datepicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
+<!-- MAGETWO-94119  -->
+*  The datepicker date filter on **Reports** > **Products** > **Ordered** now works as expected for administrators working in Australian English locales.
 
-<!--- ENGCOM-1055 -->* Magento now supports Malaysian locales. *Fix submitted by Oscar Recio in pull request [14305](https://github.com/magento/magento2/pull/14305)*. [GitHub-14089](https://github.com/magento/magento2/issues/14089)
+<!--- ENGCOM-1055  -->
+*  Magento now supports Malaysian locales. *Fix submitted by Oscar Recio in pull request [14305](https://github.com/magento/magento2/pull/14305)*. [GitHub-14089](https://github.com/magento/magento2/issues/14089)
 
-<!--- ENGCOM-2041 -->* The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16228](https://github.com/magento/magento2/pull/16228)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
+<!--- ENGCOM-2041  -->
+*  The string for `moreButtonText` in `app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js` can now be translated. *Fix submitted by Karla Saaremäe in pull request [16228](https://github.com/magento/magento2/pull/16228)*. [GitHub-16079](https://github.com/magento/magento2/issues/16079)
 
-<!--- ENGCOM-2212 -->* Magento now displays the correct  price on the product page for storefronts running Japanese locales.  *Fix submitted by Volodymyr Kublytskyi in pull request [16588](https://github.com/magento/magento2/pull/16588)*.  [GitHub-11717](https://github.com/magento/magento2/issues/11717)
+<!--- ENGCOM-2212  -->
+*  Magento now displays the correct  price on the product page for storefronts running Japanese locales.  *Fix submitted by Volodymyr Kublytskyi in pull request [16588](https://github.com/magento/magento2/pull/16588)*.  [GitHub-11717](https://github.com/magento/magento2/issues/11717)
 
-<!--- ENGCOM-2400 -->* The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags. *Fix submitted by Pratik Oza in pull request [16892](https://github.com/magento/magento2/pull/16892)*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
+<!--- ENGCOM-2400  -->
+*  The module responsible for generating the `js-translations.json` file now contains a routine that translates strings in tags. *Fix submitted by Pratik Oza in pull request [16892](https://github.com/magento/magento2/pull/16892)*. [GitHub-12081](https://github.com/magento/magento2/issues/12081)
 
-<!-- MAGETWO-87066 -->*  Magento now displays the correct payment method title on the payments page during checkout in multistore deployments where storeviews implement different locales. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
+<!-- MAGETWO-87066  -->
+*   Magento now displays the correct payment method title on the payments page during checkout in multistore deployments where storeviews implement different locales. [GitHub-7582](https://github.com/magento/magento2/issues/7582)
 
-<!-- MAGETWO-87066 -->*  The hint provided for the global configuration field on the Admin configuration page has been corrected. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
+<!-- MAGETWO-87066  -->
+*   The hint provided for the global configuration field on the Admin configuration page has been corrected. [GitHub-8958](https://github.com/magento/magento2/issues/8958)
 
-<!-- MAGETWO-87066 -->*  `region_id` is no longer overridden when a customer edits their billing address from a country that requires a value for state to a country where one is not required. [GitHub-10317](https://github.com/magento/magento2/issues/10317)
+<!-- MAGETWO-87066  -->
+*   `region_id` is no longer overridden when a customer edits their billing address from a country that requires a value for state to a country where one is not required. [GitHub-10317](https://github.com/magento/magento2/issues/10317)
 
 ### UI
 
-<!-- MAGETWO-93715-->*  Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
+<!-- MAGETWO-93715 -->
+*   Magento no longer sends duplicate delete requests as a result of an unstable Internet connection. Previously, unintentional mass deletion of products sometimes occurred as a result of an unstable Internet connection.
 
-<!-- MAGETWO-91848 -->* As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
+<!-- MAGETWO-91848  -->
+*  As you type additional characters into the text field for a product's custom option, the hint showing the number of characters left before reaching the maximum now decreases as expected.
 
-<!-- MAGETWO-83412 -->*  Previously missing translation strings have been added to the UI module. *Fix submitted by Jeroen in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
+<!-- MAGETWO-83412  -->
+*   Previously missing translation strings have been added to the UI module. *Fix submitted by Jeroen in pull request 11440*. [GitHub-5956](https://github.com/magento/magento2/issues/5956)
 
-<!--- ENGCOM-1457 -->* Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page.  *Fix submitted by Prince Patel in pull request [16664](https://github.com/magento/magento2/pull/16664)*.  [GitHub-15009](https://github.com/magento/magento2/issues/15009), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
+<!--- ENGCOM-1457  -->
+*  Administrators who lack access to the CatalogRule module can now perform operations as expected in the Admin cart price rule edit page.  *Fix submitted by Prince Patel in pull request [16664](https://github.com/magento/magento2/pull/16664)*.  [GitHub-15009](https://github.com/magento/magento2/issues/15009), [GitHub-12285](https://github.com/magento/magento2/issues/12285)
 
-<!--- ENGCOM-1541 -->* The UI component configuration XSD file (`ui-configuration.xsd`) now constrains settings so that `abstractSettings`, such as `<label>`, can only be placed and read from the top-level `<settings>` nodes, while component-specific settings, such as `<options>`, can only be placed and read from the appropriate `<settings>` descendent of `<formElements>`. *Fix submitted by Neill Robson in pull request 15161*. [GitHub-14140](https://github.com/magento/magento2/issues/14140)
+<!--- ENGCOM-1541  -->
+*  The UI component configuration XSD file (`ui-configuration.xsd`) now constrains settings so that `abstractSettings`, such as `<label>`, can only be placed and read from the top-level `<settings>` nodes, while component-specific settings, such as `<options>`, can only be placed and read from the appropriate `<settings>` descendent of `<formElements>`. *Fix submitted by Neill Robson in pull request 15161*. [GitHub-14140](https://github.com/magento/magento2/issues/14140)
 
-<!--- ENGCOM-2219 -->* Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
+<!--- ENGCOM-2219  -->
+*  Users can now press the **Esc** button on  the delete-from-cart confirmation pop-up window  without generating a `jQuery` UI error. Previously, when a customer added a product to the shopping cart, then pressed the trash icon to delete it, Magento displayed this confirmation pop-up window, but threw an error when the customer pressed the window's **Esc** button. [GitHub-14593](https://github.com/magento/magento2/issues/14593)
 
-<!--- ENGCOM-2243 -->* The `font-size` variable has been updated and standardized. *Fix submitted by Prince Patel in pull request [16664](https://github.com/magento/magento2/pull/16664)*.  [GitHub-7399](https://github.com/magento/magento2/issues/7399)
+<!--- ENGCOM-2243  -->
+*  The `font-size` variable has been updated and standardized. *Fix submitted by Prince Patel in pull request [16664](https://github.com/magento/magento2/pull/16664)*.  [GitHub-7399](https://github.com/magento/magento2/issues/7399)
 
-<!--- ENGCOM-2340 -->* We've added the `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by Hitesh in pull request [16796](https://github.com/magento/magento2/pull/16796)*.  [GitHub-15848](https://github.com/magento/magento2/issues/15848)
+<!--- ENGCOM-2340  -->
+*  We've added the `@navigation-level0-item__hover__color` missing variable for mobile and tablet view. *Fix submitted by Hitesh in pull request [16796](https://github.com/magento/magento2/pull/16796)*.  [GitHub-15848](https://github.com/magento/magento2/issues/15848)
 
-<!--- ENGCOM-2878 -->* Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Malyovanets Nickolas in pull request [17809](https://github.com/magento/magento2/pull/17809)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
+<!--- ENGCOM-2878  -->
+*  Footers now behave as expected when displaying Magento on a mobile device. *Fix submitted by Malyovanets Nickolas in pull request [17809](https://github.com/magento/magento2/pull/17809)*. [GitHub-15118](https://github.com/magento/magento2/issues/15118)
 
-<!--- ENGCOM-2690 -->* The unused totalbar block has been removed from the invoice create and credit memo create layouts. *Fix submitted by Danny Verkade in pull request 17414*. [GitHub-16653](https://github.com/magento/magento2/issues/16653), [GitHub-16655](https://github.com/magento/magento2/issues/16655)
+<!--- ENGCOM-2690  -->
+*  The unused totalbar block has been removed from the invoice create and credit memo create layouts. *Fix submitted by Danny Verkade in pull request 17414*. [GitHub-16653](https://github.com/magento/magento2/issues/16653), [GitHub-16655](https://github.com/magento/magento2/issues/16655)
 
-<!--- ENGCOM-2824 -->* The JavaScript validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified.  *Fix submitted by Dmytro Cheshun in pull request [17688](https://github.com/magento/magento2/pull/17688)*.[GitHub-17648](https://github.com/magento/magento2/issues/17648)
+<!--- ENGCOM-2824  -->
+*  The JavaScript validation rule used to validate AM/PM time settings now works as expected when JavaScript is minified.  *Fix submitted by Dmytro Cheshun in pull request [17688](https://github.com/magento/magento2/pull/17688)*.[GitHub-17648](https://github.com/magento/magento2/issues/17648)
 
-<!--- ENGCOM-2839 -->* The message list component message type now has a message type of success. Previously, this type was always `error` when the `parameters` property was specified.  *Fix submitted by Dmytro Cheshun in pull request [17703](https://github.com/magento/magento2/pull/17703)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
+<!--- ENGCOM-2839  -->
+*  The message list component message type now has a message type of success. Previously, this type was always `error` when the `parameters` property was specified.  *Fix submitted by Dmytro Cheshun in pull request [17703](https://github.com/magento/magento2/pull/17703)*. [GitHub-17700](https://github.com/magento/magento2/issues/17700)
 
-<!--- ENGCOM-2918 -->* Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by Hitesh in pull request [17911](https://github.com/magento/magento2/pull/17911)*.[GitHub-17851](https://github.com/magento/magento2/issues/17851)
+<!--- ENGCOM-2918  -->
+*  Magento now displays the wishlist icon on the shopping cart page on mobile devices. Previously, Magento cut off the wishlist icon on this page when viewed on a mobile device. *Fix submitted by Hitesh in pull request [17911](https://github.com/magento/magento2/pull/17911)*.[GitHub-17851](https://github.com/magento/magento2/issues/17851)
 
-<!--- ENGCOM-2861 -->* JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed.  *Fix submitted by Malyovanets Nickolas in pull request [17724](https://github.com/magento/magento2/pull/17724)*.[GitHub-16544](https://github.com/magento/magento2/issues/16544)
+<!--- ENGCOM-2861  -->
+*  JavaScript validation rules no longer require validation of fields where completion is not required. Previously, customers could not complete forms unless non-required fields were completed.  *Fix submitted by Malyovanets Nickolas in pull request [17724](https://github.com/magento/magento2/pull/17724)*.[GitHub-16544](https://github.com/magento/magento2/issues/16544)
 
-<!--- ENGCOM-2323 -->* When a user scrolls a page, the datepicker now retains its position relative to other page elements as expected. *Fix submitted by Hitesh in pull request 16776*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
+<!--- ENGCOM-2323  -->
+*  When a user scrolls a page, the datepicker now retains its position relative to other page elements as expected. *Fix submitted by Hitesh in pull request 16776*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
 
-<!--- ENGCOM-2649 -->* The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by torhoehn in pull request [17359](https://github.com/magento/magento2/pull/17359)*.[GitHub-17193](https://github.com/magento/magento2/issues/17193)
+<!--- ENGCOM-2649  -->
+*  The confirmation modal buttons that Magento displays when a customer sends a product to the trash are now translated as expected. *Fix submitted by torhoehn in pull request [17359](https://github.com/magento/magento2/pull/17359)*.[GitHub-17193](https://github.com/magento/magento2/issues/17193)
 
-<!--- ENGCOM-1810 -->* The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Vishal Gelani in pull request [15746](https://github.com/magento/magento2/pull/15746)*.  [GitHub-15660](https://github.com/magento/magento2/issues/15660)
+<!--- ENGCOM-1810  -->
+*  The dropdown menu is now positioned as expected under the link on the UI Component listing. *Fix submitted by Vishal Gelani in pull request [15746](https://github.com/magento/magento2/pull/15746)*.  [GitHub-15660](https://github.com/magento/magento2/issues/15660)
 
-<!---MAGETWO-82721 -->* Magento no longer displays the current date for a product when the `date` attribute is empty. [GitHub-9869](https://github.com/magento/magento2/issues/9869)
+<!---MAGETWO-82721  -->
+*  Magento no longer displays the current date for a product when the `date` attribute is empty. [GitHub-9869](https://github.com/magento/magento2/issues/9869)
 
-<!---MAGETWO-87066 -->*  Magento no longer throws a JavaScript error when a user enters a special character (for example, `/` or `&`) while adding the `stripped-min-length` validation to a UI component. [GitHub-9920](https://github.com/magento/magento2/issues/9920)
+<!---MAGETWO-87066  -->
+*   Magento no longer throws a JavaScript error when a user enters a special character (for example, `/` or `&`) while adding the `stripped-min-length` validation to a UI component. [GitHub-9920](https://github.com/magento/magento2/issues/9920)
 
-<!---MAGETWO-87531 -->*  Magento no longer throws an `Uncaught Error: Script error for: trackingCode` error on storefront pages. [GitHub-12828](https://github.com/magento/magento2/issues/12828)
+<!---MAGETWO-87531  -->
+*   Magento no longer throws an `Uncaught Error: Script error for: trackingCode` error on storefront pages. [GitHub-12828](https://github.com/magento/magento2/issues/12828)
 
-<!---MAGETWO-87153 -->*  `range-word` validation for form fields now works as expected. [GitHub-6113](https://github.com/magento/magento2/issues/6113)
+<!---MAGETWO-87153  -->
+*   `range-word` validation for form fields now works as expected. [GitHub-6113](https://github.com/magento/magento2/issues/6113)
 
 ### URL rewrites
 
-<!--- MAGETWO-85026-->* Magento now sets the value of `Store_Code` from the current store when this information is included in a URL. *Fix submitted by Oscar Recio in pull request [12545](https://github.com/magento/magento2/pull/12545)*. [GitHub-12450](https://github.com/magento/magento2/issues/12450)
+<!--- MAGETWO-85026 -->
+*  Magento now sets the value of `Store_Code` from the current store when this information is included in a URL. *Fix submitted by Oscar Recio in pull request [12545](https://github.com/magento/magento2/pull/12545)*. [GitHub-12450](https://github.com/magento/magento2/issues/12450)
 
-<!--- MAGETWO-82310-->* Magento now loads `urlrewrite` router before the Magento base router. Previously, the Magento custom URL rewrite functionality did not work when you added an additional redirection (for example, a custom redirection from `/customer/account/create` to another page). *Fix submitted by[Marc Rodriguez in pull request [11471](https://github.com/magento/magento2/pull/11471)*. [GitHub-10231](https://github.com/magento/magento2/issues/10231)
+<!--- MAGETWO-82310 -->
+*  Magento now loads `urlrewrite` router before the Magento base router. Previously, the Magento custom URL rewrite functionality did not work when you added an additional redirection (for example, a custom redirection from `/customer/account/create` to another page). *Fix submitted by[Marc Rodriguez in pull request [11471](https://github.com/magento/magento2/pull/11471)*. [GitHub-10231](https://github.com/magento/magento2/issues/10231)
 
-<!--- MAGETWO-88091-->* Switching store views now works as expected. Previously, under some conditions, users were redirected to a 404 page.[GitHub-5416](https://github.com/magento/magento2/issues/5416)
+<!--- MAGETWO-88091 -->
+*  Switching store views now works as expected. Previously, under some conditions, users were redirected to a 404 page.[GitHub-5416](https://github.com/magento/magento2/issues/5416)
 
-<!--- MAGETWO-88091-->* You can now reset a form by clicking **Reset** in **Marketing** > **SEO & Search** > **URL Rewrites**. [GitHub-10459](https://github.com/magento/magento2/issues/10459)
+<!--- MAGETWO-88091 -->
+*  You can now reset a form by clicking **Reset** in **Marketing** > **SEO & Search** > **URL Rewrites**. [GitHub-10459](https://github.com/magento/magento2/issues/10459)
 
-<!-- MAGETWO-91808 -->* Categories of the Main menu in the different store view are now updated when Varnish is enabled.
+<!-- MAGETWO-91808  -->
+*  Categories of the Main menu in the different store view are now updated when Varnish is enabled.
 
-<!--- MAGETWO-90798 -->* Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
+<!--- MAGETWO-90798  -->
+*  Magento no longer throws a 404 error when a customer navigates from the Catalog page of the default store to a custom Catalog page on a different store.
 
-<!--- MAGETWO-71407 -->* The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
+<!--- MAGETWO-71407  -->
+*  The **Reset** button no longer causes a JavaScript error on the URL rewrite creation page. [GitHub-10462](https://github.com/magento/magento2/issues/10462)
 
-<!--- ENGCOM-1210 -->* The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character.  *Fix submitted by Vinay Shah in pull request [13402](https://github.com/magento/magento2/pull/13402)*.  [GitHub-13296](https://github.com/magento/magento2/issues/13296)
+<!--- ENGCOM-1210  -->
+*  The Magento URL rewrite functionality now supports the use of special characters in category names. Previously, the category tree did not load if a category name contained a special character.  *Fix submitted by Vinay Shah in pull request [13402](https://github.com/magento/magento2/pull/13402)*.  [GitHub-13296](https://github.com/magento/magento2/issues/13296)
 
 ### Visual Merchandiser
 
-<!--- MAGETWO-87846 -->* Visual Merchandiser now includes website scope when displaying the correct prices and availability of configurable products.
+<!--- MAGETWO-87846  -->
+*  Visual Merchandiser now includes website scope when displaying the correct prices and availability of configurable products.
 
-<!--- MAGETWO-72861 -->* We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
+<!--- MAGETWO-72861  -->
+*  We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
 
 ### Web API
 
-<!--- MAGETWO-82315 -->* When you use REST to update an existing product, Magento assigns the update only to the websites that they were assigned to before the update. Previously, updating a product using the REST API (`PUT /rest/all/V1/products/example_sku`) assigned the product update to all websites automatically. *Fix submitted by Adrian Martinez in pull request [11443](https://github.com/magento/magento2/pull/11443)*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82315  -->
+*  When you use REST to update an existing product, Magento assigns the update only to the websites that they were assigned to before the update. Previously, updating a product using the REST API (`PUT /rest/all/V1/products/example_sku`) assigned the product update to all websites automatically. *Fix submitted by Adrian Martinez in pull request [11443](https://github.com/magento/magento2/pull/11443)*. [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- MAGETWO-90147 -->* When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
+<!--- MAGETWO-90147  -->
+*  When you create a credit memo comment with `POST /V1/creditmemo/:id/comments`, Magento now sends  credit memo update emails as expected. Previously,  Magento did not send this email, and no other transaction emails were sent to the customer.
 
-<!--- MAGETWO-84319 -->* Magento no longer creates duplicate shipments for orders created via API. Previously, Magento created duplicate shipments when a merchant created a shipment via the API under certain conditions (mainly with bundled products).
+<!--- MAGETWO-84319  -->
+*  Magento no longer creates duplicate shipments for orders created via API. Previously, Magento created duplicate shipments when a merchant created a shipment via the API under certain conditions (mainly with bundled products).
 
-<!--- MAGETWO-91540 -->*  Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
+<!--- MAGETWO-91540  -->
+*   Product searches using `GET V1/products` return `extension_attributes` for configurable products as expected.
 
-<!--- MAGETWO-91568 -->*  You can now include custom attributes when filtering the responses of REST calls.
+<!--- MAGETWO-91568  -->
+*   You can now include custom attributes when filtering the responses of REST calls.
 
-<!--- MAGETWO-94207 -->*  Magento now returns a 404 error and includes a descriptive error message when a  REST search is performed on a non-existent cart.
+<!--- MAGETWO-94207  -->
+*   Magento now returns a 404 error and includes a descriptive error message when a  REST search is performed on a non-existent cart.
 
-<!--- MAGETWO-81910 -->*   Magento now includes the filter groups and the sort order of the `$searchCriteria` parameter in the `searchCriteria` object that is provided for the EAV set repository. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
+<!--- MAGETWO-81910  -->
+*    Magento now includes the filter groups and the sort order of the `$searchCriteria` parameter in the `searchCriteria` object that is provided for the EAV set repository. [GitHub-11022](https://github.com/magento/magento2/issues/11022)
 
-<!--- MAGETWO-82315 -->* Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) [GitHub-11324](https://github.com/magento/magento2/issues/11324)
+<!--- MAGETWO-82315  -->
+*  Updating a product with the REST API (`PUT /rest/all/V1/products/example_sku`) no longer assigns the product to all websites automatically. (Automatic assignment to all websites now occurs only when you create the product in All Store Views scope.) [GitHub-11324](https://github.com/magento/magento2/issues/11324)
 
-<!--- ENGCOM-2066 -->* A generated Admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired.  *Fix submitted by Vijay Golani in pull request [15564](https://github.com/magento/magento2/pull/15564)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
+<!--- ENGCOM-2066  -->
+*  A generated Admin API token no longer expires immediately. Previously, when you created a token for an Admin user and have set   **Admin Token Lifetime (hours))**  to empty, Magento denied access  because the token immediately expired.  *Fix submitted by Vijay Golani in pull request [15564](https://github.com/magento/magento2/pull/15564)*. [GitHub-15564](https://github.com/magento/magento2/issues/15564)
 
-<!-- MAGETWO-87057 -->* Magento now checks for the uniqueness of attribute option values for attributes created via REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
+<!-- MAGETWO-87057  -->
+*  Magento now checks for the uniqueness of attribute option values for attributes created via REST. [GitHub-8846](https://github.com/magento/magento2/issues/8846)
 
-<!--- MAGETWO-87152 -->*  `salesRefundInvoiceV1` now saves the invoice ID as expected for a credit memo. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
+<!--- MAGETWO-87152  -->
+*   `salesRefundInvoiceV1` now saves the invoice ID as expected for a credit memo. [GitHub-11669](https://github.com/magento/magento2/issues/11669)
 
 ### Wishlist
 
-<!--- MAGETWO-85627 -->* Magento now displays an error message if you try to add products to a wishlist without first logging in. *Fix submitted by Pieter Cappelle in pull request [12681](https://github.com/magento/magento2/pull/12681)*.
+<!--- MAGETWO-85627  -->
+*  Magento now displays an error message if you try to add products to a wishlist without first logging in. *Fix submitted by Pieter Cappelle in pull request [12681](https://github.com/magento/magento2/pull/12681)*.
 
-<!--- MAGETWO-86101 -->* Magento now stores product IDs and SKUs to locally stored customer data for wishlists. *Fix submitted by James Halsall in pull request [12896](https://github.com/magento/magento2/pull/12896)*.
+<!--- MAGETWO-86101  -->
+*  Magento now stores product IDs and SKUs to locally stored customer data for wishlists. *Fix submitted by James Halsall in pull request [12896](https://github.com/magento/magento2/pull/12896)*.
 
-<!--- MAGETWO-90297 -->* `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built the wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
+<!--- MAGETWO-90297  -->
+*  `SearchCriteriaBuilder` now has a check to determine if sort order should be applied. Previously, `SearchCriteriaBuilder` built the wrong criteria (`ORDER BY part`). *Fix submitted by Nickolas Malyovanets*. [GitHub-5738](https://github.com/magento/magento2/issues/5738)
 
-<!--- MAGETWO-91615 -->*  Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
+<!--- MAGETWO-91615  -->
+*   Registered users can now create new wishlists as expected when multiple wishlists are enabled. Previously, Magento displayed an error.
 
-<!--- MAGETWO-91433 -->*  Magento no longer changes the grid view to list view on the product list page when a customer adds a product from the wishlist section to the cart, and now displays the appropriate success message.
+<!--- MAGETWO-91433  -->
+*   Magento no longer changes the grid view to list view on the product list page when a customer adds a product from the wishlist section to the cart, and now displays the appropriate success message.
 
 ## Known issues
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
@@ -97,7 +97,7 @@ This release includes over 30 security enhancements that help close cross-site s
 
 * Customer address handling has been rewritten with UI components that increase platform performance, which in turn streamlines the management of customers with 3000 and more addresses.  <!--- MAGETWO-94346 95249-->
 
-* The Admin order creation page now handles  customer accounts with 3000 addresses without performance issues.   <!--- MC-5683-->
+* The Admin order creation page now handles  customer accounts with 3000 addresses without performance issues. <!--- MC-5683-->
 
 * Magento now displays the list of additional customer addresses contained in the storefront customer address book  as a grid, which has improved performance for customers with many additional addresses associated with their accounts. [Address Book](https://docs.magento.com/m2/ee/user_guide/customers/account-dashboard-address-book.html) describes how to use this enhanced feature. <!--- MAGETWO-94347-->
 
@@ -121,7 +121,7 @@ Infrastructure improvements are core enhancements that underlie both merchant an
 
 * You can now isolate and extract MySQL Views from regular database tables with no negative effects on database backup and restoration. Support for MySQL Views was introduced in 2.3.0 with unexpected consequences to the default database backups and restore mechanism. This fix restores expected  backup and restore functionality while preserving MySQL View support the backward compatibility with legacy inventory. *Fix submitted by community member  Stepan Furman in pull request [21151](https://github.com/magento/magento2/pull/21151)*. Thank you, Stepan!
 
-* Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method. <!--- MC-4245-->*
+* Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method. <!--- MC-4245-->
 
 * <!--- MAGETWO-95068-->Checkout information now persists after a cart update**. Information previously entered by a customer during check out (such as shipping address) now persists after the customer updates their shopping cart. Previously, when a customer updated their shopping cart, all information previously entered during check out (such as shipping address) was deleted.
 
@@ -187,27 +187,38 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Installation, upgrade, deployment
 
-<!--- MC-6275-->* The commands to enable and disable debug logging have changed to `bin/magento setup:config:set --enable-debug-logging=true | false`. The previous commands, `bin/magento config:set dev/debug/debug_logging 0 | 1` are no longer supported.  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
+<!--- MC-6275 -->
+*  The commands to enable and disable debug logging have changed to `bin/magento setup:config:set --enable-debug-logging=true | false`. The previous commands, `bin/magento config:set dev/debug/debug_logging 0 | 1` are no longer supported.  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
 
-<!--- ENGCOM-3291-->* Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by Fabian Schmengler in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
+<!--- ENGCOM-3291 -->
+*  Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by Fabian Schmengler in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 
-<!--- ENGCOM-3059-->* The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by Pratik Oza in pull request [18295](https://github.com/magento/magento2/pull/18295)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
+<!--- ENGCOM-3059 -->
+*  The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by Pratik Oza in pull request [18295](https://github.com/magento/magento2/pull/18295)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
 
-<!--- MAGETWO-96428-->* The `bin/magento app:config:dump` command now disables all input fields as expected.
+<!--- MAGETWO-96428 -->
+*  The `bin/magento app:config:dump` command now disables all input fields as expected.
 
-<!--- ENGCOM-3280-->* Administrators  that have been assigned a backup module role resource can now access the backup controller as expected. s*Fix submitted by Mahesh Singh in pull request [18816](https://github.com/magento/magento2/pull/18816)*. [GitHub-18150](https://github.com/magento/magento2/issues/18150)
+<!--- ENGCOM-3280 -->
+*  Administrators  that have been assigned a backup module role resource can now access the backup controller as expected. s*Fix submitted by Mahesh Singh in pull request [18816](https://github.com/magento/magento2/pull/18816)*. [GitHub-18150](https://github.com/magento/magento2/issues/18150)
 
-<!--- ENGCOM-3160-->* The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by Logan Stellway in pull request [18393](https://github.com/magento/magento2/pull/18393)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
+<!--- ENGCOM-3160 -->
+*  The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by Logan Stellway in pull request [18393](https://github.com/magento/magento2/pull/18393)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
 
-<!--- MAGETWO-96107-->* Magento no longer displays an extraneous blank option in the country drop-down menu.
+<!--- MAGETWO-96107 -->
+*  Magento no longer displays an extraneous blank option in the country drop-down menu.
 
-<!--- MAGETWO-91764-->* Excessive timeouts no longer result from the discrepancy between storefront and Admin uses of HTTPS. The storefront now  uses HTTPS exclusively while the Admin uses HTTP.
+<!--- MAGETWO-91764 -->
+*  Excessive timeouts no longer result from the discrepancy between storefront and Admin uses of HTTPS. The storefront now  uses HTTPS exclusively while the Admin uses HTTP.
 
-<!--- ENGCOM-3786-->* The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, administrators were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by Mahesh Singh in pull request [19880](https://github.com/magento/magento2/pull/19880)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
+<!--- ENGCOM-3786 -->
+*  The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, administrators were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by Mahesh Singh in pull request [19880](https://github.com/magento/magento2/pull/19880)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
 
-<!--- ENGCOM-3701-->* Magento now skips disabled modules  when compiling static content. *Fix submitted by Shikha Mishra in pull request [19751](https://github.com/magento/magento2/pull/19751)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
+<!--- ENGCOM-3701 -->
+*  Magento now skips disabled modules  when compiling static content. *Fix submitted by Shikha Mishra in pull request [19751](https://github.com/magento/magento2/pull/19751)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
 
-<!--- MC-5620-->* The `bin/magento setup:upgrade --convert-old-scripts=1` command now supports the conversion of indexes and constraints.
+<!--- MC-5620 -->
+*  The `bin/magento setup:upgrade --convert-old-scripts=1` command now supports the conversion of indexes and constraints.
 
 <!--- MC-1364-->
 
@@ -215,681 +226,979 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### AdminGWS
 
-<!--- MAGETWO-91617-->* Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
+<!--- MAGETWO-91617 -->
+*  Magento now updates the reports table as expected when a new administrator with restricted privileges logs in and selects **Report** > **Products** > **Ordered**. Previously, Magento did not generate this report, and logged an error in `var/log/system.log`.
 
 ### Amazon Pay
 
-<!--- BUNDLE-1762-->*  Fixed a bug where the Magento order ID was not always correctly represented in Amazon Pay order details.
+<!--- BUNDLE-1762 -->
+*   Fixed a bug where the Magento order ID was not always correctly represented in Amazon Pay order details.
 
 ### Analytics
 
-<!--- ENGCOM-3263 -->* You can now save configuration settings from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by Pratik Oza in pull request [18782](https://github.com/magento/magento2/pull/18782)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
+<!--- ENGCOM-3263  -->
+*  You can now save configuration settings from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by Pratik Oza in pull request [18782](https://github.com/magento/magento2/pull/18782)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
 
 ### Authorization
 
-<!--- MAGETWO-95536-->* You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
+<!--- MAGETWO-95536 -->
+*  You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
 
 ### Backend
 
-<!--- ENGCOM-3655-->* `CustomerRepository::getList()` now loads custom attributes that are named `company`. *Fix submitted by Tegan Elizabeth Bold in pull request [19620](https://github.com/magento/magento2/pull/19620)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
+<!--- ENGCOM-3655 -->
+*  `CustomerRepository::getList()` now loads custom attributes that are named `company`. *Fix submitted by Tegan Elizabeth Bold in pull request [19620](https://github.com/magento/magento2/pull/19620)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
 
-<!--- ENGCOM-3561-->* Fixed icon behavior on the product customization page. *Fix submitted by Kajal Solanki in pull request [19405](https://github.com/magento/magento2/pull/19405)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
+<!--- ENGCOM-3561 -->
+*  Fixed icon behavior on the product customization page. *Fix submitted by Kajal Solanki in pull request [19405](https://github.com/magento/magento2/pull/19405)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
 
-<!--- ENGCOM-4054-->* The **Reload Data** button on the Admin now works as expected. *Fix submitted by Eduard Chitora in pull request [20803](https://github.com/magento/magento2/pull/20803)*. [GitHub-20802](https://github.com/magento/magento2/issues/20802)
+<!--- ENGCOM-4054 -->
+*  The **Reload Data** button on the Admin now works as expected. *Fix submitted by Eduard Chitora in pull request [20803](https://github.com/magento/magento2/pull/20803)*. [GitHub-20802](https://github.com/magento/magento2/issues/20802)
 
 ### Bundle
 
-<!--- ENGCOM-3361 -->* Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that required four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!--- ENGCOM-3361  -->
+*  Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that required four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!--- ENGCOM-3391 -->* The Bundle Product Option Repository Delete method now removes the correct option. Previously, it removed the first option, regardless of the `optionId` that was specified. *Fix submitted by Burlacu Vasilii in pull request [19027](https://github.com/magento/magento2/pull/19027)*. [GitHub-18979](https://github.com/magento/magento2/issues/18979)
+<!--- ENGCOM-3391  -->
+*  The Bundle Product Option Repository Delete method now removes the correct option. Previously, it removed the first option, regardless of the `optionId` that was specified. *Fix submitted by Burlacu Vasilii in pull request [19027](https://github.com/magento/magento2/pull/19027)*. [GitHub-18979](https://github.com/magento/magento2/issues/18979)
 
-<!--- ENGCOM-3161 MAGETWO-69959 -->* Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by Vishal Gelani in pull request [18520](https://github.com/magento/magento2/pull/18520)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
+<!--- ENGCOM-3161 MAGETWO-69959  -->
+*  Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by Vishal Gelani in pull request [18520](https://github.com/magento/magento2/pull/18520)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
 
-<!--- MAGETWO-58212-->* You can now successfully change the attribute set for a bundle product. Previously, the edit bundle page hung, and Magento threw this error, `Uncaught TypeError: Cannot read property 'length' of undefined`. [GitHub-5999](https://github.com/magento/magento2/issues/5999)
+<!--- MAGETWO-58212 -->
+*  You can now successfully change the attribute set for a bundle product. Previously, the edit bundle page hung, and Magento threw this error, `Uncaught TypeError: Cannot read property 'length' of undefined`. [GitHub-5999](https://github.com/magento/magento2/issues/5999)
 
-<!--- MAGETWO-91628-->* Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
+<!--- MAGETWO-91628 -->
+*  Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
 
-<!--- MAGETWO-91679-->* Bundle product SKUs are now built based on the order of the options set in the bundle product.  Previously, SKUs were built based on the order of the selected product ID numbers in ascending order. [GitHub-14262](https://github.com/magento/magento2/issues/14262)
+<!--- MAGETWO-91679 -->
+*  Bundle product SKUs are now built based on the order of the options set in the bundle product.  Previously, SKUs were built based on the order of the selected product ID numbers in ascending order. [GitHub-14262](https://github.com/magento/magento2/issues/14262)
 
-<!--- ENGCOM-3487 3585-->* Magento now adds all selected values to the cart when a customer adds a bundle product option using an input type checkbox. Previously, if a bundle product had three values, Magento added only two options to the cart. *Fix submitted by Mahesh Singh in pull request [19261](https://github.com/magento/magento2/pull/19261) and pull request [19437](https://github.com/magento/magento2/pull/19437)*. [GitHub-19205](https://github.com/magento/magento2/issues/19205)
+<!--- ENGCOM-3487 3585 -->
+*  Magento now adds all selected values to the cart when a customer adds a bundle product option using an input type checkbox. Previously, if a bundle product had three values, Magento added only two options to the cart. *Fix submitted by Mahesh Singh in pull request [19261](https://github.com/magento/magento2/pull/19261) and pull request [19437](https://github.com/magento/magento2/pull/19437)*. [GitHub-19205](https://github.com/magento/magento2/issues/19205)
 
-<!--- ENGCOM-3605-->* Fixed inconsistently sized title box border on the edit bundle product page when adding an item to a bundle product from the Admin. *Fix submitted by Abrar Pathan in pull request [19510](https://github.com/magento/magento2/pull/19510)*. [GitHub-19509](https://github.com/magento/magento2/issues/19509)
+<!--- ENGCOM-3605 -->
+*  Fixed inconsistently sized title box border on the edit bundle product page when adding an item to a bundle product from the Admin. *Fix submitted by Abrar Pathan in pull request [19510](https://github.com/magento/magento2/pull/19510)*. [GitHub-19509](https://github.com/magento/magento2/issues/19509)
 
-<!--- MAGETWO-97617-->* You can now add a bundle product to a requisition list from the category page. Previously, Magento threw this error, `PHP Fatal error: Uncaught Error: Call to a member function getParentProductId() on string in app/code/Magento/RequisitionList/Model/RequisitionListItem/Options/Builder.php:118`.
+<!--- MAGETWO-97617 -->
+*  You can now add a bundle product to a requisition list from the category page. Previously, Magento threw this error, `PHP Fatal error: Uncaught Error: Call to a member function getParentProductId() on string in app/code/Magento/RequisitionList/Model/RequisitionListItem/Options/Builder.php:118`.
 
 ### B2B
 
-<!--- MAGETWO-91614-->* You can now filter customers by status. Previously, Magento threw an SQL ERROR when you clicked on **Apply Filters** after setting the filter to status.
+<!--- MAGETWO-91614 -->
+*  You can now filter customers by status. Previously, Magento threw an SQL ERROR when you clicked on **Apply Filters** after setting the filter to status.
 
-<!--- MAGETWO-91754-->* Magento now loads the company profile, roles, and permissions information for a company account when **Enable Reward Points Functionality** is set to **no** in the Admin and you flush cache storage.
+<!--- MAGETWO-91754 -->
+*  Magento now loads the company profile, roles, and permissions information for a company account when **Enable Reward Points Functionality** is set to **no** in the Admin and you flush cache storage.
 
-<!--- MAGETWO-94866-->* Magento now displays products that merchants have added to the public catalog through **Product** > **Edit page** > **Shared Catalog**. Previously, these items appeared if added  through **Catalog** > **Shared Catalog**, but not through **Product** > **Edit page** > **Shared Catalog**.
+<!--- MAGETWO-94866 -->
+*  Magento now displays products that merchants have added to the public catalog through **Product** > **Edit page** > **Shared Catalog**. Previously, these items appeared if added  through **Catalog** > **Shared Catalog**, but not through **Product** > **Edit page** > **Shared Catalog**.
 
-<!--- MAGETWO-91661-->* Menus now close as expected from the Quick Order page in mobile view.
+<!--- MAGETWO-91661 -->
+*  Menus now close as expected from the Quick Order page in mobile view.
 
-<!--- MAGETWO-94887-->* Magento no longer displays a duplicate **Add product** button when you change currency from the Order currency drop-down menu while creating an order from the Admin.
+<!--- MAGETWO-94887 -->
+*  Magento no longer displays a duplicate **Add product** button when you change currency from the Order currency drop-down menu while creating an order from the Admin.
 
-<!--- MAGETWO-96598-->* Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
+<!--- MAGETWO-96598 -->
+*  Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
 
-<!--- MAGETWO-97314-->* Magento now displays custom prices in quotes, the shopping cart, and during checkout. Previously, when you moved a product with a custom price to the shopping cart from the Admin, the custom price was lost, and Magento did not display it in the shopping cart.
+<!--- MAGETWO-97314 -->
+*  Magento now displays custom prices in quotes, the shopping cart, and during checkout. Previously, when you moved a product with a custom price to the shopping cart from the Admin, the custom price was lost, and Magento did not display it in the shopping cart.
 
-<!--- MAGETWO-97131-->* A logged-in user can now log out, log in as a guest, and then check out when persistent cart is enabled. Previously, under these circumstances, the customer logged in as guest could not check out, and Magento displayed this error, `No such entity with cartId = null`.
+<!--- MAGETWO-97131 -->
+*  A logged-in user can now log out, log in as a guest, and then check out when persistent cart is enabled. Previously, under these circumstances, the customer logged in as guest could not check out, and Magento displayed this error, `No such entity with cartId = null`.
 
-<!--- MAGETWO-97315-->* Magento now correctly displays pricing for configurable products when permissions are set to prevent adding products to cart from a category.
+<!--- MAGETWO-97315 -->
+*  Magento now correctly displays pricing for configurable products when permissions are set to prevent adding products to cart from a category.
 
 ### CAPTCHA
 
-<!--- MAGETWO-94052-->* CAPTCHA now appears as expected in the Log in pop-up window.
+<!--- MAGETWO-94052 -->
+*  CAPTCHA now appears as expected in the Log in pop-up window.
 
 ### Cart and checkout
 
-<!--- ENGCOM-3194 -->* Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by Mahesh Singh in pull request [18631](https://github.com/magento/magento2/pull/18631)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
+<!--- ENGCOM-3194  -->
+*  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by Mahesh Singh in pull request [18631](https://github.com/magento/magento2/pull/18631)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
-<!--- ENGCOM-3237 -->* Custom shipping methods in custom carrier code can now include underscores. *Fix submitted by Jakub in pull request [18689](https://github.com/magento/magento2/pull/18689)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
+<!--- ENGCOM-3237  -->
+*  Custom shipping methods in custom carrier code can now include underscores. *Fix submitted by Jakub in pull request [18689](https://github.com/magento/magento2/pull/18689)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
 
-<!--- ENGCOM-3073 -->* Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by Ihor Sviziev in pull request [18331](https://github.com/magento/magento2/pull/18331)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
+<!--- ENGCOM-3073  -->
+*  Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by Ihor Sviziev in pull request [18331](https://github.com/magento/magento2/pull/18331)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
 
-<!--- ENGCOM-3189 -->* The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by Luuk Schakenraad in pull request [18596](https://github.com/magento/magento2/pull/18596)*. [GitHub-18475](https://github.com/magento/magento2/issues/18475), [GitHub-18589](https://github.com/magento/magento2/issues/18589)
+<!--- ENGCOM-3189  -->
+*  The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by Luuk Schakenraad in pull request [18596](https://github.com/magento/magento2/pull/18596)*. [GitHub-18475](https://github.com/magento/magento2/issues/18475), [GitHub-18589](https://github.com/magento/magento2/issues/18589)
 
-<!--- ENGCOM-2987 -->* Magento now dispatches a `checkout_cart_product_add_before` event in addition to a `checkout_cart_product_add_after` event. *Fix submitted by Leandro Rosa in pull request [18080](https://github.com/magento/magento2/pull/18080)*. [GitHub-17830](https://github.com/magento/magento2/issues/17830)
+<!--- ENGCOM-2987  -->
+*  Magento now dispatches a `checkout_cart_product_add_before` event in addition to a `checkout_cart_product_add_after` event. *Fix submitted by Leandro Rosa in pull request [18080](https://github.com/magento/magento2/pull/18080)*. [GitHub-17830](https://github.com/magento/magento2/issues/17830)
 
-<!--- MAGETWO-95935-->* Customer address attribute validation during checkout now permits spaces.
+<!--- MAGETWO-95935 -->
+*  Customer address attribute validation during checkout now permits spaces.
 
-<!--- MAGETWO-96812-->* Clicking multiple times on the mini cart icon no longer logs out the current customer. Previously, when a logged-in customer added a product to the cart and then clicked the shopping cart icon multiple times, Magento displayed an empty shopping cart and logged out the customer.
+<!--- MAGETWO-96812 -->
+*  Clicking multiple times on the mini cart icon no longer logs out the current customer. Previously, when a logged-in customer added a product to the cart and then clicked the shopping cart icon multiple times, Magento displayed an empty shopping cart and logged out the customer.
 
-<!--- MAGETWO-95848-->* Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
+<!--- MAGETWO-95848 -->
+*  Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
 
-<!--- MAGETWO-95739-->* Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
+<!--- MAGETWO-95739 -->
+*  Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
 
-<!--- MAGETWO-94427-->* Magento now updates the mini cart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
+<!--- MAGETWO-94427 -->
+*  Magento now updates the mini cart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
 
-<!--- MAGETWO-91658-->* Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
+<!--- MAGETWO-91658 -->
+*  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
 
-<!--- MAGETWO-91530-->* Magento now displays informative error messages when an order paid for with Authorize.Net fails.
+<!--- MAGETWO-91530 -->
+*  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
 
-<!--- MAGETWO-71375-->* Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
+<!--- MAGETWO-71375 -->
+*  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
-<!--- MAGETWO-91730-->* Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
+<!--- MAGETWO-91730 -->
+*  Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
 
-<!--- MAGETWO-91517-->* Magento no longer removes the billing and shipping address information for an order when a customer cancels the order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
+<!--- MAGETWO-91517 -->
+*  Magento no longer removes the billing and shipping address information for an order when a customer cancels the order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
 
-<!--- MAGETWO-91596-->* You can now update the quantity of grouped products  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
+<!--- MAGETWO-91596 -->
+*  You can now update the quantity of grouped products  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
-<!--- MAGETWO-91733-->* After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the mini cart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
+<!--- MAGETWO-91733 -->
+*  After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the mini cart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
 
-<!--- MAGETWO-91636-->* Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+<!--- MAGETWO-91636 -->
+*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
-<!--- ENGCOM-3578-->* `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed. *Fix submitted by Dmytro Cheshun in pull request [19425](https://github.com/magento/magento2/pull/19425)*. [GitHub-19424](https://github.com/magento/magento2/issues/19424)
+<!--- ENGCOM-3578 -->
+*  `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed. *Fix submitted by Dmytro Cheshun in pull request [19425](https://github.com/magento/magento2/pull/19425)*. [GitHub-19424](https://github.com/magento/magento2/issues/19424)
 
-<!--- ENGCOM-3386-->* Magento now validates the shipping address of a logged-in user using the default shipping address during checkout. *Fix submitted by StasKozar in pull request [19038](https://github.com/magento/magento2/pull/19038)*. [GitHub-18990](https://github.com/magento/magento2/issues/18990)
+<!--- ENGCOM-3386 -->
+*  Magento now validates the shipping address of a logged-in user using the default shipping address during checkout. *Fix submitted by StasKozar in pull request [19038](https://github.com/magento/magento2/pull/19038)*. [GitHub-18990](https://github.com/magento/magento2/issues/18990)
 
-<!--- ENGCOM-3971-->* Fixed issue displaying numbers that exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by Parag Chavare in pull request [20612](https://github.com/magento/magento2/pull/20612)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+<!--- ENGCOM-3971 -->
+*  Fixed issue displaying numbers that exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by Parag Chavare in pull request [20612](https://github.com/magento/magento2/pull/20612)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
 
-<!--- ENGCOM-3864-->* Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by Arvinda Kumar in pull request [20306](https://github.com/magento/magento2/pull/20306)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+<!--- ENGCOM-3864 -->
+*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by Arvinda Kumar in pull request [20306](https://github.com/magento/magento2/pull/20306)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
-<!--- ENGCOM-4019-->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Govind Sharma in pull request [20634](https://github.com/magento/magento2/pull/20634)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+<!--- ENGCOM-4019 -->
+*  Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Govind Sharma in pull request [20634](https://github.com/magento/magento2/pull/20634)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
-<!--- ENGCOM-4032-->* The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by Yashwant Rokde in pull request [20428](https://github.com/magento/magento2/pull/20428)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+<!--- ENGCOM-4032 -->
+*  The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by Yashwant Rokde in pull request [20428](https://github.com/magento/magento2/pull/20428)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
-<!--- ENGCOM-3984-->* The **Close** button on the mini cart no longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20615](https://github.com/magento/magento2/pull/20615)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
+<!--- ENGCOM-3984 -->
+*  The **Close** button on the mini cart no longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20615](https://github.com/magento/magento2/pull/20615)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
 
-<!--- ENGCOM-3818-->* Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by Arvinda Kumar in pull request [20144](https://github.com/magento/magento2/pull/20144)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+<!--- ENGCOM-3818 -->
+*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by Arvinda Kumar in pull request [20144](https://github.com/magento/magento2/pull/20144)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
-<!--- MAGETWO-95312-->* Fixed mini cart layout issues.
+<!--- MAGETWO-95312 -->
+*  Fixed mini cart layout issues.
 
-<!--- MAGETWO-97968-->* The mini cart is now updated as expected when a product in the cart is disabled.
+<!--- MAGETWO-97968 -->
+*  The mini cart is now updated as expected when a product in the cart is disabled.
 
-<!--- ENGCOM-3938 -->* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by ranee2jcommerce in pull request [20488](https://github.com/magento/magento2/pull/20488)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+<!--- ENGCOM-3938  -->
+*  Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by ranee2jcommerce in pull request [20488](https://github.com/magento/magento2/pull/20488)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
 
-<!--- ENGCOM-3153 -->* Magento no longer displays a console error when a customer selects one-step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
+<!--- ENGCOM-3153  -->
+*  Magento no longer displays a console error when a customer selects one-step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
 
-<!--- MAGETWO-95939 -->* Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
+<!--- MAGETWO-95939  -->
+*  Administrators with appropriate permissions can now manage customer shopping carts from the Admin. Previously, when an administrator clicked **Manage Shopping Cart** from **Admin** > **Customers** > **Customer**, Magento threw an error.
 
 ### Cart Price rules
 
-<!--- MAGETWO-96379 -->* The Cart Price Rule page now displays correct counter values for the grid as well as accurate pagination.
+<!--- MAGETWO-96379  -->
+*  The Cart Price Rule page now displays correct counter values for the grid as well as accurate pagination.
 
-<!--- MAGETWO-91784-->* Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+<!--- MAGETWO-91784 -->
+*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
 ### Catalog
 
-<!--- ENGCOM-3516 -->* Magento now displays the product page with this message `You need to choose options for your item` when you click **Add to cart** for a new product that has an attribute with the **Use in product listing** property set to **Yes**. Previously, Magento redirected the user to the cart page, and did not add the product to the cart. *Fix submitted by Vishal Gelani in pull request [19322](https://github.com/magento/magento2/pull/19322)*. [GitHub-19315](https://github.com/magento/magento2/issues/19315)
+<!--- ENGCOM-3516  -->
+*  Magento now displays the product page with this message `You need to choose options for your item` when you click **Add to cart** for a new product that has an attribute with the **Use in product listing** property set to **Yes**. Previously, Magento redirected the user to the cart page, and did not add the product to the cart. *Fix submitted by Vishal Gelani in pull request [19322](https://github.com/magento/magento2/pull/19322)*. [GitHub-19315](https://github.com/magento/magento2/issues/19315)
 
-<!--- ENGCOM-3435 -->* Magento now directs the user to a 404 page when accessing http://www.domain.com/catalog/product/compare. Previously, Magento threw this error, `Fatal error: Uncaught Error: Cannot call abstract method Magento\Framework\App\ActionInterface::execute()`. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!--- ENGCOM-3435  -->
+*  Magento now directs the user to a 404 page when accessing http://www.domain.com/catalog/product/compare. Previously, Magento threw this error, `Fatal error: Uncaught Error: Cannot call abstract method Magento\Framework\App\ActionInterface::execute()`. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!--- ENGCOM-3450 -->* Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by Torben Höhn in pull request [19179](https://github.com/magento/magento2/pull/19179)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
+<!--- ENGCOM-3450  -->
+*  Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by Torben Höhn in pull request [19179](https://github.com/magento/magento2/pull/19179)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
 
-<!--- ENGCOM-3421-->* Magento no longer throws an exception when you try to add an image to a product programmatically. *Fix submitted by Yevhenii Dumskyi in pull request [18952](https://github.com/magento/magento2/pull/18952)*. [GitHub-6803](https://github.com/magento/magento2/issues/6803)
+<!--- ENGCOM-3421 -->
+*  Magento no longer throws an exception when you try to add an image to a product programmatically. *Fix submitted by Yevhenii Dumskyi in pull request [18952](https://github.com/magento/magento2/pull/18952)*. [GitHub-6803](https://github.com/magento/magento2/issues/6803)
 
-<!--- ENGCOM-3365-->* Magento now applies the translations for the selected theme when you enable a custom design theme. Previously, Magento collected the translation files for the active main theme only, which limited the use of different translations within the additional theme. *Fix submitted by Cezary Zeglen in pull request [18998](https://github.com/magento/magento2/pull/18998)*. [GitHub-17625](https://github.com/magento/magento2/issues/17625)
+<!--- ENGCOM-3365 -->
+*  Magento now applies the translations for the selected theme when you enable a custom design theme. Previously, Magento collected the translation files for the active main theme only, which limited the use of different translations within the additional theme. *Fix submitted by Cezary Zeglen in pull request [18998](https://github.com/magento/magento2/pull/18998)*. [GitHub-17625](https://github.com/magento/magento2/issues/17625)
 
-<!--- ENGCOM-3292-->* The `bin/magento catalog:images:resize` command now processes all specified images. *Fix submitted by Vladyslav Podorozhnyi in pull request [18807](https://github.com/magento/magento2/pull/18807)*. [GitHub-18387](https://github.com/magento/magento2/issues/18387)
+<!--- ENGCOM-3292 -->
+*  The `bin/magento catalog:images:resize` command now processes all specified images. *Fix submitted by Vladyslav Podorozhnyi in pull request [18807](https://github.com/magento/magento2/pull/18807)*. [GitHub-18387](https://github.com/magento/magento2/issues/18387)
 
-<!--- ENGCOM-3184-->* You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`. *Fix submitted by Hiren Pandya in pull request [18578](https://github.com/magento/magento2/pull/18578)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+<!--- ENGCOM-3184 -->
+*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`. *Fix submitted by Hiren Pandya in pull request [18578](https://github.com/magento/magento2/pull/18578)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
 
-<!--- ENGCOM-3242-->* You can now insert multiple catalog product list widgets into a CMS page. *Fix submitted by Burlacu Vasilii in pull request [18714](https://github.com/magento/magento2/pull/18714)*. [GitHub-4468](https://github.com/magento/magento2/issues/4468)
+<!--- ENGCOM-3242 -->
+*  You can now insert multiple catalog product list widgets into a CMS page. *Fix submitted by Burlacu Vasilii in pull request [18714](https://github.com/magento/magento2/pull/18714)*. [GitHub-4468](https://github.com/magento/magento2/issues/4468)
 
-<!--- ENGCOM-3202-->* You can now use REST to add a new attribute and configure it with settings such as `is_filterable`. *Fix submitted by Mr. Lewis in pull request [18622](https://github.com/magento/magento2/pull/18622)*. [GitHub-10205](https://github.com/magento/magento2/issues/10205)
+<!--- ENGCOM-3202 -->
+*  You can now use REST to add a new attribute and configure it with settings such as `is_filterable`. *Fix submitted by Mr. Lewis in pull request [18622](https://github.com/magento/magento2/pull/18622)*. [GitHub-10205](https://github.com/magento/magento2/issues/10205)
 
-<!--- ENGCOM-2998-->* Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by Bartosz Kubicki in pull request [18019](https://github.com/magento/magento2/pull/18019)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
+<!--- ENGCOM-2998 -->
+*  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by Bartosz Kubicki in pull request [18019](https://github.com/magento/magento2/pull/18019)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
-<!--- ENGCOM-3180-->* Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by Vishal Gelani in pull request [18570](https://github.com/magento/magento2/pull/18570)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
+<!--- ENGCOM-3180 -->
+*  Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by Vishal Gelani in pull request [18570](https://github.com/magento/magento2/pull/18570)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
 
-<!--- ENGCOM-3142-->* The table rate shipping method no longer fails to return a quote when a customer uses a United States  postal code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by Vishal Gelani in pull request [18499](https://github.com/magento/magento2/pull/18499)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
+<!--- ENGCOM-3142 -->
+*  The table rate shipping method no longer fails to return a quote when a customer uses a United States  postal code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by Vishal Gelani in pull request [18499](https://github.com/magento/magento2/pull/18499)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
 
-<!--- ENGCOM-3129-->* You can now set a Boolean attribute to `is_filterable`, which allows these attributes to be included in layered navigation. *Fix submitted by Mr. Lewis in pull request [18434](https://github.com/magento/magento2/pull/18434)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
+<!--- ENGCOM-3129 -->
+*  You can now set a Boolean attribute to `is_filterable`, which allows these attributes to be included in layered navigation. *Fix submitted by Mr. Lewis in pull request [18434](https://github.com/magento/magento2/pull/18434)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
 
-<!--- ENGCOM-3047-->* `getStoreId()` now consistently returns `int`. Previously, Magento returned `string` for products but `int` for categories, which resulted in a fatal error. Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!--- ENGCOM-3047 -->
+*  `getStoreId()` now consistently returns `int`. Previously, Magento returned `string` for products but `int` for categories, which resulted in a fatal error. Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!--- ENGCOM-3055-->* `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by Jay Ghosh in pull request [18149](https://github.com/magento/magento2/pull/18149)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+<!--- ENGCOM-3055 -->
+*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by Jay Ghosh in pull request [18149](https://github.com/magento/magento2/pull/18149)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
-<!--- ENGCOM-3035-->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by Pieter Hoste in pull request [18207](https://github.com/magento/magento2/pull/18207)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720)
+<!--- ENGCOM-3035 -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by Pieter Hoste in pull request [18207](https://github.com/magento/magento2/pull/18207)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720)
 
-<!--- ENGCOM-3034-->* The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by Pratik Oza in pull request [18205](https://github.com/magento/magento2/pull/18205)*. [GitHub-17780](https://github.com/magento/magento2/issues/17780)
+<!--- ENGCOM-3034 -->
+*  The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by Pratik Oza in pull request [18205](https://github.com/magento/magento2/pull/18205)*. [GitHub-17780](https://github.com/magento/magento2/issues/17780)
 
-<!--- ENGCOM-3061-->* `getStoreId()` now consistently returns `int`. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!--- ENGCOM-3061 -->
+*  `getStoreId()` now consistently returns `int`. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!--- ENGCOM-3078-->* You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by Eduard Chitoraga in pull request [18210](https://github.com/magento/magento2/pull/18210)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
+<!--- ENGCOM-3078 -->
+*  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by Eduard Chitoraga in pull request [18210](https://github.com/magento/magento2/pull/18210)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
 
-<!--- MAGETWO-96908-->* Attribute values are now updated as expected in the `catalog_product_flat_2` table.
+<!--- MAGETWO-96908 -->
+*  Attribute values are now updated as expected in the `catalog_product_flat_2` table.
 
-<!--- MAGETWO-95802-->* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
+<!--- MAGETWO-95802 -->
+*  Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
 
-<!--- MAGETWO-94556-->* Magento now saves and properly indexes a configurable product variant that contains a longer-than-permitted SKU. Previously, when you tried to save this product, Magento threw an error. [GitHub-17436](https://github.com/magento/magento2/issues/17436)
+<!--- MAGETWO-94556 -->
+*  Magento now saves and properly indexes a configurable product variant that contains a longer-than-permitted SKU. Previously, when you tried to save this product, Magento threw an error. [GitHub-17436](https://github.com/magento/magento2/issues/17436)
 
-<!--- MAGETWO-95428-->* The product page's Recently Viewed section no longer displays the name of the current product.
+<!--- MAGETWO-95428 -->
+*  The product page's Recently Viewed section no longer displays the name of the current product.
 
-<!--- MAGETWO-91837-->* You can now use REST to update a product's media gallery.
+<!--- MAGETWO-91837 -->
+*  You can now use REST to update a product's media gallery.
 
-<!--- MAGETWO-95818-->* Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
+<!--- MAGETWO-95818 -->
+*  Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
 
-<!--- MAGETWO-95826-->* Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
+<!--- MAGETWO-95826 -->
+*  Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
 
-<!--- MAGETWO-61478-->* Magento now retains across categories any value you set for the number of categories displayed per page.
+<!--- MAGETWO-61478 -->
+*  Magento now retains across categories any value you set for the number of categories displayed per page.
 
-<!--- MAGETWO-95753-->* You can now save products with at least one tier price.
+<!--- MAGETWO-95753 -->
+*  You can now save products with at least one tier price.
 
-<!--- MAGETWO-66442-->* Changes to product images made under the All Stores scope now affect product images at the store-view level.
+<!--- MAGETWO-66442 -->
+*  Changes to product images made under the All Stores scope now affect product images at the store-view level.
 
-<!--- MAGETWO-96290-->* You can now use REST to update category positions.
+<!--- MAGETWO-96290 -->
+*  You can now use REST to update category positions.
 
-<!--- MAGETWO-91609-->* Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
+<!--- MAGETWO-91609 -->
+*  Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
 
-<!--- MAGETWO-70303-->* Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
+<!--- MAGETWO-70303 -->
+*  Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
 
-<!--- MAGETWO-91633-->* You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
+<!--- MAGETWO-91633 -->
+*  You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
 
-<!--- ENGCOM-3281-->* Magento now uses the correct column type when creating temporary tables for a flat catalog. *Fix submitted by Jason Evans in pull request [18818](https://github.com/magento/magento2/pull/18818)*. [GitHub-14571](https://github.com/magento/magento2/issues/14571)
+<!--- ENGCOM-3281 -->
+*  Magento now uses the correct column type when creating temporary tables for a flat catalog. *Fix submitted by Jason Evans in pull request [18818](https://github.com/magento/magento2/pull/18818)*. [GitHub-14571](https://github.com/magento/magento2/issues/14571)
 
-<!--- ENGCOM-3566-->* Attribute indexing no longer ignores custom source model options. *Fix submitted by Joel Rainwater in pull request [19176](https://github.com/magento/magento2/pull/19176)*. [GitHub-417](https://github.com/magento/magento2/issues/417)
+<!--- ENGCOM-3566 -->
+*  Attribute indexing no longer ignores custom source model options. *Fix submitted by Joel Rainwater in pull request [19176](https://github.com/magento/magento2/pull/19176)*. [GitHub-417](https://github.com/magento/magento2/issues/417)
 
-<!--- ENGCOM-3597-->* Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.  *Fix submitted by Govind Sharma in pull request [19408](https://github.com/magento/magento2/pull/19408)*. [GitHub-19346](https://github.com/magento/magento2/issues/19346)
+<!--- ENGCOM-3597 -->
+*  Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.  *Fix submitted by Govind Sharma in pull request [19408](https://github.com/magento/magento2/pull/19408)*. [GitHub-19346](https://github.com/magento/magento2/issues/19346)
 
-<!--- ENGCOM-3592-->* Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by SikailoISM in pull request [19451](https://github.com/magento/magento2/pull/19451)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+<!--- ENGCOM-3592 -->
+*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by SikailoISM in pull request [19451](https://github.com/magento/magento2/pull/19451)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
-<!--- ENGCOM-3641-->* You can now successfully delete a newly created attribute set. Previously, Magento displayed a 404 error under these circumstances. *Fix submitted by cedcommerce in pull request [19633](https://github.com/magento/magento2/pull/19633)*. [GitHub-19607](https://github.com/magento/magento2/issues/19607)
+<!--- ENGCOM-3641 -->
+*  You can now successfully delete a newly created attribute set. Previously, Magento displayed a 404 error under these circumstances. *Fix submitted by cedcommerce in pull request [19633](https://github.com/magento/magento2/pull/19633)*. [GitHub-19607](https://github.com/magento/magento2/issues/19607)
 
-<!--- ENGCOM-3399-->* You can now use add extension attributes to add category links to a product. Previously, Magento did not add the product links, but behaved unpredictably. *Fix submitted by Giel Berkers in pull request [19080](https://github.com/magento/magento2/pull/19080)*. [GitHub-14861](https://github.com/magento/magento2/issues/14861)
+<!--- ENGCOM-3399 -->
+*  You can now use add extension attributes to add category links to a product. Previously, Magento did not add the product links, but behaved unpredictably. *Fix submitted by Giel Berkers in pull request [19080](https://github.com/magento/magento2/pull/19080)*. [GitHub-14861](https://github.com/magento/magento2/issues/14861)
 
-<!--- ENGCOM-3673-->* When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by Malyovanets Nickolas in pull request [19341](https://github.com/magento/magento2/pull/19341)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
+<!--- ENGCOM-3673 -->
+*  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by Malyovanets Nickolas in pull request [19341](https://github.com/magento/magento2/pull/19341)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
-<!--- ENGCOM-3780-->* `CategoryLinkReposity` now lists all possible exceptions. *Fix submitted by Patrick McLain in pull request [20050](https://github.com/magento/magento2/pull/20050)*. [GitHub-20037](https://github.com/magento/magento2/issues/20037)
+<!--- ENGCOM-3780 -->
+*  `CategoryLinkReposity` now lists all possible exceptions. *Fix submitted by Patrick McLain in pull request [20050](https://github.com/magento/magento2/pull/20050)*. [GitHub-20037](https://github.com/magento/magento2/issues/20037)
 
-<!--- ENGCOM-1862-->* Merchants can now assign negative values to the custom option for a product with a fixed price from the Admin. *Fix submitted by Danny Verkade in pull request [15267](https://github.com/magento/magento2/pull/15267)*. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
+<!--- ENGCOM-1862 -->
+*  Merchants can now assign negative values to the custom option for a product with a fixed price from the Admin. *Fix submitted by Danny Verkade in pull request [15267](https://github.com/magento/magento2/pull/15267)*. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
 
-<!--- ENGCOM-3618-->* Newly added fields are now sorted according to the given `sortOrder` value in the newsletter system configuration file. Previously, you could add a new field, but could not successfully set its position. *Fix submitted by Burlacu Vasilii in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!--- ENGCOM-3618 -->
+*  Newly added fields are now sorted according to the given `sortOrder` value in the newsletter system configuration file. Previously, you could add a new field, but could not successfully set its position. *Fix submitted by Burlacu Vasilii in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!--- ENGCOM-3430-->* Merchants can now change the position of tabs on a product page. *Fix submitted by Burlacu Vasilii in pull request [19007](https://github.com/magento/magento2/pull/19007)*. [GitHub-4154](https://github.com/magento/magento2/issues/4154)
+<!--- ENGCOM-3430 -->
+*  Merchants can now change the position of tabs on a product page. *Fix submitted by Burlacu Vasilii in pull request [19007](https://github.com/magento/magento2/pull/19007)*. [GitHub-4154](https://github.com/magento/magento2/issues/4154)
 
-<!--- ENGCOM-3758-->* An incorrect variable in the phpDoc for `DataBuilder.php` has been corrected. *Fix submitted by Kunj joshi in pull request [19992](https://github.com/magento/magento2/pull/19992)*. [GitHub-19974](https://github.com/magento/magento2/issues/19974)
+<!--- ENGCOM-3758 -->
+*  An incorrect variable in the phpDoc for `DataBuilder.php` has been corrected. *Fix submitted by Kunj joshi in pull request [19992](https://github.com/magento/magento2/pull/19992)*. [GitHub-19974](https://github.com/magento/magento2/issues/19974)
 
-<!--- ENGCOM-3599-->* You can now perform a mass  update  on product attributes after configuring the minimum cart quantity globally. Previously, Magento did not display the form to update all available attributes but threw an `E_WARNING:` error when you selected **Update attributes**. *Fix submitted by Patrick McLain in pull request [19095](https://github.com/magento/magento2/pull/19095)*. [GitHub-17592](https://github.com/magento/magento2/issues/17592)
+<!--- ENGCOM-3599 -->
+*  You can now perform a mass  update  on product attributes after configuring the minimum cart quantity globally. Previously, Magento did not display the form to update all available attributes but threw an `E_WARNING:` error when you selected **Update attributes**. *Fix submitted by Patrick McLain in pull request [19095](https://github.com/magento/magento2/pull/19095)*. [GitHub-17592](https://github.com/magento/magento2/issues/17592)
 
-<!--- ENGCOM-3946-->* The product compare page now loads as expected when unconfigured attributes display **N/A** or **No**. *Fix submitted by Vivek Kumar in pull request [20231](https://github.com/magento/magento2/pull/20231)*. [GitHub-20229](https://github.com/magento/magento2/issues/20229)
+<!--- ENGCOM-3946 -->
+*  The product compare page now loads as expected when unconfigured attributes display **N/A** or **No**. *Fix submitted by Vivek Kumar in pull request [20231](https://github.com/magento/magento2/pull/20231)*. [GitHub-20229](https://github.com/magento/magento2/issues/20229)
 
-<!--- ENGCOM-3913-->* Magento now correctly sorts configurable products with tier prices or swatches on both the storefront and Admin. Previously, storefront sorting did not match Admin sorting. *Fix submitted by vshatylo in pull request [20407](https://github.com/magento/magento2/pull/20407)*. [GitHub-12194](https://github.com/magento/magento2/issues/12194)
+<!--- ENGCOM-3913 -->
+*  Magento now correctly sorts configurable products with tier prices or swatches on both the storefront and Admin. Previously, storefront sorting did not match Admin sorting. *Fix submitted by vshatylo in pull request [20407](https://github.com/magento/magento2/pull/20407)*. [GitHub-12194](https://github.com/magento/magento2/issues/12194)
 
-<!--- MAGETWO-97625-->* Magento now correctly duplicates video files when a merchant duplicates a product with an associated video. Previously, the video was duplicated as an image, not a video, and the merchant had to delete the image and re-add the video using **Add Video**.
+<!--- MAGETWO-97625 -->
+*  Magento now correctly duplicates video files when a merchant duplicates a product with an associated video. Previously, the video was duplicated as an image, not a video, and the merchant had to delete the image and re-add the video using **Add Video**.
 
-<!--- MAGETWO-97210 -->* Magento no longer hangs when you add a product by SKU to a large category (100,000 or more products).
+<!--- MAGETWO-97210  -->
+*  Magento no longer hangs when you add a product by SKU to a large category (100,000 or more products).
 
-<!--- ENGCOM-3029-->* We've improved the error message that Magento displays when validating a new (but invalid) product attribute. *Fix submitted by saravananvelu in pull request [17806](https://github.com/magento/magento2/pull/17806)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
+<!--- ENGCOM-3029 -->
+*  We've improved the error message that Magento displays when validating a new (but invalid) product attribute. *Fix submitted by saravananvelu in pull request [17806](https://github.com/magento/magento2/pull/17806)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
 
-<!--- ENGCOM-3476-->*  `getProductUrl` no longer returns the wrong URL when the current category has no products. *Fix submitted by Erik Pellikka in pull request [19232](https://github.com/magento/magento2/pull/19232)*. [GitHub-17819](https://github.com/magento/magento2/issues/17819)
+<!--- ENGCOM-3476 -->
+*   `getProductUrl` no longer returns the wrong URL when the current category has no products. *Fix submitted by Erik Pellikka in pull request [19232](https://github.com/magento/magento2/pull/19232)*. [GitHub-17819](https://github.com/magento/magento2/issues/17819)
 
-<!--- ENGCOM-3448-->* The user agent exception now sets the correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme regardless of the user agent. *Fix submitted by Alex Ghiban in pull request [19124](https://github.com/magento/magento2/pull/19124)*. [GitHub-16074](https://github.com/magento/magento2/issues/16074)
+<!--- ENGCOM-3448 -->
+*  The user agent exception now sets the correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme regardless of the user agent. *Fix submitted by Alex Ghiban in pull request [19124](https://github.com/magento/magento2/pull/19124)*. [GitHub-16074](https://github.com/magento/magento2/issues/16074)
 
-<!--- ENGCOM-4093-->* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by Pratik Oza in pull request [20907](https://github.com/magento/magento2/pull/20907)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+<!--- ENGCOM-4093 -->
+*  Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by Pratik Oza in pull request [20907](https://github.com/magento/magento2/pull/20907)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
-<!--- ENGCOM-3698-->* Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19781](https://github.com/magento/magento2/pull/19781)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+<!--- ENGCOM-3698 -->
+*  Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19781](https://github.com/magento/magento2/pull/19781)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
 
 ### CatalogInventory
 
-<!--- ENGCOM-3138-->* Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by Vishal Gelani in pull request [18481](https://github.com/magento/magento2/pull/18481)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
+<!--- ENGCOM-3138 -->
+*  Magento now validates the quantity of items in the shopping cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by Vishal Gelani in pull request [18481](https://github.com/magento/magento2/pull/18481)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
 
-<!--- ENGCOM-3845-->* Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** was set to **no**. *Fix submitted by Shikha Mishra in pull request [20252](https://github.com/magento/magento2/pull/20252)*. [GitHub-20121](https://github.com/magento/magento2/issues/20121)
+<!--- ENGCOM-3845 -->
+*  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** was set to **no**. *Fix submitted by Shikha Mishra in pull request [20252](https://github.com/magento/magento2/pull/20252)*. [GitHub-20121](https://github.com/magento/magento2/issues/20121)
 
-<!--- ENGCOM-3915-->* Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by Milind Singh in pull request [20410](https://github.com/magento/magento2/pull/20410)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+<!--- ENGCOM-3915 -->
+*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by Milind Singh in pull request [20410](https://github.com/magento/magento2/pull/20410)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
-<!--- ENGCOM-3462-->* Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value. *Fix submitted by Khodu in pull request [19206](https://github.com/magento/magento2/pull/19206)*. [GitHub-9130](https://github.com/magento/magento2/issues/9130)
+<!--- ENGCOM-3462 -->
+*  Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value. *Fix submitted by Khodu in pull request [19206](https://github.com/magento/magento2/pull/19206)*. [GitHub-9130](https://github.com/magento/magento2/issues/9130)
 
-<!--- ENGCOM-3771-->* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Oleksii Gorbulin in pull request [19997](https://github.com/magento/magento2/pull/19997)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+<!--- ENGCOM-3771 -->
+*  Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Oleksii Gorbulin in pull request [19997](https://github.com/magento/magento2/pull/19997)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
 
-<!--- MAGETWO-96377-->* In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
+<!--- MAGETWO-96377 -->
+*  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
 
 ### Catalog Rule
 
-<!--- ENGCOM-3131-->* Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English. *Fix submitted by Martin in pull request [18419](https://github.com/magento/magento2/pull/18419)*. [GitHub-12399](https://github.com/magento/magento2/issues/12399)
+<!--- ENGCOM-3131 -->
+*  Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English. *Fix submitted by Martin in pull request [18419](https://github.com/magento/magento2/pull/18419)*. [GitHub-12399](https://github.com/magento/magento2/issues/12399)
 
-<!--- ENGCOM-3143-->* If you create a catalog price rule based on categories with nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser. Previously, when you reopened these categories, no checkboxes were checked.
+<!--- ENGCOM-3143 -->
+*  If you create a catalog price rule based on categories with nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser. Previously, when you reopened these categories, no checkboxes were checked.
 
 ### Catalog URL rewrite
 
-<!--- ENGCOM-3438-->* Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by p-bystritsky in pull request [19170](https://github.com/magento/magento2/pull/19170)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532), [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!--- ENGCOM-3438 -->
+*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by p-bystritsky in pull request [19170](https://github.com/magento/magento2/pull/19170)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532), [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!--- MAGETWO-93425-->* Attempts to rewrite catalog URLs with a `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
+<!--- MAGETWO-93425 -->
+*  Attempts to rewrite catalog URLs with a `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
 
-<!--- MAGETWO-91649-->* Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
+<!--- MAGETWO-91649 -->
+*  Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
 
-<!--- MAGETWO-91532-->* Magento no longer removes product tier prices when a scheduled update contains an update to the special price.
+<!--- MAGETWO-91532 -->
+*  Magento no longer removes product tier prices when a scheduled update contains an update to the special price.
 
-<!--- MAGETWO-91495-->* You can now save and duplicate a linked product. Previously, Magento did not duplicate the product, and displayed this error, `Invalid data provided for linked products`.
+<!--- MAGETWO-91495 -->
+*  You can now save and duplicate a linked product. Previously, Magento did not duplicate the product, and displayed this error, `Invalid data provided for linked products`.
 
-<!--- ENGCOM-4050-->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [19798](https://github.com/magento/magento2/pull/19798)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
+<!--- ENGCOM-4050 -->
+*  The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [19798](https://github.com/magento/magento2/pull/19798)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 ### Cleanup and simple code refactoring
 
-<!--- ENGCOM-3861-->* Fixed alignment of the details label on the order page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20301](https://github.com/magento/magento2/pull/20301)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+<!--- ENGCOM-3861 -->
+*  Fixed alignment of the details label on the order page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20301](https://github.com/magento/magento2/pull/20301)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
-<!--- ENGCOM-3835-->* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Nainesh Waghale in pull request [20224](https://github.com/magento/magento2/pull/20224)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+<!--- ENGCOM-3835 -->
+*  Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Nainesh Waghale in pull request [20224](https://github.com/magento/magento2/pull/20224)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
-<!--- ENGCOM-3524-->* Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by Kajal Solanki in pull request [19334](https://github.com/magento/magento2/pull/19334)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+<!--- ENGCOM-3524 -->
+*  Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by Kajal Solanki in pull request [19334](https://github.com/magento/magento2/pull/19334)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
-<!--- ENGCOM-3763-->* Corrected the alignment of Contact us area that is accessed from the storefront page footers. *Fix submitted by suryakant-krish in pull request [19803](https://github.com/magento/magento2/pull/19803)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
+<!--- ENGCOM-3763 -->
+*  Corrected the alignment of Contact us area that is accessed from the storefront page footers. *Fix submitted by suryakant-krish in pull request [19803](https://github.com/magento/magento2/pull/19803)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
 
-<!--- ENGCOM-3643-->* Fixed inconsistent spacing on the manage coupon codes page on the Admin. *Fix submitted by Kajal Solanki in pull request [19659](https://github.com/magento/magento2/pull/19659)*. [GitHub-19657](https://github.com/magento/magento2/issues/19657)
+<!--- ENGCOM-3643 -->
+*  Fixed inconsistent spacing on the manage coupon codes page on the Admin. *Fix submitted by Kajal Solanki in pull request [19659](https://github.com/magento/magento2/pull/19659)*. [GitHub-19657](https://github.com/magento/magento2/issues/19657)
 
-<!--- ENGCOM-3573-->* Fixed misalignment of the tax rate checkbox on the Add New Tax Rate page. *Fix submitted by suryakant-krish in pull request [19413](https://github.com/magento/magento2/pull/19413)*. [GitHub-19379](https://github.com/magento/magento2/issues/19379)
+<!--- ENGCOM-3573 -->
+*  Fixed misalignment of the tax rate checkbox on the Add New Tax Rate page. *Fix submitted by suryakant-krish in pull request [19413](https://github.com/magento/magento2/pull/19413)*. [GitHub-19379](https://github.com/magento/magento2/issues/19379)
 
-<!--- ENGCOM-3571-->* Fixed misalignment of the attribute set name heading border on the Attribute sets pop-up window. *Fix submitted by suryakant-krish in pull request [19414](https://github.com/magento/magento2/pull/19414)*. [GitHub-19371](https://github.com/magento/magento2/issues/19371)
+<!--- ENGCOM-3571 -->
+*  Fixed misalignment of the attribute set name heading border on the Attribute sets pop-up window. *Fix submitted by suryakant-krish in pull request [19414](https://github.com/magento/magento2/pull/19414)*. [GitHub-19371](https://github.com/magento/magento2/issues/19371)
 
-<!--- ENGCOM-3960-->* Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!--- ENGCOM-3960 -->
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!--- ENGCOM-3626-->* Fixed misalignment  of the **Choose file** button on the `Select File to Import` page. *Fix submitted by suryakant in pull request [19580](https://github.com/magento/magento2/pull/19580)*. [GitHub-19579](https://github.com/magento/magento2/issues/19579)
+<!--- ENGCOM-3626 -->
+*  Fixed misalignment  of the **Choose file** button on the `Select File to Import` page. *Fix submitted by suryakant in pull request [19580](https://github.com/magento/magento2/pull/19580)*. [GitHub-19579](https://github.com/magento/magento2/issues/19579)
 
-<!--- ENGCOM-3320-->* Fixed formatting of the add link table that can be accessed from the Downloadable Information tab. *Fix submitted by Kajal Solanki in pull request [18856](https://github.com/magento/magento2/pull/18856)*. [GitHub-18854](https://github.com/magento/magento2/issues/18854)
+<!--- ENGCOM-3320 -->
+*  Fixed formatting of the add link table that can be accessed from the Downloadable Information tab. *Fix submitted by Kajal Solanki in pull request [18856](https://github.com/magento/magento2/pull/18856)*. [GitHub-18854](https://github.com/magento/magento2/issues/18854)
 
-<!--- ENGCOM-3951-->* Fixed misalignment of the title of the order page that is accessed when you check a recent order in the sidebar of listing  or account pages. *Fix submitted by Parag Chavare in pull request [20501](https://github.com/magento/magento2/pull/20501)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+<!--- ENGCOM-3951 -->
+*  Fixed misalignment of the title of the order page that is accessed when you check a recent order in the sidebar of listing  or account pages. *Fix submitted by Parag Chavare in pull request [20501](https://github.com/magento/magento2/pull/20501)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
-<!--- ENGCOM-4031-->* Fixed misalignment of  tab content on product pages in mobile view. *Fix submitted by Parag Chavare in pull request [20469](https://github.com/magento/magento2/pull/20469)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+<!--- ENGCOM-4031 -->
+*  Fixed misalignment of  tab content on product pages in mobile view. *Fix submitted by Parag Chavare in pull request [20469](https://github.com/magento/magento2/pull/20469)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
-<!--- ENGCOM-3727-->* Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`. *Fix submitted by Govind Sharma in pull request [19918](https://github.com/magento/magento2/pull/19918)*. [GitHub-19917](https://github.com/magento/magento2/issues/19917)
+<!--- ENGCOM-3727 -->
+*  Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`. *Fix submitted by Govind Sharma in pull request [19918](https://github.com/magento/magento2/pull/19918)*. [GitHub-19917](https://github.com/magento/magento2/issues/19917)
 
-<!--- ENGCOM-3659-->* Fixed the misalignment of the customizable options label on **Admin** > **Catalog** > **Product** > **Customizable Options**. *Fix submitted by Kajal Solanki in pull request [19493](https://github.com/magento/magento2/pull/19493)*. [GitHub-19492](https://github.com/magento/magento2/issues/19492)
+<!--- ENGCOM-3659 -->
+*  Fixed the misalignment of the customizable options label on **Admin** > **Catalog** > **Product** > **Customizable Options**. *Fix submitted by Kajal Solanki in pull request [19493](https://github.com/magento/magento2/pull/19493)*. [GitHub-19492](https://github.com/magento/magento2/issues/19492)
 
-<!--- ENGCOM-3706-->* Fixed problem with overlapping UI elements on the cart page when accessed from the mini cart. *Fix submitted by Vishal Gelani in pull request [19839](https://github.com/magento/magento2/pull/19839)*. [GitHub-19836](https://github.com/magento/magento2/issues/19836)
+<!--- ENGCOM-3706 -->
+*  Fixed problem with overlapping UI elements on the cart page when accessed from the mini cart. *Fix submitted by Vishal Gelani in pull request [19839](https://github.com/magento/magento2/pull/19839)*. [GitHub-19836](https://github.com/magento/magento2/issues/19836)
 
-<!--- ENGCOM-3721-->* Fixed alignment issue with the drop-down menu on the mini cart. *Fix submitted by Kajal Solanki in pull request [19508](https://github.com/magento/magento2/pull/19508)*. [GitHub-19507](https://github.com/magento/magento2/issues/19507)
+<!--- ENGCOM-3721 -->
+*  Fixed alignment issue with the drop-down menu on the mini cart. *Fix submitted by Kajal Solanki in pull request [19508](https://github.com/magento/magento2/pull/19508)*. [GitHub-19507](https://github.com/magento/magento2/issues/19507)
 
-<!--- ENGCOM-3769-->* Fixed alignment issue with radio buttons on the shopping cart page. *Fix submitted by Hitesh in pull request [20022](https://github.com/magento/magento2/pull/20022)*. [GitHub-20021](https://github.com/magento/magento2/issues/20021)
+<!--- ENGCOM-3769 -->
+*  Fixed alignment issue with radio buttons on the shopping cart page. *Fix submitted by Hitesh in pull request [20022](https://github.com/magento/magento2/pull/20022)*. [GitHub-20021](https://github.com/magento/magento2/issues/20021)
 
-<!--- ENGCOM-3948-->* Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by Parag Chavare in pull request [20519](https://github.com/magento/magento2/pull/20519)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+<!--- ENGCOM-3948 -->
+*  Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by Parag Chavare in pull request [20519](https://github.com/magento/magento2/pull/20519)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
-<!--- ENGCOM-3621-->* Fixed alignment of the bundle product information on the configure product page for a bundle product  when creating a new order. *Fix submitted by Abrar Pathan in pull request [19502](https://github.com/magento/magento2/pull/19502)*. [GitHub-19501](https://github.com/magento/magento2/issues/19501)
+<!--- ENGCOM-3621 -->
+*  Fixed alignment of the bundle product information on the configure product page for a bundle product  when creating a new order. *Fix submitted by Abrar Pathan in pull request [19502](https://github.com/magento/magento2/pull/19502)*. [GitHub-19501](https://github.com/magento/magento2/issues/19501)
 
-<!--- ENGCOM-3196 -->* The calender icon issue is now correctly aligned on the Advanced Pricing page of the Admin. *Fix submitted by Kajal Solanki in pull request [18638](https://github.com/magento/magento2/pull/18638)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
+<!--- ENGCOM-3196  -->
+*  The calender icon issue is now correctly aligned on the Advanced Pricing page of the Admin. *Fix submitted by Kajal Solanki in pull request [18638](https://github.com/magento/magento2/pull/18638)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
 
-<!--- ENGCOM-4029-->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Ajay Ajabale in pull request [20581](https://github.com/magento/magento2/pull/20581)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+<!--- ENGCOM-4029 -->
+*  Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Ajay Ajabale in pull request [20581](https://github.com/magento/magento2/pull/20581)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
-<!--- ENGCOM-3966-->* Fixed misalignment of the confirmation pop-up window that Magento displays in mobile view when you delete a product from your shopping cart. *Fix submitted by Priti in pull request [20196](https://github.com/magento/magento2/pull/20196)*. [GitHub-20176](https://github.com/magento/magento2/issues/20176)
+<!--- ENGCOM-3966 -->
+*  Fixed misalignment of the confirmation pop-up window that Magento displays in mobile view when you delete a product from your shopping cart. *Fix submitted by Priti in pull request [20196](https://github.com/magento/magento2/pull/20196)*. [GitHub-20176](https://github.com/magento/magento2/issues/20176)
 
-<!--- ENGCOM-3449-->* The `addExpressionFieldToSelect` method no longer modifies columns and instead inserts expressions into the `_fieldsToSelect` private variable (similar to how `addFieldToSelect` does). *Fix submitted by Torben Höhn in pull request [19180](https://github.com/magento/magento2/pull/19180)*. [GitHub-17635](https://github.com/magento/magento2/issues/17635)
+<!--- ENGCOM-3449 -->
+*  The `addExpressionFieldToSelect` method no longer modifies columns and instead inserts expressions into the `_fieldsToSelect` private variable (similar to how `addFieldToSelect` does). *Fix submitted by Torben Höhn in pull request [19180](https://github.com/magento/magento2/pull/19180)*. [GitHub-17635](https://github.com/magento/magento2/issues/17635)
 
-<!--- ENGCOM-3240-->* A typo in `app/code/Magento/Deploy/Console/DeployStaticOptions.php` has been corrected. *Fix submitted by Pratik Oza in pull request [18733](https://github.com/magento/magento2/pull/18733)*. [GitHub-2686](https://github.com/magento/magento2/issues/2686)
+<!--- ENGCOM-3240 -->
+*  A typo in `app/code/Magento/Deploy/Console/DeployStaticOptions.php` has been corrected. *Fix submitted by Pratik Oza in pull request [18733](https://github.com/magento/magento2/pull/18733)*. [GitHub-2686](https://github.com/magento/magento2/issues/2686)
 
-<!--- ENGCOM-3848-->* Fixed alignment of options on the Admin edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!--- ENGCOM-3848 -->
+*  Fixed alignment of options on the Admin edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
-<!--- ENGCOM-3901-->* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by Ajay Ajabale in pull request [20281](https://github.com/magento/magento2/pull/20281)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+<!--- ENGCOM-3901 -->
+*  Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by Ajay Ajabale in pull request [20281](https://github.com/magento/magento2/pull/20281)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
-<!--- ENGCOM-3899-->* Fixed issue where the horizontal scroll bar did not appear as expected on the compare products page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20368](https://github.com/magento/magento2/pull/20368)*. [GitHub-20367](https://github.com/magento/magento2/issues/20367)
+<!--- ENGCOM-3899 -->
+*  Fixed issue where the horizontal scroll bar did not appear as expected on the compare products page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20368](https://github.com/magento/magento2/pull/20368)*. [GitHub-20367](https://github.com/magento/magento2/issues/20367)
 
-<!--- ENGCOM-3936-->* Added missing bottom border to the list of customizable options on the product page when accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20498](https://github.com/magento/magento2/pull/20498)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+<!--- ENGCOM-3936 -->
+*  Added missing bottom border to the list of customizable options on the product page when accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20498](https://github.com/magento/magento2/pull/20498)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
-<!--- ENGCOM-3792-->* Corrected the position of the header for the design configuration table (**Content** > **Design** > **Configuration**). *Fix submitted by Shikha Mishra in pull request [20072](https://github.com/magento/magento2/pull/20072)*. [GitHub-20024](https://github.com/magento/magento2/issues/20024)
+<!--- ENGCOM-3792 -->
+*  Corrected the position of the header for the design configuration table (**Content** > **Design** > **Configuration**). *Fix submitted by Shikha Mishra in pull request [20072](https://github.com/magento/magento2/pull/20072)*. [GitHub-20024](https://github.com/magento/magento2/issues/20024)
 
-<!--- ENGCOM-3558-->* When you try to save a widget that contains an unexpected character, Magento now displays an informative error message  and does not save the widget. Previously, Magento saved the widget. *Fix submitted by Burlacu Vasilii in pull request [19390](https://github.com/magento/magento2/pull/19390)*. [GitHub-4136](https://github.com/magento/magento2/issues/4136)
+<!--- ENGCOM-3558 -->
+*  When you try to save a widget that contains an unexpected character, Magento now displays an informative error message  and does not save the widget. Previously, Magento saved the widget. *Fix submitted by Burlacu Vasilii in pull request [19390](https://github.com/magento/magento2/pull/19390)*. [GitHub-4136](https://github.com/magento/magento2/issues/4136)
 
-<!--- ENGCOM-3821-->* The catalog category merchandiser product list is no longer missing the move cursor in tile view. *Fix submitted by Abrar Pathan in pull request [19817](https://github.com/magento/magento2/pull/19817)*. [GitHub-19816](https://github.com/magento/magento2/issues/19816)
+<!--- ENGCOM-3821 -->
+*  The catalog category merchandiser product list is no longer missing the move cursor in tile view. *Fix submitted by Abrar Pathan in pull request [19817](https://github.com/magento/magento2/pull/19817)*. [GitHub-19816](https://github.com/magento/magento2/issues/19816)
 
-<!--- ENGCOM-3815-->* Corrected alignment of the **Detailed Rating** field on the Edit Review page.  *Fix submitted by Yashwant Rokde in pull request [20132](https://github.com/magento/magento2/pull/20132)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
+<!--- ENGCOM-3815 -->
+*  Corrected alignment of the **Detailed Rating** field on the Edit Review page.  *Fix submitted by Yashwant Rokde in pull request [20132](https://github.com/magento/magento2/pull/20132)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
 
-<!--- ENGCOM-3825-->* Corrected alignment of the store switcher in Tab view. *Fix submitted by Arvinda Kumar in pull request [20160](https://github.com/magento/magento2/pull/20160)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
+<!--- ENGCOM-3825 -->
+*  Corrected alignment of the store switcher in Tab view. *Fix submitted by Arvinda Kumar in pull request [20160](https://github.com/magento/magento2/pull/20160)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
 
-<!--- ENGCOM-3820-->* Corrected the number of products listed per row for  desktop (4), tablet (3),  and mobile (2) views. *Fix submitted by Amol Chaudhari in pull request [20168](https://github.com/magento/magento2/pull/20168)*. [GitHub-20140](https://github.com/magento/magento2/issues/20140)
+<!--- ENGCOM-3820 -->
+*  Corrected the number of products listed per row for  desktop (4), tablet (3),  and mobile (2) views. *Fix submitted by Amol Chaudhari in pull request [20168](https://github.com/magento/magento2/pull/20168)*. [GitHub-20140](https://github.com/magento/magento2/issues/20140)
 
-<!--- ENGCOM-3852-->* Hamburger menus no longer appear on pages that do not require menus. *Fix submitted by Amol Chaudhari in pull request [20214](https://github.com/magento/magento2/pull/20214)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+<!--- ENGCOM-3852 -->
+*  Hamburger menus no longer appear on pages that do not require menus. *Fix submitted by Amol Chaudhari in pull request [20214](https://github.com/magento/magento2/pull/20214)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
-<!--- ENGCOM-3842-->* Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by Nirav Patel in pull request [20241](https://github.com/magento/magento2/pull/20241)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+<!--- ENGCOM-3842 -->
+*  Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by Nirav Patel in pull request [20241](https://github.com/magento/magento2/pull/20241)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
-<!--- ENGCOM-3847-->* The Send email confirmation popup **Close** button no longer overlaps with content. *Fix submitted by Arvinda Kumar in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
+<!--- ENGCOM-3847 -->
+*  The Send email confirmation popup **Close** button no longer overlaps with content. *Fix submitted by Arvinda Kumar in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
 
-<!--- ENGCOM-3798-->* Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page. *Fix submitted by David Verholen in pull request [20094](https://github.com/magento/magento2/pull/20094)*. [GitHub-19052](https://github.com/magento/magento2/issues/19052)
+<!--- ENGCOM-3798 -->
+*  Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page. *Fix submitted by David Verholen in pull request [20094](https://github.com/magento/magento2/pull/20094)*. [GitHub-19052](https://github.com/magento/magento2/issues/19052)
 
-<!--- ENGCOM-3869-->* Store switcher now works correctly on mobile devices. *Fix submitted by Arvinda kKumar in pull request [20260](https://github.com/magento/magento2/pull/20260)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+<!--- ENGCOM-3869 -->
+*  Store switcher now works correctly on mobile devices. *Fix submitted by Arvinda kKumar in pull request [20260](https://github.com/magento/magento2/pull/20260)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
-<!--- ENGCOM-3894-->* The order view invoice template is now displayed properly in tablet view. *Fix submitted by ranee2jcommerce in pull request [20374](https://github.com/magento/magento2/pull/20374)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+<!--- ENGCOM-3894 -->
+*  The order view invoice template is now displayed properly in tablet view. *Fix submitted by ranee2jcommerce in pull request [20374](https://github.com/magento/magento2/pull/20374)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
-<!--- ENGCOM-3848-->* Fixed misalignment of the widget options on the edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!--- ENGCOM-3848 -->
+*  Fixed misalignment of the widget options on the edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
-<!--- ENGCOM-3708-->* Magento now identifies the shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by Nirav Kadiya in pull request [19788](https://github.com/magento/magento2/pull/19788)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+<!--- ENGCOM-3708 -->
+*  Magento now identifies the shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by Nirav Kadiya in pull request [19788](https://github.com/magento/magento2/pull/19788)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
-<!--- ENGCOM-3663-->* Fixed checkbox alignment on the account information page. *Fix submitted by suryakant-krish in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
+<!--- ENGCOM-3663 -->
+*  Fixed checkbox alignment on the account information page. *Fix submitted by suryakant-krish in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
 
-<!--- ENGCOM-3653-->* Fixed misalignment of search icons on the `onAttribute` page. *Fix submitted by Abrar Pathan in pull request [19643](https://github.com/magento/magento2/pull/19643)*. [GitHub-19642](https://github.com/magento/magento2/issues/19642)
+<!--- ENGCOM-3653 -->
+*  Fixed misalignment of search icons on the `onAttribute` page. *Fix submitted by Abrar Pathan in pull request [19643](https://github.com/magento/magento2/pull/19643)*. [GitHub-19642](https://github.com/magento/magento2/issues/19642)
 
-<!--- ENGCOM-3595-->* Fixed an alignment issue with the select and text boxes on the Advance Pricing page. *Fix submitted by Kajal Solanki in pull request [19473](https://github.com/magento/magento2/pull/19473)*. [GitHub-19472](https://github.com/magento/magento2/issues/19472)
+<!--- ENGCOM-3595 -->
+*  Fixed an alignment issue with the select and text boxes on the Advance Pricing page. *Fix submitted by Kajal Solanki in pull request [19473](https://github.com/magento/magento2/pull/19473)*. [GitHub-19472](https://github.com/magento/magento2/issues/19472)
 
-<!--- ENGCOM-3627-->* Corrected alignment issue with elements on the default email templates. *Fix submitted by suryakant-krish in pull request [19574](https://github.com/magento/magento2/pull/19574)*. [GitHub-19573](https://github.com/magento/magento2/issues/19573)
+<!--- ENGCOM-3627 -->
+*  Corrected alignment issue with elements on the default email templates. *Fix submitted by suryakant-krish in pull request [19574](https://github.com/magento/magento2/pull/19574)*. [GitHub-19573](https://github.com/magento/magento2/issues/19573)
 
-<!--- ENGCOM-3678-->* Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by Milind Singh in pull request [19726](https://github.com/magento/magento2/pull/19726)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
+<!--- ENGCOM-3678 -->
+*  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by Milind Singh in pull request [19726](https://github.com/magento/magento2/pull/19726)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
-<!--- ENGCOM-4113-->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by Govind Sharma in pull request [20914](https://github.com/magento/magento2/pull/20914)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
+<!--- ENGCOM-4113 -->
+*  Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by Govind Sharma in pull request [20914](https://github.com/magento/magento2/pull/20914)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
-<!--- ENGCOM-4107-->* Fixed alignment of the error message that Magento displays on the add or edit bundle product customizable options tab. *Fix submitted by Kunj Joshi in pull request [20930](https://github.com/magento/magento2/pull/20930)*. [GitHub-20908](https://github.com/magento/magento2/issues/20908)
+<!--- ENGCOM-4107 -->
+*  Fixed alignment of the error message that Magento displays on the add or edit bundle product customizable options tab. *Fix submitted by Kunj Joshi in pull request [20930](https://github.com/magento/magento2/pull/20930)*. [GitHub-20908](https://github.com/magento/magento2/issues/20908)
 
-<!--- ENGCOM-4134-->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by Amol Chaudhari in pull request [20817](https://github.com/magento/magento2/pull/20817)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+<!--- ENGCOM-4134 -->
+*  Fixed misalignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by Amol Chaudhari in pull request [20817](https://github.com/magento/magento2/pull/20817)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
-<!--- ENGCOM-4057-->* The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by Abrar Pathan in pull request [20791](https://github.com/magento/magento2/pull/20791)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+<!--- ENGCOM-4057 -->
+*  The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by Abrar Pathan in pull request [20791](https://github.com/magento/magento2/pull/20791)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
-<!--- ENGCOM-4074-->* Fixed issues with the shadows that are associated with input box and radio buttons on storefront forms. *Fix submitted by Abrar Pathan in pull request [20861](https://github.com/magento/magento2/pull/20861)*. [GitHub-20859](https://github.com/magento/magento2/issues/20859)
+<!--- ENGCOM-4074 -->
+*  Fixed issues with the shadows that are associated with input box and radio buttons on storefront forms. *Fix submitted by Abrar Pathan in pull request [20861](https://github.com/magento/magento2/pull/20861)*. [GitHub-20859](https://github.com/magento/magento2/issues/20859)
 
-<!--- ENGCOM-3854-->* Fixed  misalignment of the product option fields in the order summary of the checkout page. *Fix submitted by Pratik Oza in pull request [20138](https://github.com/magento/magento2/pull/20138)*. [GitHub-20134](https://github.com/magento/magento2/issues/20134)
+<!--- ENGCOM-3854 -->
+*  Fixed  misalignment of the product option fields in the order summary of the checkout page. *Fix submitted by Pratik Oza in pull request [20138](https://github.com/magento/magento2/pull/20138)*. [GitHub-20134](https://github.com/magento/magento2/issues/20134)
 
-<!--- ENGCOM-4053-->* Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by Priti in pull request [20558](https://github.com/magento/magento2/pull/20558)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+<!--- ENGCOM-4053 -->
+*  Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by Priti in pull request [20558](https://github.com/magento/magento2/pull/20558)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
-<!--- ENGCOM-4036-->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by ranee2jcommerce in pull request [20756](https://github.com/magento/magento2/pull/20756)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+<!--- ENGCOM-4036 -->
+*  Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by ranee2jcommerce in pull request [20756](https://github.com/magento/magento2/pull/20756)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
 
-<!--- ENGCOM-3991-->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by Govind Sharma in pull request [20159](https://github.com/magento/magento2/pull/20159)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+<!--- ENGCOM-3991 -->
+*  Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by Govind Sharma in pull request [20159](https://github.com/magento/magento2/pull/20159)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
-<!--- ENGCOM-4066-->* Fixed misalignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [20383](https://github.com/magento/magento2/pull/20383)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+<!--- ENGCOM-4066 -->
+*  Fixed misalignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [20383](https://github.com/magento/magento2/pull/20383)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
 
-<!--- ENGCOM-4016-->* Fixed misalignment of values in the currency rate column in the Order & Account Information area of the New Memo page. *Fix submitted by Dipti in pull request [20610](https://github.com/magento/magento2/pull/20610)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+<!--- ENGCOM-4016 -->
+*  Fixed misalignment of values in the currency rate column in the Order & Account Information area of the New Memo page. *Fix submitted by Dipti in pull request [20610](https://github.com/magento/magento2/pull/20610)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
-<!--- ENGCOM-3952-->* Added missing PHPDoc comments for methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [19826](https://github.com/magento/magento2/pull/19826)*.
+<!--- ENGCOM-3952 -->
+*  Added missing PHPDoc comments for methods throughout the code base. *Fix submitted by Leandro F. L. in pull request [19826](https://github.com/magento/magento2/pull/19826)*.
 
-<!--- ENGCOM-4168-->* Fixed misalignment of the My Account page's **Recently Ordered** check box in tab portrait view. *Fix submitted by Ajay Ajabale in pull request [20155](https://github.com/magento/magento2/pull/20155)*. [GitHub-20143](https://github.com/magento/magento2/issues/20143)
+<!--- ENGCOM-4168 -->
+*  Fixed misalignment of the My Account page's **Recently Ordered** check box in tab portrait view. *Fix submitted by Ajay Ajabale in pull request [20155](https://github.com/magento/magento2/pull/20155)*. [GitHub-20143](https://github.com/magento/magento2/issues/20143)
 
-<!--- ENGCOM-4001-->* Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20403](https://github.com/magento/magento2/pull/20403)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+<!--- ENGCOM-4001 -->
+*  Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20403](https://github.com/magento/magento2/pull/20403)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
-<!--- ENGCOM-4052-->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by Dipti in pull request [20493](https://github.com/magento/magento2/pull/20493)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+<!--- ENGCOM-4052 -->
+*  The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by Dipti in pull request [20493](https://github.com/magento/magento2/pull/20493)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
-<!--- ENGCOM-3764-->* Fixed misalignment of logo on Admin home page. *Fix submitted by suryakant-krish in pull request [19792](https://github.com/magento/magento2/pull/19792)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
+<!--- ENGCOM-3764 -->
+*  Fixed misalignment of logo on Admin home page. *Fix submitted by suryakant-krish in pull request [19792](https://github.com/magento/magento2/pull/19792)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
-<!--- ENGCOM-4130-->* Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Priti in pull request [20801](https://github.com/magento/magento2/pull/20801)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+<!--- ENGCOM-4130 -->
+*  Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Priti in pull request [20801](https://github.com/magento/magento2/pull/20801)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
 
-<!--- ENGCOM-4150-->* Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by dharmendra-wagento in pull request [20990](https://github.com/magento/magento2/pull/20990)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+<!--- ENGCOM-4150 -->
+*  Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by dharmendra-wagento in pull request [20990](https://github.com/magento/magento2/pull/20990)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
-<!--- ENGCOM-3891-->* Fixed irregularities with updating order status. *Fix submitted by Shikha Mishra in pull request [20349](https://github.com/magento/magento2/pull/20349)*. [GitHub-19258](https://github.com/magento/magento2/issues/19258)
+<!--- ENGCOM-3891 -->
+*  Fixed irregularities with updating order status. *Fix submitted by Shikha Mishra in pull request [20349](https://github.com/magento/magento2/pull/20349)*. [GitHub-19258](https://github.com/magento/magento2/issues/19258)
 
-<!--- ENGCOM-3822-->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Ravi Chandra in pull request [19812](https://github.com/magento/magento2/pull/19812)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+<!--- ENGCOM-3822 -->
+*  The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Ravi Chandra in pull request [19812](https://github.com/magento/magento2/pull/19812)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
 ### CMS content
 
-<!--- MAGETWO-94429-->* You can now delete from the media gallery browser any files and folders that are symlinked in `pub/media`. Previously, Magento left the image in the media gallery but displayed  no feedback in the product interface.
+<!--- MAGETWO-94429 -->
+*  You can now delete from the media gallery browser any files and folders that are symlinked in `pub/media`. Previously, Magento left the image in the media gallery but displayed  no feedback in the product interface.
 
-<!--- ENGCOM-4051-->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [20787](https://github.com/magento/magento2/pull/20787)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+<!--- ENGCOM-4051 -->
+*  Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [20787](https://github.com/magento/magento2/pull/20787)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
 
 ### Configurable products
 
-<!--- ENGCOM-3256-->* The `DateTime` class can now parse strings for all supported languages, not just English. Previously, converting from string to PHP `DateTime` object failed for locales other than `en_US`. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!--- ENGCOM-3256 -->
+*  The `DateTime` class can now parse strings for all supported languages, not just English. Previously, converting from string to PHP `DateTime` object failed for locales other than `en_US`. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
-<!--- MAGETWO-96594-->* Selected images on the product page of a configurable product are now positioned correctly. [GitHub-18410](https://github.com/magento/magento2/issues/18410)
+<!--- MAGETWO-96594 -->
+*  Selected images on the product page of a configurable product are now positioned correctly. [GitHub-18410](https://github.com/magento/magento2/issues/18410)
 
-<!--- ENGCOM-3136-->* You can now successfully save products  with SKU lengths that are less than or equal to 64 digits. Previously, Magento threw a fatal error when you tried to re-save a child product after reducing the length of its 64-digit-long SKU. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!--- ENGCOM-3136 -->
+*  You can now successfully save products  with SKU lengths that are less than or equal to 64 digits. Previously, Magento threw a fatal error when you tried to re-save a child product after reducing the length of its 64-digit-long SKU. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
-<!--- ENGCOM-3674-->* The Cart Sales Rule  now excludes already discounted products from further discounting through a coupon code. *Fix submitted by Malyovanets Nickolas in pull request [19343](https://github.com/magento/magento2/pull/19343)*. [GitHub-14020](https://github.com/magento/magento2/issues/14020)
+<!--- ENGCOM-3674 -->
+*  The Cart Sales Rule  now excludes already discounted products from further discounting through a coupon code. *Fix submitted by Malyovanets Nickolas in pull request [19343](https://github.com/magento/magento2/pull/19343)*. [GitHub-14020](https://github.com/magento/magento2/issues/14020)
 
-<!--- ENGCOM-3546-->* Translations for `tier_price.phtml` now work as expected. Previously, these translations were not included in `js-translation.json` and were not visible on the storefront. *Fix submitted by Oleksii Gorbulin in pull request [19094](https://github.com/magento/magento2/pull/19094)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
+<!--- ENGCOM-3546 -->
+*  Translations for `tier_price.phtml` now work as expected. Previously, these translations were not included in `js-translation.json` and were not visible on the storefront. *Fix submitted by Oleksii Gorbulin in pull request [19094](https://github.com/magento/magento2/pull/19094)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
 
-<!--- MAGETWO-96364-->* **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+<!--- MAGETWO-96364 -->
+*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
 ### cron
 
-<!--- ENGCOM-3062 -->* A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file.  *Fix submitted by Pieter Hoste in pull request [18209](https://github.com/magento/magento2/pull/18209)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
+<!--- ENGCOM-3062  -->
+*  A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file.  *Fix submitted by Pieter Hoste in pull request [18209](https://github.com/magento/magento2/pull/18209)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
 
 ### Customers
 
-<!--- ENGCOM-3390-->* We've added an additional check for the password hash for  customers that have been created from the Admin without a password. Previously, customers created this way could not log in. *Fix submitted by Yevhenii Dumskyi in pull request [19066](https://github.com/magento/magento2/pull/19066)*. [GitHub-19060](https://github.com/magento/magento2/issues/19060)
+<!--- ENGCOM-3390 -->
+*  We've added an additional check for the password hash for  customers that have been created from the Admin without a password. Previously, customers created this way could not log in. *Fix submitted by Yevhenii Dumskyi in pull request [19066](https://github.com/magento/magento2/pull/19066)*. [GitHub-19060](https://github.com/magento/magento2/issues/19060)
 
-<!--- ENGCOM-3351-->* Magento now displays the same order total in  the customer information orders grid and orders grid when an order is placed in a currency other than the base currency. Previously, Magento displayed the wrong order total in the Admin's customer information orders tab. *Fix submitted by Anuj Gupta in pull request [18650](https://github.com/magento/magento2/pull/18650)*. [GitHub-18618](https://github.com/magento/magento2/issues/18618)
+<!--- ENGCOM-3351 -->
+*  Magento now displays the same order total in  the customer information orders grid and orders grid when an order is placed in a currency other than the base currency. Previously, Magento displayed the wrong order total in the Admin's customer information orders tab. *Fix submitted by Anuj Gupta in pull request [18650](https://github.com/magento/magento2/pull/18650)*. [GitHub-18618](https://github.com/magento/magento2/issues/18618)
 
-<!--- ENGCOM-3372-->* Magento no longer displays the forgot password form while a customer is logged in but instead directs the customer to the customer dashboard. *Fix submitted by Oleksii Gorbulin in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
+<!--- ENGCOM-3372 -->
+*  Magento no longer displays the forgot password form while a customer is logged in but instead directs the customer to the customer dashboard. *Fix submitted by Oleksii Gorbulin in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
 
-<!--- ENGCOM-3387-->* The reset password link in the password reset mail sent to customers when they click **Reset password** on the login page now permits customers to reset their password as expected.  *Fix submitted by p-bystritsky in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
+<!--- ENGCOM-3387 -->
+*  The reset password link in the password reset mail sent to customers when they click **Reset password** on the login page now permits customers to reset their password as expected.  *Fix submitted by p-bystritsky in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
 
-<!--- ENGCOM-3014-->* Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by Dmytro Cheshun in pull request [18117](https://github.com/magento/magento2/pull/18117)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
+<!--- ENGCOM-3014 -->
+*  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by Dmytro Cheshun in pull request [18117](https://github.com/magento/magento2/pull/18117)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
 
-<!--- ENGCOM-3068-->* Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by Dmytro Cheshun in pull request [18308](https://github.com/magento/magento2/pull/18308)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
+<!--- ENGCOM-3068 -->
+*  Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by Dmytro Cheshun in pull request [18308](https://github.com/magento/magento2/pull/18308)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
 
-<!--- MAGETWO-95692-->* Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
+<!--- MAGETWO-95692 -->
+*  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
-<!--- MAGETWO-91704-->* You can now change payment methods after selecting store credit when creating an order from the Admin.
+<!--- MAGETWO-91704 -->
+*  You can now change payment methods after selecting store credit when creating an order from the Admin.
 
-<!--- MAGETWO-91644-->* Customers can now be matched in customer segments based on the number of orders in a multi-site deployment.
+<!--- MAGETWO-91644 -->
+*  Customers can now be matched in customer segments based on the number of orders in a multi-site deployment.
 
-<!--- MAGETWO-95925-->* We've improved the performance of the customer segment rule, which has improved site performance.
+<!--- MAGETWO-95925 -->
+*  We've improved the performance of the customer segment rule, which has improved site performance.
 
-<!--- MAGETWO-96007-->* Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
+<!--- MAGETWO-96007 -->
+*  Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
 
-<!--- MAGETWO-94347-->* Magento now displays the list of additional customer addresses that are contained in the storefront customer address book  as a grid, which has improved performance for customers with many additional addresses associated with their accounts.
+<!--- MAGETWO-94347 -->
+*  Magento now displays the list of additional customer addresses that are contained in the storefront customer address book  as a grid, which has improved performance for customers with many additional addresses associated with their accounts.
 
-<!--- MAGETWO-91720-->* When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
+<!--- MAGETWO-91720-->
+* When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
-<!--- MAGETWO-97397-->* Magento now assigns new accounts in multisite deployments  to the customer group that is associated with the default website scope. Previously, a new customer created from the Admin  had their customer group set to the default customer group on the default website scope.
+<!--- MAGETWO-97397-->
+* Magento now assigns new accounts in multisite deployments  to the customer group that is associated with the default website scope. Previously, a new customer created from the Admin  had their customer group set to the default customer group on the default website scope.
 
-<!--- ENGCOM-3056-->* Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password. *Fix submitted by Dmytro Cheshun in pull request [18179](https://github.com/magento/magento2/pull/18179)*. [GitHub-18170](https://github.com/magento/magento2/issues/18170)
+<!--- ENGCOM-3056 -->
+*  Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password. *Fix submitted by Dmytro Cheshun in pull request [18179](https://github.com/magento/magento2/pull/18179)*. [GitHub-18170](https://github.com/magento/magento2/issues/18170)
 
-<!--- ENGCOM-4028-->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20725](https://github.com/magento/magento2/pull/20725)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+<!--- ENGCOM-4028 -->
+*  Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20725](https://github.com/magento/magento2/pull/20725)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
-<!--- ENGCOM-3981-->* Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20630](https://github.com/magento/magento2/pull/20630)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+<!--- ENGCOM-3981 -->
+*  Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20630](https://github.com/magento/magento2/pull/20630)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
-<!--- MAGETWO-97411-->* The `Magento\Customer\Model\Customer::getDataModel` method has been optimized, which has reduced the time required to load customer accounts with many addresses.
+<!--- MAGETWO-97411 -->
+*  The `Magento\Customer\Model\Customer::getDataModel` method has been optimized, which has reduced the time required to load customer accounts with many addresses.
 
-<!--- MAGETWO-98183-->* **State/Province** field values are no longer required when creating an order from the Admin. Previously, Magento indicated that **State/Province** field values were required even though configuration settings indicated that these values were not required.
+<!--- MAGETWO-98183 -->
+*  **State/Province** field values are no longer required when creating an order from the Admin. Previously, Magento indicated that **State/Province** field values were required even though configuration settings indicated that these values were not required.
 
-<!--- ENGCOM-4063-->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20565](https://github.com/magento/magento2/pull/20565)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
+<!--- ENGCOM-4063 -->
+*  Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20565](https://github.com/magento/magento2/pull/20565)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
-<!--- ENGCOM-3368-->* Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded. *Fix submitted by Rahul Mahto in pull request [18900](https://github.com/magento/magento2/pull/18900)*. [GitHub-18839](https://github.com/magento/magento2/issues/18839)
+<!--- ENGCOM-3368 -->
+*  Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded. *Fix submitted by Rahul Mahto in pull request [18900](https://github.com/magento/magento2/pull/18900)*. [GitHub-18839](https://github.com/magento/magento2/issues/18839)
 
 ### Customer attributes
 
-<!--- MAGETWO-96845-->* Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
+<!--- MAGETWO-96845 -->
+*  Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
 
-<!--- MAGETWO-70968-->* Custom customer address attributes can now be updated when you edit an order's billing address in the Admin.
+<!--- MAGETWO-70968 -->
+*  Custom customer address attributes can now be updated when you edit an order's billing address in the Admin.
 
-<!--- MAGETWO-91659-->* You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
+<!--- MAGETWO-91659 -->
+*  You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
 
-<!--- ENGCOM-3181-->* Magento now saves  custom customer attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by Vishal Gelani in pull request [18571](https://github.com/magento/magento2/pull/18571)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
+<!--- ENGCOM-3181 -->
+*  Magento now saves  custom customer attributes as expected when  EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by Vishal Gelani in pull request [18571](https://github.com/magento/magento2/pull/18571)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
 
 ### Dashboard
 
-<!--- MAGETWO-95299-->* You can now upload PDP images larger than 1920 x 1200  without compressing and downsizing the images first. Previously, when a merchant uploaded a high quality product image (larger than 1920 X 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height.
+<!--- MAGETWO-95299 -->
+*  You can now upload PDP images larger than 1920 x 1200  without compressing and downsizing the images first. Previously, when a merchant uploaded a high quality product image (larger than 1920 X 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height.
 
-<!--- MAGETWO-96975-->*  `_sleep` and `__wakeup` have been removed, and a new `PHP.MD` rule has been added to discourage PHP serialization.
+<!--- MAGETWO-96975 -->
+*   `_sleep` and `__wakeup` have been removed, and a new `PHP.MD` rule has been added to discourage PHP serialization.
 
-<!--- ENGCOM-3857-->* Magento now validates new addresses when created from the address book telephone field on the My Account dashboard page. *Fix submitted by Dipti in pull request [20262](https://github.com/magento/magento2/pull/20262)*. [GitHub-20261](https://github.com/magento/magento2/issues/20261)
+<!--- ENGCOM-3857 -->
+*  Magento now validates new addresses when created from the address book telephone field on the My Account dashboard page. *Fix submitted by Dipti in pull request [20262](https://github.com/magento/magento2/pull/20262)*. [GitHub-20261](https://github.com/magento/magento2/issues/20261)
 
 ### Developer
 
-<!--- ENGCOM-3364-->* Email messages sent from the command line (where the email loads into another block) can now be sent successfully. *Fix submitted by p-bystritsky in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!--- ENGCOM-3364 -->
+*  Email messages sent from the command line (where the email loads into another block) can now be sent successfully. *Fix submitted by p-bystritsky in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Directory
 
-<!--- ENGCOM-4114-->* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Hiren Patel in pull request [20913](https://github.com/magento/magento2/pull/20913)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
+<!--- ENGCOM-4114 -->
+*  The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Hiren Patel in pull request [20913](https://github.com/magento/magento2/pull/20913)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
-<!--- ENGCOM-4165-->* `crontab` now updates all currency rates daily  as expected. Previously, crontab updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18981](https://github.com/magento/magento2/pull/18981)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
+<!--- ENGCOM-4165 -->
+*  `crontab` now updates all currency rates daily  as expected. Previously, crontab updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18981](https://github.com/magento/magento2/pull/18981)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
 
 ### Downloadable
 
-<!--- ENGCOM-3384-->* The order confirmation email sent when a guest checks out now includes download links as expected. *Fix submitted by Oleksandr Kravchuk in pull request [19040](https://github.com/magento/magento2/pull/19040)*. [GitHub-18323](https://github.com/magento/magento2/issues/18323), [GitHub-19003](https://github.com/magento/magento2/issues/19003), [GitHub-19034](https://github.com/magento/magento2/issues/19034)
+<!--- ENGCOM-3384 -->
+*  The order confirmation email sent when a guest checks out now includes download links as expected. *Fix submitted by Oleksandr Kravchuk in pull request [19040](https://github.com/magento/magento2/pull/19040)*. [GitHub-18323](https://github.com/magento/magento2/issues/18323), [GitHub-19003](https://github.com/magento/magento2/issues/19003), [GitHub-19034](https://github.com/magento/magento2/issues/19034)
 
-<!--- MAGETWO-91711-->* You can now delete downloadable product links without first deleting sample links.
+<!--- MAGETWO-91711 -->
+*  You can now delete downloadable product links without first deleting sample links.
 
 ### EAV
 
-<!--- ENGCOM-3236-->* You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by Patrick McLain in pull request [18720](https://github.com/magento/magento2/pull/18720)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
+<!--- ENGCOM-3236 -->
+*  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by Patrick McLain in pull request [18720](https://github.com/magento/magento2/pull/18720)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
 
-<!--- MAGETWO-94848-->* You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+<!--- MAGETWO-94848 -->
+*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
-<!--- ENGCOM-3814-->* The customer EAV decimal attribute now accepts a value of 0. *Fix submitted by Shikha Mishra in pull request [20130](https://github.com/magento/magento2/pull/20130)*. [GitHub-20030](https://github.com/magento/magento2/issues/20030)
+<!--- ENGCOM-3814 -->
+*  The customer EAV decimal attribute now accepts a value of 0. *Fix submitted by Shikha Mishra in pull request [20130](https://github.com/magento/magento2/pull/20130)*. [GitHub-20030](https://github.com/magento/magento2/issues/20030)
 
-<!--- ENGCOM-3797-->* The Magento storefront now correctly displays products with a custom attribute of type  `Media Image`. *Fix submitted by David Verholen in pull request [20096](https://github.com/magento/magento2/pull/20096)*. [GitHub-19054](https://github.com/magento/magento2/issues/19054)
+<!--- ENGCOM-3797 -->
+*  The Magento storefront now correctly displays products with a custom attribute of type  `Media Image`. *Fix submitted by David Verholen in pull request [20096](https://github.com/magento/magento2/pull/20096)*. [GitHub-19054](https://github.com/magento/magento2/issues/19054)
 
-<!--- ENGCOM-3045-->* Magento no longer changes the `source_model` when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by Pieter Hoste in pull request [18244](https://github.com/magento/magento2/pull/18244)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
+<!--- ENGCOM-3045 -->
+*  Magento no longer changes the `source_model` when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by Pieter Hoste in pull request [18244](https://github.com/magento/magento2/pull/18244)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
 
-<!--- ENGCOM-3124-->* Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by Roman Strelenko in pull request [18437](https://github.com/magento/magento2/pull/18437)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
+<!--- ENGCOM-3124 -->
+*  Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by Roman Strelenko in pull request [18437](https://github.com/magento/magento2/pull/18437)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
 
 ### Email
 
-<!--- MAGETWO-95137-->* The return path e-mail variable `system/smtp/return_path_email` now works as expected.
+<!--- MAGETWO-95137 -->
+*  The return path e-mail variable `system/smtp/return_path_email` now works as expected.
 
-<!--- ENGCOM-3744-->* Email subject headers now support UTF-8 encoding. *Fix submitted by Alexey Varlamov in pull request [19978](https://github.com/magento/magento2/pull/19978)*. [GitHub-19977](https://github.com/magento/magento2/issues/19977)
+<!--- ENGCOM-3744 -->
+*  Email subject headers now support UTF-8 encoding. *Fix submitted by Alexey Varlamov in pull request [19978](https://github.com/magento/magento2/pull/19978)*. [GitHub-19977](https://github.com/magento/magento2/issues/19977)
 
 ### Frameworks
 
-<!--- MAGETWO-97040-->* Magento no longer logs an error when you include properly escaped special characters in store view names. Previously, Magento logged errors in the `exception.log`.
+<!--- MAGETWO-97040 -->
+*  Magento no longer logs an error when you include properly escaped special characters in store view names. Previously, Magento logged errors in the `exception.log`.
 
-<!--- MAGETWO-96342-->* Magento now attempts to reconnect when a MySQL timeout occurs. Previously, Magento displayed an informative PHP-related message and did not attempt to reconnect.
+<!--- MAGETWO-96342 -->
+*  Magento now attempts to reconnect when a MySQL timeout occurs. Previously, Magento displayed an informative PHP-related message and did not attempt to reconnect.
 
-<!--- MAGETWO-94089-->* You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
+<!--- MAGETWO-94089 -->
+*  You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
 
-<!--- MAGETWO-95838-->* Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
+<!--- MAGETWO-95838 -->
+*  Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
 
-<!--- ENGCOM-3538-->* `dev/tools/grunt/configs/themes.js` has been removed from the `.gitignore` file and added to the GitHub repository. Previously, `localthemes.js` was included in  `.gitignore` and replaced during a Magento update. *Fix submitted by [Torben Höhn](https://github.com/torhoehn) in pull request [19350](https://github.com/magento/magento2/pull/19350)*. [GitHub-18949](https://github.com/magento/magento2/issues/18949)
+<!--- ENGCOM-3538 -->
+*  `dev/tools/grunt/configs/themes.js` has been removed from the `.gitignore` file and added to the GitHub repository. Previously, `localthemes.js` was included in  `.gitignore` and replaced during a Magento update. *Fix submitted by [Torben Höhn](https://github.com/torhoehn) in pull request [19350](https://github.com/magento/magento2/pull/19350)*. [GitHub-18949](https://github.com/magento/magento2/issues/18949)
 
-<!--- ENGCOM-3295-->* Magento now autoloads vendor root folders and can now run with custom Composer vendor directories. Previously, Magento's autoloader registration failed to generate the correct path when using the `COMPOSER_VENDOR_DIR` setting to specify a vendor path outside of the Magento installation root. *Fix submitted by [Rus0](https://github.com/Rus0) in pull request [18849](https://github.com/magento/magento2/pull/18849)*. [GitHub-17753](https://github.com/magento/magento2/issues/17753)
+<!--- ENGCOM-3295 -->
+*  Magento now autoloads vendor root folders and can now run with custom Composer vendor directories. Previously, Magento's autoloader registration failed to generate the correct path when using the `COMPOSER_VENDOR_DIR` setting to specify a vendor path outside of the Magento installation root. *Fix submitted by [Rus0](https://github.com/Rus0) in pull request [18849](https://github.com/magento/magento2/pull/18849)*. [GitHub-17753](https://github.com/magento/magento2/issues/17753)
 
-<!--- ENGCOM-3471-->* Newly added links on the customer dashboard are now shown as current when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19134](https://github.com/magento/magento2/pull/19134)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
+<!--- ENGCOM-3471 -->
+*  Newly added links on the customer dashboard are now shown as current when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [19134](https://github.com/magento/magento2/pull/19134)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
 
-<!--- ENGCOM-3483-->* The `fileUploader` form element in the  `ui_component` form now works as expected. Previously, during file upload, the countable interface was not implemented, and Magento threw this error, `Error Message : Warning: count(): Parameter must be an array or an object that implements Countable`.  *Fix submitted by [gmachure](https://github.com/gmachure) in pull request [19249](https://github.com/magento/magento2/pull/19249)*. [GitHub-19247](https://github.com/magento/magento2/issues/19247)
+<!--- ENGCOM-3483 -->
+*  The `fileUploader` form element in the  `ui_component` form now works as expected. Previously, during file upload, the countable interface was not implemented, and Magento threw this error, `Error Message : Warning: count(): Parameter must be an array or an object that implements Countable`.  *Fix submitted by [gmachure](https://github.com/gmachure) in pull request [19249](https://github.com/magento/magento2/pull/19249)*. [GitHub-19247](https://github.com/magento/magento2/issues/19247)
 
-<!--- ENGCOM-3243-->* Interception cache compilation has been improved, and custom profiler records are now executed in less than a second. Previously, profiled methods consumed about 70% of the first page load after `cache:flush` from either the command-line interface or the Admin. *Fix submitted by Patrick McLain in pull request [18648](https://github.com/magento/magento2/pull/18648)*. [GitHub-17680](https://github.com/magento/magento2/issues/17680)
+<!--- ENGCOM-3243 -->
+*  Interception cache compilation has been improved, and custom profiler records are now executed in less than a second. Previously, profiled methods consumed about 70% of the first page load after `cache:flush` from either the command-line interface or the Admin. *Fix submitted by Patrick McLain in pull request [18648](https://github.com/magento/magento2/pull/18648)*. [GitHub-17680](https://github.com/magento/magento2/issues/17680)
 
-<!--- ENGCOM-3535-->* `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the  web API doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+<!--- ENGCOM-3535 -->
+*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the  web API doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
-<!--- ENGCOM-3846-->* Deprecated interface `\Magento\Framework\Option\ArrayInterface` has been replaced with `\Magento\Framework\Data\OptionSourceInterface` in `lib/internal/Magento/Framework/Option/ArrayPool.php`. *Fix submitted by Milind Singh in pull request [20248](https://github.com/magento/magento2/pull/20248)*. [GitHub-20064](https://github.com/magento/magento2/issues/20064)
+<!--- ENGCOM-3846 -->
+*  Deprecated interface `\Magento\Framework\Option\ArrayInterface` has been replaced with `\Magento\Framework\Data\OptionSourceInterface` in `lib/internal/Magento/Framework/Option/ArrayPool.php`. *Fix submitted by Milind Singh in pull request [20248](https://github.com/magento/magento2/pull/20248)*. [GitHub-20064](https://github.com/magento/magento2/issues/20064)
 
-<!--- ENGCOM-4166-->* Corrected invalid return type in docblock in `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()`. Previously, the docblock of the  `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()` method stated that it would return a `bool` or an instance of `Zend\Http\Header\HeaderInterface()`. However, this method returned either a `bool` or a `string`. *Fix submitted by Milind Singh in pull request [21035](https://github.com/magento/magento2/pull/21035)*. [GitHub-21034](https://github.com/magento/magento2/issues/21034)
+<!--- ENGCOM-4166 -->
+*  Corrected invalid return type in docblock in `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()`. Previously, the docblock of the  `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()` method stated that it would return a `bool` or an instance of `Zend\Http\Header\HeaderInterface()`. However, this method returned either a `bool` or a `string`. *Fix submitted by Milind Singh in pull request [21035](https://github.com/magento/magento2/pull/21035)*. [GitHub-21034](https://github.com/magento/magento2/issues/21034)
 
-<!--- ENGCOM-3117-->* Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by Artsiom Bruneuski in pull request [18416](https://github.com/magento/magento2/pull/18416)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
+<!--- ENGCOM-3117 -->
+*  Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by Artsiom Bruneuski in pull request [18416](https://github.com/magento/magento2/pull/18416)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
 
-<!--- ENGCOM-4073-->* JavaScript translation issues on the modal buttons that Magento displays when removing items from the product compare page have been resolved. *Fix submitted by Max Fickers in pull request [20109](https://github.com/magento/magento2/pull/20109)*. [GitHub-19705](https://github.com/magento/magento2/issues/19705)
+<!--- ENGCOM-4073 -->
+*  JavaScript translation issues on the modal buttons that Magento displays when removing items from the product compare page have been resolved. *Fix submitted by Max Fickers in pull request [20109](https://github.com/magento/magento2/pull/20109)*. [GitHub-19705](https://github.com/magento/magento2/issues/19705)
 
-<!--- ENGCOM-4046-->* We've added support for `use` statements in web API interfaces and the use of non-FQN class names in `doctypes`. Previously,  you could not  import class names in interfaces that were used for the web API. *Fix submitted by Riccardo Tempesta in pull request [17424](https://github.com/magento/magento2/pull/17424)*. [GitHub-1537](https://github.com/magento/magento2/issues/1537)
+<!--- ENGCOM-4046 -->
+*  We've added support for `use` statements in web API interfaces and the use of non-FQN class names in `doctypes`. Previously,  you could not  import class names in interfaces that were used for the web API. *Fix submitted by Riccardo Tempesta in pull request [17424](https://github.com/magento/magento2/pull/17424)*. [GitHub-1537](https://github.com/magento/magento2/issues/1537)
 
-<!--- ENGCOM-3710-->* `Magento/Framework/HTTP/Adapter/Curl.php` now supports setting an HTTP version. *Fix submitted by SikailoISM in pull request [19845](https://github.com/magento/magento2/pull/19845)*. [GitHub-19442](https://github.com/magento/magento2/issues/19442)
+<!--- ENGCOM-3710 -->
+*  `Magento/Framework/HTTP/Adapter/Curl.php` now supports setting an HTTP version. *Fix submitted by SikailoISM in pull request [19845](https://github.com/magento/magento2/pull/19845)*. [GitHub-19442](https://github.com/magento/magento2/issues/19442)
 
-<!--- ENGCOM-3425-->* Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace.  *Fix submitted by Vova Yatsyuk in pull request [19143](https://github.com/magento/magento2/pull/19143)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+<!--- ENGCOM-3425 -->
+*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace.  *Fix submitted by Vova Yatsyuk in pull request [19143](https://github.com/magento/magento2/pull/19143)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
-<!--- ENGCOM-3753-->* The AMQP helper has been updated to use host, username, and password configuration from the instance under test. This allows tests to run when the AMQP service is not using default credentials or available on `localhost`. Previously, the `host` value in this helper was hardcoded. *Fix submitted by Patrick McLain in pull request [18978](https://github.com/magento/magento2/pull/18978)*. [GitHub-18953](https://github.com/magento/magento2/issues/18953)
+<!--- ENGCOM-3753 -->
+*  The AMQP helper has been updated to use host, username, and password configuration from the instance under test. This allows tests to run when the AMQP service is not using default credentials or available on `localhost`. Previously, the `host` value in this helper was hardcoded. *Fix submitted by Patrick McLain in pull request [18978](https://github.com/magento/magento2/pull/18978)*. [GitHub-18953](https://github.com/magento/magento2/issues/18953)
 
 #### Cache framework
 
-<!--- MAGETWO-64282-->* Problems with cache-cleaning for product pages for simple  products that are associated with configurable products  have been resolved. and as a result, product pages now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
+<!--- MAGETWO-64282 -->
+*  Problems with cache-cleaning for product pages for simple  products that are associated with configurable products  have been resolved. and as a result, product pages now accurately display out-of-stock status.  Previously, when an associated product went out-of-stock, Magento did not update the product page of the configurable product unless you cleaned the cache. [GitHub-8009](https://github.com/magento/magento2/issues/8009)
 
-<!--- MAGETWO-95853-->* The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
+<!--- MAGETWO-95853 -->
+*  The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
 
-<!--- MAGETWO-91694-->* Magento now removes disabled products as expected from the flat product table when **Catalog Flat Product** is enabled.
+<!--- MAGETWO-91694 -->
+*  Magento now removes disabled products as expected from the flat product table when **Catalog Flat Product** is enabled.
 
 #### Configuration framework
 
-<!--- MAGETWO-97247-->* You can now enable shared catalogs using the `config:set` command. Previously, this command enabled the shared catalog but did not create the necessary permissions to access it.
+<!--- MAGETWO-97247 -->
+*  You can now enable shared catalogs using the `config:set` command. Previously, this command enabled the shared catalog but did not create the necessary permissions to access it.
 
 #### Data framework
 
-<!--- ENGCOM-3268-->* Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by Burlacu Vasilii in pull request [18798](https://github.com/magento/magento2/pull/18798)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
+<!--- ENGCOM-3268 -->
+*  Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by Burlacu Vasilii in pull request [18798](https://github.com/magento/magento2/pull/18798)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
 
 #### Event framework
 
-<!--- ENGCOM-3422-->* `events.xml` can now have child nodes. *Fix submitted by Lisovyi Yevhenii in pull request [19146](https://github.com/magento/magento2/pull/19146)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
+<!--- ENGCOM-3422 -->
+*  `events.xml` can now have child nodes. *Fix submitted by Lisovyi Yevhenii in pull request [19146](https://github.com/magento/magento2/pull/19146)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
 
 #### JavaScript framework
 
-<!--- MAGETWO-56813-->* Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
+<!--- MAGETWO-56813 -->
+*  Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
 
 #### Message framework
 
-<!--- MAGETWO-91717-->* Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
+<!--- MAGETWO-91717 -->
+*  Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
 
 ### General fixes
 
-<!--- ENGCOM-3198-->* The navigation arrows in fotorama now stay visible after you close the zoomed fotorama. *Fix submitted by Luuk Schakenraad in pull request [18590](https://github.com/magento/magento2/pull/18590)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
+<!--- ENGCOM-3198 -->
+*  The navigation arrows in fotorama now stay visible after you close the zoomed fotorama. *Fix submitted by Luuk Schakenraad in pull request [18590](https://github.com/magento/magento2/pull/18590)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
 
-<!--- ENGCOM-3239-->* You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by Dmytro Cheshun in pull request [18730](https://github.com/magento/magento2/pull/18730)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
+<!--- ENGCOM-3239 -->
+*  You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by Dmytro Cheshun in pull request [18730](https://github.com/magento/magento2/pull/18730)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
 
-<!--- ENGCOM-3489-->* Content in  confirmation pop-up windows on the Admin no longer overlap the **Close** button. *Fix submitted by Dmytro Cheshun in pull request [19264](https://github.com/magento/magento2/pull/19264)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
+<!--- ENGCOM-3489 -->
+*  Content in  confirmation pop-up windows on the Admin no longer overlap the **Close** button. *Fix submitted by Dmytro Cheshun in pull request [19264](https://github.com/magento/magento2/pull/19264)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
 
-<!--- ENGCOM-3346-->* You can now update database credentials from the command line in non-interactive mode using `bin/magento setup:config:set`. *Fix submitted by aheadWorks Capital SIA in pull request [18970](https://github.com/magento/magento2/pull/18970)*. [GitHub-18965](https://github.com/magento/magento2/issues/18965)
+<!--- ENGCOM-3346 -->
+*  You can now update database credentials from the command line in non-interactive mode using `bin/magento setup:config:set`. *Fix submitted by aheadWorks Capital SIA in pull request [18970](https://github.com/magento/magento2/pull/18970)*. [GitHub-18965](https://github.com/magento/magento2/issues/18965)
 
-<!--- ENGCOM-3165-->* The error message displayed on the Add Product Attribute page has been improved. *Fix submitted by Aman Agarwal in pull request [17800](https://github.com/magento/magento2/pull/17800)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
+<!--- ENGCOM-3165 -->
+*  The error message displayed on the Add Product Attribute page has been improved. *Fix submitted by Aman Agarwal in pull request [17800](https://github.com/magento/magento2/pull/17800)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
 
-<!--- ENGCOM-3209-->* The datepicker icon is now correctly aligned in the Admin. *Fix submitted by Yaroslav Rogoza in pull request [18627](https://github.com/magento/magento2/pull/18627)*. [GitHub-18605](https://github.com/magento/magento2/issues/18605)
+<!--- ENGCOM-3209 -->
+*  The datepicker icon is now correctly aligned in the Admin. *Fix submitted by Yaroslav Rogoza in pull request [18627](https://github.com/magento/magento2/pull/18627)*. [GitHub-18605](https://github.com/magento/magento2/issues/18605)
 
-<!--- ENGCOM-3224-->* The magnifier now disappears as expected when a user moves their cursor off an image. *Fix submitted by gwharton in pull request [18702](https://github.com/magento/magento2/pull/18702)*. [GitHub-15035](https://github.com/magento/magento2/issues/15035)
+<!--- ENGCOM-3224 -->
+*  The magnifier now disappears as expected when a user moves their cursor off an image. *Fix submitted by gwharton in pull request [18702](https://github.com/magento/magento2/pull/18702)*. [GitHub-15035](https://github.com/magento/magento2/issues/15035)
 
-<!--- MAGETWO-91745-->* Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
+<!--- MAGETWO-91745 -->
+*  Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
 
-<!--- MAGETWO-96405-->* Magento now displays the appropriate thumbnail image for configurable products in requisition lists. Previously, Magento displayed the default placeholder thumbnail image for all configurable products.
+<!--- MAGETWO-96405 -->
+*  Magento now displays the appropriate thumbnail image for configurable products in requisition lists. Previously, Magento displayed the default placeholder thumbnail image for all configurable products.
 
-<!--- ENGCOM-3588-->* The **Select All** and **Select Visible** buttons on the notification page now work as expected. Previously, these buttons behaved the same. *Fix submitted by Shikha Mishra in pull request [19302](https://github.com/magento/magento2/pull/19302)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
+<!--- ENGCOM-3588 -->
+*  The **Select All** and **Select Visible** buttons on the notification page now work as expected. Previously, these buttons behaved the same. *Fix submitted by Shikha Mishra in pull request [19302](https://github.com/magento/magento2/pull/19302)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
 
-<!--- ENGCOM-3389-->* The note that describes the **Use in Layered Navigation: Filterable (no results)**  property now better describes the property. *Fix submitted by Vladyslav Podorozhnyi in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!--- ENGCOM-3389 -->
+*  The note that describes the **Use in Layered Navigation: Filterable (no results)**  property now better describes the property. *Fix submitted by Vladyslav Podorozhnyi in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
-<!--- ENGCOM-3258-->* Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Peter O'Callaghan in pull request [18412](https://github.com/magento/magento2/pull/18412)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357)
+<!--- ENGCOM-3258 -->
+*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Peter O'Callaghan in pull request [18412](https://github.com/magento/magento2/pull/18412)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357)
 
 ### Gift cards
 
-<!--- MAGETWO-91700-->* Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
+<!--- MAGETWO-91700 -->
+*  Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
 
-<!--- MAGETWO-91611-->* Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
+<!--- MAGETWO-91611 -->
+*  Magento now displays the correct creation date for a gift card when the **Lifetime** field is populated.
 
-<!--- ENGCOM-3379-->* Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!--- ENGCOM-3379 -->
+*  Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!--- ENGCOM-3624-->* `old_path: new_path` path mappings have been added for JavaScript files that have been relocated to `requirejs-config.js`. *Fix submitted by rbayet in pull request [19583](https://github.com/magento/magento2/pull/19583)*. [GitHub-19291](https://github.com/magento/magento2/issues/19291), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!--- ENGCOM-3624 -->
+*  `old_path: new_path` path mappings have been added for JavaScript files that have been relocated to `requirejs-config.js`. *Fix submitted by rbayet in pull request [19583](https://github.com/magento/magento2/pull/19583)*. [GitHub-19291](https://github.com/magento/magento2/issues/19291), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!--- ENGCOM-3632-->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by Nazar in pull request [19135](https://github.com/magento/magento2/pull/19135)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!--- ENGCOM-3632 -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by Nazar in pull request [19135](https://github.com/magento/magento2/pull/19135)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!--- ENGCOM-3644-->* The **Click for price** button on the home page now works as expected. *Fix submitted by Ravi Chandra in pull request [19663](https://github.com/magento/magento2/pull/19663)*. [GitHub-15922](https://github.com/magento/magento2/issues/15922)
+<!--- ENGCOM-3644 -->
+*  The **Click for price** button on the home page now works as expected. *Fix submitted by Ravi Chandra in pull request [19663](https://github.com/magento/magento2/pull/19663)*. [GitHub-15922](https://github.com/magento/magento2/issues/15922)
 
 ### Gift message
 
-<!--- MAGETWO-67269-->* Magento no longer displays unselected gift options when a customer selects **Check Out with Multiple Addresses** for an order. Previously, Magento displayed unselected gift options for the order.
+<!--- MAGETWO-67269 -->
+*  Magento no longer displays unselected gift options when a customer selects **Check Out with Multiple Addresses** for an order. Previously, Magento displayed unselected gift options for the order.
 
-<!--- ENGCOM-3985-->* Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shoopping cart. *Fix submitted by Ajay Ajabale in pull request [20605](https://github.com/magento/magento2/pull/20605)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+<!--- ENGCOM-3985 -->
+*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shoopping cart. *Fix submitted by Ajay Ajabale in pull request [20605](https://github.com/magento/magento2/pull/20605)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
 ### Gift registry
 
-<!--- MAGETWO-95833-->* Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
+<!--- MAGETWO-95833 -->
+*  Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
 
 ### Gift wrapping
 
-<!--- MAGETWO-91563-->* You can now add gift wrapping to the shopping cart to an already added product without having to add an additional product.
+<!--- MAGETWO-91563 -->
+*  You can now add gift wrapping to the shopping cart to an already added product without having to add an additional product.
 
 ### Google Analytics
 
-<!--- ENGCOM-3058-->* `referenceContainer` has been changed to `referenceBlock` in the Google Analytics module. *Fix submitted by Petar Sambolek in pull request [18290](https://github.com/magento/magento2/pull/18290)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
+<!--- ENGCOM-3058 -->
+*  `referenceContainer` has been changed to `referenceBlock` in the Google Analytics module. *Fix submitted by Petar Sambolek in pull request [18290](https://github.com/magento/magento2/pull/18290)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
 
 ### Google Tag Manager
 
-<!--- MAGETWO-96378-->* The Google Tag Manager `AddToCart` event now fires reliably on the product page when **Stores** > **Configuration** > **Sales** > **Checkout** > **Redirect to Shopping Cart** is set to  **yes**.
+<!--- MAGETWO-96378 -->
+*  The Google Tag Manager `AddToCart` event now fires reliably on the product page when **Stores** > **Configuration** > **Sales** > **Checkout** > **Redirect to Shopping Cart** is set to  **yes**.
 
 ### Import/export
 
-<!--- ENGCOM-3203-->* Magento now displays an informative error after you run check data, and also blocks import and product creation, when SKU strings are too long. Previously, the check data process permitted you to proceed with the import, but the import failed due to a system error.  *Fix submitted by Ravi Chandra in pull request [18639](https://github.com/magento/magento2/pull/18639)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
+<!--- ENGCOM-3203 -->
+*  Magento now displays an informative error after you run check data, and also blocks import and product creation, when SKU strings are too long. Previously, the check data process permitted you to proceed with the import, but the import failed due to a system error.  *Fix submitted by Ravi Chandra in pull request [18639](https://github.com/magento/magento2/pull/18639)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
 
-<!--- ENGCOM-3228-->* Magento now successfully imports products  that have a fixed price custom option with a price of zero. Previously,  the importer failed when trying to update products with a price of zero.  *Fix submitted by Antun Matanović in pull request [18284](https://github.com/magento/magento2/pull/18284)*. [GitHub-17616](https://github.com/magento/magento2/issues/17616)
+<!--- ENGCOM-3228 -->
+*  Magento now successfully imports products  that have a fixed price custom option with a price of zero. Previously,  the importer failed when trying to update products with a price of zero.  *Fix submitted by Antun Matanović in pull request [18284](https://github.com/magento/magento2/pull/18284)*. [GitHub-17616](https://github.com/magento/magento2/issues/17616)
 
-<!--- MAGETWO-94671-->* The memory required to export the media gallery has been significantly reduced. [GitHub-17320](https://github.com/magento/magento2/issues/17320)
+<!--- MAGETWO-94671 -->
+*  The memory required to export the media gallery has been significantly reduced. [GitHub-17320](https://github.com/magento/magento2/issues/17320)
 
 <!--- MAGETWO-95825-->
 * We've resolved the following issues with imported images:
@@ -898,59 +1207,83 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
    * images that were removed through the Admin before import returned after import. Magento now displays an informative error message if images are not imported as expected.
 
-<!--- MAGETWO-91569-->* Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
+<!--- MAGETWO-91569 -->
+*  Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
 
-<!--- MAGETWO-95105-->* URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
+<!--- MAGETWO-95105 -->
+*  URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
 
-<!--- MAGETWO-91544-->* Magento now correctly updates existing product URLs during import. Previously, Magento update existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
+<!--- MAGETWO-91544 -->
+*  Magento now correctly updates existing product URLs during import. Previously, Magento update existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
 
-<!--- MAGETWO-95829-->* Magento now retains product order within a category after import.
+<!--- MAGETWO-95829 -->
+*  Magento now retains product order within a category after import.
 
-<!--- MAGETWO-59265-->* You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
+<!--- MAGETWO-59265 -->
+*  You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
 
-<!--- MAGETWO-91657-->* If you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product, Magento now prompts you to enter a valid value. Previously, Magento threw an error.
+<!--- MAGETWO-91657 -->
+*  If you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product, Magento now prompts you to enter a valid value. Previously, Magento threw an error.
 
-<!--- MAGETWO-58210-->* The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
+<!--- MAGETWO-58210 -->
+*  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
 
-<!--- ENGCOM-3083-->* The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by utietze in pull request [18271](https://github.com/magento/magento2/pull/18271)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
+<!--- ENGCOM-3083 -->
+*  The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by utietze in pull request [18271](https://github.com/magento/magento2/pull/18271)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
 
-<!--- ENGCOM-3823-->* Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by p-bystritsky in pull request [20180](https://github.com/magento/magento2/pull/20180)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
+<!--- ENGCOM-3823 -->
+*  Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by p-bystritsky in pull request [20180](https://github.com/magento/magento2/pull/20180)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
 
-<!--- ENGCOM-3809-->* We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.  *Fix submitted by Rajneesh Gupta in pull request [20127](https://github.com/magento/magento2/pull/20127)*. [GitHub-20098](https://github.com/magento/magento2/issues/20098)
+<!--- ENGCOM-3809 -->
+*  We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.  *Fix submitted by Rajneesh Gupta in pull request [20127](https://github.com/magento/magento2/pull/20127)*. [GitHub-20098](https://github.com/magento/magento2/issues/20098)
 
-<!--- ENGCOM-3977-->* `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites the `$value` argument. Previously, the same name was used for different `$value` variables. *Fix submitted by Rajneesh Gupta in pull request [20625](https://github.com/magento/magento2/pull/20625)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+<!--- ENGCOM-3977 -->
+*  `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites the `$value` argument. Previously, the same name was used for different `$value` variables. *Fix submitted by Rajneesh Gupta in pull request [20625](https://github.com/magento/magento2/pull/20625)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
-<!--- MAGETWO-96381-->* Magento now exports configurable products based on swatches with the correct Admin and Default Store View labels. Previously,  the `configurable_variations` column for these configurable products contained the wrong values after import.
+<!--- MAGETWO-96381 -->
+*  Magento now exports configurable products based on swatches with the correct Admin and Default Store View labels. Previously,  the `configurable_variations` column for these configurable products contained the wrong values after import.
 
 ### Infrastructure
 
-<!--- ENGCOM-4389 -->* Magento now supports Elasticsearch 6.x. *Fix submitted by Romain Ruaud in pull request [21458](https://github.com/magento/magento2/pull/21458)*.
+<!--- ENGCOM-4389  -->
+*  Magento now supports Elasticsearch 6.x. *Fix submitted by Romain Ruaud in pull request [21458](https://github.com/magento/magento2/pull/21458)*.
 
-<!--- MC-5201 -->* Magento now supports Redis 5.0.
+<!--- MC-5201  -->
+*  Magento now supports Redis 5.0.
 
-<!--- ENGCOM-4392 -->* Expected backup and restoration functionality has been restored and MySQL View support is supported while preserving backward compatibility with pre-existing modules. *Fix submitted by community member Stepan Furman in pull request [21151](https://github.com/magento/magento2/pull/21151)*.
+<!--- ENGCOM-4392  -->
+*  Expected backup and restoration functionality has been restored and MySQL View support is supported while preserving backward compatibility with pre-existing modules. *Fix submitted by community member Stepan Furman in pull request [21151](https://github.com/magento/magento2/pull/21151)*.
 
-<!--- ENGCOM-3690-->* `transparent.js` has relocated, and orders can now be created from the Admin using PayflowPro and Authorize.Net. Previously, orders created from the Admin using PayflowPro failed, and Magento displayed an informative message indicating that an account number was invalid. *Fix submitted by Patrick McLain in pull request [19764](https://github.com/magento/magento2/pull/19764)*. [GitHub-19763](https://github.com/magento/magento2/issues/19763)
+<!--- ENGCOM-3690 -->
+*  `transparent.js` has relocated, and orders can now be created from the Admin using PayflowPro and Authorize.Net. Previously, orders created from the Admin using PayflowPro failed, and Magento displayed an informative message indicating that an account number was invalid. *Fix submitted by Patrick McLain in pull request [19764](https://github.com/magento/magento2/pull/19764)*. [GitHub-19763](https://github.com/magento/magento2/issues/19763)
 
-<!--- ENGCOM-3598-->* `json_encode` errors are now caught and logged in the console.log. Previously, the JSON serializer threw an error, which blocked all frontend behavior. *Fix submitted by Tommy Quissens in pull request [16154](https://github.com/magento/magento2/pull/16154)*. [GitHub-14937](https://github.com/magento/magento2/issues/14937)
+<!--- ENGCOM-3598 -->
+*  `json_encode` errors are now caught and logged in the console.log. Previously, the JSON serializer threw an error, which blocked all frontend behavior. *Fix submitted by Tommy Quissens in pull request [16154](https://github.com/magento/magento2/pull/16154)*. [GitHub-14937](https://github.com/magento/magento2/issues/14937)
 
-<!--- ENGCOM-3589-->* `app/bootstrap.php` has been updated to correctly define supported PHP versions. *Fix submitted by Fabrizio Balliano in pull request [19455](https://github.com/magento/magento2/pull/19455)*. [GitHub-19453](https://github.com/magento/magento2/issues/19453)
+<!--- ENGCOM-3589 -->
+*  `app/bootstrap.php` has been updated to correctly define supported PHP versions. *Fix submitted by Fabrizio Balliano in pull request [19455](https://github.com/magento/magento2/pull/19455)*. [GitHub-19453](https://github.com/magento/magento2/issues/19453)
 
-<!--- ENGCOM-3687-->* An incorrect parameter in `getCreatedAtFormatted($format)` has been corrected. *Fix submitted by Jaimin Sutariya in pull request [19537](https://github.com/magento/magento2/pull/19537)*. [GitHub-17442](https://github.com/magento/magento2/issues/17442)
+<!--- ENGCOM-3687 -->
+*  An incorrect parameter in `getCreatedAtFormatted($format)` has been corrected. *Fix submitted by Jaimin Sutariya in pull request [19537](https://github.com/magento/magento2/pull/19537)*. [GitHub-17442](https://github.com/magento/magento2/issues/17442)
 
-<!--- ENGCOM-3666-->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by Nirav Kadiya in pull request [19634](https://github.com/magento/magento2/pull/19634)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+<!--- ENGCOM-3666 -->
+*  A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by Nirav Kadiya in pull request [19634](https://github.com/magento/magento2/pull/19634)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
 
-<!--- ENGCOM-3364-->* Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by p-bystritsky in pull request [18991](https://github.com/magento/magento2/pull/18991)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!--- ENGCOM-3364 -->
+*  Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by p-bystritsky in pull request [18991](https://github.com/magento/magento2/pull/18991)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 * Message queue topic names generated as a result of asynchronous and bulk REST calls are now based on service contract names. Currently,  topic names reflect the PHP class and method names that should be invoked to handle processing. For example, a topic that was named using the older conventions (`async.V1.customers.POST`) might be named `async.magento.customer.api.accountmanagementinterface.createaccount.post`. This new naming is more semantic and allows the reuse for other Magento services.
 
 ### Integration
 
-<!--- ENGCOM-3353-->* Magento no longer throws an exception when you navigate to the OAuth page (**Backend** > **Stores** > **Configuration** > **Services** > **OAuth**). *Fix submitted by Mahesh Singh in pull request [18750](https://github.com/magento/magento2/pull/18750)*. [GitHub-18655](https://github.com/magento/magento2/issues/18655)
+<!--- ENGCOM-3353 -->
+*  Magento no longer throws an exception when you navigate to the OAuth page (**Backend** > **Stores** > **Configuration** > **Services** > **OAuth**). *Fix submitted by Mahesh Singh in pull request [18750](https://github.com/magento/magento2/pull/18750)*. [GitHub-18655](https://github.com/magento/magento2/issues/18655)
 
-<!--- ENGCOM-3355-->* The Last Logged In value displayed on the Admin's customer account page is now updated as expected when a customer is authenticated through REST. *Fix submitted by Prakash in pull request [18973](https://github.com/magento/magento2/pull/18973)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
+<!--- ENGCOM-3355 -->
+*  The Last Logged In value displayed on the Admin's customer account page is now updated as expected when a customer is authenticated through REST. *Fix submitted by Prakash in pull request [18973](https://github.com/magento/magento2/pull/18973)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
 
-<!--- ENGCOM-3053-->* Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by Pratik Oza in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
+<!--- ENGCOM-3053 -->
+*  Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by Pratik Oza in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
 
 ### Klarna
 
@@ -968,7 +1301,8 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Layered navigation
 
-<!--- MAGETWO-91753-->* You can now filter products based on color.
+<!--- MAGETWO-91753 -->
+*  You can now filter products based on color.
 
 ### Magento Shipping
 
@@ -978,69 +1312,97 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### MSRP
 
-<!--- MC-10973-->* MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
+<!--- MC-10973 -->
+*  MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
 
 ### Newsletter
 
-<!--- ENGCOM-3460-->* Magento now sets the correct `store_id` for each store when a customer subscribes to a newsletter from more than one store. *Fix submitted by Eduard Chitoraga in pull request [19195](https://github.com/magento/magento2/pull/19195)*. [GitHub-19172](https://github.com/magento/magento2/issues/19172)
+<!--- ENGCOM-3460 -->
+*  Magento now sets the correct `store_id` for each store when a customer subscribes to a newsletter from more than one store. *Fix submitted by Eduard Chitoraga in pull request [19195](https://github.com/magento/magento2/pull/19195)*. [GitHub-19172](https://github.com/magento/magento2/issues/19172)
 
-<!--- ENGCOM-3266-->* Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by Janak Bhimani in pull request [18795](https://github.com/magento/magento2/pull/18795)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
+<!--- ENGCOM-3266 -->
+*  Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by Janak Bhimani in pull request [18795](https://github.com/magento/magento2/pull/18795)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
 
-<!--- MAGETWO-91684-->* Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
+<!--- MAGETWO-91684 -->
+*  Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
 
-<!--- MAGETWO-91768-->* Magento now displays an informative message when you click the unsubscribe link in the newsletter email.
+<!--- MAGETWO-91768 -->
+*  Magento now displays an informative message when you click the unsubscribe link in the newsletter email.
 
-<!--- ENGCOM-3575-->* You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter.  *Fix submitted by Burlacu Vasilii in pull request [19419](https://github.com/magento/magento2/pull/19419)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!--- ENGCOM-3575 -->
+*  You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter.  *Fix submitted by Burlacu Vasilii in pull request [19419](https://github.com/magento/magento2/pull/19419)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!--- ENGCOM-3431-->* A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by Ravi Chandra in pull request [19164](https://github.com/magento/magento2/pull/19164)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+<!--- ENGCOM-3431 -->
+*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by Ravi Chandra in pull request [19164](https://github.com/magento/magento2/pull/19164)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
-<!--- ENGCOM-3574-->* If a customer tries to subscribe to a newsletter with an email that  already has a subscription associated with it, Magento now warns the customer rather than throws an exception. *Fix submitted by Dharmesh Vaja in pull request [19416](https://github.com/magento/magento2/pull/19416)*. [GitHub-19404](https://github.com/magento/magento2/issues/19404)
+<!--- ENGCOM-3574 -->
+*  If a customer tries to subscribe to a newsletter with an email that  already has a subscription associated with it, Magento now warns the customer rather than throws an exception. *Fix submitted by Dharmesh Vaja in pull request [19416](https://github.com/magento/magento2/pull/19416)*. [GitHub-19404](https://github.com/magento/magento2/issues/19404)
 
-<!--- ENGCOM-4179-->* You can now search for or reset the filter on newsletter problem reports from the Admin. Previously, Magento did not display filter reports when adminstrators used FireFox.  *Fix submitted by Govind Sharma in pull request [20829](https://github.com/magento/magento2/pull/20829)*. [GitHub-20828](https://github.com/magento/magento2/issues/20828)
+<!--- ENGCOM-4179 -->
+*  You can now search for or reset the filter on newsletter problem reports from the Admin. Previously, Magento did not display filter reports when adminstrators used FireFox.  *Fix submitted by Govind Sharma in pull request [20829](https://github.com/magento/magento2/pull/20829)*. [GitHub-20828](https://github.com/magento/magento2/issues/20828)
 
 ### Orders
 
-<!--- MAGETWO-94437-->* The address form in the Admin order creation workflow has been refactored to improve performance.
+<!--- MAGETWO-94437 -->
+*  The address form in the Admin order creation workflow has been refactored to improve performance.
 
-<!--- MAGETWO-69274-->* Administrators now need sales email privileges to send order comment emails to customers.
+<!--- MAGETWO-69274 -->
+*  Administrators now need sales email privileges to send order comment emails to customers.
 
 ### Page cache
 
-<!--- MAGETWO-97234-->* Pages opened by URL redirect now display prices in the currency set for the appropriate store. Previously, the opened page contained prices in the default currency (USD) rather than the selected currency for the store.
+<!--- MAGETWO-97234 -->
+*  Pages opened by URL redirect now display prices in the currency set for the appropriate store. Previously, the opened page contained prices in the default currency (USD) rather than the selected currency for the store.
 
 ### Payment methods
 
-<!--- ENGCOM-3219-->* Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by Lucas Calazans in pull request [18095](https://github.com/magento/magento2/pull/18095)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
+<!--- ENGCOM-3219 -->
+*  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by Lucas Calazans in pull request [18095](https://github.com/magento/magento2/pull/18095)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
 
-<!--- ENGCOM-3393-->* Invoice PDFs now include a populated FTP (Fixed Product Tax) amount field for orders when using Weee tax and FPT is enabled. Previously, this information was displayed in order and invoice views, bot not captured in the PDF. *Fix submitted by Mahesh Singh in pull request [19061](https://github.com/magento/magento2/pull/19061)*. [GitHub-18617](https://github.com/magento/magento2/issues/18617)
+<!--- ENGCOM-3393 -->
+*  Invoice PDFs now include a populated FTP (Fixed Product Tax) amount field for orders when using Weee tax and FPT is enabled. Previously, this information was displayed in order and invoice views, bot not captured in the PDF. *Fix submitted by Mahesh Singh in pull request [19061](https://github.com/magento/magento2/pull/19061)*. [GitHub-18617](https://github.com/magento/magento2/issues/18617)
 
-<!--- MAGETWO-96475-->*  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during  checkout when being processed through PayPal were processed.
+<!--- MAGETWO-96475 -->
+*   When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during  checkout when being processed through PayPal were processed.
 
-<!--- MAGETWO-96291-->* A pop-up window no longer blocks completion of checkout using Braintree PayPal on a mobile device.
+<!--- MAGETWO-96291 -->
+*  A pop-up window no longer blocks completion of checkout using Braintree PayPal on a mobile device.
 
-<!--- MAGETWO-95821-->* When a  customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
+<!--- MAGETWO-95821 -->
+*  When a  customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
 
-<!--- MAGETWO-91526-->* Orders created with eWay as a payment method now contain the same credit card information, which is included in the Authorize.Net response. Previously, the order did not contain any information regarding the credit card.
+<!--- MAGETWO-91526 -->
+*  Orders created with eWay as a payment method now contain the same credit card information, which is included in the Authorize.Net response. Previously, the order did not contain any information regarding the credit card.
 
-<!--- MAGETWO-97243-->* Magento now displays successful orders paid for with eWay. Previously, Magento did not display completed errors even after the transaction was accepted by eWay.
+<!--- MAGETWO-97243 -->
+*  Magento now displays successful orders paid for with eWay. Previously, Magento did not display completed errors even after the transaction was accepted by eWay.
 
-<!--- ENGCOM-3675-->* The `getList()` method now returns the vault data total count as expected. *Fix submitted by Andrea Parmeggiani in pull request [19707](https://github.com/magento/magento2/pull/19707)*. [GitHub-19706](https://github.com/magento/magento2/issues/19706)
+<!--- ENGCOM-3675 -->
+*  The `getList()` method now returns the vault data total count as expected. *Fix submitted by Andrea Parmeggiani in pull request [19707](https://github.com/magento/magento2/pull/19707)*. [GitHub-19706](https://github.com/magento/magento2/issues/19706)
 
-<!--- ENGCOM-3156-->* You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by Vishal Gelani in pull request [18521](https://github.com/magento/magento2/pull/18521)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
+<!--- ENGCOM-3156 -->
+*  You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by Vishal Gelani in pull request [18521](https://github.com/magento/magento2/pull/18521)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
 
-<!--- ENGCOM-3646-->* Payment methods are now grouped properly in the core source model. `\Magento\Payment\Model\Config\Source\Allmethods` class in the Magento core can be used as a source model for backend configuration fields. It displays available payment methods grouped by payment provider. We've added groups for previously missing payment options (PayPal, Authorize.Net, and  Braintree methods). *Fix submitted by Wojtek Naruniec in pull request [19665](https://github.com/magento/magento2/pull/19665)*. [GitHub-19664](https://github.com/magento/magento2/issues/19664)
+<!--- ENGCOM-3646 -->
+*  Payment methods are now grouped properly in the core source model. `\Magento\Payment\Model\Config\Source\Allmethods` class in the Magento core can be used as a source model for backend configuration fields. It displays available payment methods grouped by payment provider. We've added groups for previously missing payment options (PayPal, Authorize.Net, and  Braintree methods). *Fix submitted by Wojtek Naruniec in pull request [19665](https://github.com/magento/magento2/pull/19665)*. [GitHub-19664](https://github.com/magento/magento2/issues/19664)
 
-<!--- ENGCOM-3840-->* Fixed misalignment of the save-for-later checkbox on the Admin create order credit card details page. *Fix submitted by Kajal Solanki in pull request [20233](https://github.com/magento/magento2/pull/20233)*. [GitHub-20232](https://github.com/magento/magento2/issues/20232)
+<!--- ENGCOM-3840 -->
+*  Fixed misalignment of the save-for-later checkbox on the Admin create order credit card details page. *Fix submitted by Kajal Solanki in pull request [20233](https://github.com/magento/magento2/pull/20233)*. [GitHub-20232](https://github.com/magento/magento2/issues/20232)
 
-<!--- MC-4239-->* The Authorize.Net payment method has been migrated to the `accept.js` API on both the storefront and Admin.
+<!--- MC-4239 -->
+*  The Authorize.Net payment method has been migrated to the `accept.js` API on both the storefront and Admin.
 
-<!--- MC-5235-->* PayPal Express Checkout has been updated to `checkout.js v4`. This API replaces the deprecated API Express Checkout - NVP/SOAP. This update provides Magento with a single integration but with multiple payment options that merchants can choose when activating the integration​. See [PayPal Express Checkout](https://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html)
+<!--- MC-5235 -->
+*  PayPal Express Checkout has been updated to `checkout.js v4`. This API replaces the deprecated API Express Checkout - NVP/SOAP. This update provides Magento with a single integration but with multiple payment options that merchants can choose when activating the integration​. See [PayPal Express Checkout](https://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html)
 
-<!--- MAGETWO-83017-->* You can now place an order using Cybersource payment from the Admin.
+<!--- MAGETWO-83017 -->
+*  You can now place an order using Cybersource payment from the Admin.
 
-<!--- MAGETWO-83017-->* Administrators can now set additional Cybersource profile credentials (**Profile ID**, **Access key**, **Secret Key**) from the Admin and place an order from the Admin when different credentials are used on website level. Previously, Cybersource denied payments when a merchant deployed their Admin on a different domain than the store.
+<!--- MAGETWO-83017 -->
+*  Administrators can now set additional Cybersource profile credentials (**Profile ID**, **Access key**, **Secret Key**) from the Admin and place an order from the Admin when different credentials are used on website level. Previously, Cybersource denied payments when a merchant deployed their Admin on a different domain than the store.
 
-<!--- MAGETWO-94946-->* Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
+<!--- MAGETWO-94946 -->
+*  Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
 
 ### Performance
 
@@ -1053,127 +1415,179 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Product video
 
-<!--- MAGETWO-91707-->* You can now pause product videos on YouTube on storefronts running on Internet Explorer 11.x.
+<!--- MAGETWO-91707 -->
+*  You can now pause product videos on YouTube on storefronts running on Internet Explorer 11.x.
 
 ### Quote
 
-<!--- ENGCOM-3416-->* You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by Burlacu Vasilii in pull request [19130](https://github.com/magento/magento2/pull/19130)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
+<!--- ENGCOM-3416 -->
+*  You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by Burlacu Vasilii in pull request [19130](https://github.com/magento/magento2/pull/19130)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
 
-<!--- ENGCOM-3226-->* You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by Patrick McLain in pull request [18704](https://github.com/magento/magento2/pull/18704)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
+<!--- ENGCOM-3226 -->
+*  You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by Patrick McLain in pull request [18704](https://github.com/magento/magento2/pull/18704)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
 
-<!--- MAGETWO-94059-->* You can now request a quote on a storefront running on iOS 11.3.1.
+<!--- MAGETWO-94059 -->
+*  You can now request a quote on a storefront running on iOS 11.3.1.
 
-<!--- ENGCOM-3464-->* We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by Jay Ghosh in pull request [18185](https://github.com/magento/magento2/pull/18185)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
+<!--- ENGCOM-3464 -->
+*  We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by Jay Ghosh in pull request [18185](https://github.com/magento/magento2/pull/18185)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
 
-<!--- ENGCOM-3503-->* Magento now saves the correct `quote_item_id` values for products during checkout for an order being shipped to multiple addresses. *Fix submitted by Mahesh Singh in pull request [19192](https://github.com/magento/magento2/pull/19192)*. [GitHub-18349](https://github.com/magento/magento2/issues/18349)
+<!--- ENGCOM-3503 -->
+*  Magento now saves the correct `quote_item_id` values for products during checkout for an order being shipped to multiple addresses. *Fix submitted by Mahesh Singh in pull request [19192](https://github.com/magento/magento2/pull/19192)*. [GitHub-18349](https://github.com/magento/magento2/issues/18349)
 
 ### Reports
 
-<!--- MAGETWO-91553-->* Administrators with their role scope set to `custom` can now view the abandoned carts report.
+<!--- MAGETWO-91553 -->
+*  Administrators with their role scope set to `custom` can now view the abandoned carts report.
 
-<!--- ENGCOM-3560-->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Nirav Patel in pull request [19372](https://github.com/magento/magento2/pull/19372)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754)
+<!--- ENGCOM-3560 -->
+*  Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Nirav Patel in pull request [19372](https://github.com/magento/magento2/pull/19372)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754)
 
-<!--- ENGCOM-4129-->* Magento now refreshes reports statistics as expected when you select the **Refresh Lifetime Statistics** option from the Actions menu of the **Reports** > **Refresh Statistics** page. Previously, you were redirected to a 404 page when you selected this menu option. *Fix submitted by Eduard Chitoraga in pull request [20820](https://github.com/magento/magento2/pull/20820)*. [GitHub-20819](https://github.com/magento/magento2/issues/20819)
+<!--- ENGCOM-4129 -->
+*  Magento now refreshes reports statistics as expected when you select the **Refresh Lifetime Statistics** option from the Actions menu of the **Reports** > **Refresh Statistics** page. Previously, you were redirected to a 404 page when you selected this menu option. *Fix submitted by Eduard Chitoraga in pull request [20820](https://github.com/magento/magento2/pull/20820)*. [GitHub-20819](https://github.com/magento/magento2/issues/20819)
 
-<!--- ENGCOM-3257-->* Magento now displays correct prices for products at checkout when a customer uses a credit card and Authorize.Net is enabled. Previously, order items had the original price of $0.0. *Fix submitted by Patrick McLain in pull request [18768](https://github.com/magento/magento2/pull/18768)*. [GitHub-16050](https://github.com/magento/magento2/issues/16050)
+<!--- ENGCOM-3257 -->
+*  Magento now displays correct prices for products at checkout when a customer uses a credit card and Authorize.Net is enabled. Previously, order items had the original price of $0.0. *Fix submitted by Patrick McLain in pull request [18768](https://github.com/magento/magento2/pull/18768)*. [GitHub-16050](https://github.com/magento/magento2/issues/16050)
 
 ### Reviews
 
-<!--- ENGCOM-3486-->* Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by Saphal Jha in pull request [18888](https://github.com/magento/magento2/pull/18888)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
+<!--- ENGCOM-3486 -->
+*  Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by Saphal Jha in pull request [18888](https://github.com/magento/magento2/pull/18888)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
 
-<!--- MAGETWO-95491-->* The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
+<!--- MAGETWO-95491 -->
+*  The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
 
-<!--- ENGCOM-3837-->* You can now add a product review from the Admin.  Previously, when you clicked **New Review**, Magento displayed this error, `Error message showing : A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later`. *Fix submitted by Suneet K. in pull request [20146](https://github.com/magento/magento2/pull/20146)*. [GitHub-20122](https://github.com/magento/magento2/issues/20122)
+<!--- ENGCOM-3837 -->
+*  You can now add a product review from the Admin.  Previously, when you clicked **New Review**, Magento displayed this error, `Error message showing : A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later`. *Fix submitted by Suneet K. in pull request [20146](https://github.com/magento/magento2/pull/20146)*. [GitHub-20122](https://github.com/magento/magento2/issues/20122)
 
-<!--- ENGCOM-4096-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice.  *Fix submitted by Piyush Dankhara in pull request [20936](https://github.com/magento/magento2/pull/20936)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
+<!--- ENGCOM-4096 -->
+*  Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice.  *Fix submitted by Piyush Dankhara in pull request [20936](https://github.com/magento/magento2/pull/20936)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 ### Rewards
 
-<!--- MAGETWO-91647-->* Customers are now subscribed as expected to email notifications about reward points.
+<!--- MAGETWO-91647 -->
+*  Customers are now subscribed as expected to email notifications about reward points.
 
-<!--- MAGETWO-96125-->* Magento now allocates rewards points for converting an invitation to a customer when **Require Emails Confirmation** is set to **yes**.
+<!--- MAGETWO-96125 -->
+*  Magento now allocates rewards points for converting an invitation to a customer when **Require Emails Confirmation** is set to **yes**.
 
-<!--- ENGCOM-3491-->* The order status label on the  customer order status page  can now be translated. *Fix submitted by p-bystritsk in pull request [19182](https://github.com/magento/magento2/pull/19182)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+<!--- ENGCOM-3491 -->
+*  The order status label on the  customer order status page  can now be translated. *Fix submitted by p-bystritsk in pull request [19182](https://github.com/magento/magento2/pull/19182)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
-<!--- MAGETWO-91686-->* `/V1/orders/{id}` now retrieves information about used reward points.
+<!--- MAGETWO-91686 -->
+*  `/V1/orders/{id}` now retrieves information about used reward points.
 
 ### Return Merchandise Authorizations (RMA)
 
-<!--- MAGETWO-71022-->* Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
+<!--- MAGETWO-71022 -->
+*  Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
 
-<!--- MAGETWO-96158-->* Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
+<!--- MAGETWO-96158 -->
+*  Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
 
-<!--- MAGETWO-97259-->* Administrators can now process returns when a request includes a required image attribute. PPreviously, the Return Items tab displayed a validation error even though the image had  been uploaded, and if you clicked on **Details**, Magento displayed this message, `Please select a file`.
+<!--- MAGETWO-97259 -->
+*  Administrators can now process returns when a request includes a required image attribute. PPreviously, the Return Items tab displayed a validation error even though the image had  been uploaded, and if you clicked on **Details**, Magento displayed this message, `Please select a file`.
 
-<!--- MAGETWO-97132-->* You can now return bundle products from the Admin. Previously, when you clicked Submit Returns, Magento displayed an informative error message, and did not create an RMA.
+<!--- MAGETWO-97132 -->
+*  You can now return bundle products from the Admin. Previously, when you clicked Submit Returns, Magento displayed an informative error message, and did not create an RMA.
 
 ### Sales
 
-<!--- MAGETWO-96441-->* You can now remove a custom price from a product during order creation from the Admin.
+<!--- MAGETWO-96441 -->
+*  You can now remove a custom price from a product during order creation from the Admin.
 
-<!--- ENGCOM-3294-->* The message that Magento displays when a merchant tries to create a credit memo for an order with no shipping charges has been made more informative. *Fix submitted by Burlacu Vasilii in pull request [18844](https://github.com/magento/magento2/pull/18844)*. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
+<!--- ENGCOM-3294 -->
+*  The message that Magento displays when a merchant tries to create a credit memo for an order with no shipping charges has been made more informative. *Fix submitted by Burlacu Vasilii in pull request [18844](https://github.com/magento/magento2/pull/18844)*. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
 
-<!--- ENGCOM-3048-->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by Pratik Oza in pull request [18272](https://github.com/magento/magento2/pull/18272)*. [GitHub-10530](https://github.com/magento/magento2/issues/10530)
+<!--- ENGCOM-3048 -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by Pratik Oza in pull request [18272](https://github.com/magento/magento2/pull/18272)*. [GitHub-10530](https://github.com/magento/magento2/issues/10530)
 
-<!--- ENGCOM-3074-->* Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by Petar Sambolek in pull request [18288](https://github.com/magento/magento2/pull/18288)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
+<!--- ENGCOM-3074 -->
+*  Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by Petar Sambolek in pull request [18288](https://github.com/magento/magento2/pull/18288)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
 
-<!--- ENGCOM-3378-->* The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [19039](https://github.com/magento/magento2/pull/19039)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
+<!--- ENGCOM-3378 -->
+*  The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [19039](https://github.com/magento/magento2/pull/19039)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
 
-<!--- ENGCOM-3514-->* Magento now displays bundle products' child products on the **My Account** > **My Orders** > **View Order** page. *Fix submitted by Torben Höhn in pull request [19318](https://github.com/magento/magento2/pull/19318)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
+<!--- ENGCOM-3514 -->
+*  Magento now displays bundle products' child products on the **My Account** > **My Orders** > **View Order** page. *Fix submitted by Torben Höhn in pull request [19318](https://github.com/magento/magento2/pull/19318)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
 
-<!--- MAGETWO-94245-->* You can now issue a partial refund to store credit for an order made with an online payment method.
+<!--- MAGETWO-94245 -->
+*  You can now issue a partial refund to store credit for an order made with an online payment method.
 
-<!--- MAGETWO-94472-->* You can now create a credit memo for an order that contains taxes and discounts.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
+<!--- MAGETWO-94472 -->
+*  You can now create a credit memo for an order that contains taxes and discounts.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
 
-<!--- MAGETWO-91547-->* You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
+<!--- MAGETWO-91547 -->
+*  You can now create a credit memo for an order with no payment required. Previously, when an order was placed with no payment required, the **Credit Memo** button was not displayed on the order.
 
-<!--- MAGETWO-96488-->* Orders for bundle products created from the Admin now display  correct product prices.
+<!--- MAGETWO-96488 -->
+*  Orders for bundle products created from the Admin now display  correct product prices.
 
-<!--- MAGETWO-63327-->* Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
+<!--- MAGETWO-63327 -->
+*  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
-<!--- MAGETWO-96400-->* The Sales table now displays company information in billing and shipping addresses.
+<!--- MAGETWO-96400 -->
+*  The Sales table now displays company information in billing and shipping addresses.
 
-<!--- MAGETWO-96987-->* Magento no longer adds giftwrap tax to a credit memo twice.
+<!--- MAGETWO-96987 -->
+*  Magento no longer adds giftwrap tax to a credit memo twice.
 
-<!--- MAGETWO-94424-->*  Magento now displays product price and shipping costs in the default currency that was configured for that specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
+<!--- MAGETWO-94424 -->
+*   Magento now displays product price and shipping costs in the default currency that was configured for that specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
 
-<!--- ENGCOM-3828-->* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Surabhi Srivastava](https://github.com/Surabhi-Cedcoss) in pull request [20142](https://github.com/magento/magento2/pull/20142)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+<!--- ENGCOM-3828 -->
+*  Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Surabhi Srivastava](https://github.com/Surabhi-Cedcoss) in pull request [20142](https://github.com/magento/magento2/pull/20142)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
-<!--- ENGCOM-3887-->* Files uploaded for custom options can now be downloaded even when the product option is no longer available. Previously, these files could not be downloaded.  *Fix submitted by Mahesh Singh in pull request [20354](https://github.com/magento/magento2/pull/20354)*. [GitHub-20277](https://github.com/magento/magento2/issues/20277)
+<!--- ENGCOM-3887 -->
+*  Files uploaded for custom options can now be downloaded even when the product option is no longer available. Previously, these files could not be downloaded.  *Fix submitted by Mahesh Singh in pull request [20354](https://github.com/magento/magento2/pull/20354)*. [GitHub-20277](https://github.com/magento/magento2/issues/20277)
 
-<!--- ENGCOM-3699-->* Fixed an incorrect class name on orders and returns page on the Admin. *Fix submitted by Shikha Mishra in pull request [19784](https://github.com/magento/magento2/pull/19784)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
+<!--- ENGCOM-3699 -->
+*  Fixed an incorrect class name on orders and returns page on the Admin. *Fix submitted by Shikha Mishra in pull request [19784](https://github.com/magento/magento2/pull/19784)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
 
-<!--- ENGCOM-3735-->* Fixed misalignment of the **Update Qty** button on the sales order invoice. *Fix submitted by Kajal Solanki in pull request [19799](https://github.com/magento/magento2/pull/19799)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
+<!--- ENGCOM-3735 -->
+*  Fixed misalignment of the **Update Qty** button on the sales order invoice. *Fix submitted by Kajal Solanki in pull request [19799](https://github.com/magento/magento2/pull/19799)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
-<!--- ENGCOM-3720-->* Credit memos now accurately calculate refunds when default shipping charges are changed to zero. *Fix submitted by Wojtek Naruniec in pull request [19900](https://github.com/magento/magento2/pull/19900)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
+<!--- ENGCOM-3720 -->
+*  Credit memos now accurately calculate refunds when default shipping charges are changed to zero. *Fix submitted by Wojtek Naruniec in pull request [19900](https://github.com/magento/magento2/pull/19900)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
 
-<!--- ENGCOM-3225-->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18471](https://github.com/magento/magento2/pull/18471)*. [GitHub-7739](https://github.com/magento/magento2/issues/7739)
+<!--- ENGCOM-3225 -->
+*  The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18471](https://github.com/magento/magento2/pull/18471)*. [GitHub-7739](https://github.com/magento/magento2/issues/7739)
 
-<!--- ENGCOM-3452-->* The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by Ian Cassidy in pull request [18620](https://github.com/magento/magento2/pull/18620)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
+<!--- ENGCOM-3452 -->
+*  The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by Ian Cassidy in pull request [18620](https://github.com/magento/magento2/pull/18620)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
 
-<!--- ENGCOM-3594-->* You can now programmatically  cancel an invoice when the invoice state is set to `STATE_PAID`. *Fix submitted by Max O in pull request [19462](https://github.com/magento/magento2/pull/19462)*. [GitHub-18509](https://github.com/magento/magento2/issues/18509)
+<!--- ENGCOM-3594 -->
+*  You can now programmatically  cancel an invoice when the invoice state is set to `STATE_PAID`. *Fix submitted by Max O in pull request [19462](https://github.com/magento/magento2/pull/19462)*. [GitHub-18509](https://github.com/magento/magento2/issues/18509)
 
-<!--- MC-5683-->* The performance of the Admin order creation page when handling many addresses has been improved.
+<!--- MC-5683 -->
+*  The performance of the Admin order creation page when handling many addresses has been improved.
 
-<!--- ENGCOM-3484-->* Magento now displays bundle options  on the Items Ordered tab of the My Account order page. *Fix submitted by Vishal Gelani in pull request [19254](https://github.com/magento/magento2/pull/19254)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
+<!--- ENGCOM-3484 -->
+*  Magento now displays bundle options  on the Items Ordered tab of the My Account order page. *Fix submitted by Vishal Gelani in pull request [19254](https://github.com/magento/magento2/pull/19254)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
 
-<!--- ENGCOM-3755-->* The email that customers receive after completing an order now contains tracking information for their order only. Previously, Magento included tracking information for other orders, too. *Fix submitted by Nazar in pull request [19981](https://github.com/magento/magento2/pull/19981)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
+<!--- ENGCOM-3755 -->
+*  The email that customers receive after completing an order now contains tracking information for their order only. Previously, Magento included tracking information for other orders, too. *Fix submitted by Nazar in pull request [19981](https://github.com/magento/magento2/pull/19981)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
 
 ### SalesArchive
 
-<!--- MAGETWO-96022-->* Archived orders no longer reappear in the Order Management table after cron runs.
+<!--- MAGETWO-96022 -->
+*  Archived orders no longer reappear in the Order Management table after cron runs.
 
 ### SalesRule
 
-<!--- MAGETWO-91522-->* The sales rule indexer now runs without error. Previously, the sales rule indexer  returned an error during reindexing because of the Magento_AdvancedSalesRule module.
+<!--- MAGETWO-91522 -->
+*  The sales rule indexer now runs without error. Previously, the sales rule indexer  returned an error during reindexing because of the Magento_AdvancedSalesRule module.
 
-<!--- ENGCOM-3773-->* The payment method option is now displayed under the shopping cart rules condition tab. Previously, when you navigated to **Marketing** > **Promotions** > **Cart Price Rules** and opened the Conditions tab on a rule, Magento did not display payment method options. *Fix submitted by p-bystritsky in pull request [20042](https://github.com/magento/magento2/pull/20042)*. [GitHub-12549](https://github.com/magento/magento2/issues/12549)
+<!--- ENGCOM-3773 -->
+*  The payment method option is now displayed under the shopping cart rules condition tab. Previously, when you navigated to **Marketing** > **Promotions** > **Cart Price Rules** and opened the Conditions tab on a rule, Magento did not display payment method options. *Fix submitted by p-bystritsky in pull request [20042](https://github.com/magento/magento2/pull/20042)*. [GitHub-12549](https://github.com/magento/magento2/issues/12549)
 
 ### Search
 
-<!--- MAGETWO-91742-->* The default sort order field now works as expected on the Catalog Search results page.
+<!--- MAGETWO-91742 -->
+*  The default sort order field now works as expected on the Catalog Search results page.
 
-<!--- MAGETWO-91537-->* Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group.
+<!--- MAGETWO-91537 -->
+*  Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group.
 
 <!--- MAGETWO-97235-->
 * Layered navigation for Elasticsearch now includes all product sizes. If the **Filterable (with results)** option is set for a product attribute, then:
@@ -1186,181 +1600,253 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 See [Filterable attributes](https://docs.magento.com/m2/ee/user_guide/catalog/navigation-layered-filterable-attributes.html) for more information.
 
-<!--- MAGETWO-67779-->* Full text search for Elasticsearch no longer includes the `date` attribute.
+<!--- MAGETWO-67779 -->
+*  Full text search for Elasticsearch no longer includes the `date` attribute.
 
-<!--- MAGETWO-97495-->* Layered navigation results no longer include price ranges that contain no products.
+<!--- MAGETWO-97495 -->
+*  Layered navigation results no longer include price ranges that contain no products.
 
-<!--- ENGCOM-3526-->* Magento now returns a customized layout handle when there are no results for a search. This customized layout handle supports the addition of custom blocks, which permits you to  change the layout of the No results page. *Fix submitted by Yevhenii Dumskyi in pull request [18069](https://github.com/magento/magento2/pull/18069)*. [GitHub-18038](https://github.com/magento/magento2/issues/18038)
+<!--- ENGCOM-3526 -->
+*  Magento now returns a customized layout handle when there are no results for a search. This customized layout handle supports the addition of custom blocks, which permits you to  change the layout of the No results page. *Fix submitted by Yevhenii Dumskyi in pull request [18069](https://github.com/magento/magento2/pull/18069)*. [GitHub-18038](https://github.com/magento/magento2/issues/18038)
 
-<!--- ENGCOM-4045-->* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar in pull request [20727](https://github.com/magento/magento2/pull/20727)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716), [GitHub-20689](https://github.com/magento/magento2/issues/20689), [GitHub-9988](https://github.com/magento/magento2/issues/9988)
+<!--- ENGCOM-4045 -->
+*  Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar in pull request [20727](https://github.com/magento/magento2/pull/20727)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716), [GitHub-20689](https://github.com/magento/magento2/issues/20689), [GitHub-9988](https://github.com/magento/magento2/issues/9988)
 
 ### Shipping
 
-<!--- ENGCOM-3148-->* Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by vaibhavahalpara in pull request [18507](https://github.com/magento/magento2/pull/18507)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+<!--- ENGCOM-3148 -->
+*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by vaibhavahalpara in pull request [18507](https://github.com/magento/magento2/pull/18507)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
-<!--- MAGETWO-96218-->* Shipments created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when a shipment was created using REST.
+<!--- MAGETWO-96218 -->
+*  Shipments created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when a shipment was created using REST.
 
-<!--- MAGETWO-91599-->* Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
+<!--- MAGETWO-91599 -->
+*  Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
 
-<!--- MAGETWO-91702-->* Magento now uses  shipping table rates from the correct store in multistore deployments.
+<!--- MAGETWO-91702 -->
+*  Magento now uses  shipping table rates from the correct store in multistore deployments.
 
-<!--- ENGCOM-3736-->* Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses. *Fix submitted by Govind Sharma in pull request [19941](https://github.com/magento/magento2/pull/19941)*. [GitHub-19940](https://github.com/magento/magento2/issues/19940)
+<!--- ENGCOM-3736 -->
+*  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses. *Fix submitted by Govind Sharma in pull request [19941](https://github.com/magento/magento2/pull/19941)*. [GitHub-19940](https://github.com/magento/magento2/issues/19940)
 
-<!--- ENGCOM-3960-->* Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!--- ENGCOM-3960 -->
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!--- MC-4245-->* Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method.
+<!--- MC-4245 -->
+*  Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method.
 
 ### Sitemap
 
-<!--- ENGCOM-3040-->* Sitemaps now display correct base URLs for multi-store deployments. *Fix submitted by Toan Nguyen in pull request [18228](https://github.com/magento/magento2/pull/18228)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+<!--- ENGCOM-3040 -->
+*  Sitemaps now display correct base URLs for multi-store deployments. *Fix submitted by Toan Nguyen in pull request [18228](https://github.com/magento/magento2/pull/18228)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Staging
 
-<!--- MAGETWO-91782-->* An administrator  with a custom (limited) role can now edit and schedule  updates to CMS content pages.
+<!--- MAGETWO-91782 -->
+*  An administrator  with a custom (limited) role can now edit and schedule  updates to CMS content pages.
 
-<!--- MAGETWO-91662-->* Shopping cart price is now updated as expected in staging preview mode.
+<!--- MAGETWO-91662 -->
+*  Shopping cart price is now updated as expected in staging preview mode.
 
-<!--- MAGETWO-91566-->* Restricted users with access to specified sections can now save a scheduled update. Previously, Magento threw a `forbidden` error.
+<!--- MAGETWO-91566 -->
+*  Restricted users with access to specified sections can now save a scheduled update. Previously, Magento threw a `forbidden` error.
 
-<!--- MAGETWO-91525-->* Updates containing zero objects are now removed as expected from the dashboard. Previously, Magento did not remove updates with zero objects.
+<!--- MAGETWO-91525 -->
+*  Updates containing zero objects are now removed as expected from the dashboard. Previously, Magento did not remove updates with zero objects.
 
-<!--- MAGETWO-96106-->* You can now successfully create a CMS static block and schedule it for a staging update. Previously, after the update, Magento displayed an empty container on top of the page instead of the CMS content block.
+<!--- MAGETWO-96106 -->
+*  You can now successfully create a CMS static block and schedule it for a staging update. Previously, after the update, Magento displayed an empty container on top of the page instead of the CMS content block.
 
-<!--- MAGETWO-95314-->* Magento no longer throws an error when you use REST to update a product's special price if the product previously had a scheduled update to its special price or had a special price set from the Admin.
+<!--- MAGETWO-95314 -->
+*  Magento no longer throws an error when you use REST to update a product's special price if the product previously had a scheduled update to its special price or had a special price set from the Admin.
 
 ### Store
 
-<!--- ENGCOM-1928-->* The switcher-option's link `Magento/Store/view/frontend/templates/switch/languages.phtml` template has been modified to support navigating back to previous pages. Previously, you could not navigate back to the previous store view when you clicked the **Back** button when viewing the store on Firefox.  *Fix submitted by Mobecls in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!--- ENGCOM-1928 -->
+*  The switcher-option's link `Magento/Store/view/frontend/templates/switch/languages.phtml` template has been modified to support navigating back to previous pages. Previously, you could not navigate back to the previous store view when you clicked the **Back** button when viewing the store on Firefox.  *Fix submitted by Mobecls in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
-<!--- ENGCOM-3408-->* You can now define the `root_category_id` in the project `config.php`. *Fix submitted by Lars Roettig in pull request [18958](https://github.com/magento/magento2/pull/18958)*. [GitHub-18956](https://github.com/magento/magento2/issues/18956)
+<!--- ENGCOM-3408 -->
+*  You can now define the `root_category_id` in the project `config.php`. *Fix submitted by Lars Roettig in pull request [18958](https://github.com/magento/magento2/pull/18958)*. [GitHub-18956](https://github.com/magento/magento2/issues/18956)
 
 ### Swatches
 
-<!--- ENGCOM-3360-->* Store views now show the correct swatch values. *Fix submitted by Malyovanets Nickolas in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
+<!--- ENGCOM-3360 -->
+*  Store views now show the correct swatch values. *Fix submitted by Malyovanets Nickolas in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
 
-<!--- MAGETWO-95310-->* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed.
+<!--- MAGETWO-95310 -->
+*  Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, wrong colors were randomly displayed.
 
-<!--- MAGETWO-59789-->* You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
+<!--- MAGETWO-59789 -->
+*  You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
 
-<!--- MAGETWO-94990-->* All thumbnail images reload as expected after you click on a configurable option when a configurable product detail page has more than fourteen thumbnail images. Previously, not all thumbnail images reloaded.
+<!--- MAGETWO-94990 -->
+*  All thumbnail images reload as expected after you click on a configurable option when a configurable product detail page has more than fourteen thumbnail images. Previously, not all thumbnail images reloaded.
 
-<!--- ENGCOM-3920-->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by Pieter Hoste in pull request [20421](https://github.com/magento/magento2/pull/20421)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+<!--- ENGCOM-3920 -->
+*  You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by Pieter Hoste in pull request [20421](https://github.com/magento/magento2/pull/20421)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
-<!--- ENGCOM-3943-->* Fixed styles on the Add Swatch page.
+<!--- ENGCOM-3943 -->
+*  Fixed styles on the Add Swatch page.
 
 ### TargetRule
 
-<!--- MAGETWO-91708-->* Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configuration** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
+<!--- MAGETWO-91708 -->
+*  Magento no longer throws an exception when Target Rules are set to a rotation mode other than **SHUFFLE**. (You can set rotation modes in **Admin** > **System** > **Configuration** > **Catalog** > **Catalog** > **Rule-Based Product Relations**.)
 
-<!--- MAGETWO-95708-->* Magento no longer throws a fatal error when price is used in a Target Rule for actions.
+<!--- MAGETWO-95708 -->
+*  Magento no longer throws a fatal error when price is used in a Target Rule for actions.
 
 ### Tax
 
-<!--- ENGCOM-3443-->* The **Not yet calculated** string for the tax field in the checkout page's summary section  can now be translated. *Fix submitted by p-bystritsky in pull request [19174](https://github.com/magento/magento2/pull/19174)*. [GitHub-18939](https://github.com/magento/magento2/issues/18939), [GitHub-7849](https://github.com/magento/magento2/issues/7849)
+<!--- ENGCOM-3443 -->
+*  The **Not yet calculated** string for the tax field in the checkout page's summary section  can now be translated. *Fix submitted by p-bystritsky in pull request [19174](https://github.com/magento/magento2/pull/19174)*. [GitHub-18939](https://github.com/magento/magento2/issues/18939), [GitHub-7849](https://github.com/magento/magento2/issues/7849)
 
-<!--- MAGETWO-91769-->* Credit memos now include only the taxes on the product itself as expected. Previously, the credit memo included the shipping tax as well even when shipping costs were not refunded.
+<!--- MAGETWO-91769 -->
+*  Credit memos now include only the taxes on the product itself as expected. Previously, the credit memo included the shipping tax as well even when shipping costs were not refunded.
 
-<!--- MAGETWO-91639-->* Tax is no longer added when a customer group is changed to **Valid VAT ID - Intra-Union**, which has no tax rules assigned to it.
+<!--- MAGETWO-91639 -->
+*  Tax is no longer added when a customer group is changed to **Valid VAT ID - Intra-Union**, which has no tax rules assigned to it.
 
-<!--- MAGETWO-91521-->* Tax reports now correctly calculate taxes for orders that are placed in a zip code that has two or more tax rates assigned.
+<!--- MAGETWO-91521 -->
+*  Tax reports now correctly calculate taxes for orders that are placed in a zip code that has two or more tax rates assigned.
 
-<!--- ENGCOM-3564-->* Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data. *Fix submitted by Nirav Kadiya in pull request [19387](https://github.com/magento/magento2/pull/19387)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
+<!--- ENGCOM-3564 -->
+*  Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data. *Fix submitted by Nirav Kadiya in pull request [19387](https://github.com/magento/magento2/pull/19387)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
 
 ### Testing
 
-<!--- ENGCOM-3036-->* Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by Pratik Oza in pull request [18201](https://github.com/magento/magento2/pull/18201)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+<!--- ENGCOM-3036 -->
+*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by Pratik Oza in pull request [18201](https://github.com/magento/magento2/pull/18201)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
-<!--- ENGCOM-3293-->* Unit test annotations now assert exception messages correctly. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
+<!--- ENGCOM-3293 -->
+*  Unit test annotations now assert exception messages correctly. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
 
 ### Theme
 
-<!--- ENGCOM-3296-->* You can now upload favicons and logo when editing headers for a store view. Previously, Magento threw an error. *Fix submitted by Wiard van Rijin pull request [18851](https://github.com/magento/magento2/pull/18851)*. [GitHub-18688](https://github.com/magento/magento2/issues/18688)
+<!--- ENGCOM-3296 -->
+*  You can now upload favicons and logo when editing headers for a store view. Previously, Magento threw an error. *Fix submitted by Wiard van Rijin pull request [18851](https://github.com/magento/magento2/pull/18851)*. [GitHub-18688](https://github.com/magento/magento2/issues/18688)
 
-<!--- MAGETWO-91723-->* The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
+<!--- MAGETWO-91723 -->
+*  The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
 
-<!--- MAGETWO-95805-->* The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
+<!--- MAGETWO-95805 -->
+*  The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
 
-<!--- MAGETWO-91651-->* We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
+<!--- MAGETWO-91651 -->
+*  We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
 
-<!--- MAGETWO-91756-->* Wishlist and compare links now appear for related products in portrait mode in mobile view.
+<!--- MAGETWO-91756 -->
+*  Wishlist and compare links now appear for related products in portrait mode in mobile view.
 
-<!--- MAGETWO-56094-->* Text now remains in the header area when you resize a page in deployments that are running in Internet Explorer.
+<!--- MAGETWO-56094 -->
+*  Text now remains in the header area when you resize a page in deployments that are running in Internet Explorer.
 
-<!--- ENGCOM-3669-->* Clicking on the store logo on the home page now reloads the page. *Fix submitted by gwharton in pull request [19198](https://github.com/magento/magento2/pull/19198)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
+<!--- ENGCOM-3669 -->
+*  Clicking on the store logo on the home page now reloads the page. *Fix submitted by gwharton in pull request [19198](https://github.com/magento/magento2/pull/19198)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
 
-<!--- ENGCOM-3871-->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by Ajay Ajabale in pull request [20195](https://github.com/magento/magento2/pull/20195)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
+<!--- ENGCOM-3871 -->
+*  Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by Ajay Ajabale in pull request [20195](https://github.com/magento/magento2/pull/20195)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
-<!--- ENGCOM-3640-->* Fixed alignment issue with sort results on list product page.  *Fix submitted by suryakant-krish in pull request [19640](https://github.com/magento/magento2/pull/19640)*. [GitHub-19639](https://github.com/magento/magento2/issues/19639)
+<!--- ENGCOM-3640 -->
+*  Fixed alignment issue with sort results on list product page.  *Fix submitted by suryakant-krish in pull request [19640](https://github.com/magento/magento2/pull/19640)*. [GitHub-19639](https://github.com/magento/magento2/issues/19639)
 
-<!--- ENGCOM-4033-->* The `alt` attribute on the logo image is now properly escaped. *Fix submitted by Erik Pellikka in pull request [19270](https://github.com/magento/magento2/pull/19270)*. [GitHub-19269](https://github.com/magento/magento2/issues/19269)
+<!--- ENGCOM-4033 -->
+*  The `alt` attribute on the logo image is now properly escaped. *Fix submitted by Erik Pellikka in pull request [19270](https://github.com/magento/magento2/pull/19270)*. [GitHub-19269](https://github.com/magento/magento2/issues/19269)
 
 ### Translation and locales
 
-<!--- ENGCOM-3423, 3375-->* Child themes now inherit translations from their parent theme as expected (`en_US.csv` translation dictionary). *Fix submitted by Vladyslav Podorozhnyi in pull request [19018](https://github.com/magento/magento2/pull/19018) and  [19144](https://github.com/magento/magento2/pull/19144)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
+<!--- ENGCOM-3423, 3375 -->
+*  Child themes now inherit translations from their parent theme as expected (`en_US.csv` translation dictionary). *Fix submitted by Vladyslav Podorozhnyi in pull request [19018](https://github.com/magento/magento2/pull/19018) and  [19144](https://github.com/magento/magento2/pull/19144)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
 
-<!--- ENGCOM-3461-->* Swedish (Finland) locales are now supported. *Fix submitted by p-bystritsky in pull request [19203](https://github.com/magento/magento2/pull/19203)*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
+<!--- ENGCOM-3461 -->
+*  Swedish (Finland) locales are now supported. *Fix submitted by p-bystritsky in pull request [19203](https://github.com/magento/magento2/pull/19203)*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
 
-<!--- ENGCOM-3345-->* The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file. *Fix submitted by Ayaz Mittaqi in pull request [18938](https://github.com/magento/magento2/pull/18938)*. [GitHub-18931](https://github.com/magento/magento2/issues/18931)
+<!--- ENGCOM-3345 -->
+*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file. *Fix submitted by Ayaz Mittaqi in pull request [18938](https://github.com/magento/magento2/pull/18938)*. [GitHub-18931](https://github.com/magento/magento2/issues/18931)
 
 ### UI
 
-<!--- ENGCOM-3300-->* Removed use of the `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!--- ENGCOM-3300 -->
+*  Removed use of the `escapeJS` method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!--- ENGCOM-3267-->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Ashutosh Srivastva in pull request [18790](https://github.com/magento/magento2/pull/18790)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+<!--- ENGCOM-3267 -->
+*  Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Ashutosh Srivastva in pull request [18790](https://github.com/magento/magento2/pull/18790)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
-<!--- ENGCOM-3463-->* Magento no longer includes not-yet-visible new orders on the Orders page when you select all orders for a mass action (such as update or cancelation). Previously, when you selected all orders on the Orders page for a mass action, any new order simultaneously being placed on the storefront was included in the mass action. *Fix submitted by Yevhenii Dumskyi in pull request [19204](https://github.com/magento/magento2/pull/19204)*. [GitHub-18983](https://github.com/magento/magento2/issues/18983)
+<!--- ENGCOM-3463 -->
+*  Magento no longer includes not-yet-visible new orders on the Orders page when you select all orders for a mass action (such as update or cancelation). Previously, when you selected all orders on the Orders page for a mass action, any new order simultaneously being placed on the storefront was included in the mass action. *Fix submitted by Yevhenii Dumskyi in pull request [19204](https://github.com/magento/magento2/pull/19204)*. [GitHub-18983](https://github.com/magento/magento2/issues/18983)
 
-<!--- ENGCOM-3381-->* You can now set default values for the WYSIWYG edit field for editing form UI components. *Fix submitted by Oleksandr Miroshnichenko in pull request [19048](https://github.com/magento/magento2/pull/19048)*. [GitHub-10048](https://github.com/magento/magento2/issues/10048)
+<!--- ENGCOM-3381 -->
+*  You can now set default values for the WYSIWYG edit field for editing form UI components. *Fix submitted by Oleksandr Miroshnichenko in pull request [19048](https://github.com/magento/magento2/pull/19048)*. [GitHub-10048](https://github.com/magento/magento2/issues/10048)
 
-<!--- ENGCOM-3330-->* The global search icon on the Admin is now correctly aligned. *Fix submitted by Kajal Solanki in pull request [18940](https://github.com/magento/magento2/pull/18940)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!--- ENGCOM-3330 -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by Kajal Solanki in pull request [18940](https://github.com/magento/magento2/pull/18940)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!--- ENGCOM-3037-->* Merchants can now change the currency symbol back to its default value from the Admin in single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by Pratik Oza in pull request [18204](https://github.com/magento/magento2/pull/18204)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
+<!--- ENGCOM-3037 -->
+*  Merchants can now change the currency symbol back to its default value from the Admin in single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by Pratik Oza in pull request [18204](https://github.com/magento/magento2/pull/18204)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
 
-<!--- MAGETWO-91751-->* Magento now correctly renders apostrophes as entered in text fields.
+<!--- MAGETWO-91751 -->
+*  Magento now correctly renders apostrophes as entered in text fields.
 
-<!--- ENGCOM-3106-->* Admin tables now work as expected when single-store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by gwharton in pull request [18405](https://github.com/magento/magento2/pull/18405)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
+<!--- ENGCOM-3106 -->
+*  Admin tables now work as expected when single-store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by gwharton in pull request [18405](https://github.com/magento/magento2/pull/18405)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
-<!--- MAGETWO-91496-->* WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
+<!--- MAGETWO-91496 -->
+*  WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
 
-<!--- ENGCOM-3509-->* Fixed incorrect display of the pager on the My Orders page. Previously, the pager obscured page links, which prevented customers from navigating to other pages. *Fix submitted by Kajal Solanki in pull request [19298](https://github.com/magento/magento2/pull/19298)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
+<!--- ENGCOM-3509 -->
+*  Fixed incorrect display of the pager on the My Orders page. Previously, the pager obscured page links, which prevented customers from navigating to other pages. *Fix submitted by Kajal Solanki in pull request [19298](https://github.com/magento/magento2/pull/19298)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
 
-<!--- ENGCOM-3371-->* Usage of unsupported includes has been removed. Previously, when you chose a user to edit on the customers grid, Magento installations running on Internet Explorer 11.x did not load the expected page, but instead displayed this message, `object does not support method includes`.  *Fix submitted by Oleksandr Miroshnichenko in pull request [19010](https://github.com/magento/magento2/pull/19010)*. [GitHub-18562](https://github.com/magento/magento2/issues/18562)
+<!--- ENGCOM-3371 -->
+*  Usage of unsupported includes has been removed. Previously, when you chose a user to edit on the customers grid, Magento installations running on Internet Explorer 11.x did not load the expected page, but instead displayed this message, `object does not support method includes`.  *Fix submitted by Oleksandr Miroshnichenko in pull request [19010](https://github.com/magento/magento2/pull/19010)*. [GitHub-18562](https://github.com/magento/magento2/issues/18562)
 
 ### URL rewrites
 
-<!--- MAGETWO-95539-->* The storefront now properly displays the order of categories when you move categories in the Admin.
+<!--- MAGETWO-95539 -->
+*  The storefront now properly displays the order of categories when you move categories in the Admin.
 
-<!--- MAGETWO-91531-->* Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
+<!--- MAGETWO-91531 -->
+*  Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
 
-<!--- ENGCOM-3925-->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by Ankur in pull request [20344](https://github.com/magento/magento2/pull/20344)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+<!--- ENGCOM-3925 -->
+*  The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by Ankur in pull request [20344](https://github.com/magento/magento2/pull/20344)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
 
 ### VAT
 
-<!--- ENGCOM-4108-->* Greek VAT numbers can now be validated. *Fix submitted by Pieter Hoste in pull request [20548](https://github.com/magento/magento2/pull/20548)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+<!--- ENGCOM-4108 -->
+*  Greek VAT numbers can now be validated. *Fix submitted by Pieter Hoste in pull request [20548](https://github.com/magento/magento2/pull/20548)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 ### Visual Merchandiser
 
-<!--- MAGETWO-91602-->* Visual Merchandiser now correctly sorts configurable product prices in Tile view.
+<!--- MAGETWO-91602 -->
+*  Visual Merchandiser now correctly sorts configurable product prices in Tile view.
 
 ### Web API
 
-<!--- MAGETWO-70532-->* The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
+<!--- MAGETWO-70532 -->
+*  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
-<!--- MAGETWO-69021-->* All extension attributes listed in the documentation for `salesOrderRepositoryV1` API are now available.
+<!--- MAGETWO-69021 -->
+*  All extension attributes listed in the documentation for `salesOrderRepositoryV1` API are now available.
 
-<!--- ENGCOM-3834-->* Access restrictions on the order API are now enforced as expected. Previously, adminstrators with restricted privileges had complete access to orders. *Fix submitted by Milind Singh in pull request [20170](https://github.com/magento/magento2/pull/20170)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
+<!--- ENGCOM-3834 -->
+*  Access restrictions on the order API are now enforced as expected. Previously, adminstrators with restricted privileges had complete access to orders. *Fix submitted by Milind Singh in pull request [20170](https://github.com/magento/magento2/pull/20170)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
 
 ### Wishlist
 
-<!--- MAGETWO-95311-->* Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
+<!--- MAGETWO-95311 -->
+*  Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
 
-<!--- MAGETWO-91667-->* You can now add a configurable product with no options  to a gift registry from a wishlist.
+<!--- MAGETWO-91667 -->
+*  You can now add a configurable product with no options  to a gift registry from a wishlist.
 
-<!--- ENGCOM-3922-->* You can now remove a comment from a wishlist product as expected. Previously, Magento did not remove the comment, even after you clicked **Update Wish List**. *Fix submitted by Khodu in pull request [20247](https://github.com/magento/magento2/pull/20247)*. [GitHub-20245](https://github.com/magento/magento2/issues/20245)
+<!--- ENGCOM-3922 -->
+*  You can now remove a comment from a wishlist product as expected. Previously, Magento did not remove the comment, even after you clicked **Update Wish List**. *Fix submitted by Khodu in pull request [20247](https://github.com/magento/magento2/pull/20247)*. [GitHub-20245](https://github.com/magento/magento2/issues/20245)
 
-<!--- ENGCOM-3912-->* Corrected misalignment of the Edit and remove item links on the wish list page when displayed  on a screen with a resolution of 640 x 767. *Fix submitted by Nainesh Waghale in pull request [20400](https://github.com/magento/magento2/pull/20400)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
+<!--- ENGCOM-3912 -->
+*  Corrected misalignment of the Edit and remove item links on the wish list page when displayed  on a screen with a resolution of 640 x 767. *Fix submitted by Nainesh Waghale in pull request [20400](https://github.com/magento/magento2/pull/20400)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
 
-<!--- ENGCOM-3569-->* Pagination controls on the wishlist page have been restored. *Fix submitted by Ratnesh Kumar in pull request [19305](https://github.com/magento/magento2/pull/19305)*. [GitHub-19292](https://github.com/magento/magento2/issues/19292)
+<!--- ENGCOM-3569 -->
+*  Pagination controls on the wishlist page have been restored. *Fix submitted by Ratnesh Kumar in pull request [19305](https://github.com/magento/magento2/pull/19305)*. [GitHub-19292](https://github.com/magento/magento2/issues/19292)
 
 ## Known issues
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
@@ -177,27 +177,38 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Installation, upgrade, deployment
 
-<!--- ENGCOM-3291-->* Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by Fabian Schmengler in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
+<!--- ENGCOM-3291 -->
+*  Magento now sets the `id_prefix` option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.  *Fix submitted by Fabian Schmengler in pull request [18641](https://github.com/magento/magento2/pull/18641)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 
-<!--- ENGCOM-3059-->* The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by Pratik Oza in pull request [18295](https://github.com/magento/magento2/pull/18295)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
+<!--- ENGCOM-3059 -->
+*  The `./bin/magento config:show` command no longer fails with a fatal error after you run `./bin/magento app:config:dump`. *Fix submitted by Pratik Oza in pull request [18295](https://github.com/magento/magento2/pull/18295)*. [GitHub-17582](https://github.com/magento/magento2/issues/17582)
 
-<!--- MAGETWO-96428-->* The `bin/magento app:config:dump` command now disables all input fields as expected.
+<!--- MAGETWO-96428 -->
+*  The `bin/magento app:config:dump` command now disables all input fields as expected.
 
-<!--- ENGCOM-3280-->* Administrators that have been assigned a backup module role resource can now access the backup controller as expected. s*Fix submitted by Mahesh Singh in pull request [18816](https://github.com/magento/magento2/pull/18816)*. [GitHub-18150](https://github.com/magento/magento2/issues/18150)
+<!--- ENGCOM-3280 -->
+*  Administrators that have been assigned a backup module role resource can now access the backup controller as expected. s*Fix submitted by Mahesh Singh in pull request [18816](https://github.com/magento/magento2/pull/18816)*. [GitHub-18150](https://github.com/magento/magento2/issues/18150)
 
-<!--- ENGCOM-3160-->* The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by Logan Stellway in pull request [18393](https://github.com/magento/magento2/pull/18393)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
+<!--- ENGCOM-3160 -->
+*  The `getHostUrl()` method has been updated to reference `HTTP_HOST` rather than `SERVER_PORT`. *Fix submitted by Logan Stellway in pull request [18393](https://github.com/magento/magento2/pull/18393)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
 
-<!--- MAGETWO-96107-->* Magento no longer displays an extraneous blank option in the country drop-down menu.
+<!--- MAGETWO-96107 -->
+*  Magento no longer displays an extraneous blank option in the country drop-down menu.
 
-<!--- MAGETWO-91764-->* The front-end  now  uses HTTPS exclusively and back-end  uses HTTP without resulting in excessive redirects.
+<!--- MAGETWO-91764 -->
+*  The front-end  now  uses HTTPS exclusively and back-end  uses HTTP without resulting in excessive redirects.
 
-<!--- ENGCOM-3786-->* The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, administrators were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by Mahesh Singh in pull request [19880](https://github.com/magento/magento2/pull/19880)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
+<!--- ENGCOM-3786 -->
+*  The `config:set --lock-config` command  now acts as expected on all scopes. Previously, after this command was run, administrators were not able to change the configuration for the default store, but could still change it for other scopes. *Fix submitted by Mahesh Singh in pull request [19880](https://github.com/magento/magento2/pull/19880)*. [GitHub-19609](https://github.com/magento/magento2/issues/19609)
 
-<!--- ENGCOM-3701-->* Magento now skips disabled modules  when compiling static content. *Fix submitted by Shikha Mishra in pull request [19751](https://github.com/magento/magento2/pull/19751)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
+<!--- ENGCOM-3701 -->
+*  Magento now skips disabled modules  when compiling static content. *Fix submitted by Shikha Mishra in pull request [19751](https://github.com/magento/magento2/pull/19751)*. [GitHub-19605](https://github.com/magento/magento2/issues/19605)
 
-<!--- MC-5620-->* The `bin/magento setup:upgrade --convert-old-scripts=1` command now supports the conversion of indexes and constraints.
+<!--- MC-5620 -->
+*  The `bin/magento setup:upgrade --convert-old-scripts=1` command now supports the conversion of indexes and constraints.
 
-<!--- MC-6275-->* The commands to enable and disable debug logging have changed to `bin/magento setup:config:set --enable-debug-logging=true | false`. The previous commands, `bin/magento config:set dev/debug/debug_logging 0 | 1` are no longer supported.  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
+<!--- MC-6275 -->
+*  The commands to enable and disable debug logging have changed to `bin/magento setup:config:set --enable-debug-logging=true | false`. The previous commands, `bin/magento config:set dev/debug/debug_logging 0 | 1` are no longer supported.  See [Logging]({{ page.baseurl }}/config-guide/cli/logging.html).
 
 <!--- MC-1364-->
 
@@ -205,642 +216,924 @@ We've fixed hundreds of issues in the Magento 2.3.1 core code.
 
 ### Analytics
 
-<!--- ENGCOM-3263 -->* You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by Pratik Oza in pull request [18782](https://github.com/magento/magento2/pull/18782)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
+<!--- ENGCOM-3263  -->
+*  You can now save configuration from the **Admin**  > **Stores** > **Configuration** > **General** > **Advanced Reporting** without providing an industry value. Previously, Magento did not save configuration settings, and displayed this error:  `Please select a vertical.` *Fix submitted by Pratik Oza in pull request [18782](https://github.com/magento/magento2/pull/18782)*. [GitHub-15259](https://github.com/magento/magento2/issues/15259)
 
 ### Authorization
 
-<!--- MAGETWO-95536-->* You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
+<!--- MAGETWO-95536 -->
+*  You can now successfully save a role from the Admin. Previously, when you saved a role from the Admin, Magento removed all  users from the role (no matter which checkbox was checked), and displayed this message, `This user has no tokens`.
 
 ### Backend
 
-<!--- ENGCOM-3655-->* `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by Tegan Elizabeth Bold in pull request [19620](https://github.com/magento/magento2/pull/19620)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
+<!--- ENGCOM-3655 -->
+*  `CustomerRepository::getList()` now loads custom attributes named `company`. *Fix submitted by Tegan Elizabeth Bold in pull request [19620](https://github.com/magento/magento2/pull/19620)*. [GitHub-17759](https://github.com/magento/magento2/issues/17759)
 
-<!--- ENGCOM-3561-->* Fixed icon behavior on product customization page. *Fix submitted by Kajal Solanki in pull request [19405](https://github.com/magento/magento2/pull/19405)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
+<!--- ENGCOM-3561 -->
+*  Fixed icon behavior on product customization page. *Fix submitted by Kajal Solanki in pull request [19405](https://github.com/magento/magento2/pull/19405)*. [GitHub-19399](https://github.com/magento/magento2/issues/19399)
 
-<!--- ENGCOM-4054-->* The **Reload Data** button on the Admin now works as expected. *Fix submitted by Eduard Chitoraga in pull request [20803](https://github.com/magento/magento2/pull/20803)*. [GitHub-20802](https://github.com/magento/magento2/issues/20802)
+<!--- ENGCOM-4054 -->
+*  The **Reload Data** button on the Admin now works as expected. *Fix submitted by Eduard Chitoraga in pull request [20803](https://github.com/magento/magento2/pull/20803)*. [GitHub-20802](https://github.com/magento/magento2/issues/20802)
 
 ### Bundle
 
-<!--- ENGCOM-3361 -->* Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!--- ENGCOM-3361  -->
+*  Bundle special prices are now correctly rounded when you load and resave a bundle product. Previously, when you reloaded a bundle with a special price that requires four positions after the decimal (for example, 78,9473), Magento rounded the price to two decimal places. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!--- ENGCOM-3391 -->* The Bundle Product Option Repository Delete method now removes the correct option. Previously, it removed the first option, regardless of the `optionId` that was specified. *Fix submitted by Burlacu Vasilii in pull request [19027](https://github.com/magento/magento2/pull/19027)*. [GitHub-18979](https://github.com/magento/magento2/issues/18979)
+<!--- ENGCOM-3391  -->
+*  The Bundle Product Option Repository Delete method now removes the correct option. Previously, it removed the first option, regardless of the `optionId` that was specified. *Fix submitted by Burlacu Vasilii in pull request [19027](https://github.com/magento/magento2/pull/19027)*. [GitHub-18979](https://github.com/magento/magento2/issues/18979)
 
-<!--- ENGCOM-3161 MAGETWO-69959 -->* Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by Vishal Gelani in pull request [18520](https://github.com/magento/magento2/pull/18520)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
+<!--- ENGCOM-3161 MAGETWO-69959  -->
+*  Magento no longer overwrites user-defined option quantities with default values when a customer edits a bundle product from a shopping cart. *Fix submitted by Vishal Gelani in pull request [18520](https://github.com/magento/magento2/pull/18520)*. [GitHub-4942](https://github.com/magento/magento2/issues/4942)
 
-<!--- MAGETWO-58212-->* You can now successfully change the attribute set for a bundle product. Previously, the edit bundle page hung, and Magento threw this error, `Uncaught TypeError: Cannot read property 'length' of undefined`. [GitHub-5999](https://github.com/magento/magento2/issues/5999)
+<!--- MAGETWO-58212 -->
+*  You can now successfully change the attribute set for a bundle product. Previously, the edit bundle page hung, and Magento threw this error, `Uncaught TypeError: Cannot read property 'length' of undefined`. [GitHub-5999](https://github.com/magento/magento2/issues/5999)
 
-<!--- MAGETWO-91628-->* Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
+<!--- MAGETWO-91628 -->
+*  Magento now maintains the correct base price for a bundle product when you add a bundle product in one currency and then add the same bundle product option in a different currency. Previously, when you added the same bundle product option in a different currency, Magento doubled the base price.
 
-<!--- MAGETWO-91679-->* Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product. [GitHub-14262](https://github.com/magento/magento2/issues/14262)
+<!--- MAGETWO-91679 -->
+*  Bundle product SKUs are now built based on the order of the associated (selected) product ID numbers in ascending order. Previously, SKUs were built based on the order of the selected product ID numbers in ascending order instead of the order in which the option is added to the bundle product. [GitHub-14262](https://github.com/magento/magento2/issues/14262)
 
-<!--- ENGCOM-3487 3585-->* Magento now adds all selected values to the cart when a customer adds a bundle product option with input type checkbox. Previously, if a bundle product had three values, Magento added only two options to the cart. *Fix submitted by Mahesh Singh in pull request [19261](https://github.com/magento/magento2/pull/19261) and pull request [19437](https://github.com/magento/magento2/pull/19437)*. [GitHub-19205](https://github.com/magento/magento2/issues/19205)
+<!--- ENGCOM-3487 3585 -->
+*  Magento now adds all selected values to the cart when a customer adds a bundle product option with input type checkbox. Previously, if a bundle product had three values, Magento added only two options to the cart. *Fix submitted by Mahesh Singh in pull request [19261](https://github.com/magento/magento2/pull/19261) and pull request [19437](https://github.com/magento/magento2/pull/19437)*. [GitHub-19205](https://github.com/magento/magento2/issues/19205)
 
-<!--- ENGCOM-3605-->* Fixed inconsistently sized title box border on the edit bundle product page when adding an item to a bundle product from the Admin. *Fix submitted by Abrar Pathan in pull request [19510](https://github.com/magento/magento2/pull/19510)*. [GitHub-19509](https://github.com/magento/magento2/issues/19509)
+<!--- ENGCOM-3605 -->
+*  Fixed inconsistently sized title box border on the edit bundle product page when adding an item to a bundle product from the Admin. *Fix submitted by Abrar Pathan in pull request [19510](https://github.com/magento/magento2/pull/19510)*. [GitHub-19509](https://github.com/magento/magento2/issues/19509)
 
-<!--- MAGETWO-97617-->* You can now add a bundle product to a requisition list from the category page. Previously, Magento threw this error, `PHP Fatal error: Uncaught Error: Call to a member function getParentProductId() on string in app/code/Magento/RequisitionList/Model/RequisitionListItem/Options/Builder.php:118`.
+<!--- MAGETWO-97617 -->
+*  You can now add a bundle product to a requisition list from the category page. Previously, Magento threw this error, `PHP Fatal error: Uncaught Error: Call to a member function getParentProductId() on string in app/code/Magento/RequisitionList/Model/RequisitionListItem/Options/Builder.php:118`.
 
 ### CAPTCHA
 
-<!--- MAGETWO-94052-->* CAPTCHA now appears as expected in the Log in pop-up window.
+<!--- MAGETWO-94052 -->
+*  CAPTCHA now appears as expected in the Log in pop-up window.
 
 ### Cart and checkout
 
-<!--- ENGCOM-3194 -->* Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by Mahesh Singh in pull request [18631](https://github.com/magento/magento2/pull/18631)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
+<!--- ENGCOM-3194  -->
+*  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by Mahesh Singh in pull request [18631](https://github.com/magento/magento2/pull/18631)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
-<!--- ENGCOM-3237 -->* Custom shipping methods in custom carrier code can now include underscores. *Fix submitted by Jakub in pull request [18689](https://github.com/magento/magento2/pull/18689)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
+<!--- ENGCOM-3237  -->
+*  Custom shipping methods in custom carrier code can now include underscores. *Fix submitted by Jakub in pull request [18689](https://github.com/magento/magento2/pull/18689)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
 
-<!--- ENGCOM-3073 -->* Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by Ihor Sviziev in pull request [18331](https://github.com/magento/magento2/pull/18331)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
+<!--- ENGCOM-3073  -->
+*  Magento no longer displays the infinite loading indicator when an error occurs during check out. *Fix submitted by Ihor Sviziev in pull request [18331](https://github.com/magento/magento2/pull/18331)*. [GitHub-18330](https://github.com/magento/magento2/issues/18330)
 
-<!--- ENGCOM-3189 -->* The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by Luuk Schakenraad in pull request [18596](https://github.com/magento/magento2/pull/18596)*. [GitHub-18475](https://github.com/magento/magento2/issues/18475), [GitHub-18589](https://github.com/magento/magento2/issues/18589)
+<!--- ENGCOM-3189  -->
+*  The **Clear shopping cart** button now works as expected. Previously, the page reloaded, but the shopping cart was not cleared. *Fix submitted by Luuk Schakenraad in pull request [18596](https://github.com/magento/magento2/pull/18596)*. [GitHub-18475](https://github.com/magento/magento2/issues/18475), [GitHub-18589](https://github.com/magento/magento2/issues/18589)
 
-<!--- ENGCOM-2987 -->* Magento now dispatches a `checkout_cart_product_add_before` event in addition to a `checkout_cart_product_add_after` event. *Fix submitted by Leandro Rosa in pull request [18080](https://github.com/magento/magento2/pull/18080)*. [GitHub-17830](https://github.com/magento/magento2/issues/17830)
+<!--- ENGCOM-2987  -->
+*  Magento now dispatches a `checkout_cart_product_add_before` event in addition to a `checkout_cart_product_add_after` event. *Fix submitted by Leandro Rosa in pull request [18080](https://github.com/magento/magento2/pull/18080)*. [GitHub-17830](https://github.com/magento/magento2/issues/17830)
 
-<!--- MAGETWO-95935-->* Customer address attribute validation during checkout now permits spaces.
+<!--- MAGETWO-95935 -->
+*  Customer address attribute validation during checkout now permits spaces.
 
-<!--- MAGETWO-96812-->* Clicking multiple times on the mini cart icon no longer logs out the current customer. Previously, when a logged-in customer added a product to the cart and then clicked the shopping cart icon multiple times, Magento displayed an empty shopping cart and logged out the customer.
+<!--- MAGETWO-96812 -->
+*  Clicking multiple times on the mini cart icon no longer logs out the current customer. Previously, when a logged-in customer added a product to the cart and then clicked the shopping cart icon multiple times, Magento displayed an empty shopping cart and logged out the customer.
 
-<!--- MAGETWO-95848-->* Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
+<!--- MAGETWO-95848 -->
+*  Customers can now configure options for a configurable product after adding it to their shopping cart.  Previously, under these circumstances, Magento threw a fatal error.
 
-<!--- MAGETWO-95739-->* Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
+<!--- MAGETWO-95739 -->
+*  Magento now validates zip codes for new addresses as expected when the **My billing and shipping address are the same** option is unchecked.
 
-<!--- MAGETWO-94427-->* Magento now updates the mini cart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
+<!--- MAGETWO-94427 -->
+*  Magento now updates the mini cart as expected when an administrator updates the product from the Admin. Previously, if a product that had been added to the shopping cart was subsequently disabled from the Admin,  the product was still displayed in the cart.
 
-<!--- MAGETWO-91658-->* Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
+<!--- MAGETWO-91658 -->
+*  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
 
-<!--- MAGETWO-91530-->* Magento now displays informative error messages when an order paid for with Authorize.Net fails.
+<!--- MAGETWO-91530 -->
+*  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
 
-<!--- MAGETWO-71375-->* Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
+<!--- MAGETWO-71375 -->
+*  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
-<!--- MAGETWO-91730-->* Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
+<!--- MAGETWO-91730 -->
+*  Expired gift cards are no longer applied to a customer's account. Previously, if a gift card applied to a customer account expired, Magento could not complete the checkout process.
 
-<!--- MAGETWO-91517-->* Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
+<!--- MAGETWO-91517 -->
+*  Magento no longer removes the billing and shipping address information for an order when a customer cancels an order by clicking **Cancel and Return** when  using PayPal Website Payments Pro Hosted Solution. Previously, when a customer placed an order and then clicked the **Cancel and Return** link, Magento removed the billing/shipping address and displayed an error.
 
-<!--- MAGETWO-91596-->* You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
+<!--- MAGETWO-91596 -->
+*  You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
-<!--- MAGETWO-91733-->* After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the mini cart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
+<!--- MAGETWO-91733 -->
+*  After a session expires, and a customer refreshes the page, Magento displays an empty shopping cart and logs out the customer as expected. Previously, Magento displayed an empty shopping cart but the mini cart still displayed the selected items, and if the customer refreshed the page again, the shopping cart displayed the items.
 
-<!--- MAGETWO-91636-->* Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+<!--- MAGETWO-91636 -->
+*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
-<!--- ENGCOM-3578-->* `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed. *Fix submitted by Dmytro Cheshun in pull request [19425](https://github.com/magento/magento2/pull/19425)*. [GitHub-19424](https://github.com/magento/magento2/issues/19424)
+<!--- ENGCOM-3578 -->
+*  `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` now updates the checkout session quote ID as needed. *Fix submitted by Dmytro Cheshun in pull request [19425](https://github.com/magento/magento2/pull/19425)*. [GitHub-19424](https://github.com/magento/magento2/issues/19424)
 
-<!--- ENGCOM-3386-->* Magento now validates shipping address of a logged-in user using the default shipping address during checkout. *Fix submitted by StasKozar in pull request [19038](https://github.com/magento/magento2/pull/19038)*. [GitHub-18990](https://github.com/magento/magento2/issues/18990)
+<!--- ENGCOM-3386 -->
+*  Magento now validates shipping address of a logged-in user using the default shipping address during checkout. *Fix submitted by StasKozar in pull request [19038](https://github.com/magento/magento2/pull/19038)*. [GitHub-18990](https://github.com/magento/magento2/issues/18990)
 
-<!--- ENGCOM-3971-->* Fixed issue displaying numbers than exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by Parag Chavare in pull request [20612](https://github.com/magento/magento2/pull/20612)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+<!--- ENGCOM-3971 -->
+*  Fixed issue displaying numbers than exceed two digits in the **Qty:** box of the **Proceed to Checkout** pop up. *Fix submitted by Parag Chavare in pull request [20612](https://github.com/magento/magento2/pull/20612)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
 
-<!--- ENGCOM-3864-->* Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by Arvinda Kumar in pull request [20306](https://github.com/magento/magento2/pull/20306)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+<!--- ENGCOM-3864 -->
+*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by Arvinda Kumar in pull request [20306](https://github.com/magento/magento2/pull/20306)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
-<!--- ENGCOM-4019-->* Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Govind Sharma in pull request [20634](https://github.com/magento/magento2/pull/20634)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+<!--- ENGCOM-4019 -->
+*  Magento no longer throws a console error during a guest checkout when the list of allowed countries is changed from the Admin. *Fix submitted by Govind Sharma in pull request [20634](https://github.com/magento/magento2/pull/20634)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
-<!--- ENGCOM-4032-->* The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by Yashwant Rokde in pull request [20428](https://github.com/magento/magento2/pull/20428)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+<!--- ENGCOM-4032 -->
+*  The title of the shipping method no longer overlaps with **Edit** on the checkout page. *Fix submitted by Yashwant Rokde in pull request [20428](https://github.com/magento/magento2/pull/20428)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
-<!--- ENGCOM-3984-->* The **Close** button on the mini cart now longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20615](https://github.com/magento/magento2/pull/20615)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
+<!--- ENGCOM-3984 -->
+*  The **Close** button on the mini cart now longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20615](https://github.com/magento/magento2/pull/20615)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
 
-<!--- ENGCOM-3818-->* Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by Arvinda Kumar in pull request [20144](https://github.com/magento/magento2/pull/20144)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+<!--- ENGCOM-3818 -->
+*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by Arvinda Kumar in pull request [20144](https://github.com/magento/magento2/pull/20144)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
-<!--- MAGETWO-95312-->* Fixed mini cart layout issues.
+<!--- MAGETWO-95312 -->
+*  Fixed mini cart layout issues.
 
-<!--- MAGETWO-97968-->* The mini cart is now updated as expected when a product in the cart is disabled.
+<!--- MAGETWO-97968 -->
+*  The mini cart is now updated as expected when a product in the cart is disabled.
 
-<!--- ENGCOM-3153 -->* Magento no longer displays a console error when a customer selects one-step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
+<!--- ENGCOM-3153  -->
+*  Magento no longer displays a console error when a customer selects one-step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
 
-<!--- ENGCOM-3938 -->* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by ranee2jcommerce in pull request [20488](https://github.com/magento/magento2/pull/20488)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+<!--- ENGCOM-3938  -->
+*  Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by ranee2jcommerce in pull request [20488](https://github.com/magento/magento2/pull/20488)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
 
 ### Cart Price rules
 
-<!--- MAGETWO-96379 -->* The Cart Price Rule page now displays correct counter values for the grid and accurate pagination.
+<!--- MAGETWO-96379  -->
+*  The Cart Price Rule page now displays correct counter values for the grid and accurate pagination.
 
-<!--- MAGETWO-91784-->* Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+<!--- MAGETWO-91784 -->
+*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
 ### Catalog
 
-<!--- ENGCOM-3516 -->* Magento now displays the product page with this message `You need to choose options for your item` when you click **Add to cart** for a new product that has an attribute with the **Use in product listing** property set to **Yes**. Previously, Magento redirected the user to the cart page, and did not add the product to the cart. *Fix submitted by Vishal Gelani in pull request [19322](https://github.com/magento/magento2/pull/19322)*. [GitHub-19315](https://github.com/magento/magento2/issues/19315)
+<!--- ENGCOM-3516  -->
+*  Magento now displays the product page with this message `You need to choose options for your item` when you click **Add to cart** for a new product that has an attribute with the **Use in product listing** property set to **Yes**. Previously, Magento redirected the user to the cart page, and did not add the product to the cart. *Fix submitted by Vishal Gelani in pull request [19322](https://github.com/magento/magento2/pull/19322)*. [GitHub-19315](https://github.com/magento/magento2/issues/19315)
 
-<!--- ENGCOM-3435 -->* Magento now directs the user to a 404 page when accessing http://www.domain.com/catalog/product/compare. Previously, Magento threw this error, `Fatal error: Uncaught Error: Cannot call abstract method Magento\Framework\App\ActionInterface::execute()`. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
+<!--- ENGCOM-3435  -->
+*  Magento now directs the user to a 404 page when accessing http://www.domain.com/catalog/product/compare. Previously, Magento threw this error, `Fatal error: Uncaught Error: Cannot call abstract method Magento\Framework\App\ActionInterface::execute()`. *Fix submitted by p-bystritsky in pull request [18987](https://github.com/magento/magento2/pull/18987)*. [GitHub-17638](https://github.com/magento/magento2/issues/17638)
 
-<!--- ENGCOM-3450 -->* Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by Torben Höhn in pull request [19179](https://github.com/magento/magento2/pull/19179)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
+<!--- ENGCOM-3450  -->
+*  Magento now correctly calculates fixed tier price discount for products with special prices. *Fix submitted by Torben Höhn in pull request [19179](https://github.com/magento/magento2/pull/19179)*. [GitHub-18652](https://github.com/magento/magento2/issues/18652)
 
-<!--- ENGCOM-3421-->* Magento no longer throws an exception when you try to add an image to a product programmatically. *Fix submitted by Yevhenii Dumskyi in pull request [18952](https://github.com/magento/magento2/pull/18952)*. [GitHub-6803](https://github.com/magento/magento2/issues/6803)
+<!--- ENGCOM-3421 -->
+*  Magento no longer throws an exception when you try to add an image to a product programmatically. *Fix submitted by Yevhenii Dumskyi in pull request [18952](https://github.com/magento/magento2/pull/18952)*. [GitHub-6803](https://github.com/magento/magento2/issues/6803)
 
-<!--- ENGCOM-3365-->* Magento now applies the translations for the selected theme when you enable a custom design theme. Previously, Magento collected the translation files for the active main theme only, which limited the use of different translations within the additional theme. *Fix submitted by Cezary Zeglen in pull request [18998](https://github.com/magento/magento2/pull/18998)*. [GitHub-17625](https://github.com/magento/magento2/issues/17625)
+<!--- ENGCOM-3365 -->
+*  Magento now applies the translations for the selected theme when you enable a custom design theme. Previously, Magento collected the translation files for the active main theme only, which limited the use of different translations within the additional theme. *Fix submitted by Cezary Zeglen in pull request [18998](https://github.com/magento/magento2/pull/18998)*. [GitHub-17625](https://github.com/magento/magento2/issues/17625)
 
-<!--- ENGCOM-3292-->* The `bin/magento catalog:images:resize` command now processes all specified images. *Fix submitted by Vladyslav Podorozhnyi in pull request [18807](https://github.com/magento/magento2/pull/18807)*. [GitHub-18387](https://github.com/magento/magento2/issues/18387)
+<!--- ENGCOM-3292 -->
+*  The `bin/magento catalog:images:resize` command now processes all specified images. *Fix submitted by Vladyslav Podorozhnyi in pull request [18807](https://github.com/magento/magento2/pull/18807)*. [GitHub-18387](https://github.com/magento/magento2/issues/18387)
 
-<!--- ENGCOM-3184-->* You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`. *Fix submitted by Hiren Pandya in pull request [18578](https://github.com/magento/magento2/pull/18578)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+<!--- ENGCOM-3184 -->
+*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw this error, `Special price date from" Failed to parse time string`. *Fix submitted by Hiren Pandya in pull request [18578](https://github.com/magento/magento2/pull/18578)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
 
-<!--- ENGCOM-3242-->* You can now insert multiple catalog product list widgets into a CMS page. *Fix submitted by Burlacu Vasilii in pull request [18714](https://github.com/magento/magento2/pull/18714)*. [GitHub-4468](https://github.com/magento/magento2/issues/4468)
+<!--- ENGCOM-3242 -->
+*  You can now insert multiple catalog product list widgets into a CMS page. *Fix submitted by Burlacu Vasilii in pull request [18714](https://github.com/magento/magento2/pull/18714)*. [GitHub-4468](https://github.com/magento/magento2/issues/4468)
 
-<!--- ENGCOM-3202-->* You can now use REST to add a new attribute and configure it with settings such as `is_filterable`. *Fix submitted by Mr. Lewis in pull request [18622](https://github.com/magento/magento2/pull/18622)*. [GitHub-10205](https://github.com/magento/magento2/issues/10205)
+<!--- ENGCOM-3202 -->
+*  You can now use REST to add a new attribute and configure it with settings such as `is_filterable`. *Fix submitted by Mr. Lewis in pull request [18622](https://github.com/magento/magento2/pull/18622)*. [GitHub-10205](https://github.com/magento/magento2/issues/10205)
 
-<!--- ENGCOM-2998-->* Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by Bartosz Kubicki in pull request [18019](https://github.com/magento/magento2/pull/18019)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
+<!--- ENGCOM-2998 -->
+*  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by Bartosz Kubicki in pull request [18019](https://github.com/magento/magento2/pull/18019)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
-<!--- ENGCOM-3180-->* Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by Vishal Gelani in pull request [18570](https://github.com/magento/magento2/pull/18570)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
+<!--- ENGCOM-3180 -->
+*  Magento no longer changes the attribute type of `backend_type` from `varchar` to `int` when the product associated with the attribute is saved or updated in the Admin. *Fix submitted by Vishal Gelani in pull request [18570](https://github.com/magento/magento2/pull/18570)*. [GitHub-9219](https://github.com/magento/magento2/issues/9219)
 
-<!--- ENGCOM-3142-->* The table rate shipping method no longer fails to return a quote when a customer uses a United States  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by Vishal Gelani in pull request [18499](https://github.com/magento/magento2/pull/18499)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
+<!--- ENGCOM-3142 -->
+*  The table rate shipping method no longer fails to return a quote when a customer uses a United States  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by Vishal Gelani in pull request [18499](https://github.com/magento/magento2/pull/18499)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
 
-<!--- ENGCOM-3129-->* You can now set a Boolean attribute to is_filterable, which allows these attributes to be included in layered navigation. *Fix submitted by Mr. Lewis in pull request [18434](https://github.com/magento/magento2/pull/18434)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
+<!--- ENGCOM-3129 -->
+*  You can now set a Boolean attribute to is_filterable, which allows these attributes to be included in layered navigation. *Fix submitted by Mr. Lewis in pull request [18434](https://github.com/magento/magento2/pull/18434)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283)
 
-<!--- ENGCOM-3047-->* `getStoreId()` now consistently returns `int`. Previously, Magento returned `string` for products but `int` for categories, which resulted in a fatal error. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!--- ENGCOM-3047 -->
+*  `getStoreId()` now consistently returns `int`. Previously, Magento returned `string` for products but `int` for categories, which resulted in a fatal error. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!--- ENGCOM-3055-->* `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by Jay Ghosh in pull request [18149](https://github.com/magento/magento2/pull/18149)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+<!--- ENGCOM-3055 -->
+*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by Jay Ghosh in pull request [18149](https://github.com/magento/magento2/pull/18149)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
-<!--- ENGCOM-3035-->* Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by Pieter Hoste in pull request [18207](https://github.com/magento/magento2/pull/18207)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720)
+<!--- ENGCOM-3035 -->
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by Pieter Hoste in pull request [18207](https://github.com/magento/magento2/pull/18207)*. [GitHub-13720](https://github.com/magento/magento2/issues/13720)
 
-<!--- ENGCOM-3034-->* The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by Pratik Oza in pull request [18205](https://github.com/magento/magento2/pull/18205)*. [GitHub-17780](https://github.com/magento/magento2/issues/17780)
+<!--- ENGCOM-3034 -->
+*  The `bin/magento module:uninstall` command  now works as expected with Composer. Previously, there was a discrepancy between `composer.lock` and `composer.json` when this command was used to remove a module. *Fix submitted by Pratik Oza in pull request [18205](https://github.com/magento/magento2/pull/18205)*. [GitHub-17780](https://github.com/magento/magento2/issues/17780)
 
-<!--- ENGCOM-3061-->* `getStoreId()` now consistently returns `int`. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
+<!--- ENGCOM-3061 -->
+*  `getStoreId()` now consistently returns `int`. *Fix submitted by sv3n in pull request [18303](https://github.com/magento/magento2/pull/18303)*. [GitHub-18079](https://github.com/magento/magento2/issues/18079)
 
-<!--- ENGCOM-3078-->* You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by Eduard Chitoraga in pull request [18210](https://github.com/magento/magento2/pull/18210)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
+<!--- ENGCOM-3078 -->
+*  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by Eduard Chitoraga in pull request [18210](https://github.com/magento/magento2/pull/18210)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
 
-<!--- MAGETWO-96908-->* Attribute values are now updated as expected in the `catalog_product_flat_2` table.
+<!--- MAGETWO-96908 -->
+*  Attribute values are now updated as expected in the `catalog_product_flat_2` table.
 
-<!--- MAGETWO-94556-->* Magento now saves and properly indexes a configurable product variant that contains a longer-than-permitted SKU. Previously, when you tried to save this product, Magento threw an error. [GitHub-17436](https://github.com/magento/magento2/issues/17436)
+<!--- MAGETWO-94556 -->
+*  Magento now saves and properly indexes a configurable product variant that contains a longer-than-permitted SKU. Previously, when you tried to save this product, Magento threw an error. [GitHub-17436](https://github.com/magento/magento2/issues/17436)
 
-<!--- MAGETWO-95428-->* The product page's Recently View section no longer displays the name of the current product.
+<!--- MAGETWO-95428 -->
+*  The product page's Recently View section no longer displays the name of the current product.
 
-<!--- MAGETWO-91837-->* You can now use REST to update a product's media gallery.
+<!--- MAGETWO-91837 -->
+*  You can now use REST to update a product's media gallery.
 
-<!--- MAGETWO-95818-->* Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
+<!--- MAGETWO-95818 -->
+*  Magento now saves default values for category URL paths in accordance with the **Use Default Value**  and **Create a Permanent Redirect** settings. Previously, in deployments running multiple stores, if a category's URL key was changed and saved, Magento did not change the category's URL key back to the default URL key when saved with the **Use Default Value** box checked and **Create a Permanent Redirect** box unchecked.
 
-<!--- MAGETWO-95826-->* Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
+<!--- MAGETWO-95826 -->
+*  Magnifier now correctly handles zoomed sections of images when the image width/height ratio has a `~2x` difference. Previously, these sections were distorted.
 
-<!--- MAGETWO-61478-->* Magento now retains across categories any value you set for the number of categories displayed per page.
+<!--- MAGETWO-61478 -->
+*  Magento now retains across categories any value you set for the number of categories displayed per page.
 
-<!--- MAGETWO-95753-->* You can now save products with at least one tier price.
+<!--- MAGETWO-95753 -->
+*  You can now save products with at least one tier price.
 
-<!--- MAGETWO-66442-->* Changes to product images made under the All Stores scope now affect product images at the store-view level.
+<!--- MAGETWO-66442 -->
+*  Changes to product images made under the All Stores scope now affect product images at the store-view level.
 
-<!--- MAGETWO-96290-->* You can now use REST to update category positions.
+<!--- MAGETWO-96290 -->
+*  You can now use REST to update category positions.
 
-<!--- MAGETWO-91609-->* Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
+<!--- MAGETWO-91609 -->
+*  Magento now correctly displays the greater than operator (>) when you configure the catalog products list widget for a CMS block.
 
-<!--- MAGETWO-70303-->* Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
+<!--- MAGETWO-70303 -->
+*  Categories that are set to anchor **Yes** and that have disabled subcategories no longer display  products from those disabled subcategories. [GitHub-9002](https://github.com/magento/magento2/issues/9002)
 
-<!--- MAGETWO-91633-->* You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
+<!--- MAGETWO-91633 -->
+*  You can sort a grouped product's associated products across multiple pages. Previously, when you tried to sort associated products, Magento sorted only the products visible on the current page.
 
-<!--- ENGCOM-3281-->* Magento now uses the correct column type when creating temporary tables for a flat catalog. *Fix submitted by Jason Evans in pull request [18818](https://github.com/magento/magento2/pull/18818)*. [GitHub-14571](https://github.com/magento/magento2/issues/14571)
+<!--- ENGCOM-3281 -->
+*  Magento now uses the correct column type when creating temporary tables for a flat catalog. *Fix submitted by Jason Evans in pull request [18818](https://github.com/magento/magento2/pull/18818)*. [GitHub-14571](https://github.com/magento/magento2/issues/14571)
 
-<!--- ENGCOM-3566-->* Attribute indexing no longer ignores custom source model options, and the attributes associated with a custom source model were not parsed when products were filtered. Previously, when Magento indexed the attribute values used for the product filters in the category overview, it indexed only multiselect attributes that used attribute options. If a custom source model was specified, Magento did not index its values, which were consequently not taken into account when  products were filtered. *Fix submitted by Joel Rainwater in pull request [19176](https://github.com/magento/magento2/pull/19176)*. [GitHub-417](https://github.com/magento/magento2/issues/417)
+<!--- ENGCOM-3566 -->
+*  Attribute indexing no longer ignores custom source model options, and the attributes associated with a custom source model were not parsed when products were filtered. Previously, when Magento indexed the attribute values used for the product filters in the category overview, it indexed only multiselect attributes that used attribute options. If a custom source model was specified, Magento did not index its values, which were consequently not taken into account when  products were filtered. *Fix submitted by Joel Rainwater in pull request [19176](https://github.com/magento/magento2/pull/19176)*. [GitHub-417](https://github.com/magento/magento2/issues/417)
 
-<!--- ENGCOM-3597-->* Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.  *Fix submitted by Govind Sharma in pull request [19408](https://github.com/magento/magento2/pull/19408)*. [GitHub-19346](https://github.com/magento/magento2/issues/19346)
+<!--- ENGCOM-3597 -->
+*  Magento now correctly imports  `product_type` drop-down attributes. Previously, Magento displayed an error message indicating that values for these attributes were incorrect during import.  *Fix submitted by Govind Sharma in pull request [19408](https://github.com/magento/magento2/pull/19408)*. [GitHub-19346](https://github.com/magento/magento2/issues/19346)
 
-<!--- ENGCOM-3592-->* Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by SikailoISM in pull request [19451](https://github.com/magento/magento2/pull/19451)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+<!--- ENGCOM-3592 -->
+*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by SikailoISM in pull request [19451](https://github.com/magento/magento2/pull/19451)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
-<!--- ENGCOM-3641-->* You can now successfully delete a newly created attribute set. Previously, Magento displayed a 404 error under these circumstances. *Fix submitted by cedcommerce in pull request [19633](https://github.com/magento/magento2/pull/19633)*. [GitHub-19607](https://github.com/magento/magento2/issues/19607)
+<!--- ENGCOM-3641 -->
+*  You can now successfully delete a newly created attribute set. Previously, Magento displayed a 404 error under these circumstances. *Fix submitted by cedcommerce in pull request [19633](https://github.com/magento/magento2/pull/19633)*. [GitHub-19607](https://github.com/magento/magento2/issues/19607)
 
-<!--- ENGCOM-3399-->* You can now use add extension attributes to add category links to a product. Previously, Magento did not add the product links but behaved unpredictably. *Fix submitted by Giel Berkers in pull request [19080](https://github.com/magento/magento2/pull/19080)*. [GitHub-14861](https://github.com/magento/magento2/issues/14861)
+<!--- ENGCOM-3399 -->
+*  You can now use add extension attributes to add category links to a product. Previously, Magento did not add the product links but behaved unpredictably. *Fix submitted by Giel Berkers in pull request [19080](https://github.com/magento/magento2/pull/19080)*. [GitHub-14861](https://github.com/magento/magento2/issues/14861)
 
-<!--- ENGCOM-3673-->* When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by Malyovanets Nickolas in pull request [19341](https://github.com/magento/magento2/pull/19341)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
+<!--- ENGCOM-3673 -->
+*  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by Malyovanets Nickolas in pull request [19341](https://github.com/magento/magento2/pull/19341)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
-<!--- ENGCOM-3780-->* `CategoryLinkReposity` now lists all possible exceptions. *Fix submitted by Patrick McLain in pull request [20050](https://github.com/magento/magento2/pull/20050)*. [GitHub-20037](https://github.com/magento/magento2/issues/20037)
+<!--- ENGCOM-3780 -->
+*  `CategoryLinkReposity` now lists all possible exceptions. *Fix submitted by Patrick McLain in pull request [20050](https://github.com/magento/magento2/pull/20050)*. [GitHub-20037](https://github.com/magento/magento2/issues/20037)
 
-<!--- ENGCOM-1862-->* Merchants can now assign negative values to custom option for a product with a fixed price from the Admin. *Fix submitted by Danny Verkade in pull request [15267](https://github.com/magento/magento2/pull/15267)*. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
+<!--- ENGCOM-1862 -->
+*  Merchants can now assign negative values to custom option for a product with a fixed price from the Admin. *Fix submitted by Danny Verkade in pull request [15267](https://github.com/magento/magento2/pull/15267)*. [GitHub-7333](https://github.com/magento/magento2/issues/7333)
 
-<!--- ENGCOM-3618-->* Newly added fields are now sorted according to the given `sortOrder` value in the newsletter system configuration file. Previously, you could add a new field, but could not successfully set its position. *Fix submitted by Burlacu Vasilii in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!--- ENGCOM-3618 -->
+*  Newly added fields are now sorted according to the given `sortOrder` value in the newsletter system configuration file. Previously, you could add a new field, but could not successfully set its position. *Fix submitted by Burlacu Vasilii in pull request [19568](https://github.com/magento/magento2/pull/19568)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!--- ENGCOM-3430-->* Merchants can now change the position of tabs on a product page. *Fix submitted by Burlacu Vasilii in pull request [19007](https://github.com/magento/magento2/pull/19007)*. [GitHub-4154](https://github.com/magento/magento2/issues/4154)
+<!--- ENGCOM-3430 -->
+*  Merchants can now change the position of tabs on a product page. *Fix submitted by Burlacu Vasilii in pull request [19007](https://github.com/magento/magento2/pull/19007)*. [GitHub-4154](https://github.com/magento/magento2/issues/4154)
 
-<!--- ENGCOM-3758-->* An incorrect variable in the phpDoc for `DataBuilder.php` has been corrected. *Fix submitted by Kun Joshi in pull request [19992](https://github.com/magento/magento2/pull/19992)*. [GitHub-19974](https://github.com/magento/magento2/issues/19974)
+<!--- ENGCOM-3758 -->
+*  An incorrect variable in the phpDoc for `DataBuilder.php` has been corrected. *Fix submitted by Kun Joshi in pull request [19992](https://github.com/magento/magento2/pull/19992)*. [GitHub-19974](https://github.com/magento/magento2/issues/19974)
 
-<!--- ENGCOM-3599-->* You can now perform a mass  update  on product attributes after configuring the minimum cart quantity globally. Previously, Magento did not display the form to update all available attributes but threw a `E_WARNING:` error when you selected **Update attributes**. *Fix submitted by Patrick McLain in pull request [19095](https://github.com/magento/magento2/pull/19095)*. [GitHub-17592](https://github.com/magento/magento2/issues/17592)
+<!--- ENGCOM-3599 -->
+*  You can now perform a mass  update  on product attributes after configuring the minimum cart quantity globally. Previously, Magento did not display the form to update all available attributes but threw a `E_WARNING:` error when you selected **Update attributes**. *Fix submitted by Patrick McLain in pull request [19095](https://github.com/magento/magento2/pull/19095)*. [GitHub-17592](https://github.com/magento/magento2/issues/17592)
 
-<!--- ENGCOM-3946-->* The product compare page now loads as expected when unconfigured attributes display **N/A** or **No**. *Fix submitted by Vivek Kumar in pull request [20231](https://github.com/magento/magento2/pull/20231)*. [GitHub-20229](https://github.com/magento/magento2/issues/20229)
+<!--- ENGCOM-3946 -->
+*  The product compare page now loads as expected when unconfigured attributes display **N/A** or **No**. *Fix submitted by Vivek Kumar in pull request [20231](https://github.com/magento/magento2/pull/20231)*. [GitHub-20229](https://github.com/magento/magento2/issues/20229)
 
-<!--- ENGCOM-3913-->* Magento now correctly sorts configurable products with tier prices or swatches on both the storefront and Admin. Previously, storefront sorting did not match Admin sorting. *Fix submitted by vshatylo in pull request [20407](https://github.com/magento/magento2/pull/20407)*. [GitHub-12194](https://github.com/magento/magento2/issues/12194)
+<!--- ENGCOM-3913 -->
+*  Magento now correctly sorts configurable products with tier prices or swatches on both the storefront and Admin. Previously, storefront sorting did not match Admin sorting. *Fix submitted by vshatylo in pull request [20407](https://github.com/magento/magento2/pull/20407)*. [GitHub-12194](https://github.com/magento/magento2/issues/12194)
 
-<!--- MAGETWO-97625-->* Magento now correctly duplicates video files when a merchant duplicates a product with an associated video. Previously, the video was duplicated as an image, not a video, and the merchant had to delete the image and re-add the video using **Add Video**.
+<!--- MAGETWO-97625 -->
+*  Magento now correctly duplicates video files when a merchant duplicates a product with an associated video. Previously, the video was duplicated as an image, not a video, and the merchant had to delete the image and re-add the video using **Add Video**.
 
-<!--- MAGETWO-97210 -->* Browser no longer hangs when you add a product by SKU to a category
+<!--- MAGETWO-97210  -->
+*  Browser no longer hangs when you add a product by SKU to a category
 
-<!--- ENGCOM-3029-->* We've improved the error message that Magento displays when validating a new (but invalid) product attribute. *Fix submitted by saravananvelu in pull request [17806](https://github.com/magento/magento2/pull/17806)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
+<!--- ENGCOM-3029 -->
+*  We've improved the error message that Magento displays when validating a new (but invalid) product attribute. *Fix submitted by saravananvelu in pull request [17806](https://github.com/magento/magento2/pull/17806)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
 
-<!--- ENGCOM-3476-->*  `getProductUrl` no longer returns the wrong URL when the current category has no products. *Fix submitted by Erik Pellikka in pull request [19232](https://github.com/magento/magento2/pull/19232)*. [GitHub-17819](https://github.com/magento/magento2/issues/17819)
+<!--- ENGCOM-3476 -->
+*   `getProductUrl` no longer returns the wrong URL when the current category has no products. *Fix submitted by Erik Pellikka in pull request [19232](https://github.com/magento/magento2/pull/19232)*. [GitHub-17819](https://github.com/magento/magento2/issues/17819)
 
-<!--- ENGCOM-3448-->* The user agent exception now sets the correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme regardless of the user agent. *Fix submitted by Alex Ghiban in pull request [19124](https://github.com/magento/magento2/pull/19124)*. [GitHub-16074](https://github.com/magento/magento2/issues/16074)
+<!--- ENGCOM-3448 -->
+*  The user agent exception now sets the correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme regardless of the user agent. *Fix submitted by Alex Ghiban in pull request [19124](https://github.com/magento/magento2/pull/19124)*. [GitHub-16074](https://github.com/magento/magento2/issues/16074)
 
-<!--- ENGCOM-4093-->* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by Pratik Oza in pull request [20907](https://github.com/magento/magento2/pull/20907)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+<!--- ENGCOM-4093 -->
+*  Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list.  *Fix submitted by Pratik Oza in pull request [20907](https://github.com/magento/magento2/pull/20907)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
-<!--- ENGCOM-3698-->* Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19781](https://github.com/magento/magento2/pull/19781)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+<!--- ENGCOM-3698 -->
+*  Magento now displays breadcrumbs in proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19781](https://github.com/magento/magento2/pull/19781)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
 
-<!--- MAGETWO-96377-->* In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
+<!--- MAGETWO-96377 -->
+*  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
 
 ### CatalogInventory
 
-<!--- ENGCOM-3138-->* Magento now validates the quantity of items in the shoppng cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by Vishal Gelani in pull request [18481](https://github.com/magento/magento2/pull/18481)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
+<!--- ENGCOM-3138 -->
+*  Magento now validates the quantity of items in the shoppng cart against the **Maximum Qty Allowed in Shopping Cart** setting. *Fix submitted by Vishal Gelani in pull request [18481](https://github.com/magento/magento2/pull/18481)*. [GitHub-18477](https://github.com/magento/magento2/issues/18477)
 
-<!--- ENGCOM-3845-->* Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**. *Fix submitted by Shikha Mishra in pull request [20252](https://github.com/magento/magento2/pull/20252)*. [GitHub-20121](https://github.com/magento/magento2/issues/20121)
+<!--- ENGCOM-3845 -->
+*  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**. *Fix submitted by Shikha Mishra in pull request [20252](https://github.com/magento/magento2/pull/20252)*. [GitHub-20121](https://github.com/magento/magento2/issues/20121)
 
-<!--- ENGCOM-3915-->* Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by Milind Singh in pull request [20410](https://github.com/magento/magento2/pull/20410)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+<!--- ENGCOM-3915 -->
+*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by Milind Singh in pull request [20410](https://github.com/magento/magento2/pull/20410)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
-<!--- ENGCOM-3462-->* Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value. *Fix submitted by Khodu in pull request [19206](https://github.com/magento/magento2/pull/19206)*. [GitHub-9130](https://github.com/magento/magento2/issues/9130)
+<!--- ENGCOM-3462 -->
+*  Magento no longer displays a negative value on the product list page when a product's stock falls below the product's `OutOfStock` threshold value. *Fix submitted by Khodu in pull request [19206](https://github.com/magento/magento2/pull/19206)*. [GitHub-9130](https://github.com/magento/magento2/issues/9130)
 
-<!--- ENGCOM-3771-->* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Oleksii Gorbulin in pull request [19997](https://github.com/magento/magento2/pull/19997)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+<!--- ENGCOM-3771 -->
+*  Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Oleksii Gorbulin in pull request [19997](https://github.com/magento/magento2/pull/19997)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
 
-<!--- MAGETWO-96377-->* In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
+<!--- MAGETWO-96377 -->
+*  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
 
 ### Catalog Rule
 
-<!--- ENGCOM-3131-->* Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English. *Fix submitted by Martin in pull request [18419](https://github.com/magento/magento2/pull/18419)*. [GitHub-12399](https://github.com/magento/magento2/issues/12399)
+<!--- ENGCOM-3131 -->
+*  Magento no longer throws an exception when you try to edit and save a catalog price rule when the Admin language is set to a language other than English. *Fix submitted by Martin in pull request [18419](https://github.com/magento/magento2/pull/18419)*. [GitHub-12399](https://github.com/magento/magento2/issues/12399)
 
-<!--- ENGCOM-3143-->* If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
+<!--- ENGCOM-3143 -->
+*  If you create a catalog price rule based on categories with a nesting level 4 or higher, these categories now maintain the status of their checkboxes when you re-open Category Chooser.
 Previously, when you reopened these categories, no checkboxes were checked.
 
 ### Catalog URL rewrite
 
-<!--- ENGCOM-3438-->* Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by p-bystritsky in pull request [19170](https://github.com/magento/magento2/pull/19170)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532), [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+<!--- ENGCOM-3438 -->
+*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by p-bystritsky in pull request [19170](https://github.com/magento/magento2/pull/19170)*. [GitHub-18532](https://github.com/magento/magento2/issues/18532), [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
-<!--- MAGETWO-93425-->* Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
+<!--- MAGETWO-93425 -->
+*  Attempts to rewrite catalog URLs with `POST /V1/products` endpoint now  work as expected. [GitHub-16789](https://github.com/magento/magento2/issues/16789)
 
-<!--- MAGETWO-91649-->* Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
+<!--- MAGETWO-91649 -->
+*  Magento no longer ignores the store-level `url_key` of child categories when rewriting URLs process for global scope. [GitHub-13513](https://github.com/magento/magento2/issues/13513)
 
-<!--- MAGETWO-91532-->* Magento no longer removes product tier prices when a schedule update contains an update to the special price.
+<!--- MAGETWO-91532 -->
+*  Magento no longer removes product tier prices when a schedule update contains an update to the special price.
 
-<!--- ENGCOM-4050-->* The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [19798](https://github.com/magento/magento2/pull/19798)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
+<!--- ENGCOM-4050 -->
+*  The store switcher now works in multistore deployments.  Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [19798](https://github.com/magento/magento2/pull/19798)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 ### Cleanup and simple code refactoring
 
-<!--- ENGCOM-3861-->* Fixed alignment of the details label on the order page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20301](https://github.com/magento/magento2/pull/20301)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+<!--- ENGCOM-3861 -->
+*  Fixed alignment of the details label on the order page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20301](https://github.com/magento/magento2/pull/20301)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
-<!--- ENGCOM-3835-->* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Nainesh Waghale in pull request [20224](https://github.com/magento/magento2/pull/20224)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+<!--- ENGCOM-3835 -->
+*  Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Nainesh Waghale in pull request [20224](https://github.com/magento/magento2/pull/20224)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
-<!--- ENGCOM-3763-->* Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by suryakant-krish in pull request [19803](https://github.com/magento/magento2/pull/19803)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
+<!--- ENGCOM-3763 -->
+*  Corrected the alignment of Contact us area accessed from the storefront page footers. *Fix submitted by suryakant-krish in pull request [19803](https://github.com/magento/magento2/pull/19803)*. [GitHub-19800](https://github.com/magento/magento2/issues/19800)
 
-<!--- ENGCOM-3643-->* Fixed misalignment of page elements on the manage coupon codes page in the Admin. *Fix submitted by Kajal Solanki in pull request [19659](https://github.com/magento/magento2/pull/19659)*. [GitHub-19657](https://github.com/magento/magento2/issues/19657)
+<!--- ENGCOM-3643 -->
+*  Fixed misalignment of page elements on the manage coupon codes page in the Admin. *Fix submitted by Kajal Solanki in pull request [19659](https://github.com/magento/magento2/pull/19659)*. [GitHub-19657](https://github.com/magento/magento2/issues/19657)
 
-<!--- ENGCOM-3573-->* Fixed misalignment of tax rate checkbox on the Add New Tax Rate page. *Fix submitted by suryakant-krish in pull request [19413](https://github.com/magento/magento2/pull/19413)*. [GitHub-19379](https://github.com/magento/magento2/issues/19379)
+<!--- ENGCOM-3573 -->
+*  Fixed misalignment of tax rate checkbox on the Add New Tax Rate page. *Fix submitted by suryakant-krish in pull request [19413](https://github.com/magento/magento2/pull/19413)*. [GitHub-19379](https://github.com/magento/magento2/issues/19379)
 
-<!--- ENGCOM-3571-->* Fixed misalignment of the attribute set name heading border on the Attribute sets pop up. *Fix submitted by suryakant-krish in pull request [19414](https://github.com/magento/magento2/pull/19414)*. [GitHub-19371](https://github.com/magento/magento2/issues/19371)
+<!--- ENGCOM-3571 -->
+*  Fixed misalignment of the attribute set name heading border on the Attribute sets pop up. *Fix submitted by suryakant-krish in pull request [19414](https://github.com/magento/magento2/pull/19414)*. [GitHub-19371](https://github.com/magento/magento2/issues/19371)
 
-<!--- ENGCOM-3960-->* Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!--- ENGCOM-3960 -->
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!--- ENGCOM-3626-->* Fixed misalignment  of the **Choose file** button on the `Select File to Import` page. *Fix submitted by suryakant in pull request [19580](https://github.com/magento/magento2/pull/19580)*. [GitHub-19579](https://github.com/magento/magento2/issues/19579)
+<!--- ENGCOM-3626 -->
+*  Fixed misalignment  of the **Choose file** button on the `Select File to Import` page. *Fix submitted by suryakant in pull request [19580](https://github.com/magento/magento2/pull/19580)*. [GitHub-19579](https://github.com/magento/magento2/issues/19579)
 
-<!--- ENGCOM-3320-->* Fixed formatting of the add link table that can be accessed from the Downloadable Information tab. *Fix submitted by Kajal Solanki in pull request [18856](https://github.com/magento/magento2/pull/18856)*. [GitHub-18854](https://github.com/magento/magento2/issues/18854)
+<!--- ENGCOM-3320 -->
+*  Fixed formatting of the add link table that can be accessed from the Downloadable Information tab. *Fix submitted by Kajal Solanki in pull request [18856](https://github.com/magento/magento2/pull/18856)*. [GitHub-18854](https://github.com/magento/magento2/issues/18854)
 
-<!--- ENGCOM-3951-->* Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by Parag Chavare in pull request [20501](https://github.com/magento/magento2/pull/20501)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+<!--- ENGCOM-3951 -->
+*  Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by Parag Chavare in pull request [20501](https://github.com/magento/magento2/pull/20501)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
-<!--- ENGCOM-4031-->* Fixed misalignment of  tab content on the product page in mobile view. *Fix submitted by Parag Chavare in pull request [20469](https://github.com/magento/magento2/pull/20469)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+<!--- ENGCOM-4031 -->
+*  Fixed misalignment of  tab content on the product page in mobile view. *Fix submitted by Parag Chavare in pull request [20469](https://github.com/magento/magento2/pull/20469)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
-<!--- ENGCOM-3727-->* Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`. *Fix submitted by Govind Sharma in pull request [19918](https://github.com/magento/magento2/pull/19918)*. [GitHub-19917](https://github.com/magento/magento2/issues/19917)
+<!--- ENGCOM-3727 -->
+*  Corrected misspelled argument name `allowDrug` to `allowDrag` in `vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml`. *Fix submitted by Govind Sharma in pull request [19918](https://github.com/magento/magento2/pull/19918)*. [GitHub-19917](https://github.com/magento/magento2/issues/19917)
 
-<!--- ENGCOM-3659-->* Fixed the misalignment of the customizable options label on **Admin** > **Catalog** > **Product** > **Customizable Options**. *Fix submitted by Kajal Solanki in pull request [19493](https://github.com/magento/magento2/pull/19493)*. [GitHub-19492](https://github.com/magento/magento2/issues/19492)
+<!--- ENGCOM-3659 -->
+*  Fixed the misalignment of the customizable options label on **Admin** > **Catalog** > **Product** > **Customizable Options**. *Fix submitted by Kajal Solanki in pull request [19493](https://github.com/magento/magento2/pull/19493)*. [GitHub-19492](https://github.com/magento/magento2/issues/19492)
 
-<!--- ENGCOM-3706-->* Fixed problem with overlapping UI elements on the cart page when accessed from the mini cart. *Fix submitted by Vishal Gelani in pull request [19839](https://github.com/magento/magento2/pull/19839)*. [GitHub-19836](https://github.com/magento/magento2/issues/19836)
+<!--- ENGCOM-3706 -->
+*  Fixed problem with overlapping UI elements on the cart page when accessed from the mini cart. *Fix submitted by Vishal Gelani in pull request [19839](https://github.com/magento/magento2/pull/19839)*. [GitHub-19836](https://github.com/magento/magento2/issues/19836)
 
-<!--- ENGCOM-3721-->* Fixed alignment issue with the dropdown menu on the mini cart. *Fix submitted by Kajal Solanki in pull request [19508](https://github.com/magento/magento2/pull/19508)*. [GitHub-19507](https://github.com/magento/magento2/issues/19507)
+<!--- ENGCOM-3721 -->
+*  Fixed alignment issue with the dropdown menu on the mini cart. *Fix submitted by Kajal Solanki in pull request [19508](https://github.com/magento/magento2/pull/19508)*. [GitHub-19507](https://github.com/magento/magento2/issues/19507)
 
-<!--- ENGCOM-3769-->* Fixed alignment issue with radio buttons on the shopping cart page. *Fix submitted by Hitesh in pull request [20022](https://github.com/magento/magento2/pull/20022)*. [GitHub-20021](https://github.com/magento/magento2/issues/20021)
+<!--- ENGCOM-3769 -->
+*  Fixed alignment issue with radio buttons on the shopping cart page. *Fix submitted by Hitesh in pull request [20022](https://github.com/magento/magento2/pull/20022)*. [GitHub-20021](https://github.com/magento/magento2/issues/20021)
 
-<!--- ENGCOM-3948-->* Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by Parag Chavare in pull request [20519](https://github.com/magento/magento2/pull/20519)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+<!--- ENGCOM-3948 -->
+*  Fixed alignment of the bundle product radio button on the product page when you click **Customize** and **Add to cart**. *Fix submitted by Parag Chavare in pull request [20519](https://github.com/magento/magento2/pull/20519)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
-<!--- ENGCOM-3621-->* Fixed alignment of the bundle product information on the configure product page for a bundle product  when creating a new order. *Fix submitted by Abrar Pathan in pull request [19502](https://github.com/magento/magento2/pull/19502)*. [GitHub-19501](https://github.com/magento/magento2/issues/19501)
+<!--- ENGCOM-3621 -->
+*  Fixed alignment of the bundle product information on the configure product page for a bundle product  when creating a new order. *Fix submitted by Abrar Pathan in pull request [19502](https://github.com/magento/magento2/pull/19502)*. [GitHub-19501](https://github.com/magento/magento2/issues/19501)
 
-<!--- ENGCOM-3196 -->* The calender icon issue is now correctly aligned on the Advanced Pricing page of the Admin. *Fix submitted by Kajal Solanki in pull request [18638](https://github.com/magento/magento2/pull/18638)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
+<!--- ENGCOM-3196  -->
+*  The calender icon issue is now correctly aligned on the Advanced Pricing page of the Admin. *Fix submitted by Kajal Solanki in pull request [18638](https://github.com/magento/magento2/pull/18638)*. [GitHub-18581](https://github.com/magento/magento2/issues/18581)
 
-<!--- ENGCOM-4029-->* Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Ajay Ajabale in pull request [20581](https://github.com/magento/magento2/pull/20581)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+<!--- ENGCOM-4029 -->
+*  Fixed alignment issue of time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Ajay Ajabale in pull request [20581](https://github.com/magento/magento2/pull/20581)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
-<!--- ENGCOM-3966-->* Fixed misalignment of the confirmation pop-up window that Magento displays in mobile view when you delete a product from your shopping cart. *Fix submitted by Priti in pull request [20196](https://github.com/magento/magento2/pull/20196)*. [GitHub-20176](https://github.com/magento/magento2/issues/20176)
+<!--- ENGCOM-3966 -->
+*  Fixed misalignment of the confirmation pop-up window that Magento displays in mobile view when you delete a product from your shopping cart. *Fix submitted by Priti in pull request [20196](https://github.com/magento/magento2/pull/20196)*. [GitHub-20176](https://github.com/magento/magento2/issues/20176)
 
-<!--- ENGCOM-3449-->* The `addExpressionFieldToSelect` method no longer modifies columns and instead insert expression into `_fieldsToSelect` private variable (just as `addFieldToSelect` does). *Fix submitted by Torben Höhn in pull request [19180](https://github.com/magento/magento2/pull/19180)*. [GitHub-17635](https://github.com/magento/magento2/issues/17635)
+<!--- ENGCOM-3449 -->
+*  The `addExpressionFieldToSelect` method no longer modifies columns and instead insert expression into `_fieldsToSelect` private variable (just as `addFieldToSelect` does). *Fix submitted by Torben Höhn in pull request [19180](https://github.com/magento/magento2/pull/19180)*. [GitHub-17635](https://github.com/magento/magento2/issues/17635)
 
-<!--- ENGCOM-3240-->* A typo in `app/code/Magento/Deploy/Console/DeployStaticOptions.php` has been corrected. *Fix submitted by Pratik Oza in pull request [18733](https://github.com/magento/magento2/pull/18733)*. [GitHub-2686](https://github.com/magento/magento2/issues/2686)
+<!--- ENGCOM-3240 -->
+*  A typo in `app/code/Magento/Deploy/Console/DeployStaticOptions.php` has been corrected. *Fix submitted by Pratik Oza in pull request [18733](https://github.com/magento/magento2/pull/18733)*. [GitHub-2686](https://github.com/magento/magento2/issues/2686)
 
-<!--- ENGCOM-3848-->* Fixed alignment of options on the admin edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!--- ENGCOM-3848 -->
+*  Fixed alignment of options on the admin edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
-<!--- ENGCOM-3901-->* Corrected rendering of the apply discount code field in the Tab portrait view of the cart page. *Fix submitted by Ajay Ajabale in pull request [20281](https://github.com/magento/magento2/pull/20281)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+<!--- ENGCOM-3901 -->
+*  Corrected rendering of the apply discount code field in the Tab portrait view of the cart page. *Fix submitted by Ajay Ajabale in pull request [20281](https://github.com/magento/magento2/pull/20281)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
-<!--- ENGCOM-3899-->* Fixed issue where the horizontal scroll bar did not appear as expected on the compare products page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20368](https://github.com/magento/magento2/pull/20368)*. [GitHub-20367](https://github.com/magento/magento2/issues/20367)
+<!--- ENGCOM-3899 -->
+*  Fixed issue where the horizontal scroll bar did not appear as expected on the compare products page in mobile view. *Fix submitted by Arvinda Kumar in pull request [20368](https://github.com/magento/magento2/pull/20368)*. [GitHub-20367](https://github.com/magento/magento2/issues/20367)
 
-<!--- ENGCOM-3936-->* Added missing bottom border to list of customizable options on the product page accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20498](https://github.com/magento/magento2/pull/20498)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+<!--- ENGCOM-3936 -->
+*  Added missing bottom border to list of customizable options on the product page accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20498](https://github.com/magento/magento2/pull/20498)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
-<!--- ENGCOM-3792-->* Corrected the position of the header for the design configuration table (**Content** > **Design** > **Configuration**). *Fix submitted by Shikha Mishra in pull request [20072](https://github.com/magento/magento2/pull/20072)*. [GitHub-20024](https://github.com/magento/magento2/issues/20024)
+<!--- ENGCOM-3792 -->
+*  Corrected the position of the header for the design configuration table (**Content** > **Design** > **Configuration**). *Fix submitted by Shikha Mishra in pull request [20072](https://github.com/magento/magento2/pull/20072)*. [GitHub-20024](https://github.com/magento/magento2/issues/20024)
 
-<!--- ENGCOM-3558-->* When you try to save a widget that contains an unexpected character, Magento now displays an informative error message  and does not save the widget. Previously, Magento saved the widget. *Fix submitted by Burlacu Vasilii in pull request [19390](https://github.com/magento/magento2/pull/19390)*. [GitHub-4136](https://github.com/magento/magento2/issues/4136)
+<!--- ENGCOM-3558 -->
+*  When you try to save a widget that contains an unexpected character, Magento now displays an informative error message  and does not save the widget. Previously, Magento saved the widget. *Fix submitted by Burlacu Vasilii in pull request [19390](https://github.com/magento/magento2/pull/19390)*. [GitHub-4136](https://github.com/magento/magento2/issues/4136)
 
-<!--- ENGCOM-3821-->* The catalog category merchandiser product list is no longer missing the move cursor in tile view. *Fix submitted by Abrar Pathan in pull request [19817](https://github.com/magento/magento2/pull/19817)*. [GitHub-19816](https://github.com/magento/magento2/issues/19816)
+<!--- ENGCOM-3821 -->
+*  The catalog category merchandiser product list is no longer missing the move cursor in tile view. *Fix submitted by Abrar Pathan in pull request [19817](https://github.com/magento/magento2/pull/19817)*. [GitHub-19816](https://github.com/magento/magento2/issues/19816)
 
-<!--- ENGCOM-3815-->* Corrected alignment of the **Detailed Rating** field on the Edit Review page.  *Fix submitted by Yashwant Rokde in pull request [20132](https://github.com/magento/magento2/pull/20132)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
+<!--- ENGCOM-3815 -->
+*  Corrected alignment of the **Detailed Rating** field on the Edit Review page.  *Fix submitted by Yashwant Rokde in pull request [20132](https://github.com/magento/magento2/pull/20132)*. [GitHub-20120](https://github.com/magento/magento2/issues/20120)
 
-<!--- ENGCOM-3825-->* Corrected alignment of the store switcher in Tab view. *Fix submitted by Arvinda Kumar in pull request [20160](https://github.com/magento/magento2/pull/20160)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
+<!--- ENGCOM-3825 -->
+*  Corrected alignment of the store switcher in Tab view. *Fix submitted by Arvinda Kumar in pull request [20160](https://github.com/magento/magento2/pull/20160)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
 
-<!--- ENGCOM-3820-->* Corrected number of products listed per row for  desktop (4), tablet (3),  and mobile (2) views. *Fix submitted by Amol Chaudhari in pull request [20168](https://github.com/magento/magento2/pull/20168)*. [GitHub-20140](https://github.com/magento/magento2/issues/20140)
+<!--- ENGCOM-3820 -->
+*  Corrected number of products listed per row for  desktop (4), tablet (3),  and mobile (2) views. *Fix submitted by Amol Chaudhari in pull request [20168](https://github.com/magento/magento2/pull/20168)*. [GitHub-20140](https://github.com/magento/magento2/issues/20140)
 
-<!--- ENGCOM-3852-->* Hamburger menus no longer appear on page that does not have menus. *Fix submitted by Amol Chaudhari in pull request [20214](https://github.com/magento/magento2/pull/20214)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+<!--- ENGCOM-3852 -->
+*  Hamburger menus no longer appear on page that does not have menus. *Fix submitted by Amol Chaudhari in pull request [20214](https://github.com/magento/magento2/pull/20214)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
-<!--- ENGCOM-3842-->* Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by Nirav Patel in pull request [20241](https://github.com/magento/magento2/pull/20241)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+<!--- ENGCOM-3842 -->
+*  Fixed issue where drop-down toggle arrow did not close as expected on product page. *Fix submitted by Nirav Patel in pull request [20241](https://github.com/magento/magento2/pull/20241)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
-<!--- ENGCOM-3847-->* The Send email confirmation popup **Close** button no longer overlaps with content. *Fix submitted by Arvinda Kumar in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
+<!--- ENGCOM-3847 -->
+*  The Send email confirmation popup **Close** button no longer overlaps with content. *Fix submitted by Arvinda Kumar in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
 
-<!--- ENGCOM-3798-->* Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page. *Fix submitted by David Verholen in pull request [20094](https://github.com/magento/magento2/pull/20094)*. [GitHub-19052](https://github.com/magento/magento2/issues/19052)
+<!--- ENGCOM-3798 -->
+*  Corrected formatting issue on **Catalog** > **Category** > **Product** > **Assign products** page. *Fix submitted by David Verholen in pull request [20094](https://github.com/magento/magento2/pull/20094)*. [GitHub-19052](https://github.com/magento/magento2/issues/19052)
 
-<!--- ENGCOM-3869-->* Store switcher now works correctly on mobile devices. *Fix submitted by Arvinda Kumar in pull request [20260](https://github.com/magento/magento2/pull/20260)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+<!--- ENGCOM-3869 -->
+*  Store switcher now works correctly on mobile devices. *Fix submitted by Arvinda Kumar in pull request [20260](https://github.com/magento/magento2/pull/20260)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
-<!--- ENGCOM-3894-->* The order view invoice template is now displayed properly on the ipad. *Fix submitted by ranee2jcommerce in pull request [20374](https://github.com/magento/magento2/pull/20374)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+<!--- ENGCOM-3894 -->
+*  The order view invoice template is now displayed properly on the ipad. *Fix submitted by ranee2jcommerce in pull request [20374](https://github.com/magento/magento2/pull/20374)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
-<!--- ENGCOM-3848-->* Fixed misalignment of the widget options on the edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
+<!--- ENGCOM-3848 -->
+*  Fixed misalignment of the widget options on the edit widget page. *Fix submitted by Govind Sharma in pull request [20114](https://github.com/magento/magento2/pull/20114)*. [GitHub-20113](https://github.com/magento/magento2/issues/20113)
 
-<!--- ENGCOM-3708-->* Magento now identifies shipping method in the Shipping section of the order review page for orders paid with using PayPal Express. *Fix submitted by Nirav Kadiya in pull request [19788](https://github.com/magento/magento2/pull/19788)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+<!--- ENGCOM-3708 -->
+*  Magento now identifies shipping method in the Shipping section of the order review page for orders paid with using PayPal Express. *Fix submitted by Nirav Kadiya in pull request [19788](https://github.com/magento/magento2/pull/19788)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
-<!--- ENGCOM-3663-->* Fixed checkbox alignment on the account information page. *Fix submitted by suryakant-krish in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
+<!--- ENGCOM-3663 -->
+*  Fixed checkbox alignment on the account information page. *Fix submitted by suryakant-krish in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
 
-<!--- ENGCOM-3653-->* Fixed misalignment of search icons on the `onAttribute` page. *Fix submitted by Abrar Pathan in pull request [19643](https://github.com/magento/magento2/pull/19643)*. [GitHub-19642](https://github.com/magento/magento2/issues/19642)
+<!--- ENGCOM-3653 -->
+*  Fixed misalignment of search icons on the `onAttribute` page. *Fix submitted by Abrar Pathan in pull request [19643](https://github.com/magento/magento2/pull/19643)*. [GitHub-19642](https://github.com/magento/magento2/issues/19642)
 
-<!--- ENGCOM-3595-->* Fixed alignment issue with select and text boxes on the Advance Pricing page. *Fix submitted by Kajal Solanki in pull request [19473](https://github.com/magento/magento2/pull/19473)*. [GitHub-19472](https://github.com/magento/magento2/issues/19472)
+<!--- ENGCOM-3595 -->
+*  Fixed alignment issue with select and text boxes on the Advance Pricing page. *Fix submitted by Kajal Solanki in pull request [19473](https://github.com/magento/magento2/pull/19473)*. [GitHub-19472](https://github.com/magento/magento2/issues/19472)
 
-<!--- ENGCOM-3627-->* Corrected alignment issue with elements on the default email templates. *Fix submitted by suryakant-krish in pull request [19574](https://github.com/magento/magento2/pull/19574)*. [GitHub-19573](https://github.com/magento/magento2/issues/19573)
+<!--- ENGCOM-3627 -->
+*  Corrected alignment issue with elements on the default email templates. *Fix submitted by suryakant-krish in pull request [19574](https://github.com/magento/magento2/pull/19574)*. [GitHub-19573](https://github.com/magento/magento2/issues/19573)
 
-<!--- ENGCOM-3678-->* Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by Milind Singh in pull request [19726](https://github.com/magento/magento2/pull/19726)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
+<!--- ENGCOM-3678 -->
+*  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by Milind Singh in pull request [19726](https://github.com/magento/magento2/pull/19726)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
-<!--- ENGCOM-4150-->* Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by dharmendra-wagento in pull request [20990](https://github.com/magento/magento2/pull/20990)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+<!--- ENGCOM-4150 -->
+*  Corrected the behavior of the Option's New Option Type drop-down menu for customizable options.  *Fix submitted by dharmendra-wagento in pull request [20990](https://github.com/magento/magento2/pull/20990)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
-<!--- ENGCOM-4113-->* Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by Govind Sharma in pull request [20914](https://github.com/magento/magento2/pull/20914)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
+<!--- ENGCOM-4113 -->
+*  Fixed alignment of reload CAPTCHA icon on the Admin  login  page. *Fix submitted by Govind Sharma in pull request [20914](https://github.com/magento/magento2/pull/20914)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
-<!--- ENGCOM-4107-->* Fixed alignment of error message that magento displays on the add or edit bundle product customizable options tab. *Fix submitted by Kunj Joshi in pull request [20930](https://github.com/magento/magento2/pull/20930)*. [GitHub-20908](https://github.com/magento/magento2/issues/20908)
+<!--- ENGCOM-4107 -->
+*  Fixed alignment of error message that magento displays on the add or edit bundle product customizable options tab. *Fix submitted by Kunj Joshi in pull request [20930](https://github.com/magento/magento2/pull/20930)*. [GitHub-20908](https://github.com/magento/magento2/issues/20908)
 
-<!--- ENGCOM-4134-->* Fixed misalignment of the Orders and Returns section that is accessed from the footer of the Orders page. *Fix submitted by Amol Chaudhari in pull request [20817](https://github.com/magento/magento2/pull/20817)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+<!--- ENGCOM-4134 -->
+*  Fixed misalignment of the Orders and Returns section that is accessed from the footer of the Orders page. *Fix submitted by Amol Chaudhari in pull request [20817](https://github.com/magento/magento2/pull/20817)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
-<!--- ENGCOM-4057-->* The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by Abrar Pathan in pull request [20791](https://github.com/magento/magento2/pull/20791)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+<!--- ENGCOM-4057 -->
+*  The default design of the **Edit** and **Remove items** buttons on the wishlist page now match. *Fix submitted by Abrar Pathan in pull request [20791](https://github.com/magento/magento2/pull/20791)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
-<!--- ENGCOM-4074-->* Fixed issues with the shadows associated with input box and radio buttons on storefront forms. *Fix submitted by Abrar Pathan in pull request [20861](https://github.com/magento/magento2/pull/20861)*. [GitHub-20859](https://github.com/magento/magento2/issues/20859)
+<!--- ENGCOM-4074 -->
+*  Fixed issues with the shadows associated with input box and radio buttons on storefront forms. *Fix submitted by Abrar Pathan in pull request [20861](https://github.com/magento/magento2/pull/20861)*. [GitHub-20859](https://github.com/magento/magento2/issues/20859)
 
-<!--- ENGCOM-3854-->* Fixed the misalignment of the product option fields in the order summary of the checkout page. *Fix submitted by Pratik Oza in pull request [20138](https://github.com/magento/magento2/pull/20138)*. [GitHub-20134](https://github.com/magento/magento2/issues/20134)
+<!--- ENGCOM-3854 -->
+*  Fixed the misalignment of the product option fields in the order summary of the checkout page. *Fix submitted by Pratik Oza in pull request [20138](https://github.com/magento/magento2/pull/20138)*. [GitHub-20134](https://github.com/magento/magento2/issues/20134)
 
-<!--- ENGCOM-4053-->* Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by Priti in pull request [20558](https://github.com/magento/magento2/pull/20558)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+<!--- ENGCOM-4053 -->
+*  Fixed misalignment of fields on the configure product page that is accessed from the wishlist. *Fix submitted by Priti in pull request [20558](https://github.com/magento/magento2/pull/20558)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
-<!--- ENGCOM-4036-->* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by ranee2jcommerce in pull request [20756](https://github.com/magento/magento2/pull/20756)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+<!--- ENGCOM-4036 -->
+*  Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by ranee2jcommerce in pull request [20756](https://github.com/magento/magento2/pull/20756)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
 
-<!--- ENGCOM-3764-->* Fixed misalignment of logo on Admin home page. *Fix submitted by suryakant-krish in pull request [19792](https://github.com/magento/magento2/pull/19792)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
+<!--- ENGCOM-3764 -->
+*  Fixed misalignment of logo on Admin home page. *Fix submitted by suryakant-krish in pull request [19792](https://github.com/magento/magento2/pull/19792)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
-<!--- ENGCOM-3991-->* Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by Govind Sharma in pull request [20159](https://github.com/magento/magento2/pull/20159)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+<!--- ENGCOM-3991 -->
+*  Fixed misalignment of the advanced search page's price field in mobile view. *Fix submitted by Govind Sharma in pull request [20159](https://github.com/magento/magento2/pull/20159)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
-<!--- ENGCOM-4066-->* Fixed misalignment of the View and Edit Cart link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [20383](https://github.com/magento/magento2/pull/20383)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+<!--- ENGCOM-4066 -->
+*  Fixed misalignment of the View and Edit Cart link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [20383](https://github.com/magento/magento2/pull/20383)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
 
-<!--- ENGCOM-4052-->* The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by Dipti in pull request [20493](https://github.com/magento/magento2/pull/20493)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+<!--- ENGCOM-4052 -->
+*  The Widget Options left navigation block on the Add New widget Page now displays correctly in tablet view. *Fix submitted by Dipti in pull request [20493](https://github.com/magento/magento2/pull/20493)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
-<!--- ENGCOM-4016-->* Fixed misalignment of values in the currency rate column in the Order & Account Information area of the New Memo page. *Fix submitted by Dipti in pull request [20610](https://github.com/magento/magento2/pull/20610)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+<!--- ENGCOM-4016 -->
+*  Fixed misalignment of values in the currency rate column in the Order & Account Information area of the New Memo page. *Fix submitted by Dipti in pull request [20610](https://github.com/magento/magento2/pull/20610)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
-<!--- ENGCOM-3952-->* Added missing PHPDoc comment for methods throughout the code base. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [19826](https://github.com/magento/magento2/pull/19826)*.
+<!--- ENGCOM-3952 -->
+*  Added missing PHPDoc comment for methods throughout the code base. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [19826](https://github.com/magento/magento2/pull/19826)*.
 
-<!--- ENGCOM-4168-->* Fixed misalignment of the My Account page's **Recently Ordered** checkbox in  tab portrait view. *Fix submitted by Ajay Ajabale in pull request [20155](https://github.com/magento/magento2/pull/20155)*. [GitHub-20143](https://github.com/magento/magento2/issues/20143)
+<!--- ENGCOM-4168 -->
+*  Fixed misalignment of the My Account page's **Recently Ordered** checkbox in  tab portrait view. *Fix submitted by Ajay Ajabale in pull request [20155](https://github.com/magento/magento2/pull/20155)*. [GitHub-20143](https://github.com/magento/magento2/issues/20143)
 
-<!--- ENGCOM-4001-->* Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20403](https://github.com/magento/magento2/pull/20403)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+<!--- ENGCOM-4001 -->
+*  Fixed misalignment of **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20403](https://github.com/magento/magento2/pull/20403)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
-<!--- ENGCOM-4130-->* Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Priti in pull request [20801](https://github.com/magento/magento2/pull/20801)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+<!--- ENGCOM-4130 -->
+*  Fixed misalignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Priti in pull request [20801](https://github.com/magento/magento2/pull/20801)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
 
-<!--- ENGCOM-3891-->* Fixed irregularities with  updating order status. *Fix submitted by Shikha Mishra in pull request [20349](https://github.com/magento/magento2/pull/20349)*. [GitHub-19258](https://github.com/magento/magento2/issues/19258)
+<!--- ENGCOM-3891 -->
+*  Fixed irregularities with  updating order status. *Fix submitted by Shikha Mishra in pull request [20349](https://github.com/magento/magento2/pull/20349)*. [GitHub-19258](https://github.com/magento/magento2/issues/19258)
 
-<!--- ENGCOM-3822-->* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Ravi Chandra in pull request [19812](https://github.com/magento/magento2/pull/19812)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+<!--- ENGCOM-3822 -->
+*  The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Ravi Chandra in pull request [19812](https://github.com/magento/magento2/pull/19812)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
 ### CMS content
 
-<!--- MAGETWO-94429-->* You can now delete from the media gallery browser any files and folders that are symlinked in `pub/media`. Previously, the Magento left the image in the media gallery but gave you no feedback in the product interface.
+<!--- MAGETWO-94429 -->
+*  You can now delete from the media gallery browser any files and folders that are symlinked in `pub/media`. Previously, the Magento left the image in the media gallery but gave you no feedback in the product interface.
 
-<!--- ENGCOM-4051-->* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [20787](https://github.com/magento/magento2/pull/20787)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+<!--- ENGCOM-4051 -->
+*  Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [20787](https://github.com/magento/magento2/pull/20787)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
 
 ### Configurable products
 
-<!--- ENGCOM-3256-->* The DateTime class can now parse strings for all supported languages, not just English. Previously, converting from string to PHP DateTime object  failed for locales other than `en_US`. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!--- ENGCOM-3256 -->
+*  The DateTime class can now parse strings for all supported languages, not just English. Previously, converting from string to PHP DateTime object  failed for locales other than `en_US`. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
-<!--- MAGETWO-96594-->* Selected images on the product page of a configurable product are now positioned correctly. [GitHub-18410](https://github.com/magento/magento2/issues/18410)
+<!--- MAGETWO-96594 -->
+*  Selected images on the product page of a configurable product are now positioned correctly. [GitHub-18410](https://github.com/magento/magento2/issues/18410)
 
-<!--- ENGCOM-3136-->* You can now successfully save products  with SKU lengths that are less than or equal to 64 digits. Previously, Magento threw a fatal error when you tried to re-save a child product after reducing the length of its 64-digit-long SKU. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
+<!--- ENGCOM-3136 -->
+*  You can now successfully save products  with SKU lengths that are less than or equal to 64 digits. Previously, Magento threw a fatal error when you tried to re-save a child product after reducing the length of its 64-digit-long SKU. *Fix submitted by Thiago in pull request [18462](https://github.com/magento/magento2/pull/18462)*. [GitHub-18082](https://github.com/magento/magento2/issues/18082)
 
-<!--- ENGCOM-3674-->* The Cart Sales Rule  now excludes already discounted products from further discounting through a coupon code. *Fix submitted by Malyovanets Nickolas in pull request [19343](https://github.com/magento/magento2/pull/19343)*. [GitHub-14020](https://github.com/magento/magento2/issues/14020)
+<!--- ENGCOM-3674 -->
+*  The Cart Sales Rule  now excludes already discounted products from further discounting through a coupon code. *Fix submitted by Malyovanets Nickolas in pull request [19343](https://github.com/magento/magento2/pull/19343)*. [GitHub-14020](https://github.com/magento/magento2/issues/14020)
 
-<!--- ENGCOM-3546-->* Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by Oleksii Gorbulin in pull request [19094](https://github.com/magento/magento2/pull/19094)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
+<!--- ENGCOM-3546 -->
+*  Translations for `tier_price.phtml` now works as expected. Previously, these translations were not included in `js-translation.json`, and not visible on the storefront. *Fix submitted by Oleksii Gorbulin in pull request [19094](https://github.com/magento/magento2/pull/19094)*. [GitHub-19085](https://github.com/magento/magento2/issues/19085)
 
-<!--- MAGETWO-96364-->* **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+<!--- MAGETWO-96364 -->
+*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
 ### cron
 
-<!--- ENGCOM-3062 -->* A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file.  *Fix submitted by Pieter Hoste in pull request [18209](https://github.com/magento/magento2/pull/18209)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
+<!--- ENGCOM-3062  -->
+*  A new `cron.log` file dedicated to logging cron-related information has been added to Magento. This new log file reduces output previously sent to the `system.log` file, making it easier to find non-cron-related information in the `system.log` file.  *Fix submitted by Pieter Hoste in pull request [18209](https://github.com/magento/magento2/pull/18209)*. [GitHub-17190](https://github.com/magento/magento2/issues/17190)
 
 ### Customers
 
-<!--- ENGCOM-3390-->* We've added an additional check for the password hash for  customers that have been  created without a password from the Admin. Previously, customers created this way could not log in. *Fix submitted by Yevhenii Dumskyi in pull request [19066](https://github.com/magento/magento2/pull/19066)*. [GitHub-19060](https://github.com/magento/magento2/issues/19060)
+<!--- ENGCOM-3390 -->
+*  We've added an additional check for the password hash for  customers that have been  created without a password from the Admin. Previously, customers created this way could not log in. *Fix submitted by Yevhenii Dumskyi in pull request [19066](https://github.com/magento/magento2/pull/19066)*. [GitHub-19060](https://github.com/magento/magento2/issues/19060)
 
-<!--- ENGCOM-3351-->* Magento now displays the same order total in  the customer information orders grid and orders grid when an order is placed in a currency other than the base currency. Previously, Magento displayed the wrong order total in the Admin's customer information orders tab. *Fix submitted by Anuj Gupta in pull request [18650](https://github.com/magento/magento2/pull/18650)*. [GitHub-18618](https://github.com/magento/magento2/issues/18618)
+<!--- ENGCOM-3351 -->
+*  Magento now displays the same order total in  the customer information orders grid and orders grid when an order is placed in a currency other than the base currency. Previously, Magento displayed the wrong order total in the Admin's customer information orders tab. *Fix submitted by Anuj Gupta in pull request [18650](https://github.com/magento/magento2/pull/18650)*. [GitHub-18618](https://github.com/magento/magento2/issues/18618)
 
-<!--- ENGCOM-3372-->* Magento no longer displays the forgot password form while a customer is logged in but instead directs the customer to the customer dashboard. *Fix submitted by Oleksii Gorbulin in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
+<!--- ENGCOM-3372 -->
+*  Magento no longer displays the forgot password form while a customer is logged in but instead directs the customer to the customer dashboard. *Fix submitted by Oleksii Gorbulin in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
 
-<!--- ENGCOM-3387-->* The reset password link in the password reset mail sent to customers when they click **Reset password** on the login page now permits customers to reset their password as expected.  *Fix submitted by p-bystritsky in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
+<!--- ENGCOM-3387 -->
+*  The reset password link in the password reset mail sent to customers when they click **Reset password** on the login page now permits customers to reset their password as expected.  *Fix submitted by p-bystritsky in pull request [19026](https://github.com/magento/magento2/pull/19026)*. [GitHub-18256](https://github.com/magento/magento2/issues/18256)
 
-<!--- ENGCOM-3014-->* Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by Dmytro Cheshun in pull request [18117](https://github.com/magento/magento2/pull/18117)*.
+<!--- ENGCOM-3014 -->
+*  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by Dmytro Cheshun in pull request [18117](https://github.com/magento/magento2/pull/18117)*.
 
-<!--- ENGCOM-3068-->* Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by Dmytro Cheshun in pull request [18308](https://github.com/magento/magento2/pull/18308)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
+<!--- ENGCOM-3068 -->
+*  Merchants can now edit a customer account if the customer's password has expired. *Fix submitted by Dmytro Cheshun in pull request [18308](https://github.com/magento/magento2/pull/18308)*. [GitHub-18162](https://github.com/magento/magento2/issues/18162)
 
-<!--- MAGETWO-95692-->* Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
+<!--- MAGETWO-95692 -->
+*  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
-<!--- MAGETWO-91704-->* You can now change payment methods after selecting store credit when creating an order from the Admin.
+<!--- MAGETWO-91704 -->
+*  You can now change payment methods after selecting store credit when creating an order from the Admin.
 
-<!--- MAGETWO-91644-->* Customers can now be matched in customer segments based on the number of orders in a multi-site deployment.
+<!--- MAGETWO-91644 -->
+*  Customers can now be matched in customer segments based on the number of orders in a multi-site deployment.
 
-<!--- MAGETWO-95925-->* We've improved the performance of the customer segment rule, which has improved site performance.
+<!--- MAGETWO-95925 -->
+*  We've improved the performance of the customer segment rule, which has improved site performance.
 
-<!--- MAGETWO-96007-->* Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
+<!--- MAGETWO-96007 -->
+*  Magento no longer unchecks the default billing and shipping address checkboxes when you create or update a customer address using the API.
 
-<!--- MAGETWO-94347-->* Magento now displays the list of additional customer addresses contained in the storefront customer address book  as a grid, which has improved performance for customers with many additional addresses associated with their accounts.
+<!--- MAGETWO-94347 -->
+*  Magento now displays the list of additional customer addresses contained in the storefront customer address book  as a grid, which has improved performance for customers with many additional addresses associated with their accounts.
 
-<!--- MAGETWO-91720-->* When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
+<!--- MAGETWO-91720 -->
+*  When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
-<!--- MAGETWO-97397-->* Magento now assigns new accounts in multisite deployments  to the customer group that is associated with the default website scope. Previously, a new customer created from the Admin  had their customer group set to the default customer group on the default website scope.
+<!--- MAGETWO-97397 -->
+*  Magento now assigns new accounts in multisite deployments  to the customer group that is associated with the default website scope. Previously, a new customer created from the Admin  had their customer group set to the default customer group on the default website scope.
 
-<!--- ENGCOM-3056-->* Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password. *Fix submitted by Dmytro Cheshun in pull request [18179](https://github.com/magento/magento2/pull/18179)*. [GitHub-18170](https://github.com/magento/magento2/issues/18170)
+<!--- ENGCOM-3056 -->
+*  Customers who have an address associated with a country that has not been set to **allowed** can now successfully reset their password. *Fix submitted by Dmytro Cheshun in pull request [18179](https://github.com/magento/magento2/pull/18179)*. [GitHub-18170](https://github.com/magento/magento2/issues/18170)
 
-<!--- ENGCOM-4028-->* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20725](https://github.com/magento/magento2/pull/20725)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+<!--- ENGCOM-4028 -->
+*  Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20725](https://github.com/magento/magento2/pull/20725)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
-<!--- ENGCOM-3981-->* Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20630](https://github.com/magento/magento2/pull/20630)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+<!--- ENGCOM-3981 -->
+*  Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20630](https://github.com/magento/magento2/pull/20630)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
-<!--- MAGETWO-97411-->* The `Magento\Customer\Model\Customer::getDataModel` method has been optimized, which has reduced the time required to load customer accounts with many addresses.
+<!--- MAGETWO-97411 -->
+*  The `Magento\Customer\Model\Customer::getDataModel` method has been optimized, which has reduced the time required to load customer accounts with many addresses.
 
-<!--- MAGETWO-98183-->* **State/Province** field values are no longer required when creating an order from the Admin. Previously, Magento indicated that **State/Province** field values were required even though configuration settings indicated these values were not required.
+<!--- MAGETWO-98183 -->
+*  **State/Province** field values are no longer required when creating an order from the Admin. Previously, Magento indicated that **State/Province** field values were required even though configuration settings indicated these values were not required.
 
-<!--- ENGCOM-3368-->* Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded. *Fix submitted by Rahul Mahto in pull request [18900](https://github.com/magento/magento2/pull/18900)*. [GitHub-18839](https://github.com/magento/magento2/issues/18839)
+<!--- ENGCOM-3368 -->
+*  Images can now by default be successfully imported from HTTP and redirected to HTTPS. Previously, the image could not be uploaded. *Fix submitted by Rahul Mahto in pull request [18900](https://github.com/magento/magento2/pull/18900)*. [GitHub-18839](https://github.com/magento/magento2/issues/18839)
 
-<!--- ENGCOM-4063-->* Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20565](https://github.com/magento/magento2/pull/20565)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
+<!--- ENGCOM-4063 -->
+*  Magento now respects the number of lines permitted in a street address as set in  **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20565](https://github.com/magento/magento2/pull/20565)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
 ### Customer attributes
 
-<!--- MAGETWO-96845-->* Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
+<!--- MAGETWO-96845 -->
+*  Magento now loads the customer attribute page as expected, and users can edit attributes, when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
 
-<!--- MAGETWO-70968-->* Custom customer address attributes can now be updated when you edit an order's billing address in the Admin.
+<!--- MAGETWO-70968 -->
+*  Custom customer address attributes can now be updated when you edit an order's billing address in the Admin.
 
-<!--- MAGETWO-91659-->* You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
+<!--- MAGETWO-91659 -->
+*  You can now create a customer without a phone number when **Show Telephone** is set to optional. Previously, Magento displayed an informative error message and did not let you create the customer.
 
-<!--- ENGCOM-3181-->* Magento now saves customer custom attributes as expected when with EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by Vishal Gelani in pull request [18571](https://github.com/magento/magento2/pull/18571)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
+<!--- ENGCOM-3181 -->
+*  Magento now saves customer custom attributes as expected when with EAV caching is disabled.  Previously, directly saving customer information resulted in data loss. *Fix submitted by Vishal Gelani in pull request [18571](https://github.com/magento/magento2/pull/18571)*. [GitHub-12479](https://github.com/magento/magento2/issues/12479)
 
 ### Dashboard
 
-<!--- MAGETWO-95299-->* You can now upload PDP images larger than 1920 x 1200  without compressing and downsizing the images first. Previously, when a merchant uploaded a high quality product image (larger than 1920X1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height.
+<!--- MAGETWO-95299 -->
+*  You can now upload PDP images larger than 1920 x 1200  without compressing and downsizing the images first. Previously, when a merchant uploaded a high quality product image (larger than 1920X1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height.
 
-<!--- MAGETWO-96975-->*  `_sleep` and `__wakeup` have been removed, and a new `PHP.MD` rule has been added to discourage PHP serialization.
+<!--- MAGETWO-96975 -->
+*   `_sleep` and `__wakeup` have been removed, and a new `PHP.MD` rule has been added to discourage PHP serialization.
 
-<!--- ENGCOM-3857-->* Magento now validates new addresses when created from the address book telephone field on the My Account dashboard page. *Fix submitted by Dipti in pull request [20262](https://github.com/magento/magento2/pull/20262)*. [GitHub-20261](https://github.com/magento/magento2/issues/20261)
+<!--- ENGCOM-3857 -->
+*  Magento now validates new addresses when created from the address book telephone field on the My Account dashboard page. *Fix submitted by Dipti in pull request [20262](https://github.com/magento/magento2/pull/20262)*. [GitHub-20261](https://github.com/magento/magento2/issues/20261)
 
 ### Developer
 
-<!--- ENGCOM-3364-->* Email messages sent from the command line (where the email loads into another block) can now be sent successfully. *Fix submitted by p-bystritsky in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!--- ENGCOM-3364 -->
+*  Email messages sent from the command line (where the email loads into another block) can now be sent successfully. *Fix submitted by p-bystritsky in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 ### Directory
 
-<!--- ENGCOM-4114-->* The Swagger definition for eav-data-attribute-option-interface has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Hiren Patel in pull request [20913](https://github.com/magento/magento2/pull/20913)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
+<!--- ENGCOM-4114 -->
+*  The Swagger definition for eav-data-attribute-option-interface has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Hiren Patel in pull request [20913](https://github.com/magento/magento2/pull/20913)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
-<!--- ENGCOM-4165-->* crontab now updates all currency rates daily  as expected. Previously, crontab updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18981](https://github.com/magento/magento2/pull/18981)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
+<!--- ENGCOM-4165 -->
+*  crontab now updates all currency rates daily  as expected. Previously, crontab updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18981](https://github.com/magento/magento2/pull/18981)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
 
 ### Downloadable
 
-<!--- ENGCOM-3384-->* Order confirmation email sent when a guest checks out now includes download links as expected. *Fix submitted by Oleksandr Kravchuk in pull request [19040](https://github.com/magento/magento2/pull/19040)*. [GitHub-18323](https://github.com/magento/magento2/issues/18323), [GitHub-19003](https://github.com/magento/magento2/issues/19003), [GitHub-19034](https://github.com/magento/magento2/issues/19034)
+<!--- ENGCOM-3384 -->
+*  Order confirmation email sent when a guest checks out now includes download links as expected. *Fix submitted by Oleksandr Kravchuk in pull request [19040](https://github.com/magento/magento2/pull/19040)*. [GitHub-18323](https://github.com/magento/magento2/issues/18323), [GitHub-19003](https://github.com/magento/magento2/issues/19003), [GitHub-19034](https://github.com/magento/magento2/issues/19034)
 
-<!--- MAGETWO-91711-->* You can now delete downloadable product links without first deleting sample links.
+<!--- MAGETWO-91711 -->
+*  You can now delete downloadable product links without first deleting sample links.
 
 ### EAV
 
-<!--- ENGCOM-3236-->* You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by Patrick McLain in pull request [18720](https://github.com/magento/magento2/pull/18720)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
+<!--- ENGCOM-3236 -->
+*  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by Patrick McLain in pull request [18720](https://github.com/magento/magento2/pull/18720)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
 
-<!--- MAGETWO-94848-->* You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+<!--- MAGETWO-94848 -->
+*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
-<!--- ENGCOM-3814-->* The customer EAV decimal attribute now accepts a value of 0. *Fix submitted by Shikha Mishra in pull request [20130](https://github.com/magento/magento2/pull/20130)*. [GitHub-20030](https://github.com/magento/magento2/issues/20030)
+<!--- ENGCOM-3814 -->
+*  The customer EAV decimal attribute now accepts a value of 0. *Fix submitted by Shikha Mishra in pull request [20130](https://github.com/magento/magento2/pull/20130)*. [GitHub-20030](https://github.com/magento/magento2/issues/20030)
 
-<!--- ENGCOM-3797-->* The Magento storefront now correctly displays products with a custom attribute of type  `Media Image`. *Fix submitted by David Verholen in pull request [20096](https://github.com/magento/magento2/pull/20096)*. [GitHub-19054](https://github.com/magento/magento2/issues/19054)
+<!--- ENGCOM-3797 -->
+*  The Magento storefront now correctly displays products with a custom attribute of type  `Media Image`. *Fix submitted by David Verholen in pull request [20096](https://github.com/magento/magento2/pull/20096)*. [GitHub-19054](https://github.com/magento/magento2/issues/19054)
 
-<!--- ENGCOM-3045-->* Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by Pieter Hoste in pull request [18244](https://github.com/magento/magento2/pull/18244)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
+<!--- ENGCOM-3045 -->
+*  Magento no longer changes the ute source_model when you create an attribute option through the API. Previously, the `source_model` of an EAV attribute was set to `Magento\Eav\Model\Entity\Attribute\Source\Table` when updating an EAV attribute's options through the API. This eliminated the ability to update this attribute's options through the Admin. *Fix submitted by Pieter Hoste in pull request [18244](https://github.com/magento/magento2/pull/18244)*. [GitHub-13156](https://github.com/magento/magento2/issues/13156)
 
-<!--- ENGCOM-3124-->* Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by Roman Strelenko in pull request [18437](https://github.com/magento/magento2/pull/18437)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
+<!--- ENGCOM-3124 -->
+*  Magento no longer throws an SQL Join error when you use a custom EAV entity  with the `standard eav_entity` entity table. Previously, this usage resulted in an integrity constraint violation. *Fix submitted by Roman Strelenko in pull request [18437](https://github.com/magento/magento2/pull/18437)*. [GitHub-18131](https://github.com/magento/magento2/issues/18131)
 
 ### Email
 
-<!--- MAGETWO-95137-->* The return path e-mail variable `system/smtp/return_path_email` now works as expected.
+<!--- MAGETWO-95137 -->
+*  The return path e-mail variable `system/smtp/return_path_email` now works as expected.
 
-<!--- ENGCOM-3744-->* Email subject headers now support UTF-8 encoding. *Fix submitted by Alexey Varlamov in pull request [19978](https://github.com/magento/magento2/pull/19978)*. [GitHub-19977](https://github.com/magento/magento2/issues/19977)
+<!--- ENGCOM-3744 -->
+*  Email subject headers now support UTF-8 encoding. *Fix submitted by Alexey Varlamov in pull request [19978](https://github.com/magento/magento2/pull/19978)*. [GitHub-19977](https://github.com/magento/magento2/issues/19977)
 
 ### Frameworks
 
-<!--- MAGETWO-97040-->* Magento no longer logs an error when you include properly escaped special characters in the store view names. Previously, Magento logged errors in the `exception.log`.
+<!--- MAGETWO-97040 -->
+*  Magento no longer logs an error when you include properly escaped special characters in the store view names. Previously, Magento logged errors in the `exception.log`.
 
-<!--- MAGETWO-96342-->* Magento now attempts to reconnect when a MySQL timeout occurs. Previously, Magento displayed an informative PHP-related message and did not attempt to reconnect.
+<!--- MAGETWO-96342 -->
+*  Magento now attempts to reconnect when a MySQL timeout occurs. Previously, Magento displayed an informative PHP-related message and did not attempt to reconnect.
 
-<!--- MAGETWO-94089-->* You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
+<!--- MAGETWO-94089 -->
+*  You can now set all products that currently have **Set Product as New** set to **yes** set to **no**. This change affects bulk updates, CSV imports, and scheduled updates.
 
-<!--- MAGETWO-95838-->* Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
+<!--- MAGETWO-95838 -->
+*  Attributes in flat tables are now updated after the product is saved when the catalog product flat index is turned on and the indexer is set to **Save on Update**.
 
-<!--- ENGCOM-3538-->* `dev/tools/grunt/configs/themes.js` has been removed from the `.gitignore` file and added to the github repository. Previously, `localthemes.js` was included in the `.gitignore` and replaced during a Magento update. *Fix submitted by Torben Höhn in pull request [19350](https://github.com/magento/magento2/pull/19350)*. [GitHub-18949](https://github.com/magento/magento2/issues/18949)
+<!--- ENGCOM-3538 -->
+*  `dev/tools/grunt/configs/themes.js` has been removed from the `.gitignore` file and added to the github repository. Previously, `localthemes.js` was included in the `.gitignore` and replaced during a Magento update. *Fix submitted by Torben Höhn in pull request [19350](https://github.com/magento/magento2/pull/19350)*. [GitHub-18949](https://github.com/magento/magento2/issues/18949)
 
-<!--- ENGCOM-3295-->* Magento now autoloads vendor root folders and can now run with custom Composer vendor directories. Previously, Magento's autoloader registration failed to generate the correct path when using the `COMPOSER_VENDOR_DIR` setting to specify a vendor path outside of the Magento installation root. *Fix submitted by Rus0 in pull request [18849](https://github.com/magento/magento2/pull/18849)*. [GitHub-17753](https://github.com/magento/magento2/issues/17753)
+<!--- ENGCOM-3295 -->
+*  Magento now autoloads vendor root folders and can now run with custom Composer vendor directories. Previously, Magento's autoloader registration failed to generate the correct path when using the `COMPOSER_VENDOR_DIR` setting to specify a vendor path outside of the Magento installation root. *Fix submitted by Rus0 in pull request [18849](https://github.com/magento/magento2/pull/18849)*. [GitHub-17753](https://github.com/magento/magento2/issues/17753)
 
-<!--- ENGCOM-3471-->* Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by Eduard Chitoraga in pull request [19134](https://github.com/magento/magento2/pull/19134)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
+<!--- ENGCOM-3471 -->
+*  Newly added links on the customer dashboard are now shown as current as expected when the link path has been constructed from both default and new elements. Previously, the link was added, but not shown in the current state as expected. *Fix submitted by Eduard Chitoraga in pull request [19134](https://github.com/magento/magento2/pull/19134)*. [GitHub-19099](https://github.com/magento/magento2/issues/19099)
 
-<!--- ENGCOM-3483-->* The `fileUploader` form element in `ui_component` form now works as expected. Previously, during file upload, the countable interface not implemented, and Magento threw this error, `Error Message : Warning: count(): Parameter must be an array or an object that implements Countable in <base_dir>/vendor/magento/framework/File/Uploader.php on line 550`.  *Fix submitted by gmachure in pull request [19249](https://github.com/magento/magento2/pull/19249)*. [GitHub-19247](https://github.com/magento/magento2/issues/19247)
+<!--- ENGCOM-3483 -->
+*  The `fileUploader` form element in `ui_component` form now works as expected. Previously, during file upload, the countable interface not implemented, and Magento threw this error, `Error Message : Warning: count(): Parameter must be an array or an object that implements Countable in <base_dir>/vendor/magento/framework/File/Uploader.php on line 550`.  *Fix submitted by gmachure in pull request [19249](https://github.com/magento/magento2/pull/19249)*. [GitHub-19247](https://github.com/magento/magento2/issues/19247)
 
-<!--- ENGCOM-3243-->* Interception cache compilation has been improved, and custom profiler records are now executed in less than a second. Previously, profiled methods consumed about 70% of the first page load after `cache:flush` from either the command-line interface or the Admin. *Fix submitted by Patrick McLain in pull request [18648](https://github.com/magento/magento2/pull/18648)*. [GitHub-17680](https://github.com/magento/magento2/issues/17680)
+<!--- ENGCOM-3243 -->
+*  Interception cache compilation has been improved, and custom profiler records are now executed in less than a second. Previously, profiled methods consumed about 70% of the first page load after `cache:flush` from either the command-line interface or the Admin. *Fix submitted by Patrick McLain in pull request [18648](https://github.com/magento/magento2/pull/18648)*. [GitHub-17680](https://github.com/magento/magento2/issues/17680)
 
-<!--- ENGCOM-3535-->* `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+<!--- ENGCOM-3535 -->
+*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
-<!--- ENGCOM-3846-->* Deprecated interface `\Magento\Framework\Option\ArrayInterface` has been replaced with `\Magento\Framework\Data\OptionSourceInterface` in `lib/internal/Magento/Framework/Option/ArrayPool.php`. *Fix submitted by Milind Singh in pull request [20248](https://github.com/magento/magento2/pull/20248)*. [GitHub-20064](https://github.com/magento/magento2/issues/20064)
+<!--- ENGCOM-3846 -->
+*  Deprecated interface `\Magento\Framework\Option\ArrayInterface` has been replaced with `\Magento\Framework\Data\OptionSourceInterface` in `lib/internal/Magento/Framework/Option/ArrayPool.php`. *Fix submitted by Milind Singh in pull request [20248](https://github.com/magento/magento2/pull/20248)*. [GitHub-20064](https://github.com/magento/magento2/issues/20064)
 
-<!--- ENGCOM-4166-->* Corrected invalid return type in docblock in `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()`. Previously, the docblock of the  `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()` method stated that it would return a `bool` or an instance of `Zend\Http\Header\HeaderInterface()`. However, this method returned either a `bool` or a `string`. *Fix submitted by Milind Singh in pull request [21035](https://github.com/magento/magento2/pull/21035)*. [GitHub-21034](https://github.com/magento/magento2/issues/21034)
+<!--- ENGCOM-4166 -->
+*  Corrected invalid return type in docblock in `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()`. Previously, the docblock of the  `Magento\Framework\HTTP\PhpEnvironment\Request::getHeader()` method stated that it would return a `bool` or an instance of `Zend\Http\Header\HeaderInterface()`. However, this method returned either a `bool` or a `string`. *Fix submitted by Milind Singh in pull request [21035](https://github.com/magento/magento2/pull/21035)*. [GitHub-21034](https://github.com/magento/magento2/issues/21034)
 
-<!--- ENGCOM-3117-->* Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by Artsiom Bruneuski in pull request [18416](https://github.com/magento/magento2/pull/18416)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
+<!--- ENGCOM-3117 -->
+*  Magento now throws `LogicException($message, 0, $e)` instead of `LogicException($message)` as needed when running validation for communication configuration (`communication.xml`).  Previously, the  validator in `Magento\Framework\Communication\Config\Validator` did not propagate exceptions, which obscured the cause of the error. *Fix submitted by Artsiom Bruneuski in pull request [18416](https://github.com/magento/magento2/pull/18416)*. [GitHub-14555](https://github.com/magento/magento2/issues/14555)
 
-<!--- ENGCOM-4073-->* JavaScript translation issues on the modal buttons that Magento displays when removing items from product compare page have been resolved. *Fix submitted by Max Fickers in pull request [20109](https://github.com/magento/magento2/pull/20109)*. [GitHub-19705](https://github.com/magento/magento2/issues/19705)
+<!--- ENGCOM-4073 -->
+*  JavaScript translation issues on the modal buttons that Magento displays when removing items from product compare page have been resolved. *Fix submitted by Max Fickers in pull request [20109](https://github.com/magento/magento2/pull/20109)*. [GitHub-19705](https://github.com/magento/magento2/issues/19705)
 
-<!--- ENGCOM-3710-->* `Magento/Framework/HTTP/Adapter/Curl.php` now supports setting an HTTP version. *Fix submitted by SikailoISM in pull request [19845](https://github.com/magento/magento2/pull/19845)*. [GitHub-19442](https://github.com/magento/magento2/issues/19442)
+<!--- ENGCOM-3710 -->
+*  `Magento/Framework/HTTP/Adapter/Curl.php` now supports setting an HTTP version. *Fix submitted by SikailoISM in pull request [19845](https://github.com/magento/magento2/pull/19845)*. [GitHub-19442](https://github.com/magento/magento2/issues/19442)
 
-<!--- ENGCOM-3425-->* Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace.  *Fix submitted by Vova Yatsyuk in pull request [19143](https://github.com/magento/magento2/pull/19143)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+<!--- ENGCOM-3425 -->
+*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace.  *Fix submitted by Vova Yatsyuk in pull request [19143](https://github.com/magento/magento2/pull/19143)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
-<!--- ENGCOM-3753-->* The AMQP helper has been updated to use host, username, and password configuration from the instance under test. This allows tests to run when the AMQP service is not using default credentials or available on `localhost`. Previously, the `host` value in this helper was hardcoded. *Fix submitted by Patrick McLain in pull request [18978](https://github.com/magento/magento2/pull/18978)*. [GitHub-18953](https://github.com/magento/magento2/issues/18953)
+<!--- ENGCOM-3753 -->
+*  The AMQP helper has been updated to use host, username, and password configuration from the instance under test. This allows tests to run when the AMQP service is not using default credentials or available on `localhost`. Previously, the `host` value in this helper was hardcoded. *Fix submitted by Patrick McLain in pull request [18978](https://github.com/magento/magento2/pull/18978)*. [GitHub-18953](https://github.com/magento/magento2/issues/18953)
 
-<!--- ENGCOM-4046-->* We've added support for `use` statements in web API interfaces and the use of non-FQN class names in `doctypes`. Previously,  you could not  import class names in interfaces used for web API. *Fix submitted by Riccardo Tempesta in pull request [17424](https://github.com/magento/magento2/pull/17424)*. [GitHub-1537](https://github.com/magento/magento2/issues/1537)
+<!--- ENGCOM-4046 -->
+*  We've added support for `use` statements in web API interfaces and the use of non-FQN class names in `doctypes`. Previously,  you could not  import class names in interfaces used for web API. *Fix submitted by Riccardo Tempesta in pull request [17424](https://github.com/magento/magento2/pull/17424)*. [GitHub-1537](https://github.com/magento/magento2/issues/1537)
 
 #### Cache framework
 
-<!--- MAGETWO-95853-->* The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
+<!--- MAGETWO-95853 -->
+*  The images cache can now be flushed from the Admin (**Admin** > **System** > **Cache Management** and click **Flush Catalog Images Cache**). Previously, you could not delete the directory, and Magento displayed an error on the cache management page.
 
-<!--- MAGETWO-91694-->* Magento now removes disabled products as expected from the flat product table when **Catalog Flat Product** is enabled.
+<!--- MAGETWO-91694 -->
+*  Magento now removes disabled products as expected from the flat product table when **Catalog Flat Product** is enabled.
 
 #### Configuration framework
 
-<!--- MAGETWO-97247-->* You can now enable shared catalogs using the `config:set` command. Previously, this command enabled the shared catalog but did not create the necessary permissions to access it.
+<!--- MAGETWO-97247 -->
+*  You can now enable shared catalogs using the `config:set` command. Previously, this command enabled the shared catalog but did not create the necessary permissions to access it.
 
 #### Data framework
 
-<!--- ENGCOM-3268-->* Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by Burlacu Vasilii in pull request [18798](https://github.com/magento/magento2/pull/18798)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
+<!--- ENGCOM-3268 -->
+*  Class `\Magento\Framework\Data\Form\Element\Fieldset` now calls the `getBeforeElementHtml` method. *Fix submitted by Burlacu Vasilii in pull request [18798](https://github.com/magento/magento2/pull/18798)*. [GitHub-2618](https://github.com/magento/magento2/issues/2618)
 
 #### Event framework
 
-<!--- ENGCOM-3422-->* events.xml can now have child nodes. *Fix submitted by Lisovyi Yevhenii in pull request [19146](https://github.com/magento/magento2/pull/19146)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
+<!--- ENGCOM-3422 -->
+*  events.xml can now have child nodes. *Fix submitted by Lisovyi Yevhenii in pull request [19146](https://github.com/magento/magento2/pull/19146)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
 
 #### JavaScript framework
 
-<!--- MAGETWO-56813-->* Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
+<!--- MAGETWO-56813 -->
+*  Wishlist names can now contain apostrophes. Previously, a wishlist whose name contained an apostrophe could not be edited or deleted.
 
 #### Message framework
 
-<!--- MAGETWO-91717-->* Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
+<!--- MAGETWO-91717 -->
+*  Module names can now contain numbers. Previously, `magento/framework-message-queue/etc/queue_base.xml` contained a pattern that did not allow numbers to be used in `instanceType`, which resulted in the invalidation of custom message consumers in this file.
 
 ### General fixes
 
-<!--- ENGCOM-3198-->* The navigation arrows in fotorama now stay visible after you close the zoomed fotorama. *Fix submitted by Luuk Schakenraad in pull request [18590](https://github.com/magento/magento2/pull/18590)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
+<!--- ENGCOM-3198 -->
+*  The navigation arrows in fotorama now stay visible after you close the zoomed fotorama. *Fix submitted by Luuk Schakenraad in pull request [18590](https://github.com/magento/magento2/pull/18590)*. [GitHub-18585](https://github.com/magento/magento2/issues/18585)
 
-<!--- ENGCOM-3239-->* You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by Dmytro Cheshun in pull request [18730](https://github.com/magento/magento2/pull/18730)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
+<!--- ENGCOM-3239 -->
+*  You can now customize the view of tab and accordion components by using mixins to redefine the default variables in the scope of a custom theme. *Fix submitted by Dmytro Cheshun in pull request [18730](https://github.com/magento/magento2/pull/18730)*. [GitHub-18729](https://github.com/magento/magento2/issues/18729)
 
-<!--- ENGCOM-3489-->* Content in  confirmation popups on the Admin no longer overlap the **Close** button.    *Fix submitted by Dmytro Cheshun in pull request [19264](https://github.com/magento/magento2/pull/19264)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
+<!--- ENGCOM-3489 -->
+*  Content in  confirmation popups on the Admin no longer overlap the **Close** button.    *Fix submitted by Dmytro Cheshun in pull request [19264](https://github.com/magento/magento2/pull/19264)*. [GitHub-19263](https://github.com/magento/magento2/issues/19263)
 
-<!--- ENGCOM-3346-->* You can now update database credentials from the command line in non-interactive mode using `bin/magento setup:config:set`. *Fix submitted by aheadWorks Capital SIA in pull request [18970](https://github.com/magento/magento2/pull/18970)*. [GitHub-18965](https://github.com/magento/magento2/issues/18965)
+<!--- ENGCOM-3346 -->
+*  You can now update database credentials from the command line in non-interactive mode using `bin/magento setup:config:set`. *Fix submitted by aheadWorks Capital SIA in pull request [18970](https://github.com/magento/magento2/pull/18970)*. [GitHub-18965](https://github.com/magento/magento2/issues/18965)
 
-<!--- ENGCOM-3165-->* The error message displayed on the Add Product Attribute page has been improved. *Fix submitted by Aman Agarwal in pull request [17800](https://github.com/magento/magento2/pull/17800)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
+<!--- ENGCOM-3165 -->
+*  The error message displayed on the Add Product Attribute page has been improved. *Fix submitted by Aman Agarwal in pull request [17800](https://github.com/magento/magento2/pull/17800)*. [GitHub-17754](https://github.com/magento/magento2/issues/17754)
 
-<!--- ENGCOM-3209-->* The datepicker icon is now correctly aligned in the Admin. *Fix submitted by Yaroslav Rogoza in pull request [18627](https://github.com/magento/magento2/pull/18627)*. [GitHub-18605](https://github.com/magento/magento2/issues/18605)
+<!--- ENGCOM-3209 -->
+*  The datepicker icon is now correctly aligned in the Admin. *Fix submitted by Yaroslav Rogoza in pull request [18627](https://github.com/magento/magento2/pull/18627)*. [GitHub-18605](https://github.com/magento/magento2/issues/18605)
 
-<!--- ENGCOM-3224-->* The magnifier now disappears as expected when a user moves their cursor off an image. *Fix submitted by gwharton in pull request [18702](https://github.com/magento/magento2/pull/18702)*. [GitHub-15035](https://github.com/magento/magento2/issues/15035)
+<!--- ENGCOM-3224 -->
+*  The magnifier now disappears as expected when a user moves their cursor off an image. *Fix submitted by gwharton in pull request [18702](https://github.com/magento/magento2/pull/18702)*. [GitHub-15035](https://github.com/magento/magento2/issues/15035)
 
-<!--- MAGETWO-91745-->* Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
+<!--- MAGETWO-91745 -->
+*  Product pages that are included in a related products rule that uses a Price (percentage) condition now load correctly. Previously, loaded pages were blank.
 
-<!--- MAGETWO-96405-->* Magento now displays the appropriate thumbnail image for configurable products in requisition lists. Previously, Magento displayed the default placeholder thumbnail image for all configurable products.
+<!--- MAGETWO-96405 -->
+*  Magento now displays the appropriate thumbnail image for configurable products in requisition lists. Previously, Magento displayed the default placeholder thumbnail image for all configurable products.
 
-<!--- ENGCOM-3153 -->* Magento no longer displays a console error when a customer selects one step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
+<!--- ENGCOM-3153  -->
+*  Magento no longer displays a console error when a customer selects one step checkout. Previously, Magento displayed this JavaScript error, `Cannot read property 'code' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18494](https://github.com/magento/magento2/pull/18494)*. [GitHub-18164](https://github.com/magento/magento2/issues/18164)
 
-<!--- ENGCOM-3588-->* The **Select All** and **Select Visible** buttons on the notification page now work as expected. Previously, these buttons behaved the same. *Fix submitted by Shikha Mishra in pull request [19302](https://github.com/magento/magento2/pull/19302)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
+<!--- ENGCOM-3588 -->
+*  The **Select All** and **Select Visible** buttons on the notification page now work as expected. Previously, these buttons behaved the same. *Fix submitted by Shikha Mishra in pull request [19302](https://github.com/magento/magento2/pull/19302)*. [GitHub-19285](https://github.com/magento/magento2/issues/19285)
 
-<!--- ENGCOM-3389-->* The note that describes the **Use in Layered Navigation: Filterable (no results)**  property now better describes the property. *Fix submitted by Vladyslav Podorozhnyi in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!--- ENGCOM-3389 -->
+*  The note that describes the **Use in Layered Navigation: Filterable (no results)**  property now better describes the property. *Fix submitted by Vladyslav Podorozhnyi in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
-<!--- ENGCOM-3258-->* Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Peter O'Callaghan in pull request [18412](https://github.com/magento/magento2/pull/18412)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357)
+<!--- ENGCOM-3258 -->
+*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Peter O'Callaghan in pull request [18412](https://github.com/magento/magento2/pull/18412)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357)
 
 ### Gift cards
 
-<!--- MAGETWO-91700-->* Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
+<!--- MAGETWO-91700 -->
+*  Magento now consistently validates gift card prices according to the constraints of the relevant store locale.
 
-<!--- ENGCOM-3379-->* Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!--- ENGCOM-3379 -->
+*  Fixed the rendering of the check notifications counters icon on the Admin. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!--- ENGCOM-3624-->* `old_path: new_path` path mappings have been added for JavaScript files have been relocated to `requirejs-config.js`. *Fix submitted by rbayet in pull request [19583](https://github.com/magento/magento2/pull/19583)*. [GitHub-19291](https://github.com/magento/magento2/issues/19291), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!--- ENGCOM-3624 -->
+*  `old_path: new_path` path mappings have been added for JavaScript files have been relocated to `requirejs-config.js`. *Fix submitted by rbayet in pull request [19583](https://github.com/magento/magento2/pull/19583)*. [GitHub-19291](https://github.com/magento/magento2/issues/19291), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!--- ENGCOM-3632-->* Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by Nazar in pull request [19135](https://github.com/magento/magento2/pull/19135)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
+<!--- ENGCOM-3632 -->
+*  Calling `getCurrentUrl` on a store no longer adds the  `___store` parameter when **store code in URL** is set to **yes** and the current store is not the same store requested in the URL. *Fix submitted by Nazar in pull request [19135](https://github.com/magento/magento2/pull/19135)*. [GitHub-18941](https://github.com/magento/magento2/issues/18941), [GitHub-16302](https://github.com/magento/magento2/issues/16302)
 
-<!--- ENGCOM-3644-->* The **Click for price** button on the home page now works as expected. *Fix submitted by Ravi Chandra in pull request [19663](https://github.com/magento/magento2/pull/19663)*. [GitHub-15922](https://github.com/magento/magento2/issues/15922)
+<!--- ENGCOM-3644 -->
+*  The **Click for price** button on the home page now works as expected. *Fix submitted by Ravi Chandra in pull request [19663](https://github.com/magento/magento2/pull/19663)*. [GitHub-15922](https://github.com/magento/magento2/issues/15922)
 
 ### Gift message
 
-<!--- MAGETWO-67269-->* Magento no longer displays unselected gift options when a customer selects **Check Out with Multiple Addresses** for an order. Previously, Magento displayed unselected gift options for the order.
+<!--- MAGETWO-67269 -->
+*  Magento no longer displays unselected gift options when a customer selects **Check Out with Multiple Addresses** for an order. Previously, Magento displayed unselected gift options for the order.
 
-<!--- ENGCOM-3985-->* Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by Ajay Ajabale in pull request [20605](https://github.com/magento/magento2/pull/20605)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+<!--- ENGCOM-3985 -->
+*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by Ajay Ajabale in pull request [20605](https://github.com/magento/magento2/pull/20605)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
 ### Gift registry
 
-<!--- MAGETWO-95833-->* Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
+<!--- MAGETWO-95833 -->
+*  Magento now shows the correct price for configurable products in a shared gift registry. Previously, Magento displayed the original price instead of the special price for configurable products.
 
 ### Gift wrapping
 
-<!--- MAGETWO-91563-->* You can now add gift wrapping to the shopping cart to an already added product without having to add an additional product.
+<!--- MAGETWO-91563 -->
+*  You can now add gift wrapping to the shopping cart to an already added product without having to add an additional product.
 
 ### Google Analytics
 
-<!--- ENGCOM-3058-->* `referenceContainer` has been changed to `referenceBlock` in the Google Analytics module. *Fix submitted by Petar Sambolek in pull request [18290](https://github.com/magento/magento2/pull/18290)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
+<!--- ENGCOM-3058 -->
+*  `referenceContainer` has been changed to `referenceBlock` in the Google Analytics module. *Fix submitted by Petar Sambolek in pull request [18290](https://github.com/magento/magento2/pull/18290)*. [GitHub-16497](https://github.com/magento/magento2/issues/16497)
 
 ### Import/export
 
-<!--- ENGCOM-3203-->* Magento now displays an informative error after you run check data, and also blocks import and product creation, when SKU strings are too long. Previously, the check data process permitted you to proceed with the import, but the import failed due to a system error. Products were created with excessively long strings were created with all the values except SKU empty. *Fix submitted by Ravi Chandra in pull request [18639](https://github.com/magento/magento2/pull/18639)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
+<!--- ENGCOM-3203 -->
+*  Magento now displays an informative error after you run check data, and also blocks import and product creation, when SKU strings are too long. Previously, the check data process permitted you to proceed with the import, but the import failed due to a system error. Products were created with excessively long strings were created with all the values except SKU empty. *Fix submitted by Ravi Chandra in pull request [18639](https://github.com/magento/magento2/pull/18639)*. [GitHub-17865](https://github.com/magento/magento2/issues/17865)
 
-<!--- ENGCOM-3228-->* Magento now successfully imports products  that have a fixed price custom option with a price of zero. Previously,  the importer failed when trying to update products with a price of zero.  *Fix submitted by Antun Matanović in pull request [18284](https://github.com/magento/magento2/pull/18284)*. [GitHub-17616](https://github.com/magento/magento2/issues/17616)
+<!--- ENGCOM-3228 -->
+*  Magento now successfully imports products  that have a fixed price custom option with a price of zero. Previously,  the importer failed when trying to update products with a price of zero.  *Fix submitted by Antun Matanović in pull request [18284](https://github.com/magento/magento2/pull/18284)*. [GitHub-17616](https://github.com/magento/magento2/issues/17616)
 
-<!--- MAGETWO-94671-->* The memory required to export the media gallery has been significantly reduced. [GitHub-17320](https://github.com/magento/magento2/issues/17320)
+<!--- MAGETWO-94671 -->
+*  The memory required to export the media gallery has been significantly reduced. [GitHub-17320](https://github.com/magento/magento2/issues/17320)
 
 <!--- MAGETWO-95825-->
 * We've resolved the following issues with imported images:
@@ -849,61 +1142,86 @@ Previously, when you reopened these categories, no checkboxes were checked.
 
    * images that were removed through the Admin before import returned after import. Magento now displays an informative error message if images are not imported as expected.
 
-<!--- MAGETWO-91569-->* Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
+<!--- MAGETWO-91569 -->
+*  Special characters in the CSV import file no longer trigger a general system exception. Previously, special characters (for example, <code>ƒ</code>, <code>ª</code>, and <code>›</code>) halted the check data phase of import.
 
-<!--- MAGETWO-95105-->* URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
+<!--- MAGETWO-95105 -->
+*  URL Key columns that contain  accented characters are now converted properly after the import of a CSV file. Previously, if you manually assigned a URL key to a product in the Admin that contained an accent character or punctuation, Magento converted it to the regular character or removed it.
 
-<!--- MAGETWO-91544-->* Magento now correctly updates existing product URLs during import. Previously, Magento update existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
+<!--- MAGETWO-91544 -->
+*  Magento now correctly updates existing product URLs during import. Previously, Magento update existing URLs with the new URLs, but displayed a 404 error if you tried to access the product from the new URL.
 
-<!--- MAGETWO-95829-->* Magento now retains product order within a category after import.
+<!--- MAGETWO-95829 -->
+*  Magento now retains product order within a category after import.
 
-<!--- MAGETWO-59265-->* You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
+<!--- MAGETWO-59265 -->
+*  You can now properly set data for drop-down attributes during product import in deployments with multiple storeviews.
 
-<!--- MAGETWO-91657-->* Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
+<!--- MAGETWO-91657 -->
+*  Magento now prompts you to enter a valid value when you enter a value of zero for a customer group price discount by percentage when setting advanced pricing for a product.  Previously, Magento threw an error.
 
-<!--- MAGETWO-58210-->* The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
+<!--- MAGETWO-58210 -->
+*  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
 
-<!--- ENGCOM-3083-->* The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by utietze in pull request [18271](https://github.com/magento/magento2/pull/18271)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
+<!--- ENGCOM-3083 -->
+*  The upsert category process during product import now generates freshly created category URL rewrites globally and not just for the default scope. Previously, Magento created URL rewrites for the default website scope only. *Fix submitted by utietze in pull request [18271](https://github.com/magento/magento2/pull/18271)*. [GitHub-18234](https://github.com/magento/magento2/issues/18234)
 
-<!--- ENGCOM-3823-->* Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by p-bystritsky in pull request [20180](https://github.com/magento/magento2/pull/20180)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
+<!--- ENGCOM-3823 -->
+*  Magento now indicates correct stock status (in stock/out-of-stock) after importing products that have an indicated quantity but a status of out-of-stock from a CSV file. Previously, Magento imported the product quantity correctly, but not the stock status. *Fix submitted by p-bystritsky in pull request [20180](https://github.com/magento/magento2/pull/20180)*. [GitHub-15950](https://github.com/magento/magento2/issues/15950)
 
-<!--- ENGCOM-3809-->* We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.  *Fix submitted by Rajneesh Gupta in pull request [20127](https://github.com/magento/magento2/pull/20127)*. [GitHub-20098](https://github.com/magento/magento2/issues/20098)
+<!--- ENGCOM-3809 -->
+*  We've resolved multiple issues that users previously encountered when importing configurable products with images and virtual products. Previously, image import failed under certain circumstances, and Magento displayed these messages:  `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s)` and `Products are imported but configurable product has no image in Magento`.  *Fix submitted by Rajneesh Gupta in pull request [20127](https://github.com/magento/magento2/pull/20127)*. [GitHub-20098](https://github.com/magento/magento2/issues/20098)
 
-<!--- ENGCOM-3977-->* `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites the `$value` argument. Previously, the same name was used for different `$value` variables. *Fix submitted by Rajneesh Gupta in pull request [20625](https://github.com/magento/magento2/pull/20625)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+<!--- ENGCOM-3977 -->
+*  `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites the `$value` argument. Previously, the same name was used for different `$value` variables. *Fix submitted by Rajneesh Gupta in pull request [20625](https://github.com/magento/magento2/pull/20625)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
-<!--- ENGCOM-3524-->* Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by Kajal Solanki in pull request [19334](https://github.com/magento/magento2/pull/19334)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+<!--- ENGCOM-3524 -->
+*  Fixed misalignment of the import successful  message icon  in the Admin. *Fix submitted by Kajal Solanki in pull request [19334](https://github.com/magento/magento2/pull/19334)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
-<!--- MAGETWO-96381-->* Magento now exports configurable products based on swatches with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
+<!--- MAGETWO-96381 -->
+*  Magento now exports configurable products based on swatches with the correct Admin and Default Store View labels. Previously, after import the `configurable_variations` column for these configurable products contained the wrong values.
 
 ### Infrastructure
 
-<!--- ENGCOM-4389 -->* Magento now supports Elasticsearch 6.x. *Fix submitted by [Romain Ruaud](https://github.com/romainruaud) in pull request [21458](https://github.com/magento/magento2/pull/21458)*.
+<!--- ENGCOM-4389  -->
+*  Magento now supports Elasticsearch 6.x. *Fix submitted by [Romain Ruaud](https://github.com/romainruaud) in pull request [21458](https://github.com/magento/magento2/pull/21458)*.
 
-<!--- MC-5201 -->* Magento now supports Redis 5.0.
+<!--- MC-5201  -->
+*  Magento now supports Redis 5.0.
 
-<!--- ENGCOM-3690-->* `transparent.js` has been relocated, and orders can now be created from the Admin using PayflowPro and Authorize.Net. Previously, orders created from the Admin using PayflowPro failed, and Magento displayed an informative message indicating an invalid account number. *Fix submitted by Patrick McLain in pull request [19764](https://github.com/magento/magento2/pull/19764)*. [GitHub-19763](https://github.com/magento/magento2/issues/19763)
+<!--- ENGCOM-3690 -->
+*  `transparent.js` has been relocated, and orders can now be created from the Admin using PayflowPro and Authorize.Net. Previously, orders created from the Admin using PayflowPro failed, and Magento displayed an informative message indicating an invalid account number. *Fix submitted by Patrick McLain in pull request [19764](https://github.com/magento/magento2/pull/19764)*. [GitHub-19763](https://github.com/magento/magento2/issues/19763)
 
-<!--- ENGCOM-4392 -->* Expected backup and restoration functionality has been restored and MySQL View support is supported while preserving backward compatibility with pre-existing modules. *Fix submitted by community member  Stepan Furman in pull request [21151](https://github.com/magento/magento2/pull/21151)*.
+<!--- ENGCOM-4392  -->
+*  Expected backup and restoration functionality has been restored and MySQL View support is supported while preserving backward compatibility with pre-existing modules. *Fix submitted by community member  Stepan Furman in pull request [21151](https://github.com/magento/magento2/pull/21151)*.
 
-<!--- ENGCOM-3598-->* `json_encode` errors are now caught and logged in console.log. Previously, the JSON serializer threw an error, which blocked all frontend behavior, *Fix submitted by Tommy Quissens in pull request [16154](https://github.com/magento/magento2/pull/16154)*. [GitHub-14937](https://github.com/magento/magento2/issues/14937)
+<!--- ENGCOM-3598 -->
+*  `json_encode` errors are now caught and logged in console.log. Previously, the JSON serializer threw an error, which blocked all frontend behavior, *Fix submitted by Tommy Quissens in pull request [16154](https://github.com/magento/magento2/pull/16154)*. [GitHub-14937](https://github.com/magento/magento2/issues/14937)
 
-<!--- ENGCOM-3589-->* `app/bootstrap.php` has been updated to correctly define supported PHP versions. *Fix submitted by Fabrizio Balliano in pull request [19455](https://github.com/magento/magento2/pull/19455)*. [GitHub-19453](https://github.com/magento/magento2/issues/19453)
+<!--- ENGCOM-3589 -->
+*  `app/bootstrap.php` has been updated to correctly define supported PHP versions. *Fix submitted by Fabrizio Balliano in pull request [19455](https://github.com/magento/magento2/pull/19455)*. [GitHub-19453](https://github.com/magento/magento2/issues/19453)
 
-<!--- ENGCOM-3687-->* An incorrect parameter in `getCreatedAtFormatted($format)` have been corrected. *Fix submitted by Jaimin Sutariya in pull request [19537](https://github.com/magento/magento2/pull/19537)*. [GitHub-17442](https://github.com/magento/magento2/issues/17442)
+<!--- ENGCOM-3687 -->
+*  An incorrect parameter in `getCreatedAtFormatted($format)` have been corrected. *Fix submitted by Jaimin Sutariya in pull request [19537](https://github.com/magento/magento2/pull/19537)*. [GitHub-17442](https://github.com/magento/magento2/issues/17442)
 
-<!--- ENGCOM-3666-->* A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by Nirav Kadiya in pull request [19634](https://github.com/magento/magento2/pull/19634)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+<!--- ENGCOM-3666 -->
+*  A syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php` has been corrected. *Fix submitted by Nirav Kadiya in pull request [19634](https://github.com/magento/magento2/pull/19634)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
 
-<!--- ENGCOM-3364-->* Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by p-bystritsky in pull request [18991](https://github.com/magento/magento2/pull/18991)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
+<!--- ENGCOM-3364 -->
+*  Magento no longer throws an error when you send an email from the command line. Previously, Magento threw an exception because `$debugHintsPath` was missing. *Fix submitted by p-bystritsky in pull request [18991](https://github.com/magento/magento2/pull/18991)*. [GitHub-10440](https://github.com/magento/magento2/issues/10440)
 
 * Message queue topic names generated as a result of asynchronous and bulk REST calls are now based on service contract names. Currently,  topic names reflect the PHP class and method names that should be invoked to handle processing. For example, a topic that was named using the older conventions (`async.V1.customers.POST`) might be named `async.magento.customer.api.accountmanagementinterface.createaccount.post`. This new naming is more semantic and allows the reuse for other Magento services.
 
 ### Integration
 
-<!--- ENGCOM-3353-->* Magento no longer throws an exception when you navigate to the OAuth page (**Backend** > **Stores** > **Configuration** > **Services** > **OAuth**). *Fix submitted by Mahesh Singh in pull request [18750](https://github.com/magento/magento2/pull/18750)*. [GitHub-18655](https://github.com/magento/magento2/issues/18655)
+<!--- ENGCOM-3353 -->
+*  Magento no longer throws an exception when you navigate to the OAuth page (**Backend** > **Stores** > **Configuration** > **Services** > **OAuth**). *Fix submitted by Mahesh Singh in pull request [18750](https://github.com/magento/magento2/pull/18750)*. [GitHub-18655](https://github.com/magento/magento2/issues/18655)
 
-<!--- ENGCOM-3355-->* The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by Prakash in pull request [18973](https://github.com/magento/magento2/pull/18973)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
+<!--- ENGCOM-3355 -->
+*  The Last logged In value displayed on the customer account page on the Admin is now updated as expected when a customer is authenticated through REST. *Fix submitted by Prakash in pull request [18973](https://github.com/magento/magento2/pull/18973)*. [GitHub-17488](https://github.com/magento/magento2/issues/17488)
 
-<!--- ENGCOM-3053-->* Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by Pratik Oza in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
+<!--- ENGCOM-3053 -->
+*  Integrations are no longer reset after running the `bin/magento setup:upgrade` command. *Fix submitted by Pratik Oza in pull request [18273](https://github.com/magento/magento2/pull/18273)*. [GitHub-12095](https://github.com/magento/magento2/issues/12095)
 
 ### Magento Shipping
 
@@ -913,69 +1231,96 @@ Previously, when you reopened these categories, no checkboxes were checked.
 
 ### MSRP
 
-<!--- MC-10973-->* MAP (minimum advertised price) prices for the simple products belonging to a configurable product are now supported. MAP price for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
+<!--- MC-10973 -->
+*  MAP (minimum advertised price) prices for the simple products belonging to a configurable product are now supported. MAP price for these products are now successfully handled and displayed  on the configurable product page and  the category page display of the configurable product.
 
 ### Newsletter
 
-<!--- ENGCOM-3460-->* Magento now sets the correct `store_id` for each store when a customer subscribes to a newsletter from more than one stor. *Fix submitted by Eduard Chitoraga in pull request [19195](https://github.com/magento/magento2/pull/19195)*. [GitHub-19172](https://github.com/magento/magento2/issues/19172)
+<!--- ENGCOM-3460 -->
+*  Magento now sets the correct `store_id` for each store when a customer subscribes to a newsletter from more than one stor. *Fix submitted by Eduard Chitoraga in pull request [19195](https://github.com/magento/magento2/pull/19195)*. [GitHub-19172](https://github.com/magento/magento2/issues/19172)
 
-<!--- ENGCOM-3266-->* Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by Janak Bhimani in pull request [18795](https://github.com/magento/magento2/pull/18795)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
+<!--- ENGCOM-3266 -->
+*  Customers are no longer unsubscribed to a newsletter as a result of a password reset email request when **Newsletter Need to Confirm** is set to **yes** on the Admin. *Fix submitted by Janak Bhimani in pull request [18795](https://github.com/magento/magento2/pull/18795)*. [GitHub-17954](https://github.com/magento/magento2/issues/17954)
 
-<!--- MAGETWO-91684-->* Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
+<!--- MAGETWO-91684 -->
+*  Magento now permits only one newsletter subscription per email address. Previously, when a website had multiple store views, a customer could subscribe multiple times to a newsletter with one email address.
 
-<!--- MAGETWO-91768-->* Magento now displays an informative message when you click the unsubscribe link in the newsletter email.
+<!--- MAGETWO-91768 -->
+*  Magento now displays an informative message when you click the unsubscribe link in the newsletter email.
 
-<!--- ENGCOM-3575-->* You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter.  *Fix submitted by Burlacu Vasilii in pull request [19419](https://github.com/magento/magento2/pull/19419)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
+<!--- ENGCOM-3575 -->
+*  You can now add a custom field to a newsletter in the position of your choice by editing  the newsletter configuration file (`app/code/Magento/Newsletter/etc/adminhtml/system.xml`).  Previously, you could add a new field but could not select where it would appear in the newsletter.  *Fix submitted by Burlacu Vasilii in pull request [19419](https://github.com/magento/magento2/pull/19419)*. [GitHub-19418](https://github.com/magento/magento2/issues/19418)
 
-<!--- ENGCOM-3431-->* A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribe her to the newsletter. *Fix submitted by Ravi Chandra in pull request [19164](https://github.com/magento/magento2/pull/19164)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+<!--- ENGCOM-3431 -->
+*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribe her to the newsletter. *Fix submitted by Ravi Chandra in pull request [19164](https://github.com/magento/magento2/pull/19164)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
-<!--- ENGCOM-3574-->* If a customer tries to subscribe to a newsletter with an email that  already has a subscription associated with it, Magento now warns the customer rather than throws an exception. *Fix submitted by Dharmesh Vaja in pull request [19416](https://github.com/magento/magento2/pull/19416)*. [GitHub-19404](https://github.com/magento/magento2/issues/19404)
+<!--- ENGCOM-3574 -->
+*  If a customer tries to subscribe to a newsletter with an email that  already has a subscription associated with it, Magento now warns the customer rather than throws an exception. *Fix submitted by Dharmesh Vaja in pull request [19416](https://github.com/magento/magento2/pull/19416)*. [GitHub-19404](https://github.com/magento/magento2/issues/19404)
 
-<!--- ENGCOM-4179-->* You can now search for or reset the filter on newsletter problem reports from the Admin. Previously, Magento did not display filter reports when administrators used FireFox.  *Fix submitted by Govind Sharma in pull request [20829](https://github.com/magento/magento2/pull/20829)*. [GitHub-20828](https://github.com/magento/magento2/issues/20828)
+<!--- ENGCOM-4179 -->
+*  You can now search for or reset the filter on newsletter problem reports from the Admin. Previously, Magento did not display filter reports when administrators used FireFox.  *Fix submitted by Govind Sharma in pull request [20829](https://github.com/magento/magento2/pull/20829)*. [GitHub-20828](https://github.com/magento/magento2/issues/20828)
 
 ### Orders
 
-<!--- MAGETWO-94437-->* The address form in the Admin order creation workflow has been refactored to improve performance.
+<!--- MAGETWO-94437 -->
+*  The address form in the Admin order creation workflow has been refactored to improve performance.
 
-<!--- MAGETWO-69274-->* Administrators now need sales email privileges to send order comment emails to customers.
+<!--- MAGETWO-69274 -->
+*  Administrators now need sales email privileges to send order comment emails to customers.
 
 ### Page cache
 
-<!--- MAGETWO-97234-->* Pages opened by URL redirect now display prices in the currency set for the appropriate store. Previously, the opened page contained prices in the default currency (USD) rather than the selected currency for the store.
+<!--- MAGETWO-97234 -->
+*  Pages opened by URL redirect now display prices in the currency set for the appropriate store. Previously, the opened page contained prices in the default currency (USD) rather than the selected currency for the store.
 
 ### Payment methods
 
-<!--- ENGCOM-3219-->* Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by Lucas Calazans in pull request [18095](https://github.com/magento/magento2/pull/18095)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
+<!--- ENGCOM-3219 -->
+*  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by Lucas Calazans in pull request [18095](https://github.com/magento/magento2/pull/18095)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
 
-<!--- ENGCOM-3393-->* Invoice PDFs now include a populated FTP (Fixed Product Tax) amount field for orders when using Weee tax and FPT is enabled. Previously, this information was displayed in order and invoice views, but not captured in the PDF. *Fix submitted by Mahesh Singh in pull request [19061](https://github.com/magento/magento2/pull/19061)*. [GitHub-18617](https://github.com/magento/magento2/issues/18617)
+<!--- ENGCOM-3393 -->
+*  Invoice PDFs now include a populated FTP (Fixed Product Tax) amount field for orders when using Weee tax and FPT is enabled. Previously, this information was displayed in order and invoice views, but not captured in the PDF. *Fix submitted by Mahesh Singh in pull request [19061](https://github.com/magento/magento2/pull/19061)*. [GitHub-18617](https://github.com/magento/magento2/issues/18617)
 
-<!--- MAGETWO-94946-->* Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
+<!--- MAGETWO-94946 -->
+*  Tax is now calculated as expected for virtual products when PayPal is used as a payment method.
 
-<!--- MAGETWO-96475-->*  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during  checkout when being processed through PayPal were processed.
+<!--- MAGETWO-96475 -->
+*   When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during  checkout when being processed through PayPal were processed.
 
-<!--- MAGETWO-96291-->* A pop-up window no longer blocks completion of checkout using Braintree PayPal on a mobile device.
+<!--- MAGETWO-96291 -->
+*  A pop-up window no longer blocks completion of checkout using Braintree PayPal on a mobile device.
 
-<!--- MAGETWO-95821-->* When a  customer selects PayPal as a payment method but then applies for a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
+<!--- MAGETWO-95821 -->
+*  When a  customer selects PayPal as a payment method but then applies for a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
 
-<!--- MAGETWO-91526-->* Orders created with eWay as a payment method now contain the same credit card information, which is included in the Authorize.Net response. Previously, the order did not contain any information regarding the credit card.
+<!--- MAGETWO-91526 -->
+*  Orders created with eWay as a payment method now contain the same credit card information, which is included in the Authorize.Net response. Previously, the order did not contain any information regarding the credit card.
 
-<!--- MAGETWO-97243-->* Magento now displays successful orders paid for with eWay. Previously, Magento did not display completed errors even after the transaction was accepted by eWay.
+<!--- MAGETWO-97243 -->
+*  Magento now displays successful orders paid for with eWay. Previously, Magento did not display completed errors even after the transaction was accepted by eWay.
 
-<!--- ENGCOM-3675-->* The `getList()` method now returns the vault data total count as expected. *Fix submitted by Andrea Parmeggiani in pull request [19707](https://github.com/magento/magento2/pull/19707)*. [GitHub-19706](https://github.com/magento/magento2/issues/19706)
+<!--- ENGCOM-3675 -->
+*  The `getList()` method now returns the vault data total count as expected. *Fix submitted by Andrea Parmeggiani in pull request [19707](https://github.com/magento/magento2/pull/19707)*. [GitHub-19706](https://github.com/magento/magento2/issues/19706)
 
-<!--- ENGCOM-3156-->* You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by Vishal Gelani in pull request [18521](https://github.com/magento/magento2/pull/18521)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
+<!--- ENGCOM-3156 -->
+*  You can now use REST to create an order without payment. Previously, when using REST to submit an order without a payment, Magento threw an error. *Fix submitted by Vishal Gelani in pull request [18521](https://github.com/magento/magento2/pull/18521)*. [GitHub-15652](https://github.com/magento/magento2/issues/15652)
 
-<!--- ENGCOM-3646-->* Payment methods are now grouped properly in the core source model. `\Magento\Payment\Model\Config\Source\Allmethods` class in the Magento core can be used as a source model for backend configuration fields. It displays available payment methods grouped by payment provider. We've added groups for previously missing payment options (PayPal, Authorize.Net, and  Braintree methods). *Fix submitted by Wojtek Naruniec in pull request [19665](https://github.com/magento/magento2/pull/19665)*. [GitHub-19664](https://github.com/magento/magento2/issues/19664)
+<!--- ENGCOM-3646 -->
+*  Payment methods are now grouped properly in the core source model. `\Magento\Payment\Model\Config\Source\Allmethods` class in the Magento core can be used as a source model for backend configuration fields. It displays available payment methods grouped by payment provider. We've added groups for previously missing payment options (PayPal, Authorize.Net, and  Braintree methods). *Fix submitted by Wojtek Naruniec in pull request [19665](https://github.com/magento/magento2/pull/19665)*. [GitHub-19664](https://github.com/magento/magento2/issues/19664)
 
-<!--- ENGCOM-3840-->* Fixed misalignment of the save-for-later checkbox on the Admin create order credit card details page. *Fix submitted by Kajal Solanki in pull request [20233](https://github.com/magento/magento2/pull/20233)*. [GitHub-20232](https://github.com/magento/magento2/issues/20232)
+<!--- ENGCOM-3840 -->
+*  Fixed misalignment of the save-for-later checkbox on the Admin create order credit card details page. *Fix submitted by Kajal Solanki in pull request [20233](https://github.com/magento/magento2/pull/20233)*. [GitHub-20232](https://github.com/magento/magento2/issues/20232)
 
-<!--- MC-4239-->* The Authorize.Net payment method has been migrated to the `accept.js` API on both the storefront and Admin.
+<!--- MC-4239 -->
+*  The Authorize.Net payment method has been migrated to the `accept.js` API on both the storefront and Admin.
 
-<!--- MC-5235-->* PayPal Express Checkout has been updated to the JSv4​. This API replaces the deprecated API Express Checkout - NVP/SOAP. This update provides Magento with a single integration but with multiple payment options that merchants can choose when activating the integration​. See [PayPal Express Checkout](https://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html)
+<!--- MC-5235 -->
+*  PayPal Express Checkout has been updated to the JSv4​. This API replaces the deprecated API Express Checkout - NVP/SOAP. This update provides Magento with a single integration but with multiple payment options that merchants can choose when activating the integration​. See [PayPal Express Checkout](https://docs.magento.com/m2/ce/user_guide/payment/paypal-express-checkout.html)
 
 ### Performance
 
-<!--- MAGETWO-95249 94346-->* New customer address handling improves the processing of many addresses on the Admin customer details page. This functionality was rewritten with UI components to increase platform performance, which in turn facilitates the management of customers with 3000 and more addresses. This refactoring includes these changes:
+<!--- MAGETWO-95249 94346 -->
+*  New customer address handling improves the processing of many addresses on the Admin customer details page. This functionality was rewritten with UI components to increase platform performance, which in turn facilitates the management of customers with 3000 and more addresses. This refactoring includes these changes:
 
    * All actions on the Customer Addresses tab are now performed asynchronously with AJAX. This tab now contains the default billing address and default shipping address UI component blocks, customer addresses listing or grid, and customer address form in a modal window.
 
@@ -983,113 +1328,159 @@ Previously, when you reopened these categories, no checkboxes were checked.
 
 ### Product video
 
-<!--- MAGETWO-91707-->* You can now pause product videos on YouTube on storefronts running on Internet Explorer 11.x.
+<!--- MAGETWO-91707 -->
+*  You can now pause product videos on YouTube on storefronts running on Internet Explorer 11.x.
 
 ### Quote
 
-<!--- ENGCOM-3416-->* You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by Burlacu Vasilii in pull request [19130](https://github.com/magento/magento2/pull/19130)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
+<!--- ENGCOM-3416 -->
+*  You can now update a shopping cart that contains a reserved order number (for example, 000000651). *Fix submitted by Burlacu Vasilii in pull request [19130](https://github.com/magento/magento2/pull/19130)*. [GitHub-19101](https://github.com/magento/magento2/issues/19101)
 
-<!--- ENGCOM-3226-->* You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by Patrick McLain in pull request [18704](https://github.com/magento/magento2/pull/18704)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
+<!--- ENGCOM-3226 -->
+*  You can now use REST to set billing information for a customer (`customerId`) with an existing address. Previously, Magento threw an exception during address validation. *Fix submitted by Patrick McLain in pull request [18704](https://github.com/magento/magento2/pull/18704)*. [GitHub-17485](https://github.com/magento/magento2/issues/17485)
 
-<!--- MAGETWO-94059-->* You can now request a quote on a storefront running on iOS 11.3.1.
+<!--- MAGETWO-94059 -->
+*  You can now request a quote on a storefront running on iOS 11.3.1.
 
-<!--- ENGCOM-3464-->* We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by Jay Ghosh in pull request [18185](https://github.com/magento/magento2/pull/18185)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
+<!--- ENGCOM-3464 -->
+*  We fixed an issue with inaccurate floating point calculations during checkout. *Fix submitted by Jay Ghosh in pull request [18185](https://github.com/magento/magento2/pull/18185)*. [GitHub-18027](https://github.com/magento/magento2/issues/18027)
 
-<!--- ENGCOM-3503-->* Magento now saves the correct `quote_item_id` values for products during checkout for an order being shipped to multiple addresses. *Fix submitted by Mahesh Singh in pull request [19192](https://github.com/magento/magento2/pull/19192)*. [GitHub-18349](https://github.com/magento/magento2/issues/18349)
+<!--- ENGCOM-3503 -->
+*  Magento now saves the correct `quote_item_id` values for products during checkout for an order being shipped to multiple addresses. *Fix submitted by Mahesh Singh in pull request [19192](https://github.com/magento/magento2/pull/19192)*. [GitHub-18349](https://github.com/magento/magento2/issues/18349)
 
 ### Reports
 
-<!--- ENGCOM-3560-->* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Nirav Patel in pull request [19372](https://github.com/magento/magento2/pull/19372)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754)
+<!--- ENGCOM-3560 -->
+*  Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Nirav Patel in pull request [19372](https://github.com/magento/magento2/pull/19372)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754)
 
-<!--- ENGCOM-4129-->* Magento now refreshes reports statistics as expected when you select the **Refresh Lifetime Statistics** option from the Actions menu of the **Reports** > **Refresh Statistics** page. Previously, you were redirected to a 404 page when you selected this menu option. *Fix submitted by Eduard Chitoraga in pull request [20820](https://github.com/magento/magento2/pull/20820)*. [GitHub-20819](https://github.com/magento/magento2/issues/20819)
+<!--- ENGCOM-4129 -->
+*  Magento now refreshes reports statistics as expected when you select the **Refresh Lifetime Statistics** option from the Actions menu of the **Reports** > **Refresh Statistics** page. Previously, you were redirected to a 404 page when you selected this menu option. *Fix submitted by Eduard Chitoraga in pull request [20820](https://github.com/magento/magento2/pull/20820)*. [GitHub-20819](https://github.com/magento/magento2/issues/20819)
 
-<!--- ENGCOM-3257-->* Magento now displays correct prices for products at checkout when a customer uses a credit card and Authorize.Net is enabled. Previously, order items had the original price of $0.0. *Fix submitted by Patrick McLain in pull request [18768](https://github.com/magento/magento2/pull/18768)*. [GitHub-16050](https://github.com/magento/magento2/issues/16050)
+<!--- ENGCOM-3257 -->
+*  Magento now displays correct prices for products at checkout when a customer uses a credit card and Authorize.Net is enabled. Previously, order items had the original price of $0.0. *Fix submitted by Patrick McLain in pull request [18768](https://github.com/magento/magento2/pull/18768)*. [GitHub-16050](https://github.com/magento/magento2/issues/16050)
 
 ### Reviews
 
-<!--- ENGCOM-3486-->* Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by Saphal Jha in pull request [18888](https://github.com/magento/magento2/pull/18888)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
+<!--- ENGCOM-3486 -->
+*  Administrators can now access product ratings in deployments with multiple websites running different locales. *Fix submitted by Saphal Jha in pull request [18888](https://github.com/magento/magento2/pull/18888)*. [GitHub-18192](https://github.com/magento/magento2/issues/18192)
 
-<!--- MAGETWO-95491-->* The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
+<!--- MAGETWO-95491 -->
+*  The  **Save and Next** and **Save and Previous** buttons in **Marketing** > **Reviews** now work as expected.
 
-<!--- ENGCOM-3837-->* You can now add a product review from the Admin.  Previously, when you clicked **New Review**, Magento displayed this error, `Error message showing : A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later`. *Fix submitted by Suneet K. in pull request [20146](https://github.com/magento/magento2/pull/20146)*. [GitHub-20122](https://github.com/magento/magento2/issues/20122)
+<!--- ENGCOM-3837 -->
+*  You can now add a product review from the Admin.  Previously, when you clicked **New Review**, Magento displayed this error, `Error message showing : A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later`. *Fix submitted by Suneet K. in pull request [20146](https://github.com/magento/magento2/pull/20146)*. [GitHub-20122](https://github.com/magento/magento2/issues/20122)
 
-<!--- ENGCOM-4096-->* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice.  *Fix submitted by Piyush Dankhara in pull request [20936](https://github.com/magento/magento2/pull/20936)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
+<!--- ENGCOM-4096 -->
+*  Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice.  *Fix submitted by Piyush Dankhara in pull request [20936](https://github.com/magento/magento2/pull/20936)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 ### Rewards
 
-<!--- MAGETWO-96125-->* Magento now allocates rewards points for converting an invitation to a customer when **Require Emails Confirmation** is set to **yes**.
+<!--- MAGETWO-96125 -->
+*  Magento now allocates rewards points for converting an invitation to a customer when **Require Emails Confirmation** is set to **yes**.
 
-<!--- ENGCOM-3491-->* The order status label on the  customer order status page  can now be translated. *Fix submitted by p-bystritsky in pull request [19182](https://github.com/magento/magento2/pull/19182)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+<!--- ENGCOM-3491 -->
+*  The order status label on the  customer order status page  can now be translated. *Fix submitted by p-bystritsky in pull request [19182](https://github.com/magento/magento2/pull/19182)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
-<!--- MAGETWO-91686-->* `/V1/orders/{id}` now retrieves information about used reward points.
+<!--- MAGETWO-91686 -->
+*  `/V1/orders/{id}` now retrieves information about used reward points.
 
 ### Return Merchandise Authorizations (RMA)
 
-<!--- MAGETWO-71022-->* Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
+<!--- MAGETWO-71022 -->
+*  Magento now displays the correct amount in the **Remaining Quantity** field after Magento has processed a return.
 
-<!--- MAGETWO-96158-->* Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
+<!--- MAGETWO-96158 -->
+*  Return attributes that have the **Values Required** attribute  set to **no** no longer break the storefront display of those attributes.
 
-<!--- MAGETWO-97259-->* Administrators can now process returns when a request includes a required image attribute.  Previously, the Return Items tab displayed a validation error even though the image had  been uploaded, and if you clicked on **Details**, Magento displayed this message, `Please select a file`.
+<!--- MAGETWO-97259 -->
+*  Administrators can now process returns when a request includes a required image attribute.  Previously, the Return Items tab displayed a validation error even though the image had  been uploaded, and if you clicked on **Details**, Magento displayed this message, `Please select a file`.
 
-<!--- MAGETWO-97132-->* You can now return bundle products from the Admin. Previously, when you clicked Submit Returns, Magento displayed an informative error message, and did not create an RMA.
+<!--- MAGETWO-97132 -->
+*  You can now return bundle products from the Admin. Previously, when you clicked Submit Returns, Magento displayed an informative error message, and did not create an RMA.
 
 ### Sales
 
-<!--- MAGETWO-96441-->* You can now remove a custom price from a product during order creation from the Admin.
+<!--- MAGETWO-96441 -->
+*  You can now remove a custom price from a product during order creation from the Admin.
 
-<!--- ENGCOM-3294-->* The message that Magento displays when a merchant tries to create a credit memo for an order with no shipping charges has been made more informative. *Fix submitted by Burlacu Vasilii in pull request [18844](https://github.com/magento/magento2/pull/18844)*. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
+<!--- ENGCOM-3294 -->
+*  The message that Magento displays when a merchant tries to create a credit memo for an order with no shipping charges has been made more informative. *Fix submitted by Burlacu Vasilii in pull request [18844](https://github.com/magento/magento2/pull/18844)*. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
 
-<!--- ENGCOM-3048-->* You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by Pratik Oza in pull request [18272](https://github.com/magento/magento2/pull/18272)*. [GitHub-10530](https://github.com/magento/magento2/issues/10530)
+<!--- ENGCOM-3048 -->
+*  You can now print order information from the customer dashboard. Previously, when you tried to print  order information from the customer dashboard, Magento displayed this error, `Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`. *Fix submitted by Pratik Oza in pull request [18272](https://github.com/magento/magento2/pull/18272)*. [GitHub-10530](https://github.com/magento/magento2/issues/10530)
 
-<!--- ENGCOM-3074-->* Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by Petar Sambolek in pull request [18288](https://github.com/magento/magento2/pull/18288)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
+<!--- ENGCOM-3074 -->
+*  Magento no longer marks email as **not sent** when the email copy fails due to exception. Previously, Magento marked this email as not sent, and subsequently continued to resend the email. *Fix submitted by Petar Sambolek in pull request [18288](https://github.com/magento/magento2/pull/18288)*. [GitHub-17152](https://github.com/magento/magento2/issues/17152)
 
-<!--- ENGCOM-3378-->* The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [19039](https://github.com/magento/magento2/pull/19039)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
+<!--- ENGCOM-3378 -->
+*  The **Add to Cart** button in the Recently Ordered block now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [19039](https://github.com/magento/magento2/pull/19039)*. [GitHub-13157](https://github.com/magento/magento2/issues/13157)
 
-<!--- ENGCOM-3514-->* Magento now displays bundle products' child products on the **My Account** > **My Orders** > **View Order** page. *Fix submitted by Torben Höhn in pull request [19318](https://github.com/magento/magento2/pull/19318)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
+<!--- ENGCOM-3514 -->
+*  Magento now displays bundle products' child products on the **My Account** > **My Orders** > **View Order** page. *Fix submitted by Torben Höhn in pull request [19318](https://github.com/magento/magento2/pull/19318)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
 
-<!--- MAGETWO-94245-->* You can now issue a partial refund to store credit for an order made with an online payment method.
+<!--- MAGETWO-94245 -->
+*  You can now issue a partial refund to store credit for an order made with an online payment method.
 
-<!--- MAGETWO-96488-->* Orders for bundle products created from the Admin now display  correct product prices.
+<!--- MAGETWO-96488 -->
+*  Orders for bundle products created from the Admin now display  correct product prices.
 
-<!--- MAGETWO-63327-->* Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
+<!--- MAGETWO-63327 -->
+*  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
-<!--- MAGETWO-96400-->* The Sales table now displays company information in billing and shipping addresses.
+<!--- MAGETWO-96400 -->
+*  The Sales table now displays company information in billing and shipping addresses.
 
-<!--- MAGETWO-94424-->*  Magento now displays product price and shipping costs in the default currency that was configured for that specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
+<!--- MAGETWO-94424 -->
+*   Magento now displays product price and shipping costs in the default currency that was configured for that specific website for orders created from the Admin. Previously, when you have multi-site configuration with different default currencies for each website, the product and shipping prices shown while creating an admin order are incorrect.
 
-<!--- ENGCOM-3828-->* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Surabhi Srivastava in pull request [20142](https://github.com/magento/magento2/pull/20142)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+<!--- ENGCOM-3828 -->
+*  Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Surabhi Srivastava in pull request [20142](https://github.com/magento/magento2/pull/20142)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
-<!--- ENGCOM-3887-->* Files uploaded for custom options can now be downloaded even when the product option is no longer available. Previously, these files could not be downloaded.  *Fix submitted by Mahesh Singh in pull request [20354](https://github.com/magento/magento2/pull/20354)*. [GitHub-20277](https://github.com/magento/magento2/issues/20277)
+<!--- ENGCOM-3887 -->
+*  Files uploaded for custom options can now be downloaded even when the product option is no longer available. Previously, these files could not be downloaded.  *Fix submitted by Mahesh Singh in pull request [20354](https://github.com/magento/magento2/pull/20354)*. [GitHub-20277](https://github.com/magento/magento2/issues/20277)
 
-<!--- ENGCOM-3699-->* Fixed an incorrect class name on orders and returns page on the Admin. *Fix submitted by Shikha Mishra in pull request [19784](https://github.com/magento/magento2/pull/19784)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
+<!--- ENGCOM-3699 -->
+*  Fixed an incorrect class name on orders and returns page on the Admin. *Fix submitted by Shikha Mishra in pull request [19784](https://github.com/magento/magento2/pull/19784)*. [GitHub-19780](https://github.com/magento/magento2/issues/19780)
 
-<!--- ENGCOM-3735-->* Fixed misalignment of the **Update Qty** button on the sales order invoice. *Fix submitted by Kajal Solanki in pull request [19799](https://github.com/magento/magento2/pull/19799)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
+<!--- ENGCOM-3735 -->
+*  Fixed misalignment of the **Update Qty** button on the sales order invoice. *Fix submitted by Kajal Solanki in pull request [19799](https://github.com/magento/magento2/pull/19799)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
-<!--- ENGCOM-3452-->* The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by Ian Cassidy in pull request [18620](https://github.com/magento/magento2/pull/18620)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
+<!--- ENGCOM-3452 -->
+*  The `last_trans_id` column of the `sales_order_payment` table has been updated to handle the full order reference values for Amazon and Klarna extensions. *Fix submitted by Ian Cassidy in pull request [18620](https://github.com/magento/magento2/pull/18620)*. [GitHub-18615](https://github.com/magento/magento2/issues/18615)
 
-<!--- ENGCOM-3594-->* You can now programmatically  cancel an invoice when invoice state is set to `STATE_PAID`. *Fix submitted by Max O in pull request [19462](https://github.com/magento/magento2/pull/19462)*. [GitHub-18509](https://github.com/magento/magento2/issues/18509)
+<!--- ENGCOM-3594 -->
+*  You can now programmatically  cancel an invoice when invoice state is set to `STATE_PAID`. *Fix submitted by Max O in pull request [19462](https://github.com/magento/magento2/pull/19462)*. [GitHub-18509](https://github.com/magento/magento2/issues/18509)
 
-<!--- MC-5683-->* The performance of the Admin order creation page when handling many addresses has been improved.
+<!--- MC-5683 -->
+*  The performance of the Admin order creation page when handling many addresses has been improved.
 
-<!--- ENGCOM-3720-->* Credit memos now accurately calculate refunds when default shipping charges are changed to zero. *Fix submitted by Wojtek Naruniec in pull request [19900](https://github.com/magento/magento2/pull/19900)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
+<!--- ENGCOM-3720 -->
+*  Credit memos now accurately calculate refunds when default shipping charges are changed to zero. *Fix submitted by Wojtek Naruniec in pull request [19900](https://github.com/magento/magento2/pull/19900)*. [GitHub-19899](https://github.com/magento/magento2/issues/19899)
 
-<!--- ENGCOM-3755-->* The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by Nazar in pull request [19981](https://github.com/magento/magento2/pull/19981)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
+<!--- ENGCOM-3755 -->
+*  The email that customers receive after completing an order now contains tracking information for only their order. Previously, Magento included tracking information for other orders, too. *Fix submitted by Nazar in pull request [19981](https://github.com/magento/magento2/pull/19981)*. [GitHub-19887](https://github.com/magento/magento2/issues/19887)
 
-<!--- ENGCOM-3225-->* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18471](https://github.com/magento/magento2/pull/18471)*. [GitHub-7739](https://github.com/magento/magento2/issues/7739)
+<!--- ENGCOM-3225 -->
+*  The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18471](https://github.com/magento/magento2/pull/18471)*. [GitHub-7739](https://github.com/magento/magento2/issues/7739)
 
-<!--- ENGCOM-3484-->* Magento now displays bundle options  on the Items Ordered tab of the My Account order page. *Fix submitted by Vishal Gelani in pull request [19254](https://github.com/magento/magento2/pull/19254)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
+<!--- ENGCOM-3484 -->
+*  Magento now displays bundle options  on the Items Ordered tab of the My Account order page. *Fix submitted by Vishal Gelani in pull request [19254](https://github.com/magento/magento2/pull/19254)*. [GitHub-16434](https://github.com/magento/magento2/issues/16434)
 
 ### SalesRule
 
-<!--- MAGETWO-91522-->* The sales rule indexer now runs without error. Previously, the sales rule indexer  returned an error during reindexing because of the Magento_AdvancedSalesRule module.
+<!--- MAGETWO-91522 -->
+*  The sales rule indexer now runs without error. Previously, the sales rule indexer  returned an error during reindexing because of the Magento_AdvancedSalesRule module.
 
-<!--- ENGCOM-3773-->* The payment method option is now displayed under the shopping cart rules condition tab. Previously, when you navigated to **Marketing** > **Promotions** > **Cart Price Rules** and opened the Conditions tab on a rule, Magento did not display payment method options. *Fix submitted by p-bystritsky in pull request [20042](https://github.com/magento/magento2/pull/20042)*. [GitHub-12549](https://github.com/magento/magento2/issues/12549)
+<!--- ENGCOM-3773 -->
+*  The payment method option is now displayed under the shopping cart rules condition tab. Previously, when you navigated to **Marketing** > **Promotions** > **Cart Price Rules** and opened the Conditions tab on a rule, Magento did not display payment method options. *Fix submitted by p-bystritsky in pull request [20042](https://github.com/magento/magento2/pull/20042)*. [GitHub-12549](https://github.com/magento/magento2/issues/12549)
 
 ### Search
 
-<!--- MAGETWO-91742-->* The default sort order field now works as expected on the Catalog Search results page.
+<!--- MAGETWO-91742 -->
+*  The default sort order field now works as expected on the Catalog Search results page.
 
-<!--- MAGETWO-91537-->* Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group.
+<!--- MAGETWO-91537 -->
+*  Searching for a synonym that contains a hyphen and number now returns the same results as any other search term in the group.
 
 <!--- MAGETWO-97235-->
 * Layered navigation for Elasticsearch now includes all product sizes. If the **Filterable (with results)** option is set for a product attribute then:
@@ -1100,161 +1491,225 @@ Previously, when you reopened these categories, no checkboxes were checked.
 
 See [Filterable attributes](https://docs.magento.com/m2/ee/user_guide/catalog/navigation-layered-filterable-attributes.html) for more information.
 
-<!--- MAGETWO-67779-->* Full text search for Elasticsearch no longer includes the `date` attribute.
+<!--- MAGETWO-67779 -->
+*  Full text search for Elasticsearch no longer includes the `date` attribute.
 
-<!--- MAGETWO-97495-->* Layered navigation results no longer includes price ranges that contain no products.
+<!--- MAGETWO-97495 -->
+*  Layered navigation results no longer includes price ranges that contain no products.
 
-<!--- ENGCOM-3526-->* Magento now returns a customized layout handle when there are no results for a search. This customized layout handle supports the addition of custom blocks, which permits you to  change the layout of the No results page. *Fix submitted by Yevhenii Dumskyi in pull request [18069](https://github.com/magento/magento2/pull/18069)*. [GitHub-18038](https://github.com/magento/magento2/issues/18038)
+<!--- ENGCOM-3526 -->
+*  Magento now returns a customized layout handle when there are no results for a search. This customized layout handle supports the addition of custom blocks, which permits you to  change the layout of the No results page. *Fix submitted by Yevhenii Dumskyi in pull request [18069](https://github.com/magento/magento2/pull/18069)*. [GitHub-18038](https://github.com/magento/magento2/issues/18038)
 
-<!--- ENGCOM-4045-->* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar in pull request [20727](https://github.com/magento/magento2/pull/20727)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716), [GitHub-20689](https://github.com/magento/magento2/issues/20689), [GitHub-9988](https://github.com/magento/magento2/issues/9988)
+<!--- ENGCOM-4045 -->
+*  Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar in pull request [20727](https://github.com/magento/magento2/pull/20727)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716), [GitHub-20689](https://github.com/magento/magento2/issues/20689), [GitHub-9988](https://github.com/magento/magento2/issues/9988)
 
 ### Shipping
 
-<!--- ENGCOM-3148-->* Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by vaibhavahalpara in pull request [18507](https://github.com/magento/magento2/pull/18507)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+<!--- ENGCOM-3148 -->
+*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by vaibhavahalpara in pull request [18507](https://github.com/magento/magento2/pull/18507)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
-<!--- MAGETWO-96218-->* Shipments created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when a shipment was created using REST.
+<!--- MAGETWO-96218 -->
+*  Shipments created through REST now return tracking information as expected. Previously, Magento created shipment notifications without a tracking number when a shipment was created using REST.
 
-<!--- MAGETWO-91599-->* Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
+<!--- MAGETWO-91599 -->
+*  Table rates now work as expected when using the AE code (Armed Forces Europe) when calculating weight vs destination table rates.
 
-<!--- MAGETWO-91702-->* Magento now uses  shipping table rates from the correct store in multistore deployments.
+<!--- MAGETWO-91702 -->
+*  Magento now uses  shipping table rates from the correct store in multistore deployments.
 
-<!--- ENGCOM-3736-->* Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses. *Fix submitted by Govind Sharma in pull request [19941](https://github.com/magento/magento2/pull/19941)*. [GitHub-19940](https://github.com/magento/magento2/issues/19940)
+<!--- ENGCOM-3736 -->
+*  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses. *Fix submitted by Govind Sharma in pull request [19941](https://github.com/magento/magento2/pull/19941)*. [GitHub-19940](https://github.com/magento/magento2/issues/19940)
 
-<!--- ENGCOM-3960-->* Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+<!--- ENGCOM-3960 -->
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by Arvinda Kumar in pull request [20564](https://github.com/magento/magento2/pull/20564)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
-<!--- MC-4245-->* Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method.
+<!--- MC-4245 -->
+*  Magento now uses version 6.0 of the DHL XML Services schema for the DHL shipping method.
 
 ### Sitemap
 
-<!--- ENGCOM-3040-->* Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by Toan Nguyen in pull request [18228](https://github.com/magento/magento2/pull/18228)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+<!--- ENGCOM-3040 -->
+*  Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by Toan Nguyen in pull request [18228](https://github.com/magento/magento2/pull/18228)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Store
 
-<!--- ENGCOM-1928-->* The switcher-option's link `Magento/Store/view/frontend/templates/switch/languages.phtml` template has been modified to support navigating back to previous pages. Previously, you could not navigate back to the previous store view when you clicked the **Back** button when viewing the store on Firefox.  *Fix submitted by Mobecls in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
+<!--- ENGCOM-1928 -->
+*  The switcher-option's link `Magento/Store/view/frontend/templates/switch/languages.phtml` template has been modified to support navigating back to previous pages. Previously, you could not navigate back to the previous store view when you clicked the **Back** button when viewing the store on Firefox.  *Fix submitted by Mobecls in pull request [19037](https://github.com/magento/magento2/pull/19037)*. [GitHub-14007](https://github.com/magento/magento2/issues/14007)
 
-<!--- ENGCOM-3408-->* You can now define the `root_category_id` in the project `config.php`. *Fix submitted by Lars Roettig in pull request [18958](https://github.com/magento/magento2/pull/18958)*. [GitHub-18956](https://github.com/magento/magento2/issues/18956)
+<!--- ENGCOM-3408 -->
+*  You can now define the `root_category_id` in the project `config.php`. *Fix submitted by Lars Roettig in pull request [18958](https://github.com/magento/magento2/pull/18958)*. [GitHub-18956](https://github.com/magento/magento2/issues/18956)
 
 ### Swatches
 
-<!--- ENGCOM-3360-->* Store views now show the correct swatch values. *Fix submitted by Malyovanets Nickolas in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
+<!--- ENGCOM-3360 -->
+*  Store views now show the correct swatch values. *Fix submitted by Malyovanets Nickolas in pull request [18988](https://github.com/magento/magento2/pull/18988)*. [GitHub-17890](https://github.com/magento/magento2/issues/17890)
 
-<!--- MAGETWO-95310-->* Product images now display the color option you chose when you apply a color filter in layered navigation. Previously, wrong colors were randomly displayed.
+<!--- MAGETWO-95310 -->
+*  Product images now display the color option you chose when you apply a color filter in layered navigation. Previously, wrong colors were randomly displayed.
 
-<!--- MAGETWO-59789-->* You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
+<!--- MAGETWO-59789 -->
+*  You can now change the size of a swatch image as expected. [GitHub-6382](https://github.com/magento/magento2/issues/6382)
 
-<!--- MAGETWO-94990-->* All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
+<!--- MAGETWO-94990 -->
+*  All thumbnails reload as expected after you click on a configurable option when a configurable product detail page has more than 14 thumbnail images. Previously, not all thumbnails reloaded.
 
-<!--- ENGCOM-3920-->* You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by Pieter Hoste in pull request [20421](https://github.com/magento/magento2/pull/20421)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+<!--- ENGCOM-3920 -->
+*  You can now change an attribute type from swatch to dropdown without using data.  Previously, changing an attribute type from swatch to dropdown deleted swatch options for all attributes. *Fix submitted by Pieter Hoste in pull request [20421](https://github.com/magento/magento2/pull/20421)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
-<!--- ENGCOM-3943-->* Fixed styles on the Add Swatch page.
+<!--- ENGCOM-3943 -->
+*  Fixed styles on the Add Swatch page.
 
 ### Tax
 
-<!--- ENGCOM-3443-->* The "Not yet calculated" string for the tax field in the summary section of the  checkout page can now be translated. *Fix submitted by p-bystritsky in pull request [19174](https://github.com/magento/magento2/pull/19174)*. [GitHub-18939](https://github.com/magento/magento2/issues/18939), [GitHub-7849](https://github.com/magento/magento2/issues/7849)
+<!--- ENGCOM-3443 -->
+*  The "Not yet calculated" string for the tax field in the summary section of the  checkout page can now be translated. *Fix submitted by p-bystritsky in pull request [19174](https://github.com/magento/magento2/pull/19174)*. [GitHub-18939](https://github.com/magento/magento2/issues/18939), [GitHub-7849](https://github.com/magento/magento2/issues/7849)
 
-<!--- MAGETWO-91769-->* Credit memos now include only the taxes on the product as expected. Previously, the credit memo included the shipping tax as well even when shipping costs were not refunded.
+<!--- MAGETWO-91769 -->
+*  Credit memos now include only the taxes on the product as expected. Previously, the credit memo included the shipping tax as well even when shipping costs were not refunded.
 
-<!--- MAGETWO-91639-->* Tax is no longer added when a customer group is changed to **Valid VAT ID - Intra-Union**, which has no tax rules assigned to it.
+<!--- MAGETWO-91639 -->
+*  Tax is no longer added when a customer group is changed to **Valid VAT ID - Intra-Union**, which has no tax rules assigned to it.
 
-<!--- MAGETWO-91521-->* Tax reports now correctly calculate taxes for an order placed in a zip code that has two or more tax rates assigned.
+<!--- MAGETWO-91521 -->
+*  Tax reports now correctly calculate taxes for an order placed in a zip code that has two or more tax rates assigned.
 
-<!--- ENGCOM-3564-->* Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data. *Fix submitted by Nirav Kadiya in pull request [19387](https://github.com/magento/magento2/pull/19387)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
+<!--- ENGCOM-3564 -->
+*  Magento no longer uses the default tax information set in **Stores** > **Configuration** > **Sales** > **Tax** customer, quote, and order data. *Fix submitted by Nirav Kadiya in pull request [19387](https://github.com/magento/magento2/pull/19387)*. [GitHub-16684](https://github.com/magento/magento2/issues/16684)
 
 ### Testing
 
-<!--- ENGCOM-3036-->* Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by Pratik Oza in pull request [18201](https://github.com/magento/magento2/pull/18201)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+<!--- ENGCOM-3036 -->
+*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by Pratik Oza in pull request [18201](https://github.com/magento/magento2/pull/18201)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
-<!--- ENGCOM-3293-->* Unit test annotations now assert exception messages correctly. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
+<!--- ENGCOM-3293 -->
+*  Unit test annotations now assert exception messages correctly. [GitHub-6731](https://github.com/magento/magento2/issues/6731)
 
 ### Theme
 
-<!--- ENGCOM-3296-->* You can now upload favicons and logo when editing headers for a store view. Previously, Magento threw an error. *Fix submitted by Wiard van Rij in pull request [18851](https://github.com/magento/magento2/pull/18851)*. [GitHub-18688](https://github.com/magento/magento2/issues/18688)
+<!--- ENGCOM-3296 -->
+*  You can now upload favicons and logo when editing headers for a store view. Previously, Magento threw an error. *Fix submitted by Wiard van Rij in pull request [18851](https://github.com/magento/magento2/pull/18851)*. [GitHub-18688](https://github.com/magento/magento2/issues/18688)
 
-<!--- MAGETWO-91723-->* The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
+<!--- MAGETWO-91723 -->
+*  The text attribute implemented on the product page within the mobile theme now fluidly displays the entire text value. Previously, long values were truncated.
 
-<!--- MAGETWO-95805-->* The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
+<!--- MAGETWO-95805 -->
+*  The user agent rule now sets correct templates for product pages. Previously, the `footer.phtml` and `absolute_footer.phtml` templates were loaded from the desktop theme instead of the mobile theme, regardless of the user agent.
 
-<!--- MAGETWO-91651-->* We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
+<!--- MAGETWO-91651 -->
+*  We've improved the display of the navigation menu on mobile deployments. Previously, Magento displayed only a portion of any submenu accessed from a top menu.
 
-<!--- MAGETWO-91756-->* Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
+<!--- MAGETWO-91756 -->
+*  Wishlist and compare links now appear for related products in portrait mode when viewed on a mobile device.
 
-<!--- MAGETWO-56094-->* Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
+<!--- MAGETWO-56094 -->
+*  Text now remains in the header area when you resize a page in deployments running in Internet Explorer.
 
-<!--- ENGCOM-3669-->* Clicking on the store logo on the home page now reloads the page. *Fix submitted by gwharton in pull request [19198](https://github.com/magento/magento2/pull/19198)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
+<!--- ENGCOM-3669 -->
+*  Clicking on the store logo on the home page now reloads the page. *Fix submitted by gwharton in pull request [19198](https://github.com/magento/magento2/pull/19198)*. [GitHub-19142](https://github.com/magento/magento2/issues/19142)
 
-<!--- ENGCOM-3871-->* Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by Ajay Ajabale in pull request [20195](https://github.com/magento/magento2/pull/20195)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
+<!--- ENGCOM-3871 -->
+*  Fixed misalignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view.  *Fix submitted by Ajay Ajabale in pull request [20195](https://github.com/magento/magento2/pull/20195)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
-<!--- ENGCOM-3640-->* Fixed alignment issue with sort results on list product page.  *Fix submitted by suryakant-krish in pull request [19640](https://github.com/magento/magento2/pull/19640)*. [GitHub-19639](https://github.com/magento/magento2/issues/19639)
+<!--- ENGCOM-3640 -->
+*  Fixed alignment issue with sort results on list product page.  *Fix submitted by suryakant-krish in pull request [19640](https://github.com/magento/magento2/pull/19640)*. [GitHub-19639](https://github.com/magento/magento2/issues/19639)
 
-<!--- ENGCOM-4033-->* The `alt` attribute on the logo image is now properly escaped. *Fix submitted by Erik Pellikka in pull request [19270](https://github.com/magento/magento2/pull/19270)*. [GitHub-19269](https://github.com/magento/magento2/issues/19269)
+<!--- ENGCOM-4033 -->
+*  The `alt` attribute on the logo image is now properly escaped. *Fix submitted by Erik Pellikka in pull request [19270](https://github.com/magento/magento2/pull/19270)*. [GitHub-19269](https://github.com/magento/magento2/issues/19269)
 
 ### Translation and locales
 
-<!--- ENGCOM-3423, 3375-->* Child themes now inherit translations from their parent theme as expected (`en_US.csv` translation dictionary). *Fix submitted by Vladyslav Podorozhnyi in pull request [19018](https://github.com/magento/magento2/pull/19018) and  [19144](https://github.com/magento/magento2/pull/19144)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
+<!--- ENGCOM-3423, 3375 -->
+*  Child themes now inherit translations from their parent theme as expected (`en_US.csv` translation dictionary). *Fix submitted by Vladyslav Podorozhnyi in pull request [19018](https://github.com/magento/magento2/pull/19018) and  [19144](https://github.com/magento/magento2/pull/19144)*. [GitHub-17833](https://github.com/magento/magento2/issues/17833)
 
-<!--- ENGCOM-3461-->* Swedish (Finland) locales are now supported. *Fix submitted by p-bystritsky in pull request [19203](https://github.com/magento/magento2/pull/19203)*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
+<!--- ENGCOM-3461 -->
+*  Swedish (Finland) locales are now supported. *Fix submitted by p-bystritsky in pull request [19203](https://github.com/magento/magento2/pull/19203)*. [GitHub-13095](https://github.com/magento/magento2/issues/13095)
 
-<!--- ENGCOM-3345-->* The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file. *Fix submitted by Ayaz Mittaqi in pull request [18938](https://github.com/magento/magento2/pull/18938)*. [GitHub-18931](https://github.com/magento/magento2/issues/18931)
+<!--- ENGCOM-3345 -->
+*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file. *Fix submitted by Ayaz Mittaqi in pull request [18938](https://github.com/magento/magento2/pull/18938)*. [GitHub-18931](https://github.com/magento/magento2/issues/18931)
 
 ### UI
 
-<!--- ENGCOM-3300-->* Removed use of escapeJS method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
+<!--- ENGCOM-3300 -->
+*  Removed use of escapeJS method in  `app/code/Magento/SendFriend/view/frontend/templates/send.phtml`. *Fix submitted by Abrar Pathan in pull request [19053](https://github.com/magento/magento2/pull/19053)*. [GitHub-18887](https://github.com/magento/magento2/issues/18887)
 
-<!--- ENGCOM-3267-->* Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Ashutosh Srivastva in pull request [18790](https://github.com/magento/magento2/pull/18790)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+<!--- ENGCOM-3267 -->
+*  Fixed the misalignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Ashutosh Srivastva in pull request [18790](https://github.com/magento/magento2/pull/18790)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
-<!--- ENGCOM-3463-->* Magento no longer includes new orders that are not yet visible on the Orders page when you select all orders on the page for a mass action (such as update or cancelation). Previously, when you selected all orders on the Orders page for a mass action, any new order simultaneously being placed on storefront was included in the mass action. *Fix submitted by Yevhenii Dumsky in pull request [19204](https://github.com/magento/magento2/pull/19204)*. [GitHub-18983](https://github.com/magento/magento2/issues/18983)
+<!--- ENGCOM-3463 -->
+*  Magento no longer includes new orders that are not yet visible on the Orders page when you select all orders on the page for a mass action (such as update or cancelation). Previously, when you selected all orders on the Orders page for a mass action, any new order simultaneously being placed on storefront was included in the mass action. *Fix submitted by Yevhenii Dumsky in pull request [19204](https://github.com/magento/magento2/pull/19204)*. [GitHub-18983](https://github.com/magento/magento2/issues/18983)
 
-<!--- ENGCOM-3381-->* You can now set default values for the WYSIWYG edit field for editing form UI components. *Fix submitted by Oleksandr Miroshnichenko in pull request [19048](https://github.com/magento/magento2/pull/19048)*. [GitHub-10048](https://github.com/magento/magento2/issues/10048)
+<!--- ENGCOM-3381 -->
+*  You can now set default values for the WYSIWYG edit field for editing form UI components. *Fix submitted by Oleksandr Miroshnichenko in pull request [19048](https://github.com/magento/magento2/pull/19048)*. [GitHub-10048](https://github.com/magento/magento2/issues/10048)
 
-<!--- ENGCOM-3330-->* The global search icon on the Admin is now correctly aligned. *Fix submitted by Kajal Solanki in pull request [18940](https://github.com/magento/magento2/pull/18940)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
+<!--- ENGCOM-3330 -->
+*  The global search icon on the Admin is now correctly aligned. *Fix submitted by Kajal Solanki in pull request [18940](https://github.com/magento/magento2/pull/18940)*. [GitHub-18913](https://github.com/magento/magento2/issues/18913)
 
-<!--- ENGCOM-3037-->* Merchants can now change the currency symbol back to its default value from the Admin in single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by Pratik Oza in pull request [18204](https://github.com/magento/magento2/pull/18204)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
+<!--- ENGCOM-3037 -->
+*  Merchants can now change the currency symbol back to its default value from the Admin in single-store mode. Previously, when a merchant tried to change this symbol back to its default value, Magento displayed a success message, but did not change the currency symbol back to the default value. *Fix submitted by Pratik Oza in pull request [18204](https://github.com/magento/magento2/pull/18204)*. [GitHub-17567](https://github.com/magento/magento2/issues/17567)
 
-<!--- MAGETWO-91751-->* Magento now correctly renders apostrophes as entered in text fields.
+<!--- MAGETWO-91751 -->
+*  Magento now correctly renders apostrophes as entered in text fields.
 
-<!--- ENGCOM-3106-->* Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by gwharton in pull request [18405](https://github.com/magento/magento2/pull/18405)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
+<!--- ENGCOM-3106 -->
+*  Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by gwharton in pull request [18405](https://github.com/magento/magento2/pull/18405)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
-<!--- MAGETWO-91496-->* WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
+<!--- MAGETWO-91496 -->
+*  WYSIWYG editor functionality is now available in all rows of the dynamic rows UI component. Previously, this functionality was available in the first row only.
 
-<!--- ENGCOM-3509-->* Fixed incorrect display of the pager on the My Orders page. Previously, the pager obscured page links, which prevented customers from navigating to other pages. *Fix submitted by Kajal Solanki in pull request [19298](https://github.com/magento/magento2/pull/19298)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
+<!--- ENGCOM-3509 -->
+*  Fixed incorrect display of the pager on the My Orders page. Previously, the pager obscured page links, which prevented customers from navigating to other pages. *Fix submitted by Kajal Solanki in pull request [19298](https://github.com/magento/magento2/pull/19298)*. [GitHub-19286](https://github.com/magento/magento2/issues/19286)
 
-<!--- ENGCOM-3371-->* Usage of unsupported includes has been removed. Previously, when you chose a user to edit on the customers grid, Magento installations running on Internet Explorer 11.x did not load the expected page, but instead displayed this message, `object does not support method includes`.  *Fix submitted by Oleksandr Miroshnichenko in pull request [19010](https://github.com/magento/magento2/pull/19010)*. [GitHub-18562](https://github.com/magento/magento2/issues/18562)
+<!--- ENGCOM-3371 -->
+*  Usage of unsupported includes has been removed. Previously, when you chose a user to edit on the customers grid, Magento installations running on Internet Explorer 11.x did not load the expected page, but instead displayed this message, `object does not support method includes`.  *Fix submitted by Oleksandr Miroshnichenko in pull request [19010](https://github.com/magento/magento2/pull/19010)*. [GitHub-18562](https://github.com/magento/magento2/issues/18562)
 
 ### URL rewrites
 
-<!--- MAGETWO-95539-->* The storefront now properly displays the order of categories when you move categories in the Admin.
+<!--- MAGETWO-95539 -->
+*  The storefront now properly displays the order of categories when you move categories in the Admin.
 
-<!--- MAGETWO-91531-->* Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
+<!--- MAGETWO-91531 -->
+*  Product URLs are now based on the configuration information from the Admin, not the order of records in the database. Previously, the order of records in the database affected the generated URL, and some products showed category paths for product URLS when **Use Categories Path for Product URLs** was set to **no**.
 
-<!--- ENGCOM-3925-->* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by Ankur in pull request [20344](https://github.com/magento/magento2/pull/20344)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+<!--- ENGCOM-3925 -->
+*  The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key,  Magento displayed a 404 page. *Fix submitted by Ankur in pull request [20344](https://github.com/magento/magento2/pull/20344)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
 
 ### VAT
 
-<!--- ENGCOM-4108-->* Greek VAT numbers can now be validated. *Fix submitted by Pieter Hoste in pull request [20548](https://github.com/magento/magento2/pull/20548)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+<!--- ENGCOM-4108 -->
+*  Greek VAT numbers can now be validated. *Fix submitted by Pieter Hoste in pull request [20548](https://github.com/magento/magento2/pull/20548)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 ### Visual Merchandiser
 
-<!--- MAGETWO-91602-->* Visual Merchandiser now correctly sorts configurable product prices in Tile view.
+<!--- MAGETWO-91602 -->
+*  Visual Merchandiser now correctly sorts configurable product prices in Tile view.
 
 ### Web API
 
-<!--- MAGETWO-70532-->* The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
+<!--- MAGETWO-70532 -->
+*  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
-<!--- MAGETWO-69021-->* All extension attributes listed in the documentation for `salesOrderRepositoryV1` API are now available.
+<!--- MAGETWO-69021 -->
+*  All extension attributes listed in the documentation for `salesOrderRepositoryV1` API are now available.
 
-<!--- ENGCOM-3834-->* Access restrictions on the order API are now enforced as expected. Previously, adminstrators with restricted privileges had complete access to orders. *Fix submitted by Milind Singh in pull request [20170](https://github.com/magento/magento2/pull/20170)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
+<!--- ENGCOM-3834 -->
+*  Access restrictions on the order API are now enforced as expected. Previously, adminstrators with restricted privileges had complete access to orders. *Fix submitted by Milind Singh in pull request [20170](https://github.com/magento/magento2/pull/20170)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
 
 ### Wishlist
 
-<!--- MAGETWO-95311-->* Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
+<!--- MAGETWO-95311 -->
+*  Magento no longer retains entries for deleted products in the database `wishlist_item_option` table.
 
-<!--- MAGETWO-91667-->* You can now add a configurable product with no options  to a gift registry from a wishlist.
+<!--- MAGETWO-91667 -->
+*  You can now add a configurable product with no options  to a gift registry from a wishlist.
 
-<!--- ENGCOM-3922-->* You can now remove a comment from a wishlist product as expected. Previously, Magento did not remove the comment, even after you click **Update Wish List**. *Fix submitted by Khodu in pull request [20247](https://github.com/magento/magento2/pull/20247)*. [GitHub-20245](https://github.com/magento/magento2/issues/20245)
+<!--- ENGCOM-3922 -->
+*  You can now remove a comment from a wishlist product as expected. Previously, Magento did not remove the comment, even after you click **Update Wish List**. *Fix submitted by Khodu in pull request [20247](https://github.com/magento/magento2/pull/20247)*. [GitHub-20245](https://github.com/magento/magento2/issues/20245)
 
-<!--- ENGCOM-3912-->* Corrected misalignment of the Edit and remove item links on the wish list page when displayed  on a screen with a resolution of 640 x 767. *Fix submitted by Nainesh Waghale in pull request [20400](https://github.com/magento/magento2/pull/20400)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
+<!--- ENGCOM-3912 -->
+*  Corrected misalignment of the Edit and remove item links on the wish list page when displayed  on a screen with a resolution of 640 x 767. *Fix submitted by Nainesh Waghale in pull request [20400](https://github.com/magento/magento2/pull/20400)*. [GitHub-20399](https://github.com/magento/magento2/issues/20399)
 
-<!--- ENGCOM-3569-->* Pagination controls on the wishlist page have been restored. *Fix submitted by Ratnesh Kumar in pull request [19305](https://github.com/magento/magento2/pull/19305)*. [GitHub-19292](https://github.com/magento/magento2/issues/19292)
+<!--- ENGCOM-3569 -->
+*  Pagination controls on the wishlist page have been restored. *Fix submitted by Ratnesh Kumar in pull request [19305](https://github.com/magento/magento2/pull/19305)*. [GitHub-19292](https://github.com/magento/magento2/issues/19292)
 
 ## Known issues
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD004 errors in the Release Notes.

The MD004 rule requires consistent use of unordered list styles. The scope of #5241 also permits—but does not require—resolving errors related to the following rules:

- MD005: List indentation
- MD006: Start bulleted lists at the beginning of a line
- MD007: List indentation
- MD030: Spaces after list markers

This is one of many PRs related to #5241.