### PR TITLE
Magento 2.3.3 release note discussion of Elasticsearch pagination patch

### DIFF
--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -25,7 +25,7 @@ Although code for these features is bundled with quarterly releases of the Magen
 
 ## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
 
-This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
+This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine.
 Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the 'Catalog pagination issue on Elasticsearch 6.x' patch associated with the version of Magento you are running.
 
 ## Highlights

--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -23,6 +23,11 @@ For general information about security-only patches, see the Magento DevBlog pos
 
 Although code for these features is bundled with quarterly releases of the Magento core code, several of these projects (for example, Page Builder, Inventory Management, and Progressive Web Applications (PWA) Studio) are also released independently. Bug fixes for these projects are documented in separate, project-specific release information which is available in the documentation for each project.
 
+## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
+
+This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
+Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the Catalog pagination issue on Elasticsearch 6.x patch associated with the version of Magento you are running.
+
 ## Highlights
 
 Look for the following highlights in this release:

--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -26,7 +26,7 @@ Although code for these features is bundled with quarterly releases of the Magen
 ## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
 
 This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
-Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the Catalog pagination issue on Elasticsearch 6.x patch associated with the version of Magento you are running.
+Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the 'Catalog pagination issue on Elasticsearch 6.x' patch associated with the version of Magento you are running.
 
 ## Highlights
 

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -23,7 +23,7 @@ Although code for these features is bundled with quarterly releases of the Magen
 
 ## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
 
-This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
+This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine.
 Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the 'Catalog pagination issue on Elasticsearch 6.x' patch associated with the version of Magento you are running.
 
 ## Highlights

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -21,6 +21,11 @@ For general information about security-only patches, see the Magento DevBlog pos
 
 Although code for these features is bundled with quarterly releases of the Magento core code, several of these projects (for example, Page Builder, Inventory Management, and Progressive Web Applications (PWA) Studio) are also released independently. Bug fixes for these projects are documented in separate, project-specific release information which is available in the documentation for each project.
 
+## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
+
+This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
+Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the Catalog pagination issue on Elasticsearch 6.x patch associated with the version of Magento you are running.
+
 ## Highlights
 
 Look for the following highlights in this release:

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -24,7 +24,7 @@ Although code for these features is bundled with quarterly releases of the Magen
 ## Apply the Catalog pagination issue on Elasticsearch 6.x patch to resolve a critical search result pagination issue
 
 This patch resolves issues that users of Magento 2.3.3 experience in deployments where  Elasticsearch 6.x is used as the catalog search engine. 
-Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the Catalog pagination issue on Elasticsearch 6.x patch associated with the version of Magento you are running.
+Users who attempt to navigate past the first page of search results are unsuccessful, and Magento displays an error message. After this patch is installed, users will be able to page through all search results. See [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html) for specific instructions on downloading and applying Magento patches. To find the patch, navigate to [Tech Resources](https://magento.com/tech-resources/download), and select the 'Catalog pagination issue on Elasticsearch 6.x' patch associated with the version of Magento you are running.
 
 ## Highlights
 


### PR DESCRIPTION

This pull request (PR) adds information about the October 8 Catalog pagination issue on Elasticsearch patch to the Magento 2.3.3 release notes. 

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html

