### PR TITLE
Fix syntax for paths to run Actions on

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
     paths:
-      - '*.md'
+      - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes paths to run Actions on according to [Example including paths](https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-including-paths). The Actions must run on PRs with changed `.md` files. 