### PR TITLE
Fixed inconsistent code formatting

### DIFF
--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -122,6 +122,6 @@ To tell Grunt to use a custom configuration file, instead of the default one, ad
 
 1. Call the `get(%file_alias%)` method to get the configuration file.
 
-   ```
+   ```config
    var themes = fileRouter.get('themes');
    ```

--- a/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
+++ b/guides/v2.2/frontend-dev-guide/tools/using_grunt.md
@@ -90,7 +90,7 @@ To use a custom file for Grunt configuration:
 
    ```config
    {
-    "themes": "dev/tools/grunt/configs/local-themes"
+       "themes": "dev/tools/grunt/configs/local-themes"
    }
    ```
 
@@ -122,4 +122,6 @@ To tell Grunt to use a custom configuration file, instead of the default one, ad
 
 1. Call the `get(%file_alias%)` method to get the configuration file.
 
-   `var themes = fileRouter.get('themes');`
+   ```
+   var themes = fileRouter.get('themes');
+   ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the inconsistent code formatting found in the below pages

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html
- https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/tools/using_grunt.html