### PR TITLE
Small corrections to Magento 2.3.3 release notes

### DIFF
--- a/_includes/release-notes/engcomm-2-3-3-issues.md
+++ b/_includes/release-notes/engcomm-2-3-3-issues.md
@@ -2,7 +2,7 @@
 | ------- | ------- | ------- |
 | [airbone42](https://github.com/airbone42) | [#533](https://github.com/magento/magento2/issues/533) | [magento/graphql-ce#578](https://github.com/magento/graphql-ce/pull/578) |
 | [tzyganu](https://github.com/tzyganu) | [#601](https://github.com/magento/magento2/issues/601) | [magento/graphql-ce#632](https://github.com/magento/graphql-ce/pull/632) |
-| [bsstaveley](https://github.com/bsstaveley) | [#631](https://github.com/magento/magento2/issues/631) | [magento/graphql-ce#634](https://github.com/magento/graphql-ce/pull/634) |
+| [pmclain](https://github.com/pmclain) | [#631](https://github.com/magento/magento2/issues/631) | [magento/graphql-ce#634](https://github.com/magento/graphql-ce/pull/634) |
 | [dipti2jcommerce](https://github.com/dipti2jcommerce) | [#20124](https://github.com/magento/magento2/issues/20124) | [magento/magento2#20135](https://github.com/magento/magento2/pull/20135) |
 | [WalterSmulders](https://github.com/WalterSmulders) | [#21978](https://github.com/magento/magento2/issues/21978) | [magento/magento2#22020](https://github.com/magento/magento2/pull/22020) |
 | [afavata](https://github.com/afavata) | [#22045](https://github.com/magento/magento2/issues/22045) | [magento/magento2#22260](https://github.com/magento/magento2/pull/22260) |

--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -74,7 +74,7 @@ The following upgrades to core platform components boost platform security and s
 *  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**.
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
 *  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
@@ -1021,7 +1021,7 @@ This release includes the following changes to integrations for core payment met
 *  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**.
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
 *  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -72,7 +72,7 @@ The following upgrades to core platform components boost platform security and s
 *  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**.
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
 *  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
@@ -866,7 +866,7 @@ This release includes the following changes to integrations for core payment met
 *  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**.
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
 *  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.


### PR DESCRIPTION

This pull request (PR) adds a link to the CSS Critical Path documentation for the Performance boosts section of both the Commerce and Open Source notes. It also corrects an incorrect community contributor attribution in the Community contributors issues table.  

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html

