### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Part 01

### DIFF
--- a/_includes/cache/page-cache-checklists.md
+++ b/_includes/cache/page-cache-checklists.md
@@ -1,21 +1,21 @@
 ## Cacheable page checklist
 
--   Pages use GET requests
+-  Pages use GET requests
 
--   Pages render only cacheable blocks
+-  Pages render only cacheable blocks
 
--   Pages render without sensitive private data; session and customer DTO objects are empty
+-  Pages render without sensitive private data; session and customer DTO objects are empty
 
--   Functionality specific to both current session (customer) and page should be written using JavaScript (e.g., related product listing should exclude items that are already in the shopping cart)
+-  Functionality specific to both current session (customer) and page should be written using JavaScript (e.g., related product listing should exclude items that are already in the shopping cart)
 
--   Model and block level should identify themselves for invalidation support
+-  Model and block level should identify themselves for invalidation support
 
--   Declare a custom [context variable]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html#configure-page-variations) if you plan to show different public content with the same URL
+-  Declare a custom [context variable]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html#configure-page-variations) if you plan to show different public content with the same URL
 
 ## Non-cacheable page checklist
 
--   Use POST requests to modify Magento state (e.g., adding to shopping cart, wishlist, etc.)
+-  Use POST requests to modify Magento state (e.g., adding to shopping cart, wishlist, etc.)
 
--   Blocks that can't be cached should be marked as non-cacheable in the layout. However, be aware that adding a non-cacheable block to a page prevents the full page cache from caching that page.
+-  Blocks that can't be cached should be marked as non-cacheable in the layout. However, be aware that adding a non-cacheable block to a page prevents the full page cache from caching that page.
 
--   Controllers that don't use layouts should set `no-cache` HTTP headers
+-  Controllers that don't use layouts should set `no-cache` HTTP headers

--- a/_includes/cache/page-cache-overview.md
+++ b/_includes/cache/page-cache-overview.md
@@ -2,8 +2,8 @@
 
 Caching is one of the most effective ways to improve website performance. Generally speaking, there are two methods of caching content:
 
--   Client-side (browser)
--   Server-side
+-  Client-side (browser)
+-  Server-side
 
 Retrieving stored ([cached](https://glossary.magento.com/cache)) content from a previous request for the same client instead of requesting files from your server every time someone visits your site is a more efficient use of network bandwidth.
 
@@ -11,9 +11,9 @@ The Magento page cache library contains a simple PHP reverse proxy that enables 
 
 We recommend using [Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html), but you can use Magento's default caching mechanism instead, which stores cache files in any of the following:
 
--   File system (You don't need to do anything to use file-based caching.)
--   [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
--   [Redis]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+-  File system (You don't need to do anything to use file-based caching.)
+-  [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
+-  [Redis]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
 
 ## Cacheable and uncacheable pages {#cache-over-cacheable}
 
@@ -32,6 +32,6 @@ Do not configure content pages (i.e., catalog, product, and CMS pages) to be unc
 
 Reverse proxies serve "public" or shared content to more than one user. However, most Magento websites generate dynamic and personalized "private" content that should only be served to one user, which presents unique caching challenges. To address these challenges, Magento can distinguish between two types of content:
 
--   **[Public]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html)** - Public content is stored server side in your reverse proxy cache storage (e.g., file system, database, Redis, or Varnish) and is available to multiple customers. Examples of public content include header, footer, and category listing.
+-  **[Public]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html)** - Public content is stored server side in your reverse proxy cache storage (e.g., file system, database, Redis, or Varnish) and is available to multiple customers. Examples of public content include header, footer, and category listing.
 
--   **[Private]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/private-content.html)** - Private content is stored client side (e.g., browser) and is specific to an individual customer. Examples of private content include wishlist, shopping cart, customer name, and address. You should limit stored private content to a small portion of the page's total content.
+-  **[Private]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/private-content.html)** - Private content is stored client side (e.g., browser) and is specific to an individual customer. Examples of private content include wishlist, shopping cart, customer name, and address. You should limit stored private content to a small portion of the page's total content.

--- a/_includes/cloud/admin-ui-login-step.md
+++ b/_includes/cloud/admin-ui-login-step.md
@@ -1,1 +1,1 @@
-1.  [Log in]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin) to the Magento Admin UI.
+1. [Log in]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin) to the Magento Admin UI.

--- a/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
+++ b/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
@@ -14,7 +14,7 @@
 
 1. After the upload completes, refresh the cache according to the notification at the top of the page.
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 The *Custom VCL snippets* UI option shows only the snippets added through the Admin UI. You must use the Fastly API to [manage custom snippets added through the API]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).
 
 ## Delete the custom VCL snippet
@@ -27,8 +27,7 @@ You can delete custom VCL snippet code from your Fastly configuration by uploadi
    -  Save the configuration.
    -  Upload the VCL to Fastly to apply your changes.
 
--  Use the Fastly API [Delete custom VCL snippet]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-vcl) operation
- to delete the snippet completely, or submit a Magento support ticket to request deletion.
+-  Use the Fastly API [Delete custom VCL snippet]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-vcl) operation to delete the snippet completely, or submit a Magento support ticket to request deletion.
 
 [Manage custom VCL snippets]: {{site.baseurl}}/common/images/cloud/cloud-fastly-manage-snippets.png
 {: width="650px"}

--- a/_includes/cloud/data-collection.md
+++ b/_includes/cloud/data-collection.md
@@ -1,6 +1,6 @@
 To help export Production data as test data to use in Staging and Integration environments, [Run the support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html):
 
-* [CLI commands]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html#config-cli-spt-utils-db) (Recommended) to export a protected backup of customer and store data using your Magento encryption key
-* [Data Collection](http://docs.magento.com/m2/ee/user_guide/system/support-data-collector.html) tool for generating and exporting data
+*  [CLI commands]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html#config-cli-spt-utils-db) (Recommended) to export a protected backup of customer and store data using your Magento encryption key
+*  [Data Collection](http://docs.magento.com/m2/ee/user_guide/system/support-data-collector.html) tool for generating and exporting data
 
 To migrate this data, see [Migrate and deploy static files and data]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html).

--- a/_includes/cloud/enable-ssh.md
+++ b/_includes/cloud/enable-ssh.md
@@ -51,7 +51,7 @@ To create an SSH key pair:
 
    GitHub also uses the key length `-b 4096` in the command. Follow the prompts to complete the key.
 
-1. When prompted to "Enter a file in which to save the key," press **Enter** to save the file to the default location. The prompt displays the location.
+1. When prompted to "Enter a file in which to save the key," press **Enter**to save the file to the default location. The prompt displays the location.
 
 1. When prompted to enter a secure passphrase, enter a phrase to use like a password. Make note of this passphrase. You may be requested to enter it depending on tasks you complete using a terminal during development.
 

--- a/_includes/cloud/patch.md
+++ b/_includes/cloud/patch.md
@@ -2,7 +2,7 @@ This topic discusses how to test patches to your {{site.data.var.ece}} system lo
 
 When you perform a {{site.data.var.ee}} upgrade, you automatically upgrade with patches and hotfixes through the `composer update` command. If you upgrade a Cloud patch without upgrading the full {{site.data.var.ee}} application, see [Upgrade a {{site.data.var.ee}} patch](#upgrade-patch). To upgrade and test a full {{site.data.var.ee}} version (including patches and hotfixes), see [Upgrade and test {{site.data.var.ee}}]({{ page.baseurl }}/cloud/project/project-upgrade.html).
 
-{: .bs-callout .bs-callout-info}
+{: .bs-callout-info }
 We recommend installing full {{site.data.var.ee}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 
 There are two types of patches:
@@ -19,7 +19,7 @@ There are two types of patches:
 
    Copy custom patches to the `m2-hotfixes` directory and test them on your locally. After successfully testing them, push the patches to the remote server.
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Always test a patch your local system. When complete, push the local Git branch to deploy your Integration environment. Resolve any issues before you deploy to Staging or Production.
 
 For more information on Composer, see [Composer in Cloud]({{ page.baseurl }}/cloud/reference/cloud-composer.html).

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -1,28 +1,28 @@
 {:.procedure}
 To create and transfer `config.local.php`:
 
-1.  On your local workstation, find the integration server SSH URL.
+1. On your local workstation, find the integration server SSH URL.
 
-    ```bash
-    magento-cloud environment:ssh --pipe
-    ```
+   ```bash
+   magento-cloud environment:ssh --pipe
+   ```
 
-1.  Create the `config.local.php` file on the integration server.
+1. Create the `config.local.php` file on the integration server.
 
-    ```bash
-    ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
-    ```
+   ```bash
+   ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
+   ```
 
-1.  Change to the project root directory.
+1. Change to the project root directory.
 
-1.  Transfer the `config.local.php` file to your local workstation.
+1. Transfer the `config.local.php` file to your local workstation.
 
-    ```bash
-    rsync server@ssh.magentosite.cloud:app/etc/config.local.php ./app/etc/config.local.php
-    ```
+   ```bash
+   rsync server@ssh.magentosite.cloud:app/etc/config.local.php ./app/etc/config.local.php
+   ```
 
-1.  Test to ensure a successful transfer by importing the configuration file to your local environment.
+1. Test to ensure a successful transfer by importing the configuration file to your local environment.
 
-    ```bash
-    php bin/magento app:config:import
-    ```
+   ```bash
+   php bin/magento app:config:import
+   ```

--- a/_includes/comp-man/checklist.md
+++ b/_includes/comp-man/checklist.md
@@ -4,7 +4,7 @@ Before you continue, to avoid errors during your installation or update, make su
 *  Your [cron jobs](#magento-cron) are set up and running
 *  [File system permissions](#perms) are set properly
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Do not continue without performing these checks. Failure to do so could result in errors.
 
 ### Magento file system owner and group {#magento-owner-group}

--- a/_includes/comp-man/checklist_2.2.md
+++ b/_includes/comp-man/checklist_2.2.md
@@ -5,7 +5,7 @@ Before you continue, to avoid errors during your installation or update, make su
 *  [Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
 *  [File system permissions](#perms) are set properly
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Do not continue without performing these checks. Failure to do so could result in errors.
 
 ### Set a value for DATA_CONVERTER_BATCH_SIZE {#batch-size}
@@ -37,7 +37,7 @@ After your upgrade completes, you can unset the variable as follows:
 unset DATA_CONVERTER_BATCH_SIZE
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 `DATA_CONVERTER_BATCH_SIZE` requires memory; avoid setting it to a very large value (approximately 1GB) without testing it first.
 
 ### Magento file system owner and group {#magento-owner-group}

--- a/_includes/comp-man/dependency.md
+++ b/_includes/comp-man/dependency.md
@@ -4,9 +4,9 @@
 
 We suggest you try the following solutions in the order shown:
 
-* [Conflicting dependencies](#trouble-depend-conflict)
-* [File system permissions issues](#trouble-depend-permission)
-* [The Component Dependency Check status never changes](#trouble-depend-state)
+*  [Conflicting dependencies](#trouble-depend-conflict)
+*  [File system permissions issues](#trouble-depend-permission)
+*  [The Component Dependency Check status never changes](#trouble-depend-state)
 
 ### Conflicting dependencies {#trouble-depend-conflict}
 
@@ -21,7 +21,7 @@ Following is a sample failure message:
  - magento/sample-data version 0.74.0-beta15. Please try to update it to one of the following package versions: 0.74.0-beta16, 0.74.0-beta14, 0.74.0-beta13, 0.74.0-beta12, 0.74.0-beta11, 0.74.0-beta10, 0.74.0-beta9, 0.74.0-beta8, 0.74.0-beta7
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 The message you see will likely be different.
 
 Typically, component dependency conflicts result from someone manually editing the Magento 2 `composer.json` file. It can also be caused by third-party modules that depend on earlier Magento components than the ones you have installed.

--- a/_includes/comp-man/readiness-check.md
+++ b/_includes/comp-man/readiness-check.md
@@ -5,7 +5,7 @@ After the readiness check completes, see one of the following:
 
 ### Readiness check success {#compman-readiness-success}
 
-The following figure shows an example of a successful readiness check. If all tests passed, click **Next** and continue with the next step.
+The following figure shows an example of a successful readiness check. If all tests passed, click **Next**and continue with the next step.
 
 ![If all readiness checks pass, click Next and continue with the next step]({{ site.baseurl }}/common/images/extensman_readiness-success.png)
 

--- a/_includes/config-guide/custom-logger-handler-examples.md
+++ b/_includes/config-guide/custom-logger-handler-examples.md
@@ -1,7 +1,7 @@
 You can use one of the following approaches for logging into a custom file:
 
-- Set up a custom log file in the `di.xml`
-- Set up a custom file in the custom logger handler class
+-  Set up a custom log file in the `di.xml`
+-  Set up a custom file in the custom logger handler class
 
 ## Set up a custom log file in the `di.xml`
 

--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -1,7 +1,7 @@
 This section discusses the minimum settings you must choose to test Elasticsearch with Magento 2.
 For additional details about configuring Elasticsearch, see the [{{site.data.var.ee}} User Guide](http://docs.magento.com/m2/ee/user_guide/catalog/search-elasticsearch.html).
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Magento 2.3.1 adds support for Elasticsearch 6.x, and it is enabled by default.
 Magento still provides modules for Elasticsearch 2.x and 5.x, but these must be enabled in order to use these versions.
 Elasticsearch 2.x is still available but strongly discouraged. Versions 2.x and 5.x are [End of Life](https://www.elastic.co/support/eol).
@@ -48,12 +48,12 @@ or you will see:
 
 If so, try the following:
 
-* Make sure the Elasticsearch server is running.
-* If the Elasticsearch server is on a different host from Magento, log in to the Magento server and ping the Elasticsearch host. Resolve network connectivity issues and test the connection again.
-* Examine the command window in which you started Elasticsearch for stack traces and exceptions. You must resolve those before you continue. In particular, make sure you started Elasticsearch as a user with `root` privileges.
-* Make sure that [UNIX firewall and SELinux]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html#firewall-selinux) are both disabled, or set up rules to enable Elasticsearch and Magento to communicate with each other.
-* Verify the value of the **Elasticsearch Server Hostname** field. Make sure the server is available. You can try the server's IP address instead.
-* Use the command `netstat -an | grep **listen-port**` command to verify that the port specified in the **Elasticsearch Server Port** field is not being used by another process.
+*  Make sure the Elasticsearch server is running.
+*  If the Elasticsearch server is on a different host from Magento, log in to the Magento server and ping the Elasticsearch host. Resolve network connectivity issues and test the connection again.
+*  Examine the command window in which you started Elasticsearch for stack traces and exceptions. You must resolve those before you continue. In particular, make sure you started Elasticsearch as a user with `root` privileges.
+*  Make sure that [UNIX firewall and SELinux]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html#firewall-selinux) are both disabled, or set up rules to enable Elasticsearch and Magento to communicate with each other.
+*  Verify the value of the **Elasticsearch Server Hostname** field. Make sure the server is available. You can try the server's IP address instead.
+*  Use the command `netstat -an | grep **listen-port**` command to verify that the port specified in the **Elasticsearch Server Port** field is not being used by another process.
 
   For example, to see if Elasticsearch is running on its default port, use the following command:
 
@@ -97,5 +97,5 @@ bin/magento indexer:reindex
 
 1. Wait until reindexing completes.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Unlike the cache, indexers are updated by a cron job. Make sure [cron is enabled]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html) before you start using Elasticsearch.

--- a/_includes/config/install-java.md
+++ b/_includes/config/install-java.md
@@ -10,8 +10,8 @@ If the message `java: command not found` displays, you must install the Java SDK
 
 See one of the following sections:
 
-* [Install the latest JDK on CentOS](#install-prereq-java-centos)
-* [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
+*  [Install the latest JDK on CentOS](#install-prereq-java-centos)
+*  [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
 
 #### Install the JDK on CentOS {#install-prereq-java-centos}
 
@@ -23,7 +23,7 @@ Be sure to install the JDK and *not* the JRE.
 yum -y install java-1.7.0-openjdk
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Java version 7 might not be available for all operating systems. For example, you can [search the list of available packages for Ubuntu](http://packages.ubuntu.com/).
 
 #### Install the JDK on Ubuntu {#install-prereq-java-ubuntu}

--- a/_includes/config/install-java8.md
+++ b/_includes/config/install-java8.md
@@ -10,8 +10,8 @@ If the message `java: command not found` displays, you must install the Java SDK
 
 See one of the following sections:
 
-* [Install the latest JDK on CentOS](#install-prereq-java-centos)
-* [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
+*  [Install the latest JDK on CentOS](#install-prereq-java-centos)
+*  [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
 
 #### Install the JDK on CentOS   {#install-prereq-java-centos}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folder: `_includes`. 

**Part 01**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
