### PR TITLE
Fixed ordered list prefix (MD029) - Group 1

### DIFF
--- a/guides/v2.2/rest/tutorials/orders/order-create-customer.md
+++ b/guides/v2.2/rest/tutorials/orders/order-create-customer.md
@@ -19,9 +19,9 @@ functional_areas:
 
 Customers can make purchases in three ways:
 
-* As a logged-in user
-* As a guest user who logs in or creates an account when the order is placed
-* As a guest user who does not create an account
+*  As a logged-in user
+*  As a guest user who logs in or creates an account when the order is placed
+*  As a guest user who does not create an account
 
 This tutorial creates an order by a logged-in user. Magento provides additional REST endpoints for handling guest users.
 
@@ -160,5 +160,5 @@ Magento returns the customer's access token. This token must be specified in the
 ### Verify this step {#verify-step}
 
 1. Log in to the Luma [website](https://glossary.magento.com/website) using the email `jdoe@example.com` and password `Password1`.
-2. Click the account name (Jane) in the upper right corner and select **My Account**.
-3. Click **Address Book** to view the default billing and shipping addresses.
+1. Click the account name (Jane) in the upper right corner and select **My Account**.
+1. Click **Address Book** to view the default billing and shipping addresses.

--- a/guides/v2.2/rest/tutorials/orders/order-create-order.md
+++ b/guides/v2.2/rest/tutorials/orders/order-create-order.md
@@ -1576,4 +1576,4 @@ Not applicable
 ### Verify this step {#verify-step}
 
 1. Log in to the Luma store as the customer. The dashboard shows the order.
-2. Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Orders**. The order is displayed in the grid. Its status is Pending.
+1. Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Orders**. The order is displayed in the grid. Its status is Pending.

--- a/guides/v2.2/test/integration/annotations/magento-app-area.md
+++ b/guides/v2.2/test/integration/annotations/magento-app-area.md
@@ -16,8 +16,8 @@ Configure a test environment in scope of the particular [application area][] wit
 ## Fallback sequence
 
 1. Test annotation
-2. Test case annotation
-3. Default application area, which is `global`
+1. Test case annotation
+1. Default application area, which is `global`
 
 ## Test case annotation
 

--- a/guides/v2.2/test/integration/annotations/magento-cache.md
+++ b/guides/v2.2/test/integration/annotations/magento-cache.md
@@ -16,17 +16,17 @@ Enable or disable a [cache type][] using the `@magentoCache` annotation.
 
 Here,
 
-- `<type>` is a placeholder for a cache type
-- `all` is a value for any cache type
-- `enabled` or `disabled` to enable or disable the cache respectively
+-  `<type>` is a placeholder for a cache type
+-  `all` is a value for any cache type
+-  `enabled` or `disabled` to enable or disable the cache respectively
 
 ## Principles
 
 1. You can use more than one annotation for a test case or a test method.
-2. Multiple annotations are applied in the given order.
-3. Annotations from different scopes are not merged.
-4. A test method annotation completely overrides a test case annotation.
-5. All cache types are disabled by default.
+1. Multiple annotations are applied in the given order.
+1. Annotations from different scopes are not merged.
+1. A test method annotation completely overrides a test case annotation.
+1. All cache types are disabled by default.
 
 ## Test case
 
@@ -84,16 +84,15 @@ class BarTest extends \PHPUnit\Framework\TestCase
 }
 ```
 
-- Each test method without the `@magentoCache` annotation is run with all cache types enabled.
-- `testOne()` is run with all cache types enabled.
-- `testTwo()` is run with all cache types disabled.
-  The `@magentoCache config disabled` completely overrides the test case annotation.
-  The test case annotation wasn't applied in this case.
-  By default, all cache types are disabled.
-  Thus any disabling annotations does not make much sense here.
-- `testThree()` is run with all but `config` cache type enabled.
-- `testFour()` is run with all the cache types enabled.
-  All cache types are disabled initially, so `@magentoCache config disabled` doesn't make sense here.
+-  Each test method without the `@magentoCache` annotation is run with all cache types enabled.
+-  `testOne()` is run with all cache types enabled.
+-  `testTwo()` is run with all cache types disabled.
+
+   The `@magentoCache config disabled` completely overrides the test case annotation. The test case annotation wasn't applied in this case. By default, all cache types are disabled. Thus any disabling annotations does not make much sense here.
+-  `testThree()` is run with all but `config` cache type enabled.
+-  `testFour()` is run with all the cache types enabled.
+
+   All cache types are disabled initially, so `@magentoCache config disabled` doesn't make sense here.
 
 <!-- Link definitions -->
 

--- a/guides/v2.2/test/integration/annotations/magento-config-fixture.md
+++ b/guides/v2.2/test/integration/annotations/magento-config-fixture.md
@@ -13,18 +13,17 @@ To set the Magento configuration values for individual tests and revert them aft
  */
 ```
 
-- `<store_code>` is a code of the store to be configured.
-  By default, the configuration option is applied globally.
-  To specify the current store, use `current`.
-- `<config_path>` is an XPath to the configuration option.
-  See [configuration reference][] for available options.
-- `<config_value>` is a fixture value for the configuration option.
+-  `<store_code>` is a code of the store to be configured.
+
+   By default, the configuration option is applied globally. To specify the current store, use `current`.
+-  `<config_path>` is an XPath to the configuration option. See [configuration reference][] for available options.
+-  `<config_value>` is a fixture value for the configuration option.
 
 ## Principles
 
 1. The `@magentoConfigFixture` is available at the test method level only.
    It is not available on the test case level.
-2. A test can contain several configuration options.
+1. A test can contain several configuration options.
 
 ## Example
 
@@ -195,7 +194,6 @@ class ConfigFixtureTest extends \PHPUnit\Framework\TestCase
         $this->_object->initStoreAfter();
     }
 }
-
 ```
 
 <!-- Link definitions -->

--- a/guides/v2.2/test/integration/annotations/magento-data-fixture.md
+++ b/guides/v2.2/test/integration/annotations/magento-data-fixture.md
@@ -20,34 +20,35 @@ To set up a date fixture, use the `@magentoDataFixture` annotation.
  */
 ```
 
-- `<script_filename>` is a filename of the PHP script
-- `<method_name>` is a name of the method declared in the current class
+-  `<script_filename>` is a filename of the PHP script
+-  `<method_name>` is a name of the method declared in the current class
 
 ## Principles
 
 1. Do not use a direct database connection in fixtures to avoid dependencies on the database structure and vendor.
-2. Use an application API to implement your data fixtures.
-3. A method that implements a data fixture must be declared as `public` and `static`.
-4. Fixtures declared at a test level have a higher priority then fixtures declared at a test case level.
-5. Test case fixtures are applied to each test in the test case, unless a test has its own fixtures declared.
-6. Annotation declaration at a test case level doesn't affect tests that have their own annotation declarations.
+1. Use an application API to implement your data fixtures.
+1. A method that implements a data fixture must be declared as `public` and `static`.
+1. Fixtures declared at a test level have a higher priority then fixtures declared at a test case level.
+1. Test case fixtures are applied to each test in the test case, unless a test has its own fixtures declared.
+1. Annotation declaration at a test case level doesn't affect tests that have their own annotation declarations.
 
 ## Usage
 
 As mentioned above, there are two ways to declare fixtures:
 
-- as a PHP script file that is used by other tests and test cases.
-- as a local method that is used by other tests in the test cases.
+-  as a PHP script file that is used by other tests and test cases.
+-  as a local method that is used by other tests in the test cases.
 
 ### Fixture as a separate file
 
 Define the fixture in a separate file when you want to reuse it in different test cases.
 To declare the fixture, use the following conventions for a path
 
-- Relative to `dev/tests/integration/<test suite directory>`
-- With forward slashes `/`
-- No leading slash
-  Example: `Magento/Cms/_files/pages.php`
+-  Relative to `dev/tests/integration/<test suite directory>`
+-  With forward slashes `/`
+-  No leading slash
+
+   Example: `Magento/Cms/_files/pages.php`
 
 The ITF includes the declared PHP script to your test and executes it during test run.
 
@@ -78,9 +79,9 @@ The following is an example of the `testCreatePageWithSameModuleName()` test met
 The `@magentoDataFixture` can be specified for a particular test or for an entire test case.
 The basic rules for fixture annotation at different levels are:
 
-- `@magentoDataFixture` at a test case level makes the framework to apply the declared fixtures to each test in the test case.
+-  `@magentoDataFixture` at a test case level makes the framework to apply the declared fixtures to each test in the test case.
   When the final test is complete, all class-level fixtures are reverted.
-- `@magentoDataFixture` for a particular test signals the framework to revert the fixtures declared on a test case level and applies the fixtures declared at a test method level instead.
+-  `@magentoDataFixture` for a particular test signals the framework to revert the fixtures declared on a test case level and applies the fixtures declared at a test method level instead.
   When the test is complete, the ITF reverts the applied fixtures.
 
 {: .bs-callout-info }
@@ -94,8 +95,8 @@ Rollbacks are run after reverting all the fixtures related to database transacti
 
 A fixture rollback must be of the same format as the corresponding fixture: a script or a method:
 
-- A rollback script must be named according to the corresponding fixture suffixed with `_rollback` and stored in the same directory.
-- Rollback methods must be of the same class as the corresponding fixture and suffixed with `Rollback`.
+-  A rollback script must be named according to the corresponding fixture suffixed with `_rollback` and stored in the same directory.
+-  Rollback methods must be of the same class as the corresponding fixture and suffixed with `Rollback`.
 
 Examples:
 

--- a/guides/v2.2/test/js/jasmine.md
+++ b/guides/v2.2/test/js/jasmine.md
@@ -46,15 +46,15 @@ Install [fontconfig library]:<br/>
 
 *  CentOS:
 
-  ```bash
-  yum install fontconfig
-  ```
+   ```bash
+   yum install fontconfig
+   ```
 
 *  Ubuntu:
 
-  ```bash
-  apt-get install fontconfig
-  ```
+   ```bash
+   apt-get install fontconfig
+   ```
 
 "
 %}
@@ -245,10 +245,10 @@ Warning: Task "spec" not found. Use --force to continue.
 #### Solution:
 
 1. Make sure your Node.js version is up-to-date.
-2. Remove `package.json`, `Gruntfile.js`.
-3. Copy `package.json`, `Gruntfile.js` from `package.json.sample`, `Gruntfile.js.sample`.
-4. Delete the `node_modules` directory.
-5. Run `npm install` in your terminal.
+1. Remove `package.json`, `Gruntfile.js`.
+1. Copy `package.json`, `Gruntfile.js` from `package.json.sample`, `Gruntfile.js.sample`.
+1. Delete the `node_modules` directory.
+1. Run `npm install` in your terminal.
 
 ### Warning: Cannot read property 'pid' of undefined {#cannot-read-property-pid-warning}
 

--- a/guides/v2.2/test/js/test_js-unit.md
+++ b/guides/v2.2/test/js/test_js-unit.md
@@ -169,8 +169,14 @@ The output of the PHP command resembles this output:
 **JsTestDriver output:**
 
 ```bash
-$ php <magento2_root_dir>dev/tests/js/run_js_tests.php
+php <magento2_root_dir>dev/tests/js/run_js_tests.php
+```
+
+```bash
 java -jar C:\Users\mchiocca\lib\JsTestDriver.jar --config C:\git\magento2\dev\tests\js/jsTestDriver.conf --port 9876 --browser "C:\Program Files (x86)\Mozilla Firefox\firefox.exe" --tests all --testOutput C:\git\magento2\dev\tests\js/test-output
+```
+
+```terminal
 setting runnermode QUIET
 ....................................
 Total 36 tests (Passed: 36; Fails: 0; Errors: 0) (138.00 ms)

--- a/guides/v2.2/test/js/test_js-unit.md
+++ b/guides/v2.2/test/js/test_js-unit.md
@@ -80,11 +80,11 @@ For a description of these configuration parameters, see [Configuration file for
 
 Parameters are the following:
 
-* **server**. The default location of the JsTestDriver server in the form: `http://<hostname>:<port>`
-* **proxy**. Sets the JsTestDriver to behave as a proxy. The proxy parameter is an array of arrays that enables you to specify multiple matcher and server proxies.
-* **load**. Defines the list of files to load in the browser before any tests run.
-* **test**. Defines the list of test sources to run.
-* **serve**. Defines the list of [static files](https://glossary.magento.com/static-files) to load by using the same [domain](https://glossary.magento.com/domain) as the JsTestDriver.
+*  **server**. The default location of the JsTestDriver server in the form: `http://<hostname>:<port>`
+*  **proxy**. Sets the JsTestDriver to behave as a proxy. The proxy parameter is an array of arrays that enables you to specify multiple matcher and server proxies.
+*  **load**. Defines the list of files to load in the browser before any tests run.
+*  **test**. Defines the list of test sources to run.
+*  **serve**. Defines the list of [static files](https://glossary.magento.com/static-files) to load by using the same [domain](https://glossary.magento.com/domain) as the JsTestDriver.
 
 ### `jsTestDriverOrder.php` file {#jstestdriverorderphp}
 
@@ -113,25 +113,29 @@ To complete the unit tests, the PHP script completes this processing:
 
    Otherwise, the script uses the default `jsTestDriver.php.dist` configuration file.
 
-2. The script looks for the `Browser` parameter value in the `jsTestDriver` configuration file that it found.
+1. The script looks for the `Browser` parameter value in the `jsTestDriver` configuration file that it found.
+
    If the parameter is not set in the configuration file, the script uses to the default browser location, as follows:
-   * **64-bit Windows**. The location is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
-   * **Linux**. The script runs the `which firefox` command to determine the location of the Firefox executable in your PATH.
-3. If the script finds the browser executable and the `JsTestDriver.jar` file, it proceeds with the next step. Otherwise, the script fails.
-4. The script determines the order in which the JsTestDriver loads certain JavaScript files through the `jsTestDriverOrder.php` configuration file in the `<magento2_root_dir>/dev/tests/js` directory.
+
+   *  **64-bit Windows**. The location is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
+
+   *  **Linux**. The script runs the `which firefox` command to determine the location of the Firefox executable in your PATH.
+
+1. If the script finds the browser executable and the `JsTestDriver.jar` file, it proceeds with the next step. Otherwise, the script fails.
+1. The script determines the order in which the JsTestDriver loads certain JavaScript files through the `jsTestDriverOrder.php` configuration file in the `<magento2_root_dir>/dev/tests/js` directory.
 
 ## Step 1. Before you begin {#test-prereqs}
 
 On the system where you plan to run the unit tests, install the following prerequisite software:
 
-* **PHP**
-* **The Firefox browser**
+*  **PHP**
+*  **The Firefox browser**
 
-  On 64-bit Windows machines, the default installation directory is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
+   On 64-bit Windows machines, the default installation directory is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
 
-  On Linux machines, locate the browser executable in your PATH.
+   On Linux machines, locate the browser executable in your PATH.
 
-* **`JsTestDriver.jar`**
+*  **`JsTestDriver.jar`**
 
 ## Step 2. Configure unit tests {#main-api}
 
@@ -142,9 +146,10 @@ In a custom `jsTestDriver.php` configuration file or the default `jsTestDriver.p
 Browser
 : Defines the file path to the executable for the browser.
 
-  If you do not set this value, the script uses to the default browser location, as follows:
-  * **64-bit Windows**. The location is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
-  * **Linux**. The script runs the `which firefox` command to determine the location of the Firefox executable in your PATH.
+If you do not set this value, the script uses to the default browser location, as follows:
+
+*  **64-bit Windows**. The location is `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`.
+*  **Linux**. The script runs the `which firefox` command to determine the location of the Firefox executable in your PATH.
 
 JsTestDriver
 : Required. Defines the file path to the `JsTestDriver.jar` file.
@@ -153,7 +158,9 @@ JsTestDriver
 
 To run the automated JavaScript tests, run the `run_js_tests.php` script inside the PHP interpreter from the command line:
 
-    php <magento2_root_dir>/dev/tests/js/run_js_tests.php
+```bash
+php <magento2_root_dir>/dev/tests/js/run_js_tests.php
+```
 
 Find the test results in individual `.xml` files in the `<magento2_root_dir>/dev/tests/js/test-output` directory.
 
@@ -161,18 +168,22 @@ The output of the PHP command resembles this output:
 
 **JsTestDriver output:**
 
-    $ php <magento2_root_dir>dev/tests/js/run_js_tests.php
-    java -jar C:\Users\mchiocca\lib\JsTestDriver.jar --config C:\git\magento2\dev\tests\js/jsTestDriver.conf --port 9876 --browser "C:\Program Files (x86)\Mozilla Firefox\firefox.exe" --tests all --testOutput C:\git\magento2\dev\tests\js/test-output
-    setting runnermode QUIET
-    ....................................
-    Total 36 tests (Passed: 36; Fails: 0; Errors: 0) (138.00 ms)
-      Firefox 15.0 Windows: Run 36 tests (Passed: 36; Fails: 0; Errors 0) (138.00 ms)
+```bash
+$ php <magento2_root_dir>dev/tests/js/run_js_tests.php
+java -jar C:\Users\mchiocca\lib\JsTestDriver.jar --config C:\git\magento2\dev\tests\js/jsTestDriver.conf --port 9876 --browser "C:\Program Files (x86)\Mozilla Firefox\firefox.exe" --tests all --testOutput C:\git\magento2\dev\tests\js/test-output
+setting runnermode QUIET
+....................................
+Total 36 tests (Passed: 36; Fails: 0; Errors: 0) (138.00 ms)
+  Firefox 15.0 Windows: Run 36 tests (Passed: 36; Fails: 0; Errors 0) (138.00 ms)
+```
 
 On Linux, the X Server might generate one or more warning messages in the output:
 
 **X Server warning messages on Linux:**
 
-    FreeFontPath: FPE "unix/:7100" refcount is 2, should be 1; fixing.
+```terminal
+FreeFontPath: FPE "unix/:7100" refcount is 2, should be 1; fixing.
+```
 
 An X Server bug causes these benign messages, which you can ignore.
 
@@ -205,30 +216,30 @@ After the PHP interpreter runs for the first time, you can [run the JavaScript u
 Complete these steps to use PhpStorm to run unit tests:
 
 1. [Install the JsTestDriver plugin]
-2. [Start the JsTestDriver server]
-3. [Create a run configuration]
-4. [Capture a browser]
+1. [Start the JsTestDriver server]
+1. [Create a run configuration]
+1. [Capture a browser]
 
 ### Install the JsTestDriver plugin {#install-plugin}
 
 1. In PhpStorm, open **Settings** and select **Plugins**.
-2. Click **Browse Repositories...**.
-3. Right click **JSTestDriver Plugin** and select **Download and Install**.
-4. Restart PhpStorm.
+1. Click **Browse Repositories...**.
+1. Right click **JSTestDriver Plugin** and select **Download and Install**.
+1. Restart PhpStorm.
 
 ### Start the JsTestDriver server {#start-jstestdriver-server}
 
 1. At the bottom of the IDE, click **JsTestDriver Server**.
-2. In the **JsTestDriver Server** panel, click the green right arrow to start the server.
+1. In the **JsTestDriver Server** panel, click the green right arrow to start the server.
 
    The bar changes to yellow and reads `There are no captured browsers`.
 
 ### Create a run configuration {#run-configuration}
 
 1. Enter a name for the run configuration.
-2. Select **Configuration File** and provide the location of the `jsTestDriver.conf` file generated by PHP.
-3. Select **Running in IDE**.
-4. Click **Test Connection**.
+1. Select **Configuration File** and provide the location of the `jsTestDriver.conf` file generated by PHP.
+1. Select **Running in IDE**.
+1. Click **Test Connection**.
    The `Connection to http://localhost:9876 is OK, no captured browsers` message appears.
 
 ### Capture a browser {#capture-browser}
@@ -241,15 +252,15 @@ Complete these steps to use PhpStorm to run unit tests:
 
    The `Ready to run tests` message appears.
 
-2. To run the unit tests, select **Run Configuration** and click the **Run** icon.
+1. To run the unit tests, select **Run Configuration** and click the **Run** icon.
 
    A panel at the bottom of the IDE shows the test results.
 
-3. Depending on whether you have changed one or more configuration files, complete the appropriate step to run the tests:
-   * **No changed configuration files**
+1. Depending on whether you have changed one or more configuration files, complete the appropriate step to run the tests:
+   *  **No changed configuration files**
      Use PhpStorm to run the tests.
      Before you can run the tests, click the red square icon in the **JsTestDriver Server** panel to stop the JsTestDriver server that runs in PhpStorm. You must also close the captured browser.
-   * **One or more changed configuration files**
+   *  **One or more changed configuration files**
      Use the PHP interpreter at the command line to regenerate the `jsTestDriver.conf` file and run the tests.
 
 <!-- LINK DEFINITIONS -->

--- a/guides/v2.2/test/unit/unit_test_execution_phpstorm.md
+++ b/guides/v2.2/test/unit/unit_test_execution_phpstorm.md
@@ -11,8 +11,8 @@ functional_areas:
 Running tests in PhpStorm requires following steps to setup the system.
 
 1. Configuring the [PHP](https://glossary.magento.com/php) interpreter
-2. Configuring PHPUnit
-3. Creating a run configuration
+1. Configuring PHPUnit
+1. Creating a run configuration
 
 ### Configuring the PHP interpreter
 
@@ -39,8 +39,8 @@ After configuring the interpreter, the next step is to set up the PHPStorm prefe
 ![PhpStorm PHPUnit preference panel]({{ site.baseurl }}/common/images/phpstorm_phpunit_preferences_dialogue.png){: width="600px"}
 
 1. Click the **Use custom autoloader** option.
-2. Select the `vendor/autoload.php` file in your Magento 2 installation.
-3. Optionally select the `dev/tests/unit/phpunit.xml.dist` file as the **Default configuration file**. Doing this step makes creating temporary run configurations more convenient.
+1. Select the `vendor/autoload.php` file in your Magento 2 installation.
+1. Optionally select the `dev/tests/unit/phpunit.xml.dist` file as the **Default configuration file**. Doing this step makes creating temporary run configurations more convenient.
 
 Please refer to the PhpStorm documentation for further information on [enabling PHPUnit in PhpStorm](https://www.jetbrains.com/help/phpstorm/2016.1/enabling-phpunit-support.html#useAutoload).
 
@@ -53,36 +53,36 @@ There are many ways to create run configurations in PhpStorm. Here we just show 
 All start by creating a new run configuration. To do so, follow these steps:
 
 1. Select the **Run > Edit Configurations** action from the top menu.
-2. Click the **+** symbol on the top right and select **PHPUnit**.
+1. Click the **+** symbol on the top right and select **PHPUnit**.
 
 Depending on what tests should be included in the run configuration, the next steps differ.
 
 #### Running all tests
 
 1. Give the run configuration a descriptive name; for example **All Unit Tests**
-2. Test Scope: select the **Defined in the configuration file** radio button
-3. Check the **Use alternative configuration file** checkbox
-4. Select the file `dev/tests/unit/phpunit.xml.dist`
-5. Click **OK**.
+1. Test Scope: select the **Defined in the configuration file** radio button
+1. Check the **Use alternative configuration file** checkbox
+1. Select the file `dev/tests/unit/phpunit.xml.dist`
+1. Click **OK**.
 
 ![All Unit Tests run configuration]({{ site.baseurl }}/common/images/phpstorm_run_config_all_unit_tests.png){: width="600px"}
 
 #### Running the tests of one module
 
 1. Give the run configuration a descriptive name; for example, **Example_Module Unit Tests**
-2. Test Scope: select the **Directory** option
-3. Select the directory containing the modules unit tests. PHPUnit will run every file ending with `Test.php` in the selected directory branch.
-4. Click **OK**.
+1. Test Scope: select the **Directory** option
+1. Select the directory containing the modules unit tests. PHPUnit will run every file ending with `Test.php` in the selected directory branch.
+1. Click **OK**.
 
 ![Module Unit Tests run configuration]({{ site.baseurl }}/common/images/phpstorm_run_config_module_unit_tests.png){: width="600px"}
 
 #### Running the tests in a class
 
 1. Give the run configuration a descriptive name like the name of the test class; for example, **FrontControllerPluginTest**.
-2. Test Scope: select the **Class** option.
-3. Class: enter the fully qualified class name (including the PHP namespace).
-4. File: select the file containing the test class.
-5. Click **OK**.
+1. Test Scope: select the **Class** option.
+1. Class: enter the fully qualified class name (including the PHP namespace).
+1. File: select the file containing the test class.
+1. Click **OK**.
 
 ![Test Class run configuration]({{ site.baseurl }}/common/images/phpstorm_run_config_class_unit_tests.png){: width="600px"}
 
@@ -95,4 +95,3 @@ Note that the test class has to inherit from `\PHPUnit_Framework_TestCase` for P
 First select the run configuration to execute in the run configuration drop-down menu above the main editor window, then click the **Play** icon beside it.
 
 By clicking the **Debug** icon (of a bug) next to the **Play** icon, it is possible to step-debug code during test execution, if the xdebug PHP [extension](https://glossary.magento.com/extension) is installed.
-

--- a/guides/v2.2/ui_comp_guide/bk-ui_comps.md
+++ b/guides/v2.2/ui_comp_guide/bk-ui_comps.md
@@ -33,9 +33,9 @@ In Magento 2 there are basic and secondary UI components.
 
 Basic components are:
 
-* [Listing component]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html)
+*  [Listing component]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html)
 
-* [Form component]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html)
+*  [Form component]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html)
 
 All other UI components are secondary.
 
@@ -50,13 +50,13 @@ You need to configure styles manually for components on storefront.
 
 With Magento, you may apply different approaches to implementing a UI element, and use:
 
-* [PHTML](https://glossary.magento.com/phtml) template with inline JavaScript
+*  [PHTML](https://glossary.magento.com/phtml) template with inline JavaScript
 
-* PHTML template with declaration of related JavaScript file via [XML](https://glossary.magento.com/xml) [layout](https://glossary.magento.com/layout)
+*  PHTML template with declaration of related JavaScript file via [XML](https://glossary.magento.com/xml) [layout](https://glossary.magento.com/layout)
 
-* [jQuery](https://glossary.magento.com/jquery) [widget](https://glossary.magento.com/widget)
+*  [jQuery](https://glossary.magento.com/jquery) [widget](https://glossary.magento.com/widget)
 
-* Magento 2 [UI component](https://glossary.magento.com/ui-component)
+*  Magento 2 [UI component](https://glossary.magento.com/ui-component)
 
 We recommend using UI components as much as possible and tend to do the same in Magento core.
 
@@ -68,9 +68,9 @@ UI component is a combination of:
 
 1. **XML declaration** that specifies the component's configuration settings and inner structure.
 
-2. **JavaScript** class inherited from one of the Magento JavaScript framework UI components base classes (such as [UIElement]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html), [UIClass]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) or [UICollection]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html)).
+1. **JavaScript** class inherited from one of the Magento JavaScript framework UI components base classes (such as [UIElement]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html), [UIClass]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) or [UICollection]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html)).
 
-3. **Related template(s)**
+1. **Related template(s)**
 
 ### XML Declaration
 
@@ -80,9 +80,9 @@ Comparing to XML layouts, UI components use more semantical approach to declare 
 
 An instance of UI component is usually based on the hierarchy of child UI components. For example:
 
-* the Form component has Fieldsets, Tabs, and inner fields
+*  the Form component has Fieldsets, Tabs, and inner fields
 
-* the Listing component has Filters, Columns, Bookmark component, and others
+*  the Listing component has Filters, Columns, Bookmark component, and others
 
 ### JavaScript class
 
@@ -99,15 +99,15 @@ A UI component can be bound to one or more [HTML](https://glossary.magento.com/h
 A particular instance of a UI component is defined primarily by the following:
 
 1. [definition.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml): default component configuration. Can be extended in custom modules.
-2. [UI component's XML declaration]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html).
-3. [Backend/PHP modifiers]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html).
-4. Configuration inside the JavaScript classes.
+1. [UI component's XML declaration]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html).
+1. [Backend/PHP modifiers]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html).
+1. Configuration inside the JavaScript classes.
 
 ## UI component used in the frontend design area
 
-* Configured through layout XML.
+*  Configured through layout XML.
 
-* The `jsLayout` argument is used to specify information.
+*  The `jsLayout` argument is used to specify information.
 
 ```xml
 <block name="block-name" template="Magento_Module::path_to_template.phtml">
@@ -123,9 +123,9 @@ A particular instance of a UI component is defined primarily by the following:
 
 ## UI component used in the Adminhtml area
 
-* Configured through dedicated XML file (view/.../ui_component/[ui_component_name.xml])
+*  Configured through dedicated XML file (view/.../ui_component/[ui_component_name.xml])
 
-* Included in layout XML with uiComponent tag
+*  Included in layout XML with uiComponent tag
 
 ## Things to remember when working with UI components
 

--- a/guides/v2.2/ui_comp_guide/components/ui-filters.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-filters.md
@@ -55,13 +55,12 @@ See the [Admin Design Pattern Library (Filters)]({{ page.baseurl }}/pattern-libr
 To add a new customer attribute to the customer grid and make it filterable, you need to follow these steps:
 
 1. Create view/adminhtml/ui_component/customer_listing.xml to add a column component
-2. Create the column component [PHP](https://glossary.magento.com/php) class which extends Magento\Ui\Component\Listing\Columns\Column
-3. Create etc/indexer.xml to add the attribute to the customer_grid index and define it as filterable
-4. Set is_used_in_grid to true for the attribute
+1. Create the column component [PHP](https://glossary.magento.com/php) class which extends Magento\Ui\Component\Listing\Columns\Column
+1. Create etc/indexer.xml to add the attribute to the customer_grid index and define it as filterable
+1. Set is_used_in_grid to true for the attribute
 
 ## Source files
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/filters/filters.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/filters.js)
-
+-  [app/code/Magento/Ui/view/base/web/js/grid/filters/filters.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/filters.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-form.md
@@ -213,20 +213,20 @@ For more details see the <a href="{{ page.baseurl }}/ui_comp_guide/concepts/ui_c
 To create an instance of the Form component, you need to do the following:
 
 1. In your custom module, add a configuration file for the instance, for example: `customer_form.xml`.
-2. Add a set of fields (the Fieldset component with the component of the Field) for [entity](https://glossary.magento.com/entity) or     to implement the upload of meta info in the DataProvider.
-3. Create the DataProvider class for the entity that implements DataProviderInterface
-* Add a component in Magento [layout](https://glossary.magento.com/layout) as a node: `<uiComponent name="customer_form"/>`
+1. Add a set of fields (the Fieldset component with the component of the Field) for [entity](https://glossary.magento.com/entity) or     to implement the upload of meta info in the DataProvider.
+1. Create the DataProvider class for the entity that implements DataProviderInterface
+1. Add a component in Magento [layout](https://glossary.magento.com/layout) as a node: `<uiComponent name="customer_form"/>`
 
-```xml
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
-        <referenceContainer name="content">
-            ...
-            <uiComponent name="customer_form"/>
-        </referenceContainer>
-    </body>
-</page>
-```
+   ```xml
+   <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+       <body>
+           <referenceContainer name="content">
+               ...
+               <uiComponent name="customer_form"/>
+           </referenceContainer>
+       </body>
+   </page>
+   ```
 
 ### Configure the component
 

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_config_flow_concept.md
@@ -24,22 +24,22 @@ Lets consider an example with the top-level UI component, `form`.
 
 Lets imagine we have the following file structure in our [module](https://glossary.magento.com/module) `<My_Module>`:
 
-- [layout](https://glossary.magento.com/layout) `.xml` file of the Module’s page: `my_page.xml`
-- top-level UI Component (form or listing) configuration: `my_form.xml`
-- `.php` modifiers that are specific to the module
+-  [layout](https://glossary.magento.com/layout) `.xml` file of the Module’s page: `my_page.xml`
+-  top-level UI Component (form or listing) configuration: `my_form.xml`
+-  `.php` modifiers that are specific to the module
 
 Keep in mind that the Magento_UI module contains these important files:
 
-- A general, module-agnostic form definition in the `<form>` node of the `.xml` definition file: `<Magento_Ui_module_dir>/view/base/ui_component/etc/definition.xml`
-- Default `.xhtml` template for the form, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/ui_component/templates/form/default.xhtml`
-- The Form class, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/web/js/form/form.js`
+-  A general, module-agnostic form definition in the `<form>` node of the `.xml` definition file: `<Magento_Ui_module_dir>/view/base/ui_component/etc/definition.xml`
+-  Default `.xhtml` template for the form, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/ui_component/templates/form/default.xhtml`
+-  The Form class, which is referenced in `definition.xml`: `<Magento_Ui_module_dir>/view/base/web/js/form/form.js`
 
 When the request for my_page comes, the server does the following:
 
 1. Determines which UI components are used in this particular layout. In the example, the UI components that are used are defined in the `my_form` component’s `.xml` declaration file.
-2. Searches the `.xml` files with name `my_form` among all modules. The server then merges all the `my_form.xml` file(s) into a single configuration object, thus overriding the common properties, so that the latest `my_form.xml` file always has the highest priority.
+1. Searches the `.xml` files with name `my_form` among all modules. The server then merges all the `my_form.xml` file(s) into a single configuration object, thus overriding the common properties, so that the latest `my_form.xml` file always has the highest priority.
 1. Merges the resulting configuration (from Step 2 above) with the configuration from the UI module `definition.xml`. The UI module `definition.xml` configuration file has the lowest priority, and is overwritten by the merged configuration of all `my_form.xml` files.
-2. Translates the resulting configuration into JSON format and adds it to response body the following way:
+1. Translates the resulting configuration into JSON format and adds it to response body the following way:
 
 ```html
 <script type="text/x-magento-init">{"*": {"Magento_Ui/js/core/app":{<JSON_configuration>}}}</script>
@@ -48,7 +48,7 @@ When the request for my_page comes, the server does the following:
 Now it is the client's turn to process this JSON and generate the UI component's instances. The flow is following:
 
 1. RequireJS requires `Magento_Ui/js/core/app` and passes [JSON configuration]({{ page.baseurl }}/javascript-dev-guide/javascript/js_init.html#decl_tag) as a parameter.
-2. The `Magento_Ui/js/core/app` calls `layout.js` and passes the UI component’s configuration into the layout: `<Magento_Ui_module_dir>/view/base/web/js/core/renderer/layout.js`.
-3. `layout.js` creates instances of UI components. That means that each UI component’s configuration must have an explicitly declared the `component` property in JSON. This property references the `.js` file. For example, our form has the component declared in JSON like this: `"my_form":{"component":"Magento_Ui/js/form/form"}`. So the instance of this class is created, and properties from the JSON overwrites the properties from the UI component’s `defaults` property. Then resulting properties become the first-level properties of the newly created UI component's instance, and the original `defaults` property is deleted.
-4. The UI components’ `.html` templates (if there are any) are rendered by Magento `knockout.js` template engine. This means, that [bootstrap.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bootstrap.js) (required by `app.js`) passes our own [template engine]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/template/engine.js) for the Knockout.
-5. The `bootstrap.js` binds the component as a Model behind this View (template) using Knockout bindings. The UI components are now displayed on the page, and are fully interactive.
+1. The `Magento_Ui/js/core/app` calls `layout.js` and passes the UI component’s configuration into the layout: `<Magento_Ui_module_dir>/view/base/web/js/core/renderer/layout.js`.
+1. `layout.js` creates instances of UI components. That means that each UI component’s configuration must have an explicitly declared the `component` property in JSON. This property references the `.js` file. For example, our form has the component declared in JSON like this: `"my_form":{"component":"Magento_Ui/js/form/form"}`. So the instance of this class is created, and properties from the JSON overwrites the properties from the UI component’s `defaults` property. Then resulting properties become the first-level properties of the newly created UI component's instance, and the original `defaults` property is deleted.
+1. The UI components’ `.html` templates (if there are any) are rendered by Magento `knockout.js` template engine. This means, that [bootstrap.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bootstrap.js) (required by `app.js`) passes our own [template engine]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/template/engine.js) for the Knockout.
+1. The `bootstrap.js` binds the component as a Model behind this View (template) using Knockout bindings. The UI components are now displayed on the page, and are fully interactive.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -5,8 +5,6 @@ contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
 ---
 
-## Template Literals in Magento
-
 Magento provides for the use of template literals in UI components. Template literals are strings that can contain embedded expressions. They were introduced into JavaScript with ES2015 and were called "template strings" in early editions of the ES2015 / ES6 specification. Since it is a relatively new part of JavaScript, some browsers, such as Internet Explorer 11, do not support the specification. Per the specification standard, back-ticks (`` ` ``) are used instead of a single quote (`'`) or double quote (`"`) to delineate a template string. Due to the lack of browser support, Magento has a JavaScript class that will parse certain strings with a single quote (`'`) in the same way a browser that supports the specification would parse one with back-ticks.
 
 Template literals can contain expressions which will be evaluated in the current KnockoutJS context. These expressions can contain nearly any valid [JavaScript](https://glossary.magento.com/javascript). They must start with a dollar sign and be surrounded with curly braces. **Anything inside the following will be evaluated as an expression**: `${  }`. For example, they can be used—and often are—to access properties of the KnockoutJS context like this: `'${ $.submitUrl }'`. They can be used to call functions (`'${ $.loadForm($.formUrl) }'`), or whatever: `'${ 20 + 13 }'`. These expressions are parsed in `/lib/web/mage/utils/template.js`.

--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -5,7 +5,7 @@ contributor_name: SwiftOtter Studios
 contributor_link: https://swiftotter.com/
 ---
 
-# Template Literals in Magento
+## Template Literals in Magento
 
 Magento provides for the use of template literals in UI components. Template literals are strings that can contain embedded expressions. They were introduced into JavaScript with ES2015 and were called "template strings" in early editions of the ES2015 / ES6 specification. Since it is a relatively new part of JavaScript, some browsers, such as Internet Explorer 11, do not support the specification. Per the specification standard, back-ticks (`` ` ``) are used instead of a single quote (`'`) or double quote (`"`) to delineate a template string. Due to the lack of browser support, Magento has a JavaScript class that will parse certain strings with a single quote (`'`) in the same way a browser that supports the specification would parse one with back-ticks.
 
@@ -22,7 +22,7 @@ The `defaults` property should be an object and is handled in a special way. Eac
 As a result, every `defaults` child property is handled with what could be viewed as a two step process:
 
 1. Evaluate the value of the property for expressions. For example: `'${ $.submitUrl }'` could become `'https://example.com/contact/form/submit/'` (more on that later).
-2. Assign that property/value to the class itself. As a result `class.defaults.submitUrl` would become `class.submitUrl`.
+1. Assign that property/value to the class itself. As a result `class.defaults.submitUrl` would become `class.submitUrl`.
 
 This part is important because it means that JavaScript classes that extend `Class` (`magento/module-ui/view/base/web/js/lib/core/class.js`) can use the `defaults` property to assign properties to the class itself and leverage template literals during that process without any work on your part.
 
@@ -30,9 +30,9 @@ This part is important because it means that JavaScript classes that extend `Cla
 
 Certain properties of the `defaults` object are processed by an additional core JavaScript class: `links.js` (located: `magento/module-ui/view/base/web/js/lib/core/element/links.js`). The object keys in `defaults` are:
 
-- `links`
-- `imports`
-- `exports`
+-  `links`
+-  `imports`
+-  `exports`
 
 They can be used to interact with other UI Component JavaScript classes. While the full use of them is a separate topic, those values can use a colon (`:`) to separate an expression, which should evaluate to a UI Component's name, from the properties to be accessed in that class. Take this example: `'${ $.provider }:user.theme'`. If the `${ $.provider }` expression evaluates to the name of a UI Component that is currently in the registry, that component will be loaded and the value of its `user.theme` property returned.
 

--- a/guides/v2.2/ui_comp_guide/howto/new_component_declaration.md
+++ b/guides/v2.2/ui_comp_guide/howto/new_component_declaration.md
@@ -19,21 +19,21 @@ The `<container>` element is typically used for declaring custom components that
 
 The `<container>` and `<component>` elements have no mandatory attributes. The following optional attributes are available for both these elements:
 
-- `component`: link to the component's [JavaScript](https://glossary.magento.com/javascript) constructor.
-- `class`: link to the component's [PHP](https://glossary.magento.com/php) class.
-- `template`: link to component's `.html` template.
-- `provider`: link to component's data provider.
-- `sortOrder`: component's sort order
-- `displayArea`: the placeholder which defines the area for rendering the component in the [layout](https://glossary.magento.com/layout) file.
+-  `component`: link to the component's [JavaScript](https://glossary.magento.com/javascript) constructor.
+-  `class`: link to the component's [PHP](https://glossary.magento.com/php) class.
+-  `template`: link to component's `.html` template.
+-  `provider`: link to component's data provider.
+-  `sortOrder`: component's sort order
+-  `displayArea`: the placeholder which defines the area for rendering the component in the [layout](https://glossary.magento.com/layout) file.
 
 {%
 include note.html
 type = 'warning'
 content = 'If the following elements are used inside `<container>` or `<component>`, they should be specified strictly in the following order:
 
-1.  `<argument>`
-2.  `<settings>`
-3.  `<childComponent>`
+1. `<argument>`
+1. `<settings>`
+1. `<childComponent>`
 
 For the component configuration inside `<container>` and `<component>`, [use the "arbitrary" structure].'
 %}
@@ -43,7 +43,7 @@ For the component configuration inside `<container>` and `<component>`, [use the
 If the custom component you create is a [basic UI component] (like Form or Listing), you need to take the following steps to declare it:
 
 1. Specify the XML file with its configuration it in the page layout file in your module, as described in the [About XML configuration of UI components] topic.
-2. Declare the component in a separate `.xml` file using the `<container>` or `<component>` as parent node.
+1. Declare the component in a separate `.xml` file using the `<container>` or `<component>` as parent node.
 
 ## Declare a custom secondary component
 

--- a/guides/v2.2/ui_comp_guide/howto/price_rendering.md
+++ b/guides/v2.2/ui_comp_guide/howto/price_rendering.md
@@ -12,11 +12,11 @@ Magento is able to operate with a variety of prices, taxes, and product types.
 The following is a short list of Magento prices:
 
 1. Special Price.
-2. Tier Price.
-3. Grouped Price.
-4. Minimum price of composite products
-5. Price range of composite products
-6. Manufacturer price (MSRP)
+1. Tier Price.
+1. Grouped Price.
+1. Minimum price of composite products
+1. Price range of composite products
+1. Manufacturer price (MSRP)
 
 Magento represents these prices as price types (e.g. final price, minimum price, maximum price, regular price) and are separate from the actual price in the code.
 For example, Special Price is represented by the final price type in the code.
@@ -25,9 +25,9 @@ For example, Special Price is represented by the final price type in the code.
 
 Magento handles taxes as price adjustments and has 3 generic types of taxes:
 
-* Tax
-* Fixed Product Tax
-* Tax for Fixed Product Tax
+*  Tax
+*  Fixed Product Tax
+*  Tax for Fixed Product Tax
 
 Applying and rendering taxes is complicated.
 A product can have more than one price shown and taxes may or may not apply to all of them.
@@ -315,9 +315,9 @@ The following is sample template code that is rendered for the tax adjustment co
 
 ## Related Topics
 
-* [Form component][form-component]
-* [Listing component][listing-component]
-* [Declaring UI Components][ui-component-declaration]
+*  [Form component][form-component]
+*  [Listing component][listing-component]
+*  [Declaring UI Components][ui-component-declaration]
 
 [form-component]: {{ page.baseurl }}/ui_comp_guide/components/ui-form.html
 [listing-component]: {{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html

--- a/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
+++ b/guides/v2.2/ui_comp_guide/troubleshoot/ui_comp_troubleshoot_js.md
@@ -14,24 +14,24 @@ To define the UI components used on a page, you can use browser built-in develop
 To install the knockout debugging plugin for Google Chrome, take the following steps:
 
 1. Open your Google Chrome browser.
-2. Expand Google Chrome options drop-down (hamburger in upper right).
-3. Select **Settings**.
-4. In left pane, select **Extensions**.
-5. Scroll to end of the page and click **Get more extensions** link.
-6. In the **Search** field write **Knockoutjs context debugger** and press the **Enter** key.
-7. In the result, find the [extension](https://glossary.magento.com/extension) named **Knockoutjs context debugger** (usually the first result), and click **Add to Chrome**.
+1. Expand Google Chrome options drop-down (hamburger in upper right).
+1. Select **Settings**.
+1. In left pane, select **Extensions**.
+1. Scroll to end of the page and click **Get more extensions** link.
+1. In the **Search** field write **Knockoutjs context debugger** and press the **Enter** key.
+1. In the result, find the [extension](https://glossary.magento.com/extension) named **Knockoutjs context debugger** (usually the first result), and click **Add to Chrome**.
 
 To define the [UI component](https://glossary.magento.com/ui-component) using the plugin:
 
 1. Open the required page in Chrome.
-2. Point to the required element on the page, right-click and select **Inspect**. The developer tools panel opens.
-3. In the right column of the panel, click the **Knockout context** tab. The tab displays the name and the configuration of the UI component instance.
+1. Point to the required element on the page, right-click and select **Inspect**. The developer tools panel opens.
+1. In the right column of the panel, click the **Knockout context** tab. The tab displays the name and the configuration of the UI component instance.
 
 A simple example:
 
 1. Launch [Magento Admin](https://glossary.magento.com/magento-admin).
-2. Navigate to **Products** > **Catalog** and click **Add Product**. The product creation page opens.
-3. Right-click on the **Product Name** field and click **Inspect**. Go to the **Knockout context** tab. Here you can see the full context of the field, where you can find JS component file, component name, etc.
+1. Navigate to **Products** > **Catalog** and click **Add Product**. The product creation page opens.
+1. Right-click on the **Product Name** field and click **Inspect**. Go to the **Knockout context** tab. Here you can see the full context of the field, where you can find JS component file, component name, etc.
 
 ![Image Example]({{ site.baseurl }}/common/images/ui_comp_troubleshoot_chrome1.png)
 
@@ -71,16 +71,16 @@ All modern browsers support “debugging” – a special UI in developer tools 
 [DevTools] provides a lot of different tools for different tasks, but the **Sources** panel is where you debug JavaScript.
 
 1. Open the required page in Chrome.
-2. Turn on developer tools with F12 (Windows, Linux) or Cmd+Opt+I (Mac).
-3. Click the `Sources` tab.
+1. Turn on developer tools with F12 (Windows, Linux) or Cmd+Opt+I (Mac).
+1. Click the `Sources` tab.
 
 ![Sources Panel]({{ site.baseurl }}/common/images/debugging-sources-pane.png)
 
 In the previous image, we can see three zones:
 
 1. The `Resources` zone lists all the files as HTML, JavaScript, CSS.
-2. The `Source` zone shows the source code of any selected file.
-3. The `Information and control` zone is for debugging.
+1. The `Source` zone shows the source code of any selected file.
+1. The `Information and control` zone is for debugging.
 
 ### Breakpoints
 

--- a/guides/v2.3/rest/tutorials/inventory/configure-environment.md
+++ b/guides/v2.3/rest/tutorials/inventory/configure-environment.md
@@ -31,7 +31,7 @@ In this tutorial, we'll create the infrastructure needed to implement a US and a
 
    Click **Save Web Site**.
 
-2. Click **Create Store** and assign the following values:
+1. Click **Create Store** and assign the following values:
 
    Field | Value
    --- | ---
@@ -42,7 +42,7 @@ In this tutorial, we'll create the infrastructure needed to implement a US and a
 
    Click **Save Store**.
 
-3. Click **Create Store View** and assign the following values:
+1. Click **Create Store View** and assign the following values:
 
    Field | Value
    --- | ---
@@ -64,7 +64,7 @@ In this tutorial, we'll create the infrastructure needed to implement a US and a
 
    Click **Save Web Site**.
 
-2. Click **Create Store** and assign the following values:
+1. Click **Create Store** and assign the following values:
 
    Field | Value
    --- | ---
@@ -75,7 +75,7 @@ In this tutorial, we'll create the infrastructure needed to implement a US and a
 
    Click **Save Store**.
 
-3. Click **Create Store View** and assign the following values:
+1. Click **Create Store View** and assign the following values:
 
    Field | Value
    --- | ---
@@ -91,8 +91,8 @@ In this tutorial, we'll create the infrastructure needed to implement a US and a
 To make it easier to locate products and log in as a customer later in this tutorial, configure Magento to add the store code to the URL.
 
 1. Click **Stores** > Setting* > **Configuration** > **Web** and expand the **Url Options** section.
-2. Change the value of **Add Store Code to Urls** to **Yes**.
-3. Click **Save Config**.
+1. Change the value of **Add Store Code to Urls** to **Yes**.
+1. Click **Save Config**.
 
 ## Configure payment and shipping methods
 

--- a/guides/v2.3/rest/tutorials/inventory/create-customer.md
+++ b/guides/v2.3/rest/tutorials/inventory/create-customer.md
@@ -205,6 +205,7 @@ By default, a customer token is valid for 1 hour. To change this value, click **
 "password": "Password1"
 }
 ```
+
 **Response**
 
 Magento returns the customer's access token. Your integration must specify a customer token in the authorization header of every call customers make on their own behalf.
@@ -214,5 +215,5 @@ Magento returns the customer's access token. Your integration must specify a cus
 ## Verify this step {#verify-step}
 
 1. Log in to the Test website using the email `jdoe@example.com` and password `Password1`.
-2. Click the account name (Jane) in the upper right corner and select **My Account**.
-3. Click **Address Book** to view the default billing and shipping addresses.
+1. Click the account name (Jane) in the upper right corner and select **My Account**.
+1. Click **Address Book** to view the default billing and shipping addresses.

--- a/guides/v2.3/rest/tutorials/inventory/create-invoice.md
+++ b/guides/v2.3/rest/tutorials/inventory/create-invoice.md
@@ -53,4 +53,4 @@ An invoice `id`, such as `3`.
 
 1. Click **Sales** > **Invoices**. The invoice displays in the grid with a status of Paid. Then click **Sales** > **Orders**. The status is Processing.
 
-2. Click **Catalog** > **Products**. For `vp1`, Magento adjusted the value of **Quantity per Source** and **Salable Quantity** to 9998 for all sources and stocks.
+1. Click **Catalog** > **Products**. For `vp1`, Magento adjusted the value of **Quantity per Source** and **Salable Quantity** to 9998 for all sources and stocks.

--- a/guides/v2.3/rest/tutorials/inventory/create-order.md
+++ b/guides/v2.3/rest/tutorials/inventory/create-order.md
@@ -64,5 +64,5 @@ An `orderID`, such as `3`
 ## Verify this step {#verify-step}
 
 1. Log in to the US store as the customer. The dashboard shows the order.
-2. Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Orders**. The order is displayed in the grid. Its status is Pending.
-3. Click **Catalog** > **Products**. The **Salable Quantity** column shows that fewer items of the ordered products are available. The values in the **Quantity per Source** are not affected until shipment.
+1. Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Orders**. The order is displayed in the grid. Its status is Pending.
+1. Click **Catalog** > **Products**. The **Salable Quantity** column shows that fewer items of the ordered products are available. The values in the **Quantity per Source** are not affected until shipment.

--- a/guides/v2.3/rest/tutorials/inventory/create-shipment.md
+++ b/guides/v2.3/rest/tutorials/inventory/create-shipment.md
@@ -266,4 +266,4 @@ Use the same endpoint to ship the remaining 35 `sp2` items from the Reno warehou
 ## Verify this step {#verify-step}
 
 1. Click **Sales** > **Shipments**. The two shipments for this order are displayed in the grid.
-2. Click **Catalog** > **Products**. Verify that the **Quantity per Source** values are correct for each product, based on the selections you made at shipment.
+1. Click **Catalog** > **Products**. Verify that the **Quantity per Source** values are correct for each product, based on the selections you made at shipment.

--- a/guides/v2.3/rest/tutorials/inventory/run-ssa.md
+++ b/guides/v2.3/rest/tutorials/inventory/run-ssa.md
@@ -146,6 +146,6 @@ Product | Source | Quantity
 ## Verify this step {#verify-step}
 
 1. Click **Sales** > **Orders**.
-2. Click the **View** link in the Action column for the order.
-3. Click **Ship**.
-4. Select different sources from the **Sources** menu.
+1. Click the **View** link in the Action column for the order.
+1. Click **Ship**.
+1. Select different sources from the **Sources** menu.

--- a/guides/v2.3/test/integration/annotations/magento-config-fixture.md
+++ b/guides/v2.3/test/integration/annotations/magento-config-fixture.md
@@ -13,18 +13,18 @@ To set the Magento configuration values for individual tests and revert them aft
  */
 ```
 
-- `<store_code>` is a code of the store to be configured.
+-  `<store_code>` is a code of the store to be configured.
   By default, the configuration option is applied globally.
   To specify the current store, use `current`.
-- `<config_path>` is an XPath to the configuration option.
+-  `<config_path>` is an XPath to the configuration option.
   See [configuration reference][] for available options.
-- `<config_value>` is a fixture value for the configuration option.
+-  `<config_value>` is a fixture value for the configuration option.
 
 ## Principles
 
 1. The `@magentoConfigFixture` is available at a test method level only.
    It is not available on a test case level.
-2. A test can contain several configuration options.
+1. A test can contain several configuration options.
 
 ## Example
 

--- a/guides/v2.3/test/integration/annotations/magento-data-fixture.md
+++ b/guides/v2.3/test/integration/annotations/magento-data-fixture.md
@@ -20,34 +20,35 @@ To set up a date fixture, use the `@magentoDataFixture` annotation.
  */
 ```
 
-- `<script_filename>` is a filename of the PHP script.
-- `<method_name>` is a name of the method declared in the current class.
+-  `<script_filename>` is a filename of the PHP script.
+-  `<method_name>` is a name of the method declared in the current class.
 
 ## Principles
 
 1. Do not use a direct database connection in fixtures to avoid dependencies on the database structure and vendor.
-2. Use an application API to implement your data fixtures.
-3. A method that implements a data fixture must be declared as `public` and `static`.
-4. Fixtures declared at a test level have a higher priority then fixtures declared at a test case level.
-5. Test case fixtures are applied to each test in the test case, unless a test has its own fixtures declared.
-6. Annotation declaration at a test case level doesn't affect tests that have their own annotation declarations.
+1. Use an application API to implement your data fixtures.
+1. A method that implements a data fixture must be declared as `public` and `static`.
+1. Fixtures declared at a test level have a higher priority then fixtures declared at a test case level.
+1. Test case fixtures are applied to each test in the test case, unless a test has its own fixtures declared.
+1. Annotation declaration at a test case level doesn't affect tests that have their own annotation declarations.
 
 ## Usage
 
 As mentioned above, there are two ways to declare fixtures:
 
-- as a PHP script file that is used by other tests and test cases.
-- as a local method that is used by other tests in the test cases.
+-  as a PHP script file that is used by other tests and test cases.
+-  as a local method that is used by other tests in the test cases.
 
 ### Fixture as a separate file
 
 Define the fixture in a separate file when you want to reuse it in different test cases.
 To declare the fixture, use the following conventions for a path
 
-- Relative to `dev/tests/integration/<test suite directory>`
-- With forward slashes `/`
-- No leading slash
-  Example: `Magento/Cms/_files/pages.php`
+-  Relative to `dev/tests/integration/<test suite directory>`
+-  With forward slashes `/`
+-  No leading slash
+
+   Example: `Magento/Cms/_files/pages.php`
 
 The ITF includes the declared PHP script to your test and executes it during test run.
 
@@ -78,9 +79,9 @@ The following is an example of the `testCreatePageWithSameModuleName()` test met
 The `@magentoDataFixture` can be specified for a particular test or for an entire test case.
 The basic rules for fixture annotation at different levels are:
 
-- `@magentoDataFixture` at a test case level makes the framework to apply the declared fixtures to each test in the test case.
+-  `@magentoDataFixture` at a test case level makes the framework to apply the declared fixtures to each test in the test case.
   When the final test is complete, all class-level fixtures are reverted.
-- `@magentoDataFixture` for a particular test signals the framework to revert the fixtures declared on a test case level and applies the fixtures declared at a test method level instead.
+-  `@magentoDataFixture` for a particular test signals the framework to revert the fixtures declared on a test case level and applies the fixtures declared at a test method level instead.
   When the test is complete, the ITF reverts the applied fixtures.
 
 {: .bs-callout-info }
@@ -94,8 +95,8 @@ Rollbacks are run after reverting all the fixtures related to database transacti
 
 A fixture rollback must be of the same format as the corresponding fixture: a script or a method:
 
-- A rollback script must be named according to the corresponding fixture suffixed with `_rollback` and stored in the same directory.
-- Rollback methods must be of the same class as the corresponding fixture and suffixed with `Rollback`.
+-  A rollback script must be named according to the corresponding fixture suffixed with `_rollback` and stored in the same directory.
+-  Rollback methods must be of the same class as the corresponding fixture and suffixed with `Rollback`.
 
 Examples:
 

--- a/guides/v2.3/ui_comp_guide/bk-ui_comps.md
+++ b/guides/v2.3/ui_comp_guide/bk-ui_comps.md
@@ -33,9 +33,9 @@ In Magento 2 there are basic and secondary UI components.
 
 Basic components are:
 
-* [Listing component]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html)
+*  [Listing component]({{ page.baseurl }}/ui_comp_guide/components/ui-listing-grid.html)
 
-* [Form component]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html)
+*  [Form component]({{ page.baseurl }}/ui_comp_guide/components/ui-form.html)
 
 All other UI components are secondary.
 
@@ -50,13 +50,13 @@ You need to configure styles manually for components on the storefront.
 
 With Magento, you may apply different approaches to implementing a UI element, and use:
 
-* [PHTML](https://glossary.magento.com/phtml) template with inline JavaScript
+*  [PHTML](https://glossary.magento.com/phtml) template with inline JavaScript
 
-* PHTML template with declaration of related JavaScript file via [XML](https://glossary.magento.com/xml) [layout](https://glossary.magento.com/layout)
+*  PHTML template with declaration of related JavaScript file via [XML](https://glossary.magento.com/xml) [layout](https://glossary.magento.com/layout)
 
-* [jQuery](https://glossary.magento.com/jquery) [widget](https://glossary.magento.com/widget)
+*  [jQuery](https://glossary.magento.com/jquery) [widget](https://glossary.magento.com/widget)
 
-* Magento 2 [UI component](https://glossary.magento.com/ui-component)
+*  Magento 2 [UI component](https://glossary.magento.com/ui-component)
 
 We recommend using UI components as much as possible and tend to do the same in Magento core.
 
@@ -68,9 +68,9 @@ UI component is a combination of:
 
 1. **XML declaration** that specifies the component's configuration settings and inner structure.
 
-2. **JavaScript** class inherited from one of the Magento JavaScript framework UI components base classes (such as [UIElement]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html), [UIClass]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) or [UICollection]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html)).
+1. **JavaScript** class inherited from one of the Magento JavaScript framework UI components base classes (such as [UIElement]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html), [UIClass]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) or [UICollection]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html)).
 
-3. **Related template(s)**
+1. **Related template(s)**
 
 ### XML Declaration
 
@@ -101,15 +101,15 @@ A UI component can be bound to one or more [HTML](https://glossary.magento.com/h
 A particular instance of a UI component is defined primarily by the following:
 
 1. `<Magento_Ui_module_dir>/view/base/ui_component/etc/definition.xml`: default component configuration. Can be extended in custom modules.
-2. [UI component's XML declaration]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html).
-3. [Backend/PHP modifiers]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html).
-4. Configuration inside the JavaScript classes.
+1. [UI component's XML declaration]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_xmldeclaration_concept.html).
+1. [Backend/PHP modifiers]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html).
+1. Configuration inside the JavaScript classes.
 
 ## UI component used in the frontend design area
 
-* Configured through layout XML.
+*  Configured through layout XML.
 
-* The `jsLayout` argument is used to specify information.
+*  The `jsLayout` argument is used to specify information.
 
 ```xml
 <block name="block-name" template="Magento_Module::path_to_template.phtml">
@@ -125,9 +125,9 @@ A particular instance of a UI component is defined primarily by the following:
 
 ## UI component used in the Adminhtml area
 
-* Configured through dedicated XML file (view/.../ui_component/[ui_component_name.xml])
+*  Configured through dedicated XML file (view/.../ui_component/[ui_component_name.xml])
 
-* Included in layout XML with uiComponent tag
+*  Included in layout XML with uiComponent tag
 
 ## Things to remember when working with UI components
 

--- a/guides/v2.3/ui_comp_guide/components/ui-form.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-form.md
@@ -213,8 +213,8 @@ For more details see the <a href="{{ page.baseurl }}/ui_comp_guide/concepts/ui_c
 To create an instance of the Form component, you need to do the following:
 
 1. In your custom module, add a configuration file for the instance, for example: `customer_form.xml`.
-2. Add a set of fields (the Fieldset component with the component of the Field) for [entity](https://glossary.magento.com/entity) or     to implement the upload of meta info in the DataProvider.
-3. Create the DataProvider class for the entity that implements DataProviderInterface
+1. Add a set of fields (the Fieldset component with the component of the Field) for [entity](https://glossary.magento.com/entity) or     to implement the upload of meta info in the DataProvider.
+1. Create the DataProvider class for the entity that implements DataProviderInterface
 
    *  Add a component in Magento [layout](https://glossary.magento.com/layout) as a node: `<uiComponent name="customer_form"/>`
 

--- a/guides/v2.3/ui_comp_guide/components/ui-wysiwyg.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-wysiwyg.md
@@ -73,23 +73,23 @@ See [Events and observers]({{ page.baseurl }}/extension-dev-guide/events-and-obs
 
 The following are available events for use in the WYSIWYG component adapter for TinyMCE4:
 
-* `tinymceBeforeSetContent` - fires before the contents are inserted into the editor
-* `tinymcePaste` - fires when a paste is done within the editor
-* `tinymceSaveContent` - fires when the contents in the editor are saved
-* `tinymceSaveContent` (`PostProcess`) - fires when the contents in the editor are being serialized
-* `tinymceUndo` - fires when the contents have been reverted to a previous state
-* `tinymceFocus` - fires when the editor is focused
-* `tinymceBlur` - fires when the editor is blurred
-* `tinymceChange` - fires when undo level is added to the editor
-* `wysiwygEditorInitialized` - fires when the WYSIWYG editor is initialized
+*  `tinymceBeforeSetContent` - fires before the contents are inserted into the editor
+*  `tinymcePaste` - fires when a paste is done within the editor
+*  `tinymceSaveContent` - fires when the contents in the editor are saved
+*  `tinymceSaveContent` (`PostProcess`) - fires when the contents in the editor are being serialized
+*  `tinymceUndo` - fires when the contents have been reverted to a previous state
+*  `tinymceFocus` - fires when the editor is focused
+*  `tinymceBlur` - fires when the editor is blurred
+*  `tinymceChange` - fires when undo level is added to the editor
+*  `wysiwygEditorInitialized` - fires when the WYSIWYG editor is initialized
 
 ## Add a default editor
 
 Adding the default Magento WYSIWYG editor to a page requires the following steps:
 
 1. Create a layout
-2. Create a form
-3. Add a data provider, controller, and routes
+1. Create a form
+1. Add a data provider, controller, and routes
 
 The following example shows how to integrate the default Magento WYSIWYG editor as a UI component inside a custom form.
 
@@ -360,4 +360,3 @@ Here's an example that connects the data provider and modifier created in the pr
 
 {: .bs-callout-info }
 If your form already uses the [ModifierPool]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_modifier_concept.html), you can continue using it to control the configuration of your WYSIWYG components.
-

--- a/guides/v2.3/ui_comp_guide/howto/update-url-type.md
+++ b/guides/v2.3/ui_comp_guide/howto/update-url-type.md
@@ -12,10 +12,10 @@ This topic describes how to extend the existing [`UrlInput` component](../compon
 To update a page URL type, you must:
 
 1. [Create the link class](#link-class).
-2. [Add the link to the di.xml file](#di-xml).
-3. [Create the component's JavaScript implementation](#js-implementation).
-4. [Create a controller to search the page](#search-page).
-5. [Create a controller to return the page or array by `cmsPageId`](#return-page).
+1. [Add the link to the di.xml file](#di-xml).
+1. [Create the component's JavaScript implementation](#js-implementation).
+1. [Create a controller to search the page](#search-page).
+1. [Create a controller to return the page or array by `cmsPageId`](#return-page).
 
 ## Create the link class {#link-class}
 
@@ -194,6 +194,7 @@ define([
     });
 });
 ```
+
 ## Create a controller to search the page {#search-page}
 
 Create a controller to search the page using a search key.
@@ -273,6 +274,7 @@ class Search extends \Magento\Backend\App\Action
     }
 }
 ```
+
 ## Create a controller to return the page or array {#return-page}
 
 Create a controller to return the page, or empty array if the option doesn't exist, by the `cmsPageId`.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- REST
- Test
- UI Components

The MD)29 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.