### PR TITLE
GraphQL: Add fixed product tax attributes

### DIFF
--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -98,7 +98,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `discount` | ProductDiscount | The amount of the discount applied to the product. It represents the difference between the `final_price` and `regular_price`
 `final_price`| Money! | The price of the product after applying discounts
-`fixed_product_taxes` | [[FixedProductTax](#FixedProductTax)] | An array of fixed product taxes applied to a product price
+`fixed_product_taxes` | [[FixedProductTax](#FixedProductTax)] | An array of fixed product taxes applied or can be applied to a product price
 `regular_price` | Money! | The regular price of the product, without any applied discounts
 
 ### ProductDiscount object {#ProductDiscount}

--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -98,7 +98,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `discount` | ProductDiscount | The amount of the discount applied to the product. It represents the difference between the `final_price` and `regular_price`
 `final_price`| Money! | The price of the product after applying discounts
-`fixed_product_taxes` | [[FixedProductTax]] | An array of fixed product taxes applied to a product price
+`fixed_product_taxes` | [[FixedProductTax](#FixedProductTax)] | An array of fixed product taxes applied to a product price
 `regular_price` | Money! | The regular price of the product, without any applied discounts
 
 ### ProductDiscount object {#ProductDiscount}
@@ -131,7 +131,7 @@ Attribute |  Data Type | Description
 `amount` | Money | The price of the product and its currency code. See [Money object](#Money).
 `adjustments` | [PriceAdjustment] | An array of [PriceAdjustment](#PriceAdjustment) objects.
 
-##### Money object {#Money}
+#### Money object {#Money}
 
 A `Money` object defines a monetary value, including a numeric value and a currency code.
 
@@ -140,7 +140,7 @@ Attribute |  Data Type | Description
 `currency` | CurrencyEnum | A three-letter currency code, such as `USD` or `EUR`.
 `value` | Float | The price of the product
 
-##### PriceAdjustment array {#PriceAdjustment}
+#### PriceAdjustment array {#PriceAdjustment}
 
 {:.bs-callout-info}
 The `PriceAdjustment` object has been deprecated. In cases where the value for the `code` attribute was `WEEE`, use `fixed_product_taxes.label` instead. If the value was `tax` or `weee_tax`, the taxes will be included or excluded as part of the price in the `ProductPrice` or `FixedProductTax` object, respectively.

--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -98,6 +98,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `discount` | ProductDiscount | The amount of the discount applied to the product. It represents the difference between the `final_price` and `regular_price`
 `final_price`| Money! | The price of the product after applying discounts
+`fixed_product_taxes` | [[FixedProductTax]] | An array of fixed product taxes applied to a product price
 `regular_price` | Money! | The regular price of the product, without any applied discounts
 
 ### ProductDiscount object {#ProductDiscount}
@@ -109,7 +110,19 @@ Attribute |  Data Type | Description
 `amount_off` | Float | The actual value of the discount
 `percent_off` | Float | The discount expressed as a percentage
 
+### FixedProductTax object {#FixedProductTax}
+
+Some tax jurisdictions have a fixed product tax (FPT) that must be applied to certain types of products. An example FPT is the Waste Electrical and Electronic Equipment (WEEE) tax, which is collected on some types of electronics to offset the cost of recycling.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`amount` | Money | The amount of the fixed product tax
+`label` | String | The label assigned to the fixed product tax to be displayed on the frontend
+
 ### Price object {#Price}
+
+{:.bs-callout-info}
+The `Price` object has been deprecated. Use the `ProductPrice` object instead.
 
 The `Price` object defines the price of a product as well as any tax-related adjustments.
 
@@ -129,7 +142,10 @@ Attribute |  Data Type | Description
 
 ##### PriceAdjustment array {#PriceAdjustment}
 
-The `PricedAdjustment` object defines the amount of money to apply as an adjustment, the type of adjustment to apply, and whether the item is included or excluded from the adjustment.
+{:.bs-callout-info}
+The `PriceAdjustment` object has been deprecated. In cases where the value for the `code` attribute was `WEEE`, use `fixed_product_taxes.label` instead. If the value was `tax` or `weee_tax`, the taxes will be included or excluded as part of the price in the `ProductPrice` or `FixedProductTax` object, respectively.
+
+The `PriceAdjustment` object defines the amount of money to apply as an adjustment, the type of adjustment to apply, and whether the item is included or excluded from the adjustment.
 
 Attribute |  Data Type | Description
 --- | --- | ---

--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -179,7 +179,7 @@ The following query returns information about the store's catalog configuration.
 
 ### Query a store's fixed product tax configuration
 
-The following query returns enumeration values that indicate the store's fixed product tax configuration,
+The following query returns enumeration values that indicate the store's fixed product tax configuration.
 
 **Request**
 

--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -253,6 +253,26 @@ Attribute |  Data Type | Description | Example
 `product_url_suffix` | String | The suffix applied to product pages, such as `.htm` or `.html` | `.html`
 `title_separator` | String | Identifies the character that separates the category name and subcategory in the browser title bar | `-`
 
+### Supported Weee (fixed product tax) attributes
+
+The **Stores** > Settings > **Configuration** > **Sales** > **Tax** > **Fixed Product Taxes** panel contains several fields that determine how to display fixed product tax (FPT) values and descriptions. Use the following attributes to determine the values of the **Fixed Product Taxes** fields. These attributes are defined in the `WeeeGraphQl` module.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`category_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices In Product Lists** field. It indicates how FPT information is displayed on category pages
+`product_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices On Product View Page** field. It indicates how FPT information is displayed on product pages
+`sales_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices In Sales Modules** field. It indicates how FPT information is displayed on cart, checkout, and order pages
+
+The `FixedProductTaxDisplaySettings` data type is an enumeration that describes whether displayed prices include fixed product taxes and whether Magento separately displays detailed information about the FPTs.
+
+Value | Description
+--- | ---
+EXCLUDE_FPT_WITH_DETAILS | The displayed price does not include the FPT amount. The values of `ProductPrice.fixed_product_taxes` are displayed separately. This value corresponds to **Excluding FPT, Including FPT description and final price**
+EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amount. The values from `ProductPrice.fixed_product_taxes` are not displayed. This value corresponds to **Excluding FPT**
+FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
+INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**
+INCLUDE_FPT_WITHOUT_DETAILS | The displayed price includes the FPT amount without displaying the `ProductPrice.fixed_product_taxes` values. This value corresponds to **Including FPT only**
+
 ## Extend configuration data
 
 You can add your own configuration to the `storeConfig` query within your own module.
@@ -264,13 +284,13 @@ The following example adds an array-item to the `extendedConfigData` array withi
 ```xml
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-	<type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
-		<arguments xsi:type="array">
-			<argument name="extendedConfigData">
-				<item name="section_group_field" xsi:type="string">section/group/field</item>
-			</argument>
-		</arguments>
-	</type>
+  <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+    <arguments xsi:type="array">
+      <argument name="extendedConfigData">
+        <item name="section_group_field" xsi:type="string">section/group/field</item>
+      </argument>
+    </arguments>
+  </type>
 </config>
 ```
 

--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -245,12 +245,13 @@ Attribute |  Data Type | Description | Example
 --- | --- | ---
 `catalog_default_sort_by` | String | The default sort order of the search results list | `position`
 `category_url_suffix` | String | The suffix applied to category pages, such as `.htm` or `.html` | `.html`
-`grid_per_page` | Integer | The default number of products per page in Grid View | `9`
+`grid_per_page` | Int | The default number of products per page in Grid View | `9`
 `grid_per_page_values` | A list of numbers that define how many products can be displayed in List View  | `9,15,30`
 `list_mode` | String  | The format of the search results list | `grid-list`
-`list_per_page` | Integer | The default number of products per page in List View | `10`
+`list_per_page` | Int | The default number of products per page in List View | `10`
 `list_per_page_values` | String | A list of numbers that define how many products can be displayed in List View | `5,10,15,20,25`
 `product_url_suffix` | String | The suffix applied to product pages, such as `.htm` or `.html` | `.html`
+`root_category_id` | Int | The ID of the root category
 `title_separator` | String | Identifies the character that separates the category name and subcategory in the browser title bar | `-`
 
 ### Supported Weee (fixed product tax) attributes

--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -298,7 +298,7 @@ The `FixedProductTaxDisplaySettings` data type is an enumeration that describes 
 
 Value | Description
 --- | ---
-EXCLUDE_FPT_AND_INCLUDE_WITH_DETAILS | The displayed price does not include the FPT amount. The values of `ProductPrice.fixed_product_taxes` and the price including the FPT are displayed separately. This value corresponds to **Excluding FPT, Including FPT description and final price**
+EXCLUDE_FPT_AND_INCLUDE_WITH_DETAILS | The displayed price does not include the FPT amount. You must display the values of `ProductPrice.fixed_product_taxes` and the price including the FPT separately. This value corresponds to **Excluding FPT, Including FPT description and final price**
 EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amount. The values from `ProductPrice.fixed_product_taxes` are not displayed. This value corresponds to **Excluding FPT**
 FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
 INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**

--- a/guides/v2.3/graphql/queries/store-config.md
+++ b/guides/v2.3/graphql/queries/store-config.md
@@ -177,6 +177,36 @@ The following query returns information about the store's catalog configuration.
 }
 ```
 
+### Query a store's fixed product tax configuration
+
+The following query returns enumeration values that indicate the store's fixed product tax configuration,
+
+**Request**
+
+```graphql
+{
+  storeConfig {
+    category_fixed_product_tax_display_setting
+    product_fixed_product_tax_display_setting
+    sales_fixed_product_tax_display_setting
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "data": {
+    "storeConfig": {
+      "category_fixed_product_tax_display_setting": "EXCLUDE_FPT_WITHOUT_DETAILS",
+      "product_fixed_product_tax_display_setting": "EXCLUDE_FPT_AND_INCLUDE_WITH_DETAILS",
+      "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS"
+    }
+  }
+}
+```
+
 ## Output attributes
 
 ### Supported storeConfig attributes
@@ -268,7 +298,7 @@ The `FixedProductTaxDisplaySettings` data type is an enumeration that describes 
 
 Value | Description
 --- | ---
-EXCLUDE_FPT_WITH_DETAILS | The displayed price does not include the FPT amount. The values of `ProductPrice.fixed_product_taxes` are displayed separately. This value corresponds to **Excluding FPT, Including FPT description and final price**
+EXCLUDE_FPT_AND_INCLUDE_WITH_DETAILS | The displayed price does not include the FPT amount. The values of `ProductPrice.fixed_product_taxes` and the price including the FPT are displayed separately. This value corresponds to **Excluding FPT, Including FPT description and final price**
 EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amount. The values from `ProductPrice.fixed_product_taxes` are not displayed. This value corresponds to **Excluding FPT**
 FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
 INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds attributes that support fixed product taxes. It also includes miscellaneous updates for minor schema changes from Community Engineering PRs and linting.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- guides/v2.3/graphql/product/product-interface.md
- guides/v2.3/graphql/queries/store-config.md

whatsnew
Added attributes that support fixed product taxes to the [ProductInterface](https://devdocs.magento.com/guides/v2.3/graphql/product/product-interface.html) and [`storeConfig`](https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html) query.