### PR TITLE
Fixed list styles (MD004) in several more guides

### DIFF
--- a/guides/v2.2/mtf/create_test/create_new_test.md
+++ b/guides/v2.2/mtf/create_test/create_new_test.md
@@ -11,11 +11,11 @@ To make the documentation more consistent, we created a completely new test spec
 
 Create a synonym group (synonyms are a way to expand the scope of eligible matching products) with:
 
-- Scope:
-    - All Websites
-    - All Store Views
-    - Default Store View
-- Synonyms: shoes, foot wear, men shoes, women shoes.
+-  Scope:
+   -  All Websites
+   -  All Store Views
+   -  Default Store View
+-  Synonyms: shoes, foot wear, men shoes, women shoes.
 
 ### Manual testing scenario {#manual-test}
 
@@ -61,11 +61,11 @@ Create a synonym group (synonyms are a way to expand the scope of eligible match
 
 #### Step 1. Check the FTF configuration and environment {#check-mtf}
 
-* Adjust configuration. Learn how to [adjust a configuration][].
+-  Adjust configuration. Learn how to [adjust a configuration][].
 
-* Prepare Magento application. Learn how to [prepare Magento application][].
+-  Prepare Magento application. Learn how to [prepare Magento application][].
 
-* Prepare environment for test run. Learn how to [prepare environment for test run][].
+-  Prepare environment for test run. Learn how to [prepare environment for test run][].
 
 #### Step 2. Create the testing object - a fixture {#create-test-object}
 
@@ -444,8 +444,8 @@ The following code contains a data set, but doesn't have data yet:
 
 According to a New Synonym Group form we need to enter data in the `synonyms` and `scope_id` fields.
 
-- `synonyms` field. We need to [set data to a fixture field][]. The name of the field should be `<name of a fixture>/data/<name of the field>`. It is `name = "synonym/data/synonyms"`. To make data unique in each variation, we can use the [`%isolation%` placeholder][].
-- `scope_id` field. We need to [set data to a fixture field from a repository][]. The name of the field should be `<name of a fixture>/data/<name of the field>/dataset`. It is `name="synonym/data/scope_id/dataset"`. As you remember from [Step 2][], we use the [data source][] to process this field. The data source loads the Store fixture with the Store repository, and returns the name of the field we need. In a `dataset` value, we should specify a name of the Store repository `dataset name` from `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Store/Test/Repository/Store.xml`.
+-  `synonyms` field. We need to [set data to a fixture field][]. The name of the field should be `<name of a fixture>/data/<name of the field>`. It is `name = "synonym/data/synonyms"`. To make data unique in each variation, we can use the [`%isolation%` placeholder][].
+-  `scope_id` field. We need to [set data to a fixture field from a repository][]. The name of the field should be `<name of a fixture>/data/<name of the field>/dataset`. It is `name="synonym/data/scope_id/dataset"`. As you remember from [Step 2][], we use the [data source][] to process this field. The data source loads the Store fixture with the Store repository, and returns the name of the field we need. In a `dataset` value, we should specify a name of the Store repository `dataset name` from `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Store/Test/Repository/Store.xml`.
 
 | Variation #  |`synonyms`|`scope_id`
 |---
@@ -839,6 +839,7 @@ You can run the test using your IDE or the CLI. The Selenium Server must be [up 
 ```bash
 cd <magento2_root_dir>/dev/tests/functional
 ```
+
 ```bash
 vendor/bin/phpunit --filter CreateSynonymEntityTest
 ```
@@ -1002,6 +1003,7 @@ You can run the test using your IDE or the CLI. The Selenium Server must be [up 
 ```bash
 cd <magento2_root_dir>/dev/tests/functional
 ```
+
 ```bash
 vendor/bin/phpunit --filter CreateSynonymEntityTest
 ```

--- a/guides/v2.2/mtf/features/reporting.md
+++ b/guides/v2.2/mtf/features/reporting.md
@@ -11,18 +11,18 @@ The following image demonstrates example of a general flow.
 
 The [event](https://glossary.magento.com/event) manager is a core component which:
 
-- dispatches events
-- gets a list of observers
-- notifies observers depending on read [configuration] and [preset]
+-  dispatches events
+-  gets a list of observers
+-  notifies observers depending on read [configuration] and [preset]
 
 ### Event manager {#event-manger}
 
 The event manager is defined in the [`\Magento\Mtf\System\Event\EventManager`][EventManager] class that:
 
-- is an entry point to the event management system
-- fetches configuration and observers
-- handles events and passes them to observers
-- notifies selected observers according to an event tags array and configuration
+-  is an entry point to the event management system
+-  fetches configuration and observers
+-  handles events and passes them to observers
+-  notifies selected observers according to an event tags array and configuration
 
 ## `phpunit.xml` configuration {#configuration}
 
@@ -152,8 +152,8 @@ $this->eventManager->dispatchEvent(['your_event_tag'], [$your_input_parameters])
 
 It has two arguments:
 
-- Array of event tags. Event tags specify the name of event that is dispatched. It is used as a [tag] in [event preset].
-- Input parameters. The parameters used by observers as input parameters. For example, a cURL response.
+-  Array of event tags. Event tags specify the name of event that is dispatched. It is used as a [tag] in [event preset].
+-  Input parameters. The parameters used by observers as input parameters. For example, a cURL response.
 
 Example of use:
 
@@ -170,9 +170,9 @@ if (!strpos($response, 'data-ui-id="messages-message-success"')) {
 
 The following examples explain how to use the reporting tool on practice.
 
-* [Create a preset][create preset]
-* [Edit a preset][edit preset]
-* [Create and apply a custom observer][add custom observer]
+-  [Create a preset][create preset]
+-  [Edit a preset][edit preset]
+-  [Create and apply a custom observer][add custom observer]
 
 ### Create a preset {#create-preset}
 
@@ -182,16 +182,16 @@ The following example shows how to add a `custom` preset.
 
 **Reports**:
 
-- HTML code
-- screenshots
+-  HTML code
+-  screenshots
 
 **What is needed**:
 
-- [observers][observer]:
-  - `\Magento\Mtf\System\Observer\SourceCode`
-  - `\Magento\Mtf\System\Observer\Screenshot`
-- [events][event]:
-  - `failure`
+-  [observers][observer]:
+   -  `\Magento\Mtf\System\Observer\SourceCode`
+   -  `\Magento\Mtf\System\Observer\Screenshot`
+-  [events][event]:
+   -  `failure`
 
 **Solution**:
 
@@ -220,18 +220,18 @@ The following example shows how to edit the `base` preset.
 
 **Reports**:
 
-- screenshots
+-  screenshots
 
 **What is needed**:
 
-- [preset]:
-  - `base`
-- [observers][observer]:
-  - [`\Magento\Mtf\System\Observer\Screenshot`][Screenshot]
-- [events][event]:
-  - `click_before`
-  - `click_after`
-  - `set_value`
+-  [preset]:
+   -  `base`
+-  [observers][observer]:
+   -  [`\Magento\Mtf\System\Observer\Screenshot`][Screenshot]
+-  [events][event]:
+   -  `click_before`
+   -  `click_after`
+   -  `set_value`
 
 {: .bs-callout .bs-callout-warning }
 The `base` preset is stored in the FTF `<magento2>/dev/tests/functional/vendor/magento/mtf/etc/events.xml`.
@@ -261,8 +261,8 @@ You can create your own observer using existing examples.
 
 General implementation rules:
 
-- An observer must implement [`ObserverInterface`].
-- Put the class in `<magento_2_root_dir>/dev/tests/functional/lib/Magento/Mtf/System/Observer`.
+-  An observer must implement [`ObserverInterface`].
+-  Put the class in `<magento_2_root_dir>/dev/tests/functional/lib/Magento/Mtf/System/Observer`.
 
 The following example shows how to use a custom observer in the example with the `\Magento\Mtf\System\Observer\WebapiResponse` observer.
 
@@ -270,16 +270,16 @@ The following example shows how to use a custom observer in the example with the
 
 **Reports**:
 
-- Log in JSON
+-  Log in JSON
 
 **What is needed**:
 
-- [preset]:
-  - `base`
-- [observer]:
-  - `\Magento\Mtf\System\Observer\WebapiResponse`
-- [event]:
-  - `webapi_failed`
+-  [preset]:
+   -  `base`
+-  [observer]:
+   -  `\Magento\Mtf\System\Observer\WebapiResponse`
+-  [event]:
+   -  `webapi_failed`
 
 **Solution**:
 

--- a/guides/v2.2/mtf/mtf_entities/mtf_block.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_block.md
@@ -11,8 +11,8 @@ Block as a class represents a set of methods to manipulate with Magento UI block
 
 A block can have the following features:
 
-- A block can contain other blocks.
-- A block can be used in several pages and blocks.
+-  A block can contain other blocks.
+-  A block can be used in several pages and blocks.
 
 This topic shows how to create a new block and explore its structure. It discusses how to use mapping for forms in blocks and forms in tabs.
 
@@ -189,12 +189,12 @@ class Messages extends Block
 
 Magento contains basic blocks for the functional testing with a logic that you can reuse. The most popular are the following:
 
-* [`Magento\Mtf\Block\Block`]{:target="_blank"}
-* [`Magento\Mtf\Block\Form`]{:target="_blank"}
-* [`Magento\Backend\Test\Block\Widget\Tab`]{:target="_blank"}
-* [`Magento\Backend\Test\Block\Widget\FormTabs`]{:target="_blank"}
-* [`Magento\Backend\Test\Block\Widget\Grid`]{:target="_blank"}
-* [`Magento\Ui\Test\Block\Adminhtml\DataGrid`]{:target="_blank"}
+-  [`Magento\Mtf\Block\Block`]{:target="_blank"}
+-  [`Magento\Mtf\Block\Form`]{:target="_blank"}
+-  [`Magento\Backend\Test\Block\Widget\Tab`]{:target="_blank"}
+-  [`Magento\Backend\Test\Block\Widget\FormTabs`]{:target="_blank"}
+-  [`Magento\Backend\Test\Block\Widget\Grid`]{:target="_blank"}
+-  [`Magento\Ui\Test\Block\Adminhtml\DataGrid`]{:target="_blank"}
 
 ## Block identifier {#mtf_block_identifier}
 
@@ -418,9 +418,9 @@ Now each UI block has hint about its name and path. Also, you can see the path t
 
 If you want to change the representation of block details, you can change a [`Template.php`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/View/Element/Template.php):
 
-* Open `<magento2_root_dir>/lib/internal/Magento/Framework/View/Element/Template.php`
+-  Open `<magento2_root_dir>/lib/internal/Magento/Framework/View/Element/Template.php`
 
-* Find the method
+-  Find the method
 
 ```php5
 <?php
@@ -433,7 +433,7 @@ protected function _toHtml()
 }
 ```
 
-* Change the code to the following
+-  Change the code to the following
 
 ```php
 <?php
@@ -451,7 +451,7 @@ protected function _toHtml()
 }
 ```
 
-* Save the file
+-  Save the file
 
 Now you can inspect any element in a browser, and find which block contains it.
 
@@ -552,8 +552,8 @@ Let's create render for the bundle product.
 
 Details:
 
-* The [PHP](https://glossary.magento.com/php) class for the page will be generated in the Magento_Catalog module, because we did not mention module attribute in the `page` node
-* In the `block`, we indicate `name` attribute only
+-  The [PHP](https://glossary.magento.com/php) class for the page will be generated in the Magento_Catalog module, because we did not mention module attribute in the `page` node
+-  In the `block`, we indicate `name` attribute only
 
 **Step 4**. Run the page generator
 
@@ -579,17 +579,17 @@ public function getOptions(FixtureInterface $product)
 
 It contains the `getOptions()` method that:
 
-* Gets from the `Bundle/Test/Fixture/BundleProduct.php` fixture the `type_id` field value `$dataConfig['type_id']`. In our case, `type_id='bundle'`.
+-  Gets from the `Bundle/Test/Fixture/BundleProduct.php` fixture the `type_id` field value `$dataConfig['type_id']`. In our case, `type_id='bundle'`.
 
-* Calls the `hasRender()` method to check if there is a render with the name `bundle`
+-  Calls the `hasRender()` method to check if there is a render with the name `bundle`
 
-* Calls the render if there is a render with the name `bundle`
+-  Calls the render if there is a render with the name `bundle`
 
 ```php
 $this->callRender($typeId, 'getOptions', ['product' => $product])
 ```
 
-* Calls a default method if the render is absent
+-  Calls a default method if the render is absent
 
 ```php
 $this->getCustomOptionsBlock()->getOptions($product);

--- a/guides/v2.2/mtf/mtf_entities/mtf_constraint.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_constraint.md
@@ -20,18 +20,18 @@ A module in functional tests (`<magento2_root_dir>/dev/tests/app/Magento/`) stor
 
 The constraint [PHP](https://glossary.magento.com/php) class must:
 
-* Have unique name created using the following template `Assert{MagentoEntityName}{verification|action|place}`. For example:
+*  Have unique name created using the following template `Assert{MagentoEntityName}{verification|action|place}`. For example:
 
-  * `AssertUserSuccessDeleteMessage` corresponds to `Assert{entityName}{verification}`
-  * `AssertOrderPlaced` corresponds to `Assert{entityName}{action}`
-  * `AssertProductForm` corresponds to `Assert{entityName}{place}`
+   *  `AssertUserSuccessDeleteMessage` corresponds to `Assert{entityName}{verification}`
+   *  `AssertOrderPlaced` corresponds to `Assert{entityName}{action}`
+   *  `AssertProductForm` corresponds to `Assert{entityName}{place}`
 
 * Extend the [Magento\Mtf\Constraint\AbstractConstraint](https://github.com/magento/mtf/blob/develop/Magento/Mtf/Constraint/AbstractConstraint.php) class.
 
-* Contain the following methods:
+*  Contain the following methods:
 
-  * `processAssert()` which contains assertions. A `PHPUnit_Framework_Assert` class (`<magento2_root_dir>/dev/tests/functional/vendor/phpunit/phpunit/src/Framework/Assert.php`) can be used to simplify assertions.
-  * `toString()` which returns a success message if the assertion is performed successfully
+   *  `processAssert()` which contains assertions. A `PHPUnit_Framework_Assert` class (`<magento2_root_dir>/dev/tests/functional/vendor/phpunit/phpunit/src/Framework/Assert.php`) can be used to simplify assertions.
+   *  `toString()` which returns a success message if the assertion is performed successfully
 
 ### Constraint arguments
 
@@ -108,14 +108,14 @@ You can tag constraints in `<module>/Test/etc/di.xml` using a `severity` argumen
 
 You can use the following severity tags:
 
-- `high`
-- `middle`
-- `low`
+*  `high`
+*  `middle`
+*  `low`
 
 To assign severity tags do the following:
 
-* Create `di.xml` file in `Test/etc` of the module.
-* Assign `severity` to constraints in the following format:
+*  Create `di.xml` file in `Test/etc` of the module.
+*  Assign `severity` to constraints in the following format:
 
 ```xml
 <type name="Magento\[Module_name]\Test\Constraint\Assert...">

--- a/guides/v2.2/mtf/mtf_entities/mtf_dataset.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_dataset.md
@@ -43,13 +43,13 @@ The `CreateSimpleProductEntityTest.xml` data set contains:
 
 This is a data set that:
 
-- corresponds to the XSD schema `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/etc/variations.xsd`
-- relates to the `Magento\Catalog\Test\TestCase\Product\CreateSimpleProductEntityTest` test case (performs creation of the simple product)
-- relates to the ticket `MAGETWO-23414` in Jira
-- contains variation `CreateSimpleProductEntityTestVariation1` that
-  - contains data to create product with fixed price (see descriptions in the following table)
-  - defines tag that can be used to customize the test suite run
-  - defines [constraints][constraint] that will be performed after the test flow in the order they are presented in the data set
+-  corresponds to the XSD schema `<magento2_root_dir>/dev/tests/functional/vendor/magento/mtf/etc/variations.xsd`
+-  relates to the `Magento\Catalog\Test\TestCase\Product\CreateSimpleProductEntityTest` test case (performs creation of the simple product)
+-  relates to the ticket `MAGETWO-23414` in Jira
+-  contains variation `CreateSimpleProductEntityTestVariation1` that
+   -  contains data to create product with fixed price (see descriptions in the following table)
+   -  defines tag that can be used to customize the test suite run
+   -  defines [constraints][constraint] that will be performed after the test flow in the order they are presented in the data set
 
 The `CreateSimpleProductEntityTestVariation1` variation contains the following `$product` data:
 {:#ex_variation_table}
@@ -109,8 +109,8 @@ A data set is an [XML](https://glossary.magento.com/xml) file that contains test
 
 Each variation includes:
 
-- Data used during the test flow and assertions
-- Constraints that are called after the test flow
+-  Data used during the test flow and assertions
+-  Constraints that are called after the test flow
 
 The following table shows structure of the data set:
 {:#dataset_struct_table}
@@ -187,8 +187,8 @@ The FTF enables you to merge data sets from different modules. For example, if y
 
 There are two options to merge data sets in the FTF:
 
-- [add a new variation]
-- [extend an existing variation]
+-  [add a new variation]
+-  [extend an existing variation]
 
 ## HowTos {#howtos}
 
@@ -202,8 +202,8 @@ Data mapping by `name` is performed for the test methods in test case  and `proc
 
 Slash `/` means array nesting. For example:
 
-- `<data name=var/index1>value</data>` is converted as `var[index1 => value]`
-- `<data name=var/index1/index2>value</data>` is converted as `var[index1 => [index2 => value]]`
+-  `<data name=var/index1>value</data>` is converted as `var[index1 => value]`
+-  `<data name=var/index1/index2>value</data>` is converted as `var[index1 => [index2 => value]]`
 
 where `var` is a name of an argument of a [test case] or a [constraint].
 
@@ -317,7 +317,7 @@ The `checkout_data` doesn't contain source and is assigned with values from the 
 
 To add a new variation using [merging], you should simply use the name of a [test case] that you want to merge with. For example, you want to add a new variations from the Magento_ProductVideo module to the `Magento\Catalog\Test\TestCase\Product\UpdateSimpleProductEntityTest` that is placed in the Magento_Catalog module. You can create data set in the Magento_ProductVideo module, containing variations you need, and paste the test case name that you want to merge with:
 
- * Create `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/ProductVideo/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml` with the following code:
+-  Create `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/ProductVideo/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml` with the following code:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/guides/v2.2/mtf/mtf_entities/mtf_fixture-repo.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_fixture-repo.md
@@ -79,15 +79,15 @@ To create a new CMS page link the user must enter data of all required fields. T
 
 ![cms_page_link "Settings" data set for entire fixture view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_ent_fixt_repo_cms_set_ui.png)
 
-- Set the **Type** field (`field name="code"`) to "CMS Page Link". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="code" xsi:type="string">CMS Page Link</field>`.
-- Set the **Design Theme** field (`field name="theme_id"`) to "Magento Blank". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="theme_id" xsi:type="string">Magento Blank</field>`.
+-  Set the **Type** field (`field name="code"`) to "CMS Page Link". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="code" xsi:type="string">CMS Page Link</field>`.
+-  Set the **Design Theme** field (`field name="theme_id"`) to "Magento Blank". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="theme_id" xsi:type="string">Magento Blank</field>`.
 
 ### Storefront Properties form {#mtf_repo_ex_store}
 
 ![cms_page_link "Storefront properties" data set for entire fixture view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_ent_fixt_repo_cms_set_ui_storefront.png)
 
-- Set the **Frontend App Title** field to "Cms Page Link [random integer value]". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="title" xsi:type="string">Cms Page Link %isolation%</field>`.
-- Set the **Assign to Store Views** field to "All Store Views". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml):
+-  Set the **Frontend App Title** field to "Cms Page Link [random integer value]". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<field name="title" xsi:type="string">Cms Page Link %isolation%</field>`.
+-  Set the **Assign to Store Views** field to "All Store Views". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml):
 
 ```xml
 
@@ -97,18 +97,18 @@ To create a new CMS page link the user must enter data of all required fields. T
 
 ```
 
-- Provide data for the **Layout Updates** complex field. In the repository code, complex fields are represented as arrays of items. An item can be an array of items also, depending on the hierarchy of fields. This field is defined as `<field name="widget_instance" xsi:type="array"></field>`. As it is possible to create more than one instance of a layout update, we define our instance as the first element of an array with index "0" as `<item name="0" xsi:type="array"></item>`.
-  - Set the **Display on** field to "All pages:. It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">All Pages</item>`. Daughter fields are appeared, when **Display on** field is specified. All daughter fields must be wrapped in `<item name="all_pages" xsi:type="array"></item>`.
-    - Set the **Container** field to "Main content area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
-    - Set the **Template** field to "CMS Page Link Block Template". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="template" xsi:type="string">CMS Page Link Block Template</item>`.
+-  Provide data for the **Layout Updates** complex field. In the repository code, complex fields are represented as arrays of items. An item can be an array of items also, depending on the hierarchy of fields. This field is defined as `<field name="widget_instance" xsi:type="array"></field>`. As it is possible to create more than one instance of a layout update, we define our instance as the first element of an array with index "0" as `<item name="0" xsi:type="array"></item>`.
+   -  Set the **Display on** field to "All pages:. It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">All Pages</item>`. Daughter fields are appeared, when **Display on** field is specified. All daughter fields must be wrapped in `<item name="all_pages" xsi:type="array"></item>`.
+   -  Set the **Container** field to "Main content area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
+   -  Set the **Template** field to "CMS Page Link Block Template". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="template" xsi:type="string">CMS Page Link Block Template</item>`.
 
 ### Frontend App Options {#mtf_repo_ex_front}
 
 ![cms_page_link "Frontend App Options" data set for entire fixture view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_ent_fixt_repo_cms_set_ui_frontend-app.png)
 
-- Set the **Anchor Custom Text** field to "text".
-- Set the **Anchor Custom Title** field to "anchor title".
-- Choose in the **CMS Page** grid newly created CMS page.
+-  Set the **Anchor Custom Text** field to "text".
+-  Set the **Anchor Custom Title** field to "anchor title".
+-  Choose in the **CMS Page** grid newly created CMS page.
 
 ```xml
 
@@ -207,12 +207,12 @@ See the entire repository sample so far:
 
 Let's look at the repository structure.
 
-- `<config>` is a root node that defines the path to the `repository.xsd` schema.
-- `<repository>` specifies a repository class in the required `class` attribute and stores data sets. `class` contains the full name of the repository class. The repository contains data sets.
-  - In case of an entire fixture repository, the full name of the class (including the namespace) must be built as `<path to module where the fixture is placed>\Repository\<file with the name of fixture>`. Example: `Magento\Widget\Test\Repository\Widget`
-  - In case of a fixture field repository, the full name of the class (including the namespace) must be built as `<path to module where the fixture is placed>\Repository\<directory with the name of fixture>\<file with the name of field>`. Example: `Magento\Widget\Test\Repository\Widget\LayoutUpdates`.
-- `<dataset>` specifies the name of data set in the required `name` attribute. This name serves as a reference to the data set that will be used in the test. Each data set contains fields.
-- `<field>` defines the value of the field. Field can contain either value, or items if the field is complex.
+-  `<config>` is a root node that defines the path to the `repository.xsd` schema.
+-  `<repository>` specifies a repository class in the required `class` attribute and stores data sets. `class` contains the full name of the repository class. The repository contains data sets.
+   -  In case of an entire fixture repository, the full name of the class (including the namespace) must be built as `<path to module where the fixture is placed>\Repository\<file with the name of fixture>`. Example: `Magento\Widget\Test\Repository\Widget`
+   -  In case of a fixture field repository, the full name of the class (including the namespace) must be built as `<path to module where the fixture is placed>\Repository\<directory with the name of fixture>\<file with the name of field>`. Example: `Magento\Widget\Test\Repository\Widget\LayoutUpdates`.
+-  `<dataset>` specifies the name of data set in the required `name` attribute. This name serves as a reference to the data set that will be used in the test. Each data set contains fields.
+-  `<field>` defines the value of the field. Field can contain either value, or items if the field is complex.
 
 |`field` attribute   |Semantics   | Is required?  |
 |---|---|---|
@@ -240,25 +240,25 @@ Assume that we want to provide data for the [Layout](https://glossary.magento.co
 
 Case 1. **all_pages** data set:
 
-* Set the **Display on** field (`item name="page_group"`) to "All Pages", which is the subcategory of "Generic Pages" (see drop-down menu on the following screenshot). It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Generic Pages/All Pages</item>`
-* Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml)  `<item name="block" xsi:type="string">Main Content Area</item>`
+-  Set the **Display on** field (`item name="page_group"`) to "All Pages", which is the subcategory of "Generic Pages" (see drop-down menu on the following screenshot). It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Generic Pages/All Pages</item>`
+-  Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml)  `<item name="block" xsi:type="string">Main Content Area</item>`
 
 ![all_pages data set view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_repository_layout-allpages_w_dropd.png)
 
 Case 2. **on_category** data set:
 
-* Set the **Display on** field (`item name="page_group"`) to "Non-Anchor Categories" that is item of "Categories". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Categories/Non-Anchor Categories</item>`.
-* Set the **Categories** field (`item name="for"`) to "Specific Categories". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="for" xsi:type="string">Yes</item>`.
-* Set the in a tree of categories the **Default Category** (`item name="entities"`). It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="entities" xsi:type="string">category::default_subcategory</item>`.
-* Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
+-  Set the **Display on** field (`item name="page_group"`) to "Non-Anchor Categories" that is item of "Categories". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Categories/Non-Anchor Categories</item>`.
+-  Set the **Categories** field (`item name="for"`) to "Specific Categories". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="for" xsi:type="string">Yes</item>`.
+-  Set the in a tree of categories the **Default Category** (`item name="entities"`). It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="entities" xsi:type="string">category::default_subcategory</item>`.
+-  Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
 
 ![on_category data set view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_repository_layout-oncategory_w_dropd.png)
 
 Case 3. **for_cms_page_link** data set:
 
-* Set the **Display on** field (`item name="page_group"`) to "All Pages" that is item of "Generic Pages". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Generic Pages/All Pages</item>`.
-* Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
-* Set the **Template** field (`item name="template"`) to "CMS Page Link Block Template". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<`item name="template" xsi:type="string"`>CMS Page Link Block Template</item>`.
+-  Set the **Display on** field (`item name="page_group"`) to "All Pages" that is item of "Generic Pages". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="page_group" xsi:type="string">Generic Pages/All Pages</item>`.
+-  Set the **Container** field (`item name="block"`) to "Main content Area". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<item name="block" xsi:type="string">Main Content Area</item>`.
+-  Set the **Template** field (`item name="template"`) to "CMS Page Link Block Template". It corresponds to the following code in [the repository data set](#mtf_repo_widgetxml) `<`item name="template" xsi:type="string"`>CMS Page Link Block Template</item>`.
 
 ![layout_for_cms_page_link data set view on GUI]({{ site.baseurl }}/common/images/ftf/mtf_repository_layout-for-cms-page-link_w_dropd.png)
 
@@ -505,8 +505,8 @@ You can find a template for credentials in [`<magento2>/dev/tests/functional/cre
 Credentials always should stay invisible for security reasons. The FTF implicitly pastes credentials during the test run only.
 There are two ways to paste credentials:
 
-- **Using path**. If a field in a repository has a `name` that matches field `path` in `credentials.xml`, then the value of this field will be substituted for the value from `credential.xml` during the test.
-- **Using placeholder**. If a field in a repository has value wrapped in `% %` that matches the value of the `replace` field attribute in `credentials.xml`, then the value of this field will be substituted for the value from `credential.xml` during the test.
+-  **Using path**. If a field in a repository has a `name` that matches field `path` in `credentials.xml`, then the value of this field will be substituted for the value from `credential.xml` during the test.
+-  **Using placeholder**. If a field in a repository has value wrapped in `% %` that matches the value of the `replace` field attribute in `credentials.xml`, then the value of this field will be substituted for the value from `credential.xml` during the test.
 
 ### Example with substitution by <code>path</code> {#mtf_repo_credent_path}
 

--- a/guides/v2.2/mtf/mtf_entities/mtf_page.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_page.md
@@ -10,9 +10,9 @@ In the functional tests, Page Object [Design Pattern](https://glossary.magento.c
 
 Benefit of this approach is that tests don’t need to be changed after changes in the UI. Only code in corresponding block must be changed. This approach provides the following advantages:
 
-- Clean separation between test code and page specific code like locator.
-- Single repository for the services or operations provided by the page.
-- Decreased duplication of the code.
+-  Clean separation between test code and page specific code like locator.
+-  Single repository for the services or operations provided by the page.
+-  Decreased duplication of the code.
 
 You can learn from this topic how to create new page, add blocks to the page. Furthermore, it discusses mechanism of extending the page in another [module](https://glossary.magento.com/module).
 
@@ -33,7 +33,6 @@ Let's see an example of the Magento [Widget](https://glossary.magento.com/widget
 where four blocks have been added:
 
 ```xml
-
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /**
@@ -49,7 +48,6 @@ where four blocks have been added:
         <block name="systemMessageDialog" class="Magento\AdminNotification\Test\Block\System\Messages" locator='[role="dialog"].ui-popup-message' strategy="css selector" />
     </page>
 </config>
-
 ```
 
 The following table explains `<page>` attributes.
@@ -72,9 +70,9 @@ Also, block can contain a `render` node. [Read about renders in the Block topic]
 
 Depending on `area` and `mca` attributes, page can be of one of the following types:
 
-* [Admin](https://glossary.magento.com/admin) page is extended from [Magento\Mtf\Page\BackendPage][] class
-* [Storefront](https://glossary.magento.com/storefront) page is extended from [Magento\Mtf\Page\FrontendPage][] class
-* External page is extended from [Magento\Mtf\Page\ExternalPage][] class
+-  [Admin](https://glossary.magento.com/admin) page is extended from [Magento\Mtf\Page\BackendPage][] class
+-  [Storefront](https://glossary.magento.com/storefront) page is extended from [Magento\Mtf\Page\FrontendPage][] class
+-  External page is extended from [Magento\Mtf\Page\ExternalPage][] class
 
 ### Admin page {#mtf_page_admin}
 
@@ -110,9 +108,9 @@ To add blocks from different modules to the page, you can merge pages by followi
 
 **Step 2.** Assign [page attributes](#mtf_page_attributes)
 
-* with the same name as the page you want to merge
-* with the same `mca`
-* the `module` and `area` attributes can be omitted
+-  with the same name as the page you want to merge
+-  with the same `mca`
+-  the `module` and `area` attributes can be omitted
 
 **Step 3.** Add blocks to the page
 
@@ -163,7 +161,9 @@ We should create `dev/tests/functional/tests/app/Magento/Review/Test/Page/Produc
 
 And generate the updated page:
 
-    php <magento2_root_dir>/dev/tests/functional/utils/generate.php
+```bash
+php <magento2_root_dir>/dev/tests/functional/utils/generate.php
+```
 
 The result is in the `<magento2_root_dir>/dev/tests/functional/generated/Magento/Catalog/Test/Page/Product/CatalogProductView.php` with the following code:
 
@@ -297,9 +297,9 @@ To override blocks, follow:
 
 **Step 2.** Assign [page attributes](#mtf_page_attributes)
 
-* with the same name as the page you want to merge
-* with the same `mca`
-* without `module` and `area` attributes
+-  with the same name as the page you want to merge
+-  with the same `mca`
+-  without `module` and `area` attributes
 
 **Step 3.** Add blocks that you want to override (indicating a block class with new behavior)
 
@@ -307,8 +307,8 @@ To override blocks, follow:
 
 Let's see an example with the following use case:
 
-- A Magento_NewModule changes the [category](https://glossary.magento.com/category) creation behavior of a Magento_Catalog module.
-- `editForm` block from page `\Magento\Catalog\Test\Page\Adminhtml\CatalogCategoryEdit` must be changed according to new functionality.
+-  A Magento_NewModule changes the [category](https://glossary.magento.com/category) creation behavior of a Magento_Catalog module.
+-  `editForm` block from page `\Magento\Catalog\Test\Page\Adminhtml\CatalogCategoryEdit` must be changed according to new functionality.
 
 Let us see page `\Magento\Catalog\Test\Page\Adminhtml\CatalogCategoryEdit`:
 
@@ -348,18 +348,16 @@ To use the `editForm` block from the Magento_NewModule, we must follow:
 
 **Step 2.** Assign page attributes
 
- * with the same name as the page you want to merge
- * with the same `mca`
- * without `module` and `area` attributes
+-  with the same name as the page you want to merge
+-  with the same `mca`
+-  without `module` and `area` attributes
 
 ```xml
-
 <?xml version="1.0" encoding="utf-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/pages.xsd">
     <page name="CatalogCategoryEdit" mca="catalog/category/edit">
     </page>
 </config>
-
 ```
 
 **Step 3.** Add blocks that you want to redirect.
@@ -377,7 +375,9 @@ To use the `editForm` block from the Magento_NewModule, we must follow:
 
 Enter in terminal:
 
-    php <magento2_root_dir>/dev/tests/functional/utils/generate.php
+```bash
+php <magento2_root_dir>/dev/tests/functional/utils/generate.php
+```
 
 Now when you call `editForm` block from the `CatalogCategoryEdit` page, class `\Magento\NewModule\Test\Block\Adminhtml\Category\Edit\CategoryForm` will be used.
 

--- a/guides/v2.2/mtf/mtf_entities/mtf_scenariotest.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_scenariotest.md
@@ -7,17 +7,17 @@ A scenario test is a case of separate test steps where each step is a distinct c
 
 A scenario test has the following advantages:
 
-- Each step in the scenario is a separate [PHP](https://glossary.magento.com/php) class that is placed in the [module](https://glossary.magento.com/module) to which it belongs.
-- A scenario test reduces code duplication because each step can be used multiple times.
-- Scenario tests are flexible and support Magento modularity.
-- New tests can be easily created using existing steps.
+-  Each step in the scenario is a separate [PHP](https://glossary.magento.com/php) class that is placed in the [module](https://glossary.magento.com/module) to which it belongs.
+-  A scenario test reduces code duplication because each step can be used multiple times.
+-  Scenario tests are flexible and support Magento modularity.
+-  New tests can be easily created using existing steps.
 
 A scenario test is split into four logical components:
 
-- [test case], which executes tests steps in the order defined in a tests scenario.
-- [data set], which contains variations of data and constraints for test steps.
-- [test scenario], which defines order of test steps.
-- [test step], which contains a test flow.
+-  [test case], which executes tests steps in the order defined in a tests scenario.
+-  [data set], which contains variations of data and constraints for test steps.
+-  [test scenario], which defines order of test steps.
+-  [test step], which contains a test flow.
 
 ## Test case class   {#test-case}
 
@@ -107,8 +107,8 @@ Example:
 
 The example defines the following test steps:
 
-* `Config/Test/TestStep/SetupConfigurationStep.php`
-* `Catalog/Test/TestStep/CreateProductsStep.php`
+-  `Config/Test/TestStep/SetupConfigurationStep.php`
+-  `Catalog/Test/TestStep/CreateProductsStep.php`
 
 #### `next` and `prev` attributes   {#next-prev-attributes}
 
@@ -130,8 +130,8 @@ Using `next` and `prev` attributes, you can specify a previous or next test step
 
 Both examples define the following test steps and their sequence:
 
-* `Config/Test/TestStep/SetupConfigurationStep.php`.
-* `Catalog/Test/TestStep/CreateProductsStep.php`.
+-  `Config/Test/TestStep/SetupConfigurationStep.php`.
+-  `Catalog/Test/TestStep/CreateProductsStep.php`.
 
 #### `alias` attribute  {#alias-attribute}
 
@@ -152,9 +152,9 @@ Example:
 
 This example defines the following test steps and their sequence:
 
-* `Config/Test/TestStep/SetupConfigurationStep.php`
-* `Catalog/Test/TestStep/CreateProductsStep.php`
-* `Config/Test/TestStep/SetupConfigurationStep.php`
+-  `Config/Test/TestStep/SetupConfigurationStep.php`
+-  `Catalog/Test/TestStep/CreateProductsStep.php`
+-  `Config/Test/TestStep/SetupConfigurationStep.php`
 
 ## Test step class  {#test-step}
 
@@ -191,9 +191,9 @@ class YourTestStep implements TestStepInterface
 
 A tests step must implement `Magento\Mtf\TestStep\TestStepInterface` and define:
 
- - constructor (optional)
- - public method `run()` (required)
- - public method `cleanup()` (optional)
+-  constructor (optional)
+-  public method `run()` (required)
+-  public method `cleanup()` (optional)
 
 An example of `Magento\Customer\Test\TestStep\LoginCustomerOnFrontendStep`:
 
@@ -209,10 +209,10 @@ Optionally, you may use the `constructor()` method, which injects data to be use
 
 In the previous example the `constructor()`:
 
-- injects the `CmsIndex` and `CustomerAccountLogin` pages.
-- injects the `LogoutCustomerOnFrontendStep` step.
-- injects the `Customer` fixture data.
-- assigns arguments to corresponding class properties.
+-  injects the `CmsIndex` and `CustomerAccountLogin` pages.
+-  injects the `LogoutCustomerOnFrontendStep` step.
+-  injects the `Customer` fixture data.
+-  assigns arguments to corresponding class properties.
 
 ### `run()` method  {#run-method}
 
@@ -220,11 +220,11 @@ The `run()` method is required to perform a test step and contains logic of the 
 
 In the previous example the `run()` method:
 
-- logs out if the customer was logged in.
-- clicks 'Sign In' on the `LinksBlock` of the `cmsIndex` page.
-- waits for requested page loading.
-- logs in the customer on the `customerAccountLogin` page.
-- waits for logging in the customer.
+-  logs out if the customer was logged in.
+-  clicks 'Sign In' on the `LinksBlock` of the `cmsIndex` page.
+-  waits for requested page loading.
+-  logs in the customer on the `customerAccountLogin` page.
+-  waits for logging in the customer.
 
 ### `cleanup()` method  {#cleanup-method}
 
@@ -232,7 +232,7 @@ The `cleanup()` method is optional. It resets Magento to an initial state or exe
 
 In the previous example the `clean()` method:
 
-- logs out the customer.
+-  logs out the customer.
 
 <!-- LINKS DEFINITIONS -->
 

--- a/guides/v2.2/performance-best-practices/configuration.md
+++ b/guides/v2.2/performance-best-practices/configuration.md
@@ -19,8 +19,8 @@ An indexer can run in either **Update on Save** or **Update on Schedule** mode. 
 
 We recommend that you use index parallelization and that you set threads count for the index process based on:
 
-- Threads count >= max dimension count (across all indexers)
-- Threads count <= cores count
+-  Threads count >= max dimension count (across all indexers)
+-  Threads count <= cores count
 
 See the [Reindex in parallel mode section]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#config-cli-subcommands-index-reindex-parallel) of [Manage the indexers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html) for more information.
 
@@ -67,9 +67,9 @@ When you activate the **Enable JavaScript Bundling** option, you allow Magento t
 
 ### Bundling tips
 
-* Magento recommends that you use third-party tools for minification and bundling (like [r.js](http://requirejs.org/)). Magento built-in mechanisms are not optimal and are shipped as fallback alternatives.
-* Activating the HTTP2 protocol can be a good alternative to using JS bundling. The protocol provides pretty much the same benefits.
-* We do not recommend using deprecated settings like merging JS and CSS files, as they were designed only for synchronously-loaded JS in the HEAD section of the page. Using this technique can cause bundling and requireJS logic to work incorrectly.
+-  Magento recommends that you use third-party tools for minification and bundling (like [r.js](http://requirejs.org/)). Magento built-in mechanisms are not optimal and are shipped as fallback alternatives.
+-  Activating the HTTP2 protocol can be a good alternative to using JS bundling. The protocol provides pretty much the same benefits.
+-  We do not recommend using deprecated settings like merging JS and CSS files, as they were designed only for synchronously-loaded JS in the HEAD section of the page. Using this technique can cause bundling and requireJS logic to work incorrectly.
 
 ## Database maintenance schedule {#database}
 

--- a/guides/v2.2/security/two-factor-authentication.md
+++ b/guides/v2.2/security/two-factor-authentication.md
@@ -9,9 +9,9 @@ Magento Two-Factor Authentication (2FA) improves security by requiring two-step 
 
 Two-Factor Authentication gives you the ability to:
 
-- Enable authenticator support for the Admin.
-- Manage and configure authenticator settings globally or per user account.
-- Reset authenticators and manage trusted devices for users.
+-  Enable authenticator support for the Admin.
+-  Manage and configure authenticator settings globally or per user account.
+-  Reset authenticators and manage trusted devices for users.
 
 At this time, Two-Factor Authentication can be installed only from the command line.
 
@@ -46,10 +46,10 @@ See the Magento Admin User Guide to [configure](https://docs.magento.com/m2/ee/u
 
 Administrators have options to:
 
-* Review existing authenticators configured per user account
-* Require specific authenticators
-* Reset or remove authenticators to resolve access issues
-* Revoke access for devices to resolve access issues
+-  Review existing authenticators configured per user account
+-  Require specific authenticators
+-  Reset or remove authenticators to resolve access issues
+-  Revoke access for devices to resolve access issues
 
 ## Install authenticator
 
@@ -93,9 +93,9 @@ In your database, you can modify the following tables and values to affect and o
 
 Table: `core_config_data`
 
-- `msp/twofactorauth/enabled` - Set to zero to disable 2FA globally.
-- `msp/twofactorauth/force_providers` - Delete this entry to remove forced providers option.
+-  `msp/twofactorauth/enabled` - Set to zero to disable 2FA globally.
+-  `msp/twofactorauth/force_providers` - Delete this entry to remove forced providers option.
 
 Table: `msp_tfa_user_config`
 
-- Delete one user row to reset the user's 2FA preference and configuration.
+-  Delete one user row to reset the user's 2FA preference and configuration.

--- a/guides/v2.2/test/js/jasmine.md
+++ b/guides/v2.2/test/js/jasmine.md
@@ -44,13 +44,13 @@ If the command fails with the error message:
 
 Install [fontconfig library]:<br/>
 
-* CentOS:
+*  CentOS:
 
   ```bash
   yum install fontconfig
   ```
 
-* Ubuntu:
+*  Ubuntu:
 
   ```bash
   apt-get install fontconfig
@@ -124,13 +124,13 @@ define([
 
 A Jasmine test consists of main two parts:
 
-- `describe` blocks
-- `it` blocks
+*  `describe` blocks
+*  `it` blocks
 
 Both the `describe` and `it` functions contains two parameters:
 
- - a text string with description of what is going to be done
- - a function with block of code implementing described action
+*  a text string with description of what is going to be done
+*  a function with block of code implementing described action
 
 In `describe` you can use `beforeEach` and `afterEach` functions performing a preparation of what must be done before and after every `it` test followed.
 
@@ -269,6 +269,7 @@ Run in your terminal:
 ```bash
 cd <magento_root>/node_modules/grunt-contrib-jasmine
 ```
+
 ```bash
 npm install
 ```

--- a/guides/v2.3/graphql/functional-testing.md
+++ b/guides/v2.3/graphql/functional-testing.md
@@ -83,8 +83,8 @@ QUERY;
 
 The `\Magento\GraphQl\TestModule\GraphQlQueryTest.php` test case uses two test modules to determine whether the mechanisms for GraphQL extensibility work as expected. It illustrates best practices for extending an existing GraphQL endpoint.
 
-* `TestModuleGraphQlQuery` - This bare-bones module defines a `testItem` endpoint with the queryable attributes `item_id` and `name`. It's located at `<installdir>/dev/tests/api-functional/_files/TestModuleGraphQlQuery`.
-* `TestModuleGraphQlQueryExtension` - This module extends `TestModuleGraphQlQuery`, adding the `integer_list` extension attribute. It's located at `<installdir>/dev/tests/api-functional/_files/TestModuleGraphQlQueryExtension`.
+*  `TestModuleGraphQlQuery` - This bare-bones module defines a `testItem` endpoint with the queryable attributes `item_id` and `name`. It's located at `<installdir>/dev/tests/api-functional/_files/TestModuleGraphQlQuery`.
+*  `TestModuleGraphQlQueryExtension` - This module extends `TestModuleGraphQlQuery`, adding the `integer_list` extension attribute. It's located at `<installdir>/dev/tests/api-functional/_files/TestModuleGraphQlQueryExtension`.
 
 ## Creating fixtures
 
@@ -92,8 +92,8 @@ Fixtures, which are part of the testing framework, prepare preconditions in the 
 
 A fixture consists of two files:
 
-- The fixture file, which defines the test
-- A rollback file, which reverts the system to the state before the test was run
+*  The fixture file, which defines the test
+*  A rollback file, which reverts the system to the state before the test was run
 
 {:.bs-callout .bs-callout-info}
 Each fixture should have a corresponding rollback file.
@@ -200,8 +200,8 @@ $registry->register('isSecureArea', false);
 
 Your functional tests should include events that cause exceptions. Since your tests expect an exception to occur, set up your tests so that they elicit the proper responses. You can define expected exception messages either in:
 
-- The body of the test
-- The test function annotation
+-  The body of the test
+-  The test function annotation
 
 {: .bs-callout .bs-callout-tip }
 We recommend that you declare expected exceptions in the test method body, as declaring expected exceptions with annotations has been deprecated in PHPUnit 8. Existing tests that use annotations will have to be updated when Magento requires that version of PHPUnit or higher.
@@ -335,11 +335,11 @@ The `@expectExceptionMessage` annotation provides the text for the exception in 
 
 Use the following functions to cover expected exceptions:
 
-- `expectException`
-- `expectExceptionCode`
-- `expectExceptionMessage`
-- `expectExceptionMessageRegExp`
-- `expectExceptionObject`
+*  `expectException`
+*  `expectExceptionCode`
+*  `expectExceptionMessage`
+*  `expectExceptionMessageRegExp`
+*  `expectExceptionObject`
 
 ## Run functional tests
 

--- a/guides/v2.3/inventory/inventory-cli-reference.md
+++ b/guides/v2.3/inventory/inventory-cli-reference.md
@@ -11,8 +11,8 @@ functional_areas:
 
 These commands include:
 
-- Checking and resolving reservation inconsistencies affecting salable quantity
-- Adding geocodes for the Distance Priority algorithm
+-  Checking and resolving reservation inconsistencies affecting salable quantity
+-  Adding geocodes for the Distance Priority algorithm
 
 ## Resolve reservations inconsistencies
 
@@ -20,26 +20,26 @@ These commands include:
 
 {{site.data.var.im}} provides two commands to check and resolve reservation inconsistencies:
 
-- [`inventory:reservation:list-inconsistencies`](#list-inconsistencies-command)
-- [`inventory:reservation:create-compensations`](#create-compensations-command)
+-  [`inventory:reservation:list-inconsistencies`](#list-inconsistencies-command)
+-  [`inventory:reservation:create-compensations`](#create-compensations-command)
 
 ### What causes reservation inconsistencies?
 
 {{site.data.var.im}} generates reservations for key events:
 
-- Order placement (initial reservation)
-- Order shipment (compensation reservation)
-- Refund order or issue a credit memo (compensation reservation)
-- Order cancellation (compensation reservation)
+-  Order placement (initial reservation)
+-  Order shipment (compensation reservation)
+-  Refund order or issue a credit memo (compensation reservation)
+-  Order cancellation (compensation reservation)
 
 Reservation inconsistencies may occur when {{site.data.var.im}} loses the initial reservation and enters too many reservation compensations (overcompensating and leading to inconsistent amounts), or correctly places the initial reservation but loses compensational reservations.
 
 The following configurations and events can cause reservation inconsistencies:
 
-- **Upgrade Magento to 2.3.x with orders not in a final state (Complete, Canceled, or Closed).** {{site.data.var.im}} will create compensational reservations for these orders, but it will not enter or have the initial reservation that deducts from the salable quantity. We recommend using these commands after upgrading to Magento v2.3.x from 2.1.x or 2.2.x. If you have pending orders, the commands correctly update your salable quantity and reservations for sales and order fulfillment.
-- **You do not manage stock then later change this configuration.** You may start using 2.3.x with **Manage Stock** set to "No" in the Magento configuration. Magento does not place reservations at order placement and shipment events. If you later enable the **Manage Stock** configuration and some orders were created at that time, the Salable Qty would be corrupted with compensation reservation when you handle and fulfill that order.
-- **You re-assign the Stock for a Website while orders submit to that website**. The initial reservation enters for the initial stock and all compensational reservation enter to the new stock.
-- **The sum total of all reservations may not resolve to `0`.** All reservations in the scope of an Order in a final state (Complete, Canceled, Closed) should resolve to `0`, clearing all salable quantity holds.
+-  **Upgrade Magento to 2.3.x with orders not in a final state (Complete, Canceled, or Closed).** {{site.data.var.im}} will create compensational reservations for these orders, but it will not enter or have the initial reservation that deducts from the salable quantity. We recommend using these commands after upgrading to Magento v2.3.x from 2.1.x or 2.2.x. If you have pending orders, the commands correctly update your salable quantity and reservations for sales and order fulfillment.
+-  **You do not manage stock then later change this configuration.** You may start using 2.3.x with **Manage Stock** set to "No" in the Magento configuration. Magento does not place reservations at order placement and shipment events. If you later enable the **Manage Stock** configuration and some orders were created at that time, the Salable Qty would be corrupted with compensation reservation when you handle and fulfill that order.
+-  **You re-assign the Stock for a Website while orders submit to that website**. The initial reservation enters for the initial stock and all compensational reservation enter to the new stock.
+-  **The sum total of all reservations may not resolve to `0`.** All reservations in the scope of an Order in a final state (Complete, Canceled, Closed) should resolve to `0`, clearing all salable quantity holds.
 
 ### List inconsistencies command
 
@@ -51,16 +51,16 @@ bin/magento inventory:reservation:list-inconsistencies
 
 Command options:
 
-- `-c`, `--complete-orders` - Returns inconsistencies for completed orders. Incorrect reservations may still be on hold for completed orders.
-- `-i`, `--incomplete-orders` - Returns inconsistencies for incomplete orders (partially shipped, unshipped). Incorrect reservations may hold too much or not enough salable quantity for the orders.
-- `-r`, `--raw` - Raw output.
+-  `-c`, `--complete-orders` - Returns inconsistencies for completed orders. Incorrect reservations may still be on hold for completed orders.
+-  `-i`, `--incomplete-orders` - Returns inconsistencies for incomplete orders (partially shipped, unshipped). Incorrect reservations may hold too much or not enough salable quantity for the orders.
+-  `-r`, `--raw` - Raw output.
 
 Responses using `-r` return in `<ORDER_INCREMENT_ID>:<SKU>:<QUANTITY>:<STOCK-ID>` format:
 
-- Order ID indicates the scope of the inconsistency.
-- SKU indicates the product with the inconsistency.
-- Quantity sets the amount to enter for the reservation compensation.
-- Stock ID defines to scope for stock, which uses the reservations to calculate salable quantity.
+-  Order ID indicates the scope of the inconsistency.
+-  SKU indicates the product with the inconsistency.
+-  Quantity sets the amount to enter for the reservation compensation.
+-  Stock ID defines to scope for stock, which uses the reservations to calculate salable quantity.
 
 Examples:
 
@@ -92,10 +92,10 @@ bin/magento inventory:reservation:create-compensations
 
 Command options:
 
-- `-c`, `--complete-orders` - Creates reservations for completed order inconsistencies.
-- `-i`, `--incomplete-orders` - Creates reservations for incomplete order inconsistencies.
-- `-r`, `--raw` - Returns raw output.
-- `-d`, `--dry-run` - Simulates reservation creation without applying reservations.
+-  `-c`, `--complete-orders` - Creates reservations for completed order inconsistencies.
+-  `-i`, `--incomplete-orders` - Creates reservations for incomplete order inconsistencies.
+-  `-r`, `--raw` - Returns raw output.
+-  `-d`, `--dry-run` - Simulates reservation creation without applying reservations.
 
 If the format of the request is incorrect, the following message displays: A list of compensations needs to be defined as argument or STDIN.
 
@@ -138,8 +138,8 @@ No order inconsistencies were found.
 
 The merchant selects the provider of the GPS or geocode data required to calculate distances:
 
-* **Google MAP** uses [Google Maps Platform](https://cloud.google.com/maps-platform) services to calculate the distance and time between the shipping destination address and source locations. This option requires a Google billing plan and may incur charges through Google.
+-  **Google MAP** uses [Google Maps Platform](https://cloud.google.com/maps-platform) services to calculate the distance and time between the shipping destination address and source locations. This option requires a Google billing plan and may incur charges through Google.
 
-* **Offline calculation** calculates the distance using data downloaded from [geonames.org](https://www.geonames.org/) and imported into Magento with a command. This option is free of charge.
+-  **Offline calculation** calculates the distance using data downloaded from [geonames.org](https://www.geonames.org/) and imported into Magento with a command. This option is free of charge.
 
 {% include config/cli-inventory.md %}

--- a/guides/v2.3/mtf/mtf_installation.md
+++ b/guides/v2.3/mtf/mtf_installation.md
@@ -44,19 +44,24 @@ The Functional Testing Framework requires Composer, which downloads libraries de
 {: .bs-callout-info }
 If you're not sure that Composer is installed, see [Install Composer]({{page.baseurl }}/install-gde/prereq/dev_install.html#instgde-prereq-compose-install).
 
-1.    <a href="{{page.baseurl }}/install-gde/basics/basics_login.html">Open a command prompt</a>.
-1.    Log in to your Magento server as a user with permissions to modify the Magento file system. (This is typically <a href="{{page.baseurl }}/install-gde/prereq/apache-user.html">the Magento file system owner</a>.)
+1. <a href="{{page.baseurl }}/install-gde/basics/basics_login.html">Open a command prompt</a>.
+1. Log in to your Magento server as a user with permissions to modify the Magento file system. (This is typically <a href="{{page.baseurl }}/install-gde/prereq/apache-user.html">the Magento file system owner</a>.)
 
-    cd <magento2_root_dir>/dev/tests/functional/
-    composer install
+   ```bash
+   cd <magento2_root_dir>/dev/tests/functional/
+   ```
+
+   ```bash
+   composer install
+   ```
 
 ### Command fail
 
 If command failed, maybe [Composer](https://getcomposer.org) hasn't been installed globally.
 
-* Copy `composer.phar` to `/usr/local/bin/composer`.
-* To run it locally put `composer.phar` into directory, where `composer.json` file is located (that is, `<magento2>/dev/tests/functional/`).
-* And run from this directory `php composer.phar install`.
+-  Copy `composer.phar` to `/usr/local/bin/composer`.
+-  To run it locally put `composer.phar` into directory, where `composer.json` file is located (that is, `<magento2>/dev/tests/functional/`).
+-  And run from this directory `php composer.phar install`.
 
 ## Check the installation {#mtf_install_check}
 
@@ -64,13 +69,23 @@ If command failed, maybe [Composer](https://getcomposer.org) hasn't been install
 
 Check whether the `vendor` directory exists in `<magento2_root_dir>/dev/tests/functional/`.
 
-    cd <magento2_root_dir>/dev/tests/functional/
-    ls
+```bash
+cd <magento2_root_dir>/dev/tests/functional/
+```
+
+```bash
+ls
+```
 
 Find the `mtf` directory.
 
-    cd vendor/magento
-    ls
+```bash
+cd vendor/magento
+```
+
+```bash
+ls
+```
 
 ### Verify the Functional Testing Framework version {#mtf_install_check_verify}
 

--- a/guides/v2.3/performance-best-practices/advanced-js-bundling.md
+++ b/guides/v2.3/performance-best-practices/advanced-js-bundling.md
@@ -91,17 +91,17 @@ A clean Magento installation allows reaching enough good performance by splittin
 
 The following steps require you to install and have familiarity with the following tools:
 
-- [nodejs](https://nodejs.org/en/download/)
-- [r.js](http://requirejs.org/docs/optimization.html#download)
-- [PhantomJS](http://phantomjs.org/) (optional)
+-  [nodejs](https://nodejs.org/en/download/)
+-  [r.js](http://requirejs.org/docs/optimization.html#download)
+-  [PhantomJS](http://phantomjs.org/) (optional)
 
 ### Sample code
 
 Full versions of the sample code used in this article are available here:
 
-- [build.js](samples/build.js){:target="_blank"}
-- [deps.js](samples/deps.js){:target="_blank"}
-- [deps-map.sh](samples/deps-map.sh.txt){:target="_blank"}
+-  [build.js](samples/build.js){:target="_blank"}
+-  [deps.js](samples/deps.js){:target="_blank"}
+-  [deps-map.sh](samples/deps-map.sh.txt){:target="_blank"}
 
 ### Part 1: Create a bundling configuration
 
@@ -269,9 +269,9 @@ This output shows that `buildTools` is a dependency in only one of the bundle/*.
 
 Our output shows only three page types (homepage, category, and product), which tells us:
 
-* Three dependencies are unique to only one page type (shown by the number 1).
-* Three more dependencies occur on two page types (shown by the number 2).
-* The last three dependencies are common to all three of our page types (shown by the number 3).
+-  Three dependencies are unique to only one page type (shown by the number 1).
+-  Three more dependencies occur on two page types (shown by the number 2).
+-  The last three dependencies are common to all three of our page types (shown by the number 3).
 
 This tells us that we can likely improve our store's page-loading speeds by splitting our dependencies into different bundle, once we know which page types need which dependencies.
 
@@ -327,13 +327,13 @@ This is enough information to build a bundles configuration.
 
 Open the `build.js` configuration file and add your bundles to the `modules` node. Each bundle should define the following properties:
 
-* `name`— the name of the bundle. For example, a name of `bundles/cart` generates a `cart.js` bundle in a `bundles` subdirectory.
+-  `name`— the name of the bundle. For example, a name of `bundles/cart` generates a `cart.js` bundle in a `bundles` subdirectory.
 
-* `create`— a boolean flag to create the bundle (values: `true` or `false`).
+-  `create`— a boolean flag to create the bundle (values: `true` or `false`).
 
-* `include`— an array of assets (strings) included as dependencies for the page. RequireJS traces all dependencies and includes them in the bundle unless excluded.
+-  `include`— an array of assets (strings) included as dependencies for the page. RequireJS traces all dependencies and includes them in the bundle unless excluded.
 
-* `exclude`— an array of bundles or assets to exclude from the bundle.
+-  `exclude`— an array of bundles or assets to exclude from the bundle.
 
 ```javascript
 {
@@ -358,13 +358,13 @@ Open the `build.js` configuration file and add your bundles to the `modules` nod
 
 This example reuses `mage/bootstrap` and `requirejs/require` assets, placing higher priority on their most important components and components that have to be loaded synchronously. The bundles that are present are:
 
-*   `requirejs/require`—the only synchronously loaded bundle
-*   `mage/bootstrap`—the bootstrap bundle with UI components
-*   `bundles/default`—default bundle required for all pages
-*   `bundles/cart`—a bundle required for cart page
-*   `bundles/shipping`—common bundle for shopping cart and checkout page (assuming that checkout is never opened directly the checkout page loads even faster if cart page was opened previously and the shipping bundle was already loaded)
-*   `bundles/checkout`—everything for checkout
-*   `bundles/catalog`—everything for product and category pages
+-  `requirejs/require`—the only synchronously loaded bundle
+-  `mage/bootstrap`—the bootstrap bundle with UI components
+-  `bundles/default`—default bundle required for all pages
+-  `bundles/cart`—a bundle required for cart page
+-  `bundles/shipping`—common bundle for shopping cart and checkout page (assuming that checkout is never opened directly the checkout page loads even faster if cart page was opened previously and the shipping bundle was already loaded)
+-  `bundles/checkout`—everything for checkout
+-  `bundles/catalog`—everything for product and category pages
 
 ### Part 2: Generate bundles
 
@@ -380,10 +380,10 @@ php -f bin/magento setup:static-content:deploy -f -a frontend
 
 This command generates static store deployments for each theme and locale you have set up. For example, if you use the Luma theme and a custom theme with locales in English and French, you would generate four static deployments:
 
-- ...luma/en_US
-- ...luma/fr_FR
-- ...custom/en_US
-- ...custom/fr_FR
+-  ...luma/en_US
+-  ...luma/fr_FR
+-  ...custom/en_US
+-  ...custom/fr_FR
 
 To generate bundles for all store themes and locales, repeat the steps below for each store theme and locale.
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -908,7 +908,8 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 ### Page cache
 
-<!--- MAGETWO-91607-->* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode.
+<!--- MAGETWO-91607-->
+* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode.
 
 ### Payment methods
 

--- a/guides/v2.3/security/two-factor-authentication.md
+++ b/guides/v2.3/security/two-factor-authentication.md
@@ -9,9 +9,9 @@ Magento Two-Factor Authentication (2FA) improves security by requiring two-step 
 
 Two-Factor Authentication gives you the ability to:
 
-- Enable authenticator support for the Admin.
-- Manage and configure authenticator settings globally or per user account.
-- Reset authenticators and manage trusted devices for users.
+-  Enable authenticator support for the Admin.
+-  Manage and configure authenticator settings globally or per user account.
+-  Reset authenticators and manage trusted devices for users.
 
 At this time, Two-Factor Authentication can be installed only from the command line.
 
@@ -28,10 +28,10 @@ See the Magento Admin User Guide to [configure](https://docs.magento.com/m2/ee/u
 
 Administrators have options to:
 
-* Review existing authenticators configured per user account
-* Require specific authenticators
-* Reset or remove authenticators to resolve access issues
-* Revoke access for devices to resolve access issues
+-  Review existing authenticators configured per user account
+-  Require specific authenticators
+-  Reset or remove authenticators to resolve access issues
+-  Revoke access for devices to resolve access issues
 
 ## Install authenticator
 
@@ -75,9 +75,9 @@ In your database, you can modify the following tables and values to affect and o
 
 Table: `core_config_data`
 
-- `msp/twofactorauth/enabled` - Set to zero to disable 2FA globally.
-- `msp/twofactorauth/force_providers` - Delete this entry to remove forced providers option.
+-  `msp/twofactorauth/enabled` - Set to zero to disable 2FA globally.
+-  `msp/twofactorauth/force_providers` - Delete this entry to remove forced providers option.
 
 Table: `msp_tfa_user_config`
 
-- Delete one user row to reset the user's 2FA preference and configuration.
+-  Delete one user row to reset the user's 2FA preference and configuration.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD004 errors in the following guides:

- GraphQL
- Inventory
- MTF
- Performance
- Security

The MD004 rule requires consistent use of unordered list styles. The scope of #5241 also permits—but does not require—resolving errors related to the following rules:

- MD005: List indentation
- MD006: Start bulleted lists at the beginning of a line
- MD007: List indentation
- MD030: Spaces after list markers

This is one of many PRs related to #5241.