### PR TITLE
Fixed ordered list prefix (MD029) - Group 10

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-mode.md
@@ -134,7 +134,7 @@ When you change from production to developer mode, you should clear generated cl
    rm -rf <magento_root>/generated/metadata/* <magento_root>/generated/code/*
    ```
 
-2. Set the mode:
+1. Set the mode:
 
    ```bash
    bin/magento deploy:mode:set developer

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.md
@@ -35,8 +35,8 @@ You must write static view files to the Magento file system manually using the c
 To deploy static view files:
 
 1. Log in to the Magento server as, or [switch to]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html), the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
-2. Delete the contents of `<magento_root>/pub/static`, except for the `.htaccess` file. Do not delete this file.
-3. Run the static view files deployment tool `<magento_root>/bin/magento setup:static-content:deploy`.
+1. Delete the contents of `<magento_root>/pub/static`, except for the `.htaccess` file. Do not delete this file.
+1. Run the static view files deployment tool `<magento_root>/bin/magento setup:static-content:deploy`.
 
    {:.bs-callout .bs-callout-info}
    If you enable static view file merging in the Magento Admin, the `pub/static` directory system must be writable.
@@ -329,8 +329,8 @@ You might want to run the deployment process in a separate, non-production, envi
 To do this, take the following steps:
 
 1. Run [`bin/magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) to export the configuration from your production system.
-2. Copy the exported files to the non-production code base.
-3. Run [`bin/magento setup:static-content:deploy`](#config-cli-subcommands-staticview).
+1. Copy the exported files to the non-production code base.
+1. Run [`bin/magento setup:static-content:deploy`](#config-cli-subcommands-staticview).
 
 ## Troubleshooting the static view files deployment tool {#view-file-trouble}
 
@@ -351,9 +351,9 @@ Use the following steps:
    -  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
    -  [Setup wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
-2. Log in to the Magento server as, or [switch to]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html), the Magento file system owner.
-3. Delete the contents of `<magento_root>/pub/static` directory, except for the `.htaccess` file. Do not delete this file.
-4. [Run the static view files deployment tool](#config-cli-subcommands-staticview).
+1. Log in to the Magento server as, or [switch to]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html), the Magento file system owner.
+1. Delete the contents of `<magento_root>/pub/static` directory, except for the `.htaccess` file. Do not delete this file.
+1. [Run the static view files deployment tool](#config-cli-subcommands-staticview).
 
 ## Tip for developers customizing the static content deployment tool
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands.md
@@ -12,21 +12,23 @@ functional_areas:
 
 ## First steps {#config-cli-before}
 
-1.  Log in to the Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2.  Change to the following directory:
+1. Log in to the Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. Change to the following directory:
 
-        cd <magento_root>/bin
+   ```bash
+   cd <magento_root>/bin
+   ```
 
-    Examples:
+   Examples:
 
-      - Ubuntu: `cd /var/www/magento2/bin`
-      - CentOS: `cd /var/www/html/magento2/bin`
+   -  Ubuntu: `cd /var/www/magento2/bin`
+   -  CentOS: `cd /var/www/html/magento2/bin`
 
 You can run the commands in any of the following ways:
 
--   `php magento <command>`
--   `./magento <command>`
--   `magento <command>` (after [adding](http://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables) `<magento_root>/bin` to your system `PATH`)
+-  `php magento <command>`
+-  `./magento <command>`
+-  `magento <command>` (after [adding](http://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables) `<magento_root>/bin` to your system `PATH`)
 
 ## Command summary {#config-cli-summary}
 
@@ -54,7 +56,9 @@ Before you run any of these commands, you must either [install the Magento appli
 |[`bin/magento dev:template-hints:{enable/disable`}]({{ page.baseurl }}/frontend-dev-guide/themes/debug-theme.html)|Enables/disables developer template hints.|
 
 ## Help commands {#config-cli-help}
+
 {% include install/cli_help-commands.md %}
 
 ## Common arguments {#config-cli-subcommands-common}
+
 {% include install/cli_common-commands.md %}

--- a/guides/v2.2/config-guide/cron/custom-cron-tut.md
+++ b/guides/v2.2/config-guide/cron/custom-cron-tut.md
@@ -15,9 +15,9 @@ We also show you how to optionally create a cron group, which you can use to run
 
 In this tutorial, we assume the following:
 
-*   The Magento application is installed in `/var/www/html/magento2`
-*   Your Magento database username and password are both `magento`
-*   You perform all actions as the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
+*  The Magento application is installed in `/var/www/html/magento2`
+*  Your Magento database username and password are both `magento`
+*  You perform all actions as the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
 
 ## Step 1: Get a sample module {#cron-tut-get}
 
@@ -27,48 +27,65 @@ If you already have a sample module, you can use it; skip this step and the next
 
 {% collapsible To get a sample module: %}
 
-1.  Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2.  Change to a directory that is not in your Magento application root (for example, your home directory).
-2.  Clone the [`magento2-samples` repository](https://github.com/magento/magento2-samples).
+1. Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. Change to a directory that is not in your Magento application root (for example, your home directory).
+1. Clone the [`magento2-samples` repository](https://github.com/magento/magento2-samples).
 
-    For example,
-
-        cd ~
-        git clone git@github.com:magento/magento2-samples.git
-
-    If the command fails with the error `Permission denied (publickey).`, you must [add your SSH public key to GitHub.com](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account).
-4.  Make a directory to which to copy the sample code:
-
-        mkdir -p /var/www/html/magento2/app/code/Magento/SampleMinimal
-5.  Copy the sample module code:
-
-        cp -r ~/magento2-samples/sample-module-minimal/* /var/www/html/magento2/app/code/Magento/SampleMinimal
-5.  Verify the files copied properly:
-
-        ls -al /var/www/html/magento2/app/code/Magento/SampleMinimal
-
-    You should see the following result:
-
-        drwxrwsr-x.   4 magento_user apache  4096 Oct 30 13:19 .
-        drwxrwsr-x. 121 magento_user apache  4096 Oct 30 13:19 ..
-        -rw-rw-r--.   1 magento_user apache   372 Oct 30 13:19 composer.json
-        drwxrwsr-x.   2 magento_user apache  4096 Oct 30 13:19 etc
-        -rw-rw-r--.   1 magento_user apache 10376 Oct 30 13:19 LICENSE_AFL.txt
-        -rw-rw-r--.   1 magento_user apache 10364 Oct 30 13:19 LICENSE.txt
-        -rw-rw-r--.   1 magento_user apache  1157 Oct 30 13:19 README.md
-        -rw-rw-r--.   1 magento_user apache   270 Oct 30 13:19 registration.php
-        drwxrwsr-x.   3 magento_user apache  4096 Oct 30 13:19 Test
-6.  Update the Magento database and schema:
-
-    ```bash
-    bin/magento setup:upgrade
-    ```
-
-7. Clean the cache:
+   For example,
 
    ```bash
-   bin/magento cache:clean
+   cd ~
    ```
+
+   ```bash
+   git clone git@github.com:magento/magento2-samples.git
+   ```
+
+   If the command fails with the error `Permission denied (publickey).`, you must [add your SSH public key to GitHub.com](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account).
+
+1. Make a directory to which to copy the sample code:
+
+   ```bash
+   mkdir -p /var/www/html/magento2/app/code/Magento/SampleMinimal
+   ```
+
+1. Copy the sample module code:
+
+   ```bash
+   cp -r ~/magento2-samples/sample-module-minimal/* /var/www/html/magento2/app/code/Magento/SampleMinimal
+   ```
+
+1. Verify the files copied properly:
+
+   ```bash
+   ls -al /var/www/html/magento2/app/code/Magento/SampleMinimal
+   ```
+
+   You should see the following result:
+
+   ```terminal
+   drwxrwsr-x.   4 magento_user apache  4096 Oct 30 13:19 .
+   drwxrwsr-x. 121 magento_user apache  4096 Oct 30 13:19 ..
+   -rw-rw-r--.   1 magento_user apache   372 Oct 30 13:19 composer.json
+   drwxrwsr-x.   2 magento_user apache  4096 Oct 30 13:19 etc
+   -rw-rw-r--.   1 magento_user apache 10376 Oct 30 13:19 LICENSE_AFL.txt
+   -rw-rw-r--.   1 magento_user apache 10364 Oct 30 13:19 LICENSE.txt
+   -rw-rw-r--.   1 magento_user apache  1157 Oct 30 13:19 README.md
+   -rw-rw-r--.   1 magento_user apache   270 Oct 30 13:19 registration.php
+   drwxrwsr-x.   3 magento_user apache  4096 Oct 30 13:19 Test
+    ```
+
+1. Update the Magento database and schema:
+
+   ```bash
+   bin/magento setup:upgrade
+   ```
+
+1. Clean the cache:
+
+  ```bash
+  bin/magento cache:clean
+  ```
 
 {% endcollapsible %}
 
@@ -78,21 +95,21 @@ Before you continue, make sure the sample module is registered and enabled.
 
 1. Run the following command:
 
-    ```bash
-    bin/magento module:status
-    ```
+   ```bash
+   bin/magento module:status
+   ```
 
-2. Make sure that the module's name is displaying under `List of enabled modules:`.
+1. Make sure that the module's name is displaying under `List of enabled modules:`.
 
-    ```text
-    List of enabled modules:
-    ...
-    Magento_SampleMinimal
-    ...
+   ```text
+   List of enabled modules:
+   ...
+   Magento_SampleMinimal
+   ...
 
-    List of disabled modules:
-    None
-    ```
+   List of disabled modules:
+   None
+   ```
 
 If the module does not display, review [step 1](#cron-tut-get) carefully. Make sure your code is in the correct directory. Spelling and case are important; if anything is different, the module won't load. Also, don't forget to run `magento setup:upgrade`.
 
@@ -102,38 +119,42 @@ This step shows a simple class to create a cron job. The class only writes a row
 
 {% collapsible To create a class: %}
 
-1.  Create a directory for the class and change to that directory:
+1. Create a directory for the class and change to that directory:
 
-        mkdir /var/www/html/magento2/app/code/Magento/SampleMinimal/Cron && cd /var/www/html/magento2/app/code/Magento/SampleMinimal/Cron
-2.  Created a file named `Test.php` in that directory with the following contents:
+   ```bash
+   mkdir /var/www/html/magento2/app/code/Magento/SampleMinimal/Cron && cd /var/www/html/magento2/app/code/Magento/SampleMinimal/Cron
+   ```
 
-```php
-<?php
-namespace Magento\SampleMinimal\Cron;
+1. Created a file named `Test.php` in that directory with the following contents:
 
-use Psr\Log\LoggerInterface;
+   ```php
+   <?php
+   namespace Magento\SampleMinimal\Cron;
 
-class Test {
-    protected $logger;
+   use Psr\Log\LoggerInterface;
 
-    public function __construct(LoggerInterface $logger) {
-        $this->logger = $logger;
-    }
+   class Test {
+       protected $logger;
 
-   /**
-    * Write to system.log
-    *
-    * @return void
-    */
-    public function execute() {
-        $this->logger->info('Cron Works');
-    }
-}
-```
+       public function __construct(LoggerInterface $logger) {
+           $this->logger = $logger;
+       }
+
+      /**
+       * Write to system.log
+       *
+       * @return void
+       */
+       public function execute() {
+           $this->logger->info('Cron Works');
+       }
+   }
+   ```
 
 {% endcollapsible %}
 
 ## Step 4: Create `crontab.xml` {#cron-tut-crontab}
+
 `crontab.xml` sets a schedule to run your custom cron code.
 
 {% collapsible To create crontab.xml: %}
@@ -161,41 +182,53 @@ This step shows how to verify the custom cron job successfully using a SQL query
 
 {% collapsible To verify cron: %}
 
-1.  Run Magento cron jobs:
+1. Run Magento cron jobs:
 
-        php /var/www/html/magento2/bin/magento cron:run
-2.  Enter the `magento cron:run` command two or three times.
+   ```bash
+   php /var/www/html/magento2/bin/magento cron:run
+   ```
 
-    The first time you enter the command, it queues jobs; subsequently, the cron jobs are run. You must enter the command _at least_ twice.
-2.  Run the SQL query `SELECT * from cron_schedule WHERE job_code like '%custom%'` as follows:
+1. Enter the `magento cron:run` command two or three times.
 
-    1.  Enter `mysql -u magento -p`
-    2.  At the `mysql>` prompt, enter `use magento;`
-    3.  Enter `SELECT * from cron_schedule WHERE job_code like '%custom%';`
+   The first time you enter the command, it queues jobs; subsequently, the cron jobs are run. You must enter the command _at least_ twice.
 
-    The result should be similar to the following:
+1. Run the SQL query `SELECT * from cron_schedule WHERE job_code like '%custom%'` as follows:
 
-        +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
-        | schedule_id | job_code       | status  | messages | created_at          | scheduled_at        | executed_at         | finished_at         |
-        +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
-        |        3670 | custom_cronjob | success | NULL     | 2016-11-02 09:38:03 | 2016-11-02 09:38:00 | 2016-11-02 09:39:03 | 2016-11-02 09:39:03 |
-        |        3715 | custom_cronjob | success | NULL     | 2016-11-02 09:53:03 | 2016-11-02 09:53:00 | 2016-11-02 09:54:04 | 2016-11-02 09:54:04 |
-        |        3758 | custom_cronjob | success | NULL     | 2016-11-02 10:09:03 | 2016-11-02 10:09:00 | 2016-11-02 10:10:03 | 2016-11-02 10:10:03 |
-        |        3797 | custom_cronjob | success | NULL     | 2016-11-02 10:24:03 | 2016-11-02 10:24:00 | 2016-11-02 10:25:03 | 2016-11-02 10:25:03 |
-        +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
+   1. Enter `mysql -u magento -p`
+   1. At the `mysql>` prompt, enter `use magento;`
+   1. Enter `SELECT * from cron_schedule WHERE job_code like '%custom%';`
 
-3.  (Optional) Verify messages are written to Magento's system log:
+      The result should be similar to the following:
 
-        cat /var/www/html/magento2/var/log/system.log
+      ```terminal
+      +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
+      | schedule_id | job_code       | status  | messages | created_at        | scheduled_at        | executed_at         | finished_at     |
+      +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
+      |        3670 | custom_cronjob | success | NULL     | 2016-11-02 09:38:03 | 2016-11-02 09:38:00 | 2016-11-02 09:39:03 | 2016-11-02 09:39:03 |
+      |        3715 | custom_cronjob | success | NULL     | 2016-11-02 09:53:03 | 2016-11-02 09:53:00 | 2016-11-02 09:54:04 | 2016-11-02 09:54:04 |
+      |        3758 | custom_cronjob | success | NULL     | 2016-11-02 10:09:03 | 2016-11-02 10:09:00 | 2016-11-02 10:10:03 | 2016-11-02 10:10:03 |
+      |        3797 | custom_cronjob | success | NULL     | 2016-11-02 10:24:03 | 2016-11-02 10:24:00 | 2016-11-02 10:25:03 | 2016-11-02 10:25:03 |
+      +-------------+----------------+---------+----------+---------------------+---------------------+---------------------+---------------------+
+      ```
 
-    You should see one or more entries like the following:
+1. (Optional) Verify messages are written to Magento's system log:
 
-        [2016-11-02 22:17:03] main.INFO: Cron Works [] []
+   ```bash
+   cat /var/www/html/magento2/var/log/system.log
+   ```
 
-    These messages come from the `execute` method in `Test.php`:
+   You should see one or more entries like the following:
 
-        public function execute() {
-           $this->logger->info('Cron Works');
+   ```terminal
+   [2016-11-02 22:17:03] main.INFO: Cron Works [] []
+   ```
+
+   These messages come from the `execute` method in `Test.php`:
+
+   ```php
+   public function execute() {
+        $this->logger->info('Cron Works');
+   ```
 
 If the SQL command and system log contain no entries, run the `magento cron:run` command a few more times and wait. It can take some time for the database to update.
 
@@ -207,25 +240,25 @@ If the SQL command and system log contain no entries, run the `magento cron:run`
 
 {% collapsible To set up a custom cron group: %}
 
-1.  Open `crontab.xml` in a text editor.
-2.  Change `<group id="default">` to `<group id="custom_crongroup">`
-3.  Exit the text editor.
-4.  Create `/var/www/html/magento2/app/code/Magento/SampleMinimal/etc/cron_groups.xml` with the following contents:
+1. Open `crontab.xml` in a text editor.
+1. Change `<group id="default">` to `<group id="custom_crongroup">`
+1. Exit the text editor.
+1. Create `/var/www/html/magento2/app/code/Magento/SampleMinimal/etc/cron_groups.xml` with the following contents:
 
-```xml
-<?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
-    <group id="custom_crongroup">
-        <schedule_generate_every>1</schedule_generate_every>
-        <schedule_ahead_for>4</schedule_ahead_for>
-        <schedule_lifetime>2</schedule_lifetime>
-        <history_cleanup_every>10</history_cleanup_every>
-        <history_success_lifetime>60</history_success_lifetime>
-        <history_failure_lifetime>600</history_failure_lifetime>
-        <use_separate_process>1</use_separate_process>
-    </group>
-</config>
-```
+   ```xml
+   <?xml version="1.0"?>
+   <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+       <group id="custom_crongroup">
+           <schedule_generate_every>1</schedule_generate_every>
+           <schedule_ahead_for>4</schedule_ahead_for>
+           <schedule_lifetime>2</schedule_lifetime>
+           <history_cleanup_every>10</history_cleanup_every>
+           <history_success_lifetime>60</history_success_lifetime>
+           <history_failure_lifetime>600</history_failure_lifetime>
+           <use_separate_process>1</use_separate_process>
+       </group>
+   </config>
+   ```
 
 For a description of what the options mean, see [Configure custom cron jobs and cron groups reference]({{ page.baseurl }}/config-guide/cron/custom-cron-ref.html).
 
@@ -237,20 +270,26 @@ This step shows how to verify your custom cron group using the [Magento Admin](h
 
 {% collapsible To verify your custom cron group: %}
 
-1.  Run Magento cron jobs for your custom group:
+1. Run Magento cron jobs for your custom group:
 
-        php /var/www/html/magento2/bin/magento cron:run --group="custom_crongroup"
+   ```bash
+   php /var/www/html/magento2/bin/magento cron:run --group="custom_crongroup"
+   ```
 
-    Run the command at least twice.
-2.  Clean the Magento cache:
+   Run the command at least twice.
 
-        php /var/www/html/magento2/bin/magento cache:clean
-2.  Log in to the Magento Admin as an administrator.
-3.  Click **Stores** > **Settings** > **Configuration** > **Advanced** > **System**.
-4.  In the right pane, expand **Cron**.
+1. Clean the Magento cache:
 
-    Your cron group displays as follows:
+   ```bash
+   php /var/www/html/magento2/bin/magento cache:clean
+   ```
 
-    ![Your custom cron group]({{ site.baseurl }}/common/images/config_cron-group.png)
+1. Log in to the Magento Admin as an administrator.
+1. Click **Stores** > **Settings** > **Configuration** > **Advanced** > **System**.
+1. In the right pane, expand **Cron**.
+
+   Your cron group displays as follows:
+
+   ![Your custom cron group]({{ site.baseurl }}/common/images/config_cron-group.png)
 
 {% endcollapsible %}

--- a/guides/v2.2/config-guide/deployment/pipeline/example/cli.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/example/cli.md
@@ -6,7 +6,6 @@ functional_areas:
   - Deploy
   - System
   - Setup
-
 redirect_from:
   - guides/v2.2/config-guide/deployment/pipeline/example/rsync.html
   - guides/v2.3/config-guide/deployment/pipeline/example/rsync.html
@@ -17,19 +16,24 @@ This is done by using a combination of shared configurations, the `config.php` f
 
 This example uses the following configuration settings:
 
-* **Vat Number** and **Store Name** for the shared configuration settings.
-  These are found under **Stores** > Settings > **Configuration** > General > **General**.
-* **Send Emails To** for the sensitive configuration value.
-  This is found under **Stores** > Settings > **Configuration** > General > **Contacts**.
-* **Default Email Domain** for the system-specific configuration value.
-  This is found under **Stores** > Settings > **Configuration** > Customers > **Customer Configuration** > **Create New Account Options**.
+*  **Vat Number** and **Store Name** for the shared configuration settings.
+
+   These are found under **Stores** > Settings > **Configuration** > General > **General**.
+
+*  **Send Emails To** for the sensitive configuration value.
+
+   This is found under **Stores** > Settings > **Configuration** > General > **Contacts**.
+
+*  **Default Email Domain** for the system-specific configuration value.
+
+   This is found under **Stores** > Settings > **Configuration** > Customers > **Customer Configuration** > **Create New Account Options**.
 
 You can use the same procedure shown in this example to configure any settings in the following references:
 
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-* [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ## Before you begin
 
@@ -42,38 +46,40 @@ You can choose different configuration options if you wish.
 
 For the purposes of this example, we assume the following:
 
-* You use Git source control
-* The development system is available in a Git remote repository named `mconfig`
-* Your Git working branch is named `m2.2_deploy`
+*  You use Git source control
+*  The development system is available in a Git remote repository named `mconfig`
+*  Your Git working branch is named `m2.2_deploy`
 
 ## Step 1: Set the configuration in the development system {#deploy-sens-setconfig}
 
 To set the default locale and weight units in your development system:
 
 1. Log in to the Magento Admin.
-2. Click **Stores** > Settings > **Configuration** > General > **General**.
-3. If you have more than one website available, use the **Store View** list in the upper left corner to switch to a different website as the following figure shows.
+1. Click **Stores** > Settings > **Configuration** > General > **General**.
+1. If you have more than one website available, use the **Store View** list in the upper left corner to switch to a different website as the following figure shows.
 
    ![Switch websites]({{ site.baseurl }}/common/images/config_split-deploy_switch-website.png){:width="250px"}
-4. In the right pane, expand **Store Information**.
-5. If necessary, clear the **Use Default** checkbox next to the **VAT Number** and **Store Name** fields.
-6. Enter a number in the field (for example, `12345`).
-7. In the **Store Name** field, enter a value (like `My Store`).
-8. Click **Save Config**.
-9. In the left navigation, under General, click **Contacts**.
-10. In the right pane, expand **Email Options**.
-11. If necessary, clear the **Use Default** checkbox next to the **Send Emails To** field.
-12. Enter an e-mail address in the field.
-13. Click **Save Config**.
-14. Use the **Store View** list to select the **Default Config** as the following figure shows.
 
-    ![Switch to the default config]({{ site.baseurl }}/common/images/config_split-deploy_default-config.png){:width="200px"}
-15. In the left pane, click Customers > **Customer Configuration**.
-16. In the right pane, expand **Create New Account Options**.
-17. If necessary, clear the **Use system value** checkbox next to the **Default Email Domain** field.
-18. Enter a domain name in the field.
-19. Click **Save Config**.
-20. If prompted, flush the cache.
+1. In the right pane, expand **Store Information**.
+1. If necessary, clear the **Use Default** checkbox next to the **VAT Number** and **Store Name** fields.
+1. Enter a number in the field (for example, `12345`).
+1. In the **Store Name** field, enter a value (like `My Store`).
+1. Click **Save Config**.
+1. In the left navigation, under General, click **Contacts**.
+1. In the right pane, expand **Email Options**.
+1. If necessary, clear the **Use Default** checkbox next to the **Send Emails To** field.
+1. Enter an e-mail address in the field.
+1. Click **Save Config**.
+1. Use the **Store View** list to select the **Default Config** as the following figure shows.
+
+   ![Switch to the default config]({{ site.baseurl }}/common/images/config_split-deploy_default-config.png){:width="200px"}
+
+1. In the left pane, click Customers > **Customer Configuration**.
+1. In the right pane, expand **Create New Account Options**.
+1. If necessary, clear the **Use system value** checkbox next to the **Default Email Domain** field.
+1. Enter a domain name in the field.
+1. Click **Save Config**.
+1. If prompted, flush the cache.
 
 ## Step 2: Update the configuration
 
@@ -94,34 +100,36 @@ Now that you've committed your changes to the shared configuration to source con
 
 The last step in the process is to update your production system. You must do it in two parts:
 
-* [Update the sensitive and system-specific settings](#config-split-verify-sens)
-* [Update the shared settings](#config-split-verify-shared)
+*  [Update the sensitive and system-specific settings](#config-split-verify-sens)
+*  [Update the shared settings](#config-split-verify-shared)
 
 ### Update the sensitive and system-specific settings {#config-split-verify-sens}
 
 To set the sensitive and system-specific settings using environment variables, you must know the following:
 
-* Each setting's scope
+*  Each setting's scope
 
-  If you followed the instructions in [Step 1](#deploy-sens-setconfig), the scope for **Send Emails To** is website and the scope for **Default Email Domain** is global (that is, the Default Config scope).
+   If you followed the instructions in [Step 1](#deploy-sens-setconfig), the scope for **Send Emails To** is website and the scope for **Default Email Domain** is global (that is, the Default Config scope).
 
-  You need the website code to set the **Send Emails To** configuration value.
-  For more information on finding this value, see: [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
-* Configuration paths for the settings used in this example:
+   You need the website code to set the **Send Emails To** configuration value.
 
-  | Setting name         | Configuration path                     |
-  | -------------------- | -------------------------------------- |
-  | Send Emails To       | `contact/email/recipient_email`        |
-  | Default Email Domain | `customer/create_account/email_domain` |
+   For more information on finding this value, see: [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 
-  For all sensitive and system-specific configuration paths, see: [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
+*  Configuration paths for the settings used in this example:
+
+   | Setting name         | Configuration path                     |
+   | -------------------- | -------------------------------------- |
+   | Send Emails To       | `contact/email/recipient_email`        |
+   | Default Email Domain | `customer/create_account/email_domain` |
+
+   For all sensitive and system-specific configuration paths, see: [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
 
 ### Set the variables using CLI commands
 
 Use the following CLI commands to set system-specific and sensitive configuration settings:
 
-* `magento config:set` for system-specific settings
-* `magento config:sensitive:set` for sensitive settings
+*  `magento config:set` for system-specific settings
+*  `magento config:sensitive:set` for sensitive settings
 
 To set the system-specific setting **Default Email Domain**, which is in the default scope, use the following command:
 

--- a/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
@@ -10,9 +10,9 @@ functional_areas:
 
 This topic discusses technical implementation details about pipeline deployment in Magento 2.2 and later. Improvements can be divided into the following areas:
 
-*   [Configuration management](#config-deploy-configman)
-*   [Changes in the Magento Admin](#config-deploy-admin)
-*   [cron installation and removal](#config-deploy-cron)
+*  [Configuration management](#config-deploy-configman)
+*  [Changes in the Magento Admin](#config-deploy-admin)
+*  [cron installation and removal](#config-deploy-cron)
 
 This topic also discusses the [recommended workflow](#config-deploy-workflow) for pipeline deployment and provides some examples to help you understand how it works.
 
@@ -27,10 +27,9 @@ To enable you to synchronize and maintain the configuration of your development 
 As the diagram shows, we get configuration values in the following order:
 
 1. Environment variables, if they exist, override all other values.
-2. From the shared configuration files `env.php` and `config.php`.
-   Values in `env.php` override values in `config.php`.
-3. From values stored in the database.
-4. If no value exists in any of those sources, we use either the default value or NULL.
+1. From the shared configuration files `env.php` and `config.php`. Values in `env.php` override values in `config.php`.
+1. From values stored in the database.
+1. If no value exists in any of those sources, we use either the default value or NULL.
 
 ### Manage the shared configuration
 
@@ -52,8 +51,8 @@ The sensitive configuration is also stored in `app/etc/env.php`.
 
 You can manage the sensitive configuration in any of the following ways:
 
-* Environment variables
-* Save the sensitive configuration in `env.php` on your production system using the [`magento config:set:sensitive` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html)
+*  Environment variables
+*  Save the sensitive configuration in `env.php` on your production system using the [`magento config:set:sensitive` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html)
 
 ### Configuration settings locked in the Magento Admin
 
@@ -64,21 +63,21 @@ Use the [`magento config:set` or `magento config:set --lock`]({{ page.baseurl }}
 
 We changed the following behavior in the Magento Admin in production mode:
 
-* You cannot enable or disable cache types in the Admin
-* Developer settings are unavailable (**Stores** > Settings > **Configuration** > Advanced > **Developer**), including:
+*  You cannot enable or disable cache types in the Admin
+*  Developer settings are unavailable (**Stores** > Settings > **Configuration** > Advanced > **Developer**), including:
 
-   * Minify CSS, JavaScript, and HTML
-   * Merge CSS and JavaScript
-   * Server-side or client-side LESS compilation
-   * Inline translations
+   *  Minify CSS, JavaScript, and HTML
+   *  Merge CSS and JavaScript
+   *  Server-side or client-side LESS compilation
+   *  Inline translations
    * As discussed previously, any configuration setting in `config.php` or `env.php` is locked and cannot be edited in the Admin.
-   * You can change the Admin locale only to languages used by deployed themes
+   *  You can change the Admin locale only to languages used by deployed themes
 
    The following figure shows an example of the **Account Setting**> **Interface Locale** list in the Admin showing only two deployed locales:
 
    ![You can change the Admin locale only to deployed locales]({{ site.baseurl }}/common/images/config_split-deploy_admin-locale.png){:width="450px"}
 
-* You cannot change locale configurations for any scope using the Admin Panel.
+*  You cannot change locale configurations for any scope using the Admin Panel.
 
    We recommend making these changes before switching to Production mode.
 
@@ -108,8 +107,8 @@ On your development system:
 
 1. Use the `magento app:config:dump` command to write the configuration to the file system.
 
-   * `app/etc/config.php` is the shared configuration, which contains all settings _except_ sensitive and system-specific settings. This file should be in source control.
-   * `app/etc/env.php` is the system-specific configuration, which contains settings that are unique to a particular system (for example, hostnames and port numbers). This file should _not_ be in source control.
+   *  `app/etc/config.php` is the shared configuration, which contains all settings _except_ sensitive and system-specific settings. This file should be in source control.
+   *  `app/etc/env.php` is the system-specific configuration, which contains settings that are unique to a particular system (for example, hostnames and port numbers). This file should _not_ be in source control.
 
 1. Add your modified code and the shared configuration to source control.
 
@@ -144,13 +143,13 @@ On your production system:
 
 We provide the following commands to help you manage the configuration:
 
-* [`magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) to write Magento Admin configuration settings to `config.php` and `env.php` (except for sensitive settings)
-* [`magento config:set`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) to set the values of system-specific settings on the production system.
+*  [`magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) to write Magento Admin configuration settings to `config.php` and `env.php` (except for sensitive settings)
+*  [`magento config:set`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) to set the values of system-specific settings on the production system.
 
    Use the optional `--lock` option to lock the option in the Magento Admin (that is, make the setting uneditable). If a setting is already locked, use the `--lock` option to change the setting.
 
-* [`magento config:sensitive:set`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) to set the values of sensitive settings on the production system.
-* [`magento app:config:import`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html) to import configuration changes from `config.php` and `env.php` to the production system.
+*  [`magento config:sensitive:set`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) to set the values of sensitive settings on the production system.
+*  [`magento app:config:import`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html) to import configuration changes from `config.php` and `env.php` to the production system.
 
 ## Configuration management examples
 
@@ -178,9 +177,9 @@ After you make the change in the Admin, run `bin/magento app:config:dump` to wri
 
 This section discusses making the following configuration changes:
 
-* Adding a website, store, and store view (**Stores** > Settings >  **All Stores**)
-* Changing the default email domain (**Stores** > Settings > **Configuration** > Customers > **Customer Configuration**)
-* Setting the PayPal API Username and API password (**Stores** > Settings > **Configuration** > Sales > **Payment Methods** > **PayPal** > **Required PayPal Settings**)
+*  Adding a website, store, and store view (**Stores** > Settings >  **All Stores**)
+*  Changing the default email domain (**Stores** > Settings > **Configuration** > Customers > **Customer Configuration**)
+*  Setting the PayPal API Username and API password (**Stores** > Settings > **Configuration** > Sales > **Payment Methods** > **PayPal** > **Required PayPal Settings**)
 
 After you make the change in the Admin, run `bin/magento app:config:dump` on your development system. This time, not all of your changes are written to `config.php`; in fact, only the website, store, and store view are written to that file as the following snippets show.
 
@@ -188,10 +187,10 @@ After you make the change in the Admin, run `bin/magento app:config:dump` on you
 
 `config.php` contains:
 
-* Changes to the website, store, and store view.
-* Non-system-specific Elasticsearch settings
-* Non-sensitive PayPal settings
-* Comments that inform you of sensitive settings that were omitted from `config.php`
+*  Changes to the website, store, and store view.
+*  Non-system-specific Elasticsearch settings
+*  Non-sensitive PayPal settings
+*  Comments that inform you of sensitive settings that were omitted from `config.php`
 
 {% collapsible Show config.php snippets: %}
 
@@ -283,16 +282,16 @@ The PayPal settings are written to neither file because the `magento app:config:
 
 File permissions and ownership must be consistent across development, build, and production systems. To make this work, you must either:
 
-* All of the following:
+*  All of the following:
 
-   * Set up the same [Magento file system owner](https://glossary.magento.com/magento-file-system-owner) username on all systems
-   * Make sure the web server runs as the same user on all systems
-   * Make sure the Magento file system owner is in the web server group on all systems
+   *  Set up the same [Magento file system owner](https://glossary.magento.com/magento-file-system-owner) username on all systems
+   *  Make sure the web server runs as the same user on all systems
+   *  Make sure the Magento file system owner is in the web server group on all systems
 
-* Change Magento file system permissions and ownership on each system as necessary using the following guidelines:
+*  Change Magento file system permissions and ownership on each system as necessary using the following guidelines:
 
-   * Development and build: [Set pre-installation ownership and permissions (two users)]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html#perms-private)
-   * Production: [Magento ownership and permissions in development and production]({{ page.baseurl }}/config-guide/prod/prod_file-sys-perms.html)
+   *  Development and build: [Set pre-installation ownership and permissions (two users)]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html#perms-private)
+   *  Production: [Magento ownership and permissions in development and production]({{ page.baseurl }}/config-guide/prod/prod_file-sys-perms.html)
 
    {: .bs-callout-info }
    If you choose this approach, you must set file system permissions and ownership every time you pull code from your build system (if the Magento file system owner or web server user are different on your build system).
@@ -300,14 +299,14 @@ File permissions and ownership must be consistent across development, build, and
 {:.ref-header}
 Related topics
 
-* For a complete list of system-specific and sensitive settings and corresponding configuration paths, see [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
-* [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html) for detailed information about the shared configuration file
-* [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html) for detailed information about the system-specific configuration file
+*  For a complete list of system-specific and sensitive settings and corresponding configuration paths, see [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
+*  [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html) for detailed information about the shared configuration file
+*  [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html) for detailed information about the system-specific configuration file
 
 {:.ref-header}
 Next steps
 
-* [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
-* [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
-* [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
-* [config-cli-config-set]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set
+*  [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
+*  [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
+*  [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
+*  [config-cli-config-set]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set

--- a/guides/v2.2/config-guide/deployment/single-machine.md
+++ b/guides/v2.2/config-guide/deployment/single-machine.md
@@ -29,23 +29,23 @@ Contributing developers should use [this guide][6] to update their Magento insta
 
 1. Log in to your production server as, or switch to, the [Magento file system owner][10].
 
-2. Change directory to the Magento base directory:
+1. Change directory to the Magento base directory:
 
-    ```bash
-    cd <Magento base directory>
-    ```
+   ```bash
+   cd <Magento base directory>
+   ```
 
-3. Enable maintenance mode using the command:
+1. Enable maintenance mode using the command:
 
-    ```bash
-    bin/magento maintenance:enable
-    ```
+   ```bash
+   bin/magento maintenance:enable
+   ```
 
-4. Apply updates to Magento or its components using the following command pattern:
+1. Apply updates to Magento or its components using the following command pattern:
 
-    ```bash
-    composer require <package> <version> --no-update
-    ```
+   ```bash
+   composer require <package> <version> --no-update
+   ```
 
    **package**: The name of the package you want to update.
 
@@ -56,41 +56,41 @@ Contributing developers should use [this guide][6] to update their Magento insta
 
    **version**: The target version of the package you want to update.
 
-5. Update Magento's components with Composer:
+1. Update Magento's components with Composer:
 
-    ```bash
-    composer update
-    ```
+   ```bash
+   composer update
+   ```
 
-6. Update the database schema and data:
+1. Update the database schema and data:
 
-    ```bash
-    bin/magento setup:upgrade
-    ```
+   ```bash
+   bin/magento setup:upgrade
+   ```
 
-7. Compile the code:
+1. Compile the code:
 
-    ```bash
-    bin/magento setup:di:compile
-    ```
+   ```bash
+   bin/magento setup:di:compile
+   ```
 
-8. Deploy static content:
+1. Deploy static content:
 
-    ```bash
-    bin/magento setup:static-content:deploy
-    ```
+   ```bash
+   bin/magento setup:static-content:deploy
+   ```
 
-9. Clean the cache:
+1. Clean the cache:
 
-    ```bash
-    bin/magento cache:clean
-    ```
+   ```bash
+   bin/magento cache:clean
+   ```
 
-9. Exit maintenance mode:
+1. Exit maintenance mode:
 
-    ```bash
-    bin/magento maintenance:disable
-    ```
+   ```bash
+   bin/magento maintenance:disable
+   ```
 
 ## Alternative deployment strategies
 

--- a/guides/v2.2/config-guide/memcache/memcache_magento.md
+++ b/guides/v2.2/config-guide/memcache/memcache_magento.md
@@ -12,24 +12,24 @@ To configure Magento to use memcached:
 1. Open `<your Magento install dir>/app/etc/env.php` in a text editor.
 1. Locate the following:
 
-    ```php
-    'session' =>
-        array (
-        'save' => 'files',
-    ),
-    ```
+   ```php
+   'session' =>
+       array (
+       'save' => 'files',
+   ),
+   ```
 
 1. Change it as follows:
 
-    ```php
-    'session' =>
-        array (
-          'save' => 'memcached',
-          'save_path' => '<memcache ip or host>:<memcache port>'
-    ),
-    ```
+   ```php
+   'session' =>
+       array (
+         'save' => 'memcached',
+         'save_path' => '<memcache ip or host>:<memcache port>'
+   ),
+   ```
 
-    memcached has an optional startup parameters that are beyond the scope of this guide. You can find more information about them in the [memcached](http://php.net/manual/en/memcached.sessions.php) documentation, source code, and changelogs.
+   memcached has an optional startup parameters that are beyond the scope of this guide. You can find more information about them in the [memcached](http://php.net/manual/en/memcached.sessions.php) documentation, source code, and changelogs.
 
 1. Continue with the next section.
 
@@ -39,29 +39,37 @@ To verify memcached works with Magento:
 
 1. Delete the contents of the following directories under your Magento installation directory:
 
-        rm -rf var/cache/* var/page_cache/* var/session/*
+   ```bash
+   rm -rf var/cache/* var/page_cache/* var/session/*
+   ```
 
-2. Go to any page on the [storefront](https://glossary.magento.com/storefront).
+1. Go to any page on the [storefront](https://glossary.magento.com/storefront).
 
-3. Log in to the [Magento Admin](https://glossary.magento.com/magento-admin) and browse to several pages.
+1. Log in to the [Magento Admin](https://glossary.magento.com/magento-admin) and browse to several pages.
 
-    If no errors display, congratulations! memcached is working! You can optionally look at memcached storage as discussed in the next step.
+   If no errors display, congratulations! memcached is working! You can optionally look at memcached storage as discussed in the next step.
 
-    If errors display (such as an HTTP 500 (Internal Server Error)), enable developer mode and diagnose the issue. Make sure memcached is running, configured properly, and that `env.php` has no syntax errors.
+   If errors display (such as an HTTP 500 (Internal Server Error)), enable developer mode and diagnose the issue. Make sure memcached is running, configured properly, and that `env.php` has no syntax errors.
 
-4. (Optional.) Use Telnet to look at memcached storage.
+1. (Optional.) Use Telnet to look at memcached storage.
 
-        telnet <memcached host or ip> <memcached port>
-        stats items
+   ```bash
+   telnet <memcached host or ip> <memcached port>
+   ```
 
-    The results display similar to the following:
+   ```bash
+   stats items
+   ```
 
-        STAT items:3:number 1
-        STAT items:3:age 7714
-        STAT items:3:evicted 0
-        STAT items:3:evicted_nonzero 0
-        STAT items:3:evicted_time 0
-        STAT items:3:outofmemory 0
-        STAT items:3:tailrepairs 0
+   The results display similar to the following:
 
-    [Look at the keys in more detail](http://www.darkcoding.net/software/memcached-list-all-keys/)
+   ```terminal
+   STAT items:3:number 1
+   STAT items:3:age 7714
+   STAT items:3:evicted 0
+   STAT items:3:evicted_nonzero 0
+   STAT items:3:evicted_time 0
+   STAT items:3:outofmemory 0
+   STAT items:3:tailrepairs 0
+
+   [Look at the keys in more detail](http://www.darkcoding.net/software/memcached-list-all-keys/)

--- a/guides/v2.2/config-guide/memcache/memcache_ubuntu.md
+++ b/guides/v2.2/config-guide/memcache/memcache_ubuntu.md
@@ -20,26 +20,33 @@ To install and configure memcached on Ubuntu:
 
 1. As a user with `root` privileges, enter the following command:
 
-        apt-get -y update
-        apt-get -y install php5-memcached memcached
+   ```bash
+   apt-get -y update
+   ```
 
-2. Change the memcached configuration setting for `CACHESIZE` and `-l`:
+   ```bash
+   apt-get -y install php5-memcached memcached
+   ```
 
-    1. Open `/etc/memcached.conf` in a text editor.
-    2. Locate the `-m` parameter.
-    3. Change its value to at least `1GB`
-    4. Locate the `-l` parameter.
-    5. Change its value to `127.0.0.1` or `localhost`
-    6. Save your changes to `memcached.conf` and exit the text editor.
-    7. Restart memcached.
+1. Change the memcached configuration setting for `CACHESIZE` and `-l`:
 
-           service memcached restart
+   1. Open `/etc/memcached.conf` in a text editor.
+   1. Locate the `-m` parameter.
+   1. Change its value to at least `1GB`
+   1. Locate the `-l` parameter.
+   1. Change its value to `127.0.0.1` or `localhost`
+   1. Save your changes to `memcached.conf` and exit the text editor.
+   1. Restart memcached.
 
-3. Restart your web server.
+      ```bash
+      service memcached restart
+      ```
 
-       For Apache, `service apache2 restart`
+1. Restart your web server.
 
-4. Continue with the next section.
+   For Apache, `service apache2 restart`
+
+1. Continue with the next section.
 
 ## Verify memcached works before installing Magento {#config-memcache-verify-its-ub}
 
@@ -51,23 +58,25 @@ To verify memcached is recognized by the web server:
 
 1. Create a `phpinfo.php` file in the web server's docroot:
 
-    ```php
-    <?php
-    // Show all information, defaults to INFO_ALL
-    phpinfo();
-    ```
+   ```php
+   <?php
+   // Show all information, defaults to INFO_ALL
+   phpinfo();
+   ```
 
-2. Go to that page in your web browser. For example:
+1. Go to that page in your web browser. For example:
 
-   `http://192.0.2.1/phpinfo.php`
+   ```http
+   http://192.0.2.1/phpinfo.php
+   ```
 
-3. Make sure memcached displays as follows:
+1. Make sure memcached displays as follows:
 
-    ![Confirm memcached is recognized by the web server]({{ site.baseurl }}/common/images/config_memcache-ubuntu.png)
+   ![Confirm memcached is recognized by the web server]({{ site.baseurl }}/common/images/config_memcache-ubuntu.png)
 
-    Verify you are using memcached version 3.0.5 or later.
+   Verify you are using memcached version 3.0.5 or later.
 
-    If memcached does not display, restart the web server and refresh the browser page. If it still does not display, verify you installed the `php-pecl-memcached` extension.
+   If memcached does not display, restart the web server and refresh the browser page. If it still does not display, verify you installed the `php-pecl-memcached` extension.
 
 ### Verify memcached can cache data
 
@@ -78,7 +87,6 @@ For more information about this test, see [this digitalocean tutorial](https://w
 Create `cache-test.php` in the web server's docroot with the following contents:
 
 ```php
-
 $meminstance = new Memcached();
 
 $meminstance->addServer("<memcached hostname or ip>", <memcached port>);
@@ -97,7 +105,9 @@ where `<memcached hostname or ip>` is either `localhost`, `127.0.0.1`, or the me
 
 Go to that page in a web browser. For example
 
-   `http://192.0.2.1/cache-test.php`
+```http
+http://192.0.2.1/cache-test.php
+```
 
 The first time you go to the page, the following displays: `No matching key found. Refresh the browser to add it!`
 
@@ -105,29 +115,40 @@ Refresh the browser. The message changes to `Successfully retrieved the data!`
 
 Finally, you can view the memcache keys using Telnet:
 
-    telnet localhost <memcache port>
+```bash
+telnet localhost <memcache port>
+```
 
 At the prompt, enter
 
-    stats items
+```shell
+stats items
+```
 
 The result is similar to the following:
 
-    STAT items:2:number 1
-    STAT items:2:age 106
-    STAT items:2:evicted 0
-    STAT items:2:evicted_nonzero 0
-    STAT items:2:evicted_time 0
-    STAT items:2:outofmemory 0
-    STAT items:2:tailrepairs 0
-    STAT items:2:reclaimed 0
-    STAT items:2:expired_unfetched 0
-    STAT items:2:evicted_unfetched 0
+```terminal
+STAT items:2:number 1
+STAT items:2:age 106
+STAT items:2:evicted 0
+STAT items:2:evicted_nonzero 0
+STAT items:2:evicted_time 0
+STAT items:2:outofmemory 0
+STAT items:2:tailrepairs 0
+STAT items:2:reclaimed 0
+STAT items:2:expired_unfetched 0
+STAT items:2:evicted_unfetched 0
+```
 
 Flush memcached storage and quit Telnet:
 
-    flush_all
-    quit
+```shell
+flush_all
+```
+
+```shell
+quit
+```
 
 [Additional information about the Telnet test](http://www.darkcoding.net/software/memcached-list-all-keys/)
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_manual.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_manual.md
@@ -205,7 +205,7 @@ Run the preceding script:
    mysql -u root -p
    ```
 
-2. At the `mysql>` prompt, run the script as follows:
+1. At the `mysql>` prompt, run the script as follows:
 
    ```shell
    source <path>/<script>.sql
@@ -217,7 +217,7 @@ Run the preceding script:
    source /root/sql-scripts/1_foreign-sales.sql
    ```
 
-3. After the script run, enter `exit`.
+1. After the script run, enter `exit`.
 
 {% endcollapsible %}
 
@@ -471,7 +471,7 @@ Run the script as follows:
    mysql -u root -p
    ```
 
-2. At the `mysql>` prompt, run the script as follows:
+1. At the `mysql>` prompt, run the script as follows:
 
    ```shell
    source <path>/<script>.sql
@@ -483,7 +483,7 @@ Run the script as follows:
    source /root/sql-scripts/3_drop-tables.sql
    ```
 
-3. After the script runs, enter `exit`.
+1. After the script runs, enter `exit`.
 
 {% endcollapsible %}
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_masterdb.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_masterdb.md
@@ -13,8 +13,8 @@ functional_areas:
 This topic discusses how to get started with the split database solution by:
 
 1. Installing {{site.data.var.ee}} with a single master database (named `magento`)
-2. Creating two additional master databases for [checkout](https://glossary.magento.com/checkout) and OMS (named `magento_quote` and `magento_sales`)
-2. Configuring {{site.data.var.ee}} to use the checkout and sales databases
+1. Creating two additional master databases for [checkout](https://glossary.magento.com/checkout) and OMS (named `magento_quote` and `magento_sales`)
+1. Configuring {{site.data.var.ee}} to use the checkout and sales databases
 
 {:.bs-callout .bs-callout-info}
 This guide assumes all three databases are on the same host as the Magento application and that they're named `magento`, `magento_quote`, and `magento_sales`. However, the choice of where to locate the databases and what they're named is up to you. We hope our examples make the instructions easier to follow.

--- a/guides/v2.2/config-guide/multi-site/ms_apache.md
+++ b/guides/v2.2/config-guide/multi-site/ms_apache.md
@@ -32,7 +32,7 @@ If necessary, copy the existing `index.php` entry point script for your [website
 Setting up multiple stores consists of the following tasks:
 
 1. [Set up websites, stores, and store views]({{ page.baseurl }}/config-guide/multi-site/ms_websites.html) in the [Magento Admin](https://glossary.magento.com/magento-admin).
-2. Create one [Apache virtual host](#ms-apache-vhosts) per Magento website.
+1. Create one [Apache virtual host](#ms-apache-vhosts) per Magento website.
 
 ## Step 1: Create websites, stores, and store views in the Magento Admin
 

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -11,47 +11,48 @@ functional_areas:
 
 This topic discusses advanced configuration commands you can use to:
 
-*   Set any configuration option from the command line
-*   Optionally lock any configuration option so its value cannot be changed in the Magento Admin
-*   Change a configuration option that is locked in the Magento Admin
+*  Set any configuration option from the command line
+*  Optionally lock any configuration option so its value cannot be changed in the Magento Admin
+*  Change a configuration option that is locked in the Magento Admin
 
 You can use these commands to set the Magento configuration manually or using scripts. You set configuration options using a _configuration path_, which is a `/`-delimited string that uniquely identifies that configuration option. You can find configuration paths in the following references:
 
-*   [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-*   [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*   [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*   [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 You can set values at the following times:
 
-*   Before you install Magento, you can set configuration values for the default scope only.
+*  Before you install Magento, you can set configuration values for the default scope only.
 
-    That's because before you install Magento, the default scope is the only valid scope.
-*   After you install Magento, you can set configuration values for any [website](https://glossary.magento.com/website) or [store view](https://glossary.magento.com/store-view) scope.
+   That's because before you install Magento, the default scope is the only valid scope.
+
+*  After you install Magento, you can set configuration values for any [website](https://glossary.magento.com/website) or [store view](https://glossary.magento.com/store-view) scope.
 
 Use the following commands:
 
-*   `bin/magento config:set` sets any non-sensitive configuration value by its configuration path
-*   `bin/magento config:sensitive:set` sets any sensitive configuration value by its configuration path
-*   `bin/magento config:show` shows saved configuration values; values of encrypted settings are displayed as asterisks
+*  `bin/magento config:set` sets any non-sensitive configuration value by its configuration path
+*  `bin/magento config:sensitive:set` sets any sensitive configuration value by its configuration path
+*  `bin/magento config:show` shows saved configuration values; values of encrypted settings are displayed as asterisks
 
 ## Prerequisites
 
 To set a configuration value, you must know at least one of the following:
 
-*   The configuration path
-*   To set a configuration value for a particular scope, you must know the scope code.
+*  The configuration path
+*  To set a configuration value for a particular scope, you must know the scope code.
 
-    To set a configuration value for the default scope, you don't need to do anything.
+   To set a configuration value for the default scope, you don't need to do anything.
 
 ### Find the configuration path
 
 See the following references:
 
-*   [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-*   [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*   [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*   [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ### Find the scope code
 
@@ -61,14 +62,15 @@ You can find the scope code either in the Magento database or in the Magento [Ad
 
 {% collapsible To find the scope code in the Admin: %}
 
-1.  Log in to the Admin as a user who can view websites and store views.
-2.  Click **Stores** > Settings > **All Stores**.
-3.  In the right pane, click the name of the website or store view to see its code.
+1. Log in to the Admin as a user who can view websites and store views.
+1. Click **Stores** > Settings > **All Stores**.
+1. In the right pane, click the name of the website or store view to see its code.
 
-    The following figure shows a sample website code.
+   The following figure shows a sample website code.
 
-    ![Get a website or store view code from the Admin]({{ site.baseurl }}/common/images/config_configset_website-code.png){:width="450px"}
-4.  Continue with [Set configuration values](#config-cli-config-set).
+   ![Get a website or store view code from the Admin]({{ site.baseurl }}/common/images/config_configset_website-code.png){:width="450px"}
+
+1. Continue with [Set configuration values](#config-cli-config-set).
 
 {% endcollapsible %}
 
@@ -80,29 +82,42 @@ Scope codes for websites and store views are stored in the Magento database in t
 
 To find the values in the database:
 
-1.  Connect to the Magento database.
+1. Connect to the Magento database.
 
-        mysql -u <magento database username> -p
-2.  Enter the following commands:
+   ```bash
+   mysql -u <magento database username> -p
+   ```
 
-        use <magento database name>;
-        SELECT * FROM store;
-        SELECT * FROM store_website;
+1. Enter the following commands:
 
-    A sample result follows:
+   ```shell
+   use <magento database name>;
+   ```
 
-        [mysql]> SELECT * FROM store_website;
-        +------------+-------+--------------+------------+------------------+------------+
-        | website_id | code  | name         | sort_order | default_group_id | is_default |
-        +------------+-------+--------------+------------+------------------+------------+
-        |          0 | admin | Admin        |          0 |                0 |          0 |
-        |          1 | base  | Main Website |          0 |                1 |          1 |
-        |          2 | test1 | Test Website |          0 |                3 |          0 |
-        +------------+-------+--------------+------------+------------------+------------+
+   ```shell
+   SELECT * FROM store;
+   ```
 
-    Use the value in the `code` column.
+   ```shell
+   SELECT * FROM store_website;
+   ```
 
-3.  Continue with the next section.
+   A sample result follows:
+
+   ```terminal
+   [mysql]> SELECT * FROM store_website;
+   +------------+-------+--------------+------------+------------------+------------+
+   | website_id | code  | name         | sort_order | default_group_id | is_default |
+   +------------+-------+--------------+------------+------------------+------------+
+   |          0 | admin | Admin        |          0 |                0 |          0 |
+   |          1 | base  | Main Website |          0 |                1 |          1 |
+   |          2 | test1 | Test Website |          0 |                3 |          0 |
+   +------------+-------+--------------+------------+------------------+------------+
+   ```
+
+   Use the value in the `code` column.
+
+1. Continue with the next section.
 
 {% endcollapsible %}
 
@@ -133,17 +148,19 @@ Parameter | Description
 
 {:.bs-callout .bs-callout-info}
 
-* As of Magento 2.2.4, the `--lock-env` and `--lock-config` options replace the `--lock` option.
-* If you use the `--lock-env` or `--lock-config` option to set or change a value, you must use the [`bin/magento app:config:import` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html) to import the setting before you access the Admin or storefront.
+*  As of Magento 2.2.4, the `--lock-env` and `--lock-config` options replace the `--lock` option.
+*  If you use the `--lock-env` or `--lock-config` option to set or change a value, you must use the [`bin/magento app:config:import` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html) to import the setting before you access the Admin or storefront.
 
 If you enter an incorrect configuration path, this command returns an error
 
-    The "wrong/config/path" does not exist
+```text
+The "wrong/config/path" does not exist
+```
 
 See one of the following sections for more information:
 
-*   [Set configuration values that can be edited in the Magento Admin](#config-cli-config-set-edit)
-*   [Set configuration values that cannot be edited in the Magento Admin](#config-cli-config-file)
+*  [Set configuration values that can be edited in the Magento Admin](#config-cli-config-set-edit)
+*  [Set configuration values that cannot be edited in the Magento Admin](#config-cli-config-file)
 
 ### Set configuration values that can be edited in the Magento Admin {#config-cli-config-set-edit}
 
@@ -203,9 +220,9 @@ bin/magento config:show [--scope[="..."]] [--scope-code[="..."]] path
 
 where
 
-* `--scope` is the scope of configuration (default, website, store). The default value is `default`
-* `--scope-code` is the scope code of configuration (website code or store view code)
-* `path` is the configuration path in format first_part/second_part/third_part/etc *(required)*
+*  `--scope` is the scope of configuration (default, website, store). The default value is `default`
+*  `--scope-code` is the scope code of configuration (website code or store view code)
+*  `path` is the configuration path in format first_part/second_part/third_part/etc *(required)*
 
 {:.bs-callout .bs-callout-info}
 The `bin/magento config:show` command displays the values of any [encrypted values]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html) as a series of asterisks: `******`.

--- a/guides/v2.3/config-guide/cli/config-cli-subcommands-i18n.md
+++ b/guides/v2.3/config-guide/cli/config-cli-subcommands-i18n.md
@@ -15,8 +15,8 @@ Magento translations enable you to customize and localize your store for multipl
 
 This topic discusses how to generate:
 
--   Translation dictionaries, which are a convenient way to customize or translate *some* words and phrases, such as those for a custom [module](https://glossary.magento.com/module) or [theme](https://glossary.magento.com/theme).
--   Language packages, which enable you to translate *any or all* words and phrases in the Magento application.
+-  Translation dictionaries, which are a convenient way to customize or translate *some* words and phrases, such as those for a custom [module](https://glossary.magento.com/module) or [theme](https://glossary.magento.com/theme).
+-  Language packages, which enable you to translate *any or all* words and phrases in the Magento application.
 
 See [Translations overview].
 
@@ -32,14 +32,14 @@ To begin translating, use a command to generate a dictionary `.csv` file with a 
 
 Generate the dictionary and translate:
 
-1.  Extract translatable words and phrases from enabled components using the translation collection command. Content extracts into a `.csv` file.
-1.  Translate the existing words and phrases. You can also add additional custom terms as needed.
+1. Extract translatable words and phrases from enabled components using the translation collection command. Content extracts into a `.csv` file.
+1. Translate the existing words and phrases. You can also add additional custom terms as needed.
 
-You have options for using the translated dictionary:
+   You have options for using the translated dictionary:
 
-1.  You can package the translation dictionaries into a language package and provide the package to the Magento store administrator.
+1. You can package the translation dictionaries into a language package and provide the package to the Magento store administrator.
 
-1.  In the Magento Admin, the store administrator [configures the translations].
+1. In the Magento Admin, the store administrator [configures the translations].
 
 Command options:
 
@@ -62,17 +62,21 @@ To create a language pack from a translation dictionary, you *must* use the `-m|
 
 Use the following guidelines when translating words and phrases:
 
--   Change the contents of the second column only. Translate the phrases from English (`US`) to the desired language.
--   When creating dictionaries for locales, use the default Magento strings.
--   While translating, pay attention to placeholders like `%1`, `%2` and so on.
+-  Change the contents of the second column only. Translate the phrases from English (`US`) to the desired language.
+-  When creating dictionaries for locales, use the default Magento strings.
+-  While translating, pay attention to placeholders like `%1`, `%2` and so on.
 
 Magento uses the placeholders to insert context values; they are *not* used for translations. For example:
 
-    Product '%1' has been added to shopping cart.
+```text
+Product '%1' has been added to shopping cart.
+```
 
 Populates with a value:
 
-    Product 'Multimeter-2000' has been added to shopping cart.
+```text
+Product 'Multimeter-2000' has been added to shopping cart.
+```
 
 The resulting phrase must contain at least one of each placeholder.
 For example, suppose there are placeholders from `%1` to `%3` in the original phrase.
@@ -89,13 +93,13 @@ As opposed to a translation dictionary, you can translate any or all words and p
 
 This section discusses how to create a language package, which writes `.csv` files to modules and themes. To create a language package, you must perform the tasks discussed in the following sections:
 
-1.  [Collect and translate words and phrases](#config-cli-subcommands-xlate-dict).
+1. [Collect and translate words and phrases](#config-cli-subcommands-xlate-dict).
 
-   (The `--magento` parameter is required.)
+  (The `--magento` parameter is required.)
 
-2.  [Run the language package command](#config-cli-subcommands-xlate-pack-cmd).
-3.  [Create directories and files](#m2devgde-xlate-files).
-4.  (Optional.) [Configure multiple packages for a language](#m2devgde-xlate-severalpacks).
+1. [Run the language package command](#config-cli-subcommands-xlate-pack-cmd).
+1. [Create directories and files](#m2devgde-xlate-files).
+1. (Optional.) [Configure multiple packages for a language](#m2devgde-xlate-severalpacks).
 
 ### Run the language package command {#config-cli-subcommands-xlate-pack-cmd}
 
@@ -118,24 +122,24 @@ The following table explains this command's parameters and values:
 
 Language packages are located in a directory under `app/i18n/<VendorName>` in the Magento file system with the following contents:
 
--   Required license files
--   `composer.json`
--   `registration.php` that [registers] the language package
--   [`language.xml`](#config-cli-subcommands-xlate-pack-meta-xml) meta-information file
+-  Required license files
+-  `composer.json`
+-  `registration.php` that [registers] the language package
+-  [`language.xml`](#config-cli-subcommands-xlate-pack-meta-xml) meta-information file
 
 {:.bs-callout .bs-callout-info}
 You must lowercase the entire path. For example, see [`de_de`].
 
 To create these files:
 
-1.  Create a directory under `app/i18n`.
+1. Create a directory under `app/i18n`.
 
    For example, Magento language packages are located in `app/i18n/magento`
 
-2.  Add any license files you require.
-3.  Add [`composer.json`] that specifies dependencies for your language package.
-4.  Register the language package with [`registration.php`]
-5.  Add `language.xml` meta-information file as discussed in the next section.
+1. Add any license files you require.
+1. Add [`composer.json`] that specifies dependencies for your language package.
+1. Register the language package with [`registration.php`]
+1. Add `language.xml` meta-information file as discussed in the next section.
 
 #### Language package language.xml {#config-cli-subcommands-xlate-pack-meta-xml}
 
@@ -158,11 +162,11 @@ To declare a package, specify the following information:
 
 Where:
 
--   **`<code>`:** Language package locale (required)
--   **`<vendor>`:** Module's vendor name (required)
--   **`<package>`:** Language package name (required)
--   **`<sort_order>`:** Priority of uploading a package when there are several language packages available for a store
--   **`<use>`:** Parent language package locale from which to inherit dictionaries
+-  **`<code>`:** Language package locale (required)
+-  **`<vendor>`:** Module's vendor name (required)
+-  **`<package>`:** Language package name (required)
+-  **`<sort_order>`:** Priority of uploading a package when there are several language packages available for a store
+-  **`<use>`:** Parent language package locale from which to inherit dictionaries
 
 If necessary, you can specify several parent packages. The parent packages are applied on a first listed, first used basis.
 
@@ -185,17 +189,17 @@ If a language package inherits from two packages, its `language.xml` might look 
 
 In the preceding example:
 
--   `language_package_one` inherits from `en_au_package` and `en_au_package` inherits from `en_ie_package`
--   `language_package_two` inherits from `en_ca_package` and `en_ca_package` inherits from `en_us_package`
+-  `language_package_one` inherits from `en_au_package` and `en_au_package` inherits from `en_ie_package`
+-  `language_package_two` inherits from `en_ca_package` and `en_ca_package` inherits from `en_us_package`
 
 If the Magento application cannot find word or phrase in the `en_GB` package, it looks in other packages in following sequence:
 
-1.  `parent-package-one/language_package_one`
-1.  `<vendorname>/en_au_package`
-1.  `<vendorname>/en_ie_package`
-1.  `parent-package-two/language_package_two`
-1.  `<vendorname>/en_ca_package`
-1.  `<vendorname>/en_us_package`
+1. `parent-package-one/language_package_one`
+1. `<vendorname>/en_au_package`
+1. `<vendorname>/en_ie_package`
+1. `parent-package-two/language_package_two`
+1. `<vendorname>/en_ca_package`
+1. `<vendorname>/en_us_package`
 
 Specifying all inheritances between the language packages might result in creating circular inheritance chains. Use [Magento\Test\Integrity\App\Language\CircularDependencyTest] test to locate and fix such chains.
 
@@ -209,8 +213,8 @@ To enable an additional package for an existing language, name the new package a
 
 The following sections provide end-to-end examples of using the commands discussed in this topic to create translation dictionaries and translation packages:
 
--   [Example: Create a translation dictionary for a module or theme](#config-cli-subcommands-xlate-example1)
--   [Example: Create a language package](#config-cli-subcommands-xlate-example2)
+-  [Example: Create a translation dictionary for a module or theme](#config-cli-subcommands-xlate-example1)
+-  [Example: Create a language package](#config-cli-subcommands-xlate-example2)
 
 ### Example: Create a translation dictionary for a module or theme {#config-cli-subcommands-xlate-example1}
 
@@ -225,8 +229,8 @@ To add a German translation to a module or theme that you want to distribute to 
    {:.bs-callout .bs-callout-info}
    The .csv file name must _exactly match_ the locale, including the characters' case.
 
-1.  Translate the words and phrases using [these guidelines](#config-cli-subcommands-xlate-dict-trans).
-1.  If necessary, copy `xx_YY.csv` to `/var/www/html/magento2/app/code/ExampleCorp/SampleModule/i18n` or to the module's theme directory (depending on whether the translation dictionary is for a module or a theme).
+1. Translate the words and phrases using [these guidelines](#config-cli-subcommands-xlate-dict-trans).
+1. If necessary, copy `xx_YY.csv` to `/var/www/html/magento2/app/code/ExampleCorp/SampleModule/i18n` or to the module's theme directory (depending on whether the translation dictionary is for a module or a theme).
 
 ### Example: Create a language package {#config-cli-subcommands-xlate-example2}
 
@@ -234,19 +238,19 @@ Similar to the preceding example, generate a `.csv` file, but instead of specify
 
 1. Collect phrases from your module:
 
-    ```bash
-    bin/magento i18n:collect-phrases -o "/var/www/html/magento2/xx_YY.csv" -m
-    ```
+   ```bash
+   bin/magento i18n:collect-phrases -o "/var/www/html/magento2/xx_YY.csv" -m
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    The `.csv` file name must _exactly match_ the locale, including the characters' case.
+   {:.bs-callout .bs-callout-info}
+   The `.csv` file name must _exactly match_ the locale, including the characters' case.
 
 1. Translate the words and phrases using [these guidelines](#config-cli-subcommands-xlate-dict-trans).
 1. Create the language package.
 
-    ```bash
-    bin/magento i18n:pack /var/www/html/magento2/xx_YY.csv -d xx_YY
-    ```
+   ```bash
+   bin/magento i18n:pack /var/www/html/magento2/xx_YY.csv -d xx_YY
+   ```
 
 1. Create a directory for the language package.
 
@@ -312,8 +316,8 @@ Similar to the preceding example, generate a `.csv` file, but instead of specify
 
 ## Additional information
 
--   [Translations overview]
--   [Translate theme strings]
+-  [Translations overview]
+-  [Translate theme strings]
 
 [Translate theme strings]: {{ page.baseurl }}/frontend-dev-guide/translations/translate_theory.html
 [Translations overview]: {{ page.baseurl }}/frontend-dev-guide/translations/xlate.html

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -21,29 +21,29 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
-    ```bash
-    bin/magento setup:config:set --enable-debug-logging=true
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-debug-logging=true
+   ```
 
-2. Flush the cache.
+1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ### To disable debug logging
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
-    ```bash
-    bin/magento setup:config:set --enable-debug-logging=false
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-debug-logging=false
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ## Database logging
 
@@ -53,19 +53,19 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 1. Use the `dev:query-log` command to enable or disable database logging.
 
-    ```bash
-    bin/magento dev:query-log:enable
-    ```
+   ```bash
+   bin/magento dev:query-log:enable
+   ```
 
-    ```bash
-    bin/magento dev:query-log:disable
-    ```
+   ```bash
+   bin/magento dev:query-log:disable
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ## Cron logging
 
@@ -87,26 +87,26 @@ Logging to `syslog` is disabled by default.
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 
-    ```bash
-    bin/magento setup:config:set --enable-syslog-logging=true
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-syslog-logging=true
+   ```
 
-2. Flush the cache.
+1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ### To disable syslog logging
 
 1. Use the `setup:config:set` command to change the `dev/syslog/syslog_logging` database value to `false`.
 
-    ```bash
-    bin/magento setup:config:set --enable-syslog-logging=false
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-syslog-logging=false
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```

--- a/guides/v2.3/config-guide/elasticsearch/es-config-apache.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-apache.md
@@ -19,8 +19,8 @@ The reason the proxy is not secured in this example is it's easier to set up and
 
 See one of the following sections:
 
-* [Set up a proxy for Apache 2.4](#es-apache-proxy-24)
-* [Set up a proxy for Apache 2.2](#es-apache-proxy-22)
+*  [Set up a proxy for Apache 2.4](#es-apache-proxy-24)
+*  [Set up a proxy for Apache 2.2](#es-apache-proxy-22)
 
 ### Set up a proxy for Apache 2.4 {#es-apache-proxy-24}
 
@@ -28,57 +28,57 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 1. Enable `mod_proxy` as follows:
 
-    ```bash
-    a2enmod proxy_http
-    ```
+   ```bash
+   a2enmod proxy_http
+   ```
 
-2. Use a text editor to open `/etc/apache2/sites-available/000-default.conf`
-3. Add the following directive at the top of the file:
+1. Use a text editor to open `/etc/apache2/sites-available/000-default.conf`
+1. Add the following directive at the top of the file:
 
-    ```conf
-    Listen 8080
-    ```
+   ```conf
+   Listen 8080
+   ```
 
-4. Add the following at the bottom of the file:
+1. Add the following at the bottom of the file:
 
-    ```conf
-    <VirtualHost *:8080>
-        ProxyPass "/" "http://localhost:9200/"
-        ProxyPassReverse "/" "http://localhost:9200/"
-    </VirtualHost>
-    ```
+   ```conf
+   <VirtualHost *:8080>
+       ProxyPass "/" "http://localhost:9200/"
+       ProxyPassReverse "/" "http://localhost:9200/"
+   </VirtualHost>
+   ```
 
-5. Restart Apache:
+1. Restart Apache:
 
-    ```bash
-    service apache2 restart
-    ```
+   ```bash
+   service apache2 restart
+   ```
 
-6. Verify the proxy works by entering the following command:
+1. Verify the proxy works by entering the following command:
 
-    ```bash
-    curl -i http://localhost:<proxy port>/_cluster/health
-    ```
+   ```bash
+   curl -i http://localhost:<proxy port>/_cluster/health
+   ```
 
-    For example, if your proxy uses port 8080:
+   For example, if your proxy uses port 8080:
 
-    ```bash
-    curl -i http://localhost:8080/_cluster/health
-    ```
+   ```bash
+   curl -i http://localhost:8080/_cluster/health
+   ```
 
-    ```terminal
-    Messages similar to the following display to indicate success:
+   ```terminal
+   Messages similar to the following display to indicate success:
 
-    HTTP/1.1 200 OK
-    Date: Tue, 23 Feb 2016 20:38:03 GMT
-    Content-Type: application/json; charset=UTF-8
-    Content-Length: 389
-    Connection: keep-alive
+   HTTP/1.1 200 OK
+   Date: Tue, 23 Feb 2016 20:38:03 GMT
+   Content-Type: application/json; charset=UTF-8
+   Content-Length: 389
+   Connection: keep-alive
 
-    {"cluster_name":"elasticsearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":5,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}
-    ```
+   {"cluster_name":"elasticsearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":5,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}
+   ```
 
-6. Continue with [Configure Magento to use Elasticsearch](#elastic-m2-configure).
+1. Continue with [Configure Magento to use Elasticsearch](#elastic-m2-configure).
 
 ### Set up a proxy for Apache 2.2 {#es-apache-proxy-22}
 
@@ -86,49 +86,49 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 1. As a user with `root` privileges, open `/etc/httpd/conf/httpd.conf` in a text editor.
 
-2. Locate the `Listen` directive and add another listen port; for example:
+1. Locate the `Listen` directive and add another listen port; for example:
 
-    ```conf
-    Listen 8080
-    ```
+   ```conf
+   Listen 8080
+   ```
 
-2. Scroll to the bottom of the file and add the following lines:
+1. Scroll to the bottom of the file and add the following lines:
 
-    ```conf
-    <VirtualHost *:8080>
-        ProxyPass http://localhost:9200/
-        ProxyPassReverse http://localhost:9200/
-    </VirtualHost>
-    ```
+   ```conf
+   <VirtualHost *:8080>
+       ProxyPass http://localhost:9200/
+       ProxyPassReverse http://localhost:9200/
+   </VirtualHost>
+   ```
 
-3. Restart Apache:
+1. Restart Apache:
 
-   * CentOS: `service httpd restart`
-   * Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
 
-6. Verify the proxy works by entering the following command:
+1. Verify the proxy works by entering the following command:
 
-    ```bash
-    curl -i http://localhost:<proxy port>/_cluster/health
-    ```
+   ```bash
+   curl -i http://localhost:<proxy port>/_cluster/health
+   ```
 
-    For example, if your proxy uses port 8080:
+   For example, if your proxy uses port 8080:
 
-    ```bash
-    curl -i http://localhost:8080/_cluster/health
-    ```
+   ```bash
+   curl -i http://localhost:8080/_cluster/health
+   ```
 
-    Messages similar to the following display to indicate success:
+   Messages similar to the following display to indicate success:
 
-    ```terminal
-    HTTP/1.1 200 OK
-    Date: Tue, 23 Feb 2016 20:38:03 GMT
-    Content-Type: application/json; charset=UTF-8
-    Content-Length: 389
-    Connection: keep-alive
+   ```terminal
+   HTTP/1.1 200 OK
+   Date: Tue, 23 Feb 2016 20:38:03 GMT
+   Content-Type: application/json; charset=UTF-8
+   Content-Length: 389
+   Connection: keep-alive
 
-    {"cluster_name":"elasticsearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":5,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}
-    ```
+   {"cluster_name":"elasticsearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":5,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}
+   ```
 
 ## Configure Magento to use Elasticsearch {#elastic-m2-configure}
 
@@ -138,14 +138,14 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 This section discusses how to secure communication between Apache and Elasticsearch using [HTTP Basic](http://tools.ietf.org/html/rfc2617){:target="_blank") authentication with Apache. For more options, consult one of the following resources:
 
-* [Apache 2.2 authentication and authorization tutorial](http://httpd.apache.org/docs/2.2/howto/auth.html){:target="_blank"}
-* [Apache 2.4 authentication and authorization tutorial](http://httpd.apache.org/docs/2.4/howto/auth.html){:target="_blank"}
+*  [Apache 2.2 authentication and authorization tutorial](http://httpd.apache.org/docs/2.2/howto/auth.html){:target="_blank"}
+*  [Apache 2.4 authentication and authorization tutorial](http://httpd.apache.org/docs/2.4/howto/auth.html){:target="_blank"}
 
 See one of the following sections:
 
-* [Step 1: Create a password file](#es-ws-secure-apache-pwd)
-* [Step 2: Configure your secure virtual host](#es-ws-secure-finish)
-* [Verify communication is secure](#es-ws-secure-verify)
+*  [Step 1: Create a password file](#es-ws-secure-apache-pwd)
+*  [Step 2: Configure your secure virtual host](#es-ws-secure-finish)
+*  [Verify communication is secure](#es-ws-secure-verify)
 
 ### Step 1: Create a password {#es-ws-secure-apache-pwd}
 {% include config/secure-ws-apache_step1.md %}
@@ -158,36 +158,37 @@ This section discusses how to specify who can access the Apache server.
 
 1. Use a text editor to add the following contents to your secure virtual host.
 
-   * Apache 2.2: Depending on how you set up SSL, the Apache 2.2 SSL configuration might be located in `/etc/httpd/conf/httpd.conf` or `/etc/httpd/conf.d/ssl.conf`.
+   *  Apache 2.2: Depending on how you set up SSL, the Apache 2.2 SSL configuration might be located in `/etc/httpd/conf/httpd.conf` or `/etc/httpd/conf.d/ssl.conf`.
 
-   * Apache 2.4: Edit `/etc/apache2/sites-available/default-ssl.conf`
+   *  Apache 2.4: Edit `/etc/apache2/sites-available/default-ssl.conf`
 
-    ```conf
-    <Proxy *>
-        Order deny,allow
-        Allow from all
+   ```conf
+   <Proxy *>
+       Order deny,allow
+       Allow from all
 
-        AuthType Basic
-        AuthName "Elastic Server"
-        AuthBasicProvider file
-        AuthUserFile /usr/local/apache/password/.htpasswd_elasticsearch
-        Require valid-user
+       AuthType Basic
+       AuthName "Elastic Server"
+       AuthBasicProvider file
+       AuthUserFile /usr/local/apache/password/.htpasswd_elasticsearch
+       Require valid-user
 
-        # This allows OPTIONS-requests without authorization
-      <LimitExcept OPTIONS>
-            Require valid-user
-      </LimitExcept>
-    </Proxy>
-    ```
+     # This allows OPTIONS-requests without authorization
+     <LimitExcept OPTIONS>
+           Require valid-user
+     </LimitExcept>
+   </Proxy>
+   ```
 
-3. If you added the preceding to your secure virtual host, remove `Listen 8080` and the `<VirtualHost *:8080>` directives you added earlier to your unsecure virtual host.
-4. Save your changes, exit the text editor, and restart Apache:
+1. If you added the preceding to your secure virtual host, remove `Listen 8080` and the `<VirtualHost *:8080>` directives you added earlier to your unsecure virtual host.
+1. Save your changes, exit the text editor, and restart Apache:
 
-* CentOS: `service httpd restart`
-* Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
 
 {% include config/es-verify-proxy.md %}
 
-#### Next
+{:.ref-header}
+Next
 
 [Configure Elasticsearch stopwords]({{page.baseurl}}/config-guide/elasticsearch/es-config-stopwords.html)

--- a/guides/v2.3/config-guide/elasticsearch/es-config-apache.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-apache.md
@@ -66,9 +66,9 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
    curl -i http://localhost:8080/_cluster/health
    ```
 
-   ```terminal
    Messages similar to the following display to indicate success:
 
+   ```terminal
    HTTP/1.1 200 OK
    Date: Tue, 23 Feb 2016 20:38:03 GMT
    Content-Type: application/json; charset=UTF-8


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes some MD029 errors in the following guides:

- Configuration

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.