### PR TITLE
Markdown linting: Spaces after list markers (MD030) 

### DIFF
--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -7,9 +7,9 @@ The Amazon Sales Channel extension installs and adds features to integrate your 
 
 ## Requirements
 
-- **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
-- **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
-- **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
+-  **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
+-  **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
+-  **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
 
 ## Install
 

--- a/extensions/amazon-sales/release-notes/index.md
+++ b/extensions/amazon-sales/release-notes/index.md
@@ -7,15 +7,15 @@ title: Amazon Sales Channel Release Notes
 
 See the following documentation:
 
-- [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
-- [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
-- [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
+-  [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
+-  [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
+-  [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
 
 The release notes include:
 
--   {:.new}New features
--   {:.fix}Fixes and improvements
--   {:.bug}Known issues
+-  {:.new}New features
+-  {:.fix}Fixes and improvements
+-  {:.bug}Known issues
 
 ### v3.0.0
 
@@ -23,9 +23,9 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.new}**Amazon UK Marketplace Now Available**: Users can choose the United Kingdom marketplace when [creating and integrating](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/store-integration.html) an Amazon Sales Channel store. This UK upgrade includes additional support for:
 
-   - [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
+   -  [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
 
-   - [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
+   -  [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
 
 -  {:.new}**Improved Logging**: <!--CHAN-3642, 3672-->Implemented the **Enable Debug Logging** feature to collect additional synchronization data when troubleshooting is needed. See the [Sales Channels Settings](https://docs.magento.com/m2/ce/user_guide/configuration/sales-channels/global-settings.html) topic in the Configuration Reference.
 
@@ -33,31 +33,31 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.fix}**Order Creation**: <!--CHAN-3708-->Corrected an issue preventing Magento from creating orders for an Amazon order that does not match with a Magento catalog product. See [Order Settings](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/order-settings.html).
 
-- {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
+-  {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
 
 ### v2.0.0
 
 Amazon Sales Channel 2.0.0 is compatible with version 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Version 1.0.0 was available in limited release only.
 
-- {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
+-  {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
 
-- {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
+-  {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
 
-- {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
+-  {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
 
-- {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
+-  {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
 
-- {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
+-  {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
 
-- {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
+-  {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
 
--   {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
+-  {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
 
--   {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
+-  {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
 
--   {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
+-  {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
 
--   {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.
+-  {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.

--- a/extensions/b2b/index.md
+++ b/extensions/b2b/index.md
@@ -7,7 +7,7 @@ redirect_from:
  - guides/v2.3/comp-mgr/install-extensions/b2b-installation.html
 ---
 
-{: .bs-callout .bs-callout-warning }
+{: .bs-callout-warning }
 The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
 
 1. Change to your Magento installation directory and enter the following command to update your `composer.json` file and install the {{site.data.var.b2b}} extension:
@@ -49,10 +49,10 @@ The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v
     bin/magento cache:clean
     ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
   Note: In Production mode, you may receive a message to 'Please rerun Magento compile command'.  Enter the commands above. Magento does not prompt you to run the compile command in Developer mode.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 After completing the installation, you must follow the [post-installation steps](#configure-b2b).
 
 ## Configure {#configure-b2b}
@@ -91,7 +91,7 @@ The {{site.data.var.b2b}} extension uses MySQL for message queue management. If 
     bin/magento queue:consumers:start sharedCatalogUpdatePrice
     ```
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Append `&` to the command to run it in the background, return to a prompt, and continue running commands. For example: `bin/magento queue:consumers:start sharedCatalogUpdatePrice &`.
 
 Refer to [Manage message queues]({{ site.baseurl }}/guides/v2.3/config-guide/mq/manage-message-queues.html) for more information.
@@ -109,15 +109,15 @@ You may also add these two message consumers to the cron job (optional). For thi
 
 Depending on your system configuration, to prevent possible issues, you may also need to specify the following parameters when starting the services:
 
-- `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
+-  `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
 
-- `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
+-  `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
 
 ### Enable B2B features in Magento Admin
 
 After installing the {{site.data.var.b2b}} extension and starting message consumers (if you want to enable the **Shared Catalog** module), you must also enable B2B modules in Magento Admin.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 If you enable the **Shared Catalog** module, you must also enable the **Company** module. The **Quick Order** and **Requisition Lists** modules can be enabled/disabled independently.
 
 1. Access the Magento Admin and click **Stores** > **Settings** > **Configuration** > **General** > **B2B Features**.

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -11,6 +11,6 @@ This section tracks and provides installation guides and release notes for Magen
 
 ## Additional information
 
-* [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
-* [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
-* [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)
+*  [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
+*  [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
+*  [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)

--- a/extensions/install/index.md
+++ b/extensions/install/index.md
@@ -11,11 +11,11 @@ Code that extends or customizes Magento behavior is called an extension. You can
 
 Extensions include:
 
-- Modules (extend Magento capabilities)
-- Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
-- Language packages (localize the storefront and Admin)
+-  Modules (extend Magento capabilities)
+-  Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
+-  Language packages (localize the storefront and Admin)
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 This topic explains how to use the command line to install extensions you purchase from the Magento Marketplace. You can use the same procedure to install _any_ extension; all you need is the extension's [Composer](https://glossary.magento.com/composer) name and version. To find it, open the extension's `composer.json` file and note the values for `"name"` and `"version"`.
 
 Prior to installation, you may want to:
@@ -55,7 +55,7 @@ To get the extension's Composer name and version from the Magento Marketplace:
 
     ![Technical details shows the extension's Composer name]({{ site.baseurl }}/common/images/marketplace-extension-technical-details.png){:width="200px"}
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Alternatively, you can find the Composer name and version of _any_ extension (whether you purchased it on Magento Marketplace or somewhere else) in the extension's `composer.json` file.
 
 ## Update your `composer.json` file {#update-composer-json}
@@ -102,7 +102,7 @@ By default, the extension is probably disabled:
   J2t_Payplug
   ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 The extension name is in the format `<VendorName>_<ComponentName>`; it's not the same format as the Composer name. Use this format to enable the extension.
 
 ## Enable the extension
@@ -163,7 +163,7 @@ Some extensions won't work properly unless you clear Magento-generated static vi
 
 1. Configure the extension in Admin as needed.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 If you encounter errors when loading the storefront in a browser, use the following command to clear the cache:
 <br/>
 `bin/magento cache:flush`

--- a/extensions/inventory-management/index.md
+++ b/extensions/inventory-management/index.md
@@ -80,9 +80,9 @@ For more information on configurations, see [Enabling Inventory Management](http
 
 You may need to disable {{site.data.var.im}} modules to:
 
-* Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
-* Use custom or third party inventory and order management modules.
-* Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
+*  Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
+*  Use custom or third party inventory and order management modules.
+*  Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
 
 To disable {{site.data.var.im}}, see the instructions for [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html). When complete, you should see the following modules and values in `<Magento_installation_directory>/app/etc/config.php` (v1.1.2 Beta):
 
@@ -172,13 +172,13 @@ For the latest, update your metapackage version:
 
 See the following guides for more information on upgrades:
 
-* [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
-* [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
+*  [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
+*  [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
 
 ## Additional information
 
 See the following guides for more information on {{site.data.var.im}}:
 
-* [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
-* [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
-* [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information
+*  [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
+*  [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
+*  [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information

--- a/guides/v2.2/advanced-reporting/report-xml.md
+++ b/guides/v2.2/advanced-reporting/report-xml.md
@@ -16,8 +16,8 @@ A report name is the same as the `name` attribute in the `<report>` node as desc
 Report XML does not support the asterisk statement.
 All columns must be declared:
 
-* for the main table — inside the `<source>` node
-* for join tables — inside the `<link-source>` node
+*  for the main table — inside the `<source>` node
+*  for join tables — inside the `<link-source>` node
 
 Columns are added using the `<attribute>` node.
 

--- a/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
@@ -8,12 +8,12 @@ Magento incorporates the core architectural principles of object-oriented, PHP-b
 
 The following discussion focuses on how these topics apply directly to Magento:
 
-* Magento technology stack
-* Magento View Model
-* Extensibility
-* Modularity
-* Event-driven architecture
-* Security
+*  Magento technology stack
+*  Magento View Model
+*  Extensibility
+*  Modularity
+*  Event-driven architecture
+*  Security
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
@@ -18,9 +18,9 @@ Layered software is a popular, widely discussed principle in software developmen
 
 Layered application design offers many advantages, but users of Magento will appreciate:
 
-* Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
+*  Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
 
-* Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
+*  Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
@@ -8,13 +8,13 @@ menu_title: Components
 
 Magento has several core components that are used to build custom websites, applications, and integrated systems. When you change the appearance or behavior of your Magento store, you are inevitably changing one or more of these **core Magento components**, which include **modules**, **themes**, and **language packages**. Together, these core components determine much of server-side and [storefront](https://glossary.magento.com/storefront) (frontend) appearance and behavior.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Throughout the Magento documentation set, we also use the term *component* in its generic sense to mean element or part. However, the term **Magento component** explicitly refers to either a module, theme, or [language package](https://glossary.magento.com/language-package).
 
 For more information about individual Magento components, see:
 
-* [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
+*  [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
 
-* [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
+*  [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
 
-* [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)
+*  [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -14,19 +14,19 @@ For example, if you are invoking a REST web service call, rather than load all t
 
 Magento is organized into these main areas:
 
-* **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
+*  **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
 
-* **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
+*  **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
 
-* **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
+*  **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
 
-* **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
+*  **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
 
 You can also send requests to Magento using the SOAP and REST APIs. These two areas
 
-* **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
+*  **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
 
-* **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
+*  **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
 
 ## How areas work with modules {#m2arch-module-using}
 
@@ -40,11 +40,11 @@ You can enable or disable an area within a module. If this module is enabled, it
 
 ### Module/area interaction guidelines
 
-* Modules should not depend on other modules' areas.
+*  Modules should not depend on other modules' areas.
 
-* Disabling an area does not result in disabling the modules related to it.
+*  Disabling an area does not result in disabling the modules related to it.
 
-* Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
+*  Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
 
 ### Note about Magento request processing
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -24,9 +24,9 @@ A module is a directory that contains the PHP and [XML](https://glossary.magento
 
 Modules typically live in the `vendor` directory of a Magento installation, in a directory with the following PSR-0 compliant format: `vendor/<vendor>/<type>-<module-name>`, where `<type>` can be one of the following values:
 
-- **`module`** - for modules (`module-customer-import-export`)
-- **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
-- **`language`** - for language packs (`language-de_de`)
+-  **`module`** - for modules (`module-customer-import-export`)
+-  **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
+-  **`language`** - for language packs (`language-de_de`)
 
 For example, the Customer Import/Export module of Magento can be found at `vendor/magento/module-customer-import-export`.
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -10,15 +10,15 @@ Understanding how one [module](https://glossary.magento.com/module) relates to a
 
 A single module can have the following types of relationships with another module:
 
-* **uses**: module A uses module B if it invokes behavior of module B
+*  **uses**: module A uses module B if it invokes behavior of module B
 
-* **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
+*  **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
 
-* **customizes**: module A customizes module B if it modifies the behavior of module B
+*  **customizes**: module A customizes module B if it modifies the behavior of module B
 
-* **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
+*  **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
 
-* **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
+*  **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
 
 ## Relationship types and scenarios
 

--- a/guides/v2.2/architecture/archi_perspectives/framework.md
+++ b/guides/v2.2/architecture/archi_perspectives/framework.md
@@ -11,7 +11,7 @@ The Magento Framework controls how application components interact, including re
 This primarily [PHP](https://glossary.magento.com/php) software component is organized into logical groups called *libraries*, which all modules can call.  Most of the framework code sits under the domain layer or encloses the presentation, service, and domain layers. The framework contains no business logic.
 (Although the Magento Framework does not contain resource models, it does contain a [library](https://glossary.magento.com/library) of code to help implement a resource model.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Don't confuse the Magento Framework with the Zend web application framework that ships with Magento.
 
 You should never modify Framework files, although if you are extending Magento, you must know how to call Framework libraries. Modules you create will typically inherit from classes and interfaces defined in the Framework directories.
@@ -22,11 +22,11 @@ The Magento Framework provides libraries that help reduce the effort of creating
 
 The Framework is responsible for operations that are useful for potentially all modules, including:
 
-* handling HTTP protocols
+*  handling HTTP protocols
 
-* interacting with the database and filesystem
+*  interacting with the database and filesystem
 
-* rendering content
+*  rendering content
 
 ## Organization
 
@@ -42,13 +42,13 @@ lib/
     ../web
 ```
 
-* `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
+*  `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
 
-* `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
+*  `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
 
-* `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
+*  `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 The `vendor/magento/framework` directory maps to the `Magento\Framework` [namespace](https://glossary.magento.com/namespace).
 
 ## Highlights of Magento Framework

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the folders:
- extensions
- guides/v2.2/advanced-reporting
- guides/v2.2/architecture (Part 1)

## Affected DevDocs pages

- ...

## Links to Magento source code

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
