### PR TITLE
fixed MFTF version number

### DIFF
--- a/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -89,7 +89,7 @@ See the examples at the end of this section for help specifying different releas
 1. Specify additional packages.
 
    ```bash
-   composer require --dev allure-framework/allure-phpunit:~1.2.0 friendsofphp/php-cs-fixer:~2.14.0 lusitanian/oauth:~0.8.10 magento/magento-coding-standard:~3.0.0 magento/magento2-functional-testing-framework:2.4.3 pdepend/pdepend:2.5.2 phpmd/phpmd:@stable phpunit/phpunit:~6.5.0 sebastian/phpcpd:~3.0.0 squizlabs/php_codesniffer:~3.4.0 --sort-packages --no-update
+   composer require --dev allure-framework/allure-phpunit:~1.2.0 friendsofphp/php-cs-fixer:~2.14.0 lusitanian/oauth:~0.8.10 magento/magento-coding-standard:~3.0.0 magento/magento2-functional-testing-framework:2.4.5 pdepend/pdepend:2.5.2 phpmd/phpmd:@stable phpunit/phpunit:~6.5.0 sebastian/phpcpd:~3.0.0 squizlabs/php_codesniffer:~3.4.0 --sort-packages --no-update
    ```
 
 1. Remove unused packages.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the issue that the MFTF version number is wrong after updating from 2.3.2 to 2.3.3 via the CLI guide.
MFTF 2.4.5 is the right version since it is mentioned on [packagist](https://packagist.org/packages/magento/community-edition) and it is also the one taken if a new project is created via `composer create-project`.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html