### PR TITLE
GraphQL: Move CategoryInterface out of category query

### DIFF
--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -222,6 +222,9 @@ pages:
         - label: ProductInterface attributes
           url: /graphql/product/product-interface.html
 
+        - label: CategoryInterface attributes
+          url: /graphql/product/category-interface.html
+
         - label: CustomizableOptionInterface
           url: /graphql/product/customizable-option-interface.html
 

--- a/guides/v2.3/graphql/product/category-interface.md
+++ b/guides/v2.3/graphql/product/category-interface.md
@@ -1,0 +1,58 @@
+---
+group: graphql
+title: CategoryInterface attributes
+---
+
+`CategoryInterface` defines attributes that can be returned in the [`category` query]({{page.baseurl}}/graphql/queries/category.html) and the [`products` query]({{page.baseurl}}/graphql/queries/products.html).
+
+## CategoryInterface attributes
+
+The following table defines the `CategoryInterface` attributes and objects.
+
+Attribute | Type | Description
+--- | --- | ---
+`breadcrumbs` | [Breadcrumb] | A Breadcrumb object contains information the categories that comprise the breadcrumb trail for the specified category
+`created_at` | String | Timestamp indicating when the category was created
+`default_sort_by` | String | The attribute to use for sorting
+`description` | String | An optional description of the category
+`id` | Int | An ID that uniquely identifies the category
+`level` | Int | Indicates the depth of the category within the tree
+`name` | String | The display name of the category
+`path_in_store` | String | Category path in the store
+`path` | String | The path to the category, as a string of category IDs, separated by slashes (/). For example, 1/2/20
+`position` | Int | The position of the category relative to other categories at the same level in tree
+`product_count` | Int | The number of products in the category
+`products(<attributes>)` | CategoryProducts | The list of products assigned to the category
+`updated_at` | String | Timestamp indicating when the category was updated
+`url_key` | String | The URL key assigned to the category
+`url_path` | String | The URL path assigned to the category
+
+### Breadcrumb object
+
+A breadcrumb trail is a set of links that shows customers where they are in relation to other pages in the
+store.
+
+Attribute | Data type | Description
+--- | --- | ---
+`category_id` | Int | An ID that uniquely identifies the category
+`category_level` | Int | Indicates the depth of the category within the tree
+`category_name` | String |  The display name of the category
+`category_url_key` | String | The url key assigned to the category
+
+### CategoryProducts object
+
+The `products` attribute can contain the following attributes:
+
+Attribute | Data type | Description
+--- | --- | ---
+`currentPage` | Int |  Specifies which page of results to return. The default value is 1
+`pageSize` | Int | Specifies the maximum number of results to return at once. This attribute is optional. The default value is 20
+`sort` | `ProductSortInput` | Specifies which attribute to sort on, and whether to return the results in ascending or descending order. [Searches and pagination in GraphQL]({{ page.baseurl }}/graphql/search-pagination.html) describes sort orders
+
+The `CategoryProducts` object contains the following attributes:
+
+Attribute | Data type | Description
+--- | --- | ---
+`items` | [ProductInterface] | An array of products that are assigned to the category. See [ProductInterface]({{ page.baseurl }}/graphql/product/product-interface.html) for more information
+`page_info` | `SearchResultPageInfo` | An object that includes the `page_info` and `currentPage` values specified in the query
+`total_count` | Int | The number of products returned

--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -22,7 +22,7 @@ Attribute | Data type | Description
 --- | --- | ---
 `attribute_set_id` | Int | The attribute set assigned to the product
 `canonical_url` | String  | The canonical URL for the product
-`categories` | [CategoryInterface] | The categories assigned to the product. See [categories query]({{ page.baseurl }}/graphql/queries/category.html) for more information
+`categories` | [[CategoryInterface]]({{ page.baseurl }}/graphql/product/category-interface.html) | The categories assigned to the product. See [CategoryInterface attributes]({{ page.baseurl }}/graphql/product/category-interface.html) for more information
 `country_of_manufacture` | String | The product's country of origin
 `created_at` | String | Timestamp indicating when the product was created
 `crosssell_products` | [ProductInterface] | An array of cross-sell products

--- a/guides/v2.3/graphql/queries/category.md
+++ b/guides/v2.3/graphql/queries/category.md
@@ -196,61 +196,8 @@ Attribute | Data type | Description
 
 ## Output attributes {#Categories}
 
-The query returns a `CategoryTree` object, which implements `CategoryInterface`. It can contain the following top-level attributes:
+The query returns a `CategoryTree` object, which implements [`CategoryInterface`]({{page.baseurl}}/graphql/product/category-interface.html). The `CategoryTree` object can contain the following attribute, as we as all attributes defined in `CategoryInterface`:
 
 Attribute | Data type | Description
 --- | --- | ---
-`breadcrumbs` | `Breadcrumb` | A `Breadcrumb` object contains information the categories that comprise the breadcrumb trail for the specified category
-`children` | `CategoryTree` | A `CategoryTree` object that contains information about a child category. You can specify up to 10 levels of child categories
-`created_at`| String | Timestamp indicating when the category was created
-`default_sort_by`| String | The attribute to use for sorting
-`description`| String | An optional description of the category
-`id` | Int | An ID that uniquely identifies the category
-`level` | Int | Indicates the depth of the category within the tree
-`name`| String | The display name of the category
-`path_in_store`| String | Category path in the store
-`path`| String | The path to the category, as a string of category IDs, separated by slashes (/). For example, `1/2/20`
-`position`| Int | The position of the category relative to other categories at the same level in tree
-`product_count`| Int | The number of products in the category
-`products(<attributes>)` | `CategoryProducts` | The list of products assigned to the category
-`updated_at`| String | Timestamp indicating when the category was updated
-`url_key`| String | The url key assigned to the category
-`url_path`| String | The url path assigned to the category
-
-### CategoryProducts object
-
-The `products` attribute can contain the following attributes:
-
-Attribute | Data type | Description
---- | --- | ---
-`currentPage` | Int |  Specifies which page of results to return. The default value is 1
-`pageSize` | Int | Specifies the maximum number of results to return at once. This attribute is optional. The default value is 20
-`sort` | `ProductSortInput` | Specifies which attribute to sort on, and whether to return the results in ascending or descending order. [Searches and pagination in GraphQL]({{ page.baseurl }}/graphql/search-pagination.html) describes sort orders
-
-The `CategoryProducts` object contains the following attributes:
-
-Attribute | Data type | Description
---- | --- | ---
-`items` | [ProductInterface] | An array of products that are assigned to the category. See [ProductInterface]({{ page.baseurl }}/graphql/product/product-interface.html) for more information
-`page_info` | `SearchResultPageInfo` | An object that includes the `page_info` and `currentPage` values specified in the query
-`total_count` | Int | The number of products returned
-
-### Breadcrumb object
-
-A breadcrumb trail is a set of links that shows customers where they are in relation to other pages in the
-store.
-
-Attribute | Data type | Description
---- | --- | ---
-`category_id` | Int | An ID that uniquely identifies the category
-`category_level` | Int | Indicates the depth of the category within the tree
-`category_name` | String |  The display name of the category
-`category_url_key` | String | The url key assigned to the category
-
-### CategoryTree object
-
-This `CategoryTree` object contains information about the next level of subcategories of the category specified in the original query.
-
-Attribute | Data type | Description
---- | --- | ---
-`children` | [CategoryTree] | An array containing the next level of subcategories
+`children` | `CategoryTree` | An array containing the next level of subcategories. By default, you can specify up to 10 levels of child categories


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves the CategoryInterface attributes out of the `category` query topic. This is necessary because the attributes are available from the `products` query.

## Affected DevDocs pages

- graphql/product/category-interface.html
- graphql/queries/category.html

whatsnew
Moved the `CategoryInterface` attributes into their own [topic](https://devdocs.magento.com/guides/v2.3/graphql/product/category-interface.html).