### PR TITLE
Fixed list styles (MD004) in the Frontend Dev Guide

### DIFF
--- a/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
@@ -57,10 +57,10 @@ In the Magento application, the following modes of compiling `.less` files to CS
 
 To set the compilation mode, do the following:
 
-1.  In the Magento Admin, navigate to **Stores** > **Settings** > **Configuration** > ADVANCED > **Developer**.
-1.  In the **Store View** drop-down field, select **Default Config**.
-1.  Under **Frontend development workflow**, in the **Workflow type** field, select the compilation mode.
-1.  To save the settings, click **Save Config**.
+1. In the Magento Admin, navigate to **Stores** > **Settings** > **Configuration** > ADVANCED > **Developer**.
+1. In the **Store View** drop-down field, select **Default Config**.
+1. Under **Frontend development workflow**, in the **Workflow type** field, select the compilation mode.
+1. To save the settings, click **Save Config**.
 
 ### Server-side Less compilation {#server-side}
 
@@ -83,8 +83,8 @@ In server-side Less compilation mode, to have your changes applied, you need to 
 1. Clear the `var/cache` and `var/view_preprocessed` directories by deleting the directory in the file system. (if they already existed there).
 1. Trigger [static files](https://glossary.magento.com/static-files) compilation and publication. This can be done in one of the following ways:
 
-  -  Reloading the page where the modified styles are applied.
-  -  Running the [static files deployment tool]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html).
+   -  Reloading the page where the modified styles are applied.
+   -  Running the [static files deployment tool]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html).
 
 Reloading the page only triggers compilation and publication of the styles used on this very page, and does not give you the information about the errors if any. So if you made changes in `.less` files used on many pages, and want to debug them, using the deployment tool is the better option.
 
@@ -95,6 +95,7 @@ Once you save your changes, run the following command from your `<Magento_root>`
 ```bash
 bin/magento setup:static-content:deploy
 ```
+
 The tool pre-processes (including compilation) and publishes the static view files.
 
 {:.bs-callout .bs-callout-info}
@@ -104,10 +105,10 @@ All errors occurring during `.less` files compilation are handled by the [`oyejo
 
 Errors are caught as exceptions and written to the system log (by default it is `var/log/system.log`) and displayed on the screen. For each error, the following information is written:
 
-* The path to the processed file in the `var/view_preprocessed` directory.
-* The error description, including the path to file where the actual error occurred. It might be either the processed file, or the imported file.
-* The error line and the column number.
-* The content of the `.less` code in the previous and following lines.
+-  The path to the processed file in the `var/view_preprocessed` directory.
+-  The error description, including the path to file where the actual error occurred. It might be either the processed file, or the imported file.
+-  The error line and the column number.
+-  The content of the `.less` code in the previous and following lines.
 
 Example of an error message:
 
@@ -129,9 +130,9 @@ See the [Compile LESS with Grunt]({{ page.baseurl }}/frontend-dev-guide/css-topi
 
 The client-side compilation flow is similar to [server-side](#server-side). The difference is in the set of files, published to `pub/static` on the last step. In the client-side mode, the following files are published to the `pub/static/frontend/<Vendor>/<theme>/<locale>` directory:
 
-- root source (.less) files with resolved `@magento_import` directive
-- [symlinks](http://en.wikipedia.org/wiki/Symbolic_link) to the root source file that do not contain `@magento_import`
-- symlinks to all other \`.less\` files imported recursively by the `@magento_import` and `@import` directives
+-  root source (.less) files with resolved `@magento_import` directive
+-  [symlinks](http://en.wikipedia.org/wiki/Symbolic_link) to the root source file that do not contain `@magento_import`
+-  symlinks to all other \`.less\` files imported recursively by the `@magento_import` and `@import` directives
 
 {:.bs-callout .bs-callout-info}
 Symlink is not created, and a copy of the processed file is published to `pub/static` instead, if the source file differs from the processed one. One of the reasons of this difference might be the usage of the `@import` directive without file extension in the source file. See [The @import directive usage](#fedg_css-import) for more details.
@@ -152,8 +153,8 @@ There are certain types of changes, that require you to clear the `pub/static/fr
 
 This is required in the following cases:
 
-- If you change the [root source files] that contain the `@magento_import` directive, or the `@import` directive where the imported file is specified without extension.
-- If you rename, remove, or add a `.less` file imported with a `@magento_import` or `@import` directive but you did not correct the directives accordingly.
+-  If you change the [root source files] that contain the `@magento_import` directive, or the `@import` directive where the imported file is specified without extension.
+-  If you rename, remove, or add a `.less` file imported with a `@magento_import` or `@import` directive but you did not correct the directives accordingly.
 
 To clear the `pub/static/frontend/<Vendor>/<theme>/<locale>` directory, delete the directory in the file system, and reload the store pages in a browser to trigger compilation and publication.
 
@@ -183,6 +184,7 @@ If you need to import a remote CSS file in your `.less` source, use `url()` nota
 ```less
 @import url('//fonts.googleapis.com/css?family=Titillium+Web:400,300,200,600.css');
 ```
+
 To [include the font]({{ page.baseurl }}/frontend-dev-guide/css-topics/using-fonts.html) in your theme's CSS files, use the `@font-face` CSS rule for the fastest loading time.
 
 This way Magento will skip the `@import` directive while resolving paths to the local resources.
@@ -199,24 +201,26 @@ The standard `@import` directive includes a single file, which is found accordin
 To include a `.less` file using the `@magento_import` directive:
 
 1. To avoid any conflicts with the original LESS syntax, `@magento_import` must be commented out with two slashes. Otherwise, the LESS preprocessor ignores it.
-    **Example:**
-    ```less
-    //  Comment in a LESS document
 
-    //  Standard LESS import directive
-    //  ---------------------------------------------
+   **Example:**
 
-    @import 'source/_reset';
-    @import '_styles';
+   ```less
+   //  Comment in a LESS document
 
-    //
-    //  Custom Magento LESS import directives
-    //  ---------------------------------------------
+   //  Standard LESS import directive
+   //  ---------------------------------------------
 
-    //@magento_import 'source/_module.less'; // Theme modules
-    //@magento_import 'source/_widgets.less'; // Theme widgets
-    //@magento_import 'source/_extend.less'; // Extend for minor customization
-    ```
+   @import 'source/_reset';
+   @import '_styles';
+
+   //
+   //  Custom Magento LESS import directives
+   //  ---------------------------------------------
+
+   //@magento_import 'source/_module.less'; // Theme modules
+   //@magento_import 'source/_widgets.less'; // Theme widgets
+   //@magento_import 'source/_extend.less'; // Extend for minor customization
+   ```
 
 1. `@magento_import` must contain the file path. The path is specified relatively to the file, where the directive is called and put in either single ('') or double quotes (""). The best practice is to specify the file extension in the path, though technically you can omit this.
 
@@ -224,8 +228,8 @@ To include a `.less` file using the `@magento_import` directive:
 
 In the scope of static resources preprocessing, the built-in LESS preprocessor does the following:
 
-1.  Searches for all `@magento_import` directives.
-1.  Replaces the original `@magento_import` directives with the standard `@import` directives. The latter specify the paths to the particular files that correspond to the pattern specified in `@magento_import`.
+1. Searches for all `@magento_import` directives.
+1. Replaces the original `@magento_import` directives with the standard `@import` directives. The latter specify the paths to the particular files that correspond to the pattern specified in `@magento_import`.
 
 Example of how `@magento_import` is used and processed in `<Magento_Blank_theme_dir>/web/css/styles-l.less`:
 
@@ -263,4 +267,3 @@ Example of how `@magento_import` is used and processed in `<Magento_Blank_theme_
 [publication]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview
 [root source files]: {{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html#css_preprocess_terms
 [static files fallback]: {{page.baseurl}}/frontend-dev-guide/themes/theme-inherit.html#theme-inherit-static
-

--- a/guides/v2.2/frontend-dev-guide/css-topics/custom_preprocess.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/custom_preprocess.md
@@ -35,9 +35,9 @@ To add a custom preprocessor, take the following steps:
 
 1. In `<your_module_dir>/etc/di.xml`, declare the following:
 
-   * your custom adapter
-   * your processor (if relevant)
-   * the renderer for the client-side compilation (if relevant)
+   *  your custom adapter
+   *  your processor (if relevant)
+   *  the renderer for the client-side compilation (if relevant)
 
 The content of your `di.xml` will be similar to the following:
 
@@ -88,5 +88,4 @@ The content of your `di.xml` will be similar to the following:
 
 ## Related reading
 
-- [Magento PHP Developer Guide]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
-
+*  [Magento PHP Developer Guide]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-override.md
@@ -17,21 +17,21 @@ Layout files with instructions that override the default or parent theme files a
 
 Examples of customizations that involve overriding layouts:
 
-* Suppressing method invocation.
+*  Suppressing method invocation.
 
    {: .bs-callout-info }
    Overriding is not necessary if a block has a method that cancels the effect of the originally invoked method. In this case, you can customize the layout by adding a layout file where the canceling method is invoked.
 
-* Modifying method arguments.
-* Canceling block/container removal using the `remove` attribute.
-* Setting XML attributes of blocks and containers.
+*  Modifying method arguments.
+*  Canceling block/container removal using the `remove` attribute.
+*  Setting XML attributes of blocks and containers.
 
 {: .bs-callout-info}
 Certain attributes, like `htmlClass`, `htmlId`, `label` attributes can be changed in [extending layouts].
 
-* Removing block arguments.
-* Modifying and suppressing [handles] inclusion.
-* Removing all handle instructions by declaring an overriding layout file with an empty handle.
+*  Removing block arguments.
+*  Modifying and suppressing [handles] inclusion.
+*  Removing all handle instructions by declaring an overriding layout file with an empty handle.
 
 ## How to override a layout {#fedg_layout_override_howto}
 
@@ -58,8 +58,8 @@ To add an overriding base layout file (to override a base layout provided by the
 
 These files override the following layouts:
 
-- `<module_dir>/view/frontend/layout/<layout1>.xml`
-- `<module_dir>/view/frontend/layout/<layout2>.xml`
+*  `<module_dir>/view/frontend/layout/<layout1>.xml`
+*  `<module_dir>/view/frontend/layout/<layout2>.xml`
 
 ### Override theme layouts {#fedg_layout_override_theme}
 
@@ -81,8 +81,8 @@ To add an overriding theme file (to override a parent theme layout):
 
 These files override the following layouts:
 
-- `<parent_theme_dir>/<Namespace>_<Module>/layout/<layout1>.xml`
-- `<parent_theme_dir>/<Namespace>_<Module>/layout/<layout2>.xml`
+*  `<parent_theme_dir>/<Namespace>_<Module>/layout/<layout1>.xml`
+*  `<parent_theme_dir>/<Namespace>_<Module>/layout/<layout2>.xml`
 
 {:.bs-callout .bs-callout-info}
 To override page layout files, use the `page_layout` directory name instead of `layout`.
@@ -91,15 +91,15 @@ To override page layout files, use the `page_layout` directory name instead of `
 
 Although the layout overriding mechanism provides great customization flexibility, it's possible to use it to add logically irrelevant changes. We strongly recommend you not make the following changes:
 
-* Changing block name or alias. The name of a block should not be changed, and neither should the alias of a block remaining in the same parent element.
-* Changing handle inheritance. For example, you should not change the page type parent handle.
+*  Changing block name or alias. The name of a block should not be changed, and neither should the alias of a block remaining in the same parent element.
+*  Changing handle inheritance. For example, you should not change the page type parent handle.
 
 {:.ref-header}
 Related topics
 
-* [Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html)
-* [Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html)
-* [Layout instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html)
+*  [Extend a layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html)
+*  [Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html)
+*  [Layout instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html)
 
 [extending layouts]: {{page.baseurl}}/frontend-dev-guide/layouts/layout-extend.html
 [theme]: {{page.baseurl}}/frontend-dev-guide/layouts/layout-overview.html#layout-loc

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
@@ -30,8 +30,8 @@ The purpose of page layouts is to create a structured, common set of layout inst
 
 The basic view of all Magento [storefront](https://glossary.magento.com/storefront) pages is defined in two page configuration layout files located in the Magento_Theme module:
 
-* `<Magento_Theme_module_dir>/view/frontend/layout/default.xml`: defines the page layout.
-* `<Magento_Theme_module_dir>/view/frontend/layout/default_head_blocks.xml`: defines the scripts, images, and meta data included in pages' `<head>` section.
+*  `<Magento_Theme_module_dir>/view/frontend/layout/default.xml`: defines the page layout.
+*  `<Magento_Theme_module_dir>/view/frontend/layout/default_head_blocks.xml`: defines the scripts, images, and meta data included in pages' `<head>` section.
 
 These basic page configuration layouts are extended in other Magento modules and in Magento themes.
 
@@ -43,9 +43,9 @@ A *layout handle* is a uniquely identified set of [layout instructions](https://
 
 There are three kinds of layout handles:
 
-- **page-type layout handles** – Synonyms of the page type identifiers. Correspond to "full action names" of controller actions, for example, catalog_product_view.
-- **page layout handles** – Identifiers of specific pages. Correspond to controller actions with parameters that identify specific pages, for example, catalog_product_view_type_simple_id_128 or for a CMS page, cms_page_view_id_home.xml.
-- **arbitrary handles** - Do not correspond to any page type, but other handles use them by including.
+*  **page-type layout handles** – Synonyms of the page type identifiers. Correspond to "full action names" of controller actions, for example, catalog_product_view.
+*  **page layout handles** – Identifiers of specific pages. Correspond to controller actions with parameters that identify specific pages, for example, catalog_product_view_type_simple_id_128 or for a CMS page, cms_page_view_id_home.xml.
+*  **arbitrary handles** - Do not correspond to any page type, but other handles use them by including.
 
 ## Layout files types and conventions
 
@@ -55,9 +55,9 @@ For a particular page, its layout is defined by two major layout components: *pa
 
 Following are the definitions of each layout file type:
 
-* *Page layout*: an XML file declaring a page wireframe inside the `<body>` section of the HTML page markup, for example, two-column page layout.
-* *Page configuration*: an XML file declaring detailed structure, contents and meta-information of a page (includes the `<html>`, `<head>`, and `<body>` sections of the HTML page markup).
-* *Generic layout*: an XML file declaring page detailed structure and contents inside the `body` section of the HTML page markup. Used for pages returned by AJAX requests, emails, HTML snippets, and so on.
+*  *Page layout*: an XML file declaring a page wireframe inside the `<body>` section of the HTML page markup, for example, two-column page layout.
+*  *Page configuration*: an XML file declaring detailed structure, contents and meta-information of a page (includes the `<html>`, `<head>`, and `<body>` sections of the HTML page markup).
+*  *Generic layout*: an XML file declaring page detailed structure and contents inside the `body` section of the HTML page markup. Used for pages returned by AJAX requests, emails, HTML snippets, and so on.
 
 For details, refer to [Layout file types].
 
@@ -67,12 +67,12 @@ In this guide we use *layout files* when talking about concepts which are simila
 
 The following terms are used to distinguish layouts provided by different application components:
 
-* *Base layouts*: Layout files provided by modules. Conventional location:
-   * Page configuration and generic layout files: `<module_dir>/view/frontend/layout`
-   * Page layout files: `<module_dir>/view/frontend/page_layout`
-* *Theme layouts*: Layout files provided by themes. Conventional location:
-   * Page configuration and generic layout files: `<theme_dir>/<Namespace>_<Module>/layout`
-   * Page layout files: `<theme_dir>/<Namespace>_<Module>/page_layout`
+*  *Base layouts*: Layout files provided by modules. Conventional location:
+   *  Page configuration and generic layout files: `<module_dir>/view/frontend/layout`
+   *  Page layout files: `<module_dir>/view/frontend/page_layout`
+*  *Theme layouts*: Layout files provided by themes. Conventional location:
+   *  Page configuration and generic layout files: `<theme_dir>/<Namespace>_<Module>/layout`
+   *  Page layout files: `<theme_dir>/<Namespace>_<Module>/page_layout`
 
 ## Customize layout {#layout-custom}
 
@@ -104,18 +104,18 @@ After layouts are merged, Magento validates them.
 
 Layout validations and error handling depends on the [application mode] in which you Magento instance runs:
 
-- developer mode: syntax is validated in `.xml` and `.xsd` files, and `.xml` files are validated according to the xsd schema. If any validation fails, the hard failure with process halt occurs.
+*  developer mode: syntax is validated in `.xml` and `.xsd` files, and `.xml` files are validated according to the xsd schema. If any validation fails, the hard failure with process halt occurs.
 
-- production or default modes: syntax is validated in `.xml` and `.xsd` files. If validation fails, errors are logged to the `var/log` directory without throwing an exception. The validation according to the xsd schema is not performed.
+*  production or default modes: syntax is validated in `.xml` and `.xsd` files. If validation fails, errors are logged to the `var/log` directory without throwing an exception. The validation according to the xsd schema is not performed.
 
 {:.ref-header}
 Related topics
 
-* [Layout instructions]
-* [Common layout customization tasks]
-* [Extend a layout][extend]
-* [Override a layout][override]
-* [Customizing layout - step-by-step illustration]
+*  [Layout instructions]
+*  [Common layout customization tasks]
+*  [Extend a layout][extend]
+*  [Override a layout][override]
+*  [Customizing layout - step-by-step illustration]
 
 <!-- Link definitions -->
 [extend]: {{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-types.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-types.md
@@ -51,8 +51,8 @@ Sample page layout:
 
 Conventionally page layouts must be located as follows:
 
-* Module page layouts: `<module_dir>/view/frontend/page_layout`
-* Theme page layouts: `<theme_dir>/<Namespace>_<Module>/page_layout`
+*  Module page layouts: `<module_dir>/view/frontend/page_layout`
+*  Theme page layouts: `<theme_dir>/<Namespace>_<Module>/page_layout`
 
 ### Page layouts declaration {#layout-types-page-dec}
 
@@ -60,13 +60,13 @@ To be able to use a layout for actual page rendering, you need to declare it in 
 
 Conventionally layout declaration file can be located in one of the following locations:
 
-- Module layout declarations: `<module_dir>/view/frontend/layouts.xml`
-- Theme layout declaration: `<theme_dir>/<Namespace>_<Module>/layouts.xml`
+*  Module layout declarations: `<module_dir>/view/frontend/layouts.xml`
+*  Theme layout declaration: `<theme_dir>/<Namespace>_<Module>/layouts.xml`
 
 Declare a layout file using the `<layout></layout>` instruction, for which specify the following:
 
-- `<layout id="layout_file_name">`. For example, the `2columns-left.xml` page layout is declared like following: `<layout id="2columns-left"/>`
-- `<label translate="true|false">{Label_used_in_Admin}</label>`
+*  `<layout id="layout_file_name">`. For example, the `2columns-left.xml` page layout is declared like following: `<layout id="2columns-left"/>`
+*  `<label translate="true|false">{Label_used_in_Admin}</label>`
 
 Sample page layout declaration file: `<Magento_Theme_module_dir>/view/frontend/layouts.xml`
 
@@ -120,8 +120,8 @@ The page configuration adds content to the wireframe defined in a page layout fi
 
 Conventionally page configuration files must be located as follows:
 
-- Module page configurations: `<module_dir>/view/frontend/layout`
-- Theme page configurations: `<theme_dir>/<Namespace>_<Module>/layout`
+*  Module page configurations: `<module_dir>/view/frontend/layout`
+*  Theme page configurations: `<theme_dir>/<Namespace>_<Module>/layout`
 
 ### Page configuration structure and allowed layout instructions
 
@@ -396,8 +396,8 @@ Generic layouts define the contents and detailed structure inside the `<body>` s
 
 Conventionally generic layout files must be located as follows:
 
-- Module generic layouts: `<module_dir>/view/frontend/layout`
-- Theme generic layouts: `<theme_dir>/<Namespace>_<Module>/layout`
+*  Module generic layouts: `<module_dir>/view/frontend/layout`
+*  Theme generic layouts: `<theme_dir>/<Namespace>_<Module>/layout`
 
 ### Generic layout structure and allowed layout instructions
 
@@ -482,4 +482,3 @@ Sample generic layout:
     </container>
 </layout>
 ```
-

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-instructions.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-instructions.md
@@ -185,22 +185,21 @@ To pass parameters to a block use the [`<argument></argument>`](#argument) instr
 | `remove` | Allows to remove or cancel the removal of the element. When a container is removed, its child elements are removed as well. | true/false | no |
 | `display` | Allows you to disable rendering of specific block or container with all its children (both set directly and by reference). The block's/container's and its children' respective PHP objects are still generated and available for manipulation. | true/false | no |
 
-- The `remove` attribute is optional and its default value is `false`.
+*  The `remove` attribute is optional and its default value is `false`.
 
-    This implementation allows you to remove a block or container in your layout by setting the remove attribute value to `true`, or to cancel the removal of a block or container by setting the value to `false`.
+   This implementation allows you to remove a block or container in your layout by setting the remove attribute value to `true`, or to cancel the removal of a block or container by setting the value to `false`.
 
-    ```xml
-    <referenceBlock name="block.name" remove="true" />
-    ```
+   ```xml
+   <referenceBlock name="block.name" remove="true" />
+   ```
 
-- The `display` attribute is optional and its default value is true.-
+*  The `display` attribute is optional and its default value is true.-
 
-    You are always able to overwrite this value in your layout.
-    In situation when remove value is true, the display attribute is ignored.
+   You are always able to overwrite this value in your layout. In situation when remove value is true, the display attribute is ignored.
 
-    ```xml
-    <referenceContainer name="container.name" display="false" />
-    ```
+   ```xml
+   <referenceContainer name="container.name" display="false" />
+   ```
 
 ### move {#fedg_layout_xml-instruc_ex_mv}
 
@@ -210,9 +209,9 @@ Sets the declared block or container element as a child of another element in th
 <move element="name.of.an.element" destination="name.of.destination.element" as="new_alias" after="name.of.element.after" before="name.of.element.before"/>
 ```
 
-- `<move>` is skipped if the element to be moved is not defined.
-- If the `as` attribute is not defined, the current value of the element alias is used. If that is not possible, the value of the `name` attribute is used instead.
-- During layout generation, the `<move>` instruction is processed before the removal (set using the `remove` attribute). This means if any elements are moved to the element scheduled for removal, they will be removed as well.
+*  `<move>` is skipped if the element to be moved is not defined.
+*  If the `as` attribute is not defined, the current value of the element alias is used. If that is not possible, the value of the `name` attribute is used instead.
+*  During layout generation, the `<move>` instruction is processed before the removal (set using the `remove` attribute). This means if any elements are moved to the element scheduled for removal, they will be removed as well.
 
 | Attribute | Description | Values | Required? |
 |:------- |:------ |:------ |:------ |
@@ -296,70 +295,70 @@ $cssClass = $this->hasCssClass() ? ' ' . $this->getCssClass() : '';
 As was described above the argument attribute can be added with different types.
 There are examples of all argument types.
 
-- The *string* type:
+*  The *string* type:
 
-```xml
-<argument name="some_string" xsi:type="string" >Some String</argument>
-```
+   ```xml
+   <argument name="some_string" xsi:type="string" >Some String</argument>
+   ```
 
-- The *boolean* type:
+*  The *boolean* type:
 
-```xml
-<argument name="is_active" xsi:type="boolean" >true</argument>
-```
+   ```xml
+   <argument name="is_active" xsi:type="boolean" >true</argument>
+   ```
 
-- The *object* type:
+*  The *object* type:
 
-```xml
-<argument name="viewModel" xsi:type="object" >Vendor\CustomModule\ViewModel\Class</argument>
-```
+   ```xml
+   <argument name="viewModel" xsi:type="object" >Vendor\CustomModule\ViewModel\Class</argument>
+   ```
 
-The `Vendor\CustomModule\ViewModel\Class` class should implement the `\Magento\Framework\View\Element\Block\ArgumentInterface` interface.
+   The `Vendor\CustomModule\ViewModel\Class` class should implement the `\Magento\Framework\View\Element\Block\ArgumentInterface` interface.
 
-- The *number* type:
+*  The *number* type:
 
-```xml
-<argument name="some_number" xsi:type="number" >100</argument>
-```
+   ```xml
+   <argument name="some_number" xsi:type="number" >100</argument>
+   ```
 
-- The *null* type:
+*  The *null* type:
 
-```xml
-<argument name="null_value" xsi:type="null" />
-```
+   ```xml
+   <argument name="null_value" xsi:type="null" />
+   ```
 
-- The *array* type:
+*  The *array* type:
 
-```xml
-<argument name="custom_array" xsi:type="array">
-   <item name="array_key_one" xsi:type="string">First Item</item>
-   <item name="array_key_two" xsi:type="string">Second Item</item>
+   ```xml
+   <argument name="custom_array" xsi:type="array">
+      <item name="array_key_one" xsi:type="string">First Item</item>
+      <item name="array_key_two" xsi:type="string">Second Item</item>
    ...
-</argument>
-```
+   </argument>
+   ```
 
-- The *options* type:
+*  The *options* type:
 
-```xml
-<argument name="options" xsi:type="options" >Vendor\CustomModule\Source\Options\Class</argument>
-```
+   ```xml
+   <argument name="options" xsi:type="options" >Vendor\CustomModule\Source\Options\Class</argument>
+   ```
 
-The `Vendor\CustomModule\Source\Options\Class` class should implement the `\Magento\Framework\Data\OptionSourceInterface` interface.
+   The `Vendor\CustomModule\Source\Options\Class` class should implement the `\Magento\Framework\Data\OptionSourceInterface` interface.
 
-- The *url* type:
+*  The *url* type:
 
-```xml
-<argument name="shopping_cart_url" xsi:type="url" path="checkout/cart/index" />
-```
+   ```xml
+   <argument name="shopping_cart_url" xsi:type="url" path="checkout/cart/index" />
+   ```
 
-- The *helper* type:
+*  The *helper* type:
 
-```xml
-<argument name="helper_method_result" xsi:type="helper" helper="Vendor\CustomModule\Helper\Class::someMethod" >
-  <param name="paramName">paramName</param>
+   ```xml
+   <argument name="helper_method_result" xsi:type="helper" helper="Vendor\CustomModule\Helper\Class::someMethod" >
+     <param name="paramName">paramName</param>
     ...
-</argument>
-```
+   </argument>
+   ```
 
 The *helper* can use only public methods. In this example the `someMethod()` method should be public.
 The argument with *helper* type can contain `param` items which can be passed as a helper method parameters.
@@ -406,33 +405,33 @@ $helperMethodResult = $block->getData('helper_method_result');
 
 The following are common arguments for block instructions:
 
-- `cache_key`: key for saving/retrieving cached information. This is helpful if the block needs to be cached: [example]({{ page.baseurl }}/cloud/project/project-routes-more-cache.html).
+*  `cache_key`: key for saving/retrieving cached information. This is helpful if the block needs to be cached: [example]({{ page.baseurl }}/cloud/project/project-routes-more-cache.html).
 
-- `template`: sets the template for the block.
+*  `template`: sets the template for the block.
 
-    ```xml
-    <referenceBlock name="page.main.title">
-     <arguments>
-       <argument name="template" xsi:type="string">%Namespace_Module::new_template.phtml%</argument>
-     </arguments>
+   ```xml
+   <referenceBlock name="page.main.title">
+      <arguments>
+         <argument name="template" xsi:type="string">%Namespace_Module::new_template.phtml%</argument>
+      </arguments>
    </referenceBlock>
    ```
 
-- `translate_inline`: `true' = enable translation for this block.
+*  `translate_inline`: `true' = enable translation for this block.
 
    ```xml
    <argument xsi:type="string" translate="true">{strValue}</argument>
    ```
 
-- `module_name`: sets the module for the block. Usually this is determined automatically.
+*  `module_name`: sets the module for the block. Usually this is determined automatically.
 
-    ```xml
-    <block class="Namespace_Module_Block_Type" name="block.example">
+   ```xml
+   <block class="Namespace_Module_Block_Type" name="block.example">
       <arguments>
-        <argument name="label" xsi:type="string">Block Label</argument>
+         <argument name="label" xsi:type="string">Block Label</argument>
       </arguments>
-    </block>
-    ```
+   </block>
+   ```
 
 [page layout]: {{page.baseurl}}/frontend-dev-guide/layouts/layout-types.html#layout-types-page
 [page configuration]: {{page.baseurl}}/frontend-dev-guide/layouts/layout-types.html#layout-types-conf

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_css.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_css.md
@@ -13,16 +13,16 @@ Stylesheets are the main tool in responsive web design (RWD) implementation. Thi
 
 In the Blank and Luma themes, a "mobile first" approach is used. The order is:
 
-- Mobile
-- Tablet
-- Desktop
+-  Mobile
+-  Tablet
+-  Desktop
 
 This means that the styles for mobile devices (screen width less than 768px) are extended by the styles for the higher breakpoints. As the result, the extra styles are never loaded when a store is viewed on a mobile device.
 
 The mobile and desktop styles are defined in separate files:
 
-- [styles-l.less] is used to generate desktop-specific styles (768px and higher).
-- [styles-m.less] is used to generate basic and mobile-specific styles.
+-  [styles-l.less] is used to generate desktop-specific styles (768px and higher).
+-  [styles-m.less] is used to generate basic and mobile-specific styles.
 
 ## Breakpoints {#fedg_rwd_css_break}
 
@@ -30,12 +30,12 @@ Breakpoints are used in the CSS code to set up the screen width at which the des
 
 The Blank and Luma themes use Less variables to implement the following [breakpoints]({{ page.baseurl }}/frontend-dev-guide/responsive-web-design/rwd_overview.html#fedg_rwd_terms):
 
-- `@screen__xxs`: 320px
-- `@screen__xs`: 480px
-- `@screen__s`: 640px
-- `@screen__m`: 768px (in the Blank and Luma themes, this breakpoint switches between mobile and desktop views)
-- `@screen__l`: 1024px
-- `@screen__xl`: 1440px
+-  `@screen__xxs`: 320px
+-  `@screen__xs`: 480px
+-  `@screen__s`: 640px
+-  `@screen__m`: 768px (in the Blank and Luma themes, this breakpoint switches between mobile and desktop views)
+-  `@screen__l`: 1024px
+-  `@screen__xl`: 1440px
 
 You can change these breakpoints or add new ones in your custom theme. For instructions see the [Add a new breakpoint]({{ page.baseurl }}/frontend-dev-guide/responsive-web-design/rwd-breakpoints.html) topic.
 
@@ -45,8 +45,8 @@ The Blank and Luma theme styles are based on the [Magento UI library]. The libra
 
 The approach implemented in the Magento UI library, uses `@media-common` style group separation and `.media-width()` mixins which can be used in any `.less` file in a theme, as many times as needed, but it is invoked only once, in `lib/web/css/source/lib/_responsive.less`. The resulting `styles-m.css` and `styles-l.css` both have only one call of each media query with all the rules there, instead of multiple calls for the same query.
 
-- Media queries `@media-common`, `max screen__s` and `max screen__m` will be added to `styles-m.css`.
-- Media queries `min screen__m` and `min screen__l` will be added to `styles-l.css`.
+-  Media queries `@media-common`, `max screen__s` and `max screen__m` will be added to `styles-m.css`.
+-  Media queries `min screen__m` and `min screen__l` will be added to `styles-l.css`.
 
 If working on a theme which inherits from either the Blank or Luma theme, it's recommended to use `.media-width()` and style groups separation.  Otherwise the style rules will be added twice, once to `styles-m.css` and once more to `styles-l.css`.
 
@@ -118,10 +118,10 @@ You can find more information about the Magento UI library responsive mixin usag
 {:.ref-header}
 Related topics
 
-* [Create a theme]({{page.baseurl}}/frontend-dev-guide/themes/theme-create.html)
-* [CSS and Less preprocessing]({{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html)
-* [Magento UI library]({{page.baseurl}}/frontend-dev-guide/css-topics/theme-ui-lib.html)
-* [JavaScript in a responsive design]({{page.baseurl}}/frontend-dev-guide/responsive-web-design/rwd_js.html)
+-  [Create a theme]({{page.baseurl}}/frontend-dev-guide/themes/theme-create.html)
+-  [CSS and Less preprocessing]({{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html)
+-  [Magento UI library]({{page.baseurl}}/frontend-dev-guide/css-topics/theme-ui-lib.html)
+-  [JavaScript in a responsive design]({{page.baseurl}}/frontend-dev-guide/responsive-web-design/rwd_js.html)
 
 [styles-l.less]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/design/frontend/Magento/blank/web/css/styles-l.less
 [styles-m.less]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/design/frontend/Magento/blank/web/css/styles-m.less

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_overview.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_overview.md
@@ -17,10 +17,10 @@ We recommend using the Blank theme, as a starting point for your customizations.
 
 The articles in this chapter describe the particular approaches used in the Blank theme, and provide practical recommendations on how to use these approaches in your themes:
 
-- [CSS in Magento responsive design]
-- [JavaScript in Magento responsive design]
-- [Customizing RWD: illustration]
-- [Create a responsive mobile theme based on Blank]
+-  [CSS in Magento responsive design]
+-  [JavaScript in Magento responsive design]
+-  [Customizing RWD: illustration]
+-  [Create a responsive mobile theme based on Blank]
 
 ## Terms used {#fedg_rwd_terms}
   Term           Description
@@ -29,7 +29,7 @@ The articles in this chapter describe the particular approaches used in the Blan
 
 ## Recommended reading
 
-* [Magento Themes]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html)
+-  [Magento Themes]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html)
 
 [CSS in Magento responsive design]: {{page.baseurl}}/frontend-dev-guide/responsive-web-design/rwd_css.html
 [JavaScript in Magento responsive design]: {{page.baseurl}}/frontend-dev-guide/responsive-web-design/rwd_js.html

--- a/guides/v2.2/frontend-dev-guide/themes/admin_theme_apply.md
+++ b/guides/v2.2/frontend-dev-guide/themes/admin_theme_apply.md
@@ -5,6 +5,7 @@ functional_areas:
   - Frontend
   - Theme
 ---
+
 ## What's in this topic {#favicon-intro}
 
 This topic describes how to apply your custom [theme](https://glossary.magento.com/theme) for [Magento Admin](https://glossary.magento.com/magento-admin).
@@ -15,14 +16,14 @@ This topic describes how to apply your custom [theme](https://glossary.magento.c
 2. [Create a custom theme for the Admin panel]({{ page.baseurl }}/frontend-dev-guide/themes/admin_theme_create.html).
 3. [Add a new custom module]({{ page.baseurl }}/extension-dev-guide/build/build.html) or decide to use existing custom module. The module must load after the Magento_Theme module. To ensure this, add the following code in `<your_custom_module_dir>/etc/module.xml` (replace placeholders with your [module](https://glossary.magento.com/module) information):
 
-    ```xml
-    <module name="%YourVendor_YourModule%" setup_version="2.0.1"> <!-- Example: "Magento_Backend" -->
-        <sequence>
-            <module name="Magento_Theme"/>
-            <module name="Magento_Enterprise"/> <!-- For Enterprise versions only -->
-        </sequence>
-    </module>
-    ```
+   ```xml
+   <module name="%YourVendor_YourModule%" setup_version="2.0.1"> <!-- Example: "Magento_Backend" -->
+      <sequence>
+         <module name="Magento_Theme"/>
+         <module name="Magento_Enterprise"/> <!-- For Enterprise versions only -->
+      </sequence>
+   </module>
+   ```
 
 {:.bs-callout .bs-callout-info}
 If you choose to create a separate dedicated module, you can use the [Magento_SampleMinimal module from the Magento 2 sample modules repository](https://github.com/magento/magento2-samples/tree/master/sample-module-minimal) as example of a minimal module you need. If you will copy and use Magento_SampleMinimal, do not forget to enter your vendor and module naming, instead the ones used in the sample, in the `<your_module_dir>/etc/module.xml`, `<your_module_dir>/registration.php`, `and <your_module_dir>/composer.json` files.
@@ -67,8 +68,8 @@ run the `bin/magento setup:upgrade` command in your command line. If prompted, a
 
 For details about performing command line tasks, view the following topics:
 
-- [Command line configuration]({{ page.baseurl }}/config-guide/cli/config-cli.html)
-- [Uninstall or reinstall Magento: Optionally keeping generated files]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db-upgr.html)
+-  [Command line configuration]({{ page.baseurl }}/config-guide/cli/config-cli.html)
+-  [Uninstall or reinstall Magento: Optionally keeping generated files]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db-upgr.html)
 
 ## Open Admin in browser
 
@@ -76,4 +77,4 @@ The last step is to open the Admin in browser and view the new theme applied.
 
 ## See also
 
- * [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)
+-  [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)

--- a/guides/v2.2/frontend-dev-guide/themes/theme-create.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-create.md
@@ -29,8 +29,8 @@ The high-level steps required to add a new theme in the Magento system are the f
 
 ## Recommended reading
 
-* [Checklist of modules]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento){:target="_blank"}
-* [Static view files processing]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html)
+*  [Checklist of modules]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento){:target="_blank"}
+*  [Static view files processing]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html)
 
 ## Create a theme directory
 
@@ -166,10 +166,10 @@ For details about images configuration in the `view.xml` file, see the [Configur
 
 Your theme will likely contain several types of static files:
 
-* Styles
-* Fonts
-* [JavaScript](https://glossary.magento.com/javascript)
-* Images
+*  Styles
+*  Fonts
+*  [JavaScript](https://glossary.magento.com/javascript)
+*  Images
 
 Each type should be stored in a separate sub-directory of `web` in your theme folder:
 
@@ -227,12 +227,12 @@ In your custom theme, you can use a logo file with a different name and format, 
 
 The necessity of declaration depends on whether your theme has a [parent]({{page.baseurl}}/frontend-dev-guide/themes/theme-inherit.html) theme and its logo image. The following cases are possible:
 
-* Your theme does not have a parent theme:
-   - If your logo image name and format uses the default naming convention (`logo.svg`), there is no need to declare it.
-   - If your logo image name or format does not use the default naming convention, you need to [declare it in layout](#logo_declare).
-* Your theme has a parent theme:
-   - If your theme logo image has the same name and format as the parent's theme logo, there is no need to declare it.
-   - If your logo image has a different name or format, declare it in the [layout](https://glossary.magento.com/layout).
+*  Your theme does not have a parent theme:
+   *  If your logo image name and format uses the default naming convention (`logo.svg`), there is no need to declare it.
+   *  If your logo image name or format does not use the default naming convention, you need to [declare it in layout](#logo_declare).
+*  Your theme has a parent theme:
+   *  If your theme logo image has the same name and format as the parent's theme logo, there is no need to declare it.
+   *  If your logo image has a different name or format, declare it in the [layout](https://glossary.magento.com/layout).
 
 ## Declaring theme logo {#logo_declare}
 
@@ -274,4 +274,4 @@ For information on how to apply the theme for the storefront, see the [Apply and
 
 ## See also
 
-* [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)
+*  [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)

--- a/guides/v2.2/frontend-dev-guide/themes/theme-uninstall.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-uninstall.md
@@ -12,8 +12,8 @@ This topic describes how to uninstall a [storefront](https://glossary.magento.co
 
 The way a theme should be uninstalled is defined by two factors:
 
-* the way the theme was added: manually added (installed or created), installed as [composer](https://glossary.magento.com/composer) package or as an [extension](https://glossary.magento.com/extension).
-* the way Magento was installed: [using the source files from GitHub]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-clone.html) or [using Composer]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-composer.html).
+*  the way the theme was added: manually added (installed or created), installed as [composer](https://glossary.magento.com/composer) package or as an [extension](https://glossary.magento.com/extension).
+*  the way Magento was installed: [using the source files from GitHub]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-clone.html) or [using Composer]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-composer.html).
 
 The following sections describe the flow for uninstalling themes in each case.
 
@@ -36,11 +36,12 @@ To uninstall a manually added theme:
 ```bash
 mysql -u <user> -p -e "delete from <dbname>.theme where theme_path ='<Vendor>/<theme>' AND area ='frontend' limit 1"
 ```
+
 Where:
 
-- `<user>`: your Magento database username
-- `<dbname>`: your Magento database name
-- `<Vendor>/<theme>`: relative path to the theme directory
+*  `<user>`: your Magento database username
+*  `<dbname>`: your Magento database name
+*  `<Vendor>/<theme>`: relative path to the theme directory
 
 ## Uninstall a theme package {#uninstall_theme_pack}
 
@@ -79,11 +80,10 @@ You can use the Composer remove command to remove the dependency, but in that ca
 
 If the theme was installed as an extension, you can uninstall it using one of the following flows:
 
-* the same way as theme Composer packages are uninstalled, see the [Uninstall a theme package](#uninstall_theme_pack) section for details.
-* using the Component Manager.
+*  the same way as theme Composer packages are uninstalled, see the [Uninstall a theme package](#uninstall_theme_pack) section for details.
+*  using the Component Manager.
 
 To uninstall a theme extension using the Component Manager:
 
 1. In the [Magento Admin](https://glossary.magento.com/magento-admin) Panel, navigate to **System** > **Web Setup Wizard** > **Extension Manager**.
 2. In the **Actions** column, click **Select** > **Uninstall** in the theme record.
-

--- a/guides/v2.2/frontend-dev-guide/themes/theme-workflow.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-workflow.md
@@ -19,22 +19,19 @@ bin/magento deploy:mode:set developer
 
 See:
 
-* [About Magento modes]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html)
-* [Get started with command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
+*  [About Magento modes]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html)
+*  [Get started with command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
 
 {:.bs-callout .bs-callout-tip}
-To check the current mode of your Magento instance, in the root directory, run:
-```bash
-bin/magento deploy:mode:show
-```
+To check the current mode of your Magento instance, in the root directory, run: `bin/magento deploy:mode:show`.
 
 ### Create basic theme files
 
 In the `<magento_root>/app/design/frontend/<Your_Vendor>/<your_theme>` directory, create the following files:
 
-- `theme.xml`
-- `registration.php`
-- (optionally) `composer.json`
+*  `theme.xml`
+*  `registration.php`
+*  (optionally) `composer.json`
 
 For details, see [Create a new storefront theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html)
 

--- a/guides/v2.2/frontend-dev-guide/translations/xlate.md
+++ b/guides/v2.2/frontend-dev-guide/translations/xlate.md
@@ -33,41 +33,39 @@ To create a language package, the `.csv` file requires additional columns that s
 
 Localizing Magento storefronts and the Admin panel gives your company global presence for support and sales.
 
-* Magento supports two types of language packages:
+*  Magento supports two types of language packages:
 
-   * Translated Module and theme packages.
-     Magento auto-discovers packages included in the `i18n` directory of a module or theme. When installing themes and extensions, consider checking for multiple language versions to download and use.
+   *  Translated Module and theme packages. Magento auto-discovers packages included in the `i18n` directory of a module or theme. When installing themes and extensions, consider checking for multiple language versions to download and use.
 
-  * An entire dictionary in one directory.
-    Use and distribute the dictionary as a standalone component (similar to modules and themes).
+   *  An entire dictionary in one directory. Use and distribute the dictionary as a standalone component (similar to modules and themes).
 
-* Customize the default strings in Magento. For example, changing "Add to Wish List" to "Wish List".
-* Use ready-to-use language packages prepared by other users or create your own. The [Magento Marketplace] offers language packs to download and install.
-* Localize strings based on existing, or parent, translations using [language inheritance].
-* Customize your translations further by creating more than one version of a translation for the same language to cover dialects and different phrasing.
-* Contribute to [Magento translations](#translations-project) through [Magento CrowdIn project] with Magento Community Engineering. We encourage translation contributions and efforts in the project for future language packs.
+*  Customize the default strings in Magento. For example, changing "Add to Wish List" to "Wish List".
+*  Use ready-to-use language packages prepared by other users or create your own. The [Magento Marketplace] offers language packs to download and install.
+*  Localize strings based on existing, or parent, translations using [language inheritance].
+*  Customize your translations further by creating more than one version of a translation for the same language to cover dialects and different phrasing.
+*  Contribute to [Magento translations](#translations-project) through [Magento CrowdIn project] with Magento Community Engineering. We encourage translation contributions and efforts in the project for future language packs.
 
 Depending on your needs, you can use the existing [language packages](#m2devgde-xlate-languagepack), [translate Magento by yourself](#m2devgde-xlate-translating), or [contribute](#translations-project).
 
 ## Programming notes
 
-* It is recommended, but not enforced, that you do not place variables inside `__()` functions or `new Phrase()` calls. The scanner that collects the phrases from the code cannot interpret and collect the value of the variable when it is in these locations. Instead, you should place the full text in the `__()` function or `new Phrase()` call. If you need to specify a variable in these cases, ensure that it is translated correctly wherever it is defined as a string literal.
-* The [language package](https://glossary.magento.com/language-package) (`i18n` directory) can be saved to any directory of your [extension](https://glossary.magento.com/extension).
-* The phrases for translations are enabled in the [Phrase] class.
+*  It is recommended, but not enforced, that you do not place variables inside `__()` functions or `new Phrase()` calls. The scanner that collects the phrases from the code cannot interpret and collect the value of the variable when it is in these locations. Instead, you should place the full text in the `__()` function or `new Phrase()` call. If you need to specify a variable in these cases, ensure that it is translated correctly wherever it is defined as a string literal.
+*  The [language package](https://glossary.magento.com/language-package) (`i18n` directory) can be saved to any directory of your [extension](https://glossary.magento.com/extension).
+*  The phrases for translations are enabled in the [Phrase] class.
 
 ### More information
 
-* [Theme dictionaries](#m2devgde-xlate-themes)
-* [Manually translate words and phrases](#m2devgde-xlate-translating)
-* [Translation dictionaries](#m2devgde-xlate-dictionaries)
-* [Language packages](#m2devgde-xlate-languagepack)
+*  [Theme dictionaries](#m2devgde-xlate-themes)
+*  [Manually translate words and phrases](#m2devgde-xlate-translating)
+*  [Translation dictionaries](#m2devgde-xlate-dictionaries)
+*  [Language packages](#m2devgde-xlate-languagepack)
 
 ## Theme dictionaries {#m2devgde-xlate-themes}
 
 You might need to add a dictionary for the default language (en_US) in the following cases:
 
-- To replace or customize strings in the [parent theme]. For example, use "Compare" instead of "Add to Compare".
-- To prepare your [theme](https://glossary.magento.com/theme) for localization. More merchants may use your theme if it supports localization.
+*  To replace or customize strings in the [parent theme]. For example, use "Compare" instead of "Add to Compare".
+*  To prepare your [theme](https://glossary.magento.com/theme) for localization. More merchants may use your theme if it supports localization.
 
 For an example of creating a dictionary for a theme for both cases, see [Example theme translation dictionary].
 
@@ -90,13 +88,13 @@ To save and reuse translations, we recommend localizing in a dictionary.
 
 Magento translates words and phrases when all of the following conditions are met:
 
-* The Magento code base has the necessary translation dictionaries for a language
-* This language is configured by the store administrator to be used in specified scope (that is, storefront)
+*  The Magento code base has the necessary translation dictionaries for a language
+*  This language is configured by the store administrator to be used in specified scope (that is, storefront)
 
 The Magento application automatically assembles translation dictionaries located in the modules' `i18n` directory into a dictionary per language. For example, Brazilian Portuguese (`pt_BR`) translation dictionaries might be located in [module](https://glossary.magento.com/module) and theme directories similar to the following:
 
-* `<Magento_Checkout_module_dir>/i18n/pt_BR.csv`
-* `<Magento_Checkout_module_dir>/<theme>/i18n/pt_BR.csv`
+*  `<Magento_Checkout_module_dir>/i18n/pt_BR.csv`
+*  `<Magento_Checkout_module_dir>/<theme>/i18n/pt_BR.csv`
 
 {:.bs-callout .bs-callout-info}
 `<Magento_Checkout_module_dir>` stands for the `Magento_Checkout` module directory. The location of this directory depends on the way Magento was installed. See [Conventional notations for paths to modules and themes] for details.
@@ -111,8 +109,9 @@ You can generate a translation dictionary to use by itself (for example, to tran
 
 Magento enables you to create the following types of language packages:
 
-* A set of `.csv` files for modules and themes. These packages files are intended to be deployed in modules. For example:
-    ```tree
+*  A set of `.csv` files for modules and themes. These packages files are intended to be deployed in modules. For example:
+
+   ```tree
    __/app
     |__/code
     | |__/Magento
@@ -131,19 +130,17 @@ Magento enables you to create the following types of language packages:
           |__/<theme>
        |__/i18n
          |-- pt_BR.csv
-    ```
+   ```
 
-* Language packages that contain a entire dictionary in one directory.
+*  Language packages that contain a entire dictionary in one directory.
 
 You can distribute this language package as a standalone component (similar to modules and themes). Interestingly, it violates Magento's modularity principles on purpose; that is, so that a system integrator can translate variations provided by extensions.
 
 In addition to the `.csv` file that contains the language dictionary, the language package contains meta-information:
 
-* `composer.json` that contains any dependencies for the language package and a mapping to its defined [locale](https://glossary.magento.com/locale).
-   [Sample composer.json]({{ page.baseurl }}/extension-dev-guide/package/package_module.html#sample-composerjson-file)
+*  `composer.json` that contains any dependencies for the language package and a mapping to its defined [locale](https://glossary.magento.com/locale). [Sample composer.json]({{ page.baseurl }}/extension-dev-guide/package/package_module.html#sample-composerjson-file)
 
-* `language.xml`, in which you declare a language package.
-   [Sample language.xml]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-example2)
+*  `language.xml`, in which you declare a language package. [Sample language.xml]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-example2)
 
 ## Community Engineering Translations project {#translations-project}
 
@@ -160,11 +157,11 @@ If you need help understanding the context or meaning of a UI string, or have qu
 
 ## Additional information
 
-* [Translation dictionaries and packages]
-* [Use translation dictionary to customize strings]
-* [Translate theme strings]
-* [Example theme translation dictionary]
-* [Magento translations GitHub project]
+*  [Translation dictionaries and packages]
+*  [Use translation dictionary to customize strings]
+*  [Translate theme strings]
+*  [Example theme translation dictionary]
+*  [Magento translations GitHub project]
 
 [Generate a translation dictionary]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
 [language inheritance]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#m2devgde-xlate-inheritancework

--- a/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
@@ -24,10 +24,10 @@ Page layout declares the wireframe of a page inside the `<body>` section, for ex
 
 Allowed layout instructions:
 
-* [`<container>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_cont)
-* [`<referenceContainer>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_ref)
-* [`<move>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv)
-* [`<update>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_upd)
+*  [`<container>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_cont)
+*  [`<referenceContainer>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_ref)
+*  [`<move>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv)
+*  [`<update>`]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_upd)
 
 Sample page layout:
 
@@ -51,8 +51,8 @@ Sample page layout:
 
 Conventionally page layouts must be located as follows:
 
-* Module page layouts: `<module_dir>/view/frontend/page_layout`
-* Theme page layouts: `<theme_dir>/<Namespace>_<Module>/page_layout`
+*  Module page layouts: `<module_dir>/view/frontend/page_layout`
+*  Theme page layouts: `<theme_dir>/<Namespace>_<Module>/page_layout`
 
 ### Page layouts declaration {#layout-types-page-dec}
 
@@ -60,13 +60,13 @@ To be able to use a layout for actual page rendering, you need to declare it in 
 
 Conventionally layout declaration file can be located in one of the following locations:
 
-- Module layout declarations: `<module_dir>/view/frontend/layouts.xml`
-- Theme layout declaration: `<theme_dir>/<Namespace>_<Module>/layouts.xml`
+*  Module layout declarations: `<module_dir>/view/frontend/layouts.xml`
+*  Theme layout declaration: `<theme_dir>/<Namespace>_<Module>/layouts.xml`
 
 Declare a layout file using the `<layout></layout>` instruction, for which specify the following:
 
-- `<layout id="layout_file_name">`. For example, the `2columns-left.xml` page layout is declared like following: `<layout id="2columns-left"/>`
-- `<label translate="true|false">{Label_used_in_Admin}</label>`
+*  `<layout id="layout_file_name">`. For example, the `2columns-left.xml` page layout is declared like following: `<layout id="2columns-left"/>`
+*  `<label translate="true|false">{Label_used_in_Admin}</label>`
 
 Sample page layout declaration file: `<Magento_Theme_module_dir>/view/frontend/layouts.xml`
 
@@ -120,8 +120,8 @@ The page configuration adds content to the wireframe defined in a page layout fi
 
 Conventionally page configuration files must be located as follows:
 
-- Module page configurations: `<module_dir>/view/frontend/layout`
-- Theme page configurations: `<theme_dir>/<Namespace>_<Module>/layout`
+*  Module page configurations: `<module_dir>/view/frontend/layout`
+*  Theme page configurations: `<theme_dir>/<Namespace>_<Module>/layout`
 
 ### Page configuration structure and allowed layout instructions
 
@@ -397,8 +397,8 @@ Generic layouts define the contents and detailed structure inside the `<body>` s
 
 Conventionally generic layout files must be located as follows:
 
-- Module generic layouts: `<module_dir>/view/frontend/layout`
-- Theme generic layouts: `<theme_dir>/<Namespace>_<Module>/layout`
+*  Module generic layouts: `<module_dir>/view/frontend/layout`
+*  Theme generic layouts: `<theme_dir>/<Namespace>_<Module>/layout`
 
 ### Generic layout structure and allowed layout instructions
 
@@ -483,4 +483,3 @@ Sample generic layout:
     </container>
 </layout>
 ```
-

--- a/guides/v2.3/frontend-dev-guide/themes/theme-create.md
+++ b/guides/v2.3/frontend-dev-guide/themes/theme-create.md
@@ -29,8 +29,8 @@ The high-level steps required to add a new theme in the Magento system are the f
 
 ## Recommended reading
 
-* [Checklist of modules]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento){:target="_blank"}
-* [Static view files processing]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html)
+*  [Checklist of modules]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento){:target="_blank"}
+*  [Static view files processing]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-static-view.html)
 
 ## Create a theme directory
 
@@ -167,10 +167,10 @@ For details about images configuration in the `view.xml` file, see the [Configur
 
 Your theme will likely contain several types of static files:
 
-* Styles
-* Fonts
-* [JavaScript](https://glossary.magento.com/javascript)
-* Images
+*  Styles
+*  Fonts
+*  [JavaScript](https://glossary.magento.com/javascript)
+*  Images
 
 Each type should be stored in a separate sub-directory of `web` in your theme folder:
 
@@ -228,12 +228,12 @@ In your custom theme, you can use a logo file with a different name and format, 
 
 The necessity of declaration depends on whether your theme has a [parent]({{page.baseurl}}/frontend-dev-guide/themes/theme-inherit.html) theme and its logo image. The following cases are possible:
 
-* Your theme does not have a parent theme:
-  - If your logo image name and format uses the default naming convention (`logo.svg`), there is no need to declare it.
-  - If your logo image name or format does not use the default naming convention, you need to [declare it in layout](#logo_declare).
-* Your theme has a parent theme:
-  - If your theme logo image has the same name and format as the parent's theme logo, there is no need to declare it.
-  - If your logo image has a different name or format, declare it in the [layout](https://glossary.magento.com/layout).
+*  Your theme does not have a parent theme:
+   *  If your logo image name and format uses the default naming convention (`logo.svg`), there is no need to declare it.
+   *  If your logo image name or format does not use the default naming convention, you need to [declare it in layout](#logo_declare).
+*  Your theme has a parent theme:
+   *  If your theme logo image has the same name and format as the parent's theme logo, there is no need to declare it.
+   *  If your logo image has a different name or format, declare it in the [layout](https://glossary.magento.com/layout).
 
 ## Declaring theme logo {#logo_declare}
 
@@ -275,4 +275,4 @@ For information on how to apply the theme for the storefront, see the [Apply and
 
 ## See also
 
-* [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)
+*  [Uninstall a theme]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html)

--- a/guides/v2.3/frontend-dev-guide/translations/xlate.md
+++ b/guides/v2.3/frontend-dev-guide/translations/xlate.md
@@ -12,6 +12,7 @@ Also, we accept [Community Engineering contributions](#translations-project) usi
 ## Translations terms {#translate_terms}
 
 A *translation dictionary* is a comma-separated value (.csv) file with at least two columns: the original phrase in the `en_US` locale and a translation of that phrase in an another locale. Sample translation from English (`en_US`) to German (`de_DE`):
+
 ```text
 "Add to Cart","Zum Warenkorb hinzufügen"
 "Add to Compare","Hinzufügen um zu vergleichen"
@@ -32,41 +33,43 @@ To create a language package, the `.csv` file requires additional columns that s
 
 Localizing Magento storefronts and the Admin panel gives your company global presence for support and sales.
 
-* Magento supports two types of language packages:
+*  Magento supports two types of language packages:
 
-   * Translated Module and theme packages.
-          Magento auto-discovers packages included in the `i18n` directory of a module or theme. When installing themes and extensions, consider checking for multiple language versions to download and use.
+   *  Translated Module and theme packages.
 
-   * An entire dictionary in one directory.
-          Use and distribute the dictionary as a standalone component (similar to modules and themes).
+      Magento auto-discovers packages included in the `i18n` directory of a module or theme. When installing themes and extensions, consider checking for multiple language versions to download and use.
 
-* Customize the default strings in Magento. For example, changing "Add to Wish List" to "Wish List".
-* Use ready-to-use language packages prepared by other users or create your own. The [Magento Marketplace] offers language packs to download and install.
-* Localize strings based on existing, or parent, translations using [language inheritance].
-* Customize your translations further by creating more than one version of a translation for the same language to cover dialects and different phrasing.
-* Contribute to [Magento translations](#translations-project) through [Magento CrowdIn project] with Magento Community Engineering. We encourage translation contributions and efforts in the project for future language packs.
+   *  An entire dictionary in one directory.
+
+      Use and distribute the dictionary as a standalone component (similar to modules and themes).
+
+*  Customize the default strings in Magento. For example, changing "Add to Wish List" to "Wish List".
+*  Use ready-to-use language packages prepared by other users or create your own. The [Magento Marketplace] offers language packs to download and install.
+*  Localize strings based on existing, or parent, translations using [language inheritance].
+*  Customize your translations further by creating more than one version of a translation for the same language to cover dialects and different phrasing.
+*  Contribute to [Magento translations](#translations-project) through [Magento CrowdIn project] with Magento Community Engineering. We encourage translation contributions and efforts in the project for future language packs.
 
 Depending on your needs, you can use the existing [language packages](#m2devgde-xlate-languagepack), [translate Magento by yourself](#m2devgde-xlate-translating), or [contribute](#translations-project).
 
 ## Programming notes
 
-* It is recommended, but not enforced, that you do not place variables inside `__()` functions or `new Phrase()` calls. The scanner that collects the phrases from the code cannot interpret and collect the value of the variable when it is in these locations. Instead, you should place the full text in the `__()` function or `new Phrase()` call. If you need to specify a variable in these cases, ensure that it is translated correctly wherever it is defined as a string literal.
-* The [language package](https://glossary.magento.com/language-package) (`i18n` directory) can be saved to any directory of your [extension](https://glossary.magento.com/extension).
-* The phrases for translations are enabled in the [Phrase] class.
+*  It is recommended, but not enforced, that you do not place variables inside `__()` functions or `new Phrase()` calls. The scanner that collects the phrases from the code cannot interpret and collect the value of the variable when it is in these locations. Instead, you should place the full text in the `__()` function or `new Phrase()` call. If you need to specify a variable in these cases, ensure that it is translated correctly wherever it is defined as a string literal.
+*  The [language package](https://glossary.magento.com/language-package) (`i18n` directory) can be saved to any directory of your [extension](https://glossary.magento.com/extension).
+*  The phrases for translations are enabled in the [Phrase] class.
 
 ### More information
 
-* [Theme dictionaries](#m2devgde-xlate-themes)
-* [Manually translate words and phrases](#m2devgde-xlate-translating)
-* [Translation dictionaries](#m2devgde-xlate-dictionaries)
-* [Language packages](#m2devgde-xlate-languagepack)
+*  [Theme dictionaries](#m2devgde-xlate-themes)
+*  [Manually translate words and phrases](#m2devgde-xlate-translating)
+*  [Translation dictionaries](#m2devgde-xlate-dictionaries)
+*  [Language packages](#m2devgde-xlate-languagepack)
 
 ## Theme dictionaries {#m2devgde-xlate-themes}
 
 You might need to add a dictionary for the default language (en_US) in the following cases:
 
-- To replace or customize strings in the [parent theme]. For example, use "Compare" instead of "Add to Compare".
-- To prepare your [theme](https://glossary.magento.com/theme) for localization. More merchants may use your theme if it supports localization.
+*  To replace or customize strings in the [parent theme]. For example, use "Compare" instead of "Add to Compare".
+*  To prepare your [theme](https://glossary.magento.com/theme) for localization. More merchants may use your theme if it supports localization.
 
 For an example of creating a dictionary for a theme for both cases, see [Example theme translation dictionary].
 
@@ -89,13 +92,13 @@ To save and reuse translations, we recommend localizing in a dictionary.
 
 Magento translates words and phrases when all of the following conditions are met:
 
-* The Magento code base has the necessary translation dictionaries for a language
-* This language is configured by the store administrator to be used in specified scope (that is, storefront)
+*  The Magento code base has the necessary translation dictionaries for a language
+*  This language is configured by the store administrator to be used in specified scope (that is, storefront)
 
 The Magento application automatically assembles translation dictionaries located in the modules' `i18n` directory into a dictionary per language. For example, Brazilian Portuguese (`pt_BR`) translation dictionaries might be located in [module](https://glossary.magento.com/module) and theme directories similar to the following:
 
-* `<Magento_Checkout_module_dir>/i18n/pt_BR.csv`
-* `<Magento_Checkout_module_dir>/<theme>/i18n/pt_BR.csv`
+*  `<Magento_Checkout_module_dir>/i18n/pt_BR.csv`
+*  `<Magento_Checkout_module_dir>/<theme>/i18n/pt_BR.csv`
 
 {:.bs-callout .bs-callout-info}
 `<Magento_Checkout_module_dir>` stands for the `Magento_Checkout` module directory. The location of this directory depends on the way Magento was installed. See [Conventional notations for paths to modules and themes] for details.
@@ -110,8 +113,9 @@ You can generate a translation dictionary to use by itself (for example, to tran
 
 Magento enables you to create the following types of language packages:
 
-* A set of `.csv` files for modules and themes. These packages files are intended to be deployed in modules. For example:
-    ```tree
+*  A set of `.csv` files for modules and themes. These packages files are intended to be deployed in modules. For example:
+
+   ```tree
    __/app
     |__/code
     | |__/Magento
@@ -130,18 +134,17 @@ Magento enables you to create the following types of language packages:
           |__/<theme>
        |__/i18n
          |-- pt_BR.csv
-    ```
+   ```
 
-* Language packages that contain a entire dictionary in one directory.
+*  Language packages that contain a entire dictionary in one directory.
 
    You can distribute this language package as a standalone component (similar to modules and themes). Interestingly, it violates Magento's modularity principles on purpose; that is, so that a system integrator can translate variations provided by extensions.
 
 In addition to the `.csv` file that contains the language dictionary, the language package contains meta-information:
 
-* `composer.json` that contains any dependencies for the language package and a mapping to its defined [locale](https://glossary.magento.com/locale)
-   [Sample composer.json]({{ page.baseurl }}/extension-dev-guide/package/package_module.html#sample-composerjson-file)
+*  `composer.json` that contains any dependencies for the language package and a mapping to its defined [locale](https://glossary.magento.com/locale). [Sample composer.json]({{ page.baseurl }}/extension-dev-guide/package/package_module.html#sample-composerjson-file).
 
-* `language.xml`, in which you declare a language package.
+*  `language.xml`, in which you declare a language package.
    [Sample language.xml]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-example2)
 
 ## Community Engineering Translations project {#translations-project}
@@ -159,11 +162,11 @@ If you need help understanding the context or meaning of a UI string, or have qu
 
 ## Additional information
 
-* [Translation dictionaries and packages]
-* [Use translation dictionary to customize strings]
-* [Translate theme strings]
-* [Example theme translation dictionary]
-* [Magento translations GitHub project]
+*  [Translation dictionaries and packages]
+*  [Use translation dictionary to customize strings]
+*  [Translate theme strings]
+*  [Example theme translation dictionary]
+*  [Magento translations GitHub project]
 
 [Generate a translation dictionary]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
 [language inheritance]: {{page.baseurl}}/config-guide/cli/config-cli-subcommands-i18n.html#m2devgde-xlate-inheritancework


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD004 errors in the Frontend Dev Guide.

The MD004 rule requires consistent use of unordered list styles. The scope of #5241 also permits—but does not require—resolving errors related to the following rules:

- MD005: List indentation
- MD006: Start bulleted lists at the beginning of a line
- MD007: List indentation
- MD030: Spaces after list markers

This is one of many PRs related to #5241.