### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Part 03

### DIFF
--- a/_includes/contributor/rewards.md
+++ b/_includes/contributor/rewards.md
@@ -11,12 +11,12 @@ Due to the level of work required for developing and reviewing a PR, Contributor
 
 See the following examples for calculated reward points:
 
--  Contributor submits PR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
--  Contributor submits PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
--  Contributor submits PR port of existing merged PR:
-   -  Original contributor: (Improvement(base) 10 points + Complex(additional) 20 points) + Author of Ported Issue 5 points = 35 points
-   -  Porting contributor: Port(base) 5 points
--  Maintainer reviews and approves PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
+- Contributor submits PR with complex code contributions: Improvement(base) 10 points + Complex(additional) 20 points = 30 points
+- Contributor submits PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
+- Contributor submits PR port of existing merged PR:
+   - Original contributor: (Improvement(base) 10 points + Complex(additional) 20 points) + Author of Ported Issue 5 points = 35 points
+   - Porting contributor: Port(base) 5 points
+- Maintainer reviews and approves PR with complex code and tests: Improvement(base) 10 points + Complex(additional) 20 points + Test coverage(additional) 10 points = 40 points
 
 Earned achievements display as labels on GitHub PRs and for each Magento Contributor, Partner, and Maintainer on [magento.com](https://magento.com/magento-contributors).
 
@@ -54,8 +54,8 @@ Contributors and Maintainers can also earn rewards for merged submissions to the
 
 See the following examples for calculated reward points:
 
--  Contributor submits PR with HTML formatting and typos fixes: Editorial(base) 1 point
--  Contributor submits PR with code sample update and new parameter descriptions: Improvement(base) 10 points + Major update(additional) 20 points = 30 points
+- Contributor submits PR with HTML formatting and typos fixes: Editorial(base) 1 point
+- Contributor submits PR with code sample update and new parameter descriptions: Improvement(base) 10 points + Major update(additional) 20 points = 30 points
 
 ### Base achievements
 {:.no_toc}

--- a/_includes/install/allowoverrides22.md
+++ b/_includes/install/allowoverrides22.md
@@ -7,13 +7,13 @@ Failure to enable these settings typically results in no styles displaying on yo
 
 1. Open the following file for editing.
 
-   *  Ubuntu: `vim /etc/apache2/sites-available/default`
-   *  CentOS: `vim /etc/httpd/conf/httpd.conf`
+   * Ubuntu: `vim /etc/apache2/sites-available/default`
+   * CentOS: `vim /etc/httpd/conf/httpd.conf`
 
 1. Locate the block that starts with:
 
-   *  Ubuntu 12: `<Directory /var/www/>`
-   *  Ubuntu 14 or CentOS: `<Directory /var/www/html>`
+   * Ubuntu 12: `<Directory /var/www/>`
+   * Ubuntu 14 or CentOS: `<Directory /var/www/html>`
 
 1. Change the value of `AllowOverride` to `<value from Apache site>`.
 

--- a/_includes/install/allowoverrides24.md
+++ b/_includes/install/allowoverrides24.md
@@ -2,36 +2,36 @@ Use this section to enable Apache 2.4 rewrites and specify a setting for the [di
 
 Magento uses server rewrites and `.htaccess` to provide directory-level instructions for Apache.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Failure to enable these settings typically results in no styles displaying on your storefront or Admin.
 
-1.  Enable the Apache rewrite module:
+1. Enable the Apache rewrite module:
 
-    ```bash
-    a2enmod rewrite
-    ```
+   ```bash
+   a2enmod rewrite
+   ```
 
-1.  To enable Magento to use the distributed `.htaccess` configuration file, see the guidelines in the [Apache 2.4 documentation](http://httpd.apache.org/docs/current/mod/mod_rewrite.html).
+1. To enable Magento to use the distributed `.htaccess` configuration file, see the guidelines in the [Apache 2.4 documentation](http://httpd.apache.org/docs/current/mod/mod_rewrite.html).
 
-    Note that in Apache 2.4, the server's default site configuration file is `/etc/apache2/sites-available/000-default.conf`.
+   Note that in Apache 2.4, the server's default site configuration file is `/etc/apache2/sites-available/000-default.conf`.
 
-    For example, you can add the following to the end of `000-default.conf`:
+   For example, you can add the following to the end of `000-default.conf`:
 
-    ```terminal
-    <Directory "/var/www/html">
-            AllowOverride  <value from Apache site>
-    </Directory>
-    ```
+   ```terminal
+   <Directory "/var/www/html">
+       AllowOverride  <value from Apache site>
+   </Directory>
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    In some cases, additional parameters might be required. For more information, see the [Apache 2.4 documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order).
+   {: .bs-callout-info }
+   In some cases, additional parameters might be required. For more information, see the [Apache 2.4 documentation](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html#order).
 
-1.  If you changed Apache settings, restart Apache:
+1. If you changed Apache settings, restart Apache:
 
-    ```bash
-    service apache2 restart
-    ```
+   ```bash
+   service apache2 restart
+   ```
 
-    {:.bs-callout .bs-callout-info}
-    -   If you upgraded from an earlier Apache version, first look for `<Directory "/var/www/html">` or `<Directory "/var/www">` in `000-default.conf`.
-    -   You must change the value of `AllowOverride` in the directive for the directory to which you expect to install the Magento software. For example, to install in the web server docroot, edit the directive in `<Directory /var/www>`.
+   {: .bs-callout-info }
+   - If you upgraded from an earlier Apache version, first look for `<Directory "/var/www/html">` or `<Directory "/var/www">` in `000-default.conf`.
+   - You must change the value of `AllowOverride` in the directive for the directory to which you expect to install the Magento software. For example, to install in the web server docroot, edit the directive in `<Directory /var/www>`.

--- a/_includes/install/auth-tokens-get.md
+++ b/_includes/install/auth-tokens-get.md
@@ -17,9 +17,9 @@ To create authentication keys:
 
 You can also disable or delete authentication keys. For example, you can disable or delete keys for security reasons after someone leaves your organization.
 
-*  To disable keys: Click **Disable**. You can do this if you want to suspend use of your keys.
-*  To enable a previously disabled key: Click **Enable**.
-*  To delete keys: Click **Delete**.
+* To disable keys: Click **Disable**. You can do this if you want to suspend use of your keys.
+* To enable a previously disabled key: Click **Enable**.
+* To delete keys: Click **Delete**.
 
 You cannot delete or disable keys you created by signing in to your [magento.com account](https://www.magentocommerce.com/products/customer/account/login){:target="_blank"}. To manage those keys:
 

--- a/_includes/install/before-you-begin-cli.md
+++ b/_includes/install/before-you-begin-cli.md
@@ -1,5 +1,5 @@
 Before you begin, make sure that:
 
-1.  Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
-1.  You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
-1.  After you log in to the Magento server, switch to a user that has permissions to write to the Magento file system. One way to do this is discussed in [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).
+1. Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+1. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
+1. After you log in to the Magento server, switch to a user that has permissions to write to the Magento file system. One way to do this is discussed in [switch to the Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html).

--- a/_includes/install/before-you-begin-web.md
+++ b/_includes/install/before-you-begin-web.md
@@ -1,6 +1,6 @@
 Before you begin, make sure that:
 
-1.  Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
-1.  You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
-1.  You started your installation as discussed in [Getting started]({{ page.baseurl }}/install-gde/install/web/install-web.html#instgde-install-magento-web-step0).
-1.  You completed all preceding steps in the Setup Wizard.
+1. Your system meets the requirements discussed in [Magento System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
+1. You completed all prerequisite tasks discussed in [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html).
+1. You started your installation as discussed in [Getting started]({{ page.baseurl }}/install-gde/install/web/install-web.html#instgde-install-magento-web-step0).
+1. You completed all preceding steps in the Setup Wizard.

--- a/_includes/install/composer-clone.md
+++ b/_includes/install/composer-clone.md
@@ -2,8 +2,8 @@ First, check if Composer is already installed:
 
 In a command prompt, enter any of the following commands:
 
--  `composer --help`
--  `composer list --help`
+- `composer --help`
+- `composer list --help`
 
 If command help displays, Composer is already installed.
 

--- a/_includes/install/composer-overview.md
+++ b/_includes/install/composer-overview.md
@@ -1,10 +1,10 @@
 We use [Composer](https://getcomposer.org/){:target="_blank"} to manage Magento components and their dependencies. Using Composer to get the Magento software [metapackage](https://glossary.magento.com/metapackage) provides the following advantages:
 
--   Reuse third-party libraries without bundling them with source code
--   Reduce extension conflicts and compatibility issues by using a component-based architecture with robust dependency management
--   Adhere to [PHP-Framework Interoperability Group (FIG)](https://www.php-fig.org/) standards
--   Repackage Magento Open Source with other components
--   Use the Magento software in a production environment
+- Reuse third-party libraries without bundling them with source code
+- Reduce extension conflicts and compatibility issues by using a component-based architecture with robust dependency management
+- Adhere to [PHP-Framework Interoperability Group (FIG)](https://www.php-fig.org/) standards
+- Repackage Magento Open Source with other components
+- Use the Magento software in a production environment
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 You must create a Composer project from our metapackage if you want to use the Magento Web Setup Wizard to upgrade the Magento software and third-party extensions.

--- a/_includes/install/enable-disable-modules.md
+++ b/_includes/install/enable-disable-modules.md
@@ -6,22 +6,22 @@ In addition, there might be *conflicting* modules that cannot both be enabled at
 
 Examples:
 
--   Module A depends on Module B. You cannot disable Module B unless you first disable Module A.
+- Module A depends on Module B. You cannot disable Module B unless you first disable Module A.
 
--   Module A depends on Module B, both of which are disabled. You must enable module B before you can enable module A.
+- Module A depends on Module B, both of which are disabled. You must enable module B before you can enable module A.
 
--   Module A conflicts with Module B. You can disable Module A and Module B, or you can disable either module but you *cannot* enable Module A and Module B at the same time.
+- Module A conflicts with Module B. You can disable Module A and Module B, or you can disable either module but you *cannot* enable Module A and Module B at the same time.
 
--   Dependencies are declared in the `require` field in Magento's `composer.json` file for each module. Conflicts are declared in the `conflict` field in modules' `composer.json` files. We use that information to build a dependency graph: `A->B` means module A depends on module B.
+- Dependencies are declared in the `require` field in Magento's `composer.json` file for each module. Conflicts are declared in the `conflict` field in modules' `composer.json` files. We use that information to build a dependency graph: `A->B` means module A depends on module B.
 
--   A *dependency chain* is the path from a module to another one. For example, if module A depends on module B and module B depends on module C, then the dependency chain is `A->B->C`.
+- A *dependency chain* is the path from a module to another one. For example, if module A depends on module B and module B depends on module C, then the dependency chain is `A->B->C`.
 
 If you attempt to enable or disable a module that depends on other modules, the dependency graph displays in the error message.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 It's possible that module A's `composer.json` declares a conflict with module B but not vice versa.
 
 *Command line [module enable or disable subcommand]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html) only:* To force a module to be enabled or disabled regardless of its dependencies, use the optional`--force` argument.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Using `--force` can disable your Magento store and cause problems accessing the Magento Admin.

--- a/_includes/install/file-system-perms-before.md
+++ b/_includes/install/file-system-perms-before.md
@@ -4,7 +4,7 @@ This topic discusses how to set read-write permissions for the web server group 
 
 The procedure you use is different, depending on whether you use [shared hosting](#perms-shared) and have one user or if you use a [private server](#perms-private) and have two users.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 If you're using a Magento version*earlier than* 2.0.6, see [Appendix&mdash;Magento file system ownership and appendix (legacy)]({{ page.baseurl }}/install-gde/install/legacy-file-system-perms.html) instead.
 
 ## Set permissions for shared hosting (one user) {#perms-shared}
@@ -27,8 +27,8 @@ This section discusses how to set ownership and permissions for your own server 
 
 After you've performed the other tasks in this topic, enter one of the following commands to switch to that user:
 
-*  Ubuntu: `su <username>`
-*  CentOS: `su - <username>`
+* Ubuntu: `su <username>`
+* CentOS: `su - <username>`
 
 For example,
 

--- a/_includes/install/file-system-umask-over.md
+++ b/_includes/install/file-system-umask-over.md
@@ -2,13 +2,13 @@
 
 Even in a development environment, you want your Magento installation to be secure. To help prevent issues related to unauthorized people or processes doing potentially harmful things to your system, we recommend some guidelines related to file system ownership and permissions.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 If you're using an Magento version 2.0.5 or earlier, see [Appendix&mdash;Magento file system ownership and appendix (legacy)]({{ page.baseurl }}/install-gde/install/legacy-file-system-perms.html) instead of this topic. In version 2.0.6 and later, Magento does not explicitly set file or directory permissions.
 
 This topic provides some basic information about our ownership and permissions guidelines. For additional information, see:
 
-*  [Set pre-installation ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html)
-*  [Magento ownership and permissions in development and production]({{ page.baseurl }}/config-guide/prod/prod_file-sys-perms.html)
+* [Set pre-installation ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html)
+* [Magento ownership and permissions in development and production]({{ page.baseurl }}/config-guide/prod/prod_file-sys-perms.html)
 
 ### Magento file system owner
 
@@ -29,9 +29,9 @@ The Magento file system owner is any of the following:
 
    In this situation, you typically *cannot* log in to the server as, or switch to, the web server user. Instead, you have separate users:
 
-   *  The web server user, which runs the Magento Admin and storefront.
+   * The web server user, which runs the Magento Admin and storefront.
 
-   *  A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
+   * A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
 
    The web server user and the command-line user might need write permissions to the Magento file system. (The users require write access in [developer mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html) but not in production mode.) You give permissions to both users by way of a shared group to which they both belong.
 
@@ -50,9 +50,9 @@ Magento uses a three-bit mask, by default `002`, that you subtract from the UNIX
 
 Here's what that means:
 
-*  775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
+* 775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
 
-*  664 for files, which means writable by the user, writable by the group, and read-only for everyone else.
+* 664 for files, which means writable by the user, writable by the group, and read-only for everyone else.
 
 For more information about `magento_umask`, see [Optionally set a umask]({{ page.baseurl }}/install-gde/install/post-install-umask.html).
 

--- a/_includes/install/file-system-umask.md
+++ b/_includes/install/file-system-umask.md
@@ -2,19 +2,19 @@ The web server group must have write permissions to certain directories in the M
 
 Our solution is to enable you to optionally create a file named `magento_umask` in your Magento root directory that restricts permissions for the web server group and everyone else.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 We recommend changing the umask on a one-user or shared hosting system only. If you have a private Magento server, the group must have write access to the Magento file system; the umask removes write access from the group.
 
 The default umask (with no `magento_umask` specified) is `002`, which means:
 
-*  775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
+* 775 for directories, which means full control by the user, full control by the group, and enables everyone to traverse the directory. These permissions are typically required by shared hosting providers.
 
-*  664 for files, which means writable by the user, writable by the group, and read-only for everyone else
+* 664 for files, which means writable by the user, writable by the group, and read-only for everyone else
 
 A common suggestion is to use a value of `022` in the `magento_umask` file, which means:
 
-*  755 for directories: full control for the user, and everyone else can traverse directories.
-*  644 for files: read-write permissions for the user, and read-only for everyone else.
+* 755 for directories: full control for the user, and everyone else can traverse directories.
+* 644 for files: read-write permissions for the user, and read-only for everyone else.
 
 To set `magento_umask`:
 

--- a/_includes/install/first-steps-cli.md
+++ b/_includes/install/first-steps-cli.md
@@ -24,6 +24,6 @@
 
    Optionally, you can run the commands in the following ways:
 
-   -  `cd <magento_root>/bin` and run them as `./magento <command name>`
-   -  `<magento_root>/bin/magento <command name>`
-   -  `<magento_root>` is a subdirectory of your web server docroot. [Need help locating the docroot?]({{ page.baseurl }}/install-gde/basics/basics_docroot.html)
+   - `cd <magento_root>/bin` and run them as `./magento <command name>`
+   - `<magento_root>/bin/magento <command name>`
+   - `<magento_root>` is a subdirectory of your web server docroot. [Need help locating the docroot?]({{ page.baseurl }}/install-gde/basics/basics_docroot.html)

--- a/_includes/install/flow-diagram.md
+++ b/_includes/install/flow-diagram.md
@@ -6,18 +6,18 @@ The diagram shows the following:
 
    Install the prerequisite software, including PHP, Apache, and MySQL. Consult the system requirements for specific information:
 
-   *  [2.2.x system requirements]({{ site.gdeurl22 }}install-gde/system-requirements-tech.html)
-   *  [2.3.x system requirements]({{ site.gdeurl23 }}install-gde/system-requirements-tech.html)
+   * [2.2.x system requirements]({{ site.gdeurl22 }}install-gde/system-requirements-tech.html)
+   * [2.3.x system requirements]({{ site.gdeurl23 }}install-gde/system-requirements-tech.html)
 
 1. Get the Magento software.
 
-   *  For simplicity, get a compressed {{site.data.var.ce}} or {{site.data.var.ee}} [archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html), extract it on your Magento server, and start your installation.
+   * For simplicity, get a compressed {{site.data.var.ce}} or {{site.data.var.ee}} [archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html), extract it on your Magento server, and start your installation.
 
-   *  If you are more technical and you are familiar with Composer, get a {{site.data.var.ce}} or {{site.data.var.ee}} {% if page.guide_version == "2.0" %} [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html) {% else %} [metapackage]({{page.baseurl}}/install-gde/composer.html). {% endif %}
+   * If you are more technical and you are familiar with Composer, get a {{site.data.var.ce}} or {{site.data.var.ee}} {% if page.guide_version == "2.0" %} [metapackage]({{page.baseurl}}/install-gde/prereq/integrator_install.html) {% else %} [metapackage]({{page.baseurl}}/install-gde/composer.html). {% endif %}
 
-   *  If you want to contribute to the {{site.data.var.ce}} codebase or customize the Magento application, [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the Magento 2 GitHub repository. (This method requires familiarity with both GitHub and Composer.)
+   * If you want to contribute to the {{site.data.var.ce}} codebase or customize the Magento application, [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the Magento 2 GitHub repository. (This method requires familiarity with both GitHub and Composer.)
 
-   {:.bs-callout .bs-callout-info}
+   {: .bs-callout-info }
    To be able to use the Web Setup Wizard to install or upgrade the Magento software, or to manage extensions you get from Magento Marketplace, you must either get a compressed archive or a Composer metapackage. If you clone the GitHub repository, you *cannot* use the Web Setup Wizard to upgrade the Magento software and extensions. You must upgrade using [Composer and Git commands]({{ page.baseurl }}/install-gde/install/cli/dev_options.html).
 
 1. Install the Magento software using either the Web Setup Wizard or command line.

--- a/_includes/install/fully-secure.md
+++ b/_includes/install/fully-secure.md
@@ -2,8 +2,8 @@
 
 To use Secure Sockets Layer (SSL), also referred to as HTTPS, for both the Magento Admin and the storefront, you must set all of the following parameters:
 
-*  `--use-secure`: Set to `1`
-*  `--base-url-secure`: Set to a secure URL (that is, starting with `https://`)
-*  `--use-secure-admin` Set to `1`
+* `--use-secure`: Set to `1`
+* `--base-url-secure`: Set to a secure URL (that is, starting with `https://`)
+* `--use-secure-admin` Set to `1`
 
 More details about these parameters can be found later in this topic.


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folder: `_includes`. 

**Part 03**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
