### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Part 05

### DIFF
--- a/_includes/install/sampledata/sample-data-rc1-web.md
+++ b/_includes/install/sampledata/sample-data-rc1-web.md
@@ -1,9 +1,9 @@
 
 These instructions apply to you *only* if all of the following are true:
 
-*  You're using Magento Enterprise Edition (EE)
-*  You have installed optional sample data
-*  You're upgrading to {{site.data.var.ee}} RC1 or {{site.data.var.ee}} RC2 from any earlier version using the Setup Wizard
+* You're using Magento Enterprise Edition (EE)
+* You have installed optional sample data
+* You're upgrading to {{site.data.var.ee}} RC1 or {{site.data.var.ee}} RC2 from any earlier version using the Setup Wizard
 
 To upgrade to {{site.data.var.ee}} RC1 or RC2 with sample data using the Setup Wizard:
 

--- a/_includes/install/sampledata/sample-data_list-of-modules.md
+++ b/_includes/install/sampledata/sample-data_list-of-modules.md
@@ -1,33 +1,33 @@
 
 {{site.data.var.ce}} and {{site.data.var.ee}}:
 
-*  magento/module-bundle-sample-data
-*  magento/module-catalog-rule-sample-data
-*  magento/module-catalog-sample-data
-*  magento/module-cms-sample-data
-*  magento/module-configurable-sample-data
-*  magento/module-customer-sample-data
-*  magento/module-downloadable-sample-data
-*  magento/module-grouped-product-sample-data
-*  magento/module-msrp-sample-data
-*  magento/module-offline-shipping-sample-data
-*  magento/module-product-links-sample-data
-*  magento/module-review-sample-data
-*  magento/module-sales-rule-sample-data
-*  magento/module-sales-sample-data
-*  magento/module-sample-data
-*  magento/module-swatches-sample-data
-*  magento/module-tax-sample-data
-*  magento/module-theme-sample-data
-*  magento/module-widget-sample-data
-*  magento/module-wishlist-sample-data
-*  magento/sample-data
-*  magento/sample-data-media
+* magento/module-bundle-sample-data
+* magento/module-catalog-rule-sample-data
+* magento/module-catalog-sample-data
+* magento/module-cms-sample-data
+* magento/module-configurable-sample-data
+* magento/module-customer-sample-data
+* magento/module-downloadable-sample-data
+* magento/module-grouped-product-sample-data
+* magento/module-msrp-sample-data
+* magento/module-offline-shipping-sample-data
+* magento/module-product-links-sample-data
+* magento/module-review-sample-data
+* magento/module-sales-rule-sample-data
+* magento/module-sales-sample-data
+* magento/module-sample-data
+* magento/module-swatches-sample-data
+* magento/module-tax-sample-data
+* magento/module-theme-sample-data
+* magento/module-widget-sample-data
+* magento/module-wishlist-sample-data
+* magento/sample-data
+* magento/sample-data-media
 
 {{site.data.var.ee}} only:
 
-*  magento/module-customer-balance-sample-data
-*  magento/module-gift-card-sample-data
-*  magento/module-gift-registry-sample-data
-*  magento/module-multiple-wishlist-sample-data
-*  magento/module-target-rule-sample-data
+* magento/module-customer-balance-sample-data
+* magento/module-gift-card-sample-data
+* magento/module-gift-registry-sample-data
+* magento/module-multiple-wishlist-sample-data
+* magento/module-target-rule-sample-data

--- a/_includes/install/sens-data.md
+++ b/_includes/install/sens-data.md
@@ -2,13 +2,13 @@
 
 Magento uses your encryption key to encrypt the following:
 
-*  Credit card information
-*  Usernames and passwords specified in the Magento Admin configuration  (for example, logins to payment gateways)
-*  CAPTCHA values sent over the network
+* Credit card information
+* Usernames and passwords specified in the Magento Admin configuration  (for example, logins to payment gateways)
+* CAPTCHA values sent over the network
 
 Magento does *not* encrypt:
 
-*  Administrative and customer usernames and passwords (these passwords are hashed)
-*  Address
-*  Phone number
-*  Other types of personally identifiable information except for credit card numbers
+* Administrative and customer usernames and passwords (these passwords are hashed)
+* Address
+* Phone number
+* Other types of personally identifiable information except for credit card numbers

--- a/_includes/install/trouble/rc_cron.md
+++ b/_includes/install/trouble/rc_cron.md
@@ -36,9 +36,9 @@ To verify whether or not your crontab is set up:
 
    Your crontab tells you the following:
 
-   *  What PHP binary you're using (in some cases, you have more than one)
-   *  What Magento cron scripts you're running (in particular, the paths to those scripts)
-   *  Where your cron logs are located
+   * What PHP binary you're using (in some cases, you have more than one)
+   * What Magento cron scripts you're running (in particular, the paths to those scripts)
+   * Where your cron logs are located
 
    See one of the following sections for a solution to your issue.
 

--- a/_includes/install/trouble/rc_php-version.md
+++ b/_includes/install/trouble/rc_php-version.md
@@ -3,17 +3,17 @@
 
 You might encounter the following issues with the PHP version readiness check:
 
-*  The check fails because you're using an unsupported PHP version.
+* The check fails because you're using an unsupported PHP version.
 
-To solve this issue, use one of the supported versions listed in our [System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
+   To solve this issue, use one of the supported versions listed in our [System Requirements]({{ page.baseurl }}/install-gde/system-requirements.html).
 
-*  The check reports the incorrect PHP version.
+* The check reports the incorrect PHP version.
 
-Typically, this happens only to advanced users who have multiple PHP versions installed. In some cases, the readiness check fails; in other cases, it might pass.
+   Typically, this happens only to advanced users who have multiple PHP versions installed. In some cases, the readiness check fails; in other cases, it might pass.
 
-*  The PHP readiness check doesn't display the PHP version as the following figure shows.
+* The PHP readiness check doesn't display the PHP version as the following figure shows.
 
- ![]({{ site.baseurl }}/common/images/upgr-tshoot-no-cron.png)
+   ![]({{ site.baseurl }}/common/images/upgr-tshoot-no-cron.png)
 
 This is a symptom of incorrect cron job setup. For more information, see [Set up cron jobs]({{ page.baseurl }}/install-gde/install/post-install-config.html#post-install-cron).
 
@@ -25,13 +25,13 @@ We assume that if you have this issue, you're an advanced user who has likely in
 
 To resolve the issue, try the following:
 
-*  Restart your web server or php-fm.
-*  Check the `$PATH` environment variable for multiple paths to PHP
-*  Use the `which php` command to locate the first PHP executable in your path; if it's not correct, remove it or create a symlink to the correct PHP version
-*  Use a [`phpinfo.php`]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo) page to collect more information
-*  Make sure you are running a supported PHP version according to our System Requirements:
+* Restart your web server or php-fm.
+* Check the `$PATH` environment variable for multiple paths to PHP
+* Use the `which php` command to locate the first PHP executable in your path; if it's not correct, remove it or create a symlink to the correct PHP version
+* Use a [`phpinfo.php`]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpinfo) page to collect more information
+* Make sure you are running a supported PHP version according to our System Requirements:
 
-   *  [Version 2.2]({{ site.gdeurl22 }}install-gde/system-requirements.html)
-   *  [Version 2.3]({{ site.gdeurl23 }}install-gde/system-requirements.html)
+   * [Version 2.2]({{ site.gdeurl22 }}install-gde/system-requirements.html)
+   * [Version 2.3]({{ site.gdeurl23 }}install-gde/system-requirements.html)
 
-*  Set the same PHP settings for both the PHP command line and the PHP web server plug-in as discussed in [PHP configuration options]({{ page.baseurl }}/install-gde/prereq/php-settings.html)
+* Set the same PHP settings for both the PHP command line and the PHP web server plug-in as discussed in [PHP configuration options]({{ page.baseurl }}/install-gde/prereq/php-settings.html)

--- a/_includes/install/web/install-web_4-customize-store.md
+++ b/_includes/install/web/install-web_4-customize-store.md
@@ -12,8 +12,8 @@
 
    See one of the following sections for more information about enabling and disabling modules:
 
-   *  [General module configuration options](#instgde-install-magento-web-step4-depend1)
-   *  [Module dependency errors](#instgde-install-magento-web-step4-depend2)
+   * [General module configuration options](#instgde-install-magento-web-step4-depend1)
+   * [Module dependency errors](#instgde-install-magento-web-step4-depend2)
 
 1.  Click **Next**.
 
@@ -23,11 +23,11 @@ Modules are listed in **Advanced Modules Configuration** in alphabetical order; 
 
 You have the following options for any module listed:
 
-*  To enable a module that is currently disabled, select its checkbox.
-*  To disable a module that is currently enabled, clear its checkbox.
-*  Use the **Select All** checkbox to:
-   *  Enable all modules if any module is currently disabled.
-   *  Disable all available modules (that is, all modules that do not depend on other enabled modules).
+* To enable a module that is currently disabled, select its checkbox.
+* To disable a module that is currently enabled, clear its checkbox.
+* Use the **Select All** checkbox to:
+   * Enable all modules if any module is currently disabled.
+   * Disable all available modules (that is, all modules that do not depend on other enabled modules).
 
 If a module's checkbox is unavailable, some other module depends on it. In the case of a dependency, to change the state of that module, you must first perform the corresponding action on the module on which it depends.
 
@@ -46,8 +46,8 @@ If there is a dependency error, a message similar to the following displays.
 
 Click **Show details** to display details about the dependency error. You can then do any of the following:
 
-*  Select the **Skip dependency check for individual modules** to ignore the issue and continue with your installation. (Additional dependency checks are performed after you click **Next**.)
-*  Resolve the issue by taking the action indicated by the message.
+* Select the **Skip dependency check for individual modules** to ignore the issue and continue with your installation. (Additional dependency checks are performed after you click **Next**.)
+* Resolve the issue by taking the action indicated by the message.
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Use <strong>Skip dependency check for individual modules</strong> with caution. We recommend against it because a typical reason for this error is you manually edited the [deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html). Editing the deployment configuration is not recommended because future Magento software updates can undo your changes.

--- a/_includes/install/web/install-web_6-install.md
+++ b/_includes/install/web/install-web_6-install.md
@@ -4,9 +4,9 @@ After completing all preceding steps in the Setup Wizard, click **Install Now**.
 
 You have the following options:
 
-*  To see installation progress or error details, click **Console Log**.
-*  In the event of problems, click **Previous** to go back and fix incorrect entries.
-*  To try the installation again in the event of failure, click **Try Again**.
+* To see installation progress or error details, click **Console Log**.
+* In the event of problems, click **Previous** to go back and fix incorrect entries.
+* To try the installation again in the event of failure, click **Try Again**.
 
 ### Installation Success   {#instgde-install-magento-web-step5last}
 

--- a/_includes/php-dev/component-root-2.3.md
+++ b/_includes/php-dev/component-root-2.3.md
@@ -2,14 +2,14 @@
 
 A component's root directory matches the component's name and contains all its subdirectories and files. Based on how you installed Magento, you can put your component's root directory in one of two places:
 
-*  `<Magento install directory>/app`: This is the *recommended* location for component development. You can set up this environment by [Cloning the Magento 2 GitHub repository]({{page.baseurl}}/install-gde/prereq/dev_install.html).
+* `<Magento install directory>/app`: This is the *recommended* location for component development. You can set up this environment by [Cloning the Magento 2 GitHub repository]({{page.baseurl}}/install-gde/prereq/dev_install.html).
 
-   *  For modules, use `app/code`.
-   *  For storefront themes, use `app/design/frontend`.
-   *  For Admin themes, use `app/design/adminhtml`.
-   *  For language packages, use `app/i18n`.
+   * For modules, use `app/code`.
+   * For storefront themes, use `app/design/frontend`.
+   * For Admin themes, use `app/design/adminhtml`.
+   * For language packages, use `app/i18n`.
 
-*  `<Magento install directory>/vendor`: You will find this location for installations that use the [`composer create-project`]({{page.baseurl}}/install-gde/composer.html) to install the Magento 2 metapackage (which downloads the CE or EE code). You will also find this location if you install Magento by extracting the [compressed Magento 2 archive]({{page.baseurl}}/install-gde/prereq/zip_install.html).
+* `<Magento install directory>/vendor`: You will find this location for installations that use the [`composer create-project`]({{page.baseurl}}/install-gde/composer.html) to install the Magento 2 metapackage (which downloads the CE or EE code). You will also find this location if you install Magento by extracting the [compressed Magento 2 archive]({{page.baseurl}}/install-gde/prereq/zip_install.html).
 
 Magento installs third-party components in the `vendor` directory. But we recommend adding your components to the `app/code` directory. If you put your component in the `vendor` directory, Git will ignore it because Magento adds the `vendor` directory to the `.gitignore` file.
 
@@ -17,6 +17,6 @@ Magento installs third-party components in the `vendor` directory. But we recomm
 
 All components require these three files:
 
-*  `registration.php`: This file registers your component with Magento. It uses the component's root directory name as the component name. By default, the composer installs components in the `<Magento root dir>/vendor` directory. For more information, see [Component registration]({{page.baseurl}}/extension-dev-guide/build/component-registration.html).
-*  `etc/module.xml`: This file defines basic information about the component, such as component dependencies and version number. Magento uses the version number to determine which schema and data to update when executing `bin/magento setup:upgrade`.
-*  `composer.json`: This file defines the dependencies that the component needs at runtime. For more information, see [Composer integration]({{page.baseurl}}/extension-dev-guide/build/composer-integration.html).
+* `registration.php`: This file registers your component with Magento. It uses the component's root directory name as the component name. By default, the composer installs components in the `<Magento root dir>/vendor` directory. For more information, see [Component registration]({{page.baseurl}}/extension-dev-guide/build/component-registration.html).
+* `etc/module.xml`: This file defines basic information about the component, such as component dependencies and version number. Magento uses the version number to determine which schema and data to update when executing `bin/magento setup:upgrade`.
+* `composer.json`: This file defines the dependencies that the component needs at runtime. For more information, see [Composer integration]({{page.baseurl}}/extension-dev-guide/build/composer-integration.html).

--- a/_includes/php-dev/component-root.md
+++ b/_includes/php-dev/component-root.md
@@ -2,14 +2,14 @@
 
 A component's root directory is the top-level directory for that component under which its folders and files are located. Depending on how your Magento development environment was installed, your component's root directory can be located in two places:
 
-*  `<Magento install directory>/app`: This is the *recommended* location for component development. You can easily set up this type of environment by [Cloning the Magento 2 GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
+* `<Magento install directory>/app`: This is the *recommended* location for component development. You can easily set up this type of environment by [Cloning the Magento 2 GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html).
 
-   *  For modules, use `app/code`.
-   *  For storefront themes, use `app/design/frontend`.
-   *  For Admin themes, use `app/design/adminhtml`.
-   *  For language packages, use `app/i18n`.
+   * For modules, use `app/code`.
+   * For storefront themes, use `app/design/frontend`.
+   * For Admin themes, use `app/design/adminhtml`.
+   * For language packages, use `app/i18n`.
 
-*  `<Magento install directory>/vendor`: This location is found in the alternative setups where the {% if page.guide_version == "2.0" %} [`composer create-project`]({{page.baseurl}}/install-gde/prereq/integrator_install.html) {% else %} [`composer create-project`]({{page.baseurl}}/install-gde/composer.html). {% endif %} command was used to get a Magento 2 metapackage (which downloads the CE or EE code), or a [compressed Magento 2 archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html) was extracted in order to install Magento.
+* `<Magento install directory>/vendor`: This location is found in the alternative setups where the {% if page.guide_version == "2.0" %} [`composer create-project`]({{page.baseurl}}/install-gde/prereq/integrator_install.html) {% else %} [`composer create-project`]({{page.baseurl}}/install-gde/composer.html). {% endif %} command was used to get a Magento 2 metapackage (which downloads the CE or EE code), or a [compressed Magento 2 archive]({{ page.baseurl }}/install-gde/prereq/zip_install.html) was extracted in order to install Magento.
 
    Any third party components (and the Magento application itself) are downloaded and stored under the `vendor` directory. If you are using Git to manage project, this directory is typically added to the `.gitignore` file. Therefore, we recommend you do your customization work in `app/code`, not `vendor`.
 
@@ -17,6 +17,6 @@ A component's root directory is the top-level directory for that component under
 
 The following files are required for all components:
 
-*  `registration.php`: Among other things, this file specifies the directory in which the component is installed by vendors in production environments. By default, composer automatically installs components in the `<Magento root dir>/vendor` directory. For more information, see [Component registration]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html).
-*  `etc/module.xml`: This file specifies basic information about the component such as the components dependencies and its version number. This version number is used to determine schema and data updates when `bin/magento setup:upgrade` is run.
-*  `composer.json`: Specifies component dependencies and other metadata. For more information, see [Composer integration]({{ page.baseurl }}/extension-dev-guide/build/composer-integration.html).
+* `registration.php`: Among other things, this file specifies the directory in which the component is installed by vendors in production environments. By default, composer automatically installs components in the `<Magento root dir>/vendor` directory. For more information, see [Component registration]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html).
+* `etc/module.xml`: This file specifies basic information about the component such as the components dependencies and its version number. This version number is used to determine schema and data updates when `bin/magento setup:upgrade` is run.
+* `composer.json`: Specifies component dependencies and other metadata. For more information, see [Composer integration]({{ page.baseurl }}/extension-dev-guide/build/composer-integration.html).

--- a/_includes/php-dev/component-versioning.md
+++ b/_includes/php-dev/component-versioning.md
@@ -1,9 +1,9 @@
 Components have the following types of versions:
 
-*  Marketing version; in other words, the version the merchant interacts with.
+* Marketing version; in other words, the version the merchant interacts with.
 
    Your initial version might be 1.0.0 or 2.0.0, for example. You should follow [our versioning policy]({{ page.baseurl }}/extension-dev-guide/versioning) guidelines when setting your version.
 
-*  Composer version; in other words, the version of each module, theme, language package, third-party package, and dependencies.
+* Composer version; in other words, the version of each module, theme, language package, third-party package, and dependencies.
 
 Using Magento code as an example, {{site.data.var.ce}} marketing version 2.0.0 includes component versions such as 100.0.1, 100.0.2, and so on. These versioning strategy prevents collisions between the marketing version and component versions.

--- a/_includes/reference/cli-template.md
+++ b/_includes/reference/cli-template.md
@@ -53,19 +53,19 @@ This reference is generated from the Magento codebase. To change the content, yo
 
 ##### `{{ item.name }}`
 
--  Description: {{ item.description }}
+- Description: {{ item.description }}
    {% unless item.default == nil %}
    {% if item.default == false or (item.default == empty and item.default != '') %}
--  Default: `{{ item.default | inspect }}`
+- Default: `{{ item.default | inspect }}`
    {% else %}
--  Default: `{{ item.default }}`
+- Default: `{{ item.default }}`
    {% endif %}
    {% endunless %}
    {% if item.is_required %}
--  Required
+- Required
    {% endif %}
    {% if item.is_array %}
--  Array
+- Array
    {% endif %}
    {% endif %}
    {% endfor %}
@@ -78,26 +78,26 @@ This reference is generated from the Magento codebase. To change the content, yo
 
 ##### `{{ option[0] }}`
 
--  Option: `{{ opt.name }}`
+- Option: `{{ opt.name }}`
    {% if opt.shortcut contains '-' %}
--  Shortcut: `{{ opt.shortcut }}`
+- Shortcut: `{{ opt.shortcut }}`
    {% endif %}
--  Description: {{ opt.description | replace: '|', '\|'}}
+- Description: {{ opt.description | replace: '|', '\|'}}
    {% unless opt.default == nil %}
    {% if opt.default == false or (opt.default == empty and opt.default != '') %}
--  Default: `{{ opt.default | inspect }}`
+- Default: `{{ opt.default | inspect }}`
    {% else %}
--  Default: `{{ opt.default }}`
+- Default: `{{ opt.default }}`
    {% endif %}
    {% endunless %}
    {% if opt.is_value_required %}
--  Requires a value
+- Requires a value
    {% elsif opt.accept_value and opt.is_multiple %}
--  Accepts multiple values
+- Accepts multiple values
    {% elsif opt.accept_value and opt.is_multiple == false %}
--  Accepts a value
+- Accepts a value
    {% else %}
--  Does not accept a value
+- Does not accept a value
    {% endif %}
    {% endfor %}
 

--- a/_includes/vendor/types-def.md
+++ b/_includes/vendor/types-def.md
@@ -1,12 +1,12 @@
 where
 
-*  `<your component base dir>` is the base directory in which your component is located. Typical values are `app/code` or `vendor` relative to the Magento installation directory.
-*  `<vendorname>` is the component's vendor name; for example, Magento's vendor name is `magento`.
-*  `<component-type>` is one of the following:
+* `<your component base dir>` is the base directory in which your component is located. Typical values are `app/code` or `vendor` relative to the Magento installation directory.
+* `<vendorname>` is the component's vendor name; for example, Magento's vendor name is `magento`.
+* `<component-type>` is one of the following:
 
-   *  `module-`: An extension or module.
-   *  `theme-`: Theme.
-   *  `language-`: Language package.
+   * `module-`: An extension or module.
+   * `theme-`: Theme.
+   * `language-`: Language package.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Currently, themes are located under `<magento_root>/app/design/frontend` or `<magento_root>/app/design/adminhtml`.


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folder: `_includes`. 

**Part 05**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
