### PR TITLE
Fixed ordered list prefix (MD029) - Group 8

### DIFF
--- a/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_approach.md
+++ b/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_approach.md
@@ -13,7 +13,7 @@ Let's say you created a new [theme](https://glossary.magento.com/theme) inheriti
 To extend the parent theme's styles in your theme:
 
 1. In your theme directory, create a `web/css/source` sub-directory.
-2. Create a `_extend.less` file there. The path to it looks like following:
+1. Create a `_extend.less` file there. The path to it looks like following:
 
     ```tree
     <theme_dir>/
@@ -24,7 +24,7 @@ To extend the parent theme's styles in your theme:
     ...
     ```
 
-3. Add your Less code in this file.
+1. Add your Less code in this file.
 
 Extending a theme using `_extend.less` is the simplest option when you are happy with everything the parent theme has, but want to add more styles.
 
@@ -36,20 +36,21 @@ The rules and variables declared in `_extend.less` always have precedence over o
 To override parent styles (that is, override default Magento UI [library](https://glossary.magento.com/library) variables):
 
 1. In your theme directory, create a `web/css/source` sub-directory.
-2. Create a `_theme.less` file here. The path to it then looks like following:
+1. Create a `_theme.less` file here. The path to it then looks like following:
 
-    ```tree
-    <theme_dir>/
-    │  ├── web/
-    │  │   ├── css/
-    │  │   │   ├── source/
-    │  │   │      ├──_theme.less
-    ...
-    ```
-    It is important to remember that your `_theme.less` overrides the parent `_theme.less`.
+   ```tree
+   <theme_dir>/
+   │  ├── web/
+   │  │   ├── css/
+   │  │   │   ├── source/
+   │  │   │      ├──_theme.less
+   ...
+   ```
 
-3. Copy all variables you need from the parent `_theme.less`, including those which will not be changed. For example if your theme inherits from Blank, the `_theme.less` you should copy from is located at `<Magento_Blank_theme_dir>/web/css/source/_theme.less`.
-4. Make the necessary changes.
+   It is important to remember that your `_theme.less` overrides the parent `_theme.less`.
+
+1. Copy all variables you need from the parent `_theme.less`, including those which will not be changed. For example if your theme inherits from Blank, the `_theme.less` you should copy from is located at `<Magento_Blank_theme_dir>/web/css/source/_theme.less`.
+1. Make the necessary changes.
 
 The drawback of this approach is that you need to monitor and manually update your files whenever the parent's `_theme.less` is updated.
 
@@ -60,45 +61,46 @@ To make your changes easier to read and support, structure them by adding a sepa
 ### Extend component's styles {#structured_extend}
 
 1. In your theme directory, create a `web/css/source` sub-directory.
-2. Add `_buttons_extend.less` and `_extend.less` here. The path to the files looks like following:
+1. Add `_buttons_extend.less` and `_extend.less` here. The path to the files looks like following:
 
-    ```tree
-    <theme_dir>
-    │  ├── web/
-    │  │   ├── css/
-    │  │   │   ├── source/
-    │  │   │      ├──_buttons_extend.less
-    │  │   │      ├──_extend.less
-    ...
-    ```
+   ```tree
+   <theme_dir>
+   │  ├── web/
+   │  │   ├── css/
+   │  │   │   ├── source/
+   │  │   │      ├──_buttons_extend.less
+   │  │   │      ├──_extend.less
+   ...
+   ```
 
-3. In `_buttons_extend.less` add your styles for the button component.
-4. In `_extend.less` register the `_buttons_extend.less` by adding the following code: `@import '_buttons_extend.less';`
+1. In `_buttons_extend.less` add your styles for the button component.
+1. In `_extend.less` register the `_buttons_extend.less` by adding the following code: `@import '_buttons_extend.less';`
 
 ### Override component's styles {#structured_override}
 
 To override the parent theme's styles for buttons in your theme:
 
 1. In your theme directory, create a `web/css/source` sub-directory.
-2. Create a `_buttons.less` file here. The path to it looks like following:
+1. Create a `_buttons.less` file here. The path to it looks like following:
 
-    ```tree
-    <theme_dir>/
-    │  ├── web/
-    │  │   ├── css/
-    │  │   │   ├── source/
-    │  │   │      ├──_buttons.less
-    ...
-    ```
-    This file overrides the `_buttons.less` of the parent theme.
+   ```tree
+   <theme_dir>/
+   │  ├── web/
+   │  │   ├── css/
+   │  │   │   ├── source/
+   │  │   │      ├──_buttons.less
+   ...
+   ```
 
-3. Add your styles for the button component. If the file is left blank, then no styles are applied for the component.
+   This file overrides the `_buttons.less` of the parent theme.
+
+1. Add your styles for the button component. If the file is left blank, then no styles are applied for the component.
 
 ## Recommended reading
 
--   [Compile Less with Grunt]({{page.baseurl}}/frontend-dev-guide/css-topics/css_debug.html)
--   [CSS preprocessing]({{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html)
--   [Magento UI library]({{page.baseurl}}/frontend-dev-guide/css-topics/theme-ui-lib.html)
+-  [Compile Less with Grunt]({{page.baseurl}}/frontend-dev-guide/css-topics/css_debug.html)
+-  [CSS preprocessing]({{page.baseurl}}/frontend-dev-guide/css-topics/css-preprocess.html)
+-  [Magento UI library]({{page.baseurl}}/frontend-dev-guide/css-topics/theme-ui-lib.html)
 
 [Less compilation mode]: {{page.baseurl}}/frontend-dev-guide/css-guide/css_quick_guide_mode.html
 [Magento UI library component]: {{page.baseurl}}/frontend-dev-guide/css-topics/theme-ui-lib.html#library_elements

--- a/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_mode.md
+++ b/guides/v2.2/frontend-dev-guide/css-guide/css_quick_guide_mode.md
@@ -20,7 +20,7 @@ In our examples, we will change the color and font of the primary buttons. The d
 ## Before you begin
 
 1. [Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html). In your `theme.xml` file, specify Magento Luma or Magento Blank as the parent theme.
-2. [Apply your theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html#theme-apply-apply) in the [Magento Admin](https://glossary.magento.com/magento-admin).
+1. [Apply your theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html#theme-apply-apply) in the [Magento Admin](https://glossary.magento.com/magento-admin).
 
 ## Using server-side compilation mode
 

--- a/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
+++ b/guides/v2.2/frontend-dev-guide/css-topics/css-preprocess.md
@@ -49,11 +49,11 @@ In the Magento application, the following modes of compiling `.less` files to CS
 
 1. Server-side Less compilation.
 
-    This is the default compilation mode, and is the only option in [production application mode]. In this case the compilation is performed on the server, using the [Less PHP library].
+   This is the default compilation mode, and is the only option in [production application mode]. In this case the compilation is performed on the server, using the [Less PHP library].
 
-2. Client-side Less compilation.
+1. Client-side Less compilation.
 
-    When your application is not in the production mode, you can set Magento to compile `.less` files in a browser, using the [native `less.js` library]
+   When your application is not in the production mode, you can set Magento to compile `.less` files in a browser, using the [native `less.js` library]
 
 To set the compilation mode, do the following:
 
@@ -112,13 +112,15 @@ Errors are caught as exceptions and written to the system log (by default it is 
 
 Example of an error message:
 
-    Compilation from source: /var/www/magento2/app/design/adminhtml/Magento/backend/web/css/styles.less
-    variable @variable-x is undefined in file /var/www/magento2/var/view_preprocessed/css/adminhtml/Magento/backend/en_US/css/styles.less in styles.less on line 56, column 17
-          margin-left: 0;
-          width: 100%;
-          height: @variable-x;
-     }
-     .menu-wrapper,
+```terminal
+Compilation from source: /var/www/magento2/app/design/adminhtml/Magento/backend/web/css/styles.less
+variable @variable-x is undefined in file /var/www/magento2/var/view_preprocessed/css/adminhtml/Magento/backend/en_US/css/styles.less in styles.less on line 56, column 17
+        margin-left: 0;
+        width: 100%;
+        height: @variable-x;
+    }
+    .menu-wrapper,
+```
 
 ##### Debugging using Grunt
 

--- a/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
@@ -84,16 +84,16 @@ To make the necessary changes, create [extending][extend] and [overriding][overr
 The Magento application processes layout files in the following order:
 
 1. Module base files loaded.
-2. Module area files loaded.
-3. Collects all layout files from modules. The order is determined by the modules order in the module list from the `app/etc/config.php` file. (If their priorities are equal, they are sorted according to their alphabetical priority.)
-4. Determines the sequence of [inherited] themes `[<parent_theme>, ..., <parent1_theme>] <current_theme>`
-5. Iterates the sequence of themes from last ancestor to current:
+1. Module area files loaded.
+1. Collects all layout files from modules. The order is determined by the modules order in the module list from the `app/etc/config.php` file. (If their priorities are equal, they are sorted according to their alphabetical priority.)
+1. Determines the sequence of [inherited] themes `[<parent_theme>, ..., <parent1_theme>] <current_theme>`
+1. Iterates the sequence of themes from last ancestor to current:
 
    a. Adds all extending theme layout files to the list.
 
    b. Replaces overridden layout files in the list.
 
-6. Merges all layout files from the list.
+1. Merges all layout files from the list.
 
 Layout files that belong to inactive modules or modules with disabled output are ignored.
 {: .bs-callout .bs-callout-info }

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd-breakpoints.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd-breakpoints.md
@@ -14,15 +14,15 @@ Breakpoints are used in stylesheets to set up the screen width at which the desi
 To add a custom breakpoint in your theme, you need to do the following:
 
 1. Define a variable for the new breakpoint.
-2. Override the library `_responsive.less` file, and add the new rule for the new breakpoint.
-3. Implement the screen changes for the new breakpoint.
+1. Override the library `_responsive.less` file, and add the new rule for the new breakpoint.
+1. Implement the screen changes for the new breakpoint.
 
 ## Add a new breakpoint variable
 
 In your custom theme directory, add a `/web/css/source/variables.less` in one of the following ways:
 
-- if your theme [inherits]({{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html) from the other, then copy the parent's `variables.less`.
-- if your theme is a standalone one, add a new empty file.
+-  if your theme [inherits]({{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html) from the other, then copy the parent's `variables.less`.
+-  if your theme is a standalone one, add a new empty file.
 
 In `variable.less`, add the variable for your new breakpoint.
 
@@ -43,9 +43,9 @@ To implement a new breakpoint, you need to edit the `.media-width()` mixin by ad
 To do this, take the following steps:
 
 1. Copy the `_responsive.less` file to your `<your_theme_dir>/web/css/source/lib/` directory from one of the following locations:
-   - `<your_parent_theme_dir>/web/css/source/lib/_responsive.less`: overriding `_responsive.less` in the parent theme. If there's no such file or no parent theme, use the other option.
-   - `<your_theme_dir>/web/css/source/lib/_responsive.less`: the library file.
-2. In your `_responsive.less` file, add the `.media-width` [mixin](https://glossary.magento.com/mixin) rule for your breakpoint in the corresponding section (desktop or mobile, depending on the type of breakpoint you add).
+   -  `<your_parent_theme_dir>/web/css/source/lib/_responsive.less`: overriding `_responsive.less` in the parent theme. If there's no such file or no parent theme, use the other option.
+   -  `<your_theme_dir>/web/css/source/lib/_responsive.less`: the library file.
+1. In your `_responsive.less` file, add the `.media-width` [mixin](https://glossary.magento.com/mixin) rule for your breakpoint in the corresponding section (desktop or mobile, depending on the type of breakpoint you add).
 
 {:.bs-callout .bs-callout-info}
 The `@media-target` option may have one of the following values: `all`, `desktop` or `mobile`.
@@ -78,5 +78,5 @@ Example:
 
 ## Related reading
 
-- You can find information about the `_responsive.less` library file in the generated Magento UI library documentation. It is available in the following location in your Magento installation: `<your_Magento_installation>/pub/static/frontend/Magento/blank/en_US/css/docs/responsive.html`.
-- [How to make your theme responsive and mobile]({{ page.baseurl }}/frontend-dev-guide/responsive-web-design/rwd_overview.html).
+-  You can find information about the `_responsive.less` library file in the generated Magento UI library documentation. It is available in the following location in your Magento installation: `<your_Magento_installation>/pub/static/frontend/Magento/blank/en_US/css/docs/responsive.html`.
+-  [How to make your theme responsive and mobile]({{ page.baseurl }}/frontend-dev-guide/responsive-web-design/rwd_overview.html).

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_mobile.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_mobile.md
@@ -15,7 +15,7 @@ To use all the responsive approaches implemented in the Magento out-of-the-box B
 To create a mobile-specific theme:
 
 1. Create a theme as described in [Create a theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html), having specified Blank or Luma as a parent theme.
-2. Add a `<theme_dir>/Magento_Theme/layout/default_head_blocks.xml` [layout](https://glossary.magento.com/layout) file with the following content:
+1. Add a `<theme_dir>/Magento_Theme/layout/default_head_blocks.xml` [layout](https://glossary.magento.com/layout) file with the following content:
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
@@ -44,4 +44,3 @@ This will remove the desktop-specific files from your theme.
 ## Recommended reading
 
 [CSS in Magento responsive design]({{page.baseurl}}/frontend-dev-guide/responsive-web-design/rwd_css.html)
-

--- a/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_practice.md
+++ b/guides/v2.2/frontend-dev-guide/responsive-web-design/rwd_practice.md
@@ -16,23 +16,23 @@ OrangeCo wants to make their products more visible by decreasing the quantity of
 
 In the basic Blank theme, the number of products in a row for each breakpoint is the following (for the [2-column page layout]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-types.html#layout-types-page)):
 
--   1024px and more (desktop): four products
--   768px (tablet): three products
--   640px and less (mobile): two products
+-  1024px and more (desktop): four products
+-  768px (tablet): three products
+-  640px and less (mobile): two products
 
 In their custom Orange theme, OrangeCo wants to have the least number of products in a row for the desktop and tablet view, namely:
 
--   Desktop: three products
--   Tablet: two products
--   Mobile: two products
+-  Desktop: three products
+-  Tablet: two products
+-  Mobile: two products
 
 The Orange theme inherits from the Blank theme.
 
 To change the products quantity, OrangeCo take the following steps:
 
-1.  Copy the [`/Magento_Catalog/web/css/source/module/_listings.less`] file.
-2.  Put it in the corresponding location in their Orange theme directory: `app/design/frontend/OrangeCo/orange/Magento_Catalog/web/css/source/module/_listings.less`
-3.  Make the changes in the code. The following image illustrates which section of the file they change, the modified lines are highlighted:
+1. Copy the [`/Magento_Catalog/web/css/source/module/_listings.less`] file.
+1. Put it in the corresponding location in their Orange theme directory: `app/design/frontend/OrangeCo/orange/Magento_Catalog/web/css/source/module/_listings.less`
+1. Make the changes in the code. The following image illustrates which section of the file they change, the modified lines are highlighted:
 
 ![responsive practice 1]
 

--- a/guides/v2.2/frontend-dev-guide/templates/template-email.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-email.md
@@ -24,30 +24,30 @@ Override email templates by creating templates in a new directory in your custom
 Any templates configured in the Magento [Admin](https://glossary.magento.com/admin) take precedence over default or theme-based templates.
 
 1. In the Magento Admin, navigate to **MARKETING** > Communications > **Email Templates**
-2. Click **Add New Template**.
-3. If you want to use a default template as a starting point, in the **Load default template** section, choose the template and click **Load Template**. The path to the configuration settings for each default template displays in the **Currently Used For** field in the Template Information section.
+1. Click **Add New Template**.
+1. If you want to use a default template as a starting point, in the **Load default template** section, choose the template and click **Load Template**. The path to the configuration settings for each default template displays in the **Currently Used For** field in the Template Information section.
 
    Make note of this path because you will need it later when you configure this new template to be used instead of the default template.
 
    ![New template creation page with loaded default template]({{ site.baseurl }}/common/images/email_create_template21.png){:width="70%"}{:height="70%"}
 
-4. In **Template Name**, enter a name to identify the template in the Magento Admin.
-5. In **Template Subject**, add plain text to use as the Subject of the emails sent using the template you create. This field can contain system variables.
-6. Customize template content. For details, see [the section on customizing content](#customize-content).
-7. In **Template Styles**, optionally add CSS styles for the template. These styles are added inside of a `<style>` tag in the `<head>` of the email. Typically, you'll use the [Less files](#email-styles) to make style changes to emails because some email clients don't support styles in `<style>` tags.
-8. Click **Save Template**.
-9. Now that you have created a template, you must configure that template to be used:
+1. In **Template Name**, enter a name to identify the template in the Magento Admin.
+1. In **Template Subject**, add plain text to use as the Subject of the emails sent using the template you create. This field can contain system variables.
+1. Customize template content. For details, see [the section on customizing content](#customize-content).
+1. In **Template Styles**, optionally add CSS styles for the template. These styles are added inside of a `<style>` tag in the `<head>` of the email. Typically, you'll use the [Less files](#email-styles) to make style changes to emails because some email clients don't support styles in `<style>` tags.
+1. Click **Save Template**.
+1. Now that you have created a template, you must configure that template to be used:
 
    1. If you haven't done so already, log in to the Magento Admin as an administrator.
-   2. Click **STORES** > Settings > **Configuration** > SALES > **Sales Emails**.
-   3. In the left pane, locate the section that contains the template you want to override. This is the section referenced by **Currently Used For** in your new template. (See step 3 earlier in this section.)
+   1. Click **STORES** > Settings > **Configuration** > SALES > **Sales Emails**.
+   1. In the left pane, locate the section that contains the template you want to override. This is the section referenced by **Currently Used For** in your new template. (See step 3 earlier in this section.)
 
-       For example, if you created a "New Order" template, the configuration section is **Order** as the following figure shows.
+      For example, if you created a "New Order" template, the configuration section is **Order** as the following figure shows.
 
-       ![Choosing a custom template]({{ site.baseurl }}/common/images/email_choose-template21.png){:width="70%"}{:height="70%"}
+      ![Choosing a custom template]({{ site.baseurl }}/common/images/email_choose-template21.png){:width="70%"}{:height="70%"}
 
-   4. Select your newly created template from the list.
-   5. Click **Save Config**.
+   1. Select your newly created template from the list.
+   1. Click **Save Config**.
 
 ### Customize header and footer templates {#customize-header-footer}
 
@@ -109,12 +109,13 @@ You can also create your own custom variables and set their values in the Admin,
 To add a variable to your template content:
 
 1. In the Magento Admin, navigate to **MARKETING** > Communications > **Email Templates**
-2. Create a new template or edit an existing template.
-3. Click to place the cursor in the text in which to insert the variable.
-4. Click **Insert Variable**. A pop-up containing a list of variables opens, including custom variables. The variables in the **Store Contact Information** are available in all email templates whereas the variables in the **Template Variables** section are specific to the template you're editing. The following figure shows an example:
+1. Create a new template or edit an existing template.
+1. Click to place the cursor in the text in which to insert the variable.
+1. Click **Insert Variable**. A pop-up containing a list of variables opens, including custom variables. The variables in the **Store Contact Information** are available in all email templates whereas the variables in the **Template Variables** section are specific to the template you're editing. The following figure shows an example:
+
    ![The list of available variables]({{ site.baseurl }}/common/images/email_insert_variable21.png){:width="70%"}{:height="70%"}
 
-5. Click the name of the required variable. <br> The variable code is inserted in the template content.
+1. Click the name of the required variable. <br> The variable code is inserted in the template content.
 
 {:.bs-callout .bs-callout-info}
 The selection of available variables depends on which template you use as a basis. The template-specific variables are contained in a `<!--@vars @-->` comment at the top of each template on the file system. (For example, look at [app/code/Magento/Customer/view/frontend/email/account_new.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/view/frontend/email/account_new.html#L8).
@@ -308,7 +309,7 @@ Here is an overview of how the font structure for emails works:
 If you want to change the font used for emails, do the following:
 
 1. Refer to the documentation on [using fonts]({{ page.baseurl }}/frontend-dev-guide/css-topics/using-fonts.html) for details on how to add a new font.
-2. After you've added a new font and have updated the `source/_variables.less` and `source/_typography.less` files for your custom theme to refer to the new font, the emails should automatically use the specified font.
+1. After you've added a new font and have updated the `source/_variables.less` and `source/_typography.less` files for your custom theme to refer to the new font, the emails should automatically use the specified font.
 
 ## Email logo {#email-logo}
 
@@ -326,7 +327,7 @@ To customize your logo using a theme:
 
    For example, if the OrangeCo vendor wants to add a logo for their custom Orange, they must add a file in the `app/design/frontend/OrangeCo/orange/Magento_Email/web` directory.
 
-2. Copy the `<Magento_Email_module_dir>/view/frontend/email/header.html` file into a `Magento_Email/email` directory in your theme.
+1. Copy the `<Magento_Email_module_dir>/view/frontend/email/header.html` file into a `Magento_Email/email` directory in your theme.
 
    For example, the OrangeCo vendor would copy the file to this location: `app/design/frontend/OrangeCo/orange/Magento_Email/email/header.html`
 
@@ -355,13 +356,14 @@ To customize your logo using a theme:
 ### Customize the email logo using the Admin {#customize-logo-admin}
 
 1. In the Magento Admin, navigate to **CONTENT** > Design > **Configuration**. A Design Configuration page opens. It contains a grid with the available configuration scopes.
-2. In the configuration record corresponding to your store view, click **Edit**.
-3. Under **Transactional Emails** in the **Logo Image** field upload your logo and specify the alternative text for it.
+1. In the configuration record corresponding to your store view, click **Edit**.
+1. Under **Transactional Emails** in the **Logo Image** field upload your logo and specify the alternative text for it.
+
    ![System configuration]({{ site.baseurl }}/common/images/email_templ_logo21.png)
 
-4. Enter values for **Logo Width** and **Logo Height**. Based on the preceding example, you would enter `200` and `100`, respectively.
+1. Enter values for **Logo Width** and **Logo Height**. Based on the preceding example, you would enter `200` and `100`, respectively.
 
-5. Click the **Save Configuration** button.
+1. Click the **Save Configuration** button.
 
 ## Use contact information in emails {#contact-information-emails}
 
@@ -371,13 +373,13 @@ To set those values:
 
 1. To set the store name, phone number, and hours of operation:
    1. In the Magento Admin, navigate to **STORES** > Settings > **Configuration** > GENERAL > **General** > **Store Information**
-   2. Input values into the **Store Name**, **Store Phone Number**, and **Store Hours of Operation** fields.
-   3. Note: The **Store Phone Number** and **Store Hours of Operation** fields are optional.
-   4. Click the **Save Config** button.
-2. To set the store email:
+   1. Input values into the **Store Name**, **Store Phone Number**, and **Store Hours of Operation** fields.
+   1. Note: The **Store Phone Number** and **Store Hours of Operation** fields are optional.
+   1. Click the **Save Config** button.
+1. To set the store email:
    1. In the Magento Admin, navigate to **STORES** > Settings > **Configuration** > GENERAL > **General** > **Store Email Addresses** > **General Contact**
-   2. Input values into the **Sender Name** and **Sender Email** fields.
-   3. Click the **Save Config** button.
+   1. Input values into the **Sender Name** and **Sender Email** fields.
+   1. Click the **Save Config** button.
 
 The sales emails are configured to display all of the above values, if they're configured in the admin. If you want to add those values to other email templates, you can use the following variables:
 

--- a/guides/v2.2/frontend-dev-guide/templates/template-walkthrough.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-walkthrough.md
@@ -19,15 +19,15 @@ To customize a template:
 
 1. Locate the template which is associated with the page/block you want to change using [template hints]({{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html#debug-theme-templ).
 
-2. Copy the template to your theme folder according to the [template storing convention]({{ page.baseurl }}/frontend-dev-guide/templates/template-override.html#template-convention).
+1. Copy the template to your theme folder according to the [template storing convention]({{ page.baseurl }}/frontend-dev-guide/templates/template-override.html#template-convention).
 
-3. Make the required changes.
+1. Make the required changes.
 
 To add a new template in a theme:
 
 1. Add a template in your theme directory according to the template storing convention.
 
-2. Assign your template to a block in the [corresponding layout file]({{ page.baseurl }}/frontend-dev-guide/templates/template-override.html#template-layout).
+1. Assign your template to a block in the [corresponding layout file]({{ page.baseurl }}/frontend-dev-guide/templates/template-override.html#template-layout).
 
 {:.bs-callout .bs-callout-tip}
 If you add a new `.html` template, and then edit it, the changes will not apply until you delete all files in the `pub/static/frontend` and `var/view_preprocessed` directories and reload the pages. You can delete the files manually or run the `grunt clean:<theme_name>` command in CLI. For details about using Grunt in Magento see [Installing and configuring Grunt]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html).

--- a/guides/v2.2/frontend-dev-guide/themes/admin_theme_apply.md
+++ b/guides/v2.2/frontend-dev-guide/themes/admin_theme_apply.md
@@ -13,8 +13,8 @@ This topic describes how to apply your custom [theme](https://glossary.magento.c
 ## Prerequisites
 
 1. [Set]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html) your Magento application to the developer [mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached by Magento.
-2. [Create a custom theme for the Admin panel]({{ page.baseurl }}/frontend-dev-guide/themes/admin_theme_create.html).
-3. [Add a new custom module]({{ page.baseurl }}/extension-dev-guide/build/build.html) or decide to use existing custom module. The module must load after the Magento_Theme module. To ensure this, add the following code in `<your_custom_module_dir>/etc/module.xml` (replace placeholders with your [module](https://glossary.magento.com/module) information):
+1. [Create a custom theme for the Admin panel]({{ page.baseurl }}/frontend-dev-guide/themes/admin_theme_create.html).
+1. [Add a new custom module]({{ page.baseurl }}/extension-dev-guide/build/build.html) or decide to use existing custom module. The module must load after the Magento_Theme module. To ensure this, add the following code in `<your_custom_module_dir>/etc/module.xml` (replace placeholders with your [module](https://glossary.magento.com/module) information):
 
    ```xml
    <module name="%YourVendor_YourModule%" setup_version="2.0.1"> <!-- Example: "Magento_Backend" -->
@@ -34,9 +34,9 @@ If you decide to use the existing module, keep in mind, that theme declaring mig
 
 To apply the [Admin](https://glossary.magento.com/admin) theme, take the following steps:
 
-2. [Specify the new Admin theme in your module's `di.xml`](#specify_di)
-3. Update the components by running the [`bin/magento setup:upgrade`]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall.html#instgde-install-keep) command.
-4. Open the Admin in browser and view the new theme applied.
+1. [Specify the new Admin theme in your module's `di.xml`](#specify_di)
+1. Update the components by running the [`bin/magento setup:upgrade`]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall.html#instgde-install-keep) command.
+1. Open the Admin in browser and view the new theme applied.
 
 Each step is described further with more details.
 

--- a/guides/v2.2/frontend-dev-guide/themes/admin_theme_create.md
+++ b/guides/v2.2/frontend-dev-guide/themes/admin_theme_create.md
@@ -18,10 +18,10 @@ This topic describes how to create your custom theme for Magento Admin, referenc
 To create a custom [Admin](https://glossary.magento.com/admin) theme, take the following steps:
 
 1. [Create a theme directory.](#create_dir)
-2. [Add a declaration `theme.xml`.](#declare_theme)
-3. [Add `registration.php`.](#add_registry)
-4. [Optionally add `composer.json`.](#make_composer)
-5. [Optionally change theme logo.](#logo)
+1. [Add a declaration `theme.xml`.](#declare_theme)
+1. [Add `registration.php`.](#add_registry)
+1. [Optionally add `composer.json`.](#make_composer)
+1. [Optionally change theme logo.](#logo)
 
 Each step is described further.
 
@@ -78,19 +78,21 @@ To customize the Admin theme logo:
 
 1. Create a new XML file in the theme named `app/design/adminhtml/<Vendor>/<theme>/Magento_Backend/layout/admin_login.xml`.
 
-2. Add the following sample code to the new file.
-     ```xml
-    <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-login" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-        <body>
-            <referenceBlock name="logo">
-                <arguments>
-                    <argument name="logo_image_src" xsi:type="string">images/custom-logo.svg</argument>
-                </arguments>
-            </referenceBlock>
-        </body>
+1. Add the following sample code to the new file.
+
+   ```xml
+   <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-login" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+       <body>
+           <referenceBlock name="logo">
+               <arguments>
+                   <argument name="logo_image_src" xsi:type="string">images/custom-logo.svg</argument>
+               </arguments>
+           </referenceBlock>
+       </body>
     </page>
     ```
-3. Add your custom logo to the `app/design/adminhtml/<Vendor>/<theme>/web/images/` directory.
+
+1. Add your custom logo to the `app/design/adminhtml/<Vendor>/<theme>/web/images/` directory.
 
 ## Theme registration {#register_theme}
 
@@ -99,4 +101,3 @@ Once you open the Magento Admin (or reload any  Magento Admin page) having added
 ## Apply the Admin theme
 
 See the [Apply a custom Admin theme topic]({{ page.baseurl }}/frontend-dev-guide/themes/admin_theme_apply.html).
-

--- a/guides/v2.2/frontend-dev-guide/themes/debug-theme.md
+++ b/guides/v2.2/frontend-dev-guide/themes/debug-theme.md
@@ -18,10 +18,10 @@ To enable template hints:
 
 1. Click **Stores** > **Settings** > **Configuration** > ADVANCED > **Developer**.
 
-2. In the **Scope** dropdown in the upper-left corner select the view for which you want the template hints.
+1. In the **Scope** dropdown in the upper-left corner select the view for which you want the template hints.
 
-3. In the **Debug** tab, set **Template Path Hints for storefront** to **Yes**. To enable path hints for [Admin](https://glossary.magento.com/admin) set **Template Path Hints for Admin** to **Yes**.
-4. To save the changes, click **Save Config** in the upper-right corner.
+1. In the **Debug** tab, set **Template Path Hints for storefront** to **Yes**. To enable path hints for [Admin](https://glossary.magento.com/admin) set **Template Path Hints for Admin** to **Yes**.
+1. To save the changes, click **Save Config** in the upper-right corner.
 
 ![Enabling template hints]({{ site.baseurl }}/common/images/fdg_debug_theme.png)
 
@@ -73,9 +73,9 @@ Just like templates, layouts are saved on a per-module basis. You can easily loc
 After you have determined the module, you can search for the layout in the following locations:
 
 1. `<current_theme_dir>/<Namespace>_<Module>/layout/`
-2. `<parent_theme(s)_dir>/<Namespace>_<Module>/layout/`
-3. `<module_dir>/view/frontend/layout/`
-4. `<module_dir>/view/base/layout/`
+1. `<parent_theme(s)_dir>/<Namespace>_<Module>/layout/`
+1. `<module_dir>/view/frontend/layout/`
+1. `<module_dir>/view/base/layout/`
 
 There is no straightforward algorithm how to define at once the exact layout file, but in most cases layout file names are self descriptive. Also you can search them for mentions of the corresponding templates.
 
@@ -88,8 +88,8 @@ Using the Template Hints we determine that the template is `app/code/Magento/Che
 Let's search for the layout following the fallback scheme:
 
 1. Check the `app/design/frontend/Magento/blank/Magento_Checkout/` layout. To locate the required layout, search this directory for occurrences of the template name, " minicart.phtml ". No matching file is found, so we proceed to the next fallback level, which is the parent theme layouts.
-2. We can find the info about parent theme in a theme configuration file `theme.xml`, the parent theme name is specified there in the `<parent></parent>` node. In the `app/design/frontend/Magento/blank/theme.xml` there's no `<parent>` node, which means the Blank theme has no parents. So we should search on the next fallback level which is the module layouts.
-3. The Magento_Checkout layouts are located in `app/code/Magento/Checkout/view/frontend/layout/`. After searching this directory for occurrences of "`minicart.phtml`", we define that the layout we are looking for is `app/code/Magento/Checkout/view/frontend/layout/default.xml`.
+1. We can find the info about parent theme in a theme configuration file `theme.xml`, the parent theme name is specified there in the `<parent></parent>` node. In the `app/design/frontend/Magento/blank/theme.xml` there's no `<parent>` node, which means the Blank theme has no parents. So we should search on the next fallback level which is the module layouts.
+1. The Magento_Checkout layouts are located in `app/code/Magento/Checkout/view/frontend/layout/`. After searching this directory for occurrences of "`minicart.phtml`", we define that the layout we are looking for is `app/code/Magento/Checkout/view/frontend/layout/default.xml`.
 
 After you located the necessary layout file, you can create your custom layout file with the corresponding name in your theme folder to add [extending]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-extend.html) or [overriding]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-override.html) content. Please see [Customizing Theme Layouts]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-overview.html) for more details.
 
@@ -98,12 +98,12 @@ After you located the necessary layout file, you can create your custom layout f
 To locate a CSS rule that is applied to a certain element, find the template for the page that contains the element. Or you can use browser debugging tools, to locate the class name.
 After you find the class name, use text search in the theme and module styles directories to locate the `.less` or `.css` file that defines the class. Perform the search according to the following fallback scheme:
 
-2. Theme styles `<current_theme_dir>/web/css/`
-2. Module theme styles `<current_theme_dir>/<Namespace>_<Module>/web/css/`
-3. Parent theme styles `<parent_theme_dir>/web/css/`
-4. Parent theme Module styles `<parent_theme_dir>/<Namespace>_<Module>/web/css/`
-5. Module styles for the `frontend` area `<module_dir>/view/frontend/web/css/`
-6. Module styles for the `base` area `<module_dir>/view/base/web/css/`
+1. Theme styles `<current_theme_dir>/web/css/`
+1. Module theme styles `<current_theme_dir>/<Namespace>_<Module>/web/css/`
+1. Parent theme styles `<parent_theme_dir>/web/css/`
+1. Parent theme Module styles `<parent_theme_dir>/<Namespace>_<Module>/web/css/`
+1. Module styles for the `frontend` area `<module_dir>/view/frontend/web/css/`
+1. Module styles for the `base` area `<module_dir>/view/base/web/css/`
 
 Example:
 
@@ -114,6 +114,6 @@ In the mini shopping cart template `app/code/Magento/Checkout/view/frontend/temp
 So, let's search for occurrences of "`minicart-wrapper`" in according to the fallback scheme:
 
 1. Search in `app/design/frontend/Magento/blank/web/css`, the search returns no results.
-2. Search in `app/design/frontend/Magento/blank/Magento_Checkout/web/css`.The "`minicart-wrapper`" style is defined in `app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less`
+1. Search in `app/design/frontend/Magento/blank/Magento_Checkout/web/css`.The "`minicart-wrapper`" style is defined in `app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less`
 
 After you determine which `.css` or `.less` file defines the class, you can override the default class definition in your custom `.css` or `.less` files.  For details, see [CSS in themes]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-themes.html).

--- a/guides/v2.2/frontend-dev-guide/themes/favicon.md
+++ b/guides/v2.2/frontend-dev-guide/themes/favicon.md
@@ -25,16 +25,16 @@ See the following sections for details about adding favicons.
 To add a custom favicon in the Magento Admin, do the following:
 
 1. Navigate to **CONTENT** > **Design** > **Configuration**.
-2. In the scope grid, decide on which level you will configure the favicon and click **Edit** in the corresponding row.
+1. In the scope grid, decide on which level you will configure the favicon and click **Edit** in the corresponding row.
 
    ![favicon 1]({{site.baseurl}}/common/images/favicon_2_21.png)
 
-3. Under the **Other Settings** title, expand the **HTML Head** options.
-4. Next to **Favicon Icon**, click **Upload**, and select the file.
+1. Under the **Other Settings** title, expand the **HTML Head** options.
+1. Next to **Favicon Icon**, click **Upload**, and select the file.
 
    ![favicon 2]({{site.baseurl}}/common/images/favicon_1_21.png)
 
-5. Click **Save Configuration** in the upper right corner to save the changes.
+1. Click **Save Configuration** in the upper right corner to save the changes.
 
 If caching is enabled in your Admin, you get a notification that refreshing certain [cache](https://glossary.magento.com/cache) types is required. Click the link provided in the notification, and then click **Flush Magento Cache**. You can also navigate to **System** > Tools > **Cache Management** and click **Flush Magento Cache**, or run `bin/magento cache:flush`.
 
@@ -45,7 +45,7 @@ To override the default 16px x 16px favicon manually, add your custom `favicon.i
 To add favicon icons of other sizes, take the following steps:
 
 1. Add your icons in the `<your_theme_dir>/Magento_Theme/web/` directory.
-2. In the `<your_theme_dir>/Magento_Theme/layout/default_head_blocks.xml` layout file specify the paths to the icons and their sizes.
+1. In the `<your_theme_dir>/Magento_Theme/layout/default_head_blocks.xml` layout file specify the paths to the icons and their sizes.
 
 For example, if you added a `favicon-32x32.png` icon and want it to be used as a 32px x 32px favicon, your `default_head_blocks.xml` would be like following:
 
@@ -59,6 +59,5 @@ For example, if you added a `favicon-32x32.png` icon and want it to be used as a
 
 For your changes to be applied, clear the browser cache, and the following directories on the server (do not delete the `.htaccess` file!):
 
-- `pub/static`
-- all directories under `var`
-
+-  `pub/static`
+-  all directories under `var`

--- a/guides/v2.2/frontend-dev-guide/themes/theme-create.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-create.md
@@ -14,18 +14,18 @@ A new theme you create is not applied for your store automatically. You need to 
 ## Prerequisites
 
 1. For the sake of compatibility, upgradability, and easy maintenance, do not modify the out of the box Magento themes. To customize the design of your Magento store, create a new custom [theme](https://glossary.magento.com/theme).
-2. [Set]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-mode.html) your Magento application to the developer [mode]({{page.baseurl}}/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached by Magento. The recommendations about theme development we provide in this chapter are developer/default-mode specific.
+1. [Set]({{page.baseurl}}/config-guide/cli/config-cli-subcommands-mode.html) your Magento application to the developer [mode]({{page.baseurl}}/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached by Magento. The recommendations about theme development we provide in this chapter are developer/default-mode specific.
 
 ## Create a storefront theme: walkthrough {#theme-gen-walkthrough}
 
 The high-level steps required to add a new theme in the Magento system are the following:
 
 1. Create a directory for the theme under `app/design/frontend/<your_vendor_name>/<your_theme_name>`.
-2. Add a declaration file `theme.xml` and optionally create `etc` directory and create a file named `view.xml` to the theme directory.
-3. Add a `composer.json` file.
-4. Add `registration.php`.
-3. Create directories for CSS, JavaScript, images, and fonts.
-4. Configure your theme in the [Admin](https://glossary.magento.com/admin) panel.
+1. Add a declaration file `theme.xml` and optionally create `etc` directory and create a file named `view.xml` to the theme directory.
+1. Add a `composer.json` file.
+1. Add `registration.php`.
+1. Create directories for CSS, JavaScript, images, and fonts.
+1. Configure your theme in the [Admin](https://glossary.magento.com/admin) panel.
 
 ## Recommended reading
 
@@ -38,9 +38,9 @@ To create the directory for your theme:
 
 1. Go to `<magento_root>/app/design/frontend`.
 
-3. Create a new directory named according to your vendor name: `/app/design/frontend/<Vendor>`.
+1. Create a new directory named according to your vendor name: `/app/design/frontend/<Vendor>`.
 
-4. Under the `<vendor>` directory, create a directory named according to your theme.
+1. Under the `<vendor>` directory, create a directory named according to your theme.
 
     <pre>
     app/design/frontend/
@@ -58,26 +58,26 @@ After you create a directory for your theme, you must create `theme.xml` contain
 
 1. Add or copy from an existing `theme.xml` file to your theme directory `app/design/frontend/<Vendor>/<theme>`.
 
-2. Configure it using the following example:
+1. Configure it using the following example:
 
-    ```xml
-    <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
-         <title>New theme</title> <!-- your theme's name -->
-         <parent>Magento/blank</parent> <!-- the parent theme, in case your theme inherits from an existing theme -->
-         <media>
-             <preview_image>media/preview.jpg</preview_image> <!-- the path to your theme's preview image -->
-         </media>
-    </theme>
-    ```
+   ```xml
+   <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
+        <title>New theme</title> <!-- your theme's name -->
+        <parent>Magento/blank</parent> <!-- the parent theme, in case your theme inherits from an existing theme -->
+        <media>
+            <preview_image>media/preview.jpg</preview_image> <!-- the path to your theme's preview image -->
+        </media>
+   </theme>
+   ```
 
-    If you do not have a preview image for your theme, remove the `<media>` node:
+   If you do not have a preview image for your theme, remove the `<media>` node:
 
-    ```xml
-    <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
-         <title>New theme</title> <!-- your theme's name -->
-         <parent>Magento/blank</parent> <!-- the parent theme, in case your theme inherits from an existing theme -->
-    </theme>
-    ```
+   ```xml
+   <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
+        <title>New theme</title> <!-- your theme's name -->
+        <parent>Magento/blank</parent> <!-- the parent theme, in case your theme inherits from an existing theme -->
+   </theme>
+   ```
 
 If you change the theme title or parent theme information in `theme.xml` after a theme was already [registered](#register_theme), you need to open or reload any [Magento Admin](https://glossary.magento.com/magento-admin) page for your changes to be saved in the database.
 

--- a/guides/v2.2/frontend-dev-guide/themes/theme-inherit.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-inherit.md
@@ -40,11 +40,11 @@ A parent and a child theme can belong to different vendors. For example, your cu
 
 ## Differences between parent and child themes
 
-* A child theme inherits view configuration, templates, layouts, and static file from its parents.
+*  A child theme inherits view configuration, templates, layouts, and static file from its parents.
 
-* A child theme is used first, whereas the parent theme is only indirectly active; its static file, layout, templates will be used if not overridden by the child theme.
+*  A child theme is used first, whereas the parent theme is only indirectly active; its static file, layout, templates will be used if not overridden by the child theme.
 
-* Any theme can be chosen to display, whether or not it specifies a parent theme in `theme.xml`.
+*  Any theme can be chosen to display, whether or not it specifies a parent theme in `theme.xml`.
 
 ## Override view.xml file
 
@@ -61,21 +61,25 @@ The particular directories, where the system searches in the course of the fallb
 If module context is not defined for a file:
 
 1. Current theme [static files](https://glossary.magento.com/static-files) for a specific locale (the locale set for the storefront): `<theme_dir>/web/i18n/<locale>`
-2. Current theme static files: `<theme_dir>/web/`
-2. Ancestor's static files, recursively, until a theme with no parent is reached:
-- `<parent_theme_dir>/web/i18n/<locale>`
-- `<parent_theme_dir>/web/`
-3. Library static view files: `lib/web/`
+1. Current theme static files: `<theme_dir>/web/`
+1. Ancestor's static files, recursively, until a theme with no parent is reached:
+
+   *  `<parent_theme_dir>/web/i18n/<locale>`
+   *  `<parent_theme_dir>/web/`
+
+1. Library static view files: `lib/web/`
 
 If module context is defined for a file:
 
 1. Current theme and current locale module static files: `<theme_dir>/web/i18n/<locale>/<Namespace>_<Module>`
-2. Current theme module static files `<theme_dir>/<Namespace>_<Module>/web/`. Example: `app/design/frontend/OrangeCorp/orange/Magento_Catalog/web/`
-3. Ancestor themes module static files, recursively, until a theme with no ancestor is reached:
-- `<parent_theme_dir>/web/i18n/<locale>/<Namespace>_<Module>`
-- `<parent_theme_dir>/<Namespace>_<Module>/web/`
-3. Module static view files for the `frontend` area: `<module_dir>/view/frontend/web/`
-4. Module static view files for the `base` area: `<module_dir>/view/base/web/`
+1. Current theme module static files `<theme_dir>/<Namespace>_<Module>/web/`. Example: `app/design/frontend/OrangeCorp/orange/Magento_Catalog/web/`
+1. Ancestor themes module static files, recursively, until a theme with no ancestor is reached:
+
+   *  `<parent_theme_dir>/web/i18n/<locale>/<Namespace>_<Module>`
+   *  `<parent_theme_dir>/<Namespace>_<Module>/web/`
+
+1. Module static view files for the `frontend` area: `<module_dir>/view/frontend/web/`
+1. Module static view files for the `base` area: `<module_dir>/view/base/web/`
 
 **Example**
 
@@ -99,8 +103,8 @@ Once the Orange Winter theme is [applied]({{ page.baseurl }}/frontend-dev-guide/
 The fallback scheme for templates is the following (module context is always known for them):
 
 1. Current theme templates: `<theme_dir>/<Namespace>_<Module>/templates`
-2. Ancestors themes templates, recursively, until a theme with no ancestor is reached: `<parent_theme_dir>/<Namespace>_<Module>/templates`
-3. Module templates: `<module_dir>/view/frontend/templates`
+1. Ancestors themes templates, recursively, until a theme with no ancestor is reached: `<parent_theme_dir>/<Namespace>_<Module>/templates`
+1. Module templates: `<module_dir>/view/frontend/templates`
 
 So if you need to customize a certain template, you need to create an overriding one with the same name in the `../templates/<path_to_template>` directory in the theme module files. Where `<path_to_template>` is the path to the original template.
 
@@ -127,16 +131,18 @@ You can find out what exactly code changes are required to perform this and othe
 The layouts processing mechanism does not involve fallback. The system collects [layout](https://glossary.magento.com/layout) files in the following order:
 
 1. All modules layout files in sequence defined in `app/etc/config.php` respecting the [component load order]({{ page.baseurl }}/extension-dev-guide/build/module-load-order.html). For each module:
-- Layout files for the `base` area: `<module_dir>/view/base/layout/`
-- Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
+
+   *  Layout files for the `base` area: `<module_dir>/view/base/layout/`
+   *  Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
+
 1. Ancestor theme layouts, starting from the most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
-2. Current theme layouts: `<theme_dir>/<Vendor>_<Module>/layout/`
+1. Current theme layouts: `<theme_dir>/<Vendor>_<Module>/layout/`
 
 Unlike templates or images, layout can be not only overridden, but also extended. And the recommended way to customize layout is to extend it by creating theme extending layout files.
 
 To add an extending layout file:
 
-* Put your custom layout file in the `<theme_dir>/<Vendor>_<Module>/layout/` directory.
+*  Put your custom layout file in the `<theme_dir>/<Vendor>_<Module>/layout/` directory.
 
 **Example**
 
@@ -158,9 +164,8 @@ For more information about extending layout refer to the [Extend a layout]({{ pa
 Though overriding layouts is not recommended, it is still possible, and might be a solution for certain customization tasks.
 To override the instructions from an ancestor theme layout file:
 
-* Create a layout file with the same name in the `<theme_dir>/<Vendor>_<Module>/layout/override/theme/<Vendor>/<ancestor_theme>` directory.
+*  Create a layout file with the same name in the `<theme_dir>/<Vendor>_<Module>/layout/override/theme/<Vendor>/<ancestor_theme>` directory.
 
 To override module [layout instructions](https://glossary.magento.com/layout-instructions) (base layout):
 
-* Create a layout file with the same name in the `<theme_dir>/<Vendor>_<Module>/layout/override/base` directory.
-
+*  Create a layout file with the same name in the `<theme_dir>/<Vendor>_<Module>/layout/override/base` directory.

--- a/guides/v2.2/frontend-dev-guide/themes/theme-install.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-install.md
@@ -12,9 +12,9 @@ This topic describes how to install a third-party [theme](https://glossary.magen
 
 To install a theme, you need to add its code to your Magento 2 instance code base, and then register it in the database. The way a theme is distributed determines how to do this:
 
-- if a theme is just a set of files, for example an archive, add the theme manually.
-- if a theme is a [composer](https://glossary.magento.com/composer) package, install it using composer.
-- if a theme is distributed as an extension, use the **Web Setup Wizard** in [Magento Admin](https://glossary.magento.com/magento-admin).
+-  if a theme is just a set of files, for example an archive, add the theme manually.
+-  if a theme is a [composer](https://glossary.magento.com/composer) package, install it using composer.
+-  if a theme is distributed as an extension, use the **Web Setup Wizard** in [Magento Admin](https://glossary.magento.com/magento-admin).
 
 The following sections contain more information about each installation flow.
 
@@ -28,15 +28,15 @@ To install a theme manually:
 
 1. Make sure that the directory structure you are copying is `<VendorName>/<theme>`. And all the [theme files]({{ page.baseurl }}/frontend-dev-guide/themes/theme-structure.html) are in the `<theme>` directory.
 
-2. Copy this directory to the `<Magento root dir>/app/design/frontend` directory.
+1. Copy this directory to the `<Magento root dir>/app/design/frontend` directory.
 
 ## Install a theme as composer package
 
 To install the theme as composer package, follow the instructions in the [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html) topic.
 
-- Manually installed themes are stored in the `app/design/` directory. Themes loaded through Composer are located in the `vendor/` directory and can be stored anywhere in root.
+-  Manually installed themes are stored in the `app/design/` directory. Themes loaded through Composer are located in the `vendor/` directory and can be stored anywhere in root.
 
-- When the application starts up, Composer executes each file included in the `autoload.files` section. `registration.php` then registers itself as a theme.
+-  When the application starts up, Composer executes each file included in the `autoload.files` section. `registration.php` then registers itself as a theme.
 
 {:.bs-callout .bs-callout-info}
 Composer-based themes are loaded from external sources and cannot be modified directly, whereas local themes are part of the project source code and therefore can be edited directly.

--- a/guides/v2.2/frontend-dev-guide/themes/theme-uninstall.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-uninstall.md
@@ -20,8 +20,8 @@ The following sections describe the flow for uninstalling themes in each case.
 ## Prerequisites
 
 1. [Set your Magento application to the developer or default mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
-2. Make sure that the theme is not applied on the storefront. To do this, in the [Admin](https://glossary.magento.com/admin) panel navigate to **Content** > **Design** > **Configuration** and make sure that your custom theme is not applied for any [store view](https://glossary.magento.com/store-view).
-2. Make sure that the theme is not defined as a parent for any registered theme. To do this, in the Admin panel, navigate to **Content** > **Design** > **Themes**. Make sure that your theme is not mentioned in the **Parent Theme** column. If it is mentioned, you need to uninstall the child theme first.
+1. Make sure that the theme is not applied on the storefront. To do this, in the [Admin](https://glossary.magento.com/admin) panel navigate to **Content** > **Design** > **Configuration** and make sure that your custom theme is not applied for any [store view](https://glossary.magento.com/store-view).
+1. Make sure that the theme is not defined as a parent for any registered theme. To do this, in the Admin panel, navigate to **Content** > **Design** > **Themes**. Make sure that your theme is not mentioned in the **Parent Theme** column. If it is mentioned, you need to uninstall the child theme first.
 
 ## Uninstall a manually added theme
 
@@ -30,8 +30,8 @@ In case if your theme was created or installed manually, the uninstall procedure
 To uninstall a manually added theme:
 
 1. Navigate to the vendor directory where the theme was installed. This directory should be: `<Magento root dir>/app/design/frontend/<VendorName>`.
-2. Remove the theme directory.
-3. Remove the theme record from database. If you are using MySQL, run the following command to do this:
+1. Remove the theme directory.
+1. Remove the theme record from database. If you are using MySQL, run the following command to do this:
 
 ```bash
 mysql -u <user> -p -e "delete from <dbname>.theme where theme_path ='<Vendor>/<theme>' AND area ='frontend' limit 1"
@@ -58,7 +58,7 @@ To uninstall a theme Composer package if your Magento instance was installed by 
 Take the following steps:
 
 1. Open the `<Magento root dir>/composer.json` file.
-2. Find a line with a reference to theme package and delete it. The reference would look like following:
+1. Find a line with a reference to theme package and delete it. The reference would look like following:
 
    ```json
    "require": {
@@ -67,11 +67,13 @@ Take the following steps:
    },
    ```
 
-3. To update the project dependencies, run:
+1. To update the project dependencies, run:
 
-    composer update
+   ```bash
+   composer update
+   ```
 
-4. Use the `magento theme:uninstall` CLI command as described in the [Uninstall themes Composer package]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html) topic.
+1. Use the `magento theme:uninstall` CLI command as described in the [Uninstall themes Composer package]({{ page.baseurl }}/install-gde/install/cli/install-cli-theme-uninstall.html) topic.
 
 {:.bs-callout .bs-callout-info}
 You can use the Composer remove command to remove the dependency, but in that case, you must delete the theme record from the database manually.
@@ -86,4 +88,4 @@ If the theme was installed as an extension, you can uninstall it using one of th
 To uninstall a theme extension using the Component Manager:
 
 1. In the [Magento Admin](https://glossary.magento.com/magento-admin) Panel, navigate to **System** > **Web Setup Wizard** > **Extension Manager**.
-2. In the **Actions** column, click **Select** > **Uninstall** in the theme record.
+1. In the **Actions** column, click **Select** > **Uninstall** in the theme record.

--- a/guides/v2.2/frontend-dev-guide/themes/theme-workflow.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-workflow.md
@@ -38,9 +38,9 @@ For details, see [Create a new storefront theme]({{ page.baseurl }}/frontend-dev
 ### Apply the theme
 
 1. In the Admin Panel, go to **CONTENT** > **Design** > **Configuration**
-2. Find the record corresponding to your store view and click **Edit**.
-3. In the **Applied Theme** drop-down, select your newly created theme.
-4. Click **Save Configuration**.
+1. Find the record corresponding to your store view and click **Edit**.
+1. In the **Applied Theme** drop-down, select your newly created theme.
+1. Click **Save Configuration**.
 
 For details, see [Apply and configure a storefront theme]({{ page.baseurl }}/frontend-dev-guide/themes/theme-apply.html)
 
@@ -48,9 +48,9 @@ For details, see [Apply and configure a storefront theme]({{ page.baseurl }}/fro
 
 #### Grunt (recommended)
 
-* [Setup Grunt]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html)
-* [Add the theme to Grunt configuration]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#add_theme)
-* [Track changes]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#grunt_commands)
+*  [Setup Grunt]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html)
+*  [Add the theme to Grunt configuration]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#add_theme)
+*  [Track changes]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#grunt_commands)
 
 #### Client-side compilation
 
@@ -68,22 +68,22 @@ See [Using custom CSS preprocessor]({{ page.baseurl }}/frontend-dev-guide/css-to
 
 See:
 
-* [Quick start guide to working with styles]({{ page.baseurl }}/frontend-dev-guide/css-guide/css_quick_guide_overview.html)
-* [All about styles in Magento themes]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-overview.html)
+*  [Quick start guide to working with styles]({{ page.baseurl }}/frontend-dev-guide/css-guide/css_quick_guide_overview.html)
+*  [All about styles in Magento themes]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-overview.html)
 
 ### Debug
 
 See:
 
-* [Locate the CSS/Less file you need to change]({{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html)
-* [CSS source maps]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#source_maps)
-* [Track changes using Grunt]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#use_cases)
+*  [Locate the CSS/Less file you need to change]({{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html)
+*  [CSS source maps]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#source_maps)
+*  [Track changes using Grunt]({{ page.baseurl }}/frontend-dev-guide/css-topics/css_debug.html#use_cases)
 
 ### Clean cache and/or static files if necessary
 
-* Certain changes in styles require cleaning previously pre-processed and published static view files. Run `grunt clean <theme>` or manually clear the `pub/static` and `var/view_preprocessed` directories. Do this after any changes in server-side compilation mode. For the client-side or Grunt compilation, see [Clean static files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception) for details.
+*  Certain changes in styles require cleaning previously pre-processed and published static view files. Run `grunt clean <theme>` or manually clear the `pub/static` and `var/view_preprocessed` directories. Do this after any changes in server-side compilation mode. For the client-side or Grunt compilation, see [Clean static files]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-preprocess.html#css_exception) for details.
 
-* Changes in layout and templates requires cleaning cache. See [Clean cache]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_cache) for details.
+*  Changes in layout and templates requires cleaning cache. See [Clean cache]({{ page.baseurl }}/frontend-dev-guide/cache_for_frontdevs.html#clean_cache) for details.
 
 ### Make sure that the same styles are delivered to production (optional)
 
@@ -92,6 +92,7 @@ When you finish developing and your styles are ready to go to production, you ca
 ### Switch to production mode
 
 In the Magento root directory, run:
+
 ```php
 bin/magento deploy:mode:set production
 ```

--- a/guides/v2.2/frontend-dev-guide/translations/translate_theory.md
+++ b/guides/v2.2/frontend-dev-guide/translations/translate_theory.md
@@ -5,7 +5,7 @@ functional_areas:
   - Frontend
 ---
 
- This topic describes how to add theme strings so that the i18n tool can collect and add the strings to the dictionary.
+This topic describes how to add theme strings so that the i18n tool can collect and add the strings to the dictionary.
 
 Your custom theme may contain new strings that are not present in out-of-the-box Magento themes.
 To ensure your theme displays correctly with any language applied on a store view, verify the unique strings of your theme are added to the translation [i18n tool] when [generating the dictionary].
@@ -40,14 +40,14 @@ To ensure that your new string is added to the dictionary and translated, use th
 
 For example:
 
-- When only a string is added in the email template:
+-  When only a string is added in the email template:
     {% raw %}
     ```html
     {{trans "Lorem Ipsum is simply dummy text of the printing"}}
     ```
     {% endraw %}
 
-- When only a string is added with a variable value in the email template:
+-  When only a string is added with a variable value in the email template:
     {% raw %}
     ```html
     {{trans "%items items" items="numItems"}}
@@ -58,19 +58,19 @@ For example:
 
 To ensure that the text you add in `.html` templates of UI components is added to the dictionary, mark the text using the `i18n` custom binding. The following code samples illustrate how to use custom bindings:
 
-- When a string is added in the scope of an HTML element:
+-  When a string is added in the scope of an HTML element:
 
     ```html
     <span data-bind="i18n: 'Sign In'"></span>
     ```
 
-- When a string is added with no binding to an HTML element:
+-  When a string is added with no binding to an HTML element:
 
     ```html
     <!-- ko i18n: 'You have no items in your shopping cart.' --><!-- /ko -->
     ```
 
-- When a string is added as an attribute of an HTML element:
+-  When a string is added as an attribute of an HTML element:
 
     ```html
     <input type="text" data-bind="attr: {placeholder: $t('First Name')}" />
@@ -99,21 +99,21 @@ To ensure that the text you add in a `.js` file is collected by the i18n tool an
 
 1. Link the `mage/translate` library:
 
-    ```javascript
-    define (['jquery', 'mage/translate'], function ($) {...});
-    ```
+   ```javascript
+   define (['jquery', 'mage/translate'], function ($) {...});
+   ```
 
-2. Use the `$.mage.__('')` function when adding a string:
+1. Use the `$.mage.__('')` function when adding a string:
 
-    ```javascript
-    $.mage.__('<string>');
-    ```
+   ```javascript
+   $.mage.__('<string>');
+   ```
 
-    If your string contains a variable, to add a placeholder for this variable to the string stored in the dictionary, use the syntax similar to the following:
+   If your string contains a variable, to add a placeholder for this variable to the string stored in the dictionary, use the syntax similar to the following:
 
-    ```javascript
-    $.mage.__('Hello %1').replace('%1', yourVariable);
-    ```
+   ```javascript
+   $.mage.__('Hello %1').replace('%1', yourVariable);
+   ```
 
 In this example, the `'Hello %1'` string is added to the dictionary when the i18n tool is run.
 

--- a/guides/v2.3/frontend-dev-guide/themes/admin_theme_create.md
+++ b/guides/v2.3/frontend-dev-guide/themes/admin_theme_create.md
@@ -18,10 +18,10 @@ This topic describes how to create your custom theme for Magento Admin, referenc
 To create a custom [Admin](https://glossary.magento.com/admin) theme, take the following steps:
 
 1. [Create a theme directory.](#create_dir)
-2. [Add a declaration `theme.xml`.](#declare_theme)
-3. [Add `registration.php`.](#add_registry)
-4. [Optionally add `composer.json`.](#make_composer)
-5. [Optionally change theme logo.](#logo)
+1. [Add a declaration `theme.xml`.](#declare_theme)
+1. [Add `registration.php`.](#add_registry)
+1. [Optionally add `composer.json`.](#make_composer)
+1. [Optionally change theme logo.](#logo)
 
 Each step is described further.
 
@@ -75,19 +75,21 @@ To customize the Admin theme logo:
 
 1. Create a new XML file in the theme named `app/design/adminhtml/<Vendor>/<theme>/Magento_Backend/layout/admin_login.xml`.
 
-2. Add the following sample code to the new file.
-     ```xml
-    <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-login" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-        <body>
-            <referenceBlock name="logo">
-                <arguments>
-                    <argument name="logo_image_src" xsi:type="string">images/custom-logo.svg</argument>
-                </arguments>
-            </referenceBlock>
-        </body>
+1. Add the following sample code to the new file.
+
+   ```xml
+   <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-login" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+       <body>
+           <referenceBlock name="logo">
+               <arguments>
+                   <argument name="logo_image_src" xsi:type="string">images/custom-logo.svg</argument>
+               </arguments>
+           </referenceBlock>
+       </body>
     </page>
-    ```
-3. Add your custom logo to the `app/design/adminhtml/<Vendor>/<theme>/web/images/` directory.
+   ```
+
+1. Add your custom logo to the `app/design/adminhtml/<Vendor>/<theme>/web/images/` directory.
 
 ## Theme registration {#register_theme}
 
@@ -96,4 +98,3 @@ Once you open the Magento Admin (or reload any  Magento Admin page) having added
 ## Apply the Admin theme
 
 See the [Apply a custom Admin theme topic]({{ page.baseurl }}/frontend-dev-guide/themes/admin_theme_apply.html).
-


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- Frontend Dev

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.