### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - b2b

### DIFF
--- a/guides/v2.2/b2b/bk-b2b.md
+++ b/guides/v2.2/b2b/bk-b2b.md
@@ -16,8 +16,8 @@ Unlike the standard business-to-consumer model, {{site.data.var.b2b}} (Business 
 
 There are two basic actors in B2B model:
 
-* A **seller** is an admin user that accesses the system from the Magento Admin panel.
-* A **buyer** is any customer associated with a company account who accesses the system from the storefront.
+*  A **seller** is an admin user that accesses the system from the Magento Admin panel.
+*  A **buyer** is any customer associated with a company account who accesses the system from the storefront.
 
 The Company component is the key entity within B2B on which all other features are in some way dependent. It allows joining multiple buyers that belong to the same company into a single company account (or corporate account). The company admin is able to build the company structure (divisions, subdivisions and users) in the appropriate hierarchy and provide different user roles and permissions to the company members. Such a hierarchy allows the company admin to control user activity within an account: ordering, quoting, purchasing, access to company credit info or profile, etc. In addition, a seller can configure how the buying company operates at the website: including the payment methods, pricing levels, the ability to negotiate over prices, and the ability to create requisition lists.
 
@@ -55,5 +55,5 @@ SharedCatalog | Defines the visibility of products and prices in the catalog and
 
 ## Related information
 
-* [Install the B2B extension]({{ site.baseurl }}/extensions/b2b/)
-* [Getting started with {{site.data.var.b2b}}](http://docs.magento.com/m2/b2b/user_guide/getting-started.html)
+*  [Install the B2B extension]({{ site.baseurl }}/extensions/b2b/)
+*  [Getting started with {{site.data.var.b2b}}](http://docs.magento.com/m2/b2b/user_guide/getting-started.html)

--- a/guides/v2.2/b2b/company-object.md
+++ b/guides/v2.2/b2b/company-object.md
@@ -338,7 +338,7 @@ None
 
 ## Related information
 
-* [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
-* [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
-* [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
-* [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)
+*  [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
+*  [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
+*  [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
+*  [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)

--- a/guides/v2.2/b2b/company-structures.md
+++ b/guides/v2.2/b2b/company-structures.md
@@ -283,7 +283,7 @@ The following example moves Bryce Martin (`structure_id = 4`) to the West team (
 
 ## Related information
 
-* [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
-* [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
-* [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
-* [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
+*  [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
+*  [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
+*  [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
+*  [Manage company roles]({{ page.baseurl }}/b2b/roles.html)

--- a/guides/v2.2/b2b/company-users.md
+++ b/guides/v2.2/b2b/company-users.md
@@ -186,7 +186,7 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
-* [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
-* [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
-* [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)
+*  [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
+*  [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
+*  [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
+*  [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)

--- a/guides/v2.2/b2b/company.md
+++ b/guides/v2.2/b2b/company.md
@@ -16,7 +16,7 @@ The `Company` module allows multiple buyers that belong to the same company to v
 
 ## Related information
 
-* [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
-* [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
-* [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
-* [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)
+*  [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
+*  [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
+*  [Manage company roles]({{ page.baseurl }}/b2b/roles.html)
+*  [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)

--- a/guides/v2.2/b2b/credit-manage.md
+++ b/guides/v2.2/b2b/credit-manage.md
@@ -9,9 +9,9 @@ functional_areas:
 
 The company credit entity operates with the following attributes:
 
-* Credit limit
-* Available credit
-* Outstanding balance
+*  Credit limit
+*  Available credit
+*  Outstanding balance
 
 The credit limit is allocated by seller, while available credit and outstanding balance are automatically calculated by the system based on the buyer transactions (place an order, return) and seller's transactions (refund, reimburse, update credit limit, cancel order).
 

--- a/guides/v2.2/b2b/negotiable-checkout.md
+++ b/guides/v2.2/b2b/negotiable-checkout.md
@@ -963,7 +963,7 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
-* [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
-* [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
-* [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)
+*  [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
+*  [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
+*  [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
+*  [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)

--- a/guides/v2.2/b2b/negotiable-manage.md
+++ b/guides/v2.2/b2b/negotiable-manage.md
@@ -54,8 +54,8 @@ Name | Description | Format | Requirements
 
 Before negotiable quote can begin, the following conditions must be met:
 
-* A regular Magento quote has been created (`POST /V1/customers/:customerId/carts` or `POST /V1/customers/carts/mine`)
-* The quote contains items (`POST /V1/carts/:quoteId/items`)
+*  A regular Magento quote has been created (`POST /V1/customers/:customerId/carts` or `POST /V1/customers/carts/mine`)
+*  The quote contains items (`POST /V1/carts/:quoteId/items`)
 
 If the negotiable quote requires a shipping address (for negotiation or tax calculations), you can add it to the standard quote before initiating the negotiable quote (`POST /V1/carts/:cartId/shipping-information`)
 
@@ -98,15 +98,15 @@ When you submit a negotiable quote to the buyer, the status for the buyer change
 
 The seller can send a request to submit the quote to the buyer. The request can be submitted only for quotes in the following system states:
 
-* Created
-* Processing by admin
-* Submitted by customer
+*  Created
+*  Processing by admin
+*  Submitted by customer
 
 When the quote is submitted to the buyer:
 
-* Magento checks catalog prices (price per item), cart rules, and discounts then recalculates the prices and taxes. The shipping price and the negotiated price are not affected (if they are entered into the quote).
-* Items that are no longer active or available for this buyer are removed from quote and prices are recalculated.
-* The quote state is changed to Submitted by admin.
+*  Magento checks catalog prices (price per item), cart rules, and discounts then recalculates the prices and taxes. The shipping price and the negotiated price are not affected (if they are entered into the quote).
+*  Items that are no longer active or available for this buyer are removed from quote and prices are recalculated.
+*  The quote state is changed to Submitted by admin.
 
 **Service Name**
 
@@ -177,9 +177,9 @@ To set the shipping method, the quote must be in the `created`, `processing_by_a
 
 The seller can send a request to decline the quote. The request can be submitted only for quotes in the following system states:
 
-* Created
-* Processing by admin
-* Submitted by customer
+*  Created
+*  Processing by admin
+*  Submitted by customer
 
 When you decline a quote, all custom pricing will be removed from the quote. The buyer will be able to place an order using their standard catalog prices and discounts.
 
@@ -332,7 +332,7 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
-* [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
-* [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
-* [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)
+*  [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
+*  [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
+*  [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
+*  [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)

--- a/guides/v2.2/b2b/negotiable-order-workflow.md
+++ b/guides/v2.2/b2b/negotiable-order-workflow.md
@@ -8,9 +8,9 @@ This topic describes how REST calls can be used to place items in a shopping car
 
 ## Prerequisites
 
-* You have [installed and enabled]({{ site.baseurl }}/extensions/b2b/) {{site.data.var.b2b}}.
-* You have [created a company]({{ page.baseurl }}/b2b/company-object.html) and a [company user]({{ page.baseurl }}/b2b/company-object.html).
-* You have an integration or [admin authorization token]({{ page.baseurl }}/rest/tutorials/orders/order-admin-token.html) to make calls on behalf of seller, and a [customer token]({{ page.baseurl }}/rest/tutorials/orders/order-create-customer.html#get-token) to make calls on behalf of the company user.
+*  You have [installed and enabled]({{ site.baseurl }}/extensions/b2b/) {{site.data.var.b2b}}.
+*  You have [created a company]({{ page.baseurl }}/b2b/company-object.html) and a [company user]({{ page.baseurl }}/b2b/company-object.html).
+*  You have an integration or [admin authorization token]({{ page.baseurl }}/rest/tutorials/orders/order-admin-token.html) to make calls on behalf of seller, and a [customer token]({{ page.baseurl }}/rest/tutorials/orders/order-create-customer.html#get-token) to make calls on behalf of the company user.
 
 ## Prepare the order
 
@@ -997,8 +997,8 @@ Authorization Bearer <admin token>
 
 ## Related information
 
-* [Order processing tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html)
-* [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
-* [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
-* [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
-* [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
+*  [Order processing tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html)
+*  [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
+*  [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
+*  [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
+*  [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)

--- a/guides/v2.2/b2b/negotiable-quote.md
+++ b/guides/v2.2/b2b/negotiable-quote.md
@@ -20,10 +20,10 @@ The negotiable quote lifecycle includes a number of stages, as shown on the diag
 
 The quoting process itself can be a continuous process, with a number of repeating cycles until the agreement is reached.
 
-* The buyer creates and submits a negotiable quote
-* The seller reviews and modifies or declines the quote
-* The buyer reviews the seller's counteroffer
-* Upon agreement, the buyer begins the checkout process and the system converts the negotiable quote into an order
+*  The buyer creates and submits a negotiable quote
+*  The seller reviews and modifies or declines the quote
+*  The buyer reviews the seller's counteroffer
+*  Upon agreement, the buyer begins the checkout process and the system converts the negotiable quote into an order
 
 {:.bs-callout .bs-callout-info}
 You cannot negotiate prices on individual items.
@@ -66,7 +66,7 @@ The following diagram shows the negotiable quote lifecycle from the perspective 
 
 ## Related information
 
-* [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
-* [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
-* [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
-* [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)
+*  [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
+*  [Update a negotiable quote]({{ page.baseurl }}/b2b/negotiable-update.html)
+*  [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
+*  [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)

--- a/guides/v2.2/b2b/negotiable-update.md
+++ b/guides/v2.2/b2b/negotiable-update.md
@@ -78,8 +78,8 @@ The `negotiated_price_type` can have one of the following values:
 
 The buyer can add, update, or delete items from the quote under the following conditions:
 
-* The quote is in one of the following system states: `created`, `processing_by_admin`, or `submitted_by_customer`.
-* The quote doesn't have a negotiated price.
+*  The quote is in one of the following system states: `created`, `processing_by_admin`, or `submitted_by_customer`.
+*  The quote doesn't have a negotiated price.
 
 **Sample Usage**
 
@@ -153,7 +153,7 @@ Authorization Bearer <customer token>
 
 ## Related information
 
-* [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
-* [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
-* [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
-* [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)
+*  [Integrate with the NegotiableQuote module]({{ page.baseurl }}/b2b/negotiable-quote.html)
+*  [Manage negotiable quotes]({{ page.baseurl }}/b2b/negotiable-manage.html)
+*  [Negotiable quote checkout]({{ page.baseurl }}/b2b/negotiable-checkout.html)
+*  [Place a negotiable quote order]({{ page.baseurl }}/b2b/negotiable-order-workflow.html)

--- a/guides/v2.2/b2b/roles.md
+++ b/guides/v2.2/b2b/roles.md
@@ -15,11 +15,11 @@ Within a company, customers may have different job roles, levels of responsibili
 
 {{site.data.var.b2b}} defines the following types of resources:
 
-* Sales
-* Negotiable quotes
-* Company profile
-* Company user management
-* Company credit
+*  Sales
+*  Negotiable quotes
+*  Company profile
+*  Company user management
+*  Company credit
 
 Each of these resources contains a hierarchy of other resources. When a Company Admin grants or blocks access to a resource from the store UI, the action applies to all sub-resources, unless explicitly overridden. However, if you grant or block access using web APIs, you must specify each resource individually.
 
@@ -1190,7 +1190,7 @@ None
 
 ## Related information
 
-* [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
-* [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
-* [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
-* [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)
+*  [Integrate with the Company module]({{ page.baseurl }}/b2b/company.html)
+*  [Manage company objects]({{ page.baseurl }}/b2b/company-object.html)
+*  [Manage company users]({{ page.baseurl }}/b2b/company-users.html)
+*  [Manage company structures]({{ page.baseurl }}/b2b/company-structures.html)

--- a/guides/v2.2/b2b/shared-cat-company.md
+++ b/guides/v2.2/b2b/shared-cat-company.md
@@ -102,6 +102,6 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
-* [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
-* [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)
+*  [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
+*  [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
+*  [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)

--- a/guides/v2.2/b2b/shared-cat-manage.md
+++ b/guides/v2.2/b2b/shared-cat-manage.md
@@ -183,6 +183,6 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
-* [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)
-* [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)
+*  [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
+*  [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)
+*  [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)

--- a/guides/v2.2/b2b/shared-cat-product-assign.md
+++ b/guides/v2.2/b2b/shared-cat-product-assign.md
@@ -10,9 +10,9 @@ functional_areas:
 
 The shared catalog configuration process includes assigning categories and products to the shared catalog. To assign these items to a shared catalog, the following conditions must be met:
 
-* The category structure must already be defined. You cannot create a new category to be included in a shared catalog. Use endpoints like `POST /V1/categories` to create a new category.
+*  The category structure must already be defined. You cannot create a new category to be included in a shared catalog. Use endpoints like `POST /V1/categories` to create a new category.
 
-* Each category must already be populated with products. You cannot add a new product to a category to be included in a shared catalog. Use endpoints like `POST /V1/products` to create a new product.
+*  Each category must already be populated with products. You cannot add a new product to a category to be included in a shared catalog. Use endpoints like `POST /V1/products` to create a new product.
 
 ## Assign categories
 
@@ -242,6 +242,6 @@ Not applicable
 
 ## Related information
 
-* [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
-* [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
-* [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)
+*  [Integrate with the SharedCatalog module]({{ page.baseurl }}/b2b/shared-catalog.html)
+*  [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
+*  [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)

--- a/guides/v2.2/b2b/shared-catalog.md
+++ b/guides/v2.2/b2b/shared-catalog.md
@@ -23,7 +23,7 @@ Custom shared catalogs can be assigned to companies only. They cannot be set for
 
 ## Related information
 
-* [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
-* [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)
-* [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)
-* [Manage prices for multiple products]({{ page.baseurl }}/rest/modules/catalog-pricing.html)
+*  [Manage shared catalogs]({{ page.baseurl }}/b2b/shared-cat-manage.html)
+*  [Assign categories and products]({{ page.baseurl }}/b2b/shared-cat-product-assign.html)
+*  [Assign companies]({{ page.baseurl }}/b2b/shared-cat-company.html)
+*  [Manage prices for multiple products]({{ page.baseurl }}/rest/modules/catalog-pricing.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folders:
- `guides/v2.2/b2b`
- `guides/v2.3/b2b`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
