### PR TITLE
Removing external links from Community Resources

### DIFF
--- a/community/resources/resources.md
+++ b/community/resources/resources.md
@@ -5,21 +5,11 @@ redirect_from:
   - /community/resources/index.html
 ---
 
-This Community collection of resources links to blog posts, podcasts, presentations, and books created by members of the [Magento](https://glossary.magento.com/magento) community and core developers separated into popular topics.
+## Magento DevBlog
 
-New items will be added incrementally, and older links rotated out. Keep an eye on this space for the latest community resources!
+The [Magento DevBlog][0] is a great resource for news about Magento, new community resources (articles, tutorials, etc.), events and other Magento-related items.
 
-Another community-based resource, focused on describing the Magento 2 environment, is the [Magento 2 Awesome List][0].
-
-Do you know of a popular resource about Magento 2 that has been released/published within the past year?
-Does it fill gaps in our current docs and provide important information?
-[Let us know][1]!
-
-{:.bs-callout .bs-callout-info}
-Magento does not officially endorse any of the linked blogs, books, presentation, or podcasts linked below.
-They are listed here because the content has been well received within the Magento community.
-
-## Best Practices
+## Best practices
 
 See our collection of best and leading practices, common solutions, and more in the [Community contributed best practices]({{ site.baseurl }}/community/resources/best-practices.html) guide. If you have excellent best practices, tips and tricks, and work-arounds, feel free to [contribute][]!
 
@@ -37,62 +27,6 @@ We have [channels][] for each project, but the following channels are recommende
 - [public-backlog][]: Discussions of the Magento 2 backlog
 - [devdocs][]: Documentation contribution support
 
-## Resources and guides
-
-- *Video* [How to contribute during Magento Contribution Days][57] by [Max Pronko][35]
-- *GitHub* [Magento Resources][23] curated list by [Alessandro Ronchi][30]
-- *Blog posts* [Thoughts on Magento, PHP, JavaScript, Laravel, React, Docker, and user interface design][56] by [Mark Shust][38]
-- *Videos* [Mage2.tv][24] by [Vinai Kopp][48]
-- *Podcast* [MageTalk][25] by [Phillip Jackson and Kalen][27]
-- *Vlog* [eCommerceAholic][26] by [TJ Gamble][28]
-- *Statistics* [Magestats][32] by [Marcel Hauri][33]
-- *Videos* [Magento Dev Channel with Max Pronko][34] by [Max Pronko][35]
-- *Courses* [Magento Courses][36] by [Max Pronko][35]
-- *Videos* [Mage2Katas][47] by [Vinai Kopp][48]
-- *Blog posts* [The Magento Blog][54]  by Fooman
-
-## Magento APIs
-
-- *Presentation* [Magento 2 Integrations][2] by [Joshua Warren][31]
-- *Presentation* [Integrations with Magento, end to end story: RabbitMQ, APIs][3] by Eugene Tulika
-
-## Install/deploy
-
-- *GitHub* [Magento 2 Docker][37] by [Mark Shust][38] (supports Magento 2.3.0, PHP 7.2, Elasticsearch)
-- *Presentation* [48 Hour Launches and Other Lessons Learned With Large-Scale Digital Transformations][29] by Joshua Warren of Creatuity
-- *Blog post* [Magento 2 - Launch Checklist][21] by [Syed Muneeb Ul Hasan][42]
-- *Presentation* [Magento 2 Deployment: What you should know][4] by [Olga KopyLova][43]
-- *Blog post* [Magento 2 deployment without the downtime][5] by Robert Egginton
-- *Blog post* [Deploying Magento 2 - History & Overview][6] by [Matthias Walter][44]
-- *Blog post* [Deploying Magento 2 using Capistrano][17] by [David Alger][45]
-- *Blog post* [Deploying Magento 2 with Composer and Envoyer][16] by [Nick Rigby][46]
-- *GitHub* [Magento 2 Docker][18] by meanbee
-- *GitHub* [Magento 2 Dockergento][39] by ModestCoders
-- *Presentation* [Zero Downtime in Magento 2, Is it Possible?][40] by [Óscar Recio][41]
-
-## Testing
-
-- *Blog post* [Unit testing in Magento 2][49] by [Inchoo]
-- *Blog post* [Magento2 Functional Testing Framework(MFTF)][51] by [WelKul][52]
-- *Blog post* [A Quick Guide to Automation Test in Magento 2][53] by Luong Ngoc Son
-- *Presentation* [Writing testable code][10] by [Vinai Kopp][48] (**Bonus:** [Video Presentation][11])
-- *Blog post* [Integration Tests with Magento 2][19] by Andreas von Studnitz
-
-## Mastering Magento 2
-
-- *Blog post* [10 Practical Rules to Build High Quality Magento 2 Module][20] by Max Pronko
-- *Presentation* [Stop Flushing the F#@king Cache, Indexing and Caching in Magento 2][22] by John Hughes]
-- *Blog* [Alan Storm blog][55]
-- *Book* [Magento 2 DIY][7] by Viktor Khliupko
-- *Book* [Magento 2 Cookbook][8] by Ray Bogman and Vladimir Kerkhoff
-- *Presentation* [Staging and Preview][9] by Igor Melnykov
-- *Blog post* [Introducing UI Components][13] by Alan Storm
-- *Presentation* [Micro Services][14] by Ivan Chepurnyi
-
-## Performance
-
--  *Presentation* [Premium performance with PHP 7 and Varnish][15] by Miguel Balparda
-
 [contribute]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [technical guidelines]: {{ site.baseurl }}/guides/v2.3/coding-standards/technical-guidelines.html
 [coding standards]: {{ site.baseurl }}/guides/v2.3/coding-standards/bk-coding-standards.html
@@ -105,62 +39,6 @@ We have [channels][] for each project, but the following channels are recommende
 [appdesign]: https://magentocommeng.slack.com/messages/CBSL1DF8B
 [coding-standards]: https://magentocommeng.slack.com/messages/CFC88F1C6
 [announcements]: https://magentocommeng.slack.com/messages/C7FA71S3V
-[0]: https://github.com/DavidLambauer/awesome-magento2
+[0]: https://community.magento.com/t5/Magento-DevBlog/bg-p/devblog
 [1]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
-[2]: http://www.slideshare.net/StaceyWhitney1/mage-titans-usa-2016-joshua-warren-magento-2-integrations
-[3]: http://www.slideshare.net/vrann/mage-titans-usa-2016-magentofacebookrabbitmq
-[4]: http://www.slideshare.net/OlgaKopylova2/m2-deployment
-[5]: https://www.c3media.co.uk/blog/c3-news/magento-2-deployment-without-downtime/
-[6]: https://dev98.de/2017/01/06/deploying-magento2-history-overview-14/
-[7]: https://leanpub.com/magento2diy
-[8]: https://www.packtpub.com/web-development/magento-2-cookbook
-[9]: http://www.slideshare.net/StaceyWhitney1/mage-titans-usa-2016-igor-melnykov-staging-and-preview
-[10]: http://www.slideshare.net/vinaikopp/writing-testable-code-for-magento-1-and-2-2016-romaina
-[11]: https://www.youtube.com/watch?v=eF2EoF0WKoo
-[12]: https://leanpub.com/tdd-magento-extension
-[13]: http://alanstorm.com/magento_2_introducing_ui_components/
-[14]: https://www.dropbox.com/s/j9a65kmqo5s4zys/MageTitansUSA%202016%20-%20Creating%20Micro-Services%20for%20Magento%202.pdf?dl=0
-[15]: http://www.slideshare.net/StaceyWhitney1/mage-titans-usa-2016-miguel-balparda-magento-2-premium-performance-with-php-7-and-varnish
-[16]: https://nickrigby.uk/magento/deploying-magento-2-with-composer-and-envoyer.html
-[17]: http://davidalger.com/development/magento/deploying-magento-2-using-capistrano/
-[18]: https://github.com/meanbee/docker-magento2
-[19]: https://www.integer-net.com/integration-tests-with-magento-2/
-[20]: https://medium.com/@maxpronko/10-practical-rules-to-build-high-quality-magento-2-module-e6fe2c9461ac
-[21]: https://magenticians.com/magento-2-launch-checklist/
-[22]: https://docs.google.com/presentation/d/1NdtNz_LBxk-JsCBy8AvekZAkSPWOE0WCzE14Y9ki-5Q/mobilepresent?slide=id.g3444c1e91c_0_10
-[23]: https://github.com/aleron75/mageres
-[24]: https://www.mage2.tv
-[25]: https://magetalk.com/
-[26]: https://www.youtube.com/channel/UCSH4_56yf5khLwTK9q71IGw
-[27]: https://magetalk.com/about/
-[28]: https://twitter.com/ecommerceaholic
-[29]: https://creatuity.com/m/download-joshua-warrens-magetitans-2018-presentation
-[30]: https://twitter.com/aleron75
-[31]: https://twitter.com/JoshuaSWarren
-[32]: https://magestats.net/
-[33]: https://twitter.com/mhauri
-[34]: https://www.youtube.com/maxpronko
-[35]: https://twitter.com/max_pronko
-[36]: https://www.maxpronko.com/all-courses/
-[37]: https://github.com/markshust/docker-magento
-[38]: https://twitter.com/markshust
-[39]: https://github.com/ModestCoders/magento2-dockergento
-[40]: https://www.slideshare.net/OscarRecioSoria/zero-downtime-in-magento-2-is-it-possible
-[41]: https://twitter.com/osrecio
-[42]: https://twitter.com/syed_muneebb
-[43]: https://twitter.com/buskamuza
-[44]: https://twitter.com/mat_walter
-[45]: https://twitter.com/blackbooker
-[46]: https://twitter.com/nick_rigby
-[47]: http://mage2katas.com/
-[48]: https://twitter.com/VinaiKopp
-[49]: https://inchoo.net/magento-2/unit-testing-magento-2/
-[50]: https://inchoo.net/blog/
-[51]: https://webkul.com/blog/magento2-functional-testing-mftf/
-[52]: https://webkul.com/blog/
-[53]: https://bsscommerce.com/confluence/a-quick-guide-to-automation-test-in-magento-2/
-[54]: https://store.fooman.co.nz/blog
-[55]: https://alanstorm.com/
-[56]: https://markshust.com/
-[57]: https://www.youtube.com/watch?v=ceNeYpCEmys
 [channels]: https://github.com/magento/magento2/wiki/Slack-Channels

--- a/guides/v2.2/config-guide/deployment/pipeline/index.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/index.md
@@ -14,10 +14,9 @@ functional_areas:
 
 You can optionally use other deployment methods, including:
 
-* Secure copying with SCP or rsync
-* [Capistrano](http://capistranorb.com/documentation/overview/what-is-capistrano)
-* The [Deployer tool](https://deployer.org/)
-* Other methods discussed on the [Community resources page]({{ site.baseurl }}/community/resources/resources.html#installdeploy)
+*  Secure copying with SCP or rsync
+*  [Capistrano](http://capistranorb.com/documentation/overview/what-is-capistrano)
+*  The [Deployer tool](https://deployer.org/)
 
 ## Manage the configuration
 
@@ -29,10 +28,10 @@ We also provide a way to synchronize the configuration of your systems:
 
 For a complete list of configuration paths, see the following references:
 
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-* [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ## Assumptions
 

--- a/guides/v2.2/config-guide/deployment/single-machine.md
+++ b/guides/v2.2/config-guide/deployment/single-machine.md
@@ -18,8 +18,8 @@ For less technical users, i.e. business users, we recommend using the [System Up
 
 ## Assumptions
 
-* You installed Magento using [Composer][8] or a [compressed archive][7].
-* You are directly applying updates to the server.
+*  You installed Magento using [Composer][8] or a [compressed archive][7].
+*  You are directly applying updates to the server.
 
 {:.bs-callout .bs-callout-warning}
 This guide does not apply if you used `git clone` to install Magento.
@@ -31,63 +31,79 @@ Contributing developers should use [this guide][6] to update their Magento insta
 
 2. Change directory to the Magento base directory:
 
-        cd <Magento base directory>
+    ```bash
+    cd <Magento base directory>
+    ```
 
 3. Enable maintenance mode using the command:
 
-        bin/magento maintenance:enable
+    ```bash
+    bin/magento maintenance:enable
+    ```
 
 4. Apply updates to Magento or its components using the following command pattern:
 
-        composer require <package> <version> --no-update
+    ```bash
+    composer require <package> <version> --no-update
+    ```
 
    **package**: The name of the package you want to update.
 
    For example:
 
-   * `magento/product-community-edition`
-   * `magento/product-enterprise-edition`
+   *  `magento/product-community-edition`
+   *  `magento/product-enterprise-edition`
 
    **version**: The target version of the package you want to update.
 
 5. Update Magento's components with Composer:
 
-        composer update
+    ```bash
+    composer update
+    ```
 
 6. Update the database schema and data:
 
-        bin/magento setup:upgrade
+    ```bash
+    bin/magento setup:upgrade
+    ```
 
 7. Compile the code:
 
-        bin/magento setup:di:compile
+    ```bash
+    bin/magento setup:di:compile
+    ```
 
 8. Deploy static content:
 
-        bin/magento setup:static-content:deploy
+    ```bash
+    bin/magento setup:static-content:deploy
+    ```
 
 9. Clean the cache:
 
-        bin/magento cache:clean
+    ```bash
+    bin/magento cache:clean
+    ```
 
 9. Exit maintenance mode:
 
-        bin/magento maintenance:disable
+    ```bash
+    bin/magento maintenance:disable
+    ```
 
 ## Alternative deployment strategies
-
-For deployment strategies developed by the Magento community, see the blog posts listed under the [Install/deploy][11] section in our Community Resources page.
 
 In Magento 2.2, a near-zero downtime deployment model will be available for a variety of complex environments, including {{site.data.var.ece}}.
 
 {:.ref-header}
 Related topics
 
-* [Enable or disable maintenance mode][4]
-* [Command line upgrade][1]
-* [Update the Magento application][2]
-* [User Guide: Web Setup Wizard][3]
-* [Running the System Upgrade][9]
+*  [Enable or disable maintenance mode][4]
+*  [Command line upgrade][1]
+*  [Update the Magento application][2]
+*  [User Guide: Web Setup Wizard][3]
+*  [Running the System Upgrade][9]
 
 [0]: {{ page.baseurl }}/
 [1]: {{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html
@@ -100,4 +116,3 @@ Related topics
 [8]: {{ page.baseurl }}/install-gde/composer.html
 [9]: {{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html
 [10]: {{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html#magento-file-system-owner
-[11]: {{ site.baseurl }}/community/resources/resources.html#installdeploy


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is an end run around https://github.com/magento/devdocs/pull/4944 because I don't think the author is coming back to sign the CLA.

## Affected DevDocs pages

- https://devdocs.magento.com/community/resources/resources.html