### PR TITLE
Fixed ordered list prefix (MD029) - Group 9

### DIFF
--- a/guides/v2.2/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.2/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -111,15 +111,15 @@ Under the created `etc` directory, create a new directory called `adminhtml`. Un
 The `menu.xml` file provided below adds two items in the Content section of the left navigation:
 
 1. A new separate section with the title **Greetings** under Content.
-2. A link with the label **Hello World** that leads to a page request for `exampleadminnewpage/helloworld/index` underneath that new section.
+1. A link with the label **Hello World** that leads to a page request for `exampleadminnewpage/helloworld/index` underneath that new section.
 
 ![Hello World menu item]({{ site.baseurl }}/common/images/ext-best-practices/hello-world-menu-item.png){:width="322px" height="400px"}
 
 The following parts make up the generated page request link to the **Hello World** page:
 
-* `exampleadminnewpage` - This is the `frontName`. Because its purpose is to help route requests to the correct module, we give it the same name as the module, but this is not required.
-* `helloworld` - This specifies the name of the controller to use.
-* `index` - In the XML file, since the action for the controller is not specified, Magento uses the default value `index`.
+*  `exampleadminnewpage` - This is the `frontName`. Because its purpose is to help route requests to the correct module, we give it the same name as the module, but this is not required.
+*  `helloworld` - This specifies the name of the controller to use.
+*  `index` - In the XML file, since the action for the controller is not specified, Magento uses the default value `index`.
 
 [//]: # (Stop list rendering before collapsible, see: https://github.com/magento/devdocs/issues/2655)
 {% collapsible File content for menu.xml %}
@@ -218,6 +218,9 @@ Create the necessary directories for the files by running the following commands
 
 ```bash
 mkdir -pm view/adminhtml/layout
+```
+
+```bash
 mkdir -pm view/adminhtml/templates
 ```
 
@@ -311,10 +314,10 @@ The module is now complete. Your module's directory structure under `app/code` s
 Now that the module is code-complete, run the following commands to install it:
 
 1. `bin/magento module:status` - This command shows a list of enabled/disabled modules.
-2. `bin/magento module:enable MyCompany_ExampleAdminNewPage` - If necessary, run this to enable the disabled module.
-3. `bin/magento setup:upgrade` - This command will properly register the module with Magento.
-4. `bin/magento setup:di:compile` - This command compiles classes used in dependency injections.
-5. `bin/magento cache:clean` - This command cleans the cache.
+1. `bin/magento module:enable MyCompany_ExampleAdminNewPage` - If necessary, run this to enable the disabled module.
+1. `bin/magento setup:upgrade` - This command will properly register the module with Magento.
+1. `bin/magento setup:di:compile` - This command compiles classes used in dependency injections.
+1. `bin/magento cache:clean` - This command cleans the cache.
 
 Once the module installation has completed, the link to the **Hello World** page should appear in the **Greetings** section under **Content** in the left navigation in the admin area. Clicking this link will take you to a page that looks like the one pictured below.
 

--- a/guides/v2.2/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
+++ b/guides/v2.2/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
@@ -19,31 +19,31 @@ Identify the data you need to convert to JSON in the database.
 Your extension *must* convert data in the following cases:
 
 1. The extension stores serialized data provided by a core [module](https://glossary.magento.com/module) that now uses the JSON format.
-2. The extension uses the automatic serializing mechanism provided by the Magento framework (i.e. the extension declares `\Magento\Framework\Model\ResourceModel\Db\AbstractDb::$_serializableFields`).
+1. The extension uses the automatic serializing mechanism provided by the Magento framework (i.e. the extension declares `\Magento\Framework\Model\ResourceModel\Db\AbstractDb::$_serializableFields`).
 
 Your extension will continue working in Magento 2.2 and above in the following cases, but we recommend you switch to using the JSON format for security reasons:
 
 1. The extension stores its own serialized data.
-2. The extension is responsible for serializing and unserializing data stored in core tables.
+1. The extension is responsible for serializing and unserializing data stored in core tables.
 
 ### API Overview
 
 This tutorial uses the following framework [API](https://glossary.magento.com/api) in the following ways:
 
-* `\Magento\Framework\DB\FieldDataConverter` - This class converts values for a field in a table from one format to another.
-   * `\Magento\Framework\DB\FieldDataConverterFactory` - This class creates instances of the `FieldDataConverter` with the appropriate data converter implementation.
-   * `\Magento\Framework\DB\AggregatedFieldDataConverter` - This is a service class that allows specifying multiple fields from different tables at once. This class creates instances of the `FieldDataConverter` class and accepts a list of `\Magento\Framework\DB\FieldToConvert` value objects with field information. A single `convert()` method call is limited to one DB connection.
-* `\Magento\Framework\DB\DataConverter\DataConverterInterface` - This interface is for classes that convert data between different formats or types of data.
-* `\Magento\Framework\DB\FieldDataConverter` - This class accepts query modifiers for updating specific rows. Here is API for the query modifiers part:
-   * `\Magento\Framework\DB\Select\QueryModifierInterface` - Interface for classes that add a condition to the database query to target specific entries.
-   * `\Magento\Framework\DB\Select\QueryModifierFactory` - This class creates instances of specific implementations of `QueryModifierInterface`.
-   * `\Magento\Framework\DB\Select\InQueryModifier` - An implementation of the `QueryModifierInterface` that adds an IN condition to a query.
-   * `\Magento\Framework\DB\Select\LikeQueryModifier` - An implementation of the `QueryModifierInterface` that adds a LIKE condition to a query.
-   * `\Magento\Framework\DB\Select\CompositeQueryModifier` - An implementation of the `QueryModifierInterface` that allows the application of multiple query modifiers.
+*  `\Magento\Framework\DB\FieldDataConverter` - This class converts values for a field in a table from one format to another.
+   *  `\Magento\Framework\DB\FieldDataConverterFactory` - This class creates instances of the `FieldDataConverter` with the appropriate data converter implementation.
+   *  `\Magento\Framework\DB\AggregatedFieldDataConverter` - This is a service class that allows specifying multiple fields from different tables at once. This class creates instances of the `FieldDataConverter` class and accepts a list of `\Magento\Framework\DB\FieldToConvert` value objects with field information. A single `convert()` method call is limited to one DB connection.
+*  `\Magento\Framework\DB\DataConverter\DataConverterInterface` - This interface is for classes that convert data between different formats or types of data.
+*  `\Magento\Framework\DB\FieldDataConverter` - This class accepts query modifiers for updating specific rows. Here is API for the query modifiers part:
+   *  `\Magento\Framework\DB\Select\QueryModifierInterface` - Interface for classes that add a condition to the database query to target specific entries.
+   *  `\Magento\Framework\DB\Select\QueryModifierFactory` - This class creates instances of specific implementations of `QueryModifierInterface`.
+   *  `\Magento\Framework\DB\Select\InQueryModifier` - An implementation of the `QueryModifierInterface` that adds an IN condition to a query.
+   *  `\Magento\Framework\DB\Select\LikeQueryModifier` - An implementation of the `QueryModifierInterface` that adds a LIKE condition to a query.
+   *  `\Magento\Framework\DB\Select\CompositeQueryModifier` - An implementation of the `QueryModifierInterface` that allows the application of multiple query modifiers.
 
   You can create your own query modifier or use any of the ones listed in the `app/etc/di.xml` file.
 
-* `\Magento\Framework\Module\Manager` - This class checks the status of a module.
+*  `\Magento\Framework\Module\Manager` - This class checks the status of a module.
 
 ## Step 1: Create the basic upgrade script
 {:#step-1}
@@ -436,8 +436,8 @@ $this->aggregatedFieldConverter->convert($fieldsToUpdate, $salesSetup->getConnec
 
 ## Related Topics
 
-* [Serialize Library][0]
-* [Extension Lifecycle][1]
+*  [Serialize Library][0]
+*  [Extension Lifecycle][1]
 
 [0]: {{ page.baseurl }}/extension-dev-guide/framework/serializer.html "Serialize Library"
 [1]: {{ page.baseurl }}/extension-dev-guide/prepare/lifecycle.html "Extension Lifecycle"

--- a/guides/v2.2/extension-dev-guide/build/di-xml-file.md
+++ b/guides/v2.2/extension-dev-guide/build/di-xml-file.md
@@ -20,18 +20,18 @@ As a general rule, the area specific `di.xml` files should configure dependencie
 Magento loads the configuration in the following stages:
 
 1. Initial (`app/etc/di.xml`)
-2. Global (`<moduleDir>/etc/di.xml`)
-3. Area-specific (`<moduleDir>/etc/<area>/di.xml`)
+1. Global (`<moduleDir>/etc/di.xml`)
+1. Area-specific (`<moduleDir>/etc/<area>/di.xml`)
 
 During [bootstrapping]({{ page.baseurl }}/config-guide/bootstrap/magento-bootstrap.html), each application entry point loads the appropriate `di.xml` files for the requested [area]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_and_areas.html).
 
 **Examples:**
 
-* In `index.php`, the [`\Magento\Framework\App\Http`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Http.php#L130-L132){:target="_blank"} class loads the area based on the front-name provided in the [URL](https://glossary.magento.com/url).
+*  In `index.php`, the [`\Magento\Framework\App\Http`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Http.php#L130-L132){:target="_blank"} class loads the area based on the front-name provided in the [URL](https://glossary.magento.com/url).
 
-* In `static.php`, the [`\Magento\Framework\App\StaticResource`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/StaticResource.php#L101-L104){:target="_blank"} class also loads the area based on the URL in the request.
+*  In `static.php`, the [`\Magento\Framework\App\StaticResource`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/StaticResource.php#L101-L104){:target="_blank"} class also loads the area based on the URL in the request.
 
-* In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the `crontab` area.
+*  In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the `crontab` area.
 
 ## Type configuration
 
@@ -56,8 +56,8 @@ You can configure the type in your `di.xml` configuration node in the following 
 
 The preceding example declares the following types:
 
-* `moduleConfig`: A virtual type that extends the type `Magento\Core\Model\Config`.
-* `Magento\Core\Model\App`: All instances of this type receive an instance of `moduleConfig` as a dependency.
+*  `moduleConfig`: A virtual type that extends the type `Magento\Core\Model\Config`.
+*  `Magento\Core\Model\App`: All instances of this type receive an instance of `moduleConfig` as a dependency.
 
 ### Virtual types
 
@@ -347,9 +347,9 @@ See [sensitive and environment settings]({{ page.baseurl }}/extension-dev-guide/
 
 ### Information related to pipeline deployment
 
-*   [Guidelines for specifying system-specific and sensitive configuration values]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)
-*   [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-*   [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Guidelines for specifying system-specific and sensitive configuration values]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ## Get dependency injection configuration information for a class
 
@@ -397,6 +397,6 @@ Plugins for the Preference:
 {:.ref-header}
 Related topics
 
-* [ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)
-* [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
-* [Sensitive and environment settings]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)
+*  [ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)
+*  [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
+*  [Sensitive and environment settings]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)

--- a/guides/v2.2/extension-dev-guide/build/enable-module.md
+++ b/guides/v2.2/extension-dev-guide/build/enable-module.md
@@ -32,8 +32,8 @@ After you have built the component and are ready to enable it in your Magento en
 The general order of operations for `setup:upgrade` is:
 
 1.  **Schema install/upgrade.**
-2.  **Schema post-upgrade**— handles any additional updates. These recurring upgrades occur independently and regardless of any changes to the schema.
-3.  **Data install/upgrade** — installs the data. Taken from `setup/InstallData.php`.
+1.  **Schema post-upgrade**— handles any additional updates. These recurring upgrades occur independently and regardless of any changes to the schema.
+1.  **Data install/upgrade** — installs the data. Taken from `setup/InstallData.php`.
 
 ## Disable a component
 

--- a/guides/v2.2/extension-dev-guide/build/module-load-order.md
+++ b/guides/v2.2/extension-dev-guide/build/module-load-order.md
@@ -40,10 +40,10 @@ For each particular scenario, files of the same type are loaded from different c
 
 In another scenario, let's say you want to load all of the [layout](https://glossary.magento.com/layout) files with the name `default.xml`. __Component A__ specifies __component B__ in `<sequence>`. The files load in the following order:
 
-42. `component X/view/frontend/layout/default.xml`&mdash;Either we don't care about when component X loads or perhaps component B requires it to be loaded before it.
-42. `component B/view/frontend/layout/default.xml`
-42. `component A/view/frontend/layout/default.xml`&mdash;Loads after __component B__ because __component B__ is listed in __component A's__ `<sequence>` tag.
-42. `component Z/view/frontend/layout/default.xml`&mdash;Either we don't care about the sequence for component Z or perhaps component Z requires component A files to be loaded before it.
+1. `component X/view/frontend/layout/default.xml`&mdash;Either we don't care about when component X loads or perhaps component B requires it to be loaded before it.
+1. `component B/view/frontend/layout/default.xml`
+1. `component A/view/frontend/layout/default.xml`&mdash;Loads after __component B__ because __component B__ is listed in __component A's__ `<sequence>` tag.
+1. `component Z/view/frontend/layout/default.xml`&mdash;Either we don't care about the sequence for component Z or perhaps component Z requires component A files to be loaded before it.
 
 There are no limitations&mdash;you can specify any valid component in `<sequence>`.
 
@@ -52,6 +52,7 @@ If you do specify a component in `<sequence>`, make sure that you have also adde
 {:.bs-callout .bs-callout-info }
 Take care when using `<sequence>` in multiple components because it's possible to define circular dependencies. If you do, Magento aborts the installation when it detects the circular dependency.
 
-## Next
+{:.ref-header}
+Next
 
 [Enable or disable your component]({{ page.baseurl }}/extension-dev-guide/build/enable-module.html)

--- a/guides/v2.2/extension-dev-guide/cache/page-caching/private-content.md
+++ b/guides/v2.2/extension-dev-guide/cache/page-caching/private-content.md
@@ -101,9 +101,9 @@ Use only HTTP POST or PUT methods to change state (e.g., adding to a shopping ca
 
 Other examples:
 
-- [Checkout]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Checkout/etc/frontend/sections.xml){:target="_blank"}
+-  [Checkout]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Checkout/etc/frontend/sections.xml){:target="_blank"}
 
-- [Customer]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/etc/frontend/sections.xml){:target="_blank"}
+-  [Customer]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/etc/frontend/sections.xml){:target="_blank"}
 
 ## Version private content {#config-priv-vers}
 
@@ -112,11 +112,12 @@ Private content, which is stored in the browser local storage, uses the `private
 Versioning works as follows:
 
 1. The user performs some action, such as adding to a cart, that results in an POST or PUT request to the Magento application.
-2. The server generates the `private_content_version` cookie for this user and returns the response to the browser.
-3. [JavaScript](https://glossary.magento.com/javascript) interprets the presence of the `private_content_version` cookie to mean that private content is present on the page, so it sends an AJAX request to the Magento server to get the current private content.
-4. The server's reply is cached in the browser's local storage.
+1. The server generates the `private_content_version` cookie for this user and returns the response to the browser.
+1. [JavaScript](https://glossary.magento.com/javascript) interprets the presence of the `private_content_version` cookie to mean that private content is present on the page, so it sends an AJAX request to the Magento server to get the current private content.
+1. The server's reply is cached in the browser's local storage.
 
-    Subsequent requests with the same data version are retrieved from local storage.
-5. Any future HTTP POST or PUT request changes the value of `private_content_version` and results in the updated content being cached by the browser.
+   Subsequent requests with the same data version are retrieved from local storage.
+
+1. Any future HTTP POST or PUT request changes the value of `private_content_version` and results in the updated content being cached by the browser.
 
 {% include cache/page-cache-checklists.md%}

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/database-caching.md
@@ -14,8 +14,8 @@ This topic discusses how to use the Magento 2 database for caching. After you co
 
 This topic discusses how to set up database caching and how to verify database caching is working. We discuss the following options:
 
-* Using the `default` cache frontend, in which case you modify `di.xml` only.
-* Using a custom [cache](https://glossary.magento.com/cache) frontend, in which case you modify `env.php` only.
+*  Using the `default` cache frontend, in which case you modify `di.xml` only.
+*  Using a custom [cache](https://glossary.magento.com/cache) frontend, in which case you modify `env.php` only.
 
 {:.bs-callout .bs-callout-warning}
 Database caching&mdash;like file-based caching&mdash; works well in a development environment but we _strongly recommend_ you use [Varnish] in production instead.
@@ -34,72 +34,72 @@ To enable database caching using the `default` frontend, you must modify `<magen
 To modify `di.xml`:
 
 1. Log in to the Magento server as, or switch to, the [Magento file system owner].
-2. Enter the following commands to make a copy of `di.xml`:
+1. Enter the following commands to make a copy of `di.xml`:
 
-    ```bash
-    cd <magento_root>/app/etc
-    ```
+   ```bash
+   cd <magento_root>/app/etc
+   ```
 
-    ```bash
-    cp di.xml di.xml.bak
-    ```
+   ```bash
+   cp di.xml di.xml.bak
+   ```
 
-3. Open `di.xml` in a text editor and locate the following block:
+1. Open `di.xml` in a text editor and locate the following block:
 
-    ```xml
-    <type name="Magento\Framework\App\Cache\Frontend\Pool">
-           <arguments>
-              <argument name="frontendSettings" xsi:type="array">
-                  <item name="page_cache" xsi:type="array">
-                      <item name="backend_options" xsi:type="array">
-                        <item name="cache_dir" xsi:type="string">page_cache</item>
-                      </item>
-                  </item>
-              </argument>
-           </arguments>
-        </type>
-        <type name="Magento\Framework\App\Cache\Type\FrontendPool">
-           <arguments>
-              <argument name="typeFrontendMap" xsi:type="array">
-                <item name="full_page" xsi:type="string">page_cache</item>
-              </argument>
-           </arguments>
-        </type>
-    ```
-
- The `<type name="Magento\Framework\App\Cache\Frontend\Pool">` node configures options for the in-memory pool of all frontend cache instances.
-
- The `<type name="Magento\Framework\App\Cache\Type\FrontendPool">` node configures cache frontend options specific to each cache type.
-
-4. Replace the entire block with the following:
-
-    ```xml
-    <type name="Magento\Framework\App\Cache\Frontend\Pool">
+   ```xml
+   <type name="Magento\Framework\App\Cache\Frontend\Pool">
           <arguments>
-              <argument name="frontendSettings" xsi:type="array">
-                  <item name="page_cache" xsi:type="array">
-                        <item name="backend" xsi:type="string">database</item>
-                    </item>
-                    <item name="<your cache id>" xsi:type="array">
-                        <item name="backend" xsi:type="string">database</item>
-                    </item>
-              </argument>
+             <argument name="frontendSettings" xsi:type="array">
+                 <item name="page_cache" xsi:type="array">
+                     <item name="backend_options" xsi:type="array">
+                       <item name="cache_dir" xsi:type="string">page_cache</item>
+                     </item>
+                 </item>
+             </argument>
           </arguments>
-    </type>
-    <type name="Magento\Framework\App\Cache\Type\FrontendPool">
+       </type>
+       <type name="Magento\Framework\App\Cache\Type\FrontendPool">
           <arguments>
-              <argument name="typeFrontendMap" xsi:type="array">
-                 <item name="backend" xsi:type="string">database</item>
-              </argument>
+             <argument name="typeFrontendMap" xsi:type="array">
+               <item name="full_page" xsi:type="string">page_cache</item>
+             </argument>
           </arguments>
-    </type>
-    ```
+       </type>
+   ```
 
-    where `<your cache id>` is your unique cache identifier.
+   The `<type name="Magento\Framework\App\Cache\Frontend\Pool">` node configures options for the in-memory pool of all frontend cache instances.
 
-5. Save your changes to `di.xml` and exit the text editor.
+   The `<type name="Magento\Framework\App\Cache\Type\FrontendPool">` node configures cache frontend options specific to each cache type.
 
-7. Continue with [Verify database caching is working].
+1. Replace the entire block with the following:
+
+   ```xml
+   <type name="Magento\Framework\App\Cache\Frontend\Pool">
+         <arguments>
+             <argument name="frontendSettings" xsi:type="array">
+                 <item name="page_cache" xsi:type="array">
+                       <item name="backend" xsi:type="string">database</item>
+                   </item>
+                   <item name="<your cache id>" xsi:type="array">
+                       <item name="backend" xsi:type="string">database</item>
+                   </item>
+             </argument>
+         </arguments>
+   </type>
+   <type name="Magento\Framework\App\Cache\Type\FrontendPool">
+         <arguments>
+             <argument name="typeFrontendMap" xsi:type="array">
+                <item name="backend" xsi:type="string">database</item>
+             </argument>
+         </arguments>
+   </type>
+   ```
+
+   where `<your cache id>` is your unique cache identifier.
+
+1. Save your changes to `di.xml` and exit the text editor.
+
+1. Continue with [Verify database caching is working].
 
 ## Database caching using a custom cache frontend {#mage-cache-db-env}
 
@@ -111,42 +111,42 @@ Due to a known issue, a custom cache frontend still results in some objects bein
 To enable database caching using a custom cache frontend, you must modify `<magento_root>/app/etc/env.php` as follows:
 
 1. Log in to the Magento server as, or switch to, the [Magento file system owner].
-2. Enter the following commands to make a copy of `env.php`:
+1. Enter the following commands to make a copy of `env.php`:
 
-    ```bash
-    cd <magento_root>/app/etc
-    ```
+   ```bash
+   cd <magento_root>/app/etc
+   ```
 
-    ```bash
-    cp env.php env.php.bak
-    ```
+   ```bash
+   cp env.php env.php.bak
+   ```
 
-3. Open `env.php` in a text editor and add the following anywhere, such as before `'cache_types' =>`:
+1. Open `env.php` in a text editor and add the following anywhere, such as before `'cache_types' =>`:
 
-    ```php
-    'cache' => [
-        'frontend' => [
-            '<unique frontend id>' => [
-                 <cache options>
-            ],
-        ],
-        'type' => [
-             <cache type 1> => [
-                 'frontend' => '<unique frontend id>'
-            ],
-        ],
-        'type' => [
-             <cache type 2> => [
-                 'frontend' => '<unique frontend id>'
-            ],
-        ],
-    ],
-    ```
+   ```php
+   'cache' => [
+       'frontend' => [
+           '<unique frontend id>' => [
+                <cache options>
+           ],
+       ],
+       'type' => [
+            <cache type 1> => [
+                'frontend' => '<unique frontend id>'
+           ],
+       ],
+       'type' => [
+            <cache type 2> => [
+               'frontend' => '<unique frontend id>'
+           ],
+       ],
+   ],
+   ```
 
-    An example is shown in [Configuration examples].
+   An example is shown in [Configuration examples].
 
-4. Save your changes to `env.php` and exit the text editor.
-5. Continue with the next section.
+1. Save your changes to `env.php` and exit the text editor.
+1. Continue with the next section.
 
 ## Verify database caching is working {#mage-cache-db-verify}
 
@@ -155,31 +155,30 @@ To verify database caching is working, clear the current cache directories, go t
 Use the following steps:
 
 1. If you haven't done so already, log in to the Magento server as, or switch to, the [Magento file system owner].
-2. Clear the current cache directories:
+1. Clear the current cache directories:
 
-    ```bash
-    rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/metadata/* <magento_root>/generated/code/*
-    ```
+   ```bash
+   rm -rf <magento_root>/var/cache/* <magento_root>/var/page_cache/* <magento_root>/generated/metadata/* <magento_root>/generated/code/*
+   ```
 
-3. In a web browser, go to any cacheable page (such as the [storefront](https://glossary.magento.com/storefront) front door page).
+1. In a web browser, go to any cacheable page (such as the [storefront](https://glossary.magento.com/storefront) front door page).
 
  If exceptions display, verify `di.xml` syntax and try again. (To see exceptions in the browser, you must [enable developer mode].)
-4. Enter the following commands:
+1. Enter the following commands:
 
-    ```bash
-    ls <magento_root>/var/cache/*
-    ```
+   ```bash
+   ls <magento_root>/var/cache/*
+   ```
 
-    ```bash
-    ls <magento_root>/var/page_cache/*
-    ```
+   ```bash
+   ls <magento_root>/var/page_cache/*
+   ```
 
-    {:.bs-callout .bs-callout-info }
-    Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching.
-    If you use the `default` cache frontend, you don't have this issue.
+   {:.bs-callout .bs-callout-info }
+   Due to a known issue, a custom cache frontend still results in some objects being cached to the file system; however, fewer assets are cached compared to file system caching. If you use the `default` cache frontend, you don't have this issue.
 
-3. Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
-4. Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
+1. Verify both directories are empty; if not, edit `di.xml` again and correct any issues.
+1. Use a database tool such as [phpMyAdmin] to verify there is data in the `cache` and `cache_tag` tables.
 
    The following figures show examples. The important thing is that there are rows in the tables. *The data in your tables will be different than the following*.
 

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -12,96 +12,98 @@ menu_order: 3
 Magento enables your component to add commands to our [Symfony-like command-line interface (CLI)](https://symfony.com/doc/current/components/console.html).
 
 ### About the Magento CLI
+
 {% include install/new-cli-intro.md %}
 
 ### Prerequisites
 
 Before you begin, make sure you understand the following:
 
-* All Magento command-line interface (CLI) commands rely on the Magento application and must have access to its context, dependency injections, plug-ins, and so on.
-* All CLI commands should be implemented in the scope of your [module](https://glossary.magento.com/module) and should depend on the module's status.
-* Your command can use the Object Manager and Magento dependency injection features; for example, it can use [constructor dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#constructor-injection).
-* You must register your commands as discussed in any of the following sections:
+*  All Magento command-line interface (CLI) commands rely on the Magento application and must have access to its context, dependency injections, plug-ins, and so on.
+*  All CLI commands should be implemented in the scope of your [module](https://glossary.magento.com/module) and should depend on the module's status.
+*  Your command can use the Object Manager and Magento dependency injection features; for example, it can use [constructor dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#constructor-injection).
+*  You must register your commands as discussed in any of the following sections:
 
-   * [Add CLI commands using dependency injection](#cli-sample)
-   * [Add CLI commands using the Composer autoloader](#cli-autoload)
+   *  [Add CLI commands using dependency injection](#cli-sample)
+   *  [Add CLI commands using the Composer autoloader](#cli-autoload)
 
 ## Add CLI commands using dependency injection {#cli-sample}
+
 The Magento 2 sample modules provide a demonstration of many programming techniques, including adding a CLI command using [dependency injection](https://glossary.magento.com/dependency-injection). Look at the [`sample-module-command`](https://github.com/magento/magento2-samples/tree/master/sample-module-command){:target="_blank"} for an example. The module's [README.md](https://github.com/magento/magento2-samples/blob/master/sample-module-command/README.md){:target="_blank"} discusses how to install it.
 
 Following is a summary of the process:
 
 1. Create a Command class (the recommended location is `<your component root dir>/Console/Command`).
 
- See [`<Magento_Store_module_dir>/Console/Command/StoreListCommand.php`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Store/Console/Command/StoreListCommand.php) for example.
+   See [`<Magento_Store_module_dir>/Console/Command/StoreListCommand.php`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Store/Console/Command/StoreListCommand.php) for example.
 
-```php
-<?php
-    namespace Magento\CommandExample\Console\Command;
+   ```php
+   <?php
+       namespace Magento\CommandExample\Console\Command;
 
-    use Symfony\Component\Console\Command\Command;
-    use Symfony\Component\Console\Input\InputInterface;
-    use Symfony\Component\Console\Input\InputOption;
-    use Symfony\Component\Console\Output\OutputInterface;
+       use Symfony\Component\Console\Command\Command;
+       use Symfony\Component\Console\Input\InputInterface;
+       use Symfony\Component\Console\Input\InputOption;
+       use Symfony\Component\Console\Output\OutputInterface;
 
-    /**
-     * Class SomeCommand
-     */
-    class SomeCommand extends Command
-    {
-        /**
-         * @inheritDoc
-         */
-        protected function configure()
-        {
-            $this->setName('my:first:command');
-            $this->setDescription('This is my first console command.');
+       /**
+        * Class SomeCommand
+        */
+       class SomeCommand extends Command
+       {
+           /**
+            * @inheritDoc
+            */
+           protected function configure()
+           {
+               $this->setName('my:first:command');
+               $this->setDescription('This is my first console command.');
 
-            parent::configure();
-        }
+               parent::configure();
+           }
 
-        /**
-         * @param InputInterface $input
-         * @param OutputInterface $output
-         *
-         * @return null|int
-         */
-        protected function execute(InputInterface $input, OutputInterface $output)
-        {
-            $output->writeln('<info>Success Message.</info>');
-            $output->writeln('<error>An error encountered.</error>');
-        }
-    }
-```
+           /**
+            * @param InputInterface $input
+            * @param OutputInterface $output
+            *
+            * @return null|int
+            */
+           protected function execute(InputInterface $input, OutputInterface $output)
+           {
+               $output->writeln('<info>Success Message.</info>');
+               $output->writeln('<error>An error encountered.</error>');
+           }
+       }
+   ```
 
-{: .bs-callout-info }
-You can style the output text by using `<error>This is an error message</error>` or `<info>This is a success message</info>`.
+   {: .bs-callout-info }
+   You can style the output text by using `<error>This is an error message</error>` or `<info>This is a success message</info>`.
 
-2. Declare your Command class in `Magento\Framework\Console\CommandListInterface` using dependency injection (`<your component root dir>/etc/di.xml`):
+1. Declare your Command class in `Magento\Framework\Console\CommandListInterface` using dependency injection (`<your component root dir>/etc/di.xml`):
 
-```xml
-    <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-        ...
-        <type name="Magento\Framework\Console\CommandList">
-            <arguments>
-                <argument name="commands" xsi:type="array">
-                    <item name="commandexample_somecommand" xsi:type="object">Magento\CommandExample\Console\Command\SomeCommand</item>
-                </argument>
-            </arguments>
-        </type>
-        ...
-    </config>
-```
+   ```xml
+   <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+       ...
+       <type name="Magento\Framework\Console\CommandList">
+           <arguments>
+               <argument name="commands" xsi:type="array">
+                   <item name="commandexample_somecommand" xsi:type="object">Magento\CommandExample\Console\Command\SomeCommand</item>
+               </argument>
+           </arguments>
+       </type>
+       ...
+   </config>
+   ```
 
-3. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
+1. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
 
-    ```bash
-    cd <magento_root>/var
-    ```
+   ```bash
+   cd <magento_root>/var
+   ```
 
-    ```bash
-    rm -rf cache/* page_cache/* di/* generation/*
-    ```
+   ```bash
+   rm -rf cache/* page_cache/* di/* generation/*
+   ```
 
 ## Add CLI commands using the Composer autoloader {#cli-autoload}
 

--- a/guides/v2.2/extension-dev-guide/configuration/importers.md
+++ b/guides/v2.2/extension-dev-guide/configuration/importers.md
@@ -17,45 +17,45 @@ Use the [`magento app:config:import` command]({{ page.baseurl }}/config-guide/cl
 
 Currently Magento has the following importers:
 
-* `Magento\Config\Model\Config\Importer`
-* `Magento\Store\Model\Config\Importer`
-* `Magento\Theme\Model\Config\Importer`
+*  `Magento\Config\Model\Config\Importer`
+*  `Magento\Store\Model\Config\Importer`
+*  `Magento\Theme\Model\Config\Importer`
 
 ## `ImporterInterface`
 
 All Magento importers implement the interface [`Magento\Framework\App\DeploymentConfig\ImporterInterface`][importer-interface]{:target="_blank"} and define the following methods:
 
-* `import(array $data)` - The argument `$data` is the configuration array from `config.php`.
+*  `import(array $data)` - The argument `$data` is the configuration array from `config.php`.
 
-  This method should return the array of messages generated during the import process.
+   This method should return the array of messages generated during the import process.
 
-* `getWarningMessages(array $data)` - Generates and returns the array of warning messages that contain information about what will be changed in the system.
+*  `getWarningMessages(array $data)` - Generates and returns the array of warning messages that contain information about what will be changed in the system.
 
-  The `$data` argument is the same as for the method `import`.
+   The `$data` argument is the same as for the method `import`.
 
-  If this method returns an empty array, the import proceeds without interaction.
+   If this method returns an empty array, the import proceeds without interaction.
 
-  You can also provide a message such as `Do you want to continue [yes/no]?`
+   You can also provide a message such as `Do you want to continue [yes/no]?`
 
-  If the user enters `no`, import is canceled; otherwise, if the user enters `yes`, the import is processed.
+   If the user enters `no`, import is canceled; otherwise, if the user enters `yes`, the import is processed.
 
 ### Implement your own importer
 
 1. Create an `Importer` class that implements [`Magento\Framework\App\DeploymentConfig\ImporterInterface`][importer-interface]{:target="_blank"}.
-2. Register your importer in your module's [`di.xml`]({{ page.baseurl }}/extension-dev-guide/depend-inj.html):
+1. Register your importer in your module's [`di.xml`]({{ page.baseurl }}/extension-dev-guide/depend-inj.html):
 
-```xml
-<type name="Magento\Deploy\Model\DeploymentConfig\ImporterPool">
-    <arguments>
-        <argument name="importers" xsi:type="array">
-            <item name="i18n" xsi:type="array">
-                <item name="class" xsi:type="string">Vendor\Module\Model\Config\Importer</item>
-                <item name="sortOrder" xsi:type="number">110</item>
-            </item>
-        </argument>
-    </arguments>
-</type>
-```
+   ```xml
+   <type name="Magento\Deploy\Model\DeploymentConfig\ImporterPool">
+       <arguments>
+           <argument name="importers" xsi:type="array">
+               <item name="i18n" xsi:type="array">
+                   <item name="class" xsi:type="string">Vendor\Module\Model\Config\Importer</item>
+                   <item name="sortOrder" xsi:type="number">110</item>
+               </item>
+           </argument>
+       </arguments>
+   </type>
+   ```
 
 The sample code in the preceding example registers the importer `Vendor\Module\Model\Config\Importer` for the `i18n` array in `config.php`.
 
@@ -66,8 +66,8 @@ An array cannot be imported by more than one importer.
 
 ## More information
 
-* [Sensitive and system-specific settings]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)
-* [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html)
-* [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html)
+*  [Sensitive and system-specific settings]({{ page.baseurl }}/extension-dev-guide/configuration/sensitive-and-environment-settings.html)
+*  [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html)
+*  [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html)
 
 [importer-interface]:{{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/DeploymentConfig/ImporterInterface.php

--- a/guides/v2.2/extension-dev-guide/package/package_module.md
+++ b/guides/v2.2/extension-dev-guide/package/package_module.md
@@ -134,11 +134,11 @@ Third party repositories are supported.
 Prerequisite: Git must be set up on your machine.
 
 1. Navigate to your component directory, with the `composer.json` file in the root, and make it a new Git repository. See the [GitHub documentation](https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/) for details.
-2. When you have committed and pushed your component to your GitHub repository, you can either:
-  * Use [Composer to refer to it directly](https://getcomposer.org/doc/05-repositories.md#vcs), or
-  * Use the following steps to refer to the package through Packagist.
-    1. Register an account at [packagist.org](https://packagist.org/).
-    2. Click the Submit Package button and paste your GitHub repository link. Packagist automatically gathers the information from the component's `composer.json` file and link it to the GitHub repository, allowing you to reference the package as `vendor/module` without any additional repository information, because this is required solely using GitHub.
+1. When you have committed and pushed your component to your GitHub repository, you can either:
+   *  Use [Composer to refer to it directly](https://getcomposer.org/doc/05-repositories.md#vcs), or
+   *  Use the following steps to refer to the package through Packagist.
+      1. Register an account at [packagist.org](https://packagist.org/).
+      1. Click the Submit Package button and paste your GitHub repository link. Packagist automatically gathers the information from the component's `composer.json` file and link it to the GitHub repository, allowing you to reference the package as `vendor/module` without any additional repository information, because this is required solely using GitHub.
 
 ### Hosting on a private repository {#private_repos}
 
@@ -146,21 +146,20 @@ Prerequisite: Git must be set up on your machine.
 If you use the Setup Wizard, you must use the Magento Marketplace repository. A private repository can be used for development or private code but installation must be done with a command line interface (you can install a package that specifies a private repository only with a command line installation).
 
 1. Set up your own Composer packaging repository using a system such as [Satis](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md) or [Private Packagist](https://packagist.com/).
-2. Create the package in a way similar to the described above.
-3. Submit/register the package on your own repository. For example, it can be hosted as a reference to a code repository or submitted as a zip-archive.
-4. To use the private packaging repository in a project, add the following to your `composer.json`file:
+1. Create the package in a way similar to the described above.
+1. Submit/register the package on your own repository. For example, it can be hosted as a reference to a code repository or submitted as a zip-archive.
+1. To use the private packaging repository in a project, add the following to your `composer.json`file:
 
-```json
-
-{
-    "repositories": [
-        {
-            "type": "composer",
-            "url": [repository url here]
-        }
-    ]
-}
-```
+   ```json
+   {
+     "repositories": [
+         {
+             "type": "composer",
+             "url": [repository url here]
+         }
+     ]
+   }
+   ```
 
 All packages on the private repository can now be referenced within the `require` field.
 

--- a/guides/v2.2/extension-dev-guide/prepare/dev-summary.md
+++ b/guides/v2.2/extension-dev-guide/prepare/dev-summary.md
@@ -6,12 +6,12 @@ title: Roadmap for developing and packaging components
 To develop your component, use the following steps:
 
 1. Learn about [using Composer with your component]({{ page.baseurl }}/extension-dev-guide/build/composer-integration.html).
-2. [Build your component]({{ page.baseurl }}/extension-dev-guide/build/build.html){:target="_blank"}
-3. [Package a component]({{ page.baseurl }}/extension-dev-guide/package/package_module.html){:target="_blank"}
+1. [Build your component]({{ page.baseurl }}/extension-dev-guide/build/build.html){:target="_blank"}
+1. [Package a component]({{ page.baseurl }}/extension-dev-guide/package/package_module.html){:target="_blank"}
 
    Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
 
-4. [Validate your component]({{ page.baseurl }}/extension-dev-guide/validate/test-module.html)
-4. Upload the components to the Magento Marketplace.
+1. [Validate your component]({{ page.baseurl }}/extension-dev-guide/validate/test-module.html)
+1. Upload the components to the Magento Marketplace.
 
    See the [Magento Marketplace User Guide](http://docs.magento.com/marketplace/user_guide/getting-started.html){:target="_blank"} for details.

--- a/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -115,15 +115,15 @@ Under the created `etc` directory, create a new directory called `adminhtml`. Un
 The `menu.xml` file provided below adds two items in the Content section of the left navigation:
 
 1. A new separate section with the title **Greetings** under Content.
-2. A link with the label **Hello World** that leads to a page request for `exampleadminnewpage/helloworld/index` underneath that new section.
+1. A link with the label **Hello World** that leads to a page request for `exampleadminnewpage/helloworld/index` underneath that new section.
 
 ![Hello World menu item]({{ site.baseurl }}/common/images/ext-best-practices/hello-world-menu-item.png){:width="322px" height="400px"}
 
 The following parts make up the generated page request link to the **Hello World** page:
 
-* `exampleadminnewpage` - This is the `frontName`. Because its purpose is to help route requests to the correct module, we give it the same name as the module, but this is not required.
-* `helloworld` - This specifies the name of the controller to use.
-* `index` - In the XML file, since the action for the controller is not specified, Magento uses the default value `index`.
+*  `exampleadminnewpage` - This is the `frontName`. Because its purpose is to help route requests to the correct module, we give it the same name as the module, but this is not required.
+*  `helloworld` - This specifies the name of the controller to use.
+*  `index` - In the XML file, since the action for the controller is not specified, Magento uses the default value `index`.
 
 [//]: # (Stop list rendering before collapsible, see: https://github.com/magento/devdocs/issues/2655)
 {% collapsible File content for menu.xml %}
@@ -294,10 +294,10 @@ MyCompany
 Now that the module is code-complete, run the following commands to install it:
 
 1. `bin/magento module:status` - This command shows a list of enabled/disabled modules.
-2. `bin/magento module:enable MyCompany_ExampleAdminNewPage` - If necessary, run this to enable the disabled module.
-3. `bin/magento setup:upgrade` - This command will properly register the module with Magento.
-4. `bin/magento setup:di:compile` - This command compiles classes used in dependency injections.
-5. `bin/magento cache:clean` - This command cleans the cache.
+1. `bin/magento module:enable MyCompany_ExampleAdminNewPage` - If necessary, run this to enable the disabled module.
+1. `bin/magento setup:upgrade` - This command will properly register the module with Magento.
+1. `bin/magento setup:di:compile` - This command compiles classes used in dependency injections.
+1. `bin/magento cache:clean` - This command cleans the cache.
 
 Once the module installation has completed, the link to the **Hello World** page should appear in the **Greetings** section under **Content** in the left navigation in the admin area. Clicking this link will take you to a page that looks like the one pictured below.
 

--- a/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
+++ b/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.md
@@ -43,17 +43,17 @@ Old data scripts cannot be converted automatically. The following steps help mak
 
 1. Generate a patch stub.
 
-    ```bash
-    bin/magento setup:db-declaration:generate-patch [options] <module-name> <patch-name>
-    ```
+   ```bash
+   bin/magento setup:db-declaration:generate-patch [options] <module-name> <patch-name>
+   ```
 
-    where `[options]` can be any of the following:
+   where `[options]` can be any of the following:
 
-    `--revertable[=true | false]` - Determines whether the patch is revertable. The default value is `false`.
+   `--revertable[=true | false]` - Determines whether the patch is revertable. The default value is `false`.
 
-    `--type[=<type>]` - Specifies what type of patch to generate. The default is `data`.
+   `--type[=<type>]` - Specifies what type of patch to generate. The default is `data`.
 
-2. All released modules that previously used upgrade scripts must support backward compatibility by implementing `\Magento\Framework\Setup\Patch\PatchVersionInterface` and the `getVersion` method. This method allows you to skip changes that were applied in previous versions and were done by old scripts. The returned value of the `getVersion` method in this case should be equal to the value of a version in `version_compare` function in old scripts. When the `InstallData.php` script does not have any versions to compare, you can specify the first version of your module. See [Develop declarative data and schema patches]({{ page.baseurl }}/extension-dev-guide/declarative-schema/data-patches.html) for more information.
+1. All released modules that previously used upgrade scripts must support backward compatibility by implementing `\Magento\Framework\Setup\Patch\PatchVersionInterface` and the `getVersion` method. This method allows you to skip changes that were applied in previous versions and were done by old scripts. The returned value of the `getVersion` method in this case should be equal to the value of a version in `version_compare` function in old scripts. When the `InstallData.php` script does not have any versions to compare, you can specify the first version of your module. See [Develop declarative data and schema patches]({{ page.baseurl }}/extension-dev-guide/declarative-schema/data-patches.html) for more information.
 
 ## Dry run mode
 
@@ -64,6 +64,7 @@ To enable dry run mode, run one of the following commands:
 ```bash
 bin/magento setup:install --dry-run=1
 ```
+
 ```bash
 bin/magento setup:upgrade --dry-run=1
 ```

--- a/guides/v2.3/extension-dev-guide/indexing.md
+++ b/guides/v2.3/extension-dev-guide/indexing.md
@@ -59,11 +59,13 @@ The following components are involved in the indexing process:
 
 Each index can perform the following types of reindex operations:
 
-* Full reindex, which means rebuilding all the indexing-related database tables
-  Full reindexing can be caused by a variety of things, including creating a new web store or new customer group.
-  You can optionally fully reindex at any time using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html).
+*  Full reindex, which means rebuilding all the indexing-related database tables
 
-* Partial reindex, which means rebuilding the database tables only for the things that changed (like changing a single product attribute or price)
+   Full reindexing can be caused by a variety of things, including creating a new web store or new customer group.
+
+   You can optionally fully reindex at any time using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html).
+
+*  Partial reindex, which means rebuilding the database tables only for the things that changed (like changing a single product attribute or price)
 
 The type of reindex performed in each particular case depends on the type of changes made in the dictionary or in the system. This dependency is specific for [each indexer](#m2devgde-indexing-outofbox).
 
@@ -75,9 +77,9 @@ The following figure shows the logic for partial reindexing.
 
 Depending on whether an index data is up to date, an indexer status value is one of the following:
 
-* valid - data is synchronized, no reindex required
-* invalid - the original data was changed, the index should be updated
-* working - indexing is in progress
+*  valid - data is synchronized, no reindex required
+*  invalid - the original data was changed, the index should be updated
+*  working - indexing is in progress
 
 The Magento indexing mechanism uses the status value in reindex triggering process. You can check the status of an indexer in the [Admin](https://glossary.magento.com/admin) panel in **System >** Tools **> Index Management** or manually using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#view-indexer-status).
 
@@ -85,8 +87,8 @@ The Magento indexing mechanism uses the status value in reindex triggering proce
 
 Reindexing can be performed in two modes:
 
-* Update on Save - index tables are updated immediately after the dictionary data is changed.
-* Update by Schedule - index tables are updated by cron job according to the configured schedule.
+*  Update on Save - index tables are updated immediately after the dictionary data is changed.
+*  Update by Schedule - index tables are updated by cron job according to the configured schedule.
 
 {:.bs-callout .bs-callout-info}
 **Update by Schedule** does not support the `customer_grid` indexer. You must either use **Update on Save** or reindex the customer grid manually (`bin/magento indexer:reindex customer_grid`). See the [Help Center article](https://support.magento.com/hc/en-us/articles/360025481892-New-customer-records-are-not-displayed-in-the-Customers-grid-after-importing-them-from-CSV).
@@ -94,10 +96,10 @@ Reindexing can be performed in two modes:
 To set these options:
 
 1. Log in to the [Magento Admin](https://glossary.magento.com/magento-admin).
-2. Click **System >** Tools **> Index Management**.
-3. Select the checkbox next to each type of indexer to change.
-4. From the **Actions** list, click the indexing mode.
-5. Click **Submit**.
+1. Click **System >** Tools **> Index Management**.
+1. Select the checkbox next to each type of indexer to change.
+1. From the **Actions** list, click the indexing mode.
+1. Click **Submit**.
 
 You can also reindex from the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#configure-indexers)
 
@@ -124,9 +126,9 @@ For example part of `Magento/Catalog/etc/mview.xml` is tracking category to prod
 
 Explanation of nodes:
 
-* The `view` node defines an indexer. The `id` attribute is a name of the indexer table, the `class` attribute is indexer executor, the `group` attribute defines the indexer group.
-* The `subscriptions` node is a list of tables for tracking changes.
-* The `table` node defines the certain table to observe and track changes. The attribute `name` is a name of an observable table, the attribute `entity_column` is an identifier column of entity to be re-indexed. So, in case of `catalog_category_product`, whenever one or more categories is saved, updated or deleted in `catalog_category_entity` the `execute` method of `Magento\Catalog\Model\Indexer\Category\Product` will be called with argument `ids` containing ids of entities from column defined under `entity_column` attribute. If indexer type is set to "Update on Save" the method is called right away after the operation. If it set to "Update by Schedule" the mechanism creates a record in the change log table using MYSQL triggers.
+*  The `view` node defines an indexer. The `id` attribute is a name of the indexer table, the `class` attribute is indexer executor, the `group` attribute defines the indexer group.
+*  The `subscriptions` node is a list of tables for tracking changes.
+*  The `table` node defines the certain table to observe and track changes. The attribute `name` is a name of an observable table, the attribute `entity_column` is an identifier column of entity to be re-indexed. So, in case of `catalog_category_product`, whenever one or more categories is saved, updated or deleted in `catalog_category_entity` the `execute` method of `Magento\Catalog\Model\Indexer\Category\Product` will be called with argument `ids` containing ids of entities from column defined under `entity_column` attribute. If indexer type is set to "Update on Save" the method is called right away after the operation. If it set to "Update by Schedule" the mechanism creates a record in the change log table using MYSQL triggers.
 
 A change log table is created according to the naming rule - INDEXER_TABLE_NAME + '_cl', in case of `catalog_category_product` it will be `catalog_category_product_cl`.
 The table contains the `version_id` auto-increment column and `entity_id` column that contains identifiers of entities to be re-indexed.
@@ -173,8 +175,8 @@ it defines IDs to be re-indexed from the change log by last applied `version_id`
 
 You can reindex by:
 
-* Using a [cron job]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html), which is preferred because indexing runs every minute.
-* Using the [`magento indexer:reindex [indexer]`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#config-cli-subcommands-index-reindex) command, which reindexes selected indexers, or all indexers, one time only.
+*  Using a [cron job]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html), which is preferred because indexing runs every minute.
+*  Using the [`magento indexer:reindex [indexer]`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#config-cli-subcommands-index-reindex) command, which reindexes selected indexers, or all indexers, one time only.
 
 ## Magento indexers {#m2devgde-indexing-outofbox}
 

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues.md
@@ -42,9 +42,9 @@ Implement `\Magento\Framework\MessageQueue\ConsumerInterface::process($maxNumber
 Perform the following actions:
 
 1. Define the queue name associated with current consumer using `\Magento\Framework\MessageQueue\ConsumerConfigurationInterface::getQueueName`.
-2. Select `$maxNumberOfMessages` message records, filtering on the  `queue_name` field. You must join on all 3 tables. To accomplish this, you may want to extract fewer records at a time to improve load distribution between multiple consumers.
-3. Decode the message using topic name taken from the `\Magento\Framework\MessageQueue\ConsumerConfigurationInterface`.
-4. Invoke callback  `Magento\Framework\MessageQueue\ConsumerConfigurationInterface::getCallback` and pass the decoded data as an argument.
+1. Select `$maxNumberOfMessages` message records, filtering on the  `queue_name` field. You must join on all 3 tables. To accomplish this, you may want to extract fewer records at a time to improve load distribution between multiple consumers.
+1. Decode the message using topic name taken from the `\Magento\Framework\MessageQueue\ConsumerConfigurationInterface`.
+1. Invoke callback  `Magento\Framework\MessageQueue\ConsumerConfigurationInterface::getCallback` and pass the decoded data as an argument.
 
 ## Override topic configuration
 

--- a/guides/v2.3/extension-dev-guide/package/package_module.md
+++ b/guides/v2.3/extension-dev-guide/package/package_module.md
@@ -134,11 +134,13 @@ Third party repositories are supported.
 Prerequisite: Git must be set up on your machine.
 
 1. Navigate to your component directory, with the `composer.json` file in the root, and make it a new Git repository. See the [GitHub documentation](https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/) for details.
-2. When you have committed and pushed your component to your GitHub repository, you can either:
-  * Use [Composer to refer to it directly](https://getcomposer.org/doc/05-repositories.md#vcs), or
-  * Use the following steps to refer to the package through Packagist.
-    1. Register an account at [packagist.org](https://packagist.org/).
-    2. Click the Submit Package button and paste your GitHub repository link. Packagist automatically gathers the information from the component's `composer.json` file and link it to the GitHub repository, allowing you to reference the package as `vendor/module` without any additional repository information, because this is required solely using GitHub.
+1. When you have committed and pushed your component to your GitHub repository, you can either:
+
+   *  Use [Composer to refer to it directly](https://getcomposer.org/doc/05-repositories.md#vcs), or
+   *  Use the following steps to refer to the package through Packagist.
+
+      1. Register an account at [packagist.org](https://packagist.org/).
+      1. Click the Submit Package button and paste your GitHub repository link. Packagist automatically gathers the information from the component's `composer.json` file and link it to the GitHub repository, allowing you to reference the package as `vendor/module` without any additional repository information, because this is required solely using GitHub.
 
 ### Hosting on a private repository {#private_repos}
 
@@ -146,21 +148,20 @@ Prerequisite: Git must be set up on your machine.
 If you use the Setup Wizard, you must use the Magento Marketplace repository. A private repository can be used for development or private code but installation must be done with a command line interface (you can install a package that specifies a private repository only with a command line installation).
 
 1. Set up your own Composer packaging repository using a system such as [Satis](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md) or [Private Packagist](https://packagist.com/).
-2. Create the package in a way similar to the described above.
-3. Submit/register the package on your own repository. For example, it can be hosted as a reference to a code repository or submitted as a zip-archive.
-4. To use the private packaging repository in a project, add the following to your `composer.json`file:
+1. Create the package in a way similar to the described above.
+1. Submit/register the package on your own repository. For example, it can be hosted as a reference to a code repository or submitted as a zip-archive.
+1. To use the private packaging repository in a project, add the following to your `composer.json`file:
 
-```json
-
-{
-    "repositories": [
-        {
-            "type": "composer",
-            "url": [repository url here]
-        }
-    ]
-}
-```
+   ```json
+   {
+       "repositories": [
+           {
+               "type": "composer",
+               "url": [repository url here]
+           }
+       ]
+   }
+   ```
 
 All packages on the private repository can now be referenced within the `require` field.
 

--- a/guides/v2.3/extension-dev-guide/versioning/dependencies.md
+++ b/guides/v2.3/extension-dev-guide/versioning/dependencies.md
@@ -13,45 +13,45 @@ Magento platform clients need notifications about breaking changes for their ins
 To achieve this, all third-party modules must obey the following rules:
 
 1. You must specify the dependency on all modules listed in the `require` section of your module's `composer.json` file.
-2. Do not specify a dependency on meta packages (e.g. `product-community-edition`).
-3. Specify a module's MAJOR and/or MINOR version number if you use any of that module's customization points.
-4. Specify a module's MAJOR, MINOR, and PATCH versions if you call or customize a module's private code.
+1. Do not specify a dependency on meta packages (e.g. `product-community-edition`).
+1. Specify a module's MAJOR and/or MINOR version number if you use any of that module's customization points.
+1. Specify a module's MAJOR, MINOR, and PATCH versions if you call or customize a module's private code.
 
 ## Service Provider Interfaces
 
 A PHP Interface in Magento can be used several ways by the core product and extension developers.
 
-* **As an API**. An interface is called by PHP code.
-* **As a Service Provider Interface (SPI)**. An interface can be implemented, allowing code to provide functionality to the platform.
-* **As both**. For example, in a service contract, we expect all calls to a [module](https://glossary.magento.com/module) to be done through the Interface (API), but we also have support for third parties to provide alternate implementations (SPI). APIs and SPIs are not mutually exclusive. Therefore, we do not distinguish them separately. SPIs are annotated the same as APIs.
+*  **As an API**. An interface is called by PHP code.
+*  **As a Service Provider Interface (SPI)**. An interface can be implemented, allowing code to provide functionality to the platform.
+*  **As both**. For example, in a service contract, we expect all calls to a [module](https://glossary.magento.com/module) to be done through the Interface (API), but we also have support for third parties to provide alternate implementations (SPI). APIs and SPIs are not mutually exclusive. Therefore, we do not distinguish them separately. SPIs are annotated the same as APIs.
 
 However, the dependency rules are different:
 
-* If a module uses (calls) an API, it should be dependent on the MAJOR version and the system provides backward compatibility in scope of current major version.
+*  If a module uses (calls) an API, it should be dependent on the MAJOR version and the system provides backward compatibility in scope of current major version.
 
-  **API dependency example**
+   **API dependency example**
 
-    ```json
-    {
-      "require": {
-      "magento/customer": "~2.0",
-      },
-    }
-    ```
+   ```json
+   {
+     "require": {
+     "magento/customer": "~2.0",
+     },
+   }
+   ```
 
-* If a module implements an API/SPI, it should be dependent on the MAJOR+MINOR version, and the system provides backward compatibility in scope of the current minor version.
+*  If a module implements an API/SPI, it should be dependent on the MAJOR+MINOR version, and the system provides backward compatibility in scope of the current minor version.
+
    **SPI dependency example**
 
-    ```json
-    {
-      ...
-      "require": {
-      "magento/customer": "~2.0.0",
-      },
-      ...
-    }
-
-    ```
+   ```json
+   {
+     ...
+     "require": {
+     "magento/customer": "~2.0.0",
+     },
+     ...
+   }
+   ```
 
 ## Determine module dependency
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the following guides:

- Extension Dev
- Extension Dev Best Practices

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.