### PR TITLE
Fixed final list style (MD004) errors

### DIFF
--- a/_checks/styles/style-rules-prod
+++ b/_checks/styles/style-rules-prod
@@ -1,7 +1,7 @@
 rule 'MD001'
 exclude_rule 'MD002'
 rule 'MD003', :style => :atx
-exclude_rule 'MD004'
+rule 'MD004'
 exclude_rule 'MD005'
 exclude_rule 'MD006'
 exclude_rule 'MD007'

--- a/guides/v2.2/coding-standards/technical-guidelines.md
+++ b/guides/v2.2/coding-standards/technical-guidelines.md
@@ -20,19 +20,19 @@ These guidelines came from many years of hard work, experience, and discussions.
 
 Use [RFC2119] to interpret keywords like:
 
-* MUST and MUST NOT
+*  MUST and MUST NOT
 
-* REQUIRED
+*  REQUIRED
 
-* SHALL and SHALL NOT
+*  SHALL and SHALL NOT
 
-* SHOULD and SHOULD NOT
+*  SHOULD and SHOULD NOT
 
-* RECOMMENDED
+*  RECOMMENDED
 
-* MAY
+*  MAY
 
-* OPTIONAL
+*  OPTIONAL
 
 ## 1. Basic programming principles
 
@@ -439,11 +439,11 @@ You need to read configuration from different sources (like database or filesyst
 
 5.1. All exceptions that are surfaced to the end user MUST produce error messages in the following format:
 
-* Symptom
+*  Symptom
 
-* Details
+*  Details
 
-* Solution or workaround
+*  Solution or workaround
 
 {:start="5.2"}
 5.2. Exceptions MUST NOT be handled in the same function where they are thrown.
@@ -500,9 +500,9 @@ You need to read configuration from different sources (like database or filesyst
 
 6.2.1. According to CQRS, the Presentation layer hosts the Command and the Query Infrastructures:
 
-* **Command** for Actions
+*  **Command** for Actions
 
-* **Query** for [Layout](https://glossary.magento.com/layout) and its elements (Blocks and UI Components)
+*  **Query** for [Layout](https://glossary.magento.com/layout) and its elements (Blocks and UI Components)
 
 6.2.2. Request, Response, Session, Store Manager and Cookie objects MUST be used only in the Presentation layer.
 
@@ -544,15 +544,15 @@ You need to read configuration from different sources (like database or filesyst
 
 6.4.3.1. Strict typing is enforced for Service and Data interfaces located under `MyCompany/MyModuleApi/Api`. Only the following types are allowed:
 
-* Scalar types: `string` (including Date and DateTime); `int`; `float`; `boolean`
+*  Scalar types: `string` (including Date and DateTime); `int`; `float`; `boolean`
 
-* Data interfaces
+*  Data interfaces
 
-* One-dimensional indexed arrays of scalars or data interfaces: for example `string[]`, `\MyCompany\MyModuleApi\Api\Data\SomeInterface[]`. Hash maps (associative arrays) are not supported.
+*  One-dimensional indexed arrays of scalars or data interfaces: for example `string[]`, `\MyCompany\MyModuleApi\Api\Data\SomeInterface[]`. Hash maps (associative arrays) are not supported.
 
-* Nullable scalars or data interfaces: for example `string|null`. Using just `null` is prohibited.
+*  Nullable scalars or data interfaces: for example `string|null`. Using just `null` is prohibited.
 
-* `void`
+*  `void`
 
 6.4.3.2. Service contracts SHOULD support batch data processing. For example, an entity persisting method SHOULD accept an array of entities to persist instead of a single entity. Customizations implemented through plugins SHOULD be adjusted respectively.
 
@@ -560,11 +560,11 @@ You need to read configuration from different sources (like database or filesyst
 
 6.4.3.4. Batch operations that modify state MUST accept an array of entities and return a response object that contains:
 
-* An array of successfully processed items
+*  An array of successfully processed items
 
-* An array of items with retriable errors
+*  An array of items with retriable errors
 
-* An array of items with non-retriable errors
+*  An array of items with non-retriable errors
 
 6.4.3.5. Batch operations that modify state SHOULD be implemented in the most performant manner and SHOULD NOT load modified entities to generate response.
 
@@ -608,27 +608,27 @@ You need to read configuration from different sources (like database or filesyst
 
 7.1. An Application Instance consists of:
 
-* Code
+*  Code
 
-* Environment Configuration
+*  Environment Configuration
 
-* Data
+*  Data
 
 7.2. Code includes:
 
-* application codebase
+*  application codebase
 
-* [XML](https://glossary.magento.com/xml) configuration
+*  [XML](https://glossary.magento.com/xml) configuration
 
-* generated code and [static files](https://glossary.magento.com/static-files)
+*  generated code and [static files](https://glossary.magento.com/static-files)
 
-* database structure
+*  database structure
 
-* system configuration values
+*  system configuration values
 
-* configuration scopes (stores/store groups/websites)
+*  configuration scopes (stores/store groups/websites)
 
-* [CMS](https://glossary.magento.com/cms) entities
+*  [CMS](https://glossary.magento.com/cms) entities
 
 7.3. Environment Configuration includes information about application services connection.
 
@@ -730,16 +730,16 @@ You need to read configuration from different sources (like database or filesyst
 
 11.3.1.1. Page file names MUST follow this pattern:
 
-* `{Admin or Storefront}{Description}Page.xml`, where `{Description}` briefly describes the page under test.
-* Use [PascalCase](http://wiki.c2.com/?PascalCase).
-* Example: `AdminProductAttributeGridPage.xml`
+*  `{Admin or Storefront}{Description}Page.xml`, where `{Description}` briefly describes the page under test.
+*  Use [PascalCase](http://wiki.c2.com/?PascalCase).
+*  Example: `AdminProductAttributeGridPage.xml`
 
 11.3.1.2. Page `name` attribute MUST be the same as the file name.
 
 11.3.1.3. Page `module` attribute MUST follow this pattern:
 
-* `{VendorName}_{ModuleName}`
-* Example: `Magento_Backend`
+*  `{VendorName}_{ModuleName}`
+*  Example: `Magento_Backend`
 
 11.3.1.4. There MUST be only one `<page>` entity per file.
 
@@ -747,9 +747,9 @@ You need to read configuration from different sources (like database or filesyst
 
 11.3.2.1. Section file names MUST follow this pattern:
 
-* `{Admin or Storefront}{Description}Section.xml`, where `{Description}` briefly describes the section under test.
-* Use [PascalCase](http://wiki.c2.com/?PascalCase).
-* Example: `StorefrontCheckoutCartSummarySection.xml`
+*  `{Admin or Storefront}{Description}Section.xml`, where `{Description}` briefly describes the section under test.
+*  Use [PascalCase](http://wiki.c2.com/?PascalCase).
+*  Example: `StorefrontCheckoutCartSummarySection.xml`
 
 11.3.2.2. Section `name` attribute MUST be the same as the file name.
 
@@ -771,9 +771,9 @@ You need to read configuration from different sources (like database or filesyst
 
 11.3.4.1. Data entity file names MUST follow this pattern:
 
-* `{Type}Data.xml`, where `{Type}` describes the type of entities.
-* Use [PascalCase](http://wiki.c2.com/?PascalCase).
-* Examples: `ProductData.xml` or `CustomerData.xml`
+*  `{Type}Data.xml`, where `{Type}` describes the type of entities.
+*  Use [PascalCase](http://wiki.c2.com/?PascalCase).
+*  Examples: `ProductData.xml` or `CustomerData.xml`
 
 11.3.4.2. Data entities SHOULD make use of `unique="suffix"` or `unique="prefix"` to ensure that tests using the entity can be repeatedly ran against the same environment.
 
@@ -783,9 +783,9 @@ You need to read configuration from different sources (like database or filesyst
 
 11.3.5.1. Action group file names MUST follow this pattern:
 
-- If the action group is making an assertion, then use the following format: `Assert{Admin or Storefront}{Functionality}ActionGroup.xml` where `{Functionality}` briefly describes what the action group is doing.
-- Otherwise use this format: `{Admin or Storefront}{Functionality}ActionGroup.xml`
-- Example: `AssertStorefrontMinicartContainsProductActionGroup.xml`
+*  If the action group is making an assertion, then use the following format: `Assert{Admin or Storefront}{Functionality}ActionGroup.xml` where `{Functionality}` briefly describes what the action group is doing.
+*  Otherwise use this format: `{Admin or Storefront}{Functionality}ActionGroup.xml`
+*  Example: `AssertStorefrontMinicartContainsProductActionGroup.xml`
 
 11.3.5.2. Action group arguments MUST specify the `type` attribute.
 

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman-checklist.md
@@ -7,10 +7,10 @@ functional_areas:
 
 Before you continue, to avoid errors during your installation or update, make sure you verify *all* of the following:
 
-* You set up a [Magento file system owner](#magento-owner-group) and shared that owner's group with the web server user group
-* Your [cron jobs](#magento-cron) are set up and running
-* [Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
-* [File system permissions](#perms) are set properly
+*  You set up a [Magento file system owner](#magento-owner-group) and shared that owner's group with the web server user group
+*  Your [cron jobs](#magento-cron) are set up and running
+*  [Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
+*  [File system permissions](#perms) are set properly
 
 {: .bs-callout .bs-callout-warning  }
 Do not continue without performing these checks. Failure to do so could result in errors.
@@ -22,30 +22,33 @@ This conversion occurs during the upgrade and it can take a long time, depending
 
 The following tables are affected the most:
 
-* `catalogrule`
-* `core_config_data`
-* `magento_reward_history`
-* `quote_payment`
-* `quote`
-* `sales_order_payment`
-* `sales_order`
-* `salesrule`
-* `url_rewrite`
+*  `catalogrule`
+*  `core_config_data`
+*  `magento_reward_history`
+*  `quote_payment`
+*  `quote`
+*  `sales_order_payment`
+*  `sales_order`
+*  `salesrule`
+*  `url_rewrite`
 
 If you have a large amount of data, you can improve performance by setting the value of an environment variable, `DATA_CONVERTER_BATCH_SIZE`.
 By default, it's set to a value of 50,000.
 
 To set the variable, enter the following command as the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner) in a bash shell prompt:
+
 ```bash
 export DATA_CONVERTER_BATCH_SIZE <value>
 ```
 
 For example,
+
 ```bash
 export DATA_CONVERTER_BATCH_SIZE 100000
 ```
 
 After your upgrade completes, you can unset the variable as follows:
+
 ```bash
 unset DATA_CONVERTER_BATCH_SIZE
 ```
@@ -62,6 +65,7 @@ The [Magento file system owner](https://glossary.magento.com/magento-file-system
 Magento requires three cron jobs, all running as the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
 
 To verify your cron jobs are set up properly, enter the following command as the Magento file system owner:
+
 ```bash
 crontab -l
 ```
@@ -94,6 +98,7 @@ Directories in the Magento file system must be writable by the [Magento file sys
 To verify your file system permissions are set properly, either log in to the Magento server or use your hosting provider's file manager application.
 
 For example, enter the following command if the Magento application is installed in `/var/www/html/magento2`:
+
 ```bash
 ls -al /var/www/html/magento2
 ```
@@ -137,10 +142,10 @@ drwxrws---. 29 magento_user apache   4096 Jun  7 07:53 vendor
 
 Here,
 
-- most of the files are `-rw-rw----`, which is 660
-- `drwxrwx---` = 770
-- `-rw-rw-rw-` = 666
-- the Magento file system owner is `magento_user`.
+*  most of the files are `-rw-rw----`, which is 660
+*  `drwxrwx---` = 770
+*  `-rw-rw-rw-` = 666
+*  the Magento file system owner is `magento_user`.
 
 To get more detailed information, you can optionally enter the following command:
 

--- a/guides/v2.2/mrg/intro.md
+++ b/guides/v2.2/mrg/intro.md
@@ -9,15 +9,15 @@ The [Module](https://glossary.magento.com/module) Reference Guide contains infor
 
 The information includes:
 
-- module description
-- API description
+-  module description
+-  API description
 
 Information is being published gradually, until we complete work on automation of the process.
 
 {:.ref-header}
 Related topics
 
-* [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
-* [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)
-* [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)
-* [REST Reference]({{ page.baseurl }}/rest/bk-rest.html)
+-  [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
+-  [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)
+-  [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)
+-  [REST Reference]({{ page.baseurl }}/rest/bk-rest.html)

--- a/guides/v2.3/graphql/functional-testing.md
+++ b/guides/v2.3/graphql/functional-testing.md
@@ -200,8 +200,8 @@ $registry->register('isSecureArea', false);
 
 Your functional tests should include events that cause exceptions. Since your tests expect an exception to occur, set up your tests so that they elicit the proper responses. You can define expected exception messages either in:
 
--  The body of the test
--  The test function annotation
+*  The body of the test
+*  The test function annotation
 
 {: .bs-callout .bs-callout-tip }
 We recommend that you declare expected exceptions in the test method body, as declaring expected exceptions with annotations has been deprecated in PHPUnit 8. Existing tests that use annotations will have to be updated when Magento requires that version of PHPUnit or higher.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) resolves the final MD004 errors in the MD004-integration branch and enables the rule.

Related to #5241 

There are two errors in the MRG (B2B) that are blocking this. Since we're supposed to be generating MRG topics from `_data/` files, I'm not sure why this error is popping up. There must be an issue with the new method of generation.

```
guides/v2.2/mrg/b2b/CompanyCredit.md:49: MD004 Unordered list style
guides/v2.2/mrg/b2b/CompanyCredit.md:51: MD004 Unordered list style
```