### PR TITLE
Fixed ordered list prefix (MD029) - Group 4

### DIFF
--- a/guides/v2.2/marketplace/eqp/auth.md
+++ b/guides/v2.2/marketplace/eqp/auth.md
@@ -6,7 +6,7 @@ title: Authentication
 All API requests must be authenticated using [HTTP Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). The REST APIs use a two-step process to authenticate a client application and authorize access to resources:
 
 1. Obtain a session token using an application ID and secret.
-2. Provide the session token as an HTTP Authorization Bearer header to access a resource.
+1. Provide the session token as an HTTP Authorization Bearer header to access a resource.
 
 First, you must create an application on the [Developer Portal](https://developer.magento.com) to obtain an application ID and secret for sandbox and production endpoints.
 
@@ -17,8 +17,8 @@ Information about how to create applications will be announced when the EQP REST
 
 You must use an application ID and secret to obtain a session token. See the following list for examples of an application ID and secret:
 
-* **id**—AQ17NZ49WC
-* **secret**—8820c99614d65f923df7660276f20e029d73e2ca
+*  **id**—AQ17NZ49WC
+*  **secret**—8820c99614d65f923df7660276f20e029d73e2ca
 
 The following endpoint grants an application session token:
 
@@ -61,10 +61,10 @@ A successful HTTP 200 OK response will be sent for a valid application ID and se
 }
 ```
 
-* The `mage_id` value will identify the user account associated with the client application.
-* The `ust` value (user session token) must be used as the `Authorization Bearer` header for all subsequent API calls.
-* The session token is valid only for the time specified in `expires_in` (seconds).
-* When session token expires, a new token must be obtained as described above.
+*  The `mage_id` value will identify the user account associated with the client application.
+*  The `ust` value (user session token) must be used as the `Authorization Bearer` header for all subsequent API calls.
+*  The session token is valid only for the time specified in `expires_in` (seconds).
+*  When session token expires, a new token must be obtained as described above.
 
 ## Authorization Bearer
 

--- a/guides/v2.2/marketplace/eqp/packages.md
+++ b/guides/v2.2/marketplace/eqp/packages.md
@@ -382,8 +382,8 @@ You can submit a package in either of the following ways:
 *  A single POST request with all required fields set. You must explicitly indicate that you are for technical and marketing review using the `action` parameter.
 *  A series of requests, typically in the following order:
    1. A single POST request with the minimum required fields set and `action` set to `draft` in either `technical`, `marketing`, or both. This request accepts the new package and saves it on the Developer Portal for further updates. It returns a unique `submission_id` for subsequent PUT operations.
-   2. One or more PUT requests in which you configure the package parameters. In these requests, set `action` to `draft` in `technical`, `marketing`, or both.
-   3. A final PUT request indicating submission for `technical`, `marketing`, or both.
+   1. One or more PUT requests in which you configure the package parameters. In these requests, set `action` to `draft` in `technical`, `marketing`, or both.
+   1. A final PUT request indicating submission for `technical`, `marketing`, or both.
 
 You can update one or more parameters in `draft` mode, but the API does not check for validation errors.
 

--- a/guides/v2.2/migration/migration-manually.md
+++ b/guides/v2.2/migration/migration-manually.md
@@ -31,13 +31,13 @@ This section applies to you *only* if you store media files in the Magento datab
 
 1. Log in to the Magento 1 Admin Panel as an administrator.
 
-2. Click **System** > **Configuration** > ADVANCED > **System**.
+1. Click **System** > **Configuration** > ADVANCED > **System**.
 
-3. In the right pane, scroll to **Storage Configuration for Media**.
+1. In the right pane, scroll to **Storage Configuration for Media**.
 
-4. From the **Select Media Database** list, click the name of your [media storage](https://glossary.magento.com/media-storage) database.
+1. From the **Select Media Database** list, click the name of your [media storage](https://glossary.magento.com/media-storage) database.
 
-5. Click **Synchronize**.
+1. Click **Synchronize**.
 
 Then, repeat the same steps in your Magento 2 Admin panel.
 
@@ -49,9 +49,9 @@ However, do *not* copy the `.htaccess` files located in the Magento 1 `media` fo
 
 ## Storefront design
 
-* Design in files (CSS, JS, templates, [XML](https://glossary.magento.com/xml) layouts) changed its location and format
+*  Design in files (CSS, JS, templates, [XML](https://glossary.magento.com/xml) layouts) changed its location and format
 
-* [Layout](https://glossary.magento.com/layout) Updates stored in database. Placed through Magento 1 Admin in [CMS](https://glossary.magento.com/cms) Pages, CMS Widgets, [Category](https://glossary.magento.com/category) Pages and Product Pages
+*  [Layout](https://glossary.magento.com/layout) Updates stored in database. Placed through Magento 1 Admin in [CMS](https://glossary.magento.com/cms) Pages, CMS Widgets, [Category](https://glossary.magento.com/category) Pages and Product Pages
 
 ## Access Control Lists (ACLs)
 
@@ -67,4 +67,4 @@ You may adjust the time zone for a database entity using the `\Migration\Handler
 {:.ref-header}
 Related topics
 
-* <a href="{{ page.baseurl }}/migration/migration-migrate-after.html">After migration</a>
+*  <a href="{{ page.baseurl }}/migration/migration-migrate-after.html">After migration</a>

--- a/guides/v2.2/migration/migration-migrate-data.md
+++ b/guides/v2.2/migration/migration-migrate-data.md
@@ -10,7 +10,7 @@ menu_order: 2
 ## Before you start: routine preparation
 
 1. Log in to Magento server as [the file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. Change to the Magento installation directory or make sure it is added to your system PATH.
+1. Change to the Magento installation directory or make sure it is added to your system PATH.
 
 See the [First steps]({{ page.baseurl }}/migration/migration-migrate.html#migration-command-run-first) section for more details.
 

--- a/guides/v2.2/migration/migration-migrate-settings.md
+++ b/guides/v2.2/migration/migration-migrate-settings.md
@@ -18,7 +18,7 @@ According to our data migration [order]({{ page.baseurl }}/migration/migration-m
 
 1. Log in to Magento server as [the file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 
-2. Change to the Magento `/bin` directory or make sure it is added to your system PATH.
+1. Change to the Magento `/bin` directory or make sure it is added to your system PATH.
 
 {: .bs-callout-info }
 Ensure Magento is deployed in default mode. Developer mode can cause validation errors in the migration tool.
@@ -35,9 +35,9 @@ bin/magento migrate:settings [-r|--reset] {<path to config.xml>}
 
 where:
 
-* `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration
+*  `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration
 
-* `{<path to config.xml>}` is the absolute file system path to the migration tool's [`config.xml`]({{page.baseurl}}/migration/migration-tool-configure.html#migration-configure) file; this argument is required.
+*  `{<path to config.xml>}` is the absolute file system path to the migration tool's [`config.xml`]({{page.baseurl}}/migration/migration-tool-configure.html#migration-configure) file; this argument is required.
 
 {: .bs-callout-info }
 This command does not migrate all configuration settings. Verify all settings in the Magento 2 [Admin](https://glossary.magento.com/admin) before proceeding.
@@ -74,4 +74,4 @@ For more details, see the [Settings migration mode]({{ page.baseurl }}/migration
 
 ## Next migration step
 
-* [Migrate data]({{ page.baseurl }}/migration/migration-migrate-data.html)
+*  [Migrate data]({{ page.baseurl }}/migration/migration-migrate-data.html)

--- a/guides/v2.2/migration/migration-migrate.md
+++ b/guides/v2.2/migration/migration-migrate.md
@@ -17,9 +17,9 @@ During the migration process, **do not:**
 
 1. Make any changes in the Magento 1 [Admin](https://glossary.magento.com/admin) except for order management (shipping, creating invoice, credit memos, etc.)
 
-2. Alter any code
+1. Alter any code
 
-3. Make changes in the Magento 2 Admin and [storefront](https://glossary.magento.com/storefront)
+1. Make changes in the Magento 2 Admin and [storefront](https://glossary.magento.com/storefront)
 
 {: .bs-callout .bs-callout-tip }
 All operations in Magento 1 storefront are allowed at this time.
@@ -46,9 +46,9 @@ where:
 
 1. `<mode>` may be: [`settings`]({{ page.baseurl }}/migration/migration-migrate-settings.html), [`data`]({{ page.baseurl }}/migration/migration-migrate-data.html), or [`delta`]({{ page.baseurl }}/migration/migration-migrate-delta.html)
 
-2. `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration.
+1. `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration.
 
-3. `{<path to config.xml>}` is the absolute file system path to `config.xml`; this argument is required.
+1. `{<path to config.xml>}` is the absolute file system path to `config.xml`; this argument is required.
 
 {: .bs-callout-info }
 Logs are written to the `<magento_root>/var/` directory.
@@ -58,7 +58,7 @@ Logs are written to the `<magento_root>/var/` directory.
 When we created the Data Migration Tool, we assumed the following data transfer sequence:
 
 1. [Settings]({{ page.baseurl }}/migration/migration-migrate-settings.html)
-2. [Data]({{ page.baseurl }}/migration/migration-migrate-data.html)
-3. [Changes]({{ page.baseurl }}/migration/migration-migrate-delta.html)
+1. [Data]({{ page.baseurl }}/migration/migration-migrate-data.html)
+1. [Changes]({{ page.baseurl }}/migration/migration-migrate-delta.html)
 
 That's why we strongly recommend to keep this order to migrate quickly and with no issues.

--- a/guides/v2.2/migration/migration-overview-how.md
+++ b/guides/v2.2/migration/migration-overview-how.md
@@ -7,18 +7,18 @@ This topic provides a high-level overview of how data is migrated from Magento 1
 
 ## Terminology
 
-* **Modes** - an ordered set of operations for migrating data from Magento 1.x to Magento 2.x.
-* **Steps** - the tasks in a mode that define the kinds of data to migrate.
-* **Stages** - the tasks in step that validate, transfer, and verify the data.
-* **Map files** - XML files that define the rules and connections between Magento 1.x and Magento 2.x data structures for completing the stages.
+*  **Modes** - an ordered set of operations for migrating data from Magento 1.x to Magento 2.x.
+*  **Steps** - the tasks in a mode that define the kinds of data to migrate.
+*  **Stages** - the tasks in step that validate, transfer, and verify the data.
+*  **Map files** - XML files that define the rules and connections between Magento 1.x and Magento 2.x data structures for completing the stages.
 
 ## Modes
 
 The Data Migration Tool splits the migration process into three phases or *modes* in order to transfer and adapt data from Magento 1.x to Magento 2.x. The three modes are listed here and must be run in this order:
 
 1. **Settings Mode**: migrates the system configuration and website-related settings.
-2. **Data Mode**: migrates database assets in bulk.
-3. **Delta Mode**: migrates incremental changes (changes since the last run), such as new customers and orders.
+1. **Data Mode**: migrates database assets in bulk.
+1. **Delta Mode**: migrates incremental changes (changes since the last run), such as new customers and orders.
 
 ![Migration Modes]
 
@@ -32,9 +32,9 @@ The Data Migration Tool uses a list of *steps* within each mode to migrate a par
 
 Within each step are three *stages* that are always executed in this order to ensure the data gets properly migrated:
 
-1. **Integrity Check**: Compares the table field names, types,  and other info to verify compatibility between Magento 1 and 2 data structures.
-2. **Data Transfer**: Transfers the data table by table from Magento 1 and 2.
-3. **Volume Check**: Compares the number of records  between tables to verify that the transfer was successful.
+1. **Integrity Check**: Compares the table field names, types, and other info to verify compatibility between Magento 1 and 2 data structures.
+1. **Data Transfer**: Transfers the data table by table from Magento 1 and 2.
+1. **Volume Check**: Compares the number of records between tables to verify that the transfer was successful.
 
 ![Migration Steps]
 

--- a/guides/v2.2/migration/migration-plan.md
+++ b/guides/v2.2/migration/migration-plan.md
@@ -57,21 +57,15 @@ In such migration testing, follow these steps:
 
    For example: the `enterprise_salesarchive_archive_orders` cron job moves old orders to archive. Running this job during migration is safe because the Delta mode takes the job into account and thus properly processes the archived orders.
 
-{:start="4"}
-
 1. Use the Data Migration Tool to migrate settings and websites.
 
 1. Copy your Magento 1.x media files to Magento 2.x.
 
    You must copy these files manually from the `magento1-root/media` directory to `magento2-root/pub/media`.
 
-{:start="6"}
-
 1. Use the Data Migration Tool to bulk copy your data from Magento 1 database to Magento 2 database.
 
    If some of your extensions have data you want to migrate, you might need to install these extensions adapted for Magento 2. In case the extensions have a different structure in Magento 2 database, use the mapping files provided with the Data Migration Tool.
-
-{:start="7"}
 
 1. Reindex all Magento 2.x indexers. For details, see the [Configuration guide].
 

--- a/guides/v2.2/migration/migration-plan.md
+++ b/guides/v2.2/migration/migration-plan.md
@@ -17,21 +17,21 @@ Migration is a perfect moment to make serious changes and get your site ready fo
 
 ## Step 1: Review extensions on your current site
 
-* What extensions have you installed?
+*  What extensions have you installed?
 
-* Have you identified if you need all these extensions on your new site?  (There might be old ones you can safely remove.)
+*  Have you identified if you need all these extensions on your new site?  (There might be old ones you can safely remove.)
 
-* Have you determined if Magento 2 versions of your extensions exist?  (Visit [Magento Marketplace] to find the latest versions or contact your extension provider.)
+*  Have you determined if Magento 2 versions of your extensions exist?  (Visit [Magento Marketplace] to find the latest versions or contact your extension provider.)
 
-* What database assets from your extensions do you want to migrate?
+*  What database assets from your extensions do you want to migrate?
 
 ## Step 2: Build and prepare Magento 2 store for migration
 
-* Set up a Magento 2 hardware system using topology and design that at least matches your existing Magento 1 system
+*  Set up a Magento 2 hardware system using topology and design that at least matches your existing Magento 1 system
 
-* Install Magento 2.x (with all modules of this release) and the Data Migration Tool on a system that meets the [Magento system requirements]
+*  Install Magento 2.x (with all modules of this release) and the Data Migration Tool on a system that meets the [Magento system requirements]
 
-* Make your custom adjustments to the Data Migration Tool code in case you do not need to migrate some data (like CMS Pages, Sales Rules, etc.) or want to convert your Magento customization during migration. Read the Data Migration Tool's [Technical Specification] to better understand how migration works from inside
+*  Make your custom adjustments to the Data Migration Tool code in case you do not need to migrate some data (like CMS Pages, Sales Rules, etc.) or want to convert your Magento customization during migration. Read the Data Migration Tool's [Technical Specification] to better understand how migration works from inside
 
 ## Step 3: Dry run
 
@@ -39,19 +39,19 @@ Before you start migration on the production environment, it would be best to go
 
 In such migration testing, follow these steps:
 
-* Copy your Magento 1 store to a staging server
+*  Copy your Magento 1 store to a staging server
 
-* Fully migrate the replicated Magento 1 store to Magento 2
+*  Fully migrate the replicated Magento 1 store to Magento 2
 
-* Thoroughly test your new store
+*  Thoroughly test your new store
 
 ## Step 4: Start your migration
 
 1. Make sure that the Data Migration Tool has a network access to connect to Magento 1 and Magento 2 databases. Open the corresponding ports in your firewall.
 
-2. Stop all activities in the Magento 1.x Admin Panel, except for order management, such as shipping, creating invoice, credit memos, etc (the list of allowed activities can be extended by adjusting settings of the Delta mode in the Data Migration Tool). **Note:** such activities must not be resumed until your Magento 2 store goes live.
+1. Stop all activities in the Magento 1.x Admin Panel, except for order management, such as shipping, creating invoice, credit memos, etc (the list of allowed activities can be extended by adjusting settings of the Delta mode in the Data Migration Tool). **Note:** such activities must not be resumed until your Magento 2 store goes live.
 
-3. We recommend to stop all Magento 1.x cron jobs.
+1. We recommend to stop all Magento 1.x cron jobs.
 
    Still, if some jobs are required to run during migration, make sure they do not create new database entities or change the existing ones in the way that such entities cannot be processed by the Delta mode.
 
@@ -59,21 +59,21 @@ In such migration testing, follow these steps:
 
 {:start="4"}
 
-4. Use the Data Migration Tool to migrate settings and websites.
+1. Use the Data Migration Tool to migrate settings and websites.
 
-5. Copy your Magento 1.x media files to Magento 2.x.
+1. Copy your Magento 1.x media files to Magento 2.x.
 
    You must copy these files manually from the `magento1-root/media` directory to `magento2-root/pub/media`.
 
 {:start="6"}
 
-6. Use the Data Migration Tool to bulk copy your data from Magento 1 database to Magento 2 database.
+1. Use the Data Migration Tool to bulk copy your data from Magento 1 database to Magento 2 database.
 
    If some of your extensions have data you want to migrate, you might need to install these extensions adapted for Magento 2. In case the extensions have a different structure in Magento 2 database, use the mapping files provided with the Data Migration Tool.
 
 {:start="7"}
 
-7. Reindex all Magento 2.x indexers. For details, see the [Configuration guide].
+1. Reindex all Magento 2.x indexers. For details, see the [Configuration guide].
 
 ## Step 5: Make changes to the migrated data (if needed)
 
@@ -87,9 +87,9 @@ For example, a product deleted from Magento 2: the one that has been bought on y
 
 After migrating data, you must incrementally capture data updates that have been added in the Magento 1 store (such as new orders, reviews, and changes in customer profiles) and transfer these updates to the Magento 2 store using the Delta mode.
 
-* Start the incremental migration; updates will run continually. You can stop transferring updates at any time by pressing `Ctrl+C`
+*  Start the incremental migration; updates will run continually. You can stop transferring updates at any time by pressing `Ctrl+C`
 
-* Test your Magento 2 site during this time to catch any issues as soon as possible. In case of such issues, press `Ctrl+C` to stop incremental migration and start it again after issues are resolved
+*  Test your Magento 2 site during this time to catch any issues as soon as possible. In case of such issues, press `Ctrl+C` to stop incremental migration and start it again after issues are resolved
 
 {: .bs-callout-info }
 Volume check warnings may appear in case you conduct testing of your Magento 2 site and run migration process at the same time. It happens because in Magento 2 you create entities that do not exist in Magento 1 instance.
@@ -100,19 +100,19 @@ Now that your Magento 2 site is up-to-date with Magento 1 and is functioning nor
 
 1. Put your Magento 1 system in maintenance mode (DOWNTIME STARTS).
 
-2. Press Control+C in the migration tool command window to stop incremental updates.
+1. Press Control+C in the migration tool command window to stop incremental updates.
 
-3. Start your Magento 2 cron jobs.
+1. Start your Magento 2 cron jobs.
 
-4. In your Magento 2 system, reindex the stock indexer. For more information, see the [Configuration guide].
+1. In your Magento 2 system, reindex the stock indexer. For more information, see the [Configuration guide].
 
-5. Using a tool of your choice, hit pages in your Magento 2 system to cache pages in advance of customers who use your storefront.
+1. Using a tool of your choice, hit pages in your Magento 2 system to cache pages in advance of customers who use your storefront.
 
-6. Perform any final verification of your Magento 2 site.
+1. Perform any final verification of your Magento 2 site.
 
-7. Change DNS, load balancers, and so on to point to new production hardware (DOWNTIME ENDS).
+1. Change DNS, load balancers, and so on to point to new production hardware (DOWNTIME ENDS).
 
-8. Magento 2 store is now ready to use. You and your customers can resume all activities.
+1. Magento 2 store is now ready to use. You and your customers can resume all activities.
 
 <!-- LINK ADDRESSES -->
 [Magento system requirements]: {{ page.baseurl }}/install-gde/system-requirements-tech.html

--- a/guides/v2.2/migration/migration-tool-install.md
+++ b/guides/v2.2/migration/migration-tool-install.md
@@ -60,8 +60,8 @@ Before installing, make sure you have:
 To install the Data Migration Tool, you must update `composer.json` in the Magento root installation directory to provide the location of the Data Migration Tool package.
 
 1. Log in to your Magento server as, or switch to, <a href="{{ page.baseurl }}/install-gde/prereq/apache-user.html">the Magento file system owner</a>.
-2. Change to Magento 2 root directory.
-3. Enter the following commands:
+1. Change to Magento 2 root directory.
+1. Enter the following commands:
 
    ```bash
    composer config repositories.magento composer https://repo.magento.com
@@ -83,15 +83,15 @@ To install the Data Migration Tool, you must update `composer.json` in the Magen
    composer require magento/data-migration-tool:2.2.0
    ```
 
-4. When prompted, enter your <a href="{{ page.baseurl }}/install-gde/prereq/connect-auth.html">authentication keys</a>. Your public key is your username; your private key is your password.
+1. When prompted, enter your <a href="{{ page.baseurl }}/install-gde/prereq/connect-auth.html">authentication keys</a>. Your public key is your username; your private key is your password.
 
 ### Install from GitHub {#install-github}
 
 If you've cloned Magento 2 from the GitHub repository, follow the steps below to install the Data Migration Tool.
 
 1. Log in to your Magento server as, or switch to, <a href="{{ page.baseurl }}/install-gde/prereq/apache-user.html">the Magento file system owner</a>.
-2. Change to Magento 2 root directory.
-3. Enter the following commands:
+1. Change to Magento 2 root directory.
+1. Enter the following commands:
 
    ```bash
    composer config repositories.data-migration-tool git https://github.com/magento/data-migration-tool
@@ -117,9 +117,9 @@ If you've cloned Magento 2 from the GitHub repository, follow the steps below to
 
 1. Change to your Data Migration Tool directory: `<vendor>/magento/data-migration-tool`.
 
-2. Open [`composer.json`][composer-json] in a text editor.
+1. Open [`composer.json`][composer-json] in a text editor.
 
-3. The `version` entry in that file is the version of the Data Migration Tool.
+1. The `version` entry in that file is the version of the Data Migration Tool.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/migration/migration-tool-internal-spec.md
+++ b/guides/v2.2/migration/migration-tool-internal-spec.md
@@ -261,8 +261,8 @@ Delta functionality is responsible for delivering the rest of data that was adde
 The tool should be run in three different modes in particular order:
 
 1. settings - migration of system settings
-2. data - main migration of data
-3. delta - migration of the rest of data that was added after main migration
+1. data - main migration of data
+1. delta - migration of the rest of data that was added after main migration
 
 Each mode has its own list of steps to be executed. See config.xml
 
@@ -271,7 +271,7 @@ Each mode has its own list of steps to be executed. See config.xml
 Settings migration mode of this tool is used to transfer following entities:
 
 1. Websites, stores, store views.
-2. Store configuration (mainly Stores->Configuration in M2 or System->Configuration in M1)
+1. Store configuration (mainly Stores->Configuration in M2 or System->Configuration in M1)
 
 All store configuration keeps its data in core_config_data table in database. settings.xml file contains rules for this table that are applied during migration process. This file describes settings that should be ignored, renamed or should change their values. settings.xml file has the following structure:
 

--- a/guides/v2.2/migration/migration-tool-upgrade.md
+++ b/guides/v2.2/migration/migration-tool-upgrade.md
@@ -55,8 +55,8 @@ See the [Install Data Migration Tool]({{ page.baseurl }}/migration/migration-too
 ## Upgrade Data Migration Tool {#data-migrate-upgr}
 
 1. Log in to your Magento server as, or switch to, [the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/apache-user.html).
-2. Change to Magento 2 root directory.
-3. Enter the following command:
+1. Change to Magento 2 root directory.
+1. Enter the following command:
 
    ```bash
    composer require magento/data-migration-tool:<version>
@@ -70,7 +70,7 @@ See the [Install Data Migration Tool]({{ page.baseurl }}/migration/migration-too
    composer require magento/data-migration-tool:2.1.2
    ```
 
-4. Wait while the command completes.
+1. Wait while the command completes.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/migration/migration-tool.md
+++ b/guides/v2.2/migration/migration-tool.md
@@ -19,9 +19,9 @@ The Tool operates in three modes:
 
 1. **Settings**: migrates configuration settings
 
-2. **Data**: bulk migrates main data in the database
+1. **Data**: bulk migrates main data in the database
 
-3. **Delta**: transfers incremental data updates, added to Magento 1 [storefront](https://glossary.magento.com/storefront) and [Admin](https://glossary.magento.com/admin) Panel while running previous migration modes
+1. **Delta**: transfers incremental data updates, added to Magento 1 [storefront](https://glossary.magento.com/storefront) and [Admin](https://glossary.magento.com/admin) Panel while running previous migration modes
 
 ## Steps
 

--- a/guides/v2.2/mrg/ee/Staging.md
+++ b/guides/v2.2/mrg/ee/Staging.md
@@ -185,9 +185,9 @@ There are several rules validating updates intersection:
 
 1. Update can be created only in the future. You cannot create an update in a past.
 
-2. Temporary updates cannot intersect with each other. For example, if you have an update for the "New Brand Snowboard" product from December 23 till December 26, a period of another update for "New Brand Snowboard" cannot intersect the period from December 23 till December 26. In other words, one entity cannot have more than one [temporary update](#temporary-update) scheduled to the same time.
+1. Temporary updates cannot intersect with each other. For example, if you have an update for the "New Brand Snowboard" product from December 23 till December 26, a period of another update for "New Brand Snowboard" cannot intersect the period from December 23 till December 26. In other words, one entity cannot have more than one [temporary update](#temporary-update) scheduled to the same time.
 
-3. Permanent update cannot start during temporary update. For example, if you have an update for the "New Brand Snowboard" product from December 23 till December 26, you cannot create [permanent update](#permanent-update) starting during this period of time.
+1. Permanent update cannot start during temporary update. For example, if you have an update for the "New Brand Snowboard" product from December 23 till December 26, you cannot create [permanent update](#permanent-update) starting during this period of time.
 
 #### View/Edit/Copy an update
 

--- a/guides/v2.2/mtf/create_test/create_new_test.md
+++ b/guides/v2.2/mtf/create_test/create_new_test.md
@@ -22,40 +22,40 @@ Create a synonym group (synonyms are a way to expand the scope of eligible match
 **Variation 1:**
 
 1. Log in to [Admin](https://glossary.magento.com/admin).
-2. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
-3. Click the "New Synonyms Group" button.
-4. Enter data in the "Synonyms" field.
-5. Click the "Save Synonym Group" button.
-6. Verify the synonym group saved successfully
+1. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
+1. Click the "New Synonyms Group" button.
+1. Enter data in the "Synonyms" field.
+1. Click the "Save Synonym Group" button.
+1. Verify the synonym group saved successfully
 
 **Variation 2:**
 
 1. Log in to Admin.
-2. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
-3. Click the "New Synonyms Group" button.
-4. Select "All Store Views" in a "Scope" field.
-5. Enter data in the "Synonyms" field.
-6. Click the "Save Synonym Group" button.
-7. Verify the synonym group saved successfully
+1. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
+1. Click the "New Synonyms Group" button.
+1. Select "All Store Views" in a "Scope" field.
+1. Enter data in the "Synonyms" field.
+1. Click the "Save Synonym Group" button.
+1. Verify the synonym group saved successfully
 
 **Variation 3:**
 
 1. Log in to Admin.
-2. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
-3. Click the "New Synonyms Group" button.
-4. Select "Default Store View" in a "Scope" field.
-5. Enter data in the "Synonyms" field.
-6. Click the "Save Synonym Group" button.
-7. Verify the synonym group saved successfully
+1. Browse to "Marketing" > "SEO & Search" > "Search Synonyms".
+1. Click the "New Synonyms Group" button.
+1. Select "Default Store View" in a "Scope" field.
+1. Enter data in the "Synonyms" field.
+1. Click the "Save Synonym Group" button.
+1. Verify the synonym group saved successfully
 
 ### Automated testing scenario {#auto-test}
 
 1. Log in to Admin.
-2. Open the Search Synonym page.
-3. Click the "New Synonym Group" button.
-4. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
-5. Click the "Save Synonym Group" button.
-6. Verify the synonym group saved successfully
+1. Open the Search Synonym page.
+1. Click the "New Synonym Group" button.
+1. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
+1. Click the "Save Synonym Group" button.
+1. Verify the synonym group saved successfully
 
 ### Test creation {#test-creation}
 
@@ -250,9 +250,9 @@ class ScopeId extends DataSource
 This data source:
 
 1. Checks if a field has a `dataset` key in a value that comes from a variation. If it doesn't, then field is assigned a value from the variation.
-2. If it does, then a new Store fixture is created with a `dataset` from a Store repository (`<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Store/Test/Repository/Store.xml`).
-3. Checks if the `store_id` field exists in the Store fixture. If it doesn't, a new Store in Magento is created.
-4. Returns a Store `name` value.
+1. If it does, then a new Store fixture is created with a `dataset` from a Store repository (`<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Store/Test/Repository/Store.xml`).
+1. Checks if the `store_id` field exists in the Store fixture. If it doesn't, a new Store in Magento is created.
+1. Returns a Store `name` value.
 
 We should save it as `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Search/Test/Fixture/Synonym/ScopeId.php`.
 
@@ -367,11 +367,11 @@ use Magento\Search\Test\Fixture\Synonym;
 /**
  * Steps:
  * 1. Log in to Admin.
- * 2. Open the Search Synonym page.
- * 3. Click the "New Synonym Group" button.
- * 4. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
- * 5. Click the "Save Synonym Group" button.
- * 6. Verify the synonym group saved successfully.
+ * 1. Open the Search Synonym page.
+ * 1. Click the "New Synonym Group" button.
+ * 1. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
+ * 1. Click the "Save Synonym Group" button.
+ * 1. Verify the synonym group saved successfully.
  */
 class CreateSynonymEntityTest extends Injectable
 {
@@ -520,8 +520,8 @@ In the next step we will create [blocks][] that implements logic in these pages.
 Let's see in the [test description][] what actions must be performed:
 
 1. Click the "New Synonym Group" button.
-2. Enter data according to a data set.
-3. Click the "Save Synonym Group" button.
+1. Enter data according to a data set.
+1. Click the "Save Synonym Group" button.
 
 **How to code 'Click the "New Synonym Group" button'**
 
@@ -701,10 +701,10 @@ All methods are defined in blocks ([Step 6][]) that are grouped in pages ([Step 
 Remember our test flow:
 
 1. Log in to Admin
-2. Open the Search Synonym page
-3. Click the "New Synonym Group" button
-4. Enter data according to a data set
-5. Click the "Save Synonym Group" button
+1. Open the Search Synonym page
+1. Click the "New Synonym Group" button
+1. Enter data according to a data set
+1. Click the "Save Synonym Group" button
 
 Let's code it!
 
@@ -780,11 +780,11 @@ use Magento\Search\Test\Page\Adminhtml\SynonymsNew;
 /**
  * Steps:
  * 1. Log in to Admin.
- * 2. Open the Search Synonym page.
- * 3. Click the "New Synonym Group" button.
- * 4. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
- * 5. Click the "Save Synonym Group" button.
- * 6. Verify the synonym group saved successfully
+ * 1. Open the Search Synonym page.
+ * 1. Click the "New Synonym Group" button.
+ * 1. Enter data according to a data set. For each variation, the synonyms must have unique identifiers.
+ * 1. Click the "Save Synonym Group" button.
+ * 1. Verify the synonym group saved successfully
  */
 class CreateSynonymEntityTest extends Injectable
 {

--- a/guides/v2.2/mtf/features/parallel_execution.md
+++ b/guides/v2.2/mtf/features/parallel_execution.md
@@ -10,8 +10,8 @@ Parallel execution is applicable for [test suites] only. It decreases the time o
 A general mechanism is:
 
 1. The FTF creates the list of all test cases in a test suite.
-2. The FTF creates the required quantity of sessions corresponding to the quantity of threads defined in `<magento2_root_dir>/dev/tests/functional/phpunit.xml`.
-3. The FTF distributes test cases between sessions. When a sessions is free, a new test case from the queue runs.
+1. The FTF creates the required quantity of sessions corresponding to the quantity of threads defined in `<magento2_root_dir>/dev/tests/functional/phpunit.xml`.
+1. The FTF distributes test cases between sessions. When a sessions is free, a new test case from the queue runs.
 
 Comparatively to the common testing flow
 

--- a/guides/v2.2/mtf/features/reporting.md
+++ b/guides/v2.2/mtf/features/reporting.md
@@ -114,7 +114,7 @@ The list of ready-to-use observers is the following:
 A tag contains name of an event. When you want to process any event by a particular [observer], you need to:
 
 1. [Dispatch][dispatch] the event.
-2. Add a tag with name of the event to required observer in corresponding [event preset].
+1. Add a tag with name of the event to required observer in corresponding [event preset].
 
 In terms of XML, it is represented as an element `<tag />` in `events.xml`. `<tag />` is a child element of an `<observer>` element. See the following example:
 

--- a/guides/v2.2/mtf/features/webdriver.md
+++ b/guides/v2.2/mtf/features/webdriver.md
@@ -9,8 +9,8 @@ The Functional Testing Framework (FTF) enables you to change a web driver [libra
 
 Web drivers provided with the FTF are the following:
 
-- [PHPUnit_Selenium library] (default)
-- [Facebook web driver library]
+-  [PHPUnit_Selenium library] (default)
+-  [Facebook web driver library]
 
 Both implement the [`DriverInterface.php`] interface. The interface declares methods that are used in web page automation such as `click()`, `isVisible()`, `setValue()`, `dragAndDrop()` etc.
 
@@ -23,42 +23,42 @@ Use provided in the FTF web drivers as examples.
 To set up the Facebook web driver, use the following steps:
 
 1. In `<magento2_root_dir>/dev/tests/functional/etc/di.xml`, add the `<preference for="Magento\Mtf\Client\DriverInterface" type="Magento\Mtf\Client\Driver\Facebook\Driver" />` element.
-2. In `<magento2_root_dir>/dev/tests/functional/composer.json`, move the `"facebook/webdriver": "dev-master"` entry from the `"suggest"` list to the `"require"` list.
-3. Run in your terminal:
+1. In `<magento2_root_dir>/dev/tests/functional/composer.json`, move the `"facebook/webdriver": "dev-master"` entry from the `"suggest"` list to the `"require"` list.
+1. Run in your terminal:
 
-```bash
-cd <magento2_root_dir>/dev/tests/functional
-```
+   ```bash
+   cd <magento2_root_dir>/dev/tests/functional
+   ```
 
-```bash
-composer update
-```
+   ```bash
+   composer update
+   ```
 
-{: .bs-callout-info }
-You still need to [run the Selenium Server]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html#mtf_quickstart_env_selenium) in order to run the tests, because at this point the test run procedure is not yet changed.
+   {: .bs-callout-info }
+   You still need to [run the Selenium Server]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html#mtf_quickstart_env_selenium) in order to run the tests, because at this point the test run procedure is not yet changed.
 
 ## Add and setup a custom web driver
 
 To add a custom web driver, you must implement the [`DriverInterface.php`] interface.
 
 1. Create the `<magento2_root_dir>/dev/tests/functional/lib/Magento/Mtf/Client/Driver/<Your_driver>` directory.
-2. In the directory, create the `Driver.php` class which implements [`DriverInterface.php`].
+1. In the directory, create the `Driver.php` class which implements [`DriverInterface.php`].
 
 To setup the custom web driver, follow:
 
 1. In `<magento2_root_dir>/dev/tests/functional/etc/di.xml`, add the `<preference for="Magento\Mtf\Client\DriverInterface" type="Magento\Mtf\Client\Driver\<Your_driver>\Driver" />` element.
-2. In `<magento2_root_dir>/dev/tests/functional/composer.json`, add corresponding entry to the `"require"` list (if related module is available on [Packagist]). And run in your terminal:
+1. In `<magento2_root_dir>/dev/tests/functional/composer.json`, add corresponding entry to the `"require"` list (if related module is available on [Packagist]). And run in your terminal:
 
-```bash
-cd <magento2_root_dir>/dev/tests/functional
-```
+   ```bash
+   cd <magento2_root_dir>/dev/tests/functional
+   ```
 
-```bash
-composer update
-```
+   ```bash
+   composer update
+   ```
 
-{: .bs-callout-info }
-You still need to [run the Selenium Server]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html#mtf_quickstart_env_selenium) in order to run the tests, because at this point the test run procedure is not yet changed.
+   {: .bs-callout-info }
+   You still need to [run the Selenium Server]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html#mtf_quickstart_env_selenium) in order to run the tests, because at this point the test run procedure is not yet changed.
 
 <!-- LINKS DEFINITION -->
 

--- a/guides/v2.2/mtf/mtf_entities/mtf_block.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_block.md
@@ -381,9 +381,9 @@ Renders help to unify a polymorphic behavior of the block. If you want to test t
 A basic flow is the following:
 
 1. Get name and path of the block you want to test
-2. Create block class with logic you need for the tests
-3. Add block to the page
-4. Run the page generator
+1. Create block class with logic you need for the tests
+1. Add block to the page
+1. Run the page generator
 
 #### How to determine a block name and a path {#mtf_block_path}
 
@@ -600,12 +600,12 @@ $this->getCustomOptionsBlock()->getOptions($product);
 There are some rules that should be followed to define a selector:
 
 1. Use [CSS](https://glossary.magento.com/css) and XPath strategies.
-2. To work with forms, use the `name` attribute as a selector.
-3. If an attribute is static (not auto-generated), use the `id` attribute.
-4. If you cannot use `id`, use `data-*` attributes.
-5. We recommend not to use the `class` attribute, because it can be changed and not unique very often.
-6. Do not use complex hard-coded structures like `//div/div[2]//tbody//tr[1]/td[0]`, they can be unpredictably changed.
-7. Do not use enclosed text such as button or label names like `//button[contains(., "Sign in")]`
+1. To work with forms, use the `name` attribute as a selector.
+1. If an attribute is static (not auto-generated), use the `id` attribute.
+1. If you cannot use `id`, use `data-*` attributes.
+1. We recommend not to use the `class` attribute, because it can be changed and not unique very often.
+1. Do not use complex hard-coded structures like `//div/div[2]//tbody//tr[1]/td[0]`, they can be unpredictably changed.
+1. Do not use enclosed text such as button or label names like `//button[contains(., "Sign in")]`
 
 <!-- LINK DEFINITIONS -->
 [page]: {{ page.baseurl }}/mtf/mtf_entities/mtf_page.html

--- a/guides/v2.2/mtf/mtf_entities/mtf_page.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_page.md
@@ -22,9 +22,9 @@ The general flow is the following:
 
 1. Create an [XML](https://glossary.magento.com/xml) file in the Page directory of the module to which it belongs
 
-2. Add the previously created blocks presented on this page to the `<page>` node
+1. Add the previously created blocks presented on this page to the `<page>` node
 
-3. Run the page generator
+1. Run the page generator
 
 Let's see an example of the Magento [Widget](https://glossary.magento.com/widget) page:
 

--- a/guides/v2.2/mtf/mtf_installation.md
+++ b/guides/v2.2/mtf/mtf_installation.md
@@ -27,7 +27,7 @@ In `php.ini` file, make sure `extension=php_openssl.dll` is not commented out.
 #### Check if the Functional Testing Framework has been already installed {#mtf_install_pre_mtf-check}
 
 1. Find directory `<magento2_root_dir>/dev/tests/functional/`.
-2. Find the `vendor` directory. If the directory exists, you already have the Functional Testing Framework installed in `vendor/magento/mtf`.
+1. Find the `vendor` directory. If the directory exists, you already have the Functional Testing Framework installed in `vendor/magento/mtf`.
 
 ## Perform the installation {#mtf_install_perform}
 
@@ -37,7 +37,7 @@ The Functional Testing Framework requires Composer, which downloads libraries de
 If you're not sure that Composer is installed, see [Install Composer][].
 
 1. [Open a command prompt][].
-2. Log in to your Magento server as a user with permissions to modify the Magento file system. (This is typically [the Magento file system owner][].)
+1. Log in to your Magento server as a user with permissions to modify the Magento file system. (This is typically [the Magento file system owner][].)
 
 ```bash
 cd <magento2_root_dir>/dev/tests/functional/

--- a/guides/v2.2/mtf/mtf_quickstart/mtf_quickstart_magento.md
+++ b/guides/v2.2/mtf/mtf_quickstart/mtf_quickstart_magento.md
@@ -8,9 +8,9 @@ title: Quick start. Prepare Magento application
 A Selenium web-driver cannot enter data to fields with [WYSIWYG](https://glossary.magento.com/wysiwyg). This option disables the WYSIWYG and enables the web-driver to process these fields as simple text areas.
 
 1. Log in to the [Magento Admin](https://glossary.magento.com/magento-admin) as an administrator.
-2. Follow **Stores &gt; Configuration &gt; General &gt; Content Management &gt; WYSIWYG Options**.
-3. Set **Enable WYSIWYG Editor** to **Disabled Completely**.
-4. Click **Save Config**.
+1. Follow **Stores &gt; Configuration &gt; General &gt; Content Management &gt; WYSIWYG Options**.
+1. Set **Enable WYSIWYG Editor** to **Disabled Completely**.
+1. Click **Save Config**.
 
 ![Change content settings]({{ site.baseurl }}/common/images/ftf/mtf_qstart_mag_wysiwyg.png){:width="650px"}
 
@@ -19,20 +19,20 @@ A Selenium web-driver cannot enter data to fields with [WYSIWYG](https://glossar
 Enable the **Admin Account Sharing** setting to avoid unpredictable logout during testing session. And disable the **Add Secret Key in URLs** setting to open pages using direct URLs.
 
 1. Follow **Stores &gt; Configuration &gt; Advanced &gt; [Admin](https://glossary.magento.com/admin) &gt; Security**.
-2. Set **Admin Account Sharing** to **Yes**.
-3. Set **Add Secret Key to URLs** to **No**.
+1. Set **Admin Account Sharing** to **Yes**.
+1. Set **Add Secret Key to URLs** to **No**.
 
 ![Change security settings]({{ site.baseurl }}/common/images/ftf/mtf_qstart_mag_secur.png){:width="650px"}
 
 ## Refresh page cache
 
-* Go to **Cache Management**.
+*  Go to **Cache Management**.
 
 ![Cache Management message]({{ site.baseurl }}/common/images/ftf/mtf_cache_mngt.png){:width="650px"}
 
-* Select the checkboxes next to **Configuration** and **Page Cache**.
-* From the **Actions** list in the upper left, click **Refresh**.
-* Click **Submit**.
+*  Select the checkboxes next to **Configuration** and **Page Cache**.
+*  From the **Actions** list in the upper left, click **Refresh**.
+*  Click **Submit**.
 
 ## Enable CLI commands
 
@@ -67,4 +67,3 @@ location ~* ^/dev/tests/functional/utils($|/) {
 ```
 
 [&lt;&lt; Adjust configuration]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html) | [Prepare environment for test run &gt;&gt;]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
-

--- a/guides/v2.3/migration/migration-migrate-settings.md
+++ b/guides/v2.3/migration/migration-migrate-settings.md
@@ -18,7 +18,7 @@ According to our data migration [order]({{ page.baseurl }}/migration/migration-m
 
 1. Log in to Magento server as [the file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 
-2. Change to the Magento `/bin` directory or make sure it is added to your system PATH.
+1. Change to the Magento `/bin` directory or make sure it is added to your system PATH.
 
 {: .bs-callout-info }
 Ensure Magento is deployed in default mode. Developer mode can cause validation errors in the migration tool.
@@ -35,9 +35,9 @@ bin/magento migrate:settings [-r|--reset] {<path to config.xml>}
 
 where:
 
-* `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration
+*  `[-r|--reset]` is an optional argument that starts migration from the beginning. You can use this argument for testing migration
 
-* `{<path to config.xml>}` is the absolute file system path to the migration tool's [`config.xml`]({{page.baseurl}}/migration/migration-tool-configure.html#migration-configure) file; this argument is required.
+*  `{<path to config.xml>}` is the absolute file system path to the migration tool's [`config.xml`]({{page.baseurl}}/migration/migration-tool-configure.html#migration-configure) file; this argument is required.
 
 {: .bs-callout-info }
 This command does not migrate all configuration settings. Verify all settings in the Magento 2 [Admin](https://glossary.magento.com/admin) before proceeding.
@@ -74,4 +74,4 @@ For more details, see the [Settings migration mode]({{ page.baseurl }}/migration
 
 ## Next migration step
 
-* [Migrate data]({{ page.baseurl }}/migration/migration-migrate-data.html)
+*  [Migrate data]({{ page.baseurl }}/migration/migration-migrate-data.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- Marketplace
- Migration
- MRG (2.2 only)
- MTF

The MD)29 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.