### PR TITLE
Fixed ordered list prefix (MD029) - Group 12

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -50,10 +50,10 @@ To set a configuration value, you must know at least one of the following:
 
 See the following references:
 
-*   [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-*   [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*   [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*   [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ### Find the scope code
 
@@ -61,14 +61,15 @@ You can find the scope code either in the Magento database or in the Magento [Ad
 
 #### Find the scope code in the Admin
 
-1.  Log into Admin as a user who can view websites and store views.
-2.  Click **Stores** > **Settings** > **All Stores**.
-3.  In the right pane, click the name of the website or store view to see its code.
+1. Log into Admin as a user who can view websites and store views.
+1. Click **Stores** > **Settings** > **All Stores**.
+1. In the right pane, click the name of the website or store view to see its code.
 
-    The following figure shows a sample website code.
+   The following figure shows a sample website code.
 
-    ![Get a website or store view code from the Admin]({{ site.baseurl }}/common/images/config_configset_website-code.png){:width="450px"}
-4.  Continue with [Set configuration values](#config-cli-config-set).
+   ![Get a website or store view code from the Admin]({{ site.baseurl }}/common/images/config_configset_website-code.png){:width="450px"}
+
+1. Continue with [Set configuration values](#config-cli-config-set).
 
 #### Find the scope code in the database
 
@@ -76,29 +77,42 @@ Scope codes for websites and store views are stored in the Magento database in t
 
 To find the values in the database:
 
-1.  Connect to the Magento database:
+1. Connect to the Magento database:
 
-        mysql -u <magento database username> -p
-2.  Enter the following commands:
+   ```bash
+   mysql -u <magento database username> -p
+   ```
 
-        use <magento database name>;
-        SELECT * FROM store;
-        SELECT * FROM store_website;
+1. Enter the following commands:
 
-    A sample result follows:
+   ```shell
+   use <magento database name>;
+   ```
 
-        [mysql]> SELECT * FROM store_website;
-        +------------+-------+--------------+------------+------------------+------------+
-        | website_id | code  | name         | sort_order | default_group_id | is_default |
-        +------------+-------+--------------+------------+------------------+------------+
-        |          0 | admin | Admin        |          0 |                0 |          0 |
-        |          1 | base  | Main Website |          0 |                1 |          1 |
-        |          2 | test1 | Test Website |          0 |                3 |          0 |
-        +------------+-------+--------------+------------+------------------+------------+
+   ```shell
+   SELECT * FROM store;
+   ```
 
-    Use the value in the `code` column.
+   ```shell
+   SELECT * FROM store_website;
+   ```
 
-3.  Continue with the next section.
+   A sample result follows:
+
+   ```terminal
+   [mysql]> SELECT * FROM store_website;
+   +------------+-------+--------------+------------+------------------+------------+
+   | website_id | code  | name         | sort_order | default_group_id | is_default |
+   +------------+-------+--------------+------------+------------------+------------+
+   |          0 | admin | Admin        |          0 |                0 |          0 |
+   |          1 | base  | Main Website |          0 |                1 |          1 |
+   |          2 | test1 | Test Website |          0 |                3 |          0 |
+   +------------+-------+--------------+------------+------------------+------------+
+   ```
+
+   Use the value in the `code` column.
+
+1. Continue with the next section.
 
 ## Set configuration values {#config-cli-config-set}
 
@@ -107,6 +121,7 @@ To set system-specific configuration values on Magento 2.2.0 - 2.2.3, use:
 ```bash
 bin/magento config:set [--scope="..."] [--scope-code="..."] [-l | --lock] path value
 ```
+
 To set system-specific configuration values on Magento 2.2.4 and higher (on the 2.2 branch), use:
 
 ```bash
@@ -136,12 +151,14 @@ If you use the `--lock`, `--lock-env`, or `--lock-config` option to set or chang
 
 If you enter an incorrect configuration path, this command returns an error:
 
-    The "wrong/config/path" does not exist
+```terminal
+The "wrong/config/path" does not exist
+```
 
 See one of the following sections for more information:
 
-*   [Set configuration values that can be edited in the Magento Admin](#config-cli-config-set-edit)
-*   [Set configuration values that cannot be edited in the Magento Admin](#config-cli-config-file)
+*  [Set configuration values that can be edited in the Magento Admin](#config-cli-config-set-edit)
+*  [Set configuration values that cannot be edited in the Magento Admin](#config-cli-config-file)
 
 ### Set configuration values that can be edited in the Magento Admin {#config-cli-config-set-edit}
 
@@ -201,9 +218,9 @@ bin/magento config:show [--scope[="..."]] [--scope-code[="..."]] path
 
 In this case:
 
-* `--scope` is the scope of configuration (`default`, `website`, `store`). The default value is `default`.
-* `--scope-code` is the scope code of configuration (website code or store view code).
-* `path` is the configuration path in format `first_part/second_part/third_part/etc` *(required)*.
+*  `--scope` is the scope of configuration (`default`, `website`, `store`). The default value is `default`.
+*  `--scope-code` is the scope code of configuration (website code or store view code).
+*  `path` is the configuration path in format `first_part/second_part/third_part/etc` *(required)*.
 
 {:.bs-callout .bs-callout-info}
 The `bin/magento config:show` command displays the values of any [encrypted values]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html) as a series of asterisks: `******`.

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.md
@@ -8,6 +8,7 @@ functional_areas:
 ---
 
 ## Overview of cron {#config-cli-cron-overview}
+
 {% include config/cron-overview.md %}
 
 To run cron in a web browser, see [Secure cron.php to run in a browser]({{ page.baseurl }}/config-guide/secy/secy-cron.html)
@@ -26,10 +27,13 @@ You should remove the Magento crontab only before uninstalling the Magento appli
 
 To remove the Magento crontab:
 
-1.  Log in as or switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2.  Change to the Magento installation directory.
-3.  Enter the following command:
-      `bin/magento cron:remove`
+1. Log in as or switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. Change to the Magento installation directory.
+1. Enter the following command:
+
+   ```bash
+   bin/magento cron:remove
+   ```
 
 {:.bs-callout .bs-callout-info}
 This command has no effect on cron jobs outside the `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
@@ -39,18 +43,22 @@ This command has no effect on cron jobs outside the `#~ MAGENTO START` and `#~ M
 Command options:
 
 ```bash
-  bin/magento cron:run [--group="<cron group name>"]
+bin/magento cron:run [--group="<cron group name>"]
 ```
 
 where `--group` specifies the cron group to run (omit this option to run cron for all groups)
 
 To run the indexing cron job, enter:
 
-`bin/magento cron:run --group index`
+```bash
+bin/magento cron:run --group index`
+```
 
 To run the default cron job, enter:
 
-`bin/magento cron:run --group default`
+```bash
+bin/magento cron:run --group default
+```
 
 To set up custom cron jobs and groups, see [Configure custom cron jobs and cron groups]({{ page.baseurl }}/config-guide/cron/custom-cron.html).
 
@@ -65,23 +73,23 @@ All exceptions from cron jobs are logged by `\Magento\Cron\Observer\ProcessCronQ
 
 In addition to being logged in `cron.log`:
 
-- Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<install_directory>/var/log/support_report.log`.
+-  Failed jobs with `ERROR` and `MISSED` statuses are logged to the `<install_directory>/var/log/support_report.log`.
 
-- Jobs with an `ERROR` status are always logged as `CRITICAL` in `<install_directory>/var/log/exception.log`.
+-  Jobs with an `ERROR` status are always logged as `CRITICAL` in `<install_directory>/var/log/exception.log`.
 
-- Jobs with a `MISSED` status are logged as `INFO` in the `<install_directory>/var/log/debug.log` directory (developer mode only).
+-  Jobs with a `MISSED` status are logged as `INFO` in the `<install_directory>/var/log/debug.log` directory (developer mode only).
 
 {%
 include note.html
 type='info'
 content='All cron data is also written to the `cron_schedule` table in the Magento database. The table provides a history of cron jobs, including:
 
-- Job ID and code
-- Status
-- Created date
-- Scheduled date
-- Executed date
-- Finished date
+-  Job ID and code
+-  Status
+-  Created date
+-  Scheduled date
+-  Executed date
+-  Finished date
 
 To see records in the table, log in to the Magento database on the command line and enter `SELECT * from cron_schedule;`.'
 %}

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-i18n.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-i18n.md
@@ -15,8 +15,8 @@ Magento translations enable you to customize and localize your store for multipl
 
 This topic discusses how to generate:
 
-- Translation dictionaries, which are a convenient way to customize or translate *some* words and phrases, such as those for a custom [module](https://glossary.magento.com/module) or [theme](https://glossary.magento.com/theme).
-- Language packages, which enable you to translate *any or all* words and phrases in the Magento application.
+-  Translation dictionaries, which are a convenient way to customize or translate *some* words and phrases, such as those for a custom [module](https://glossary.magento.com/module) or [theme](https://glossary.magento.com/theme).
+-  Language packages, which enable you to translate *any or all* words and phrases in the Magento application.
 
 See [Translations overview].
 
@@ -41,11 +41,11 @@ You have options for using the translated dictionary:
 
 1. In the Magento Admin, the store administrator configures the translations.
 
-    Command options:
+   Command options:
 
-    ```bash
-    bin/magento i18n:collect-phrases [-o|--output="<csv file path and name>"] [-m|--magento] <path to directory to translate>
-    ```
+   ```bash
+   bin/magento i18n:collect-phrases [-o|--output="<csv file path and name>"] [-m|--magento] <path to directory to translate>
+   ```
 
 The following table explains this command's parameters and values:
 
@@ -62,26 +62,34 @@ To create a language pack from a translation dictionary, you *must* use the `-m|
 
 Use the following guidelines when translating words and phrases:
 
-- Change the contents of the second column only. Translate the phrases from English (`US`) to the desired language.
-- When creating dictionaries for locales, use the default Magento strings.
-- While translating, pay attention to placeholders like `%1`, `%2` and so on.
+-  Change the contents of the second column only. Translate the phrases from English (`US`) to the desired language.
+-  When creating dictionaries for locales, use the default Magento strings.
+-  While translating, pay attention to placeholders like `%1`, `%2` and so on.
 
 Magento uses the placeholders to insert context values; they are *not* used for translations. For example:
 
-    Product '%1' has been added to shopping cart.
+```text
+Product '%1' has been added to shopping cart.
+```
 
 Populates with a value:
 
-    Product 'Multimeter-2000' has been added to shopping cart.
+```text
+Product 'Multimeter-2000' has been added to shopping cart.
+```
 
 The resulting phrase must contain at least one of each placeholder.
 For example, suppose there are placeholders from `%1` to `%3` in the original phrase.
- The translation can have as many of these placeholders in any order, but there must be at least one occurrence of `%1`, `%2`, and `%3`.
+
+The translation can have as many of these placeholders in any order, but there must be at least one occurrence of `%1`, `%2`, and `%3`.
+
 The translation cannot contain placeholder values not present in the original value (for example, `%4`, `%5`, and so on).
 
 An example of translating a phrase:
 
-    "Buy %1 for %2 (%3 incl. tax) each","Compre %1 por %2 (%3 incl. imposto) cada"
+```text
+"Buy %1 for %2 (%3 incl. tax) each","Compre %1 por %2 (%3 incl. imposto) cada"
+```
 
 ## Create a language package {#config-cli-subcommands-xlate-pack}
 
@@ -93,9 +101,9 @@ This section discusses how to create a language package, which writes `.csv` fil
 
    (The `--magento` parameter is required.)
 
-2. [Run the language package command](#config-cli-subcommands-xlate-pack-cmd).
-3. [Create directories and files](#m2devgde-xlate-files).
-4. (Optional.) [Configure multiple packages for a language](#m2devgde-xlate-severalpacks).
+1. [Run the language package command](#config-cli-subcommands-xlate-pack-cmd).
+1. [Create directories and files](#m2devgde-xlate-files).
+1. (Optional.) [Configure multiple packages for a language](#m2devgde-xlate-severalpacks).
 
 ### Run the language package command {#config-cli-subcommands-xlate-pack-cmd}
 
@@ -118,10 +126,10 @@ The following table explains this command's parameters and values:
 
 Language packages are located in a directory under `app/i18n/<VendorName>` in the Magento file system with the following contents:
 
-- Required license files
-- `composer.json`
-- `registration.php` that [registers] the language package
-- [`language.xml`](#config-cli-subcommands-xlate-pack-meta-xml) meta-information file
+-  Required license files
+-  `composer.json`
+-  `registration.php` that [registers] the language package
+-  [`language.xml`](#config-cli-subcommands-xlate-pack-meta-xml) meta-information file
 
 {:.bs-callout .bs-callout-info}
 You must lowercase the entire path. For example, see [`de_de`].
@@ -130,12 +138,12 @@ To create these files:
 
 1. Create a directory under `app/i18n`.
 
-    For example, Magento language packages are located in `app/i18n/magento`
+   For example, Magento language packages are located in `app/i18n/magento`
 
-2. Add any license files you require.
-3. Add [`composer.json`] that specifies dependencies for your language package.
-4. Register the language package with [`registration.php`]
-5. Add `language.xml` meta-information file as discussed in the next section.
+1. Add any license files you require.
+1. Add [`composer.json`] that specifies dependencies for your language package.
+1. Register the language package with [`registration.php`]
+1. Add `language.xml` meta-information file as discussed in the next section.
 
 #### Language package language.xml {#config-cli-subcommands-xlate-pack-meta-xml}
 
@@ -158,11 +166,11 @@ To declare a package, specify the following information:
 
 Where:
 
-- **`<code>`:** Language package locale (required)
-- **`<vendor>`:** Module's vendor name (required)
-- **`<package>`:** Language package name (required)
-- **`<sort_order>`:** Priority of uploading a package when there are several language packages available for a store
-- **`<use>`:** Parent language package locale from which to inherit dictionaries
+-  **`<code>`:** Language package locale (required)
+-  **`<vendor>`:** Module's vendor name (required)
+-  **`<package>`:** Language package name (required)
+-  **`<sort_order>`:** Priority of uploading a package when there are several language packages available for a store
+-  **`<use>`:** Parent language package locale from which to inherit dictionaries
 
 If necessary, you can specify several parent packages. The parent packages are applied on a first listed, first used basis.
 
@@ -185,8 +193,8 @@ If a language package inherits from two packages, its `language.xml` might look 
 
 In the preceding example:
 
-- `language_package_one` inherits from `en_au_package` and `en_au_package` inherits from `en_ie_package`
-- `language_package_two` inherits from `en_ca_package` and `en_ca_package` inherits from `en_us_package`
+-  `language_package_one` inherits from `en_au_package` and `en_au_package` inherits from `en_ie_package`
+-  `language_package_two` inherits from `en_ca_package` and `en_ca_package` inherits from `en_us_package`
 
 If the Magento application cannot find word or phrase in the `en_GB` package, it looks in other packages in following sequence:
 
@@ -209,8 +217,8 @@ To enable an additional package for an existing language, name the new package a
 
 The following sections provide end-to-end examples of using the commands discussed in this topic to create translation dictionaries and translation packages:
 
-- [Example: Create a translation dictionary for a module or theme](#config-cli-subcommands-xlate-example1)
-- [Example: Create a language package](#config-cli-subcommands-xlate-example2)
+-  [Example: Create a translation dictionary for a module or theme](#config-cli-subcommands-xlate-example1)
+-  [Example: Create a language package](#config-cli-subcommands-xlate-example2)
 
 ### Example: Create a translation dictionary for a module or theme {#config-cli-subcommands-xlate-example1}
 
@@ -218,12 +226,12 @@ To add a German translation to a module or theme that you want to distribute to 
 
 1. Collect phrases from your module:
 
-    ```bash
-    bin/magento i18n:collect-phrases -o "/var/www/html/magento2/app/code/ExampleCorp/SampleModule/i18n/xx_YY.csv" /var/www/html/magento2/app/code/ExampleCorp/SampleModule
-    ```
+   ```bash
+   bin/magento i18n:collect-phrases -o "/var/www/html/magento2/app/code/ExampleCorp/SampleModule/i18n/xx_YY.csv" /var/www/html/magento2/app/code/ExampleCorp/SampleModule
+   ```
 
-{:.bs-callout .bs-callout-info}
-    The .csv file name must _exactly match_ the locale, including the characters' case.
+   {:.bs-callout .bs-callout-info}
+   The .csv file name must _exactly match_ the locale, including the characters' case.
 
 1. Translate the words and phrases using [these guidelines](#config-cli-subcommands-xlate-dict-trans).
 1. If necessary, copy `xx_YY.csv` to `/var/www/html/magento2/app/code/ExampleCorp/SampleModule/i18n` or to the module's theme directory (depending on whether the translation dictionary is for a module or a theme).
@@ -234,23 +242,23 @@ Similar to the preceding example, generate a `.csv` file, but instead of specify
 
 1. Collect phrases from your module:
 
-    ```bash
-    bin/magento i18n:collect-phrases -o "/var/www/html/magento2/xx_YY.csv" -m
-    ```
+   ```bash
+   bin/magento i18n:collect-phrases -o "/var/www/html/magento2/xx_YY.csv" -m
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    The `.csv` file name must _exactly match_ the locale, including the characters' case.
+   {:.bs-callout .bs-callout-info}
+   The `.csv` file name must _exactly match_ the locale, including the characters' case.
 
 1. Translate the words and phrases using [these guidelines](#config-cli-subcommands-xlate-dict-trans).
 1. Create the language package.
 
-    ```bash
-    bin/magento i18n:pack /var/www/html/magento2/xx_YY.csv -d xx_YY
-    ```
+   ```bash
+   bin/magento i18n:pack /var/www/html/magento2/xx_YY.csv -d xx_YY
+   ```
 
 1. Create a directory for the language package.
 
-    For example, `/var/www/html/magento2/app/i18n/ExampleCorp/xx_yy`
+   For example, `/var/www/html/magento2/app/i18n/ExampleCorp/xx_yy`
 
 1. In that directory, add all of the following:
 

--- a/guides/v2.2/config-guide/cli/logging.md
+++ b/guides/v2.2/config-guide/cli/logging.md
@@ -21,29 +21,29 @@ As of Magento 2.2.8, you can no longer use the `bin/magento config:set dev/debug
 
 1. Use the `setup:config:set` command to enable debug logging for the current mode.
 
-    ```bash
-    bin/magento setup:config:set --enable-debug-logging=true
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-debug-logging=true
+   ```
 
-2. Flush the cache.
+1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ### To disable debug logging
 
 1. Use the `setup:config:set` command to disable debug logging for the current mode.
 
-    ```bash
-    bin/magento setup:config:set --enable-debug-logging=false
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-debug-logging=false
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ## Database logging
 
@@ -53,18 +53,19 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
 1. Use the `dev:query-log` command to enable or disable database logging.
 
-    ```bash
-    bin/magento dev:query-log:enable
-    ```
-    ```bash
-    bin/magento dev:query-log:disable
-    ```
+   ```bash
+   bin/magento dev:query-log:enable
+   ```
+
+   ```bash
+   bin/magento dev:query-log:disable
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ## Cron logging
 
@@ -82,26 +83,26 @@ By default, Magento writes _syslog_ logs to the operating system `syslog` file.
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `true`.
 
-    ```bash
-    bin/magento setup:config:set --enable-syslog-logging=true
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-syslog-logging=true
+   ```
 
-2. Flush the cache.
+1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```
 
 ### To disable syslog logging
 
 1. Use the `config:set` command to change the `dev/syslog/syslog_logging` database value to `false`.
 
-    ```bash
-    bin/magento setup:config:set --enable-syslog-logging=false
-    ```
+   ```bash
+   bin/magento setup:config:set --enable-syslog-logging=false
+   ```
 
 1. Flush the cache.
 
-    ```bash
-    bin/magento cache:flush
-    ```
+   ```bash
+   bin/magento cache:flush
+   ```

--- a/guides/v2.2/config-guide/elasticsearch/es-config-stopwords.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-stopwords.md
@@ -19,10 +19,10 @@ You must manage your Elasticsearch stopwords using `.csv` files located in the `
 
 For more information about how Elasticsearch uses stopwords, see the following resources:
 
-* [Stopwords: Performance Versus Precision](https://www.elastic.co/guide/en/elasticsearch/guide/current/stopwords.html)
-* [Pros and Cons of Stopwords](https://www.elastic.co/guide/en/elasticsearch/guide/current/pros-cons-stopwords.html)
-* [Using Stopwords](https://www.elastic.co/guide/en/elasticsearch/guide/current/using-stopwords.html)
-* [Stopwords and Performance](https://www.elastic.co/guide/en/elasticsearch/guide/current/stopwords-performance.html)
+*  [Stopwords: Performance Versus Precision](https://www.elastic.co/guide/en/elasticsearch/guide/current/stopwords.html)
+*  [Pros and Cons of Stopwords](https://www.elastic.co/guide/en/elasticsearch/guide/current/pros-cons-stopwords.html)
+*  [Using Stopwords](https://www.elastic.co/guide/en/elasticsearch/guide/current/using-stopwords.html)
+*  [Stopwords and Performance](https://www.elastic.co/guide/en/elasticsearch/guide/current/stopwords-performance.html)
 
 ## Configure stopwords {#config-stopwords}
 
@@ -32,63 +32,65 @@ The default lifetime for stopwords file [cache](https://glossary.magento.com/cac
 
 See one of the following topics for more information:
 
-* [Edit stopwords for an existing locale](#config-edit-stopwords)
-* [Create stopwords for a new locale](#config-create-stopwords)
+*  [Edit stopwords for an existing locale](#config-edit-stopwords)
+*  [Create stopwords for a new locale](#config-create-stopwords)
 
 ### Edit stopwords for an existing locale {#config-edit-stopwords}
 
 To edit stopwords:
 
 1. Log in to your Magento server, or switch to the [Magento file system owner]({{page.baseurl}}/install-gde/prereq/file-sys-perms-over.html#magento-file-system-owner).
-2. Use a text editor to open a stopword file in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
+1. Use a text editor to open a stopword file in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
 
    `.csv` files use the naming convention `stopwords_<locale_code>.csv`. For example, the German stopword file is named `stopwords_de_DE.csv`.
-3. Add words, remove words, or change words in the file.
+
+1. Add words, remove words, or change words in the file.
 
    (Each stopword in a file starts on a new line.)
-4. Save your changes and exit the text editor.
-5. Clean the Magento configuration cache.
 
-   * Magento Admin: **System** > Tools > **Cache Management**. Select the **Configuration** checkbox and, from the list above it, click **Refresh**. Click **Submit** to complete the action.
+1. Save your changes and exit the text editor.
+1. Clean the Magento configuration cache.
 
-   * Command line: As the Magento file system owner, enter the following command:
+   *  Magento Admin: **System** > Tools > **Cache Management**. Select the **Configuration** checkbox and, from the list above it, click **Refresh**. Click **Submit** to complete the action.
+
+   *  Command line: As the Magento file system owner, enter the following command:
 
    ```bash
    bin/magento magento cache:clean config
    ```
 
-6.Check the results by searching for terms on your [storefront](https://glossary.magento.com/storefront).x
+1. Check the results by searching for terms on your [storefront](https://glossary.magento.com/storefront).x
 
 ### Create stopwords for a new locale {#config-create-stopwords}
 
 To add stopwords for a locale:
 
 1. Log in to your Magento server, or switch to, the [Magento file system owner]({{page.baseurl}}/install-gde/prereq/file-sys-perms-over.html#magento-file-system-owner).
-2. Use a text editor to create a stopword file named `stopwords_<locale_code>.csv` in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
+1. Use a text editor to create a stopword file named `stopwords_<locale_code>.csv` in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
 
    For example, to create stopwords for the Italian locale, name the file `stopwords_it_IT.csv`.
 
-3. In your stopword file, make sure each stopword is on a separate line.
-4. Save your changes and exit the text editor.
-5. In the same directory, open `esconfig.xml` in a text editor.
-6. Add a line to `esconfig.xml` as follows:
+1. In your stopword file, make sure each stopword is on a separate line.
+1. Save your changes and exit the text editor.
+1. In the same directory, open `esconfig.xml` in a text editor.
+1. Add a line to `esconfig.xml` as follows:
 
    ```xml
    <LOCALE_CODE>stopwords_LOCALE_CODE.csv</LOCALE_CODE>
    ```
 
-    For example, to add an Italian stopword file, add the following line:
+   For example, to add an Italian stopword file, add the following line:
 
-    ```text
-    <it_IT>stopwords_it_IT.csv</it_IT>
-    ```
+   ```text
+   <it_IT>stopwords_it_IT.csv</it_IT>
+   ```
 
-7. Save the changes to `esconfig.xml` and exit the text editor.
-8. Clean the Magento configuration cache.
+1. Save the changes to `esconfig.xml` and exit the text editor.
+1. Clean the Magento configuration cache.
 
-   * Magento Admin: **System** > Tools > **Cache Management**. Select the **Configuration** checkbox and, from the list above it, click **Refresh**. Click **Submit** to complete the action.
+   *  Magento Admin: **System** > Tools > **Cache Management**. Select the **Configuration** checkbox and, from the list above it, click **Refresh**. Click **Submit** to complete the action.
 
-   * Command line: As the Magento file system owner, enter the following command:
+   *  Command line: As the Magento file system owner, enter the following command:
 
       ```bash
       bin/magento magento cache:clean config
@@ -100,8 +102,8 @@ To add stopwords for a locale:
 
 This section discusses how to optionally change the default stopword directory from one of the following:
 
-* `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords`
-* `<magento_root>/app/code/Magento/Elasticsearch/etc/stopwords/`
+*  `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords`
+*  `<magento_root>/app/code/Magento/Elasticsearch/etc/stopwords/`
 
 The location depends on how you installed the Magento software. If you cloned the Magento 2 GitHub repository, the path is under `app/code`. If you installed a compressed archive or a metapackage, the path is under `vendor`.
 
@@ -113,7 +115,7 @@ To change the directory:
 
    If you got an archive or the metapackage, it's located at `vendor/magento/module-elasticsearch/etc/di.xml`
 
-2. Change the value of `fileDir` to the desired directory:
+1. Change the value of `fileDir` to the desired directory:
 
     ```xml
     <type name="Magento\Elasticsearch\SearchAdapter\Query\Preprocessor\Stopwords">

--- a/guides/v2.2/config-guide/elasticsearch/es-overview.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-overview.md
@@ -9,27 +9,27 @@ functional_areas:
   - Setup
 ---
 
-* [Configure nginx and Elasticsearch][]
-* [Configure Apache and Elasticsearch][]
-* [Configure Elasticsearch stopwords][]
+*  [Configure nginx and Elasticsearch][]
+*  [Configure Apache and Elasticsearch][]
+*  [Configure Elasticsearch stopwords][]
 
 ## Elasticsearch overview {#overview}
 
 In Magento 2.2, you can use [Elasticsearch][] for searching your [catalog](https://glossary.magento.com/catalog).
 
-* Elasticsearch performs quick and advanced searches on products in the catalog
-* Elasticsearch Analyzers support multiple languages
-* Supports stop words and synonyms
-* Indexing does not impact customers until reindex is completed
+*  Elasticsearch performs quick and advanced searches on products in the catalog
+*  Elasticsearch Analyzers support multiple languages
+*  Supports stop words and synonyms
+*  Indexing does not impact customers until reindex is completed
 
-  Elasticsearch returns search results based on the last generated index until the new one has been completely indexed so there's no disruption to customers
+   Elasticsearch returns search results based on the last generated index until the new one has been completely indexed so there's no disruption to customers
 
-* Accurate, performant, scalable
-* Works well out of the box
-* Easy to horizontally scale
-* Supports real-time data and analysis
-* Can be used as a document-oriented data store
-* Applications in framework beyond search&mdash;reporting, personalization, performance, and storage
+*  Accurate, performant, scalable
+*  Works well out of the box
+*  Easy to horizontally scale
+*  Supports real-time data and analysis
+*  Can be used as a document-oriented data store
+*  Applications in framework beyond search&mdash;reporting, personalization, performance, and storage
 
 ### Supported versions {#es-spt-versions}
 
@@ -42,7 +42,7 @@ Follow the instructions in [Downgrade Elasticsearch Client][].
 
 {{site.data.var.ee}} version 2.2.x supports the following Elasticsearch versions:
 
-* Elasticsearch [6.6.x][]
+*  Elasticsearch [6.6.x][]
 
 Magento 2.2.8 uses [Elasticsearch PHP client][] version 6.
 (Before version 2.2.3, Magento used PHP client version 5.1.)
@@ -55,38 +55,42 @@ The following figure shows our recommended configuration. All of the tasks we di
 
 The preceding diagram shows:
 
-* The Magento application and Elasticsearch are installed on different hosts.
+*  The Magento application and Elasticsearch are installed on different hosts.
 
-  Running on separate hosts is secure, enables Elasticsearch to be scaled, and is necessary for proxying to work.
+   Running on separate hosts is secure, enables Elasticsearch to be scaled, and is necessary for proxying to work.
   Clustering Elasticsearch is beyond the scope of this guide but you can find more information in the [Elasticsearch documentation][].
-* Each host has its own web server; the web servers don't have to be the same.
 
-  For example, the Magento application can run Apache and Elasticsearch can run nginx.
-* Both web servers use Transport Layer Security (TLS).
+*  Each host has its own web server; the web servers don't have to be the same.
 
-  Setting up TLS is beyond the scope of our documentation.
+   For example, the Magento application can run Apache and Elasticsearch can run nginx.
+
+*  Both web servers use Transport Layer Security (TLS).
+
+   Setting up TLS is beyond the scope of our documentation.
 
 Search requests are processed as follows:
 
 1. A search request from a user is received by the Magento web server, which forwards it to the Elasticsearch server.
 
    You configure Elasticsearch in the Magento Admin to connect to the proxy's host and port. We recommend the web server's SSL port (by default, 443).
-2. The Elasticsearch web server (listening on port 443) proxies the request to the Elasticsearch server (by default, it listens on port 9200).
-3. Access to Elasticsearch is further protected by HTTP Basic authentication.
+
+1. The Elasticsearch web server (listening on port 443) proxies the request to the Elasticsearch server (by default, it listens on port 9200).
+1. Access to Elasticsearch is further protected by HTTP Basic authentication.
 
    For any request to reach Elasticsearch, it must travel over SSL *and* provide a valid username and password.
-4. Elasticsearch processes the search request.
-5. Communication returns along the same route, with the Elasticsearch web server acting as a secure reverse proxy.
+
+1. Elasticsearch processes the search request.
+1. Communication returns along the same route, with the Elasticsearch web server acting as a secure reverse proxy.
 
 ## Install prerequisites and Elasticsearch {#es-prereq}
 
 The tasks discussed in this section require the following:
 
-* [Firewall and SELinux][]
-* [Install the Java Software Development Kit (JDK)][]
-* [Install Elasticsearch 6][]
-* [Upgrade from Elasticsearch 2.x/5.x to 6.x][]
-* [Configure Magento to use Elasticsearch][]
+*  [Firewall and SELinux][]
+*  [Install the Java Software Development Kit (JDK)][]
+*  [Install Elasticsearch 6][]
+*  [Upgrade from Elasticsearch 2.x/5.x to 6.x][]
+*  [Configure Magento to use Elasticsearch][]
 
 {% include config/solr-elastic-selinux.md %}
 
@@ -103,22 +107,22 @@ The tasks discussed in this section require the following:
 
 1. If not already running, start Elasticsearch:
 
-    ```bash
-    sudo service elasticsearch start
-    ```
+   ```bash
+   sudo service elasticsearch start
+   ```
 
 1. Verify that Elasticsearch is working by entering the following command on the server on which it is running:
 
-    ```bash
-    curl -XGET '<host>:9200/_cat/health?v&pretty'
-    ```
+   ```bash
+   curl -XGET '<host>:9200/_cat/health?v&pretty'
+   ```
 
-    A message similar to the following is displayed:
+   A message similar to the following is displayed:
 
-    ```terminal
-    epoch      timestamp cluster       status node.total node.data shards pri relo init unassign pending_tasks
-    1519701563 03:19:23  elasticsearch green           1         1      0   0    0    0        0             0
-    ```
+   ```terminal
+   epoch      timestamp cluster       status node.total node.data shards pri relo init unassign pending_tasks
+   1519701563 03:19:23  elasticsearch green           1         1      0   0    0    0        0             0
+   ```
 
 ## Upgrading Elasticsearch {#es-upgrade6}
 
@@ -137,9 +141,9 @@ For additional information, see [Elasticsearch documentation][]
 {:.ref-header}
 Next step
 
-* [Configure nginx and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-nginx.html)
-* [Configure Apache and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-apache.html)
-* [Configure Magento to use Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/configure-magento.html)
+*  [Configure nginx and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-nginx.html)
+*  [Configure Apache and Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/es-config-apache.html)
+*  [Configure Magento to use Elasticsearch]({{ page.baseurl }}/config-guide/elasticsearch/configure-magento.html)
 
 <!-- Link Definitions -->
 [Downgrade Elasticsearch Client]: {{page.baseurl}}/config-guide/elasticsearch/es-downgrade.html

--- a/guides/v2.2/config-guide/memcache/memcache_centos.md
+++ b/guides/v2.2/config-guide/memcache/memcache_centos.md
@@ -20,33 +20,48 @@ To install memcached on CentOS, perform the following tasks as a user with `root
 
 1. Install memcached and its dependencies:
 
-        yum -y update
-        yum install -y libevent libevent-devel
-        yum install -y memcached
-        yum install -y php-pecl-memcached
+   ```bash
+   yum -y update
+   ```
 
-{:.bs-callout .bs-callout-info}
-The syntax of the preceding commands might depend on what package repositories you use. For example, if you use webtatic and PHP 5.6, enter <code>yum install -y php56w-pecl-memcache</code>. Use `yum search memcache|grep php` to find the appropriate package name.
+   ```bash
+   yum install -y libevent libevent-devel
+   ```
 
-2. Change the memcached configuration setting for `CACHESIZE` and `OPTIONS`:
+   ```bash
+   yum install -y memcached
+   ```
 
-    1. Open `/etc/sysconfig/memcached` in a text editor.
-    1. Locate the value for `CACHESIZE` and change it to at least 1GB. For example
+   ```bash
+   yum install -y php-pecl-memcached
+   ```
 
-           CACHESIZE="1GB"
+   {:.bs-callout .bs-callout-info}
+   The syntax of the preceding commands might depend on what package repositories you use. For example, if you use webtatic and PHP 5.6, enter <code>yum install -y php56w-pecl-memcache</code>. Use `yum search memcache|grep php` to find the appropriate package name.
 
-    1. Locate the value for `OPTIONS` and change it to `localhost` or `127.0.0.1`
+1. Change the memcached configuration setting for `CACHESIZE` and `OPTIONS`:
 
-    For more information about configuring memcached, see [the memcached wiki](https://code.google.com/p/memcached/wiki/NewConfiguringServer).
+   1. Open `/etc/sysconfig/memcached` in a text editor.
+   1. Locate the value for `CACHESIZE` and change it to at least 1GB. For example
+
+      ```conf
+      CACHESIZE="1GB"
+      ```
+
+   1. Locate the value for `OPTIONS` and change it to `localhost` or `127.0.0.1`
+
+   For more information about configuring memcached, see [the memcached wiki](https://code.google.com/p/memcached/wiki/NewConfiguringServer).
 
 1. Save your changes to `memcached` and exit the text editor.
 1. Restart memcached.
 
-        service memcached restart
+   ```bash
+   service memcached restart
+   ```
 
 1. Restart your web server.
 
-    For Apache, `service httpd restart`
+   For Apache, `service httpd restart`
 
 1. Continue with the next section.
 
@@ -60,23 +75,23 @@ To verify memcached is recognized by the web server:
 
 1. Create a `phpinfo.php` file in the web server's docroot:
 
-    ```php
-    <?php
-    // Show all information, defaults to INFO_ALL
-    phpinfo();
-    ```
+   ```php
+   <?php
+   // Show all information, defaults to INFO_ALL
+   phpinfo();
+   ```
 
 1. Go to that page in your web browser.
 
-    For example, `http://192.0.2.1/phpinfo.php`
+   For example, `http://192.0.2.1/phpinfo.php`
 
 1. Make sure memcache displays as follows:
 
    ![Confirm memcache is recognized by the web server]({{ site.baseurl }}/common/images/config_memcache.png)
 
-  Verify you're using memcached version 3.0.5 or later.
+   Verify you're using memcached version 3.0.5 or later.
 
-  If memcache does not display, restart the web server and refresh the browser page. If it still does not display, verify you installed the `php-pecl-memcache` extension.
+   If memcache does not display, restart the web server and refresh the browser page. If it still does not display, verify you installed the `php-pecl-memcache` extension.
 
 ### Create a memcache test consisting of a MySQL database and PHP script
 
@@ -86,7 +101,9 @@ The test uses a MySQL database, table, and data to verify you can retrieve the d
 
 Create the MySQL database:
 
-    mysql -u root -p
+```bash
+mysql -u root -p
+```
 
 At the `mysql` prompt, enter the following commands:
 
@@ -102,7 +119,6 @@ exit
 Create `cache-test.php` in your web server's docroot:
 
 ```php
-
 $meminstance = new Memcached();
 
 $meminstance->addServer('<memcached hostname or ip>', <memcached port>);
@@ -132,8 +148,13 @@ where `<memcached hostname or ip>` is either `localhost`, `127.0.0.1`, or the me
 
 Run the script from the command line.
 
-    cd <web server docroot>
-    php cache-test.php
+```bash
+cd <web server docroot>
+```
+
+```bash
+php cache-test.php
+```
 
 The first result is `got result from mysql`. This means that the key did not exist in memcached but it was retrieved from MySQL.
 
@@ -141,26 +162,36 @@ The second result is `got result from memcached`, which verifies that the value 
 
 Finally, you can view the memcache keys using Telnet:
 
-    telnet localhost <memcache port>
+```bash
+telnet localhost <memcache port>
+```
 
 At the prompt, enter
 
-    stats items
+```shell
+stats items
+```
 
 The result is similar to the following:
 
-    STAT items:3:number 1
-    STAT items:3:age 1075
-    STAT items:3:evicted 0
-    STAT items:3:evicted_nonzero 0
-    STAT items:3:evicted_time 0
-    STAT items:3:outofmemory 0
-    STAT items:3:tailrepairs 0
+```terminal
+STAT items:3:number 1
+STAT items:3:age 1075
+STAT items:3:evicted 0
+STAT items:3:evicted_nonzero 0
+STAT items:3:evicted_time 0
+STAT items:3:outofmemory 0
+STAT items:3:tailrepairs 0
 
 Flush the memcache storage and quit Telnet:
 
-    flush_all
-    quit
+```shell
+flush_all
+```
+
+```shell
+quit
+```
 
 [Additional information about the Telnet test](http://www.darkcoding.net/software/memcached-list-all-keys/)
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_manual.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_manual.md
@@ -375,7 +375,7 @@ If you are using a [Network Database (NDB)](http://dev.mysql.com/doc/refman/5.6/
    sed -ei 's/InnoDb/NDB/' <file name>.sql
    ```
 
-2. Remove rows with a FULLTEXT key from dumps because NDB tables do not support FULLTEXT.
+1. Remove rows with a FULLTEXT key from dumps because NDB tables do not support FULLTEXT.
 
 ### Restore tables to the quote database
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all remaining MD029 errors in the following guides (except includes):

- Configuration

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.