### PR TITLE
Updated information related to reward points for Issue Triage activities

### DIFF
--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -45,7 +45,7 @@ Test coverage | 10 | Contribution contains fix or improvement and new tests or t
 MFTF test coverage| 10 | Contribution contains MFTF tests
 Bug fix | 10 | Contribution fixes one or more known issues from GitHub
 Author of Ported Issue | 5 | Additional points for a contribution that ports (up or back port) a previous PR across release lines by another contributor
-Issue Triage: Confirmed | 5 | Public issue report is verified and confirmed. Description contains all required information to be easily reproduced by provided steps
+Issue Triage: Confirmed | 5 | A public issue report is verified and confirmed. The description contains all the required information needed to easily reproduce the issue with the provided steps
 Issue Triage: Rejected/Closed | 4 | Public issue report is verified and closed/rejected because it is "not a bug" or "cannot be reproduced" by provided steps in the description on the supported Magento versions
 
 ## DevDocs awards and points

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -45,7 +45,8 @@ Test coverage | 10 | Contribution contains fix or improvement and new tests or t
 MFTF test coverage| 10 | Contribution contains MFTF tests
 Bug fix | 10 | Contribution fixes one or more known issues from GitHub
 Author of Ported Issue | 5 | Additional points for a contribution that ports (up or back port) a previous PR across release lines by another contributor
-Issue Triage | 3 | Public issue report is verified and confirmed
+Issue Triage: Confirmed | 5 | Public issue report is verified and confirmed. Description contains all required information to be easily reproduced by provided steps
+Issue Triage: Rejected/Closed | 4 | Public issue report is verified and closed/rejected because it is "not a bug" or "cannot be reproduced" by provided steps in the description on the supported Magento versions
 
 ## DevDocs awards and points
 

--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -46,7 +46,7 @@ MFTF test coverage| 10 | Contribution contains MFTF tests
 Bug fix | 10 | Contribution fixes one or more known issues from GitHub
 Author of Ported Issue | 5 | Additional points for a contribution that ports (up or back port) a previous PR across release lines by another contributor
 Issue Triage: Confirmed | 5 | A public issue report is verified and confirmed. The description contains all the required information needed to easily reproduce the issue with the provided steps
-Issue Triage: Rejected/Closed | 4 | Public issue report is verified and closed/rejected because it is "not a bug" or "cannot be reproduced" by provided steps in the description on the supported Magento versions
+Issue Triage: Rejected/Closed | 4 | A public issue report is verified and closed/rejected because it is "not a bug" or "cannot be reproduced" using the provided steps in the description on the supported Magento versions
 
 ## DevDocs awards and points
 


### PR DESCRIPTION
## Purpose of this pull request

Starting from 1st of October EngCom increased reward points for Issue Triage activities.
- For each Confirmed Issue = 5 points (previously was 3)
- For each Rejected/Closed Issue = 4 points (previously was 3)

All implementation activities are done now.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- **Additional achievements** section of https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html




