### PR TITLE
Fixed ordered list prefix (MD029) - Group 14

### DIFF
--- a/_videos/fundamentals/add-a-javascript-module.md
+++ b/_videos/fundamentals/add-a-javascript-module.md
@@ -16,10 +16,10 @@ It will illustrate how Magento 2 works with JavaScript files, executing the code
 The steps we’ll need to take are:
 
 1. Create a new module.
-2. Create a requirejs-config.js and a JavaScript module file.
-3. Create a layout update to add a template that will enable the JavaScript module.
-4. Create a template file.
-5. Add the module and test it.
+1. Create a requirejs-config.js and a JavaScript module file.
+1. Create a layout update to add a template that will enable the JavaScript module.
+1. Create a template file.
+1. Add the module and test it.
 
 Let’s go through each step.
 
@@ -29,7 +29,13 @@ We will create a new module called Learning_Js:
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 mkdir app/code/Learning
+```
+
+```bash
 mkdir app/code/Learning/Js
 ```
 
@@ -70,7 +76,13 @@ Next, we’ll create a view folder:
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 mkdir app/code/Learning/Js/view
+```
+
+```bash
 mkdir app/code/Learning/Js/view/frontend
 ```
 
@@ -94,6 +106,9 @@ Then add the JavaScript module:
 
 ```bash
 mkdir app/code/Learning/Js/view/frontend/web
+```
+
+```bash
 mkdir app/code/Learning/Js/view/frontend/web/js
 ```
 
@@ -121,7 +136,13 @@ First, we need to create the layout folder:
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 mkdir app/code/Learning/Js/view/frontend
+```
+
+```bash
 mkdir app/code/Learning/Js/view/frontend/layout
 ```
 
@@ -148,6 +169,9 @@ Now, we’ll create the template that will enable JavaScript.
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 mkdir app/code/Learning/Js/view/frontend/templates
 ```
 
@@ -180,7 +204,13 @@ Finally, let’s add our module and test the result.
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 bin/magento setup:upgrade
+```
+
+```bash
 bin/magento cache:clean
 ```
 

--- a/_videos/fundamentals/add-a-new-table-to-database.md
+++ b/_videos/fundamentals/add-a-new-table-to-database.md
@@ -18,20 +18,20 @@ The install scripts run only once, while the upgrade scripts are executed every 
 
 To look at all four script types, we’ll complete the following greeting page tasks:
 
-* Create a `greeting_message` table with the columns greeting_id and message.
-* Add two records: “Happy New Year” and “Happy Holidays”.
-* Modify the table by adding another field, “season”, to which we add the records “Happy Thanksgiving” and “Fall'”.
-* Update the types for the first and second records.
+*  Create a `greeting_message` table with the columns greeting_id and message.
+*  Add two records: “Happy New Year” and “Happy Holidays”.
+*  Modify the table by adding another field, “season”, to which we add the records “Happy Thanksgiving” and “Fall'”.
+*  Update the types for the first and second records.
 
 The steps we need to take to accomplish these tasks are:
 
 1. Create a new module.
-2. Create an InstallSchema script.
-3. Create an InstallData script.
-4. Add a new module and verify that a table with the data was created.
-5. Create an UpgradeSchema script.
-6. Create an UpgradeData script.
-7. Run the upgrade scripts and verify that the table has changed.
+1. Create an InstallSchema script.
+1. Create an InstallData script.
+1. Add a new module and verify that a table with the data was created.
+1. Create an UpgradeSchema script.
+1. Create an UpgradeData script.
+1. Run the upgrade scripts and verify that the table has changed.
 
 ## Step 1: Create a new module
 
@@ -41,7 +41,13 @@ Navigate to the `app/code` folder and create the folders `Learning` and `Learnin
 
 ```bash
 cd <magento2_root>/app/code
+```
+
+```bash
 mkdir Learning
+```
+
+```bash
 mkdir Learning/GreetingMessage
 ```
 
@@ -93,6 +99,9 @@ To create an InstallSchema script, navigate to the `app/code/Learning/GreetingMe
 
 ```bash
 cd <magento2_root>/app/code/Learning/GreetingMessage
+```
+
+```bash
 mkdir Setup
 ```
 
@@ -216,6 +225,9 @@ Run the `setup:upgrade` script to verify that a table with the initial data is t
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 php bin/magento setup:upgrade
 ```
 
@@ -380,6 +392,9 @@ Run the SetupUpgrade script again:
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 php bin/magento setup:upgrade
 ```
 

--- a/_videos/fundamentals/add-new-product-attribute.md
+++ b/_videos/fundamentals/add-new-product-attribute.md
@@ -14,18 +14,18 @@ This is quite a broad topic, but in this video we will discuss the simple proces
 
 For this exercise, assume that the sample data set is installed.
 
-* We will add an attribute called clothing_material with the possible values: Cotton, Leather, Silk, Denim, Fur, and Wool.
-* We will make this attribute visible on the product view page, in bold text.
-* We will assign it to the Default attribute set and add a restriction that any “bottom” clothing, like slacks, cannot be the material Fur.
+*  We will add an attribute called clothing_material with the possible values: Cotton, Leather, Silk, Denim, Fur, and Wool.
+*  We will make this attribute visible on the product view page, in bold text.
+*  We will assign it to the Default attribute set and add a restriction that any “bottom” clothing, like slacks, cannot be the material Fur.
 
 We will need to take the following steps to add the new attribute:
 
 1. Create a new module.
-2. Add an InstallData script.
-3. Add a source model.
-4. Add a backend model.
-5. Add a frontend model.
-6. Execute the InstallData script and verify that it works.
+1. Add an InstallData script.
+1. Add a source model.
+1. Add a backend model.
+1. Add a frontend model.
+1. Execute the InstallData script and verify that it works.
 
 Let’s go through each step.
 
@@ -35,7 +35,13 @@ As Magento is modular based, we start the process by creating a new module calle
 
 ```bash
 cd <magento2_root>/app/code
+```
+
+```bash
 mkdir Learning
+```
+
+```bash
 mkdir Learning/ClothingMaterial
 ```
 
@@ -313,6 +319,9 @@ Now we can run our code and check the results:
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 php bin/magento setup:upgrade
 ```
 

--- a/_videos/fundamentals/create-a-new-module.md
+++ b/_videos/fundamentals/create-a-new-module.md
@@ -12,10 +12,10 @@ Module is a structural element of Magento 2 – the whole system is built upon m
 To create a module, you need to complete the following high-level steps:
 
 1. Create the module folder.
-2. Create the `etc/module.xml` file.
-3. Create the `registration.php` file.
-4. Run the `bin/magento setup:upgrade` script to install the new module.
-5. Check that the module is working.
+1. Create the `etc/module.xml` file.
+1. Create the `registration.php` file.
+1. Run the `bin/magento setup:upgrade` script to install the new module.
+1. Check that the module is working.
 
 Let’s go through each of these steps in detail.
 
@@ -36,8 +36,8 @@ Each module name in Magento 2 consists of two parts – the vendor and the modul
 Let’s create the folder app/code/Learning and inside this folder place another folder: FirstUnit. If you're using the command line, the code would be:
 
 1. `cd` to the root folder
-2. `mkdir app/code/Learning`
-3. `mkdir app/code/Learning/FirstUnit`
+1. `mkdir app/code/Learning`
+1. `mkdir app/code/Learning/FirstUnit`
 
 ## Make sure you have permission to create files and folders in your installation
 
@@ -45,9 +45,9 @@ Next, you need to create an `etc/module.xml` file. This file is required for the
 
 This file contains the following information:
 
-* Module name
-* Module version
-* Dependencies
+*  Module name
+*  Module version
+*  Dependencies
 
 Module name is defined by the folders we just created, because in Magento 2, class names must follow the folder structure. Because we created the folders `Learning/FirstUnit`, our module name will be `Learning_FirstUnit` and all classes that belong to this module will begin with `Learning\FirstUnit` – for example: `Learning\FirstUnit\Observer\Test`.
 
@@ -74,9 +74,9 @@ Then put the following code into it:
 
 Note that in the XML file we specified:
 
-* Module name: `Learning_FirstUnit` (based on the folders we created)
-* Version: 0.0.1 (initial version of our module)
-* Dependency: Magento_Catalog. We could have multiple dependencies. In this case, we would put `<module name=”..” />` nodes under the sequence node.
+*  Module name: `Learning_FirstUnit` (based on the folders we created)
+*  Version: 0.0.1 (initial version of our module)
+*  Dependency: Magento_Catalog. We could have multiple dependencies. In this case, we would put `<module name=”..” />` nodes under the sequence node.
 
 ## Create the registration.php file
 

--- a/_videos/fundamentals/create-a-new-page.md
+++ b/_videos/fundamentals/create-a-new-page.md
@@ -6,29 +6,30 @@ title: "Create a New Page"
 thumbnail: "fundamentals/thumbs/create-new-page.png"
 menu_order: 1
 ---
+
 In this video on how to create a new page, we’ll create a page which returns JSON with one parameter: the message “HELLO WORLD!”
 
 To add a new page in Magento 2, you need to create a new controller. In Magento 2, a controller is a file located at a specific place which responds to a specific route. A route in Magento 2 is a standard URL that consists of three parts:
 
-* frontName
-* controllerName
-* actionName
+*  frontName
+*  controllerName
+*  actionName
 
 We’ll look at how those three parts of a route correspond to a certain file.
 
 So the steps we need to take to add a new page are:
 
 1. Create a new module.
-2. Add a routes.xml file.
-3. Add a controller (action) file.
+1. Add a routes.xml file.
+1. Add a controller (action) file.
 
 To create a module, you need to complete the following high-level steps:
 
 1. Create the module folder.
-2. Create the etc/module.xml file.
-3. Create the registration.php file.
-4. Run the “bin/magento setup:upgrade” script to install the new module.
-5. Check that the module is working.
+1. Create the etc/module.xml file.
+1. Create the registration.php file.
+1. Run the “bin/magento setup:upgrade” script to install the new module.
+1. Check that the module is working.
 
 Let’s go through each step.
 
@@ -38,7 +39,13 @@ We will create a new module called `Learning_HelloPage`
 
 ```bash
 cd <magento2_root>/app/code
+```
+
+```bash
 mkdir Learning
+```
+
+```bash
 mkdir Learning/HelloPage
 ```
 
@@ -50,6 +57,7 @@ Learning/HelloPage/etc/module.xml
 ```
 
 ### registration.php
+
 ```php
 <?php /**
 * Copyright © 2016 Magento. All rights reserved. * See COPYING.txt for license details.
@@ -60,6 +68,7 @@ __DIR__
 ```
 
 ### module.xml
+
 ```xml
 <?xml version="1.0"?>
 <!--
@@ -108,7 +117,13 @@ Let’s add the controller now.
 
 ```bash
 cd <magento2_root>/app/code/Learning/HelloPage
+```
+
+```bash
 mkdir Controller
+```
+
+```bash
 mkdir Controller/Page
 ```
 
@@ -155,6 +170,9 @@ Note we created a JSON-type page. This can be seen in the results factory that w
 
 ```bash
 cd <magento2_root>
+```
+
+```bash
 php bin/magento setup:upgrade
 ```
 

--- a/guides/v2.2/advanced-reporting/overview.md
+++ b/guides/v2.2/advanced-reporting/overview.md
@@ -11,11 +11,11 @@ Magento collects data and sends this information to the MBI for analytics.
 ## Prerequisites
 
 1. The website must run on a public web server.
-2. The domain must have a valid security (SSL) certificate.
-3. Magento must have been installed or upgraded successfully without error.
-4. In the Magento configuration, the [Base URL (Secure) setting][base url]{:target="_blank"} for the store view must point to the secure URL. For example https://yourdomain.com.
-5. In the Magento configuration, **Use Secure URLs on Storefront**, **and Use Secure URLs in Admin** must be set to **Yes**.
-6. Make sure that [Magento crontab]{:target="_blank"} is created and cron jobs are running on the installed server.
+1. The domain must have a valid security (SSL) certificate.
+1. Magento must have been installed or upgraded successfully without error.
+1. In the Magento configuration, the [Base URL (Secure) setting][base url]{:target="_blank"} for the store view must point to the secure URL. For example https://yourdomain.com.
+1. In the Magento configuration, **Use Secure URLs on Storefront**, **and Use Secure URLs in Admin** must be set to **Yes**.
+1. Make sure that [Magento crontab]{:target="_blank"} is created and cron jobs are running on the installed server.
 
 The merchant can now click on the Go to Advanced Reporting button on the Admin dashboard to launch the advanced reporting features at `https://advancedreporting.rjmetrics.com/report`.
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_depend.md
@@ -10,13 +10,13 @@ A *software dependency* identifies  one software component's reliance on another
 
 Each Magento [module](https://glossary.magento.com/module) is responsible for a unique feature. In practice, this means that:
 
-* Several modules cannot be responsible for one feature.
+*  Several modules cannot be responsible for one feature.
 
-* One module cannot be responsible for several features.
+*  One module cannot be responsible for several features.
 
-* Module dependencies on other modules must be declared explicitly. You must also declare any dependency upon other components (for example, a theme, language package, or library).
+*  Module dependencies on other modules must be declared explicitly. You must also declare any dependency upon other components (for example, a theme, language package, or library).
 
-* Removing or disabling a module does not result in disabling other modules.
+*  Removing or disabling a module does not result in disabling other modules.
 
 ## Two types of dependencies {#m2devgde-moddep-declare-dep}
 
@@ -26,10 +26,10 @@ There are two types of Magento [module](https://glossary.magento.com/module) dep
 
 A module with a *hard dependency* on another module cannot function without the module it depends on. These modules:
 
-* Contain code that directly uses logic from another module, such as class constants, static methods, public class properties, interfaces, and traits.
-* Contain strings that include class names, method names, class constants, class properties, interfaces, and traits from another module.
-* Deserializes an object declared in another module.
-* Uses or modifies the database tables used by another module.
+*  Contain code that directly uses logic from another module, such as class constants, static methods, public class properties, interfaces, and traits.
+*  Contain strings that include class names, method names, class constants, class properties, interfaces, and traits from another module.
+*  Deserializes an object declared in another module.
+*  Uses or modifies the database tables used by another module.
 
 The `require` section of `app/code/<Vendor>/<Module>/composer.json` file contains hard dependency definitions for the module. For example:
 
@@ -53,9 +53,9 @@ The `require` section of `app/code/<Vendor>/<Module>/composer.json` file contain
 
 A module with a *soft dependency* on another module can function properly without the other module, even if it has a dependency on the other module. These modules:
 
-* Directly check another module's availability.
-* Extend another module's configuration.
-* Extend another module's [layout](https://glossary.magento.com/layout).
+*  Directly check another module's availability.
+*  Extend another module's configuration.
+*  Extend another module's [layout](https://glossary.magento.com/layout).
 
 The `<sequence>` section of `app/code/<Vendor>/<Module>/etc/module.xml` file contains soft dependency definitions for the module. For example:
 
@@ -77,17 +77,17 @@ If a module uses code from another module, it should declare the dependency expl
 Magento installs modules in the following order:
 
 1. The module serving as a dependency for another module
-2. The module dependent on it
+1. The module dependent on it
 
 ## Appropriate dependencies
 
 Although Magento architecture favors loosely coupled software components, modules can contain dependencies upon these software components:
 
-* other modules
+*  other modules
 
-* [PHP](https://glossary.magento.com/php) extensions
+*  [PHP](https://glossary.magento.com/php) extensions
 
-* libraries (either Magento Framework [library](https://glossary.magento.com/library) or third party libraries)
+*  libraries (either Magento Framework [library](https://glossary.magento.com/library) or third party libraries)
 
 {:.bs-callout .bs-callout-tip}
 Note: You can lose the historical information contained in a module if the module is removed or disabled. We recommend alternative storage of module information before you remove or disable a module.
@@ -96,9 +96,9 @@ Note: You can lose the historical information contained in a module if the modul
 
 Avoid creating these dependencies:
 
-* Circular (both direct and indirect)
-* Undeclared
-* Incorrect
+*  Circular (both direct and indirect)
+*  Undeclared
+*  Incorrect
 
 ## Dependencies between modules in different presentation layers {#m2devgde-moddep-diff-layer}
 
@@ -123,9 +123,9 @@ At a high level, there are three main steps for managing module dependencies:
 
 1. Name and declare the module in the `module.xml` file.
 
-2. Declare any dependencies that the module has (whether on other modules or on a different component) in the module's `composer.json` file.
+1. Declare any dependencies that the module has (whether on other modules or on a different component) in the module's `composer.json` file.
 
-3. (*Optional*) Define the desired load order of config files and `.css` files in the `module.xml` file.
+1. (*Optional*) Define the desired load order of config files and `.css` files in the `module.xml` file.
 
 Example: Module A declares a dependency upon Module B. Thus, in Module A's `module.xml` file, Module B is listed in the `<sequence>` list, so that B's files are loaded before A's. Additionally, you must declare a dependency upon Module B in A's `composer.json` file. Furthermore, in the [deployment configuration]({{page.baseurl}}/config-guide/config/config-php.html), Modules A and B must both be defined as enabled.
 

--- a/guides/v2.3/architecture/archi_perspectives/webapi-vision.md
+++ b/guides/v2.3/architecture/archi_perspectives/webapi-vision.md
@@ -65,7 +65,7 @@ To extend an interface, use [extension attributes]({{ page.baseurl }}/extension-
 
 1. Add a `schema.graphqls` file to the `<ModuleName>GraphQl` module. Magento merges this file with configurations from other modules using the same merge rules as other types of configuration.
 
-2. Write any necessary plugins for existing resolvers related to the query, or create a custom resolver and enable it via override in `schema.graphqls`
+1. Write any necessary plugins for existing resolvers related to the query, or create a custom resolver and enable it via override in `schema.graphqls`
 
 ## Model Consistency Constraints
 
@@ -78,8 +78,8 @@ Any new design related to Web API must satisfy the following constraints to keep
 1. Authentication must be done via `\Magento\Authorization\Model\UserContextInterface`.
 1. Customer-specific identifiers (such as customer ID or cart ID) must be deducted from the record of the successfully authenticated customer. They must not be accepted via request parameters.
 1. All new web API endpoints must be covered with web API functional tests.
-    * For REST and SOAP, by default, the same test will be executed in the scope of different continuous integration jobs. The base class for REST and SOAP tests is `\Magento\TestFramework\TestCase\WebapiAbstract`
-    * The base class for GraphQL tests is: `\Magento\TestFramework\TestCase\GraphQlAbstract`
+    *  For REST and SOAP, by default, the same test will be executed in the scope of different continuous integration jobs. The base class for REST and SOAP tests is `\Magento\TestFramework\TestCase\WebapiAbstract`
+    *  The base class for GraphQL tests is: `\Magento\TestFramework\TestCase\GraphQlAbstract`
 1. Web API requests must be processed by custom front controllers with optimized routing to prevent the admin and storefront areas from executing routers.
 1. Web API schema should be strictly typed. (All complex types should eventually be resolved to scalar types.)
 1. Authentication parameters must be passed via headers.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all remaining MD029 errors in the following guides (except includes):

- Advanced Reporting
- Architecture
- Videos

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.