### PR TITLE
Fixed ordered list prefix (MD029) - Group 2

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
@@ -28,13 +28,13 @@ Follow these steps to download and apply this patch:
 
 1. Access the Downloads page [here](https://magento.com/tech-resources/download#download2288).
 
-2. Select the Git-based option from **Select your format**.
+1. Select the Git-based option from **Select your format**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## Highlights
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
@@ -29,15 +29,15 @@ Follow these steps to download and apply this patch:
 
 1. Access [My Account](https://account.magento.com/customer/account/login).
 
-2. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
+1. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
 
-3. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
+1. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## Highlights
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
@@ -26,13 +26,13 @@ Follow these steps to download and apply this patch:
 
 1. Access the Downloads page [here](https://magento.com/tech-resources/download#download2288).
 
-2. Select the Git-based option from **Select your format**.
+1. Select the Git-based option from **Select your format**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## PayPal Payflow Pro active carding activity update
 
@@ -1182,9 +1182,9 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 1. Navigate to **Stores**  > **Settings**  > **Configuration**  >  **Sales**  > **Shipping Methods**. Then, expand the **UPS** section.
 
-2. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
+1. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
 
-3. Tap **Save Config**.
+1. Tap **Save Config**.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
@@ -27,15 +27,15 @@ Follow these steps to download and apply this patch:
 
 1. Access [My Account](https://account.magento.com/customer/account/login).
 
-2. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
+1. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
 
-3. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
+1. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## PayPal Payflow Pro active carding activity update
 
@@ -1225,9 +1225,9 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 1. Navigate to **Stores**  > **Settings**  > **Configuration**  >  **Sales**  > **Shipping Methods**. Then, expand the **UPS** section.
 
-2. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
+1. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
 
-3. Tap **Save Config**.
+1. Tap **Save Config**.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/backward-incompatible-changes/reference.md
+++ b/guides/v2.2/release-notes/backward-incompatible-changes/reference.md
@@ -14,7 +14,7 @@ All changes are generated automatically using the codebase of the corresponding 
 The changes are aggregated into two tables:
 
 1. **Changes in classes** that contains backward incompatible changes made to the Magento classes
-2. **Changes in interfaces** that contains backward incompatible changes made to the Magento interfaces
+1. **Changes in interfaces** that contains backward incompatible changes made to the Magento interfaces
 
 ## 2.2.8 - 2.2.9 {#releases-2_2_8-2_2_9}
 

--- a/guides/v2.3/performance-best-practices/advanced-js-bundling.md
+++ b/guides/v2.3/performance-best-practices/advanced-js-bundling.md
@@ -19,7 +19,7 @@ It is designed to provide optimal bundles and be less error-prone than the built
 Bundling JavaScript modules for better performance is about reducing two things:
 
 1. The number of server requests.
-2. The size of those server requests.
+1. The size of those server requests.
 
 In a modular application, the number of server requests can reach into the hundreds. For example, the following screen shot shows only the start of the list of JavaScript modules loaded on the home page of a clean Magento installation.
 
@@ -108,6 +108,7 @@ Full versions of the sample code used in this article are available here:
 #### 1\. Add a build.js file
 
 Create a `build.js` file in the Magento root directory. This file will contain the entire build configuration for your bundles.
+
 ```javascript
 ({
     optimize: 'none',
@@ -120,6 +121,7 @@ Later, we will change the `optimize:` setting from_ `none` to `uglify2` to minif
 #### 2\. Add RequireJS dependencies, shims, paths, and map
 
 Add the following RequireJS build configuration nodes, `deps`, `shim`, `paths`, and `map`, to your build file:
+
 ```javascript
 ({
     optimize: 'none',
@@ -143,6 +145,7 @@ Within this file, you will find multiple entries for each of the configuration n
 #### 4\. Add a modules node
 
 At the end of the `build.js` file, add the modules[] array as a placeholder for the bundles you will define for your storefront later.
+
 ```javascript
 ({
     optimize: 'none',
@@ -162,7 +165,7 @@ At the end of the `build.js` file, add the modules[] array as a placeholder for 
 You can retrieve all the RequireJS module dependencies from your store's page types by using:
 
 1. PhantomJS from the command line (assuming you have PhantomJS installed).
-2. RequireJS command in your browser's console.
+1. RequireJS command in your browser's console.
 
 #### To use PhantomJS:
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.md
@@ -23,15 +23,15 @@ Follow these steps to download and apply this patch:
 
 1. Access [My Account](https://account.magento.com/customer/account/login).
 
-2. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
+1. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
 
-3. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
+1. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > Tools > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > Tools > **Cache Management**).
 
 ## Highlights
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.md
@@ -22,13 +22,13 @@ Follow these steps to download and apply this patch:
 
 1. Access the Downloads page [here](https://magento.com/tech-resources/download#download2288).
 
-2. Select the Git-based option from **Select your format**.
+1. Select the Git-based option from **Select your format**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## Highlights
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.md
@@ -29,15 +29,15 @@ Follow these steps to download and apply this patch:
 
 1. Access [My Account](https://account.magento.com/customer/account/login).
 
-2. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
+1. Navigate to the **Downloads** tab. Select the Magento edition and version you need.
 
-3. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
+1. Select **Support Patches and Security Patches**, then **PRODSECBUG-2198**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## PayPal Payflow Pro active carding activity update
 
@@ -1873,9 +1873,9 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 1. Navigate to **Stores**  > **Settings**  > **Configuration**  >  **Sales**  > **Shipping Methods**. Then, expand the **UPS** section.
 
-2. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
+1. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
 
-3. Tap **Save Config**.
+1. Tap **Save Config**.
 
 * **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.md
@@ -27,13 +27,13 @@ Follow these steps to download and apply this patch:
 
 1. Access the Downloads page [here](https://magento.com/tech-resources/download#download2288).
 
-2. Select the Git-based option from **Select your format**.
+1. Select the Git-based option from **Select your format**.
 
-4. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
+1. Download the patch and upload to a specific directory in your Magento installation such as `m2-hotfixes` (confirm  that the directory is not accessible publicly).
 
-5. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
+1. From your project root, apply the patch.  `git apply ./m2-hotfixes/<patch-file-name>`.
 
-6. Refresh the cache from the Admin (**System** > **Cache Management**).
+1. Refresh the cache from the Admin (**System** > **Cache Management**).
 
 ## PayPal Payflow Pro active carding activity update
 
@@ -1736,9 +1736,9 @@ If UPS Type is set to `United Parcel Service` in the UPS Shipping Method Config
 
 1. Navigate to **Stores**  > **Settings**  > **Configuration**  >  **Sales**  > **Shipping Methods**. Then, expand the **UPS** section.
 
-2. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
+1. At the **UPS Type** field, clear the Use system value checkbox. Then, change **UPS Type** to `United Parcel Service XML`. The Gateway URL populates correctly when this value is selected.
 
-3. Tap **Save Config**.
+1. Tap **Save Config**.
 
 * **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 

--- a/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
+++ b/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
@@ -9,7 +9,7 @@ redirect_from:
 The changes are aggregated into two tables:
 
 1. **Changes in classes** that contains backward incompatible changes made to the PHP classes
-2. **Changes in interfaces** that contains backward incompatible changes made to the PHP interfaces
+1. **Changes in interfaces** that contains backward incompatible changes made to the PHP interfaces
 
 ## 2.3.1 - 2.3.2
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- Release notes
- Performance Best Practices

The MD)29 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.