### PR TITLE
Fixed ordered list prefix (MD029) - Group 15

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -14,8 +14,8 @@ about: Create an issue about a bug on the devdocs website
 <!-- (OPTIONAL) What needs to be done to replicate this issue? (provide Gist if needed) -->
 
 1. First Step
-2. Second Step
-3. Etc.
+1. Second Step
+1. Etc.
 
 ## Expected result
 

--- a/_includes/comp-man/backup.md
+++ b/_includes/comp-man/backup.md
@@ -22,7 +22,7 @@ To back up:
    {:.bs-callout .bs-callout-info}
    We strongly recommend you <em>do</em> back up in the event of issues.
 
-2. Wait while backups are created and continue with any of the following:
+1. Wait while backups are created and continue with any of the following:
 
 The following page displays to confirm a successful backup.
 

--- a/_includes/config/multi-site_verify.md
+++ b/_includes/config/multi-site_verify.md
@@ -1,15 +1,20 @@
 Unless you have DNS set up for your stores' URLs, you must add a static route to the host in your `hosts` file:
 
 1. Locate your operating system's [`hosts` file](https://en.wikipedia.org/wiki/Hosts_(file)#Location_in_the_file_system).
-2. Add the static route in the format:
+1. Add the static route in the format:
 
-        <ip address> french.mysite.mg
-        <ip address> german.mysite.mg
-3. Go to one of the following URLs in your browser:
+   ```conf
+   <ip address> french.mysite.mg
+   <ip address> german.mysite.mg
+   ```
 
-        http://mysite.mg/admin
-        http://french.mysite.mg/frenchstoreview
-        http://german.mysite.mg/germanstoreview
+1. Go to one of the following URLs in your browser:
+
+   ```http
+   http://mysite.mg/admin
+   http://french.mysite.mg/frenchstoreview
+   http://german.mysite.mg/germanstoreview
+   ```
 
 You're done!
 

--- a/_includes/config/secure-ws-apache_step1.md
+++ b/_includes/config/secure-ws-apache_step1.md
@@ -12,7 +12,7 @@ First, see if you have the Apache `htpasswd` utility is installed as follows:
 
    If a path displays, it is installed; if the command returns no output, `htpasswd` is not installed.
 
-2. If necessary, install `htpasswd`:
+1. If necessary, install `htpasswd`:
 
    *  Ubuntu: `apt-get -y install apache2-utils`
    *  CentOS: `yum -y install httpd-tools`

--- a/_includes/config/split-db.md
+++ b/_includes/config/split-db.md
@@ -3,14 +3,14 @@
 Create checkout and OMS master databases as follows:
 
 1. Log in to your database server as any user.
-2. Enter the following command to get to a MySQL command prompt:
+1. Enter the following command to get to a MySQL command prompt:
 
    ```bash
    mysql -u root -p
    ```
 
-3. Enter the MySQL `root` user's password when prompted.
-4. Enter the following commands in the order shown to create database instances named `magento_quote` and `magento_sales` with the same usernames and passwords:
+1. Enter the MySQL `root` user's password when prompted.
+1. Enter the following commands in the order shown to create database instances named `magento_quote` and `magento_sales` with the same usernames and passwords:
 
    ```shell
    create database magento_quote;
@@ -28,9 +28,9 @@ Create checkout and OMS master databases as follows:
    GRANT ALL ON magento_sales.* TO magento_sales@localhost IDENTIFIED BY 'magento_sales';
    ```
 
-5. Enter `exit` to quit the command prompt.
+1. Enter `exit` to quit the command prompt.
 
-6. Verify the databases, one at a time:
+1. Verify the databases, one at a time:
 
    Checkout database:
 

--- a/_includes/config/split-deploy/example_build-sync.md
+++ b/_includes/config/split-deploy/example_build-sync.md
@@ -1,8 +1,8 @@
 To update your build system:
 
 1. Log in to your build system as, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
-2. Change to the build system's Magento root directory.
-3. Pull the changes to `app/etc/config.php` from source control.
+1. Change to the build system's Magento root directory.
+1. Pull the changes to `app/etc/config.php` from source control.
 
    The Git command follows:
 
@@ -10,19 +10,19 @@ To update your build system:
    git pull mconfig m2.2_deploy
    ```
 
-4. Compile code:
+1. Compile code:
 
    ```bash
    php bin/magento setup:di:compile
    ```
 
-5. After code has been compiled, generate static view files:
+1. After code has been compiled, generate static view files:
 
    ```bash
    php bin/magento setup:static-content:deploy -f
    ```
 
-6. Check the changes into source control.
+1. Check the changes into source control.
 
    The Git command follows:
 

--- a/_includes/design/icon-fonts.md
+++ b/_includes/design/icon-fonts.md
@@ -2,8 +2,8 @@ If you want to add your own icons, each icon will need to be in its own SVG file
 
 1. Go to [https://icomoon.io/app/](https://icomoon.io/app/) or download this app in Chrome web store.
 
-2. Upload your icons in SVG format into the app.
+1. Upload your icons in SVG format into the app.
 
-3. Specify desired font names and specify the Unicode characters to map the icons. Setting the icons to Private User Area will disable screen-readers or other accessibility tools to read your icon's characters (read "Unicode" section here).
+1. Specify desired font names and specify the Unicode characters to map the icons. Setting the icons to Private User Area will disable screen-readers or other accessibility tools to read your icon's characters (read "Unicode" section here).
 
-4. Then initialize a download in the app to generate the icon font and [CSS](https://glossary.magento.com/css) style sheet.
+1. Then initialize a download in the app to generate the icon font and [CSS](https://glossary.magento.com/css) style sheet.

--- a/_includes/install/allowoverrides22.md
+++ b/_includes/install/allowoverrides22.md
@@ -10,40 +10,40 @@ Failure to enable these settings typically results in no styles displaying on yo
    *  Ubuntu: `vim /etc/apache2/sites-available/default`
    *  CentOS: `vim /etc/httpd/conf/httpd.conf`
 
-2. Locate the block that starts with:
+1. Locate the block that starts with:
 
    *  Ubuntu 12: `<Directory /var/www/>`
    *  Ubuntu 14 or CentOS: `<Directory /var/www/html>`
 
-3. Change the value of `AllowOverride` to `<value from Apache site>`.
+1. Change the value of `AllowOverride` to `<value from Apache site>`.
 
-    An example for Ubuntu 12 follows.
+   An example for Ubuntu 12 follows.
 
-    ```conf
-    <Directory /var/www/>
-    Options Indexes FollowSymLinks MultiViews
-    AllowOverride <value from Apache site>
-    Order allow,deny
-    Allow from all
-    <Directory>
-    ```
+   ```conf
+   <Directory /var/www/>
+   Options Indexes FollowSymLinks MultiViews
+   AllowOverride <value from Apache site>
+   Order allow,deny
+   Allow from all
+   <Directory>
+   ```
 
    {:.bs-callout .bs-callout-info}
    The preceding values for `Order` might not work in all cases. For more information, see the Apache documentation ([2.2](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order)), [2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_host.html#order)).
 
-4. Save the file and exit the text editor.
-5. *Ubuntu only*. Configure Apache to use the `mod_rewrite` module.
+1. Save the file and exit the text editor.
+1. *Ubuntu only*. Configure Apache to use the `mod_rewrite` module.
 
-    ```bash
-    cd /etc/apache2/mods-enabled
-    ```
+   ```bash
+   cd /etc/apache2/mods-enabled
+   ```
 
-    ```bash
-    ln -s ../mods-available/rewrite.load
-    ```
+   ```bash
+   ln -s ../mods-available/rewrite.load
+   ```
 
-6. If you changed Apache settings, restart Apache.
+1. If you changed Apache settings, restart Apache.
 
-    ```bash
-    service apache2 restart
-    ```
+   ```bash
+   service apache2 restart
+   ```

--- a/_includes/install/auth-json.md
+++ b/_includes/install/auth-json.md
@@ -21,7 +21,7 @@ When choosing token permissions, select all checkboxes in the `repo` scope. Comp
 ### Create `auth.json` file
 
 1. Log in to your Magento server as the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. Create the `auth.json` file in the user's home directory. For example, if `magento_user` is your Unix username, then create `/home/magento_user/.composer/auth.json`.
+1. Create the `auth.json` file in the user's home directory. For example, if `magento_user` is your Unix username, then create `/home/magento_user/.composer/auth.json`.
 
 ### Edit `auth.json` file
 

--- a/_includes/install/auth-tokens-get.md
+++ b/_includes/install/auth-tokens-get.md
@@ -3,15 +3,15 @@ The `repo.magento.com` repository is where Magento 2 and third-party Composer pa
 To create authentication keys:
 
 1. Log in to the [Magento Marketplace](https://marketplace.magento.com){:target="_blank"}. If you don't have an account, click **Register**.
-2. Click your account name in the top-right of the page and select **My Profile**.
+1. Click your account name in the top-right of the page and select **My Profile**.
 
-3. Click **Access Keys** in the Marketplace tab.
+1. Click **Access Keys** in the Marketplace tab.
 
    ![Get your secure access keys on Magento Marketplace]({{ site.baseurl }}/common/images/cloud_access-key.png){:width="500px"}
 
-4. Click **Create a New Access Key**. Enter a specific name for the keys (e.g., the name of the developer receiving the keys) and click **OK**.
+1. Click **Create a New Access Key**. Enter a specific name for the keys (e.g., the name of the developer receiving the keys) and click **OK**.
 
-5. New public and private keys are now associated with your account that you can click to copy. Save this information or keep the page open when working with your Magento project. Use the **Public key** as your username and the **Private key** as your password.
+1. New public and private keys are now associated with your account that you can click to copy. Save this information or keep the page open when working with your Magento project. Use the **Public key** as your username and the **Private key** as your password.
 
 ### Manage your authentication keys
 
@@ -24,9 +24,9 @@ You can also disable or delete authentication keys. For example, you can disable
 You cannot delete or disable keys you created by signing in to your [magento.com account](https://www.magentocommerce.com/products/customer/account/login){:target="_blank"}. To manage those keys:
 
 1. Log in to your [magento.com account](https://www.magentocommerce.com/products/customer/account/login){:target="_blank"}.
-2. Click **My Account** at the top of the page.
-3. Click **Account Settings** > **Downloads Access Token**.
+1. Click **My Account** at the top of the page.
+1. Click **Account Settings** > **Downloads Access Token**.
 
    ![Access your keys]({{ site.baseurl }}/common/images/connect_keys1.png){:width="200px"}
 
-4. Click **Generate new token** to replace and disable an existing token.
+1. Click **Generate new token** to replace and disable an existing token.

--- a/_includes/install/composer-clone.md
+++ b/_includes/install/composer-clone.md
@@ -13,14 +13,14 @@ To install Composer:
 
 1. Change to or create an empty directory on your Magento server.
 
-2. Enter the following commands:
+1. Enter the following commands:
 
-    ```bash
-    curl -sS https://getcomposer.org/installer | php
-    ```
+   ```bash
+   curl -sS https://getcomposer.org/installer | php
+   ```
 
-    ```bash
-    mv composer.phar /usr/local/bin/composer
-    ```
+   ```bash
+   mv composer.phar /usr/local/bin/composer
+   ```
 
 For additional installation options, see the [Composer installation documentation](https://getcomposer.org/download/).

--- a/_includes/install/file-system-umask.md
+++ b/_includes/install/file-system-umask.md
@@ -7,25 +7,25 @@ We recommend changing the umask on a one-user or shared hosting system only. If 
 
 The default umask (with no `magento_umask` specified) is `002`, which means:
 
-* 775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
+*  775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
 
-* 664 for files, which means writable by the user, writable by the group, and read-only for everyone else
+*  664 for files, which means writable by the user, writable by the group, and read-only for everyone else
 
 A common suggestion is to use a value of `022` in the `magento_umask` file, which means:
 
-* 755 for directories: full control for the user, and everyone else can traverse directories.
-* 644 for files: read-write permissions for the user, and read-only for everyone else.
+*  755 for directories: full control for the user, and everyone else can traverse directories.
+*  644 for files: read-write permissions for the user, and read-only for everyone else.
 
 To set `magento_umask`:
 
 1. In a command line terminal, log in to your Magento server as a [Magento file system owner][].
-2. Navigate to the Magento install directory:
+1. Navigate to the Magento install directory:
 
    ```bash
    cd <Magento install directory>
    ```
 
-3. Use the following command to create a file named `magento_umask` and write the `umask` value to it.
+1. Use the following command to create a file named `magento_umask` and write the `umask` value to it.
 
    ```bash
    echo <desired umask number> > magento_umask
@@ -33,7 +33,7 @@ To set `magento_umask`:
 
    You should now have a file named `magento_umask` in the `<Magento install dir>` with the only content being the `umask` number.
 
-4. Log out and log back in as the [Magento file system owner][] to apply the changes.
+1. Log out and log back in as the [Magento file system owner][] to apply the changes.
 
 <!-- Link Definitions -->
 

--- a/_includes/install/flow-diagram.md
+++ b/_includes/install/flow-diagram.md
@@ -9,7 +9,7 @@ The diagram shows the following:
    *  [2.2.x system requirements]({{ site.gdeurl22 }}install-gde/system-requirements-tech.html)
    *  [2.3.x system requirements]({{ site.gdeurl23 }}install-gde/system-requirements-tech.html)
 
-2. Get the Magento software.
+1. Get the Magento software.
 
    *  For simplicity, get a compressed {{site.data.var.ce}} or {{site.data.var.ee}} [archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html), extract it on your Magento server, and start your installation.
 
@@ -20,7 +20,7 @@ The diagram shows the following:
    {:.bs-callout .bs-callout-info}
    To be able to use the Web Setup Wizard to install or upgrade the Magento software, or to manage extensions you get from Magento Marketplace, you must either get a compressed archive or a Composer metapackage. If you clone the GitHub repository, you *cannot* use the Web Setup Wizard to upgrade the Magento software and extensions. You must upgrade using [Composer and Git commands]({{ page.baseurl }}/install-gde/install/cli/dev_options.html).
 
-3. Install the Magento software using either the Web Setup Wizard or command line.
+1. Install the Magento software using either the Web Setup Wizard or command line.
 
    For simplicity, only the Web Setup Wizard is shown in the diagram.
 
@@ -28,4 +28,4 @@ The diagram shows the following:
 
    If the step fails because prerequisite software isn't set up correctly, review our [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
 
-4. Verify the installation by viewing your storefront and the Magento Admin.
+1. Verify the installation by viewing your storefront and the Magento Admin.

--- a/_includes/install/releasenotes/ce_install_20.md
+++ b/_includes/install/releasenotes/ce_install_20.md
@@ -35,7 +35,7 @@ composer create-project --repository=https://repo.magento.com/ magento/project-c
 After you get the Open Source software:
 
 1. [Set file system ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
-2. Install the Magento software:
+1. Install the Magento software:
 
    *  [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
    *  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)

--- a/_includes/install/releasenotes/ee_install_20.md
+++ b/_includes/install/releasenotes/ee_install_20.md
@@ -35,7 +35,7 @@ composer create-project --repository=https://repo.magento.com/ magento/project-e
 After you get the Commerce software:
 
 1. [Set file system ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
-2. Install the Magento software:
+1. Install the Magento software:
 
    *  [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
    *  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)

--- a/_includes/install/releasenotes/get-ce-software_zip.md
+++ b/_includes/install/releasenotes/get-ce-software_zip.md
@@ -11,7 +11,7 @@ Archives are available in the following formats: `.zip`, `.tar.bz2`, `.tar.gz`
 To get the Magento Open Source software archive:
 
 1. Go to [http://magento.com/download](http://magento.com/download){:target="_blank"}.
-2. Choose either the software or the software and sample data:
+1. Choose either the software or the software and sample data:
 
    *  `Magento-CE-<version>.*` (without sample data)
    *  `Magento-CE-<version>+Samples.*` (with sample data)

--- a/_includes/install/sampledata/sample-data-clone.md
+++ b/_includes/install/sampledata/sample-data-clone.md
@@ -15,128 +15,132 @@ You can use sample data with either the `develop` branch (more current) or a rel
 
 See the following sections:
 
-* [Clone the sample data repository](#clone-sample-repo)
-* [Set file system ownership and permissions](#samp-data-perms)
+*  [Clone the sample data repository](#clone-sample-repo)
+*  [Set file system ownership and permissions](#samp-data-perms)
 
 ## Clone the sample data repository {#clone-sample-repo}
 
 This section discusses how to install Magento sample data by cloning the sample data repository. You can clone the sample data repository in any of the following ways:
 
-* Clone with the [SSH protocol](#clone-sample-repo-ssh)
-* Clone with the [HTTPS protocol](#instgde-prereq-compose-clone-https)
+*  Clone with the [SSH protocol](#clone-sample-repo-ssh)
+*  Clone with the [HTTPS protocol](#instgde-prereq-compose-clone-https)
 
 ### Clone with SSH {#clone-sample-repo-ssh}
 
 To clone the Magento sample data GitHub repository using the SSH protocol:
 
 1. In a web browser, go to [the Magento sample data repository](https://github.com/magento/magento2-sample-data).
-2. Next to the name of the branch, click **SSH** from the list.
-3. Click **Copy to clipboard**
+1. Next to the name of the branch, click **SSH** from the list.
+1. Click **Copy to clipboard**
 
-    The following figure shows an example.
+   The following figure shows an example.
 
-    ![Clone the Magento GitHub repository using SSH]({{ site.baseurl }}/common/images/install_mage2_clone-ssh.png){:width="650px"}
-4. Change to your web server's docroot directory.
+   ![Clone the Magento GitHub repository using SSH]({{ site.baseurl }}/common/images/install_mage2_clone-ssh.png){:width="650px"}
 
-    Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
+1. Change to your web server's docroot directory.
 
-    Need [help locating the docroot?]({{ page.baseurl }}/install-gde/basics/basics_docroot.html)
-5. Enter `git clone` and paste the value you obtained from step 1.
+   Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
 
-    An example follows:
+   Need [help locating the docroot?]({{ page.baseurl }}/install-gde/basics/basics_docroot.html)
 
-    ```bash
-    git clone git@github.com:magento/magento2-sample-data.git
-    ```
+1. Enter `git clone` and paste the value you obtained from step 1.
 
-6. Wait for the repository to clone on your server.
+   An example follows:
 
-    {:.bs-callout .bs-callout-info}
-    If the following error displays, make sure you [shared your SSH key](https://help.github.com/articles/generating-ssh-keys/) with GitHub:<br>
+   ```bash
+   git clone git@github.com:magento/magento2-sample-data.git
+   ```
 
-    ```terminal
-    Cloning into 'magento2'...
-    Permission denied (publickey).
-    fatal: The remote end hung up unexpectedly
-    ```
+1. Wait for the repository to clone on your server.
 
-7. Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
+   {:.bs-callout .bs-callout-info}
+   If the following error displays, make sure you [shared your SSH key](https://help.github.com/articles/generating-ssh-keys/) with GitHub:<br>
 
-    For example:
+   ```terminal
+   Cloning into 'magento2'...
+   Permission denied (publickey).
+   fatal: The remote end hung up unexpectedly
+   ```
 
-    If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
+1. Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
 
-    If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
+   For example:
 
-    To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
+   If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
 
-    ```bash
-    git checkout 2.2.5
-    ```
+   If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
 
-8. Change to `<magento_root>`.
-9. Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
+   To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
 
-    ```bash
-    php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="<path_to_your_magento_instance>"
-    ```
+   ```bash
+   git checkout 2.2.5
+   ```
 
-10. Wait for the command to complete.
+1. Change to `<magento_root>`.
+1. Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
 
-11. See [Set file system permissions and ownership](#samp-data-perms).
+   ```bash
+   php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="<path_to_your_magento_instance>"
+   ```
+
+1. Wait for the command to complete.
+
+1. See [Set file system permissions and ownership](#samp-data-perms).
 
 ### Clone with HTTPS {#instgde-prereq-compose-clone-https}
 
 To clone the Magento sample data GitHub repository using the HTTPS protocol:
 
 1. In a web browser, go to [the Magento sample data repository](https://github.com/magento/magento2-sample-data).
-2. On the right side of the page, under the **clone URL** field, click **HTTPS**.
-3. Click **Copy to clipboard**.
+1. On the right side of the page, under the **clone URL** field, click **HTTPS**.
+1. Click **Copy to clipboard**.
 
-    The following figure shows an example.
+   The following figure shows an example.
 
-    ![Clone the Magento GitHub repository using HTTPS]({{ site.baseurl }}/common/images/install_mage2_clone-https.png){:width="650px"}
-4. Change to your web server's docroot directory.
+   ![Clone the Magento GitHub repository using HTTPS]({{ site.baseurl }}/common/images/install_mage2_clone-https.png){:width="650px"}
 
-    Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
-5. Enter `git clone` and paste the value you obtained from step 1.
+1. Change to your web server's docroot directory.
 
-    An example follows:
+   Typically, for Ubuntu, it's `/var/www` and for CentOS it's `/var/www/html`.
 
-    ```bash
-    git clone https://github.com/magento/magento2-sample-data.git
-    ```
+1. Enter `git clone` and paste the value you obtained from step 1.
 
-6. Wait for the repository to clone on your server.
-7. Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
+   An example follows:
 
-    For example:
+   ```bash
+   git clone https://github.com/magento/magento2-sample-data.git
+   ```
 
-    If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
+1. Wait for the repository to clone on your server.
+1. Ensure you checkout the branch of the sample data repository that corresponds with the branch you used from the main `magento2` repository.
 
-    If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
+   For example:
 
-    To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
+   If you used the `2.2-develop` branch of the Magento 2 repository, the Sample Data branch should be `2.2-develop`.
 
-    ```bash
-    git checkout 2.2.5
-    ```
+   If you used the `2.2.5` branch of the Magento 2 repository, the Sample Data branch should be `2.2.5`.
 
-8. Change to `<magento_root>`.
-9. Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
+   To checkout the correct branch, run the following command from the sample data repository's root directory (assuming you need the `2.2.5` branch):
 
-    ```bash
-    php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="<path_to_your_magento_instance>"
-    ```
+   ```bash
+   git checkout 2.2.5
+   ```
 
-    For example,
+1. Change to `<magento_root>`.
+1. Enter the following command to create symbolic links between the files you just cloned so sample data works properly:
 
-    ```bash
-    php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="/var/www/magento2"
-    ```
+   ```bash
+   php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="<path_to_your_magento_instance>"
+   ```
 
-10. Wait for the command to complete.
-11. See the next section.
+   For example,
+
+   ```bash
+   php -f <sample-data_clone_dir>/dev/tools/build-sample-data.php -- --ce-source="/var/www/magento2"
+   ```
+
+1. Wait for the command to complete.
+1. See the next section.
 
 {:.bs-callout .bs-callout-warning}
 If you're installing sample data _after_ installing Magento, you must also run the following command to update the database and schema:
@@ -152,33 +156,33 @@ Because the `php build-sample-data.php` script creates symlinks between the samp
 To set file system permissions and ownership on the sample data repository:
 
 1. Change to your sample data clone directory.
-2. Set ownership:
+1. Set ownership:
 
-    ```bash
-    chown -R :<your web server group name> .
-    ```
+   ```bash
+   chown -R :<your web server group name> .
+   ```
 
-    Typical examples:
+   Typical examples:
 
-    CentOS: `chown -R :apache .`
+   *  CentOS: `chown -R :apache .`
 
-    Ubuntu: `chown -R :www-data .`
+   *  Ubuntu: `chown -R :www-data .`
 
-3. Set permissions:
+1. Set permissions:
 
-    ```bash
-    find . -type d -exec chmod g+ws {} +
-    ```
+   ```bash
+   find . -type d -exec chmod g+ws {} +
+   ```
 
-4. Clear static files:
+1. Clear static files:
 
-    ```bash
-    cd <your {{site.data.var.ce}} install dir>/var
-    ```
+   ```bash
+   cd <your {{site.data.var.ce}} install dir>/var
+   ```
 
-    ```bash
-    rm -rf cache/* page_cache/* generation/*
-    ```
+   ```bash
+   rm -rf cache/* page_cache/* generation/*
+   ```
 
 <!-- ABBREVIATIONS -->
 

--- a/_includes/install/sampledata/sample-data-rc1-web.md
+++ b/_includes/install/sampledata/sample-data-rc1-web.md
@@ -10,23 +10,23 @@ To upgrade to {{site.data.var.ee}} RC1 or RC2 with sample data using the Setup W
 {% collapsible Click to expand/collapse content %}
 
 1. Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. Change to the Magento installation directory.
-3. Open `composer.lock` in a text editor.
-4. Change the following:
+1. Change to the Magento installation directory.
+1. Open `composer.lock` in a text editor.
+1. Change the following:
 
-    From:
+   From:
 
-    ```json
-    "type": "magento2-module-customer-balance"
-    ```
+   ```json
+   "type": "magento2-module-customer-balance"
+   ```
 
-    To:
+   To:
 
-    ```json
-    "type": "magento2-module"
-    ```
+   ```json
+   "type": "magento2-module"
+   ```
 
-5. Save your changes to `composer.lock` and exit the text editor.
+1. Save your changes to `composer.lock` and exit the text editor.
 
 {% include install/sampledata/file-sys-perms-digest.md %}
 

--- a/_includes/install/trouble/rc_cron.md
+++ b/_includes/install/trouble/rc_cron.md
@@ -6,7 +6,7 @@ This section discusses how to see if cron is currently running and to verify whe
 To verify whether or not your crontab is set up:
 
 1. Log in to your Magento server as, or switch to, the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. See if the following file exists:
+1. See if the following file exists:
 
    ```bash
    ls -al <magento_root>/var/.setup_cronjob_status
@@ -14,7 +14,7 @@ To verify whether or not your crontab is set up:
 
    If the file exists, cron has run successfully in the past. If the file _does not_ exist, either you haven't yet installed Magento or cron isn't running. In either case, continue with the next step.
 
-3. Get more detail about cron.
+1. Get more detail about cron.
 
    As a user with `root` privileges, enter the following command:
 

--- a/_includes/install/ulimit.md
+++ b/_includes/install/ulimit.md
@@ -26,14 +26,14 @@ The syntax for `ulimit` depends on the UNIX shell you use. The preceding setting
 To optionally set the value in the user's Bash shell:
 
 1. If you haven't done so already, switch to the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
-2. Open `/home/<username>/.bashrc` in a text editor.
-3. Add the following line:
+1. Open `/home/<username>/.bashrc` in a text editor.
+1. Add the following line:
 
    ```bash
    ulimit -s 65536
    ```
 
-4. Save your changes to `.bashrc` and exit the text editor.
+1. Save your changes to `.bashrc` and exit the text editor.
 
 {:.bs-callout .bs-callout-warning}
 We recommend you avoid setting a value for [`pcre.recursion_limit`](http://php.net/manual/en/pcre.configuration.php) in `php.ini` because it can result in incomplete rollbacks with no failure notice.

--- a/_includes/install/web/install-web.md
+++ b/_includes/install/web/install-web.md
@@ -5,8 +5,8 @@ This section discusses how to install the Magento software using a web-based wiz
 Before you begin, make sure that:
 
 1. Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
-2. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
-4. After you log in to the Magento server, [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
+1. After you log in to the Magento server, [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
 
 ### Enabling and disabling modules   {#instgde-install-web-enable-mod}
 
@@ -26,7 +26,7 @@ To install the Magento software using the Setup Wizard:
 
 1. Start a web browser.
 
-2. Enter the following URL in the browser's address or location bar:
+1. Enter the following URL in the browser's address or location bar:
 
    ```text
    http://<Magento host or IP>/<path to Magento root>/setup
@@ -38,6 +38,6 @@ To install the Magento software using the Setup Wizard:
    http://192.0.2.10/magento2/setup
    ```
 
-3. On the initial page, click **Agree and Set Up Magento**.
+1. On the initial page, click **Agree and Set Up Magento**.
 
-4. Continue with the following topics in the order presented to complete the installation.
+1. Continue with the following topics in the order presented to complete the installation.

--- a/_includes/install/web/install-web_1-readiness.md
+++ b/_includes/install/web/install-web_1-readiness.md
@@ -6,4 +6,4 @@
 
    Click **More detail** if available to see more information about each check.
 
-2. Click **Next**.
+1. Click **Next**.

--- a/_includes/install/web/install-web_5-create-admin.md
+++ b/_includes/install/web/install-web_5-create-admin.md
@@ -9,4 +9,4 @@
    |New Password|Enter the administrator's password.|
    |Confirm Password|Enter the password again for verification.|
 
-2. Click **Next**.
+1. Click **Next**.

--- a/_includes/webapi/tutorials/configure-shipping-methods.md
+++ b/_includes/webapi/tutorials/configure-shipping-methods.md
@@ -11,5 +11,5 @@ Free shipping | `freeshipping` | No
 To change which offline shipping methods are available:
 
 1. Select **Stores** > **Settings** > **Configuration** > **Sales** > **Shipping Methods** in Admin.
-2. Enable or disable the shipping methods as desired.
-3. Click **Save Config**.
+1. Enable or disable the shipping methods as desired.
+1. Click **Save Config**.

--- a/_includes/webapi/tutorials/set-payment-methods.md
+++ b/_includes/webapi/tutorials/set-payment-methods.md
@@ -11,5 +11,5 @@ Zero Subtotal Checkout | `free` | Yes
 In this tutorial, configure Magento to accept bank transfer payments. To allow bank transfer payments (or any other offline payment method) as a payment method:
 
 1. Log in to [Admin](https://glossary.magento.com/admin) and select **Stores** > **Settings** > **Configuration** > **Sales** > **Payment Methods**.
-2. Enable the [payment method](https://glossary.magento.com/payment-method.
-3. Click **Save Config**.
+1. Enable the [payment method](https://glossary.magento.com/payment-method.
+1. Click **Save Config**.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes all MD029 errors in the `_includes/` directory (except cloud):

The MD029 rule requires all ordered list prefixes to be consistent. We've chosen "one" as our prefix. The scope of #5248 also permits—but does not require—resolving errors related to the following rules:

- MD030: Spaces after list markers

This is one of three PRs related to #5248.