### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Part 04

### DIFF
--- a/_includes/install/get-software_zip.md
+++ b/_includes/install/get-software_zip.md
@@ -1,7 +1,7 @@
 The following table discusses where to get the Magento software. We provide the following downloads:
 
-*  {{site.data.var.ce}} or {{site.data.var.ee}} software only
-*  {{site.data.var.ce}} or {{site.data.var.ee}} software with sample data (designed to help you learn Magento faster)
+* {{site.data.var.ce}} or {{site.data.var.ee}} software only
+* {{site.data.var.ce}} or {{site.data.var.ee}} software with sample data (designed to help you learn Magento faster)
 
 These packages are easy to get and install. You don't need to use Composer, all you need to do is to upload a package to your Magento server or hosted platform, unpack it, and run the web-based Setup Wizard.
 
@@ -33,8 +33,8 @@ Archives are available in the following formats: `.zip`, `.tar.bz2`, `.tar.gz`
   <li>In the right pane, click <strong>Magento Enterprise Edition 2.X</strong> > <strong>Full Release</strong> or <strong>Magento Enterprise Edition 2.X</strong> > <strong>Full Release + Sample Data</strong> for the software.</li>
   <li>Follow the instructions on your screen to complete the {{site.data.var.ee}} download:
     <ul><li><code>Magento-EE-&lt;version>.*</code> (without sample data)</li>
-      <li><code>Magento-EE-&lt;version>+Samples.*</code> (with sample data)</li></ul>
-
+      <li><code>Magento-EE-&lt;version>+Samples.*</code> (with sample data)</li>
+    </ul>
   </li>
   <li>Transfer the installation package to your development system.</li></ol></td>
 </tr>

--- a/_includes/install/install-roadmap.md
+++ b/_includes/install/install-roadmap.md
@@ -10,37 +10,37 @@ Do you know what a "terminal" application is? Do you know what operating system 
 
 Topics include:
 
-*  [Choose how to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
-*  [System requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
-*  [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html)
-*  [The Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
+* [Choose how to get the Magento software]({{ page.baseurl }}/install-gde/bk-install-guide.html)
+* [System requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+* [Prerequisites]({{ page.baseurl }}/install-gde/prereq/prereq-overview.html)
+* [The Magento file system owner]({{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html)
 
 ## Installation part 2: Installing
 
 Topics include:
 
-*  [Command line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-*  [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
-*  [Optional sample data]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data.html)
+* [Command line installation]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+* [Setup Wizard installation]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+* [Optional sample data]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data.html)
 
 ## Installation part 3: Post-installation
 
 Topics include:
 
-*  [Verifying]({{ page.baseurl }}/install-gde/install/verify.html)
-*  [Configuring]({{ page.baseurl }}/install-gde/install/post-install-config.html)
-*  [Optional sample data (after installing Magento)]({{ page.baseurl }}/install-gde/install/sample-data-after-magento.html)
+* [Verifying]({{ page.baseurl }}/install-gde/install/verify.html)
+* [Configuring]({{ page.baseurl }}/install-gde/install/post-install-config.html)
+* [Optional sample data (after installing Magento)]({{ page.baseurl }}/install-gde/install/sample-data-after-magento.html)
 
 ## Upgrade, update
 
 Topics include:
 
-*  [Upgrading (or *patching* the Magento application)]({{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html)
-*  [Updating components (including install, uninstall, update, enable, disable)]({{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html)
-*  *Contributing developers only*: [Contributing developers&mdash;update, reinstall Magento]({{ page.baseurl }}/install-gde/install/cli/dev_options.html)
+* [Upgrading (or *patching* the Magento application)]({{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html)
+* [Updating components (including install, uninstall, update, enable, disable)]({{ page.baseurl }}/comp-mgr/bk-compman-upgrade-guide.html)
+* *Contributing developers only*: [Contributing developers&mdash;update, reinstall Magento]({{ page.baseurl }}/install-gde/install/cli/dev_options.html)
 
 ## Deploy to production
 
 [Deploy Magento to production]({{ page.baseurl }}/config-guide/prod/prod_deploy.html)
 
-*[Contributing developers]: A developer who contributes code to the Magento 2 CE codebase
+* [Contributing developers]: A developer who contributes code to the Magento 2 CE codebase

--- a/_includes/install/patch/apply-patch.md
+++ b/_includes/install/patch/apply-patch.md
@@ -1,7 +1,7 @@
 To apply a patch:
 
-1.  Copy the patch file to your Magento installation directory.
-1.  As the Magento file system owner, use one of the following commands to extract it:
+1. Copy the patch file to your Magento installation directory.
+1. As the Magento file system owner, use one of the following commands to extract it:
 
 | Patch file format | Command to extract              |
 | ----------------- | ------------------------------- |
@@ -9,5 +9,5 @@ To apply a patch:
 | .tar.gz           | `tar -zxf <patch name>.tar.gz`  |
 | .tar.bz2          | `tar -jxf <patch name>.tar.bz2` |
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 If you don't have command line access to your Magento server, extract the patch locally and transfer the files to the server using an FTP application.

--- a/_includes/install/patch/get-patch-ee.md
+++ b/_includes/install/patch/get-patch-ee.md
@@ -4,19 +4,19 @@ You can get a {{site.data.var.ee}} patch in any of the following ways:
 
 To get a patch from the {{site.data.var.ee}} merchant portal:
 
-1.  Go to [www.magento.com](http://www.magento.com).
-1.  In the top horizontal navigation bar, click **My Account**.
-1.  Log in with your Magento username and password.
-1.  In the left navigation bar, click **Downloads**.
-1.  Click **Magento Enterprise Edition** > **2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
-1.  Transfer the patch to your development system.
+1. Go to [www.magento.com](http://www.magento.com).
+1. In the top horizontal navigation bar, click **My Account**.
+1. Log in with your Magento username and password.
+1. In the left navigation bar, click **Downloads**.
+1. Click **Magento Enterprise Edition** > **2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
+1. Transfer the patch to your development system.
 
 #### From the {{site.data.var.ee}} partner portal
 
 To get a patch from the {{site.data.var.ee}} partner portal:
 
-1.  Log in to [partners.magento.com](https://partners.magento.com/English/?rdir=/files.aspx).
-1.  Click **Magento Enterprise Edition** > **Magento Enterprise Edition 2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
-1.  In the left navigation bar, click **Downloads**.
-1.  Follow the instructions on your screen to download the desired patch.
-1.  Transfer the patch to your development system.
+1. Log in to [partners.magento.com](https://partners.magento.com/English/?rdir=/files.aspx).
+1. Click **Magento Enterprise Edition** > **Magento Enterprise Edition 2.X** > **Magento Enterprise Edition 2.x Release** > **Support Patches**.
+1. In the left navigation bar, click **Downloads**.
+1. Follow the instructions on your screen to download the desired patch.
+1. Transfer the patch to your development system.

--- a/_includes/install/paypal-tls1-2.md
+++ b/_includes/install/paypal-tls1-2.md
@@ -4,8 +4,8 @@ PayPal recently announced they will require Transport Layer Security (TLS) versi
 
 More information:
 
-*  [Details (PayPal security bulletin)](https://www.paypal.com/uk/webapps/mpp/ssl-security-update)
-*  [PayPal live payments switching in June 2016 (PayPal technical blog)](https://devblog.paypal.com/upcoming-security-changes-notice/#tls)
+* [Details (PayPal security bulletin)](https://www.paypal.com/uk/webapps/mpp/ssl-security-update)
+* [PayPal live payments switching in June 2016 (PayPal technical blog)](https://devblog.paypal.com/upcoming-security-changes-notice/#tls)
 
 ### Symptom
 
@@ -60,15 +60,15 @@ If you're already running CentOS 6.8 or later, no action is necessary. According
 
 You have the following options:
 
-*  (Recommended). Upgrade your Magento server to CentOS 6.8 or later.
+* (Recommended). Upgrade your Magento server to CentOS 6.8 or later.
 
    Its recommended repositories support current versions of TLS with `libcurl`. Using CentOS 6.8 or later is the most secure way to continue operating your store and accepting PayPal.
 
    CentOS 6.8 has a `libcurl` version that defaults to TLS 1.2.
 
-*  (Less secure, *not recommended*). Upgrade to `libcurl` 7.34 or later on CentOS 6 using a non-recommended third-party repository.
+* (Less secure, *not recommended*). Upgrade to `libcurl` 7.34 or later on CentOS 6 using a non-recommended third-party repository.
 
    One possible solution is to use the information on [serverfault](http://serverfault.com/questions/321321/upgrade-curl-to-latest-on-centos).
 
-   {:.bs-callout .bs-callout-info}
+   {: .bs-callout-info }
    Installing software from non-recommended repositories can change other system packages and can result in issues. We strongly recommend you upgrade `libcurl` in a development environment and *thoroughly test* all payment processors you use as well as any other critical software before putting this into production.

--- a/_includes/install/releasenotes/20_release-notes-links.md
+++ b/_includes/install/releasenotes/20_release-notes-links.md
@@ -1,58 +1,58 @@
 
 {% collapsibleh2 Magento Open Source 2.0 Release Notes %}
 
-*  [Version 2.0.18]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.18CE.html){:target="_blank"}
-*  [Version 2.0.17]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.17CE.html){:target="_blank"}
-*  [Version 2.0.16]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.16CE.html){:target="_blank"}
-*  [Version 2.0.15]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.15CE.html){:target="_blank"}
-*  [Version 2.0.14]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.14CE.html){:target="_blank"}
-*  [Version 2.0.13]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.13CE.html){:target="_blank"}
-*  [Version 2.0.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.12CE.html){:target="_blank"}
-*  [Version 2.0.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.11CE.html){:target="_blank"}
-*  [Version 2.0.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.10CE.html){:target="_blank"}
-*  [Version 2.0.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.9CE.html){:target="_blank"}
-*  [Version 2.0.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.8CE.html){:target="_blank"}
-*  [Version 2.0.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.7CE.html){:target="_blank"}
-*  [Version 2.0.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.6CE.html){:target="_blank"}
-*  [Version 2.0.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.5CE.html){:target="_blank"}
-*  [Version 2.0.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.4CE.html){:target="_blank"}
-*  [Version 2.0.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.3CE.html){:target="_blank"}
-*  [Version 2.0.2](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.2.html){:target="_blank"}
-*  [Version 2.0.1](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.1.html){:target="_blank"}
-*  [Version 2.0.0](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.html){:target="_blank"}
+* [Version 2.0.18]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.18CE.html){:target="_blank"}
+* [Version 2.0.17]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.17CE.html){:target="_blank"}
+* [Version 2.0.16]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.16CE.html){:target="_blank"}
+* [Version 2.0.15]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.15CE.html){:target="_blank"}
+* [Version 2.0.14]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.14CE.html){:target="_blank"}
+* [Version 2.0.13]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.13CE.html){:target="_blank"}
+* [Version 2.0.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.12CE.html){:target="_blank"}
+* [Version 2.0.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.11CE.html){:target="_blank"}
+* [Version 2.0.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.10CE.html){:target="_blank"}
+* [Version 2.0.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.9CE.html){:target="_blank"}
+* [Version 2.0.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.8CE.html){:target="_blank"}
+* [Version 2.0.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.7CE.html){:target="_blank"}
+* [Version 2.0.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.6CE.html){:target="_blank"}
+* [Version 2.0.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.5CE.html){:target="_blank"}
+* [Version 2.0.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.4CE.html){:target="_blank"}
+* [Version 2.0.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.3CE.html){:target="_blank"}
+* [Version 2.0.2](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.2.html){:target="_blank"}
+* [Version 2.0.1](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.1.html){:target="_blank"}
+* [Version 2.0.0](http://docs.magento.com/m2/ce/user_guide/magento/release-notes-ce-2.0.html){:target="_blank"}
 
 {% endcollapsibleh2 %}
 
 {% collapsibleh2 Magento Commerce 2.0 Release Notes %}
 
-*  [Version 2.0.18]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.18EE.html){:target="_blank"}
-*  [Version 2.0.17]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.17EE.html){:target="_blank"}
-*  [Version 2.0.16]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.16EE.html){:target="_blank"}
-*  [Version 2.0.15]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.15EE.html){:target="_blank"}
-*  [Version 2.0.14]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.14EE.html){:target="_blank"}
-*  [Version 2.0.13]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.13EE.html){:target="_blank"}
-*  [Version 2.0.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.12EE.html){:target="_blank"}
-*  [Version 2.0.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.11EE.html){:target="_blank"}
-*  [Version 2.0.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.10EE.html){:target="_blank"}
-*  [Version 2.0.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.9EE.html){:target="_blank"}
-*  [Version 2.0.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.8EE.html){:target="_blank"}
-*  [Version 2.0.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.7EE.html){:target="_blank"}
-*  [Version 2.0.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.6EE.html){:target="_blank"}
-*  [Version 2.0.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.5EE.html){:target="_blank"}
-*  [Version 2.0.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.4EE.html){:target="_blank"}
-*  [Version 2.0.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.3EE.html){:target="_blank"}
-*  [Version 2.0.2](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.2.html){:target="_blank"}
-*  [Version 2.0.1](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.1.html){:target="_blank"}
-*  [Version 2.0.0](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.html){:target="_blank"}
+* [Version 2.0.18]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.18EE.html){:target="_blank"}
+* [Version 2.0.17]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.17EE.html){:target="_blank"}
+* [Version 2.0.16]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.16EE.html){:target="_blank"}
+* [Version 2.0.15]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.15EE.html){:target="_blank"}
+* [Version 2.0.14]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.14EE.html){:target="_blank"}
+* [Version 2.0.13]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.13EE.html){:target="_blank"}
+* [Version 2.0.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.12EE.html){:target="_blank"}
+* [Version 2.0.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.11EE.html){:target="_blank"}
+* [Version 2.0.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.10EE.html){:target="_blank"}
+* [Version 2.0.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.9EE.html){:target="_blank"}
+* [Version 2.0.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.8EE.html){:target="_blank"}
+* [Version 2.0.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.7EE.html){:target="_blank"}
+* [Version 2.0.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.6EE.html){:target="_blank"}
+* [Version 2.0.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.5EE.html){:target="_blank"}
+* [Version 2.0.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.4EE.html){:target="_blank"}
+* [Version 2.0.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.0.3EE.html){:target="_blank"}
+* [Version 2.0.2](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.2.html){:target="_blank"}
+* [Version 2.0.1](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.1.html){:target="_blank"}
+* [Version 2.0.0](http://docs.magento.com/m2/ee/user_guide/magento/release-notes-ee-2.0.html){:target="_blank"}
 
 {% endcollapsibleh2 %}
 
 {% collapsibleh2 Magento Commerce (Cloud) 2.0 Release Notes %}
 
-*  [Magento Commerce (Cloud) version 2.1.5 and 2.0.13 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.5.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.4.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.4.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.4 and 2.0.12]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.4.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.3 and 2.0.11]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.2 and 2.0.10]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.2.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.5 and 2.0.13 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.5.html){:target="_blank"}
+* [magento-cloud-configuration release 101.4.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.4.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.4 and 2.0.12]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.4.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.3 and 2.0.11]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.2 and 2.0.10]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.2.html){:target="_blank"}
 
 {% endcollapsibleh2 %}

--- a/_includes/install/releasenotes/20rc_release-notes-links.md
+++ b/_includes/install/releasenotes/20rc_release-notes-links.md
@@ -1,16 +1,16 @@
 
 {% collapsibleh3 Magento Open Source 2.1 Release Candidate Notes %}
 
-*  [Open Source 2.1 Release Candidate 3 (RC3)]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC3EE.html){:target="_blank"}
-*  [Open Source 2.1 RC2)]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC2EE.html){:target="_blank"}
-*  [Open Source 2.1 RC1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC1EE.html){:target="_blank"}
+* [Open Source 2.1 Release Candidate 3 (RC3)]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC3EE.html){:target="_blank"}
+* [Open Source 2.1 RC2)]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC2EE.html){:target="_blank"}
+* [Open Source 2.1 RC1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC1EE.html){:target="_blank"}
 
 {% endcollapsibleh3 %}
 
 {% collapsibleh3 Magento Commerce 2.1 Release Candidate Notes %}
 
-*  [Commerce 2.1 RC3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC3CE.html){:target="_blank"}
-*  [Commerce 2.1 RC2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC2CE.html){:target="_blank"}
-*  [Commerce 2.1 RC1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC1CE.html){:target="_blank"}
+* [Commerce 2.1 RC3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC3CE.html){:target="_blank"}
+* [Commerce 2.1 RC2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC2CE.html){:target="_blank"}
+* [Commerce 2.1 RC1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1_RC1CE.html){:target="_blank"}
 
 {% endcollapsibleh3 %}

--- a/_includes/install/releasenotes/21_release-notes-links.md
+++ b/_includes/install/releasenotes/21_release-notes-links.md
@@ -1,52 +1,52 @@
 
 {% collapsibleh2 Magento Open Source 2.1 Release Notes %}
 
-*  [Version 2.1.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.12CE.html){:target="_blank"}
-*  [Version 2.1.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.11CE.html){:target="_blank"}
-*  [Version 2.1.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.10CE.html){:target="_blank"}
-*  [Version 2.1.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.9CE.html){:target="_blank"}
-*  [Version 2.1.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.8CE.html){:target="_blank"}
-*  [Version 2.1.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.7CE.html){:target="_blank"}
-*  [Version 2.1.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.6CE.html){:target="_blank"}
-*  [Version 2.1.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.5CE.html){:target="_blank"}
-*  [Version 2.1.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.4CE.html){:target="_blank"}
-*  [Version 2.1.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.3CE.html){:target="_blank"}
-*  [Version 2.1.2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.2CE.html){:target="_blank"}
-*  [Version 2.1.1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.1CE.html){:target="_blank"}
-*  [Version 2.1.0]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.0CE.html){:target="_blank"}
+* [Version 2.1.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.12CE.html){:target="_blank"}
+* [Version 2.1.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.11CE.html){:target="_blank"}
+* [Version 2.1.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.10CE.html){:target="_blank"}
+* [Version 2.1.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.9CE.html){:target="_blank"}
+* [Version 2.1.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.8CE.html){:target="_blank"}
+* [Version 2.1.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.7CE.html){:target="_blank"}
+* [Version 2.1.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.6CE.html){:target="_blank"}
+* [Version 2.1.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.5CE.html){:target="_blank"}
+* [Version 2.1.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.4CE.html){:target="_blank"}
+* [Version 2.1.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.3CE.html){:target="_blank"}
+* [Version 2.1.2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.2CE.html){:target="_blank"}
+* [Version 2.1.1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.1CE.html){:target="_blank"}
+* [Version 2.1.0]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.0CE.html){:target="_blank"}
 
 {% endcollapsibleh2 %}
 
 {% collapsibleh2 Magento Commerce 2.1 Release Notes %}
 
-*  [Version 2.1.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.12EE.html){:target="_blank"}
-*  [Version 2.1.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.11EE.html){:target="_blank"}
-*  [Version 2.1.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.10EE.html){:target="_blank"}
-*  [Version 2.1.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.9EE.html){:target="_blank"}
-*  [Version 2.1.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.8EE.html){:target="_blank"}
-*  [Version 2.1.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.7EE.html){:target="_blank"}
-*  [Version 2.1.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.6EE.html){:target="_blank"}
-*  [Version 2.1.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.5EE.html){:target="_blank"}
-*  [Version 2.1.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.4EE.html){:target="_blank"}
-*  [Version 2.1.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.3EE.html){:target="_blank"}
-*  [Version 2.1.2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.2EE.html){:target="_blank"}
-*  [Version 2.1.1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.1EE.html){:target="_blank"}
-*  [Version 2.1.0]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.0EE.html){:target="_blank"}
+* [Version 2.1.12]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.12EE.html){:target="_blank"}
+* [Version 2.1.11]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.11EE.html){:target="_blank"}
+* [Version 2.1.10]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.10EE.html){:target="_blank"}
+* [Version 2.1.9]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.9EE.html){:target="_blank"}
+* [Version 2.1.8]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.8EE.html){:target="_blank"}
+* [Version 2.1.7]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.7EE.html){:target="_blank"}
+* [Version 2.1.6]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.6EE.html){:target="_blank"}
+* [Version 2.1.5]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.5EE.html){:target="_blank"}
+* [Version 2.1.4]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.4EE.html){:target="_blank"}
+* [Version 2.1.3]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.3EE.html){:target="_blank"}
+* [Version 2.1.2]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.2EE.html){:target="_blank"}
+* [Version 2.1.1]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.1EE.html){:target="_blank"}
+* [Version 2.1.0]({{ page.baseurl }}/release-notes/ReleaseNotes2.1.0EE.html){:target="_blank"}
 
 {% endcollapsibleh2 %}
 
 {% collapsibleh2 Magento Commerce (Cloud) 2.1 Release Notes %}
 
-*  [magento-cloud-configuration release 101.9.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.9.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.8.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.8.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.7.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.7.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.6.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.6.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.5.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.5.html){:target="_blank"}
-*  [magento-cloud-configuration release 101.4.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.4.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.6 through 2.1.11 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.6-2.1.11.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.5 and 2.0.13 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.5.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.4 and 2.0.12]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.4.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.3 and 2.0.11]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html){:target="_blank"}
-*  [Magento Commerce (Cloud) version 2.1.2 and 2.0.10]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.2.html){:target="_blank"}
+* [magento-cloud-configuration release 101.9.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.9.html){:target="_blank"}
+* [magento-cloud-configuration release 101.8.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.8.html){:target="_blank"}
+* [magento-cloud-configuration release 101.7.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.7.html){:target="_blank"}
+* [magento-cloud-configuration release 101.6.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.6.html){:target="_blank"}
+* [magento-cloud-configuration release 101.5.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.5.html){:target="_blank"}
+* [magento-cloud-configuration release 101.4.x Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes101.4.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.6 through 2.1.11 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.6-2.1.11.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.5 and 2.0.13 Release Notes]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.5.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.4 and 2.0.12]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.4.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.3 and 2.0.11]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.3.html){:target="_blank"}
+* [Magento Commerce (Cloud) version 2.1.2 and 2.0.10]({{ page.baseurl }}/cloud/release-notes/CloudReleaseNotes2.1.2.html){:target="_blank"}
 
 {% endcollapsibleh2 %}

--- a/_includes/install/releasenotes/ce_install_20.md
+++ b/_includes/install/releasenotes/ce_install_20.md
@@ -3,9 +3,9 @@
 
 See one of the following sections:
 
-*  [Get Magento Open Source using Composer](#install-ce-composer)
-*  [Get Magento Open Source using a compressed archive](#get-zip)
-*  [Complete the installation](#install-complete)
+* [Get Magento Open Source using Composer](#install-ce-composer)
+* [Get Magento Open Source using a compressed archive](#get-zip)
+* [Complete the installation](#install-complete)
 
 ### Get the Magento Open Source software using Composer {#install-ce-composer}
 {:.no_toc}
@@ -37,12 +37,12 @@ After you get the Open Source software:
 1. [Set file system ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 1. Install the Magento software:
 
-   *  [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
-   *  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+   * [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+   * [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
 
 ## Upgrade from an earlier version {#upgrade}
 
 To upgrade to version 2.0.x from an earlier version:
 
-*  [Web Setup Wizard (System Upgrade)]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
-*  [Command-line upgrade]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html)
+* [Web Setup Wizard (System Upgrade)]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
+* [Command-line upgrade]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html)

--- a/_includes/install/releasenotes/ee_install_20.md
+++ b/_includes/install/releasenotes/ee_install_20.md
@@ -3,9 +3,9 @@
 
 See one of the following sections:
 
-*  [Get Magento Commerce using Composer](#install-rc-composer)
-*  [Get Magento Commerce using a compressed archive](#get-zip)
-*  [Complete the installation](#install-complete)
+* [Get Magento Commerce using Composer](#install-rc-composer)
+* [Get Magento Commerce using a compressed archive](#get-zip)
+* [Complete the installation](#install-complete)
 
 ### Get Magento Commerce using Composer {#install-rc-composer}
 {:.no_toc}
@@ -37,12 +37,12 @@ After you get the Commerce software:
 1. [Set file system ownership and permissions]({{ page.baseurl }}/install-gde/prereq/file-system-perms.html).
 1. Install the Magento software:
 
-   *  [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
-   *  [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+   * [Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+   * [Command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
 
 ## Upgrade from an earlier version {#upgrade}
 
 To upgrade to version 2.0.x from an earlier version:
 
-*  [Web Setup Wizard (System Upgrade)]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
-*  [Command-line upgrade]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html)
+* [Web Setup Wizard (System Upgrade)]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
+* [Command-line upgrade]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html)

--- a/_includes/install/releasenotes/get-ce-software_zip.md
+++ b/_includes/install/releasenotes/get-ce-software_zip.md
@@ -1,8 +1,8 @@
 
 The following table discusses where to get the Magento software. We provide the following downloads:
 
-*  Magento Open Source software only
-*  Magento Open Source software with sample data (designed to help you learn Magento faster)
+* Magento Open Source software only
+* Magento Open Source software with sample data (designed to help you learn Magento faster)
 
 These packages are easy to get and install. You don't need to use Composer, all you need to do is to upload a package to your Magento server or hosted platform, unpack it, and run the web-based Setup Wizard.
 
@@ -13,7 +13,7 @@ To get the Magento Open Source software archive:
 1. Go to [http://magento.com/download](http://magento.com/download){:target="_blank"}.
 1. Choose either the software or the software and sample data:
 
-   *  `Magento-CE-<version>.*` (without sample data)
-   *  `Magento-CE-<version>+Samples.*` (with sample data)
+   * `Magento-CE-<version>.*` (without sample data)
+   * `Magento-CE-<version>+Samples.*` (with sample data)
 
    `<version>` is the three-digit release number (for example, `2.0.7`, `2.1.0`, and so on).

--- a/_includes/install/releasenotes/get-ee-software_zip.md
+++ b/_includes/install/releasenotes/get-ee-software_zip.md
@@ -1,8 +1,8 @@
 
 The following table discusses where to get the Magento software. We provide the following downloads:
 
-*  Magento Commerce software only
-*  Magento Commerce software with sample data (designed to help you learn Magento faster)
+* Magento Commerce software only
+* Magento Commerce software with sample data (designed to help you learn Magento faster)
 
 These packages are easy to get and install. You don't need to use Composer, all you need to do is to upload a package to your Magento server or hosted platform, unpack it, and run the web-based Setup Wizard.
 
@@ -16,7 +16,7 @@ To get the Magento Commerce archive:
 1. In the right pane, click **Magento Commerce 2.X** > **Full Release** or **Magento Commerce 2.X** > **Full Release + Sample Data** for the software.
 1. Follow the instructions on your screen to complete the Magento Commerce download:
 
-   *  `Magento-EE-<version>.*` (without sample data)
-   *  `Magento-EE-<version>+Samples.*` (with sample data)
+   * `Magento-EE-<version>.*` (without sample data)
+   * `Magento-EE-<version>+Samples.*` (with sample data)
 
 1. Transfer the installation package to your development system.

--- a/_includes/install/sampledata/sample-data-clone.md
+++ b/_includes/install/sampledata/sample-data-clone.md
@@ -10,20 +10,20 @@ Contributing developers can use this method of installing sample data *only* if 
 * You use {{site.data.var.ce}}
 * You [cloned the Magento 2 repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 You can use sample data with either the `develop` branch (more current) or a released branch (such as `2.2` or `2.2.5` (more stable)). We recommend you use a released branch because it's more stable. If you're contributing code to the Magento 2 repository and you need the most recent code, use the `develop` branch. Regardless of the branch you choose, you must [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the corresponding branch of the Magento 2 GitHub repository. For example, sample data for the `develop` branch can be used *only* with the Magento 2 `develop` branch.
 
 See the following sections:
 
-*  [Clone the sample data repository](#clone-sample-repo)
-*  [Set file system ownership and permissions](#samp-data-perms)
+* [Clone the sample data repository](#clone-sample-repo)
+* [Set file system ownership and permissions](#samp-data-perms)
 
 ## Clone the sample data repository {#clone-sample-repo}
 
 This section discusses how to install Magento sample data by cloning the sample data repository. You can clone the sample data repository in any of the following ways:
 
-*  Clone with the [SSH protocol](#clone-sample-repo-ssh)
-*  Clone with the [HTTPS protocol](#instgde-prereq-compose-clone-https)
+* Clone with the [SSH protocol](#clone-sample-repo-ssh)
+* Clone with the [HTTPS protocol](#instgde-prereq-compose-clone-https)
 
 ### Clone with SSH {#clone-sample-repo-ssh}
 
@@ -142,7 +142,7 @@ To clone the Magento sample data GitHub repository using the HTTPS protocol:
 1. Wait for the command to complete.
 1. See the next section.
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 If you're installing sample data _after_ installing Magento, you must also run the following command to update the database and schema:
 
 ```bash
@@ -164,9 +164,9 @@ To set file system permissions and ownership on the sample data repository:
 
    Typical examples:
 
-   *  CentOS: `chown -R :apache .`
+   * CentOS: `chown -R :apache .`
 
-   *  Ubuntu: `chown -R :www-data .`
+   * Ubuntu: `chown -R :www-data .`
 
 1. Set permissions:
 
@@ -186,6 +186,6 @@ To set file system permissions and ownership on the sample data repository:
 
 <!-- ABBREVIATIONS -->
 
-*[contributing developer]: A developer who contributes code to the Magento 2 CE codebase
-*[contributing developers]: Developers who contribute code to the Magento 2 CE codebase
-*[Contributing developers]: Developers who contribute code to the Magento 2 CE codebase
+* [contributing developer]: A developer who contributes code to the Magento 2 CE codebase
+* [contributing developers]: Developers who contribute code to the Magento 2 CE codebase
+* [Contributing developers]: Developers who contribute code to the Magento 2 CE codebase

--- a/_includes/install/sampledata/sample-data-other-cmds.md
+++ b/_includes/install/sampledata/sample-data-other-cmds.md
@@ -2,9 +2,9 @@
 
 This topic discusses how to:
 
-*  [Remove sample data modules](#inst-sample-remove) from the Magento installation `composer.json`. This option does *not* remove sample data from the database.
+* [Remove sample data modules](#inst-sample-remove) from the Magento installation `composer.json`. This option does *not* remove sample data from the database.
 
-*  [Prepare to update sample data](#inst-sample-reset) (for example, before updating the Magento application).
+* [Prepare to update sample data](#inst-sample-reset) (for example, before updating the Magento application).
 
 ## First steps {#sample-first}
 

--- a/_includes/install/sampledata/sample-data-rc1-cli.md
+++ b/_includes/install/sampledata/sample-data-rc1-cli.md
@@ -2,8 +2,8 @@
 
 These instructions apply to {{site.data.var.ce}} and {{site.data.var.ee}} users *only* if all of the following are true:
 
-*  You have installed optional sample data
-*  You are upgrading to Magento {{ page.guide_version }} (including a Release Candidate) from any earlier version using the command line
+* You have installed optional sample data
+* You are upgrading to Magento {{ page.guide_version }} (including a Release Candidate) from any earlier version using the command line
 
 To upgrade to Magento {{ page.guide_version }} sample data using the command line:
 
@@ -25,7 +25,7 @@ To upgrade to Magento {{ page.guide_version }} sample data using the command lin
    composer require <sample data module-1>:<version> ... <sample data module-n>:<version> --no-update
    ```
 
-   *  Example for {{site.data.var.ce}}:
+   * Example for {{site.data.var.ce}}:
 
       ```bash
       composer require magento/product-community-edition {{ page.guide_version }}.0 --no-update
@@ -35,7 +35,7 @@ To upgrade to Magento {{ page.guide_version }} sample data using the command lin
       composer require magento/module-bundle-sample-data:100.1.0 magento/module-widget-sample-data:100.1.0 magento/module-theme-sample-data:100.1.0 magento/module-catalog-sample-data:100.1.0 magento/module-customer-sample-data:100.1.0 magento/module-cms-sample-data:100.1.0  magento/module-catalog-rule-sample-data:100.1.0 magento/module-sales-rule-sample-data:100.1.0 magento/module-review-sample-data:100.1.0 magento/module-tax-sample-data:100.1.0 magento/module-sales-sample-data:100.1.0 magento/module-grouped-product-sample-data:100.1.0 magento/module-downloadable-sample-data:100.1.0 magento/module-msrp-sample-data:100.1.0 magento/module-configurable-sample-data:100.1.0 magento/module-product-links-sample-data:100.1.0 magento/module-wishlist-sample-data:100.1.0 magento/module-swatches-sample-data:100.1.0 magento/sample-data-media:100.1.0 magento/module-offline-shipping-sample-data:100.1.0 --no-update
       ```
 
-   *  Example for {{site.data.var.ee}}:
+   * Example for {{site.data.var.ee}}:
 
       ```bash
       composer require magento/product-enterprise-edition {{ page.guide_version }}.0 --no-update


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folder: `_includes`. 

**Part 04**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
