### PR TITLE
Fix link for U2F Keys

### DIFF
--- a/guides/v2.3/security/two-factor-authentication.md
+++ b/guides/v2.3/security/two-factor-authentication.md
@@ -43,7 +43,7 @@ After enabling and configuring 2FA for your Magento instance, Magento Admin user
 | : --------- | : --------- | : ------- |
 | [Google Authenticator](https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DAndroid&hl=en)  | Generate and enter code from mobile app Requirements: Enable in Admin  | `google`|
 | [Authy](https://authy.com/)  | SMS, call, token, and one touch <br/>Requirements: Enable in Admin and API keys  | `authy` |
-| [U2F Keys](https://docs.magento.com/m2/2.1/ee/user_guide/stores/security-two-factor-authentication-use.html)   | Physical device to authenticate, like [YubiKey](https://www.yubico.com/). <br/>Requirements: Enable in Admin  | `u2fkey` |
+| [U2F Keys](https://docs.magento.com/m2/ee/user_guide/stores/security-two-factor-authentication-use.html?#u2f-key)   | Physical device to authenticate, like [YubiKey](https://www.yubico.com/). <br/>Requirements: Enable in Admin  | `u2fkey` |
 | [Duo Security](https://duo.com/)  | SMS and push notification. <br/>Requirements: Enable in Admin, Integration and Secret keys, API hostname  | `duo` |
 
 ## Troubleshooting


### PR DESCRIPTION
## Purpose of this pull request

This PR fixes the link for "U2F Keys"

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html