### PR TITLE
Added page-builder-types to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _algolia_api_key
 /mbi/
 /page-builder/
 /page-builder-migration/
+/page-builder-types/
 /guides/m1x/
 /mftf/
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the page-builder-types directory to the .gitignore file.

## Affected DevDocs pages

None.
