### PR TITLE
Fixed ordered list prefix (MD029) - Group 6

### DIFF
--- a/guides/v2.2/howdoi/checkout/checkout-add-custom-carrier.md
+++ b/guides/v2.2/howdoi/checkout/checkout-add-custom-carrier.md
@@ -17,9 +17,9 @@ This topic describes how to add a custom shipping carrier.
 To add a new shipping carrier to the Magento checkout:
 
 1. [Create a new module](#create-module)
-2. [Add the carrier configuration](#create-configuration)
-3. [Create the carrier model](#carrier-model)
-4. [Enable the module](#enable-module)
+1. [Add the carrier configuration](#create-configuration)
+1. [Create the carrier model](#carrier-model)
+1. [Enable the module](#enable-module)
 
 ## Step 1: Create a new module {#create-module}
 
@@ -100,14 +100,14 @@ To add a module configuration use the following source code snippets.
 
 The `system.xml` source code declares custom shipping module options:
 
-- Enabled
-- Title
-- Method Name
-- Shipping Cost
-- Ship to Applicable Countries
-- Ship to Specific Countries
-- Show Method if Not Applicable
-- Sort Order
+-  Enabled
+-  Title
+-  Method Name
+-  Shipping Cost
+-  Ship to Applicable Countries
+-  Ship to Specific Countries
+-  Show Method if Not Applicable
+-  Sort Order
 
 ```xml
 <?xml version="1.0"?>

--- a/guides/v2.2/howdoi/checkout/checkout_address.md
+++ b/guides/v2.2/howdoi/checkout/checkout_address.md
@@ -14,20 +14,20 @@ This topic describes how to implement a custom shipping address renderer.
 
 Out of the box, Magento [checkout](https://glossary.magento.com/checkout) consists of two steps:
 
-- Shipping Information
-- Review and Payment Information
+-  Shipping Information
+-  Review and Payment Information
 
 On the Shipping Information checkout step Magento renders all addresses previously saved by a shopper. The shopper can then select the one to be used for shipping by clicking it. The default address renderers cover the majority of use cases, but Magento provides way to register custom address renderer for a new address type.
 
 To implement shipping address rendering in checkout, you need to take the following steps:
 
 1. [Create the JS renderer component (shipping address renderer)](#create).
-2. [Create a template for the shipping address renderer.](#template)
-3. [Create the JS model for the shipping rate processor](#rate_processor).
-4. [Create the JS model for the shipping address saving processor](#save).
-5. [Create the JS component registering the processors](#register).
-6. [Declare the new components in the checkout page layout.](#layout).
-7. [Add the shipping address renderer to the "Ship-To" block (optional)](#ship_to).
+1. [Create a template for the shipping address renderer.](#template)
+1. [Create the JS model for the shipping rate processor](#rate_processor).
+1. [Create the JS model for the shipping address saving processor](#save).
+1. [Create the JS component registering the processors](#register).
+1. [Declare the new components in the checkout page layout.](#layout).
+1. [Add the shipping address renderer to the "Ship-To" block (optional)](#ship_to).
 
 ## Step 1: Create the JS renderer component (shipping address renderer) {#create}
 

--- a/guides/v2.2/howdoi/checkout/checkout_carrier.md
+++ b/guides/v2.2/howdoi/checkout/checkout_carrier.md
@@ -15,9 +15,9 @@ This topic describes how to add shipping address validations for a custom [shipp
 To add new shipping carrier validations to the Magento checkout, do the following:
 
 1. [Create validation rules](#rules).
-2. [Create validator](#validator).
-3. [Register validator and rules in the validators pool](#register).
-4. [Add the validators and rules to the checkout layout](#layout).
+1. [Create validator](#validator).
+1. [Register validator and rules in the validators pool](#register).
+1. [Add the validators and rules to the checkout layout](#layout).
 
 {: .bs-callout-info }
 During checkout, when a customer fills the shipping address form, shipping carrier validations trigger the shipping rates request. That is why adding shipping carrier validations for your custom shipping method is mandatory.

--- a/guides/v2.2/howdoi/checkout/checkout_custom_checkbox.md
+++ b/guides/v2.2/howdoi/checkout/checkout_custom_checkbox.md
@@ -17,8 +17,8 @@ Let's consider a case where you need to add a checkbox whose state (selected or 
 To implement such a checkbox, take the following steps:
 
 1. [Create a plugin for the process method](#create-plugin) of the `<Magento_Checkout_module_dir>/Block/Checkout/LayoutProcessor.php` class.
-2. [Declare the plugin in your module's `di.xml`](#declare-plugin).
-3. [Create a JS component for the checkbox with custom logic](#create-jscomponent).
+1. [Declare the plugin in your module's `di.xml`](#declare-plugin).
+1. [Create a JS component for the checkbox with custom logic](#create-jscomponent).
 
 ## Create a plugin for the `LayoutProcessor`'s process method {#create-plugin}
 

--- a/guides/v2.2/howdoi/checkout/checkout_customize.md
+++ b/guides/v2.2/howdoi/checkout/checkout_customize.md
@@ -17,7 +17,7 @@ This topic contains the basic information about how to customize the view of an 
 To change the `.js` implementation and template used for components rendering, you need to declare the new files in the checkout page [layout](https://glossary.magento.com/layout). To do this, take the following steps:
 
 1. In your custom module directory, create the following new file: `<your_module_dir>/view/frontend/layout/checkout_index_index.xml`. (For your checkout customization to be applied correctly, your custom [module](https://glossary.magento.com/module) should depend on the Magento_Checkout module.)
-2. In this file, add the following:
+1. In this file, add the following:
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
@@ -34,9 +34,9 @@ To change the `.js` implementation and template used for components rendering, y
 </page>
 ```
 
-3. In the `<Magento_Checkout_module_dir>/view/frontend/layout/checkout_index_index.xml` file, find the component that you need to customize. Copy the corresponding node and all parent nodes up to `<argument>`. There is no need to leave all the attributes and values of parent nodes, as you are not going to change them.
+1. In the `<Magento_Checkout_module_dir>/view/frontend/layout/checkout_index_index.xml` file, find the component that you need to customize. Copy the corresponding node and all parent nodes up to `<argument>`. There is no need to leave all the attributes and values of parent nodes, as you are not going to change them.
 
-4. Change the path to the component's `.js` file, template or any other property.
+1. Change the path to the component's `.js` file, template or any other property.
 
 Example:
 

--- a/guides/v2.2/howdoi/checkout/checkout_edit_form.md
+++ b/guides/v2.2/howdoi/checkout/checkout_edit_form.md
@@ -17,8 +17,8 @@ The forms used on the Checkout page are implemented using Knockout JS.
 To change the template of the form field, do the following:
 
 1. [Create a custom HTML template for knockout JS script that will render the form field](#template).
-2. [Specify the new template in the Checkout page layout](#layout).
-3. [Clear files after modification](#modify).
+1. [Specify the new template in the Checkout page layout](#layout).
+1. [Clear files after modification](#modify).
 
 ## Prerequisites
 
@@ -108,4 +108,4 @@ In this file, add content similar to the following:
 If you modify your custom `.html` template after it was applied on the store pages, the changes will not apply until you do the following:
 
 1. Delete all files in the `pub/static/frontend` and `var/view_preprocessed` directories.
-2. Reload the pages.
+1. Reload the pages.

--- a/guides/v2.2/howdoi/checkout/checkout_form.md
+++ b/guides/v2.2/howdoi/checkout/checkout_form.md
@@ -17,8 +17,8 @@ Most of the elements, including the default forms on the Checkout page are imple
 Magento provides the ability to add a custom form to any of the checkout steps: Shipping Information, Review and Payment Information, or custom. In order to add a custom form that is a UI component, take the following steps:
 
 1. [Create the JS implementation of the form UI component](#component).
-2. [Create the knockout.js HTML template for rendering the form](#template).
-3. [Declare the form in the checkout page layout](#layout).
+1. [Create the knockout.js HTML template for rendering the form](#template).
+1. [Declare the form in the checkout page layout](#layout).
 
 ## Prerequisites
 
@@ -154,7 +154,7 @@ It should be similar to the following:
 If you modify your custom `.html` template after it was applied on the store pages, the changes will not apply until you do the following:
 
 1. Delete all files in the `pub/static/frontend` and `var/view_preprocessed` directories.
-2. Reload the pages.
+1. Reload the pages.
 
 ### Static forms {#static_form}
 
@@ -291,4 +291,3 @@ $textField = [
 If you use the code samples provided as examples in this topic, this would result in adding the following form to the Shipping Information step:
 
 ![The input form with four fields]({{ site.baseurl }}/common/images/how_checkout_form.png)
-

--- a/guides/v2.2/howdoi/checkout/checkout_new_field.md
+++ b/guides/v2.2/howdoi/checkout/checkout_new_field.md
@@ -15,10 +15,10 @@ You can add new fields to default [checkout](https://glossary.magento.com/checko
 To add your custom field to the checkout address form and access its value on the client side:
 
 1. [Add the field to layout](#add).
-2. [Add a JS mixin to modify data submission](#mixin).
-3. [Load your mixin](#load_mixin).
-4. [Add the field to address model](#field).
-5. [Access the value of the custom field on server side](#access).
+1. [Add a JS mixin to modify data submission](#mixin).
+1. [Load your mixin](#load_mixin).
+1. [Add the field to address model](#field).
+1. [Access the value of the custom field on server side](#access).
 
 ## Step 1: Add the field to layout {#add}
 
@@ -200,6 +200,6 @@ class MyBlock extends Template {
 ```
 
 {:.ref-header}
-Related topics
+Related topic
 
-- [EAV and extension attributes]({{ page.baseurl }}/extension-dev-guide/attributes.html)
+[EAV and extension attributes]({{ page.baseurl }}/extension-dev-guide/attributes.html)

--- a/guides/v2.2/howdoi/checkout/checkout_new_step.md
+++ b/guides/v2.2/howdoi/checkout/checkout_new_step.md
@@ -20,8 +20,8 @@ The default Magento [Checkout](https://glossary.magento.com/checkout) consists o
 You can add a custom checkout step, it should be implemented as a [UI component](https://glossary.magento.com/ui-component). For the sake of compatibility, upgradability and easy maintenance, do not edit the default Magento code, add your customizations in a separate [module](https://glossary.magento.com/module).
 
 1. [Create the view part of the checkout step component](#create-view).
-2. [Add your step to the Checkout page layout](#checkout).
-3. [Create mixins for payment and shipping steps (optional)](#create-mixin).
+1. [Add your step to the Checkout page layout](#checkout).
+1. [Create mixins for payment and shipping steps (optional)](#create-mixin).
 
 ## Step 1: Create the view part of the checkout step component {#create-view}
 
@@ -216,7 +216,7 @@ Create a mixin as follows:
     }
     ```
 
-2. Create the mixin. We'll use the same mixin for both payment and shipping:
+1. Create the mixin. We'll use the same mixin for both payment and shipping:
 
     ```js
     define(

--- a/guides/v2.2/howdoi/checkout/checkout_order.md
+++ b/guides/v2.2/howdoi/checkout/checkout_order.md
@@ -15,8 +15,8 @@ This topic describes how to add custom validations to be performed before the or
 To add custom validations before the order placement action, you must do the following:
 
 1. [Create the validator](#validator).
-2. [Add validator to the validators pool](#pool).
-3. [Declare the validation in the checkout layout](#layout).
+1. [Add validator to the validators pool](#pool).
+1. [Declare the validation in the checkout layout](#layout).
 
 ## Step 1: Create the validator {#validator}
 

--- a/guides/v2.2/howdoi/checkout/checkout_payment.md
+++ b/guides/v2.2/howdoi/checkout/checkout_payment.md
@@ -12,17 +12,17 @@ functional_areas:
 
 Out of the box, Magento [checkout](https://glossary.magento.com/checkout) consists of two steps:
 
-- Shipping Information
-- Review and Payment Information
+-  Shipping Information
+-  Review and Payment Information
 
 On the Review and Payment Information step the enabled payment methods are rendered. This topic describes how to add your custom [payment method](https://glossary.magento.com/payment-method) to this list.
 
 To implement a payment method rendering in checkout, you need to take the following steps:
 
 1. [Create the `.js` file implementing the component (payment method renderer).](#create)
-2. [Create the `.js` component registering the payment method renderer.](#register)
-3. [Create a template for the payment method renderer.](#template)
-4. [Declare the new payment in the checkout page layout.](#layout)
+1. [Create the `.js` component registering the payment method renderer.](#register)
+1. [Create a template for the payment method renderer.](#template)
+1. [Declare the new payment in the checkout page layout.](#layout)
 
 ## Step 1: Create the .js component file {#create}
 

--- a/guides/v2.2/howdoi/checkout/checkout_shipping_methods.md
+++ b/guides/v2.2/howdoi/checkout/checkout_shipping_methods.md
@@ -13,8 +13,8 @@ This topic describes how to customize list of shipping methods displayed on the 
 Let's consider a case where you need to add a collapsible text field with description for each shipping method in this list. To achieve this, you need to take the following steps:
 
 1. [Create a new template for the shipping method item](#method-item).
-2. [Create a new template for the shipping method list](#method-list).
-3. [Override the shipping step configuration](#shipping).
+1. [Create a new template for the shipping method list](#method-list).
+1. [Override the shipping step configuration](#shipping).
 
 ## Step 1: Create new template for shipping method item {#method-item}
 
@@ -22,9 +22,9 @@ In your custom module directory, create a new file: `<your_module_dir>/view/fron
 
 It is copied from the `<Magento_Checkout_module_dir>/view/frontend/web/template/shipping-address/shipping-method-item.html` template, with the following modifications:
 
-* A `<tr>` element added to contain the shipping method description
-* A column with trigger elements that provide the collapse/expand functionality added
-* The entire sample wrapped in `<tbody>` to provide the general collapsible context for rows
+*  A `<tr>` element added to contain the shipping method description
+*  A column with trigger elements that provide the collapse/expand functionality added
+*  The entire sample wrapped in `<tbody>` to provide the general collapsible context for rows
 
 ```html
 <!-- Initialize collapsible binding -->
@@ -79,8 +79,8 @@ It is copied from the `<Magento_Checkout_module_dir>/view/frontend/web/template/
 
 In your custom module directory, create a new file: `<your_module_dir>/view/frontend/web/template/custom-method-list-template.html`. In this file, add the following code. It uses the code from the `app/code/Magento/Checkout/view/frontend/web/template/shipping-address/shipping-method-list.html` template, with the following modifications:
 
-* A column for triggers added in `<thead>`
-* `tbody` moved to the item template for collapsible context
+*  A column for triggers added in `<thead>`
+*  `tbody` moved to the item template for collapsible context
 
 ```html
 <div id="checkout-shipping-method-load">

--- a/guides/v2.2/howdoi/customize-form-configuration.md
+++ b/guides/v2.2/howdoi/customize-form-configuration.md
@@ -15,7 +15,7 @@ To customize the product creation form, take the following steps:
 
 1. In your custom module, add an empty `product_form.xml` in the `<your_module_dir>/view/adminhtml/ui_component/` directory.
 
-2. In this file, add content similar to the following:
+1. In this file, add content similar to the following:
 
 ```xml
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
@@ -78,6 +78,6 @@ To delete an existing field, or field set, in your `product_form.xml` use the fo
 
 For reference, view the product form configuration files of the Magento modules:
 
-* `<Magento_Catalog_module_dir>/view/adminhtml/ui_component/product_form.xml`
-* `<Magento_CatalogInventory_module_dir>/view/adminhtml/ui_component/product_form.xml`
-* `<Magento_ConfigurableProduct_module_dir>/view/adminhtml/ui_component/product_form.xml`
+*  `<Magento_Catalog_module_dir>/view/adminhtml/ui_component/product_form.xml`
+*  `<Magento_CatalogInventory_module_dir>/view/adminhtml/ui_component/product_form.xml`
+*  `<Magento_ConfigurableProduct_module_dir>/view/adminhtml/ui_component/product_form.xml`

--- a/guides/v2.2/howdoi/customize-modifier-class.md
+++ b/guides/v2.2/howdoi/customize-modifier-class.md
@@ -18,7 +18,7 @@ The `Magento\Catalog\Ui\DataProvider\Product\Form\ProductDataProvider` data prov
 To add your custom modifier, you need to do the following:
 
 1. [Add the modifier code.](#modifier)
-2. [Add it to the modifiers' pool in `di.xml`](#pool)
+1. [Add it to the modifiers' pool in `di.xml`](#pool)
 
 ## Add your modifier {#modifier}
 
@@ -119,9 +119,9 @@ To access product model within your modifier, it's recommended to use an instanc
 
 For reference, view the modifier classes in the Magento modules, for example:
 
-- [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AdvancedPricing`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AdvancedPricing.php)
-- [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AttributeSet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AttributeSet.php)
-- [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php)
-- [`Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts.php)
+-  [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AdvancedPricing`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AdvancedPricing.php)
+-  [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AttributeSet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/AttributeSet.php)
+-  [`Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php)
+-  [`Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/Data/AssociatedProducts.php)
 
 For reference about setting conditions for displaying certain elements for certain product types, view `<Magento_Catalog_module_dir>/Ui/DataProvider/Product/Form/Modifier/Eav.php#L476`.

--- a/guides/v2.3/howdoi/checkout/checkout-add-custom-carrier.md
+++ b/guides/v2.3/howdoi/checkout/checkout-add-custom-carrier.md
@@ -17,9 +17,9 @@ This topic describes how to add a custom shipping carrier.
 To add a new shipping carrier to the Magento checkout:
 
 1. [Create a new module](#create-module)
-2. [Add the carrier configuration](#create-configuration)
-3. [Create the carrier model](#carrier-model)
-4. [Enable the module](#enable-module)
+1. [Add the carrier configuration](#create-configuration)
+1. [Create the carrier model](#carrier-model)
+1. [Enable the module](#enable-module)
 
 ## Step 1: Create a new module {#create-module}
 
@@ -100,14 +100,14 @@ To add a module configuration use the following source code snippets.
 
 The `system.xml` source code declares custom shipping module options:
 
-- Enabled
-- Title
-- Method Name
-- Shipping Cost
-- Ship to Applicable Countries
-- Ship to Specific Countries
-- Show Method if Not Applicable
-- Sort Order
+-  Enabled
+-  Title
+-  Method Name
+-  Shipping Cost
+-  Ship to Applicable Countries
+-  Ship to Specific Countries
+-  Show Method if Not Applicable
+-  Sort Order
 
 ```xml
 <?xml version="1.0"?>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- How Do I

The MD)29 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.