### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Part 02

### DIFF
--- a/_includes/config/cron-overview.md
+++ b/_includes/config/cron-overview.md
@@ -11,10 +11,10 @@ Several Magento features require at least one cron job, which schedules activiti
 
 We recommend you run cron as the [Magento file system owner]({{ page.baseurl }}/config-guide/cli/config-cli.html#config-install-cli-first). Do *not* run cron as `root`; we also recommend against running cron as the web server user.
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 You can no longer run `dev/tools/cron.sh` because the script has been removed.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Magento depends on proper cron job configuration for many important system functions, including indexing. Failure to set it up properly means Magento won't function as expected.
 
 UNIX systems schedule tasks to be performed by particular users using a *crontab*, which is a file that contains instructions to the cron daemon that tell the daemon in effect to "run this command at this time on this date". Each user has its own crontab, and commands in any given crontab are executed as the user who owns it.

--- a/_includes/config/es-webserver-overview.md
+++ b/_includes/config/es-webserver-overview.md
@@ -4,7 +4,7 @@ This topic discusses an example of securing communication between your web serve
 
 (An older term, Secure Sockets Layer (SSL), is frequently used interchangeably with TLS. In this topic, we refer to *TLS*.)
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Unless otherwise noted, all commands in this topic must be entered as a user with `root` privileges.
 
 ### Recommendations

--- a/_includes/config/locate-session.md
+++ b/_includes/config/locate-session.md
@@ -2,13 +2,13 @@
 
 This topic discusses how to locate where your session files are stored. The Magento application uses the following logic to store session files:
 
-* If you configured memcached, sessions are stored in RAM; for more information, see [Use memcached for session storage]({{ page.baseurl }}/config-guide/memcache/memcache.html).
-* If you configured Redis, sessions are stored on the Redis server; for more information, see [Use Redis for page caching or session storage]({{ page.baseurl }}/config-guide/redis/config-redis.html).
-* If you're using the default file-based session storage, we store sessions in the following locations in the order shown:
+*  If you configured memcached, sessions are stored in RAM; for more information, see [Use memcached for session storage]({{ page.baseurl }}/config-guide/memcache/memcache.html).
+*  If you configured Redis, sessions are stored on the Redis server; for more information, see [Use Redis for page caching or session storage]({{ page.baseurl }}/config-guide/redis/config-redis.html).
+*  If you're using the default file-based session storage, we store sessions in the following locations in the order shown:
 
-  1. Directory defined in [`env.php`](#session-where-env)
-  1. Directory defined in [`php.ini`](#session-where-phpini)
-  1. `<magento_root>/var/session` directory
+   1. Directory defined in [`env.php`](#session-where-env)
+   1. Directory defined in [`php.ini`](#session-where-phpini)
+   1. `<magento_root>/var/session` directory
 
 ### `env.php` example {#session-where-env}
 

--- a/_includes/config/multi-site_verify.md
+++ b/_includes/config/multi-site_verify.md
@@ -18,7 +18,7 @@ Unless you have DNS set up for your stores' URLs, you must add a static route to
 
 You're done!
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 
 *  Additional tasks might be required to deploy multiple websites in a hosted environment; check with your hosting provider for more information.
 *  Additional tasks are required to set up {{site.data.var.ece}}; for more information, see [Set up multiple Cloud websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html)

--- a/_includes/config/php-memcache.md
+++ b/_includes/config/php-memcache.md
@@ -14,5 +14,5 @@ Because PHP has no native support for memcache, you must install an extension fo
 
    The exact name is `php5-memcached` for Ubuntu and `php-pecl-memcached` for CentOS
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 For simplicity, we use the PHP `memcache` extension in this guide although we provide examples for both when configuring Magento to use memcache.

--- a/_includes/config/setup-cron.md
+++ b/_includes/config/setup-cron.md
@@ -10,7 +10,7 @@ Magento uses cron for two sets of tasks, and for each, cron can run with a diffe
 
  You can find the web server plug-in configuration using [`phpinfo.php`]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo).
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 
 *  To avoid issues during installation and upgrade, we strongly recommend you apply the same PHP settings to both the PHP command-line configuration and to the PHP web server plug-in's configuration. For more information, see [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html).
 *  In a multi-node system, crontab can run on only one node. This applies to you only if you set up more than one webnode for reasons related to performance or scalability.
@@ -59,7 +59,7 @@ where
 
 The first command (`magento cron:run`) reindexes indexers, sends automated e-mails, generates the sitemap, and so on. Usually it's associated with the PHP command line `.ini` file. The other two commands are used by the Component Manager and System Upgrade.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 If you're a contributing developer (that is, you [cloned the Magento 2 GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html)), only the first line applies to you. See the examples that follow for details.
 
 **Example 1:** Everyone except contributing developers

--- a/_includes/config/setup-cron_2.2.md
+++ b/_includes/config/setup-cron_2.2.md
@@ -8,7 +8,7 @@ Magento uses cron for two sets of tasks, and for each, cron can run with a diffe
 
 *  Web server PHP plug-in configuration: Two other cron jobs are used by the [Component Manager and System Upgrade utilities]({{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html).
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 
 *  To avoid issues during installation and upgrade, we strongly recommend you apply the same PHP settings to both the PHP command-line configuration and to the PHP web server plug-in's configuration. For more information, see [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html).
 *  In a multi-node system, crontab can run on only one node. This applies to you only if you set up more than one webnode for reasons related to performance or scalability.

--- a/_includes/config/setup-cron_2.3_how-to.md
+++ b/_includes/config/setup-cron_2.3_how-to.md
@@ -10,9 +10,9 @@ To create the Magento crontab:
 1. Change to your Magento installation directory.
 1. Enter the following command:
 
-    ```bash
-    bin/magento cron:install [--force]
-    ```
+   ```bash
+   bin/magento cron:install [--force]
+   ```
 
 Use `--force` to rewrite an existing Magento crontab.
 

--- a/_includes/config/split-deploy/config-mgmt-over1.md
+++ b/_includes/config/split-deploy/config-mgmt-over1.md
@@ -10,7 +10,7 @@
 
    The system-specific configuration file, `app/etc/env.php`, should _not_ be included in source control or otherwise shared between systems. Instead, use the [`magento config:set` and `magento:sensitive:set` commands]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) to provide values for those settings in your production system.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 These new methods to manage your configuration are optional. You don't have to use them, although we strongly recommend you do.
 
 Most of the time, the configuration options you set in the shared, system-specific, or sensitive configuration cannot be edited in the Magento Admin. This helps keep your settings consistent across all systems. (You can optionally use the [`magento config:set` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) without the `--lock` option to configure settings that are editable in the Admin.)

--- a/_includes/config/split-deploy/example_save-shared-config.md
+++ b/_includes/config/split-deploy/example_save-shared-config.md
@@ -1,42 +1,42 @@
-1.  Log in to your development system as, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
+1. Log in to your development system as, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
 
-1.  Enter the following commands in the order shown:
+1. Enter the following commands in the order shown:
 
-    ```bash
-    cd <Magento root dir>
-    php bin/magento app:config:dump
-    ```
+   ```bash
+   cd <Magento root dir>
+   php bin/magento app:config:dump
+   ```
 
-    For example, if Magento is installed in `/var/www/html/magento2`, enter:
+   For example, if Magento is installed in `/var/www/html/magento2`, enter:
 
-    ```bash
-    cd /var/www/html/magento2
-    php bin/magento app:config:dump
-    ```
+   ```bash
+   cd /var/www/html/magento2
+   php bin/magento app:config:dump
+   ```
 
-1.  If you use Git, enter the following command to confirm that `app/etc/config.php` was updated:
+1. If you use Git, enter the following command to confirm that `app/etc/config.php` was updated:
 
-    ```bash
-    git status
-    ```
+   ```bash
+   git status
+   ```
 
-    You should see output similar to the following:
+   You should see output similar to the following:
 
-    ```terminal
-    On branch m2.2_deploy
-    Changed but not updated:
-      (use "git add &lt;file>..." to update what will be committed)
-      (use "git checkout -- &lt;file>..." to discard changes in working directory)
-           modified:   app/etc/config.php
-    ```
+   ```terminal
+   On branch m2.2_deploy
+   Changed but not updated:
+     (use "git add &lt;file>..." to update what will be committed)
+     (use "git checkout -- &lt;file>..." to discard changes in working directory)
+          modified:   app/etc/config.php
+   ```
 
-    {:.bs-callout .bs-callout-warning}
-    Do _not_ submit changes to the `generated`, `pub/media`, or `pub/static` directories to source control. You'll generate those files on your build system. The development system likely has code, themes, and so on that are not ready for use on the production system.
+   {: .bs-callout-warning }
+   Do _not_ submit changes to the `generated`, `pub/media`, or `pub/static` directories to source control. You'll generate those files on your build system. The development system likely has code, themes, and so on that are not ready for use on the production system.
 
-1.  Check in your changes to `app/etc/config.php` only to source control.
+1. Check in your changes to `app/etc/config.php` only to source control.
 
-    The Git command follows:
+   The Git command follows:
 
-    ```bash
-    git add app/etc/config.php && git commit -m "Updated shared configuration" && git push mconfig m2.2_deploy
-    ```
+   ```bash
+   git add app/etc/config.php && git commit -m "Updated shared configuration" && git push mconfig m2.2_deploy
+   ```

--- a/_includes/config/split-deploy/split-deploy-overview.md
+++ b/_includes/config/split-deploy/split-deploy-overview.md
@@ -24,13 +24,13 @@ Staging system
 Production system
 : Your live store. You should make minimal configuration changes here and no changes to:
 
-   - websites
-   - stores
-   - store views
-   - products
-   - product view settings
-   - catalog
-   - categories
-   - category view settings.
+   -  websites
+   -  stores
+   -  store views
+   -  products
+   -  product view settings
+   -  catalog
+   -  categories
+   -  category view settings.
 
  You should make all those types of changes in your development system.

--- a/_includes/contributor/labels.md
+++ b/_includes/contributor/labels.md
@@ -3,34 +3,34 @@
 
 Release line labels indicate the specific Magento release lines affected by the issue or PR. For example, if working on a fix for 2.2.6, you would apply the Release Line: 2.2. This effectively includes all releases in this line.
 
-* `Release Line: 2.2`
-* `Release Line: 2.3`
+*  `Release Line: 2.2`
+*  `Release Line: 2.3`
 
 ### Progress
 {:.no_toc}
 
 Progress labels indicate the Pull Request status on each review stage:
 
-* `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
-* `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
-* `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
-* `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
+*  `Progress: needs update` - The Community Engineering Team needs additional information from the reporter to properly prioritize and process the pull request. <!-- needs update -->
+*  `Progress: on hold` - The pull request is on hold due and will be further reviewed to accept or reject.
+*  `Progress: accept` - The pull request has been accepted and will be merged into mainline code. <!-- accept -->
+*  `Progress: reject` - The pull request has been rejected and will not be merged into mainline code. Possible reasons can include but are not limited to: issue has already been fixed in another code contribution, or there is an issue with the code contribution. <!-- reject -->
 
 ### Contribution awards
 {:.no_toc}
 
 The level of investigation, research, and work required for a task may differ. Contribution Rewards labels  indicate what type of contribution awards will be applied when completing an issue and PR. Some awards will provide higher points and rewards than others.
 
-* `Award: complex`
-* `Award: advanced`
-* `Award: special achievement`
-* `Award: category of expertise`
-* `Award: test coverage`
-* `Award: devdocs update`
-* `Award: MFTF test coverage`
-* `Award: bug fix`
-* `Cleanup`
-* `Port`
+*  `Award: complex`
+*  `Award: advanced`
+*  `Award: special achievement`
+*  `Award: category of expertise`
+*  `Award: test coverage`
+*  `Award: devdocs update`
+*  `Award: MFTF test coverage`
+*  `Award: bug fix`
+*  `Cleanup`
+*  `Port`
 
 ### Partners
 {:.no_toc}
@@ -39,11 +39,11 @@ All partners Pull Requests should be marked with label `partners-contribution`. 
 
 Example labels:
 
-* `partners-contribution`
-* `Partner: Atwix`
-* `Partner: Comwrap`
-* `Partner: Interactiv4`
-* `Partner: Wagento`
+*  `partners-contribution`
+*  `Partner: Atwix`
+*  `Partner: Comwrap`
+*  `Partner: Interactiv4`
+*  `Partner: Wagento`
 
 ### Components
 {:.no_toc}
@@ -52,9 +52,9 @@ Component labels indicate the components affected by the Pull Request. To learn 
 
 Example labels:
 
-* `Component: Catalog`
-* `Component: Report`
-* `Component: Checkout`
+*  `Component: Catalog`
+*  `Component: Report`
+*  `Component: Checkout`
 
 For edge cases, `Component: Other` and `Component: Multiple` may be used.
 
@@ -65,43 +65,43 @@ Event labels mark recommended issues and submitted PRs for a specific event. Eve
 
 Example labels:
 
-* `Event: mm18in`
-* `Event: mm17es`
-* `Event: mlau18`
+*  `Event: mm18in`
+*  `Event: mm17es`
+*  `Event: mlau18`
 
 ### General
 {:.no_toc}
 
 General labels include a variety of tasks and definitions for pull requests and issues.
 
-* `good first issue` - Indicates a good issue for first-time contributors.
-* `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
-* `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
+*  `good first issue` - Indicates a good issue for first-time contributors.
+*  `help wanted` - Indicates the creator or author needs help with a decision, advice for resolving, and so on.
+*  `triage wanted` - Indicates the issues are under triage. See this information to learn more about the [Triage Wanted program](https://github.com/magento/magento2/wiki/Triage-Wanted).
 
 ### Issue resolution status
 {:.no_toc}
 
 Labels applied to issues through verification and completion. For details on the process, see [GitHub Issues Processing Workflow](https://github.com/magento/magento2/wiki/GitHub-Issues-Processing-Workflow).
 
-* `Issue: Format is not valid` - Gate 1 failed. Automatic verification by the Automated Contributor Assistant failed and the issue needs updates. The [format](https://github.com/magento/magento2/tree/2.3-develop/.github/ISSUE_TEMPLATE) of the issue description and minimum required information is not provided: Preconditions, Steps to Reproduce, Actual Result, Expected Result. Previous label `G1 Failed`.
-* `Issue: Format is valid` - Gate 1 passed. Automatic verification by the Automated Contributor Assistant passed for all issue content. Previous label `G1 Passed`.
-* `Issue: Clear Description` - Gate 2 passed. The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce. Previous label `G2 Passed`.
-* `Issue: Cannot Reproduce` - Gate 3 failed. The issue could not be reproduced or validated. Previous label `Cannot Reproduce`.
-* `Issue: Confirmed` - Gate 3 passed. Manual verification of the issue description and reproduction steps was confirmed. Previous label `G3 Passed`.
-* `Issue: Ready for Work` - Gate 4 passed. The issue is acknowledged and added to the backlog for open development. Previous label `acknowledged`.
-* `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
-* `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
+*  `Issue: Format is not valid` - Gate 1 failed. Automatic verification by the Automated Contributor Assistant failed and the issue needs updates. The [format](https://github.com/magento/magento2/tree/2.3-develop/.github/ISSUE_TEMPLATE) of the issue description and minimum required information is not provided: Preconditions, Steps to Reproduce, Actual Result, Expected Result. Previous label `G1 Failed`.
+*  `Issue: Format is valid` - Gate 1 passed. Automatic verification by the Automated Contributor Assistant passed for all issue content. Previous label `G1 Passed`.
+*  `Issue: Clear Description` - Gate 2 passed. The Community Engineering Team has confirmed that this issue contains the minimum required information to reproduce. Previous label `G2 Passed`.
+*  `Issue: Cannot Reproduce` - Gate 3 failed. The issue could not be reproduced or validated. Previous label `Cannot Reproduce`.
+*  `Issue: Confirmed` - Gate 3 passed. Manual verification of the issue description and reproduction steps was confirmed. Previous label `G3 Passed`.
+*  `Issue: Ready for Work` - Gate 4 passed. The issue is acknowledged and added to the backlog for open development. Previous label `acknowledged`.
+*  `Reproduced on 2.2.x` - The Community Engineering Team reproduced the issue on latest 2.2.x release.
+*  `Reproduced on 2.3.x` - The Community Engineering Team reproduced the issue on latest 2.3.x release.
 
-* `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
-* `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
-* `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
+*  `Fixed in 2.2.x` - The issue has been fixed in one of the 2.2.x releases or in 2.2-develop branch and will be available with the upcoming patch release.
+*  `Fixed in 2.3.x` - The issue has been fixed in one of the 2.3.x releases or in 2.3-develop branch and will be available with the upcoming patch release.
+*  `non-issue` - A described behavior in the issue description is valid and shouldn't be changed in Magento code base.
 
 ### DevDocs
 {:.no_toc}
 
 All [contributions to DevDocs](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) receive the following labels:
 
-* `New topic`- New topic submissions for content that has never existed on DevDocs such as tutorials, references, instructions, and so on
-* `Major update` - Significant original updates to existing content
-* `Technical` - Updates to the code or processes that alter the technical content of the document, such as code snippets, reference documentation, parameter names and values, and other relevant content
-* `Editorial` - Fixes for typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies
+*  `New topic`- New topic submissions for content that has never existed on DevDocs such as tutorials, references, instructions, and so on
+*  `Major update` - Significant original updates to existing content
+*  `Technical` - Updates to the code or processes that alter the technical content of the document, such as code snippets, reference documentation, parameter names and values, and other relevant content
+*  `Editorial` - Fixes for typos, grammatical inconsistencies, or minor rewrites to correct inaccuracies

--- a/_includes/install/allowoverrides24.md
+++ b/_includes/install/allowoverrides24.md
@@ -5,33 +5,33 @@ Magento uses server rewrites and `.htaccess` to provide directory-level instruct
 {:.bs-callout .bs-callout-info}
 Failure to enable these settings typically results in no styles displaying on your storefront or Admin.
 
-1.  Enable the Apache rewrite module:
+1. Enable the Apache rewrite module:
 
-    ```bash
-    a2enmod rewrite
-    ```
+   ```bash
+   a2enmod rewrite
+   ```
 
-1.  To enable Magento to use the distributed `.htaccess` configuration file, see the guidelines in the [Apache 2.4 documentation](http://httpd.apache.org/docs/current/mod/mod_rewrite.html).
+1. To enable Magento to use the distributed `.htaccess` configuration file, see the guidelines in the [Apache 2.4 documentation](http://httpd.apache.org/docs/current/mod/mod_rewrite.html).
 
-    Note that in Apache 2.4, the server's default site configuration file is `/etc/apache2/sites-available/000-default.conf`.
+   Note that in Apache 2.4, the server's default site configuration file is `/etc/apache2/sites-available/000-default.conf`.
 
-    For example, you can add the following to the end of `000-default.conf`:
+   For example, you can add the following to the end of `000-default.conf`:
 
-    ```terminal
-    <Directory "/var/www/html">
-            AllowOverride  <value from Apache site>
-    </Directory>
-    ```
+   ```terminal
+   <Directory "/var/www/html">
+       AllowOverride  <value from Apache site>
+   </Directory>
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    In some cases, additional parameters might be required. For more information, see the [Apache 2.4 documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order).
+   {:.bs-callout .bs-callout-info}
+   In some cases, additional parameters might be required. For more information, see the [Apache 2.4 documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order).
 
-1.  If you changed Apache settings, restart Apache:
+1. If you changed Apache settings, restart Apache:
 
-    ```bash
-    service apache2 restart
-    ```
+   ```bash
+   service apache2 restart
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    -   If you upgraded from an earlier Apache version, first look for `<Directory "/var/www/html">` or `<Directory "/var/www">` in `000-default.conf`.
-    -   You must change the value of `AllowOverride` in the directive for the directory to which you expect to install the Magento software. For example, to install in the web server docroot, edit the directive in `<Directory /var/www>`.
+   {:.bs-callout .bs-callout-info}
+   -  If you upgraded from an earlier Apache version, first look for `<Directory "/var/www/html">` or `<Directory "/var/www">` in `000-default.conf`.
+   -  You must change the value of `AllowOverride` in the directive for the directory to which you expect to install the Magento software. For example, to install in the web server docroot, edit the directive in `<Directory /var/www>`.

--- a/_includes/install/before-you-begin-cli.md
+++ b/_includes/install/before-you-begin-cli.md
@@ -1,5 +1,5 @@
 Before you begin, make sure that:
 
-1.  Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
-1.  You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
-1.  After you log in to the Magento server, switch to a user that has permissions to write to the Magento file system. One way to do this is discussed in [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+1. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
+1. After you log in to the Magento server, switch to a user that has permissions to write to the Magento file system. One way to do this is discussed in [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).

--- a/_includes/install/before-you-begin-web.md
+++ b/_includes/install/before-you-begin-web.md
@@ -1,6 +1,6 @@
 Before you begin, make sure that:
 
-1.  Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
-1.  You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
-1.  You started your installation as discussed in [Getting started]({{ page.baseurl }}/install-gde/install/web/install-web.html#instgde-install-magento-web-step0).
-1.  You completed all preceding steps in the Setup Wizard.
+1. Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
+1. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
+1. You started your installation as discussed in [Getting started]({{ page.baseurl }}/install-gde/install/web/install-web.html#instgde-install-magento-web-step0).
+1. You completed all preceding steps in the Setup Wizard.

--- a/_includes/install/composer-overview.md
+++ b/_includes/install/composer-overview.md
@@ -1,10 +1,10 @@
 We use [Composer](https://getcomposer.org/){:target="_blank"} to manage Magento components and their dependencies. Using Composer to get the Magento software [metapackage](https://glossary.magento.com/metapackage) provides the following advantages:
 
--   Reuse third-party libraries without bundling them with source code
--   Reduce extension conflicts and compatibility issues by using a component-based architecture with robust dependency management
--   Adhere to [PHP-Framework Interoperability Group (FIG)](https://www.php-fig.org/) standards
--   Repackage Magento Open Source with other components
--   Use the Magento software in a production environment
+-  Reuse third-party libraries without bundling them with source code
+-  Reduce extension conflicts and compatibility issues by using a component-based architecture with robust dependency management
+-  Adhere to [PHP-Framework Interoperability Group (FIG)](https://www.php-fig.org/) standards
+-  Repackage Magento Open Source with other components
+-  Use the Magento software in a production environment
 
 {:.bs-callout .bs-callout-warning}
 You must create a Composer project from our metapackage if you want to use the Magento Web Setup Wizard to upgrade the Magento software and third-party extensions.

--- a/_includes/install/enable-disable-modules.md
+++ b/_includes/install/enable-disable-modules.md
@@ -6,15 +6,15 @@ In addition, there might be *conflicting* modules that cannot both be enabled at
 
 Examples:
 
--   Module A depends on Module B. You cannot disable Module B unless you first disable Module A.
+-  Module A depends on Module B. You cannot disable Module B unless you first disable Module A.
 
--   Module A depends on Module B, both of which are disabled. You must enable module B before you can enable module A.
+-  Module A depends on Module B, both of which are disabled. You must enable module B before you can enable module A.
 
--   Module A conflicts with Module B. You can disable Module A and Module B, or you can disable either module but you *cannot* enable Module A and Module B at the same time.
+-  Module A conflicts with Module B. You can disable Module A and Module B, or you can disable either module but you *cannot* enable Module A and Module B at the same time.
 
--   Dependencies are declared in the `require` field in Magento's `composer.json` file for each module. Conflicts are declared in the `conflict` field in modules' `composer.json` files. We use that information to build a dependency graph: `A->B` means module A depends on module B.
+-  Dependencies are declared in the `require` field in Magento's `composer.json` file for each module. Conflicts are declared in the `conflict` field in modules' `composer.json` files. We use that information to build a dependency graph: `A->B` means module A depends on module B.
 
--   A *dependency chain* is the path from a module to another one. For example, if module A depends on module B and module B depends on module C, then the dependency chain is `A->B->C`.
+-  A *dependency chain* is the path from a module to another one. For example, if module A depends on module B and module B depends on module C, then the dependency chain is `A->B->C`.
 
 If you attempt to enable or disable a module that depends on other modules, the dependency graph displays in the error message.
 

--- a/_includes/install/file-system-perms-before_22.md
+++ b/_includes/install/file-system-perms-before_22.md
@@ -27,8 +27,8 @@ This section discusses how to set ownership and permissions for your own server 
 
 After you've performed the other tasks in this topic, enter one of the following commands to switch to that user:
 
-* Ubuntu: `su <username>`
-* CentOS: `su - <username>`
+*  Ubuntu: `su <username>`
+*  CentOS: `su - <username>`
 
 For example,
 

--- a/_includes/install/file-system-perms-oneuser.md
+++ b/_includes/install/file-system-perms-oneuser.md
@@ -29,15 +29,15 @@ To set permissions before you install the Magento software:
 
 1. To optionally enter all commands on one line, enter the following, assuming Magento is installed in `/var/www/html/magento2`:
 
-    ```bash
-    cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} + && chmod u+x bin/magento
-    ```
+   ```bash
+   cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} + && chmod u+x bin/magento
+   ```
 
-If you haven't done so already, get the Magento software in one of the following ways:
+   If you haven't done so already, get the Magento software in one of the following ways:
 
-* [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
-* [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
-* [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+   * [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+   * [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+   * [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 1. After you have set file system ownership and permissions, continue with any of the following:
 

--- a/_includes/install/file-system-perms-oneuser_22.md
+++ b/_includes/install/file-system-perms-oneuser_22.md
@@ -3,30 +3,30 @@ To set permissions before you install the Magento software:
 1. Log in to your Magento server.
 1. Use a file manager application provided by your shared hosting provider to verify write permissions are set on the following directories:
 
-    * `vendor` (Composer or compressed archive installation)
-    * `app/etc`
-    * `pub/static`
-    * `var`
-    * `generated`
-    * Any other static resources
+   *  `vendor` (Composer or compressed archive installation)
+   *  `app/etc`
+   *  `pub/static`
+   *  `var`
+   *  `generated`
+   *  Any other static resources
 
 1. If you have command-line access, enter the following commands in the order shown:
 
-    ```bash
-    cd <magento_root>
+   ```bash
+   cd <magento_root>
    ```
 
-    ```bash
-    find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} +
-    ```
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type f -exec chmod u+w {} +
+   ```
 
-    ```bash
-    find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} +
-    ```
+   ```bash
+   find var generated vendor pub/static pub/media app/etc -type d -exec chmod u+w {} +
+   ```
 
-    ```bash
-    chmod u+x bin/magento
-    ```
+   ```bash
+   chmod u+x bin/magento
+   ```
 
 To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2`:
 
@@ -36,14 +36,14 @@ cd /var/www/html/magento2 && find var generated vendor pub/static pub/media app/
 
 1. If you haven't done so already, get the Magento software in one of the following ways:
 
-    * [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
-    * [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
-    * [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+   *  [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+   *  [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+   *  [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 1. After you have set file system ownership and permissions, continue with any of the following:
 
-    * [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-    * [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+   *  [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+   *  [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
 {:.bs-callout .bs-callout-info}
 To further restrict permissions after installing the Magento software, you [configure a Magento umask]({{ page.baseurl }}/install-gde/install/post-install-umask.html).

--- a/_includes/install/file-system-perms-twouser.md
+++ b/_includes/install/file-system-perms-twouser.md
@@ -1,11 +1,11 @@
 Complete the following tasks in the order shown:
 
-* [About the shared group](#mage-owner-about-group)
-* [Step 1: Create the Magento file system owner and give the user a strong password](#mage-owner-create-user)
-* [Step 2: Find the web server group](#install-update-depend-user-findgroup)
-* [Step 3: Put the Magento file system owner in the web server's group](#install-update-depend-user-add2group)
-* [Step 4: Get the Magento software](#perms-get-software)
-* [Step 5: Set ownership and permissions for the shared group](#perms-set-two-users)
+*  [About the shared group](#mage-owner-about-group)
+*  [Step 1: Create the Magento file system owner and give the user a strong password](#mage-owner-create-user)
+*  [Step 2: Find the web server group](#install-update-depend-user-findgroup)
+*  [Step 3: Put the Magento file system owner in the web server's group](#install-update-depend-user-add2group)
+*  [Step 4: Get the Magento software](#perms-get-software)
+*  [Step 5: Set ownership and permissions for the shared group](#perms-set-two-users)
 
 ### About the shared group {#mage-owner-about-group}
 
@@ -54,7 +54,7 @@ Because the point of creating this user is to provide added security, make sure 
 
 To find the web server user's group:
 
-* CentOS:
+*  CentOS:
 
 ```bash
 grep -E -i '^user|^group' /etc/httpd/conf/httpd.conf
@@ -68,7 +68,7 @@ grep -Ei '^user|^group' /etc/httpd/conf/httpd.conf
 
 Typically, the user and group name are both `apache`.
 
-* Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group.
+*  Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group.
 
 Typically, the username and the group name are both `www-data`.
 
@@ -76,8 +76,8 @@ Typically, the username and the group name are both `www-data`.
 
 To put the Magento file system owner in the web server's group (assuming the typical Apache group name for CentOS and Ubuntu), enter the following command as a user with `root` privileges:
 
-* CentOS: `usermod -a -G apache <username>`
-* Ubuntu: `usermod -a -G www-data <username>`
+*  CentOS: `usermod -a -G apache <username>`
+*  Ubuntu: `usermod -a -G www-data <username>`
 
 {:.bs-callout .bs-callout-info}
 The `-a -G` options are important because they add `apache` or `www-data` as a _secondary_ group to the user account, which preserves the user's _primary_ group. Adding a secondary group to a user account helps [restrict file ownership and permissions](#perms-set-two-users) to ensure members of a shared group only have access to certain files.
@@ -105,16 +105,16 @@ Typically, the username and primary group name are the same.
 
 To complete the task, restart the web server:
 
-* Ubuntu: `service apache2 restart`
-* CentOS: `service httpd restart`
+*  Ubuntu: `service apache2 restart`
+*  CentOS: `service httpd restart`
 
 ### Step 4: Get the Magento software {#perms-get-software}
 
 If you haven't done so already, get the Magento software in one of the following ways:
 
-* [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
-* [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
-* [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+*  [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+*  [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+*  [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 ### Step 5: Set ownership and permissions for the shared group {#perms-set-two-users}
 
@@ -149,5 +149,5 @@ chmod u+x bin/magento
 
 After you have set file system ownership and permissions, continue with any of the following:
 
-* [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-* [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+*  [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+*  [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)

--- a/_includes/install/file-system-perms-twouser_22.md
+++ b/_includes/install/file-system-perms-twouser_22.md
@@ -1,11 +1,11 @@
 Complete the following tasks in the order shown:
 
-* [About the shared group](#mage-owner-about-group)
-* [Step 1: Create the Magento file system owner and give the user a strong password](#mage-owner-create-user)
-* [Step 2: Find the web server group](#install-update-depend-user-findgroup)
-* [Step 3: Put the Magento file system owner in the web server's group](#install-update-depend-user-add2group)
-* [Step 4: Get the Magento software](#perms-get-software)
-* [Step 5: Set ownership and permissions for the shared group](#perms-set-two-users)
+*  [About the shared group](#mage-owner-about-group)
+*  [Step 1: Create the Magento file system owner and give the user a strong password](#mage-owner-create-user)
+*  [Step 2: Find the web server group](#install-update-depend-user-findgroup)
+*  [Step 3: Put the Magento file system owner in the web server's group](#install-update-depend-user-add2group)
+*  [Step 4: Get the Magento software](#perms-get-software)
+*  [Step 5: Set ownership and permissions for the shared group](#perms-set-two-users)
 
 ### About the shared group {#mage-owner-about-group}
 
@@ -54,7 +54,7 @@ Because the point of creating this user is to provide added security, make sure 
 
 To find the web server user's group:
 
-* CentOS:
+*  CentOS:
 
 ```bash
 grep -E -i '^user|^group' /etc/httpd/conf/httpd.conf
@@ -68,7 +68,7 @@ grep -Ei '^user|^group' /etc/httpd/conf/httpd.conf
 
 Typically, the user and group name are both `apache`.
 
-* Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group.
+*  Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group.
 
 Typically, the username and the group name are both `www-data`.
 
@@ -76,8 +76,8 @@ Typically, the username and the group name are both `www-data`.
 
 To put the Magento file system owner in the web server's primary group (assuming the typical Apache group name for CentOS and Ubuntu), enter the following command as a user with `root` privileges:
 
-* CentOS: `usermod -a -G apache <username>`
-* Ubuntu: `usermod -a -G www-data <username>`
+*  CentOS: `usermod -a -G apache <username>`
+*  Ubuntu: `usermod -a -G www-data <username>`
 
 {:.bs-callout .bs-callout-info}
 The `-a -G` options are important because they add `apache` or `www-data` as a _secondary_ group to the user account, which preserves the user's _primary_ group. Adding a secondary group to a user account helps [restrict file ownership and permissions](#perms-set-two-users) to ensure members of a shared group only have access to certain files.
@@ -105,16 +105,16 @@ Typically, the username and primary group name are the same.
 
 To complete the task, restart the web server:
 
-* Ubuntu: `service apache2 restart`
-* CentOS: `service httpd restart`
+*  Ubuntu: `service apache2 restart`
+*  CentOS: `service httpd restart`
 
 ### Step 4: Get the Magento software {#perms-get-software}
 
 If you haven't done so already, get the Magento software in one of the following ways:
 
-* [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
-* [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
-* [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
+*  [Compressed archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html)
+*  [Composer metapackage]({{ page.baseurl }}/install-gde/composer.html)
+*  [Clone the repository (contributing developers only)]({{ page.baseurl }}/install-gde/prereq/dev_install.html)
 
 ### Step 5: Set ownership and permissions for the shared group {#perms-set-two-users}
 
@@ -149,5 +149,5 @@ chmod u+x bin/magento
 
 After you have set file system ownership and permissions, continue with any of the following:
 
-* [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-* [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+*  [Command-line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+*  [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)

--- a/_includes/install/file-system-umask-over.md
+++ b/_includes/install/file-system-umask-over.md
@@ -19,7 +19,7 @@ The Magento file system owner is sometimes referred to as the *command-line user
 
 The Magento file system owner is any of the following:
 
-* A single user, which is typical of shared hosting.
+*  A single user, which is typical of shared hosting.
 
    Shared hosting providers enable you to log in to the Magento server as one user. This user can log in, transfer files using FTP, and this user also runs the web server.
 

--- a/_includes/install/new-cli-intro.md
+++ b/_includes/install/new-cli-intro.md
@@ -1,16 +1,16 @@
 Magento has one command-line interface that performs both installation and configuration tasks: `<magento_root>/bin/magento`. The new interface performs multiple tasks, including:
 
-- Installing Magento (and related tasks such as creating or updating the database schema, creating the deployment configuration, and so on).
-- Clearing the cache.
-- Managing indexes, including reindexing.
-- Creating translation dictionaries and translation packages.
-- Generating non-existent classes such as factories and interceptors for plug-ins, generating the dependency injection configuration for the object manager.
-- Deploying static view files.
-- Creating CSS from Less.
+-  Installing Magento (and related tasks such as creating or updating the database schema, creating the deployment configuration, and so on).
+-  Clearing the cache.
+-  Managing indexes, including reindexing.
+-  Creating translation dictionaries and translation packages.
+-  Generating non-existent classes such as factories and interceptors for plug-ins, generating the dependency injection configuration for the object manager.
+-  Deploying static view files.
+-  Creating CSS from Less.
 
 Other benefits:
 
-- A single command (`<magento_root>/bin/magento list`) lists all available installation and configuration commands.
-- Consistent user interface based on Symfony.
-- The CLI is extensible so third party developers can "plug in" to it. This has the additional benefit of eliminating users' learning curve.
-- Commands for disabled modules do not display.
+-  A single command (`<magento_root>/bin/magento list`) lists all available installation and configuration commands.
+-  Consistent user interface based on Symfony.
+-  The CLI is extensible so third party developers can "plug in" to it. This has the additional benefit of eliminating users' learning curve.
+-  Commands for disabled modules do not display.

--- a/_includes/install/patch/apply-patch.md
+++ b/_includes/install/patch/apply-patch.md
@@ -1,7 +1,7 @@
 To apply a patch:
 
-1.  Copy the patch file to your Magento installation directory.
-1.  As the Magento file system owner, use one of the following commands to extract it:
+1. Copy the patch file to your Magento installation directory.
+1. As the Magento file system owner, use one of the following commands to extract it:
 
 | Patch file format | Command to extract              |
 | ----------------- | ------------------------------- |

--- a/_includes/install/patch/get-patch-ee.md
+++ b/_includes/install/patch/get-patch-ee.md
@@ -4,19 +4,19 @@ You can get a {{site.data.var.ee}} patch in any of the following ways:
 
 To get a patch from the {{site.data.var.ee}} merchant portal:
 
-1.  Go to [www.magento.com](http://www.magento.com).
-1.  In the top horizontal navigation bar, click **My Account**.
-1.  Log in with your Magento username and password.
-1.  In the left navigation bar, click **Downloads**.
-1.  Click **Magento Enterprise Edition** > **2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
-1.  Transfer the patch to your development system.
+1. Go to [www.magento.com](http://www.magento.com).
+1. In the top horizontal navigation bar, click **My Account**.
+1. Log in with your Magento username and password.
+1. In the left navigation bar, click **Downloads**.
+1. Click **Magento Enterprise Edition** > **2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
+1. Transfer the patch to your development system.
 
 #### From the {{site.data.var.ee}} partner portal
 
 To get a patch from the {{site.data.var.ee}} partner portal:
 
-1.  Log in to [partners.magento.com](https://partners.magento.com/English/?rdir=/files.aspx).
-1.  Click **Magento Enterprise Edition** > **Magento Enterprise Edition 2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
-1.  In the left navigation bar, click **Downloads**.
-1.  Follow the instructions on your screen to download the desired patch.
-1.  Transfer the patch to your development system.
+1. Log in to [partners.magento.com](https://partners.magento.com/English/?rdir=/files.aspx).
+1. Click **Magento Enterprise Edition** > **Magento Enterprise Edition 2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
+1. In the left navigation bar, click **Downloads**.
+1. Follow the instructions on your screen to download the desired patch.
+1. Transfer the patch to your development system.

--- a/_includes/install/php-versions-template.md
+++ b/_includes/install/php-versions-template.md
@@ -2,6 +2,6 @@ Supported PHP versions:
 
 {% for version in supported_php_versions %}
 
-* {{ version }}
+*  {{ version }}
 
 {% endfor %}

--- a/_includes/install/prereq.md
+++ b/_includes/install/prereq.md
@@ -1,4 +1,4 @@
 Before you continue, make sure you've done all of the following:
 
-- Set up a server that meets our [system requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
-- Created the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
+-  Set up a server that meets our [system requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+-  Created the [Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)

--- a/_includes/install/sampledata/sample-data-clone.md
+++ b/_includes/install/sampledata/sample-data-clone.md
@@ -7,8 +7,8 @@ If you're not a contributing developer, choose one of the other options displaye
 
 Contributing developers can use this method of installing sample data *only* if all of the following are true:
 
-* You use {{site.data.var.ce}}
-* You [cloned the Magento 2 repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
+*  You use {{site.data.var.ce}}
+*  You [cloned the Magento 2 repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
 
 {:.bs-callout .bs-callout-warning}
 You can use sample data with either the `develop` branch (more current) or a released branch (such as `2.2` or `2.2.5` (more stable)). We recommend you use a released branch because it's more stable. If you're contributing code to the Magento 2 repository and you need the most recent code, use the `develop` branch. Regardless of the branch you choose, you must [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the corresponding branch of the Magento 2 GitHub repository. For example, sample data for the `develop` branch can be used *only* with the Magento 2 `develop` branch.

--- a/_includes/install/sampledata/sample-data-composer.md
+++ b/_includes/install/sampledata/sample-data-composer.md
@@ -1,10 +1,10 @@
 
 This section discusses how to install sample data if you got the Magento software in any of the following ways:
 
-* Downloaded a compressed archive from [Magento](https://magento.com/tech-resources/download).
+*  Downloaded a compressed archive from [Magento](https://magento.com/tech-resources/download).
 
   If you downloaded an archive from GitHub, this method won't work because the `composer.json` file doesn't contain the `repo.magento.com` URL.
-* Used `composer create-project`
+*  Used `composer create-project`
 
 You can use this method of getting sample data for both {{site.data.var.ce}} or {{site.data.var.ee}}, but you must use the same [authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) you used to install Magento.
 

--- a/_includes/install/trouble/rc_perms.md
+++ b/_includes/install/trouble/rc_perms.md
@@ -7,8 +7,8 @@ Directories in the Magento file system must be writable by the web server user a
 
 The way you resolve the issue depends on whether you have a one-user or two-user setup:
 
-* *One user* means you log in to the Magento server as the same user that also runs the web server. This type of setup is common in shared hosting environments.
-* *Two users* means you typically *cannot* log in as, or switch to, the web server user. You typically log in as one user and run the web server as a different user. This is typical in private hosting or if you have your own server.
+*  *One user* means you log in to the Magento server as the same user that also runs the web server. This type of setup is common in shared hosting environments.
+*  *Two users* means you typically *cannot* log in as, or switch to, the web server user. You typically log in as one user and run the web server as a different user. This is typical in private hosting or if you have your own server.
 
 ### One-user resolution
 

--- a/_includes/install/web/install-web_4-customize-store.md
+++ b/_includes/install/web/install-web_4-customize-store.md
@@ -15,7 +15,7 @@
    *  [General module configuration options](#instgde-install-magento-web-step4-depend1)
    *  [Module dependency errors](#instgde-install-magento-web-step4-depend2)
 
-1.  Click **Next**.
+1. Click **Next**.
 
 ### General module configuration options   {#instgde-install-magento-web-step4-depend1}
 

--- a/_includes/performance/development-environment.md
+++ b/_includes/performance/development-environment.md
@@ -15,18 +15,20 @@ These commands were built for use in production mode only.
 
 **Do not run** production commands in development mode:
 
-* ```bash
-  bin/magento setup:di:compile
-  ```
-  `setup:di:compile` generates auto-generated classes and optimized configuration caches.
-  In development mode, Magento performs the generation on-demand; you do not need to run it.
-  If you modified a signature of a class and need to re-generate its auto-generated factories/proxies/interceptors, remove those classes or the _generated_ folder.
+*  ```bash
+   bin/magento setup:di:compile
+   ```
 
-* ```bash
-  bin/magento setup:static-content:deploy
-  ```
-  `setup:static-content:deploy` deploys static content for a store.
-  In development mode, Magento performs it on-demand; you do not need to run it.
+   `setup:di:compile` generates auto-generated classes and optimized configuration caches.
+   In development mode, Magento performs the generation on-demand; you do not need to run it.
+   If you modified a signature of a class and need to re-generate its auto-generated factories/proxies/interceptors, remove those classes or the _generated_ folder.
+
+*  ```bash
+   bin/magento setup:static-content:deploy
+   ```
+
+   `setup:static-content:deploy` deploys static content for a store.
+   In development mode, Magento performs it on-demand; you do not need to run it.
 
 ## Normal page load time on a virtual machine
 


### PR DESCRIPTION
## Purpose of this pull request


This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folder: `_includes`. 

**Part 02**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
