### PR TITLE
Fixed ordered list prefix (MD029) - Group 5

### DIFF
--- a/guides/v2.2/install-gde/basics/basics_docroot.md
+++ b/guides/v2.2/install-gde/basics/basics_docroot.md
@@ -53,7 +53,7 @@ To find the docroot on your server:
         /etc/nginx/nginx.conf (nginx)
         ```
 
-2. Search the file for `DocumentRoot` or `root`.
+1. Search the file for `DocumentRoot` or `root`.
 
    Typically, the default Apache docroot on Ubuntu _and_ CentOS is `/var/www/html` whereas the default nginx docroot on CentOS is `/usr/share/nginx/html`. For example:
 

--- a/guides/v2.2/install-gde/install-quick-ref.md
+++ b/guides/v2.2/install-gde/install-quick-ref.md
@@ -41,14 +41,14 @@ If not, see the [Installation overview]({{ page.baseurl }}/install-gde/bk-instal
 ## Installation part 1: Getting started
 
 1. See the [system requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
-2. If your system lacks any requirements, see the prerequisites documentation:
+1. If your system lacks any requirements, see the prerequisites documentation:
 
    *  [Apache]({{ page.baseurl }}/install-gde/prereq/apache.html)
    *  [PHP]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
    *  [MySQL]({{ page.baseurl }}/install-gde/prereq/mysql.html)
 
-3. ust as importantly, set up the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) on the server.
-4. Switch to the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
+1. ust as importantly, set up the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) on the server.
+1. Switch to the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
 
 ### Get the Magento software
 

--- a/guides/v2.2/install-gde/install/cli/dev_add-update.md
+++ b/guides/v2.2/install-gde/install/cli/dev_add-update.md
@@ -18,7 +18,7 @@ To update components if you're *not* a contributing developer, see [Updating the
 You can either add a `require` section to `composer.json` or you can use the `composer require` command as follows:
 
 1. Log in to the Magento server, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
-2. Change to the directory to which you cloned the Magento application. For example,
+1. Change to the directory to which you cloned the Magento application. For example,
 
     ```bash
     cd /var/www/magento2

--- a/guides/v2.2/install-gde/install/hosted/hosted_start_db.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_start_db.md
@@ -17,24 +17,24 @@ To configure a MySQL database and database user:
 
    ![Start out creating a database]({{ site.baseurl }}/common/images/install-merch_conf-db.png){:width="550px"}
 
-2. In the **New Database** field, enter a unique name for your database and click **Create Database**.
+1. In the **New Database** field, enter a unique name for your database and click **Create Database**.
 
    ![Create a database]({{ site.baseurl }}/common/images/install-merch_create-db.png){:width="550px"
 
-3. In the MySQL Users section, enter information in the provided fields and click **Create User**.
+1. In the MySQL Users section, enter information in the provided fields and click **Create User**.
 
    {:.bs-callout .bs-callout-info}
    Give the database user a strong password and <em>write down</em> the username and password you choose. You can optionally click **Password Generator** to create a strong password for you.
 
    ![Create a database user]({{ site.baseurl }}/common/images/install-merch_create-db-user.png){:width="550px"}
 
-4. In the Add User to Database section, click the name of your Magento database and database user from the respective fields and click **Add**.
+1. In the Add User to Database section, click the name of your Magento database and database user from the respective fields and click **Add**.
 
    ![Add the user to the database]({{ site.baseurl }}/common/images/install-merch_add-user-to-db.png){:width="350px"}
 
    The Manage User Privileges page displays.
 
-5. Select the **ALL PRIVILEGES** checkbox at the top of the page and click **Make Changes**.
+1. Select the **ALL PRIVILEGES** checkbox at the top of the page and click **Make Changes**.
 
    ![Give the database user all privileges to the database]({{ site.baseurl }}/common/images/install-merch_db-user-privs.png){:width="750px"}
 

--- a/guides/v2.2/install-gde/install/hosted/hosted_start_php.md
+++ b/guides/v2.2/install-gde/install/hosted/hosted_start_php.md
@@ -16,23 +16,23 @@ functional_areas:
 To configure PHP:
 
 1. If necessary, start the cPanel and click **Home** to return to the [home page](https://glossary.magento.com/home-page).
-2. In the Software section, click **Select PHP Version**.
+1. In the Software section, click **Select PHP Version**.
 
    ![Start out configuring PHP]({{ site.baseurl }}/common/images/install-merch_php.png){:width="550px"}
 
-3. From the **PHP Version** list at the top of the page, click either **5.5** or **5.6**.
+1. From the **PHP Version** list at the top of the page, click either **5.5** or **5.6**.
 
-4. Click **Set as current**.
+1. Click **Set as current**.
 
    The checkboxes following the PHP version are referred to as *PHP extensions*.
 
-4. Select all of the following checkboxes: **gd**, **intl**, **mbstring**, **mcrypt**, **opcache**, **pdo**, **pdo_mysql**, and **xsl**.
+1. Select all of the following checkboxes: **gd**, **intl**, **mbstring**, **mcrypt**, **opcache**, **pdo**, **pdo_mysql**, and **xsl**.
 
    You can optionally select other PHP extensions if you want.
 
    ![Select PHP extensions]({{ site.baseurl }}/common/images/install-merch_php-ext.png){:width="750px"}
 
-5. Click **Save**.
+1. Click **Save**.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/install-gde/install/prepare-install.md
+++ b/guides/v2.2/install-gde/install/prepare-install.md
@@ -14,8 +14,8 @@ We now use [Composer](http://getcomposer.org) to resolve dependencies before you
 [Composer](https://glossary.magento.com/composer) is a separate application that manages [PHP](https://glossary.magento.com/php) dependencies. Before you can install the Magento software, you must perform the following tasks in the order shown:
 
 1. [Install the Composer software]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
-2. [Create the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) so Composer writes files to the web server docroot as the correct user.
-3. Run the [<code>composer install</code> command](#install-composer-install) from your Magento root directory (for example, `/var/www/magento2/`).
+1. [Create the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html) so Composer writes files to the web server docroot as the correct user.
+1. Run the [<code>composer install</code> command](#install-composer-install) from your Magento root directory (for example, `/var/www/magento2/`).
 
 The Magento root directory is a subdirectory of your web server's docroot. Need help locating the docroot? Click [here]({{ page.baseurl }}/install-gde/basics/basics_docroot.html).
 
@@ -32,17 +32,21 @@ For you to be able to run the Magento application, make sure you perform all tas
 Update installation dependencies as follows:
 
 1. Log in to your Magento server as the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner) or [switch to that user]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. Change to the Magento installation directory and run `composer install`. Examples:
+1. Change to the Magento installation directory and run `composer install`. Examples:
 
-    CentOS:
+   CentOS:
 
-        cd /var/www/html/magento2 && composer install
+   ```bash
+   cd /var/www/html/magento2 && composer install
+   ```
 
-    Ubuntu:
+   Ubuntu:
 
-        cd /var/www/magento2 && composer install
+   ```bash
+   cd /var/www/magento2 && composer install
+   ```
 
-    This command updates package dependencies and can take a few minutes to complete.
+   This command updates package dependencies and can take a few minutes to complete.
 
 The following error might display:
 
@@ -60,5 +64,5 @@ Related topics
 
 Install the Magento software:
 
-* [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-* [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+*  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+*  [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)

--- a/guides/v2.2/install-gde/prereq/install-rabbitmq.md
+++ b/guides/v2.2/install-gde/prereq/install-rabbitmq.md
@@ -22,7 +22,7 @@ Message queues provide an asynchronous communications mechanism in which the sen
 The message queue system must be established before you install Magento. The basic sequence is
 
 1. Install RabbitMQ and any prerequisites.
-2. Connect RabbitMQ and Magento.
+1. Connect RabbitMQ and Magento.
 
 {:.bs-callout .bs-callout-info}
 A basic message queue system can be implemented on {{site.data.var.ee}} using cron instead of RabbitMQ. See [Configure message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html) for more information.
@@ -30,6 +30,7 @@ A basic message queue system can be implemented on {{site.data.var.ee}} using cr
 ## Install RabbitMQ on Ubuntu {#ubuntu-install}
 
 To install RabbitMQ on Ubuntu 16 enter the following command:
+
 ```bash
 sudo apt install -y rabbitmq-server
 ```
@@ -39,7 +40,7 @@ This command also installs the required Erlang packages.
 If you have an older version of Ubuntu, RabbitMQ recommends installing the package from their [website](https://glossary.magento.com/website).
 
 1. Download [rabbitmq-server_3.6.6-1_all.deb](https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.6/rabbitmq-server_3.6.6-1_all.deb).
-2. Install the package with `dpkg`.
+1. Install the package with `dpkg`.
 
 Refer to [Installing on Debian/Ubuntu](https://www.rabbitmq.com/install-debian.html) for more information.
 
@@ -52,9 +53,11 @@ RabbitMQ was written using the Erlang programming language, which must be instal
 See [Manual installation](https://www.erlang-solutions.com/resources/download.html) for more information.
 
 Run the following commands to install this feature.
+
 ```bash
 wget http://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
 ```
+
 ```bash
 rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 ```
@@ -64,11 +67,12 @@ rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 The RabbitMQ server is included on CentOS, but the version is often old. RabbitMQ recommends installing the package from their website.
 
 1. Download [rabbitmq-server-3.5.6-1.noarch.rpm](https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.6/rabbitmq-server-3.5.6-1.noarch.rpm).
-2. Run the following commands as a user with root permissions:
+1. Run the following commands as a user with root permissions:
 
 ```bash
 rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
 ```
+
 ```bash
 yum install rabbitmq-server-3.5.6-1.noarch.rpm
 ```
@@ -79,11 +83,11 @@ Refer to [Installing on RPM-based Linux](https://www.rabbitmq.com/install-rpm.ht
 
 Review the official RabbitMQ documentation to configure and manage RabbitMQ. Pay attention to the following items:
 
-* Environment variables
-* Port access
-* Default user accounts
-* Starting and stopping the broker
-* System limits
+*  Environment variables
+*  Port access
+*  Default user accounts
+*  Starting and stopping the broker
+*  System limits
 
 ## Connect RabbitMQ to {{site.data.var.ee}}
 

--- a/guides/v2.2/install-gde/prereq/optional.md
+++ b/guides/v2.2/install-gde/prereq/optional.md
@@ -68,7 +68,7 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
 
 1. Open `/etc/ntp.conf` in a text editor.
 
-2. Look for lines similar to the following:
+1. Look for lines similar to the following:
 
    ```conf
    server 0.centos.pool.ntp.org
@@ -76,9 +76,9 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
    server 2.centos.pool.ntp.org
    ```
 
-3. Replace those lines or add additional lines that specify your NTP pool server or other NTP servers. It's a good idea to specify more than one.
+1. Replace those lines or add additional lines that specify your NTP pool server or other NTP servers. It's a good idea to specify more than one.
 
-4. An example of using three United States-based NTP servers follows:
+1. An example of using three United States-based NTP servers follows:
 
    ```conf
    server 0.us.pool.ntp.org
@@ -86,15 +86,15 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
    server 2.us.pool.ntp.org
    ```
 
-5. Save your changes to `/etc/ntp.conf` and exit the text editor.
+1. Save your changes to `/etc/ntp.conf` and exit the text editor.
 
-4. Restart the service.
+1. Restart the service.
 
-   * Ubuntu: `service ntp restart`
+   *  Ubuntu: `service ntp restart`
 
-   * CentOS: `service ntpd restart`
+   *  CentOS: `service ntpd restart`
 
-4. Enter `date` to check the server's date.
+1. Enter `date` to check the server's date.
 
    If the date is incorrect, make sure the NTP client port (typically, UDP 123) is open in your firewall.
 
@@ -103,6 +103,7 @@ Selecting pool servers is up to you. If you use NTP pool servers, ntp.org recomm
    If all else fails, try rebooting the server.
 
 ## Create phpinfo.php {#install-optional-phpinfo}
+
 [`phpinfo.php`](http://php.net/manual/en/function.phpinfo.php){:target="_blank"} displays a large amount of information about [PHP](https://glossary.magento.com/php) and its extensions.
 
 {:.bs-callout .bs-callout-info}
@@ -154,15 +155,15 @@ To install phpmyadmin on Ubuntu:
    apt-get install phpmyadmin
    ```
 
-2. Follow the prompts on your screen to complete the installation.
+1. Follow the prompts on your screen to complete the installation.
 
-3. To use phpmyadmin, enter the following URL in your browser's address or location field:
+1. To use phpmyadmin, enter the following URL in your browser's address or location field:
 
    ```http
    http://<web server host or IP>/phpmyadmin
    ```
 
-4. When prompted, log in using your MySQL database `root` or administrative user's username and password.
+1. When prompted, log in using your MySQL database `root` or administrative user's username and password.
 
 ## Install phpmyadmin on CentOS {#install-optional-phpmyadmin-centos}
 

--- a/guides/v2.2/install-gde/trouble/php/tshoot_70pct.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_70pct.md
@@ -25,11 +25,11 @@ Set all of the following as appropriate.
 #### All web servers and Varnish
 
 1. Locate your `php.ini` using a [`phpinfo.php`]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo) file.
-2. As a user with `root` privileges, open `php.ini` in a text editor.
-3. Locate the `max_execution_time` setting.
-4. Change its value to `18000`.
-5. Save your changes to `php.ini` and exit the text editor.
-6. Restart Apache:
+1. As a user with `root` privileges, open `php.ini` in a text editor.
+1. Locate the `max_execution_time` setting.
+1. Change its value to `18000`.
+1. Save your changes to `php.ini` and exit the text editor.
+1. Restart Apache:
 
    *  CentOS: `service httpd restart`
    *  Ubuntu: `service apache2 restart`

--- a/guides/v2.2/install-gde/trouble/php/tshoot_opcache.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_opcache.md
@@ -57,17 +57,17 @@ If you have more than one `opcache.ini`, modify all of them.
 #### Step 2: Enable `opcache.save_comments`
 
 1. Open your OPcache configuration file in a text editor.
-2. Locate `opcache.save_comments` and uncomment it if necessary.
-3. Make sure its value is set to `1`.
-4. Save your changes and exit the text editor.
-5. Restart your web server:
+1. Locate `opcache.save_comments` and uncomment it if necessary.
+1. Make sure its value is set to `1`.
+1. Save your changes and exit the text editor.
+1. Restart your web server:
 
    *  Apache, Ubuntu: `service apache2 restart`
    *  Apache, CentOS: `service httpd restart`
    *  nginx, Ubuntu and CentOS: `service nginx restart`
 
-6. Regenerate DI configuration and all missing classes that can be auto-generated:
+1. Regenerate DI configuration and all missing classes that can be auto-generated:
 
-    ```bash
-    bin/magento setup:di:compile`
-    ```
+   ```bash
+   bin/magento setup:di:compile`
+   ```

--- a/guides/v2.2/install-gde/trouble/php/tshoot_session.md
+++ b/guides/v2.2/install-gde/trouble/php/tshoot_session.md
@@ -47,8 +47,8 @@ Typical locations follow:
 ### Workaround
 
 1. As a user with `root` privileges, open `php.ini` in a text editor.
-2. Locate `session.save_handler`
-3. Set it in any of the following ways:
+1. Locate `session.save_handler`
+1. Set it in any of the following ways:
 
    *  To comment it out:
 

--- a/guides/v2.2/install-gde/tutorials/change-docroot-to-pub.md
+++ b/guides/v2.2/install-gde/tutorials/change-docroot-to-pub.md
@@ -34,11 +34,11 @@ The sample configuration overrides your server's docroot settings to serve files
 
 To complete this tutorial, you'll need access to a working Magento installation running on a [LAMP](https://en.wikipedia.org/wiki/LAMP_(software_bundle)){:target="_blank"} stack:
 
--   Linux
--   Apache (2.2+)
--   MySQL (5.6+)
--   PHP (5.6 or 7.0)
--   Magento (2.0+)
+-  Linux
+-  Apache (2.2+)
+-  MySQL (5.6+)
+-  PHP (5.6 or 7.0)
+-  Magento (2.0+)
 
 {:.bs-callout .bs-callout-info}
 Refer to [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html) and the [Installation Guide]({{ page.baseurl }}/install-gde/bk-install-guide.html) for more information.
@@ -47,30 +47,33 @@ Refer to [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.h
 
 The name and location of your virtual host file depends on which version of Apache you're running. This example shows the name and location of the virtual host file on Apache v2.4.
 
-1.  Log in to your Magento server.
-2.  Edit your virtual host file:
+1. Log in to your Magento server.
+1. Edit your virtual host file:
 
         vim /etc/apache2/sites-available/000-default.conf
 
-3.  Add the path to your Magento `pub/` directory to the `DocumentRoot` directive:
+1. Add the path to your Magento `pub/` directory to the `DocumentRoot` directive:
 
-    ```
-    <VirtualHost *:80>
+   ```conf
+   <VirtualHost *:80>
 
-            ServerAdmin webmaster@localhost
-            DocumentRoot /var/www/html/magento2ce/pub
+           ServerAdmin webmaster@localhost
+           DocumentRoot /var/www/html/magento2ce/pub
 
-            ErrorLog ${APACHE_LOG_DIR}/error.log
-            CustomLog ${APACHE_LOG_DIR}/access.log combined
+           ErrorLog ${APACHE_LOG_DIR}/error.log
+           CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-            <Directory "/var/www/html">
-                        AllowOverride all
-            </Directory>
-    </VirtualHost>
-    ```
-4.  Restart Apache:
+           <Directory "/var/www/html">
+                       AllowOverride all
+           </Directory>
+   </VirtualHost>
+   ```
 
-        systemctl restart apache2
+1. Restart Apache:
+
+   ```bash
+   systemctl restart apache2
+   ```
 
 ## 2. Update your base URL
 
@@ -79,54 +82,70 @@ If you appended a directory name to your server's hostname or IP address to crea
 {: .bs-callout-info }
 Replace `192.168.33.10` with your server's hostname.
 
-1.  Log in to the Magento database:
+1. Log in to the Magento database:
 
-        mysql -u <user> -p
+   ```bash
+   mysql -u <user> -p
+   ```
 
-2.  Specify the Magento database you created when you installed Magento:
+1. Specify the Magento database you created when you installed Magento:
 
-        use <database-name>
+   ```shell
+   use <database-name>
+   ```
 
-3.  Update the base URL:
+1. Update the base URL:
 
-        UPDATE core_config_data SET value='http://192.168.33.10' WHERE path='web/unsecure/base_url';
+   ```shell
+   UPDATE core_config_data SET value='http://192.168.33.10' WHERE path='web/unsecure/base_url';
+   ```
 
 ## 3. Switch modes
 [Magento modes]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html), which include `production` and `developer`, are designed to improve security and make development easier. As the names suggest, you should switch to `developer` mode when extending or customizing Magento and switch to `production` mode when running Magento in a live environment.
 
 Switching between modes is an important step in verifying that your server configuration is working properly. You can switch between modes using the Magento CLI tool:
 
-1.  Go to your Magento installation directory.
-2.  Switch to `production` mode.
+1. Go to your Magento installation directory.
+1. Switch to `production` mode.
 
-        bin/magento deploy:mode:set production
-        bin/magento cache:flush
+   ```bash
+   bin/magento deploy:mode:set production
+   ```
 
-3.  Refresh your browser and verify that the storefront displays properly.
-4.  Switch to `developer` mode.
+   ```bash
+   bin/magento cache:flush
+   ```
 
-        bin/magento deploy:mode:set developer
-        bin/magento cache:flush
+1. Refresh your browser and verify that the storefront displays properly.
+1. Switch to `developer` mode.
 
-5.  Refresh your browser and verify that the storefront displays properly.
+   ```bash
+   bin/magento deploy:mode:set developer
+   ```
+
+   ```bash
+   bin/magento cache:flush
+   ```
+
+1. Refresh your browser and verify that the storefront displays properly.
 
 ## 4. Verify the storefront
 
 Go to the [storefront](https://glossary.magento.com/storefront) in a web browser to verify that everything is working.
 
-1.  Open a web browser and enter your server's hostname or IP address in the address bar. For example, http://192.168.33.10.
+1. Open a web browser and enter your server's hostname or IP address in the address bar. For example, http://192.168.33.10.
 
-    The following figure shows a sample storefront page. If it displays as follows, your installation was a success!
+   The following figure shows a sample storefront page. If it displays as follows, your installation was a success!
 
-    ![Magento storefront which verifies a successful installation]({{ site.baseurl }}/common/images/install-success_store.png){:.width="450px"}
+   ![Magento storefront which verifies a successful installation]({{ site.baseurl }}/common/images/install-success_store.png){:.width="450px"}
 
-    Refer to the [troubleshooting section]({{ page.baseurl }}/install-gde/trouble/tshoot_no-styles.html) if the page displays a 404 (Not Found) or fails to load other assets like images, CSS, and JS.
+   Refer to the [troubleshooting section]({{ page.baseurl }}/install-gde/trouble/tshoot_no-styles.html) if the page displays a 404 (Not Found) or fails to load other assets like images, CSS, and JS.
 
-2.  Try accessing the Magento directory for the Web Setup Wizard from a browser. Append "_setup/_" to your server's hostname or IP address in the address bar:
+1. Try accessing the Magento directory for the Web Setup Wizard from a browser. Append "_setup/_" to your server's hostname or IP address in the address bar:
 
-    If you see a 404 or the "Access denied" message, you've successfully restricted access to the Magento file system.
+   If you see a 404 or the "Access denied" message, you've successfully restricted access to the Magento file system.
 
-    ![Access denied]({{ site.baseurl }}/common/images/access-denied.png)
+   ![Access denied]({{ site.baseurl }}/common/images/access-denied.png)
 
 ## Congratulations! You're finished.
 {:.no_toc}

--- a/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/custom_js.md
@@ -18,11 +18,11 @@ To add a custom JS component (module), take the following steps:
    -  Your theme JS files: `<theme_dir>/web/js` or `<theme_dir>/<VendorName>_<ModuleName>/web/js`. In this case the component is available in your theme and its [child themes]({{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html).
    -  Your module view JS files: `<module_dir>/view/frontend/web/js`. In this case the component is available in all modules and themes (if your module is enabled).
 
-2. Optionally, in the corresponding [module](https://glossary.magento.com/module) or theme, create a `requirejs-config.js` configuration file, if it does not yet exist there and set path for your resource. The RequireJS configuration file can be placed in one of the following locations:
+1. Optionally, in the corresponding [module](https://glossary.magento.com/module) or theme, create a `requirejs-config.js` configuration file, if it does not yet exist there and set path for your resource. The RequireJS configuration file can be placed in one of the following locations:
 
--  Your theme: `<theme_dir>`
--  Module within your theme: `<theme_dir>/<module_dir>`
--  Your module (depending on the needed area - **base**, **frontend**, **adminhtml**): `<module_dir>/view/<area>`
+   -  Your theme: `<theme_dir>`
+   -  Module within your theme: `<theme_dir>/<module_dir>`
+   -  Your module (depending on the needed area - **base**, **frontend**, **adminhtml**): `<module_dir>/view/<area>`
 
 ## Replace a default JS component {#js_replace}
 
@@ -150,7 +150,7 @@ To disable the auto-loading of default Magento JS components and widget initiali
     var config = { deps: [ ] };
     ```
 
-2. Put the `requirejs-config.js` file in one of the following
+1. Put the `requirejs-config.js` file in one of the following
   locations:
 
    -  Your custom theme files: `<theme_dir>`

--- a/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
@@ -41,10 +41,10 @@ JS resources are accessed using relative paths.
 *  File published to `pub/static`: `pub/static/frontend/Magento/<theme>/<locale>/Magento_ConfigurableProduct/js/configurable.js`. Here `<theme>` and `<locale>` are the currently applied in your instance [theme](https://glossary.magento.com/theme) and [locale](https://glossary.magento.com/locale).
 *  Called in script:
 
-   ```javascript
+    ```javascript
     require(["Magento_ConfigurableProduct/js/configurable"], function(Configurable){
     });
-   ```
+    ```
 
 **Example 2**
 
@@ -52,10 +52,10 @@ JS resources are accessed using relative paths.
 *  File published to `pub/static`: `pub/static/frontend/Magento/<theme>/<locale>/js/theme.js`
 *  Called in script:
 
-  ```javascript
-    require(["js/theme.js"], function(){
-    });
-  ```
+   ```javascript
+   require(["js/theme.js"], function(){
+   });
+   ```
 
 **Example 3**
 
@@ -63,10 +63,10 @@ JS resources are accessed using relative paths.
 *  File published to `pub/static`: `pub/static/<area>/Magento/<theme>/<locale>/jquery.js`
 *  Called in script:
 
-   ```javascript
+    ```javascript
     require(["jquery"], function($){
     });
-   ```
+    ```
 
 Relative paths are also used in for [mapping and setting `paths` in requirejs-config.js configuration files]({{ page.baseurl }}/javascript-dev-guide/javascript/js-resources.html).
 
@@ -144,14 +144,14 @@ To include a 3rd party library and use it within the entire website (using the [
 
 1. Download the library and copy `slick.min.js` to the `<theme_path>/web/js` folder
 
-2. Copy `slick.less` and `slick-theme.less` to the `<theme_path>/web/css/source` folder. Also add both files to `<theme_path>/web/css/source/_extend.less`.
+1. Copy `slick.less` and `slick-theme.less` to the `<theme_path>/web/css/source` folder. Also add both files to `<theme_path>/web/css/source/_extend.less`.
 
    ```less
    @import "slick.less";
    @import "slick-theme.less";
    ```
 
-3. Create or update the theme's `requirejs-config.js` file.
+1. Create or update the theme's `requirejs-config.js` file.
 
    `<theme_path>/requirejs-config.js`
 
@@ -213,11 +213,11 @@ To make configurations more precise and specific to different modules and themes
 All configurations are collected and executed in the following order:
 
 1. Library configurations.
-2. Configurations at the module level.
-3. Configurations at the theme module level for the ancestor themes.
-4. Configurations at the theme module level for a current theme.
-5. Configurations at the theme level for the ancestor themes.
-6. Configurations at the theme level for the current theme.
+1. Configurations at the module level.
+1. Configurations at the theme module level for the ancestor themes.
+1. Configurations at the theme module level for a current theme.
+1. Configurations at the theme level for the ancestor themes.
+1. Configurations at the theme level for the current theme.
 
 The `baseUrl` parameter for RequireJS is specified in the following files:
 

--- a/guides/v2.2/javascript-dev-guide/javascript/js_debug.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/js_debug.md
@@ -14,17 +14,18 @@ This topic discusses how to define which [JavaScript](https://glossary.magento.c
 
 To locate scripts used for a certain element:
 
-1.  Open the store page in a browser, and locate the element\'s `class` or `id` using browser debugging tools, such as Firebug (Firefox) or Inspect Element (Chrome).
-2.  Select to view the page source.
-3.  Find the corresponding element in the page source and see if there are `data-mage-init` or `<script type="text/x-magento-init">` calls on this element, its children or parents. The calls contain the names of the scripts, as described in [JavaScript initialization].
-4.  To find the source file of the used script:
-    1.  In the `<head></head>` section of the page source, click link to `requirejs-config.js` file. The file contains the Magento RequireJS configuration, collected from all modules of the current [theme](https://glossary.magento.com/theme).
-        {:.bs-callout .bs-callout-tip}
-                Alternatively, you can open the `requirejs-config.js` file from the file system: `pub/static/_requirejs/frontend/<Vendor>/<theme>/<locale>/requirejs-config.js`
+1. Open the store page in a browser, and locate the element\'s `class` or `id` using browser debugging tools, such as Firebug (Firefox) or Inspect Element (Chrome).
+1. Select to view the page source.
+1. Find the corresponding element in the page source and see if there are `data-mage-init` or `<script type="text/x-magento-init">` calls on this element, its children or parents. The calls contain the names of the scripts, as described in [JavaScript initialization].
+1. To find the source file of the used script:
+   1. In the `<head></head>` section of the page source, click link to `requirejs-config.js` file. The file contains the Magento RequireJS configuration, collected from all modules of the current [theme](https://glossary.magento.com/theme).
 
-    2.  In the `var config = {...}` section of `requirejs-config.js`, find the required script name, and view the path to its source file. This path is relative to certain directories, depending on whether it contains [module](https://glossary.magento.com/module) reference:
-        -   If the module context is not specified, the path is relative to `<theme_dir>/web` (current theme). If the file is not found there, according to the [assets fallback], it is searched for in parent theme `web` directory, and then `lib/web`(library) directory.
-        -   If the module context is specified, the path is relative to `<theme_dir>/<Namespace>_<Module>/web` (current theme module). If the file is not found there, according to the assets fallback, it is searched for in the same location in the parent theme files, and then in the `<module_dir>` (module) directory.
+      {:.bs-callout .bs-callout-tip}
+      Alternatively, you can open the `requirejs-config.js` file from the file system: `pub/static/_requirejs/frontend/<Vendor>/<theme>/<locale>/requirejs-config.js`
+
+   1. In the `var config = {...}` section of `requirejs-config.js`, find the required script name, and view the path to its source file. This path is relative to certain directories, depending on whether it contains [module](https://glossary.magento.com/module) reference:
+      -  If the module context is not specified, the path is relative to `<theme_dir>/web` (current theme). If the file is not found there, according to the [assets fallback], it is searched for in parent theme `web` directory, and then `lib/web`(library) directory.
+      -  If the module context is specified, the path is relative to `<theme_dir>/<Namespace>_<Module>/web` (current theme module). If the file is not found there, according to the assets fallback, it is searched for in the same location in the parent theme files, and then in the `<module_dir>` (module) directory.
 
 ## Locate JS component: example
 
@@ -39,22 +40,24 @@ Search the page source for `store.menu` (illustration follows):
 ![Search the page source for the store.menu string]
 
 We can see that there\'s a `data-mage-init` attribute in the scope of the `<div id= "store.menu"></div>`
-```
+
+```js
 data-mage-init='{"menu":{"responsive":true, "expanded":true, "position":{"my":"left top","at":"left bottom"}}}
 ```
 
 According to the JS components initialization notation, this means that this code calls `menu.js`.
 
 To find the source file of `menu.js`, open `requirejs-config.js` by clicking the link to it in the section of the page source. The path to `menu.js` is specified there as follows:
-```
+
+```js
     "menu":                   "mage/menu",
 ```
 
 This means we should check for `mage/menu.js` the following locations, in the following priority order (according to the [assets fallback rules]):
 
-1.  `<Magento_Luma_theme_dir>/web/js` (current theme JS files)
-2.  `<Magento_Blank_theme_dir>/web/js` (parent theme JS files)
-3.  `lib/web` (library files)
+1. `<Magento_Luma_theme_dir>/web/js` (current theme JS files)
+1. `<Magento_Blank_theme_dir>/web/js` (parent theme JS files)
+1. `lib/web` (library files)
 
 There is no `mage/menu.js` in the current theme or parent theme JS files, so the source file for menu component used for the main navigation menu is [`lib/web/mage/menu.js`]
 

--- a/guides/v2.2/javascript-dev-guide/javascript/js_practice.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/js_practice.md
@@ -15,8 +15,8 @@ In their Orange theme, OrangeCo wants to remove the "Click on image to view it f
 The high-level steps for this task are the following:
 
 1. Define how the message is output.
-2. Add the custom script extending the default one.
-3. Update RequireJS configuration to use the custom script instead of the default one.
+1. Add the custom script extending the default one.
+1. Update RequireJS configuration to use the custom script instead of the default one.
 
 Let's look at each step in more detail.
 
@@ -24,10 +24,10 @@ Let's look at each step in more detail.
 
 OrangeCo needs to define how the message is output. To do this, they take the following steps:
 
-1.  Open a product page.
-2.  Select to view the page source.
-3.  Search for the "Click on image to view it full sized" string. The illustration of the search result follows: ![Page source search result]
-4.  View that it is output by [`gallery.js`].
+1. Open a product page.
+1. Select to view the page source.
+1. Search for the "Click on image to view it full sized" string. The illustration of the search result follows: ![Page source search result]
+1. View that it is output by [`gallery.js`].
 
 We see that the script which OrangeCo needs to alter is `gallery.js`.
 
@@ -38,6 +38,7 @@ To be able to extend `gallery.js`, OrangeCo needs to know the path to it. To get
 ### Step 2: Add the custom widget extending the gallery widget {#add_code1}
 
 In the `app/design/OrangeCo/orange/web/js` OrangeCo adds `orange-gallery.js` with the following content:
+
 ```javascript
 define([
   'jquery',
@@ -58,6 +59,7 @@ define([
 ### Step 3: Update the RequireJS configuration {#config1}
 
 OrangeCo adds the custom `app/design/OrangeCo/orange/requirejs-config.js` with the following content:
+
 ```javascript
 var config = {
   "map": {
@@ -75,8 +77,8 @@ The new behavior is applied once the store pages are reloaded.
 OrangeCo wants to use the [jCarousel widget] to display product images on product pages. The high level steps for this task are the following:
 
 1. Define how product images are displayed by default.
-2. Add the custom script to the file system.
-3. Update RequireJS configuration to use the custom script instead of the default one.
+1. Add the custom script to the file system.
+1. Update RequireJS configuration to use the custom script instead of the default one.
 
 Let's look at each step in more detail.
 
@@ -91,22 +93,23 @@ OrangeCo needs to add a "wrapper" script.
 
 To do this, OrangeCo adds the following files in the `app/design/OrangeCo/orange/web/js` directory:
 
--   The jCarousel widget source file: `jquery.jcarousel.js`
--   A \"wrapper\" `orange-carousel.js` with the following content:
-    ```javascript
-        define([
-          'jquery',
-          'js/jquery.jcarousel'
-        ], function($){
+-  The jCarousel widget source file: `jquery.jcarousel.js`
+-  A \"wrapper\" `orange-carousel.js` with the following content:
 
-          return function (config, element) {
-           var jCarouselConfig = {
-             list: '.items.thumbs',
-             items: '.item.thumb'
-           };
-           $(element).jcarousel(jCarouselConfig);
-          }
-        });
+   ```javascript
+       define([
+         'jquery',
+         'js/jquery.jcarousel'
+       ], function($){
+
+         return function (config, element) {
+          var jCarouselConfig = {
+            list: '.items.thumbs',
+            items: '.item.thumb'
+          };
+          $(element).jcarousel(jCarouselConfig);
+         }
+       });
     ```
 
 ### Step 3: Update RequireJS configuration

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_accordion.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_accordion.md
@@ -38,7 +38,7 @@ Optionally, you can specify the following:
 Accordions support arbitrary markup, but the following requirements should be kept:
 
 1. Titles and contents are specified in the same order in DOM: first title, then contents.
-2. The header, trigger and content are specified, either by adding the `data-*` attributes for the corresponding children elements or by specifying these elements with selectors as options.
+1. The header, trigger and content are specified, either by adding the `data-*` attributes for the corresponding children elements or by specifying these elements with selectors as options.
 
 Mark-up examples:
 

--- a/guides/v2.3/install-gde/install-quick-ref.md
+++ b/guides/v2.3/install-gde/install-quick-ref.md
@@ -41,14 +41,14 @@ If not, see the [Installation overview][].
 ## Installation part 1: Getting started
 
 1. See the [system requirements][].
-2. If your system lacks any requirements, see the prerequisites documentation:
+1. If your system lacks any requirements, see the prerequisites documentation:
 
    *  [Apache][]
    *  [PHP][]
    *  [MySQL][]
 
-3. Just as importantly, set up the [Magento file system owner][]on the server.
-4. Switch to the [Magento file system owner][].
+1. Just as importantly, set up the [Magento file system owner][]on the server.
+1. Switch to the [Magento file system owner][].
 
 ### Get the Magento software
 

--- a/guides/v2.3/install-gde/prereq/install-rabbitmq.md
+++ b/guides/v2.3/install-gde/prereq/install-rabbitmq.md
@@ -18,7 +18,7 @@ Message queues provide an asynchronous communications mechanism in which the sen
 The message queue system must be established before you install Magento. The basic sequence is
 
 1. Install RabbitMQ and any prerequisites.
-2. Connect RabbitMQ and Magento.
+1. Connect RabbitMQ and Magento.
 
 {:.bs-callout .bs-callout-info"}
 A basic message queue system can be implemented using cron instead of RabbitMQ. See [Configure message queues]({{page.baseurl}}/config-guide/mq/manage-mysql.html) for more information.
@@ -36,7 +36,7 @@ This command also installs the required Erlang packages.
 If you have an older version of Ubuntu, RabbitMQ recommends installing the package from their [website](https://glossary.magento.com/website).
 
 1. Download [rabbitmq-server_3.6.6-1_all.deb](https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.6/rabbitmq-server_3.6.6-1_all.deb){:target="_blank"}.
-2. Install the package with `dpkg`.
+1. Install the package with `dpkg`.
 
 Refer to [Installing on Debian/Ubuntu](https://www.rabbitmq.com/install-debian.html){:target="_blank"} for more information.
 
@@ -63,7 +63,7 @@ rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 The RabbitMQ server is included on CentOS, but the version is often old. RabbitMQ recommends installing the package from their website.
 
 1. Download [rabbitmq-server-3.5.6-1.noarch.rpm](https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.6/rabbitmq-server-3.5.6-1.noarch.rpm){:target="_blank"}.
-2. Run the following commands as a user with root permissions:
+1. Run the following commands as a user with root permissions:
 
     ```bash
     rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
@@ -79,11 +79,11 @@ Refer to [Installing on RPM-based Linux](https://www.rabbitmq.com/install-rpm.ht
 
 Review the official RabbitMQ documentation to configure and manage RabbitMQ. Pay attention to the following items:
 
-* Environment variables
-* Port access
-* Default user accounts
-* Starting and stopping the broker
-* System limits
+*  Environment variables
+*  Port access
+*  Default user accounts
+*  Starting and stopping the broker
+*  System limits
 
 ## Install Magento with RabbitMQ and connect to {{site.data.var.ce}} or {{site.data.var.ee}}
 

--- a/guides/v2.3/install-gde/prereq/nginx.md
+++ b/guides/v2.3/install-gde/prereq/nginx.md
@@ -18,10 +18,10 @@ Installation instructions vary based on which operating system you are using. Se
 
 If you're new to all this and need some help getting started, we suggest the following:
 
-* [Is the Magento software installed already?]({{page.baseurl }}/install-gde/basics/basics_magento-installed.html)
-* [What is the software that the Magento server needs to run?]({{page.baseurl }}/install-gde/basics/basics_software.html)
-* [What operating system is my server running?]({{page.baseurl }}/install-gde/basics/basics_os-version.html)
-* [How do I log in to my Magento server using a terminal, command prompt, or SSH?]({{page.baseurl }}/install-gde/basics/basics_login.html)
+*  [Is the Magento software installed already?]({{page.baseurl }}/install-gde/basics/basics_magento-installed.html)
+*  [What is the software that the Magento server needs to run?]({{page.baseurl }}/install-gde/basics/basics_software.html)
+*  [What operating system is my server running?]({{page.baseurl }}/install-gde/basics/basics_os-version.html)
+*  [How do I log in to my Magento server using a terminal, command prompt, or SSH?]({{page.baseurl }}/install-gde/basics/basics_login.html)
 
 ## Ubuntu 16
 
@@ -43,41 +43,41 @@ To install and configure `php-fpm`:
 
 1. Install `php-fpm` and `php-cli`:
 
-    ```bash
-    apt-get -y install php7.2-fpm php7.2-cli
-    ```
+   ```bash
+   apt-get -y install php7.2-fpm php7.2-cli
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    This command installs the latest available version of PHP 7.2.X. See [Magento 2.3.x technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for supported PHP versions.
+   {:.bs-callout .bs-callout-info}
+   This command installs the latest available version of PHP 7.2.X. See [Magento 2.3.x technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for supported PHP versions.
 
 1. Open the `php.ini` files in an editor:
 
-    ```bash
-    vim /etc/php/7.2/fpm/php.ini
-    ```
+   ```bash
+   vim /etc/php/7.2/fpm/php.ini
+   ```
 
-    ```bash
-    vim /etc/php/7.2/cli/php.ini
-    ```
+   ```bash
+   vim /etc/php/7.2/cli/php.ini
+   ```
 
 1. Edit both files to match the following lines:
 
-    ```conf
-    memory_limit = 2G
-    max_execution_time = 1800
-    zlib.output_compression = On
-    ```
+   ```conf
+   memory_limit = 2G
+   max_execution_time = 1800
+   zlib.output_compression = On
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
+   {:.bs-callout .bs-callout-info}
+   We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
 
 1. Save and exit the editor.
 
 1. Restart the `php-fpm` service:
 
-    ```bash
-    systemctl restart php7.2-fpm
-    ```
+   ```bash
+   systemctl restart php7.2-fpm
+   ```
 
 ### Install and configure MySQL
 
@@ -87,11 +87,11 @@ Refer to [MySQL]({{page.baseurl }}/install-gde/prereq/mysql.html) for more infor
 
 There are several ways to download the Magento software, including:
 
-* [Get the Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+*  [Get the Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
 
-* [Download an archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+*  [Download an archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
 
-* [Clone the git repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+*  [Clone the git repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 For this example, we'll install using Composer and the command line.
 
@@ -102,72 +102,84 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Change to the web server docroot directory or a directory that you have configured as a virtual host docroot. For this example, we're using the Ubuntu default `/var/www/html`.
 
-    ```bash
-    cd /var/www/html
-    ```
+   ```bash
+   cd /var/www/html
+   ```
 
 1. Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-    ```bash
-    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
-    ```
+   ```bash
+   curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+   ```
 
 1. Create a new Composer project using the {{site.data.var.ce}} or {{site.data.var.ee}} metapackage.
 
-    **{{site.data.var.ce}}**
+   **{{site.data.var.ce}}**
 
-    ```bash
-    composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
-    ```
+   ```bash
+   composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
+   ```
 
-    **{{site.data.var.ee}}**
+   **{{site.data.var.ee}}**
 
-    ```bash
-    composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
-    ```
+   ```bash
+   composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
+   ```
 
-    When prompted, enter your [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html). Your _public key_ is your username; your _private key_ is your password.
+   When prompted, enter your [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html). Your _public key_ is your username; your _private key_ is your password.
 
 1. Set read-write permissions for the web server group before you install the Magento software. This is necessary so that the Setup Wizard and command line can write files to the Magento file system.
 
-    ```terminal
-    cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
-    chown -R :www-data . # Ubuntu
-    chmod u+x bin/magento
-    ```
+   ```bash
+   cd /var/www/html/<magento install directory>
+   ```
+
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+   ```
+
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+   ```
+
+   ```bash
+   chown -R :www-data . # Ubuntu
+   ```
+
+   ```bash
+   chmod u+x bin/magento
+   ```
 
 1. Install Magento from the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html). This example assumes that the Magento install directory is named `magento2ee`, the `db-host` is on the same machine (`localhost`), and that the `db-name`, `db-user`, and `db-password` are all `magento`:
 
-    ```bash
-    bin/magento setup:install \
-    --base-url=http://localhost/magento2ee \
-    --db-host=localhost \
-    --db-name=magento \
-    --db-user=magento \
-    --db-password=magento \
-    --backend-frontname=admin \
-    --admin-firstname=admin \
-    --admin-lastname=admin \
-    --admin-email=admin@admin.com \
-    --admin-user=admin \
-    --admin-password=admin123 \
-    --language=en_US \
-    --currency=USD \
-    --timezone=America/Chicago \
-    --use-rewrites=1
-    ```
+   ```bash
+   bin/magento setup:install \
+   --base-url=http://localhost/magento2ee \
+   --db-host=localhost \
+   --db-name=magento \
+   --db-user=magento \
+   --db-password=magento \
+   --backend-frontname=admin \
+   --admin-firstname=admin \
+   --admin-lastname=admin \
+   --admin-email=admin@admin.com \
+   --admin-user=admin \
+   --admin-password=admin123 \
+   --language=en_US \
+   --currency=USD \
+   --timezone=America/Chicago \
+   --use-rewrites=1
+   ```
 
 1. Switch to developer mode:
 
-    ```bash
-    cd /var/www/html/magento2/bin
-    ```
+   ```bash
+   cd /var/www/html/magento2/bin
+   ```
 
-    ```bash
-    ./magento deploy:mode:set developer
-    ```
+   ```bash
+   ./magento deploy:mode:set developer
+   ```
 
 ### Configure nginx {#configure-nginx-ubuntu}
 
@@ -177,25 +189,25 @@ These instructions assume you're using the Ubuntu default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-    ```bash
-    vim /etc/nginx/sites-available/magento
-    ```
+   ```bash
+   vim /etc/nginx/sites-available/magento
+   ```
 
-2. Add the following configuration:
+1. Add the following configuration:
 
-    ```conf
-    upstream fastcgi_backend {
-      server  unix:/run/php/php7.2-fpm.sock;
-    }
+   ```conf
+   upstream fastcgi_backend {
+     server  unix:/run/php/php7.2-fpm.sock;
+   }
 
-    server {
+   server {
 
-      listen 80;
-      server_name www.magento-dev.com;
-      set $MAGE_ROOT /var/www/html/magento2;
-      include /var/www/html/magento2/nginx.conf.sample;
-    }
-    ```
+     listen 80;
+     server_name www.magento-dev.com;
+     set $MAGE_ROOT /var/www/html/magento2;
+     include /var/www/html/magento2/nginx.conf.sample;
+   }
+   ```
 
 {:.bs-callout .bs-callout-info}
 The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -206,21 +218,21 @@ The `include` directive must point to the sample nginx configuration file in you
 
 1. Activate the newly created virtual host by creating a symlink to it in the `/etc/nginx/sites-enabled` directory:
 
-    ```bash
-    ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
-    ```
+   ```bash
+   ln -s /etc/nginx/sites-available/magento /etc/nginx/sites-enabled
+   ```
 
 1. Verify that the syntax is correct:
 
-    ```bash
-    nginx -t
-    ```
+   ```bash
+   nginx -t
+   ```
 
 1. Restart nginx:
 
-    ```bash
-    systemctl restart nginx
-    ```
+   ```bash
+   systemctl restart nginx
+   ```
 
 ### Verify the installation
 
@@ -258,9 +270,9 @@ Magento requires several [PHP](php-settings.html) extensions to function properl
 
 1. Install `php-fpm`:
 
-    ```bash
-    yum -y install php70w-fpm
-    ```
+   ```bash
+   yum -y install php70w-fpm
+   ```
 
 1. Open the `/etc/php.ini` file in an editor.
 
@@ -268,20 +280,20 @@ Magento requires several [PHP](php-settings.html) extensions to function properl
 
 1. Edit the file to match the following lines:
 
-    ```conf
-    memory_limit = 2G
-    max_execution_time = 1800
-    zlib.output_compression = On
-    ```
+   ```conf
+   memory_limit = 2G
+   max_execution_time = 1800
+   zlib.output_compression = On
+   ```
 
 {:.bs-callout .bs-callout-info}
 We recommend setting the memory limit to 2G when testing Magento. Refer to [Required PHP settings]({{page.baseurl }}/install-gde/prereq/php-settings.html) for more information.
 
 1. Uncomment the session path directory and set the path:
 
-    ```conf
-    session.save_path = "/var/lib/php/session"
-    ```
+   ```conf
+   session.save_path = "/var/lib/php/session"
+   ```
 
 1. Save and exit the editor.
 
@@ -289,62 +301,62 @@ We recommend setting the memory limit to 2G when testing Magento. Refer to [Requ
 
 1. Edit the file to match the following lines:
 
-    ```conf
-    user = nginx
-    group = nginx
-    listen = /run/php-fpm/php-fpm.sock
-    listen.owner = nginx
-    listen.group = nginx
-    listen.mode = 0660
-    ```
+   ```conf
+   user = nginx
+   group = nginx
+   listen = /run/php-fpm/php-fpm.sock
+   listen.owner = nginx
+   listen.group = nginx
+   listen.mode = 0660
+   ```
 
 1. Uncomment the environment lines:
 
-    ```conf
-    env[HOSTNAME] = $HOSTNAME
-    env[PATH] = /usr/local/bin:/usr/bin:/bin
-    env[TMP] = /tmp
-    env[TMPDIR] = /tmp
-    env[TEMP] = /tmp
-    ```
+   ```conf
+   env[HOSTNAME] = $HOSTNAME
+   env[PATH] = /usr/local/bin:/usr/bin:/bin
+   env[TMP] = /tmp
+   env[TMPDIR] = /tmp
+   env[TEMP] = /tmp
+   ```
 
 1. Save and exit the editor.
 
 1. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-    ```bash
-    mkdir -p /var/lib/php/session/
-    ```
+   ```bash
+   mkdir -p /var/lib/php/session/
+   ```
 
-    ```bash
-    chown -R apache:apache /var/lib/php/
-    ```
+   ```bash
+   chown -R apache:apache /var/lib/php/
+   ```
 
 1. Create a new directory for the PHP session path and change the owner to the `apache` user and group:
 
-    ```bash
-    mkdir -p /run/php-fpm/
-    ```
+   ```bash
+   mkdir -p /run/php-fpm/
+   ```
 
-    ```bash
-    chown -R apache:apache /run/php-fpm/
-    ```
+   ```bash
+   chown -R apache:apache /run/php-fpm/
+   ```
 
 1. Start the `php-fpm` service and configure it to start at boot time:
 
-    ```bash
-    systemctl start php-fpm
-    ```
+   ```bash
+   systemctl start php-fpm
+   ```
 
-    ```bash
-    systemctl enable php-fpm
-    ```
+   ```bash
+   systemctl enable php-fpm
+   ```
 
 1. Verify that the `php-fpm` service is running:
 
-    ```bash
-    netstat -pl | grep php-fpm.sock
-    ```
+   ```bash
+   netstat -pl | grep php-fpm.sock
+   ```
 
 ### Install and configure MySQL
 
@@ -354,11 +366,11 @@ Refer to [MySQL]({{page.baseurl }}/install-gde/prereq/mysql.html) for more infor
 
 There are several ways to download the Magento software, including:
 
-* [Get the Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+*  [Get the Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
 
-* [Download an archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+*  [Download an archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
 
-* [Clone the git repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+*  [Clone the git repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 For this example, we'll install using Composer and the command line.
 
@@ -369,72 +381,84 @@ You cannot use the Web Setup Wizard when installing Magento on nginx. You must u
 
 1. Change to the web server docroot directory or a directory that you have configured as a virtual host docroot. For this example, we're using the Ubuntu default `/var/www/html`.
 
-    ```bash
-    cd /var/www/html
-    ```
+   ```bash
+   cd /var/www/html
+   ```
 
 1. Install Composer globally. You'll need Composer to update dependencies before installing Magento:
 
-    ```bash
-    curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
-    ```
+   ```bash
+   curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/bin --filename=composer
+   ```
 
 1. Create a new Composer project using the {{site.data.var.ce}} or {{site.data.var.ee}} metapackage.
 
-    **{{site.data.var.ce}}**
+   **{{site.data.var.ce}}**
 
-    ```bash
-    composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
-    ```
+   ```bash
+   composer create-project --repository=https://repo.magento.com/ magento/project-community-edition <install-directory-name>
+   ```
 
-    **{{site.data.var.ee}}**
+   **{{site.data.var.ee}}**
 
-    ```bash
-    composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
-    ```
+   ```bash
+   composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
+   ```
 
-    When prompted, enter your [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html). Your _public key_ is your username; your _private key_ is your password.
+   When prompted, enter your [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html). Your _public key_ is your username; your _private key_ is your password.
 
 1. Set read-write permissions for the web server group before you install the Magento software. This is necessary so that the Setup Wizard and command line can write files to the Magento file system.
 
-    ```terminal
-    cd /var/www/html/<magento install directory>
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
-    chown -R :www-data . # Ubuntu
-    chmod u+x bin/magento
-    ```
+   ```bash
+   cd /var/www/html/<magento install directory>
+   ```
+
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+   ```
+
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+   ```
+
+   ```bash
+   chown -R :www-data . # Ubuntu
+   ```
+
+   ```bash
+   chmod u+x bin/magento
+   ```
 
 1. Install Magento from the [command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html). This example assumes that the Magento install directory is named `magento2ee`, the `db-host` is on the same machine (`localhost`), and that the `db-name`, `db-user`, and `db-password` are all `magento`:
 
-    ```bash
-    bin/magento setup:install \
-    --base-url=http://localhost/magento2ee \
-    --db-host=localhost \
-    --db-name=magento \
-    --db-user=magento \
-    --db-password=magento \
-    --backend-frontname=admin \
-    --admin-firstname=admin \
-    --admin-lastname=admin \
-    --admin-email=admin@admin.com \
-    --admin-user=admin \
-    --admin-password=admin123 \
-    --language=en_US \
-    --currency=USD \
-    --timezone=America/Chicago \
-    --use-rewrites=1
-    ```
+   ```bash
+   bin/magento setup:install \
+   --base-url=http://localhost/magento2ee \
+   --db-host=localhost \
+   --db-name=magento \
+   --db-user=magento \
+   --db-password=magento \
+   --backend-frontname=admin \
+   --admin-firstname=admin \
+   --admin-lastname=admin \
+   --admin-email=admin@admin.com \
+   --admin-user=admin \
+   --admin-password=admin123 \
+   --language=en_US \
+   --currency=USD \
+   --timezone=America/Chicago \
+   --use-rewrites=1
+   ```
 
 1. Switch to developer mode:
 
-    ```bash
-    cd /var/www/html/magento2/bin
-    ```
+   ```bash
+   cd /var/www/html/magento2/bin
+   ```
 
-    ```bash
-    ./magento deploy:mode:set developer
-    ```
+   ```bash
+   ./magento deploy:mode:set developer
+   ```
 
 ### Configure nginx {#configure-nginx-centos}
 
@@ -444,25 +468,25 @@ These instructions assume you're using the CentOS default location for the nginx
 
 1. Create a new virtual host for your Magento site:
 
-    ```bash
-    vim /etc/nginx/conf.d/magento.conf
-    ```
+   ```bash
+   vim /etc/nginx/conf.d/magento.conf
+   ```
 
 1. Add the following configuration:
 
-    ```conf
-    upstream fastcgi_backend {
-      server  unix:/run/php-fpm/php-fpm.sock;
-    }
+   ```conf
+   upstream fastcgi_backend {
+     server  unix:/run/php-fpm/php-fpm.sock;
+   }
 
-    server {
+   server {
 
-      listen 80;
-      server_name www.magento-dev.com;
-      set $MAGE_ROOT /usr/share/nginx/html/magento2;
-      include /usr/share/nginx/html/magento2/nginx.conf.sample;
-    }
-    ```
+     listen 80;
+     server_name www.magento-dev.com;
+     set $MAGE_ROOT /usr/share/nginx/html/magento2;
+     include /usr/share/nginx/html/magento2/nginx.conf.sample;
+   }
+   ```
 
 {:.bs-callout .bs-callout-info}
 The `include` directive must point to the sample nginx configuration file in your Magento installation directory.
@@ -473,15 +497,15 @@ The `include` directive must point to the sample nginx configuration file in you
 
 1. Verify that the syntax is correct:
 
-    ```bash
-    nginx -t
-    ```
+   ```bash
+   nginx -t
+   ```
 
 1. Restart nginx:
 
-    ```bash
-    systemctl restart nginx
-    ```
+   ```bash
+   systemctl restart nginx
+   ```
 
 ### Configure SELinux and Firewalld
 
@@ -495,61 +519,61 @@ To configure SELinux and firewalld:
 
 1. Install SELinux management tools:
 
-    ```bash
-    yum -y install policycoreutils-python
-    ```
+   ```bash
+   yum -y install policycoreutils-python
+   ```
 
 1. Run the following commands to change the security context for the Magento installation directory:
 
-    ```bash
-    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
-    ```
+   ```bash
+   semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/app/etc(/.*)?'
+   ```
 
-    ```bash
-    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
-    ```
+   ```bash
+   semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/var(/.*)?'
+   ```
 
-    ```bash
-    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
-    ```
+   ```bash
+   semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/media(/.*)?'
+   ```
 
-    ```bash
-    semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
-    ```
+   ```bash
+   semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/nginx/html/magento2/pub/static(/.*)?'
+   ```
 
-    ```bash
-    restorecon -Rv '/usr/share/nginx/html/magento2/'
-    ```
+   ```bash
+   restorecon -Rv '/usr/share/nginx/html/magento2/'
+   ```
 
 1. Install the firewalld package:
 
-    ```bash
-    yum -y install firewalld
-    ```
+   ```bash
+   yum -y install firewalld
+   ```
 
 1. Start the firewall service and configure it to start at boot time:
 
-    ```bash
-    systemctl start firewalld
-    ```
+   ```bash
+   systemctl start firewalld
+   ```
 
-    ```bash
-    systemctl enable firewalld
-    ```
+   ```bash
+   systemctl enable firewalld
+   ```
 
 1. Run the following commands to open ports for HTTP and HTTPS so you can access the Magento base URL from a web browser:
 
-    ```bash
-    firewall-cmd --permanent --add-service=http
-    ```
+   ```bash
+   firewall-cmd --permanent --add-service=http
+   ```
 
-    ```bash
-    firewall-cmd --permanent --add-service=https
-    ```
+   ```bash
+   firewall-cmd --permanent --add-service=https
+   ```
 
-    ```bash
-    firewall-cmd --reload
-    ```
+   ```bash
+   firewall-cmd --reload
+   ```
 
 ### Verify the installation
 

--- a/guides/v2.3/install-gde/prereq/zip_install.md
+++ b/guides/v2.3/install-gde/prereq/zip_install.md
@@ -27,14 +27,14 @@ To transfer the Magento software archive to your server:
 
    There are many ways to configure FTP and SCP. Following are a few packages you can use. Magento does not recommend particular software.
 
-   * Windows: [WinSCP](https://winscp.net/eng/download.php) or [Filezilla](https://filezilla-project.org/download.php)
-   * Mac OS: [CyberDuck](https://cyberduck.io/?l=en) or [Filezilla](https://filezilla-project.org/download.php)
+   *  Windows: [WinSCP](https://winscp.net/eng/download.php) or [Filezilla](https://filezilla-project.org/download.php)
+   *  Mac OS: [CyberDuck](https://cyberduck.io/?l=en) or [Filezilla](https://filezilla-project.org/download.php)
 
-2. Create a connection to your Magento server.
+1. Create a connection to your Magento server.
 
    Follow the prompts on your screen or consult the documentation provided with your FTP software for more information.
 
-3. After you log in to your server, browse to locate the {{site.data.var.ce}} or {{site.data.var.ee}} archive on your local system.
+1. After you log in to your server, browse to locate the {{site.data.var.ce}} or {{site.data.var.ee}} archive on your local system.
 
    On the remote system, browse to locate the web server docroot directory.
 
@@ -42,42 +42,42 @@ To transfer the Magento software archive to your server:
 
    ![]({{ site.baseurl }}/common/images/install-merch_ftp-transfer.png)
 
-4. Transfer the archive from your local system to the web server docroot directory.
+1. Transfer the archive from your local system to the web server docroot directory.
 
    On some FTP client software, you do this by dragging and dropping.
 
-5. Wait while the transfer completes.
-6. Log in to your Magento server, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
-7. Change to the web server docroot or the virtual host directory.
-7. Create a subdirectory for the Magento software.
+1. Wait while the transfer completes.
+1. Log in to your Magento server, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
+1. Change to the web server docroot or the virtual host directory.
+1. Create a subdirectory for the Magento software.
 
-    If you set up a virtual host, the subdirectory name must match the name in your virtual host.
+   If you set up a virtual host, the subdirectory name must match the name in your virtual host.
 
-    For example,
+   For example,
 
-    ```bash
-    mkdir magento2ce
-    ```
+   ```bash
+   mkdir magento2ce
+   ```
 
-    ```bash
-    mkdir magento2ee
-    ```
+   ```bash
+   mkdir magento2ee
+   ```
 
-    You can also use a generic directory name
+   You can also use a generic directory name
 
-    ```bash
-    mkdir magento2
-    ```
+   ```bash
+   mkdir magento2
+   ```
 
-7. Copy the Magento archive to that directory.
+1. Copy the Magento archive to that directory.
 
-    For example,
+   For example,
 
-    ```bash
-    cp /var/www/Magento-CE-2.0.0+Samples.tar.bz2 magento2
-    ```
+   ```bash
+   cp /var/www/Magento-CE-2.0.0+Samples.tar.bz2 magento2
+   ```
 
-8. Continue with the next section.
+1. Continue with the next section.
 
 ## Extract the software on your server {#zip-extract}
 
@@ -98,5 +98,5 @@ Related topics
 
 Install the Magento software:
 
-* [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-* [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+*  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+*  [Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)

--- a/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.md
+++ b/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.md
@@ -6,10 +6,10 @@ title: Modify docroot to improve security
 In a standard installation with an Apache web server, Magento is installed to the default web root: `/var/www/html/magento2`.
 Within the `magento2` folder are:
 
-- /pub/
-- /setup/
-- /var/
-- other folders
+-  /pub/
+-  /setup/
+-  /var/
+-  other folders
 
 The Magento app is served from `/var/www/html/magento2/pub`. The rest of the Magento file system is vulnerable because it is accessible from a browser.
 Setting the webroot to the `pub/` directory prevents site visitors from accessing the Web Setup Wizard and other sensitive areas of the Magento file system from a browser.
@@ -45,11 +45,11 @@ When used in your server block that defines your site, the `nginx.conf.sample` c
 
 To complete this tutorial, you will need access to a working Magento installation running on a [LAMP](https://en.wikipedia.org/wiki/LAMP_(software_bundle)){:target="_blank"} stack:
 
--   Linux
--   Apache (2.2+)
--   MySQL (5.6+)
--   PHP (7.1.3+ or 7.2)
--   Magento (2.0+)
+-  Linux
+-  Apache (2.2+)
+-  MySQL (5.6+)
+-  PHP (7.1.3+ or 7.2)
+-  Magento (2.0+)
 
 {:.bs-callout .bs-callout-info}
 Refer to [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html) and the [Installation Guide]({{ page.baseurl }}/install-gde/bk-install-guide.html) for more information.
@@ -58,14 +58,14 @@ Refer to [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.h
 
 The name and location of your virtual host file depends on which version of Apache you are running. This example shows the name and location of the virtual host file on Apache v2.4.
 
-1.  Log in to your Magento server.
-2.  Edit your virtual host file:
+1. Log in to your Magento server.
+1. Edit your virtual host file:
 
    ```bash
    vim /etc/apache2/sites-available/000-default.conf
    ```
 
-3.  Add the path to your Magento `pub/` directory to the `DocumentRoot` directive:
+1. Add the path to your Magento `pub/` directory to the `DocumentRoot` directive:
 
    ```conf
     <VirtualHost *:80>
@@ -82,7 +82,7 @@ The name and location of your virtual host file depends on which version of Apac
     </VirtualHost>
     ```
 
-4.  Restart Apache:
+1. Restart Apache:
 
    ```bash
    systemctl restart apache2
@@ -95,58 +95,70 @@ If you appended a directory name to your server's hostname or IP address to crea
 {: .bs-callout-info }
 Replace `192.168.33.10` with your server's hostname.
 
-1.  Log in to the Magento database:
+1. Log in to the Magento database:
 
-        mysql -u <user> -p
+   ```bash
+   mysql -u <user> -p
+   ```
 
-2.  Specify the Magento database you created when you installed Magento:
+1. Specify the Magento database you created when you installed Magento:
 
-        use <database-name>
+   ```shell
+   use <database-name>
+   ```
 
-3.  Update the base URL:
+1. Update the base URL:
 
-        UPDATE core_config_data SET value='http://192.168.33.10' WHERE path='web/unsecure/base_url';
+   ```shell
+   UPDATE core_config_data SET value='http://192.168.33.10' WHERE path='web/unsecure/base_url';
+   ```
 
 ## 3. Switch modes
 [Magento modes]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html), which include `production` and `developer`, are designed to improve security and make development easier. As the names suggest, you should switch to `developer` mode when extending or customizing Magento and switch to `production` mode when running Magento in a live environment.
 
 Switching between modes is an important step in verifying that your server configuration is working properly. You can switch between modes using the Magento CLI tool:
 
-1.  Go to your Magento installation directory.
-2.  Switch to `production` mode.
+1. Go to your Magento installation directory.
+1. Switch to `production` mode.
 
    ```bash
    bin/magento deploy:mode:set production
+   ```
+
+   ```bash
    bin/magento cache:flush
    ```
 
-3.  Refresh your browser and verify that the storefront displays properly.
-4.  Switch to `developer` mode.
+1. Refresh your browser and verify that the storefront displays properly.
+1. Switch to `developer` mode.
 
    ```bash
    bin/magento deploy:mode:set developer
+   ```
+
+   ```bash
    bin/magento cache:flush
    ```
 
-5.  Refresh your browser and verify that the storefront displays properly.
+1. Refresh your browser and verify that the storefront displays properly.
 
 ## 4. Verify the storefront
 
 Go to the [storefront](https://glossary.magento.com/storefront) in a web browser to verify that everything is working.
 
-1.  Open a web browser and enter your server's hostname or IP address in the address bar. For example, http://192.168.33.10.
+1. Open a web browser and enter your server's hostname or IP address in the address bar. For example, http://192.168.33.10.
 
-    The following figure shows a sample storefront page. If it displays as follows, your installation was a success!
+   The following figure shows a sample storefront page. If it displays as follows, your installation was a success!
 
-    ![Magento storefront which verifies a successful installation]({{ site.baseurl }}/common/images/install-success_store.png){:.width="450px"}
+   ![Magento storefront which verifies a successful installation]({{ site.baseurl }}/common/images/install-success_store.png){:.width="450px"}
 
-    Refer to the [troubleshooting section]({{ page.baseurl }}/install-gde/trouble/tshoot_no-styles.html) if the page displays a 404 (Not Found) or fails to load other assets like images, CSS, and JS.
+   Refer to the [troubleshooting section]({{ page.baseurl }}/install-gde/trouble/tshoot_no-styles.html) if the page displays a 404 (Not Found) or fails to load other assets like images, CSS, and JS.
 
-2.  Try accessing the Magento directory for the Web Setup Wizard from a browser. Append "_setup/_" to your server's hostname or IP address in the address bar:
+1. Try accessing the Magento directory for the Web Setup Wizard from a browser. Append "_setup/_" to your server's hostname or IP address in the address bar:
 
-    If you see a 404 or the "Access denied" message, you've successfully restricted access to the Magento file system.
+   If you see a 404 or the "Access denied" message, you've successfully restricted access to the Magento file system.
 
-    ![Access denied]({{ site.baseurl }}/common/images/access-denied.png)
+   ![Access denied]({{ site.baseurl }}/common/images/access-denied.png)
 
 ## Congratulations! You're finished.
 {:.no_toc}

--- a/guides/v2.3/inventory/reservations.md
+++ b/guides/v2.3/inventory/reservations.md
@@ -11,19 +11,19 @@ Reservations prevent the merchant from overselling products, even in cases where
 
 Magento creates a reservation for each product when the following events occur:
 
-* A customer or merchant places an order.
-* A customer or merchant fully or partially cancels an order.
-* The merchant creates a shipment for a physical product.
-* The merchant creates an invoice for a virtual or downloadable product.
-* The merchant issues a credit memo.
+*  A customer or merchant places an order.
+*  A customer or merchant fully or partially cancels an order.
+*  The merchant creates a shipment for a physical product.
+*  The merchant creates an invoice for a virtual or downloadable product.
+*  The merchant issues a credit memo.
 
 Reservations are append-only operations, similar to a log of events. The initial reservation is assigned a negative quantity value. All subsequent reservations created while processing the order are positive values. When the order is complete, the sum of all reservations for the product is 0.
 
 Before Magento can issue a reservation in response to a new order, it determines whether there are enough salable items to fulfill the order. The following quantities factor into the calculation:
 
-* **StockItem quantity**. The StockItem quantity is the aggregated amount of inventory from all the physical sources for the current sales channel. If the Baltimore source has 20 units of a product, the Austin source has 25 units of the same product, while the Reno source has 10, and all these sources are linked to Stock A, then the StockItem count for thus product is 55 (20 + 25 + 10). (When items are shipped, the Inventory indexer updates the quantities available at each source.)
+*  **StockItem quantity**. The StockItem quantity is the aggregated amount of inventory from all the physical sources for the current sales channel. If the Baltimore source has 20 units of a product, the Austin source has 25 units of the same product, while the Reno source has 10, and all these sources are linked to Stock A, then the StockItem count for thus product is 55 (20 + 25 + 10). (When items are shipped, the Inventory indexer updates the quantities available at each source.)
 
-* **Outstanding reservations**. Magento totals all the initial reservations that have not been compensated. This number will always be negative. If customer A has a reservation for 10 items, and customer B has a reservation 5 for items, then outstanding reservations for the product total -15.
+*  **Outstanding reservations**. Magento totals all the initial reservations that have not been compensated. This number will always be negative. If customer A has a reservation for 10 items, and customer B has a reservation 5 for items, then outstanding reservations for the product total -15.
 
 Therefore, the merchant can fulfill an incoming order as long as the customer orders less than 40 (55 + -15) units.
 
@@ -46,11 +46,11 @@ Parameter | Data type | Description
 
 The metadata `event_type` can have the following values:
 
-* `order_placed`
-* `order_canceled`
-* `shipment_created`
-* `creditmemo_created`
-* `invoice_created`
+*  `order_placed`
+*  `order_canceled`
+*  `shipment_created`
+*  `creditmemo_created`
+*  `invoice_created`
 
 Currently, the metadata object type must be `order`, and the object ID is the order ID.
 
@@ -70,7 +70,7 @@ The following example shows the sequence of reservations generated for a simple 
    event_type = order_placed
     ```
 
-2. The customer sends an invoice for 20 items, essentially canceling 5 of the units ordered.
+1. The customer sends an invoice for 20 items, essentially canceling 5 of the units ordered.
 
    ```text
    reservation_id = 2
@@ -80,7 +80,7 @@ The following example shows the sequence of reservations generated for a simple 
    event_type = order_canceled
    ```
 
-3. The merchant ships the purchased 20 units.
+1. The merchant ships the purchased 20 units.
 
    ```text
    reservation_id = 3


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- Installation
- JS Dev
- Inventory

The MD)29 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.