### PR TITLE
Fix for broken link to github repo

### DIFF
--- a/guides/v2.2/frontend-dev-guide/themes/theme-images.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-images.md
@@ -20,7 +20,7 @@ The conventional location of `view.xml` for a theme is:
 <theme_dir>/etc/view.xml
 ```
 
-For example, here is the `view.xml` of the Magento Blank theme: [`app/design/frontend/Magento/blank/etc/view.xml`]({{ site.mage2bloburl }}{{ page.guide_version }}/app/design/frontend/Magento/blank/etc/view.xml).
+For example, here is the `view.xml` of the Magento Blank theme: [`app/design/frontend/Magento/blank/etc/view.xml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/design/frontend/Magento/blank/etc/view.xml).
 
 In `view.xml`, image properties are configured in the scope of `<images module="Magento_Catalog">` element:
 


### PR DESCRIPTION
Link on this page generated as
`https://github.com/magento/magento2/blob2.2/app/design/frontend/Magento/blank/etc/view.xml`
which is ... well wrong.

## Purpose of this pull request

Fix for  link in 2.2 guide.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/themes/theme-images.html

see `app/design/frontend/Magento/blank/etc/view.xml` link.

 
