### PR TITLE
Md030 architecture folder Part 2

### DIFF
--- a/_includes/cache/page-cache-checklists.md
+++ b/_includes/cache/page-cache-checklists.md
@@ -1,21 +1,21 @@
 ## Cacheable page checklist
 
--   Pages use GET requests
+-  Pages use GET requests
 
--   Pages render only cacheable blocks
+-  Pages render only cacheable blocks
 
--   Pages render without sensitive private data; session and customer DTO objects are empty
+-  Pages render without sensitive private data; session and customer DTO objects are empty
 
--   Functionality specific to both current session (customer) and page should be written using JavaScript (e.g., related product listing should exclude items that are already in the shopping cart)
+-  Functionality specific to both current session (customer) and page should be written using JavaScript (e.g., related product listing should exclude items that are already in the shopping cart)
 
--   Model and block level should identify themselves for invalidation support
+-  Model and block level should identify themselves for invalidation support
 
--   Declare a custom [context variable]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html#configure-page-variations) if you plan to show different public content with the same URL
+-  Declare a custom [context variable]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html#configure-page-variations) if you plan to show different public content with the same URL
 
 ## Non-cacheable page checklist
 
--   Use POST requests to modify Magento state (e.g., adding to shopping cart, wishlist, etc.)
+-  Use POST requests to modify Magento state (e.g., adding to shopping cart, wishlist, etc.)
 
--   Blocks that can't be cached should be marked as non-cacheable in the layout. However, be aware that adding a non-cacheable block to a page prevents the full page cache from caching that page.
+-  Blocks that can't be cached should be marked as non-cacheable in the layout. However, be aware that adding a non-cacheable block to a page prevents the full page cache from caching that page.
 
--   Controllers that don't use layouts should set `no-cache` HTTP headers
+-  Controllers that don't use layouts should set `no-cache` HTTP headers

--- a/_includes/cache/page-cache-overview.md
+++ b/_includes/cache/page-cache-overview.md
@@ -2,8 +2,8 @@
 
 Caching is one of the most effective ways to improve website performance. Generally speaking, there are two methods of caching content:
 
--   Client-side (browser)
--   Server-side
+-  Client-side (browser)
+-  Server-side
 
 Retrieving stored ([cached](https://glossary.magento.com/cache)) content from a previous request for the same client instead of requesting files from your server every time someone visits your site is a more efficient use of network bandwidth.
 
@@ -11,9 +11,9 @@ The Magento page cache library contains a simple PHP reverse proxy that enables 
 
 We recommend using [Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html), but you can use Magento's default caching mechanism instead, which stores cache files in any of the following:
 
--   File system (You don't need to do anything to use file-based caching.)
--   [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
--   [Redis]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+-  File system (You don't need to do anything to use file-based caching.)
+-  [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
+-  [Redis]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
 
 ## Cacheable and uncacheable pages {#cache-over-cacheable}
 
@@ -32,6 +32,6 @@ Do not configure content pages (i.e., catalog, product, and CMS pages) to be unc
 
 Reverse proxies serve "public" or shared content to more than one user. However, most Magento websites generate dynamic and personalized "private" content that should only be served to one user, which presents unique caching challenges. To address these challenges, Magento can distinguish between two types of content:
 
--   **[Public]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html)** - Public content is stored server side in your reverse proxy cache storage (e.g., file system, database, Redis, or Varnish) and is available to multiple customers. Examples of public content include header, footer, and category listing.
+-  **[Public]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/public-content.html)** - Public content is stored server side in your reverse proxy cache storage (e.g., file system, database, Redis, or Varnish) and is available to multiple customers. Examples of public content include header, footer, and category listing.
 
--   **[Private]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/private-content.html)** - Private content is stored client side (e.g., browser) and is specific to an individual customer. Examples of private content include wishlist, shopping cart, customer name, and address. You should limit stored private content to a small portion of the page's total content.
+-  **[Private]({{ page.baseurl }}/extension-dev-guide/cache/page-caching/private-content.html)** - Private content is stored client side (e.g., browser) and is specific to an individual customer. Examples of private content include wishlist, shopping cart, customer name, and address. You should limit stored private content to a small portion of the page's total content.

--- a/_includes/cloud/admin-ui-login-step.md
+++ b/_includes/cloud/admin-ui-login-step.md
@@ -1,1 +1,1 @@
-1.  [Log in]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin) to the Magento Admin UI.
+1. [Log in]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin) to the Magento Admin UI.

--- a/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
+++ b/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
@@ -14,7 +14,7 @@
 
 1. After the upload completes, refresh the cache according to the notification at the top of the page.
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 The *Custom VCL snippets* UI option shows only the snippets added through the Admin UI. You must use the Fastly API to [manage custom snippets added through the API]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).
 
 ## Delete the custom VCL snippet
@@ -27,8 +27,7 @@ You can delete custom VCL snippet code from your Fastly configuration by uploadi
    -  Save the configuration.
    -  Upload the VCL to Fastly to apply your changes.
 
--  Use the Fastly API [Delete custom VCL snippet]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-vcl) operation
- to delete the snippet completely, or submit a Magento support ticket to request deletion.
+-  Use the Fastly API [Delete custom VCL snippet]({{ page.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-vcl) operation to delete the snippet completely, or submit a Magento support ticket to request deletion.
 
 [Manage custom VCL snippets]: {{site.baseurl}}/common/images/cloud/cloud-fastly-manage-snippets.png
 {: width="650px"}

--- a/_includes/cloud/data-collection.md
+++ b/_includes/cloud/data-collection.md
@@ -1,6 +1,6 @@
 To help export Production data as test data to use in Staging and Integration environments, [Run the support utilities]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html):
 
-* [CLI commands]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html#config-cli-spt-utils-db) (Recommended) to export a protected backup of customer and store data using your Magento encryption key
-* [Data Collection](http://docs.magento.com/m2/ee/user_guide/system/support-data-collector.html) tool for generating and exporting data
+*  [CLI commands]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-spt-util.html#config-cli-spt-utils-db) (Recommended) to export a protected backup of customer and store data using your Magento encryption key
+*  [Data Collection](http://docs.magento.com/m2/ee/user_guide/system/support-data-collector.html) tool for generating and exporting data
 
 To migrate this data, see [Migrate and deploy static files and data]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html).

--- a/_includes/cloud/enable-ssh.md
+++ b/_includes/cloud/enable-ssh.md
@@ -51,7 +51,7 @@ To create an SSH key pair:
 
    GitHub also uses the key length `-b 4096` in the command. Follow the prompts to complete the key.
 
-1. When prompted to "Enter a file in which to save the key," press **Enter** to save the file to the default location. The prompt displays the location.
+1. When prompted to "Enter a file in which to save the key," press **Enter**to save the file to the default location. The prompt displays the location.
 
 1. When prompted to enter a secure passphrase, enter a phrase to use like a password. Make note of this passphrase. You may be requested to enter it depending on tasks you complete using a terminal during development.
 

--- a/_includes/cloud/patch.md
+++ b/_includes/cloud/patch.md
@@ -2,7 +2,7 @@ This topic discusses how to test patches to your {{site.data.var.ece}} system lo
 
 When you perform a {{site.data.var.ee}} upgrade, you automatically upgrade with patches and hotfixes through the `composer update` command. If you upgrade a Cloud patch without upgrading the full {{site.data.var.ee}} application, see [Upgrade a {{site.data.var.ee}} patch](#upgrade-patch). To upgrade and test a full {{site.data.var.ee}} version (including patches and hotfixes), see [Upgrade and test {{site.data.var.ee}}]({{ page.baseurl }}/cloud/project/project-upgrade.html).
 
-{: .bs-callout .bs-callout-info}
+{: .bs-callout-info }
 We recommend installing full {{site.data.var.ee}} upgrades for important security updates. Full upgrades include all associated patches and hotfixes.
 
 There are two types of patches:
@@ -19,7 +19,7 @@ There are two types of patches:
 
    Copy custom patches to the `m2-hotfixes` directory and test them on your locally. After successfully testing them, push the patches to the remote server.
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Always test a patch your local system. When complete, push the local Git branch to deploy your Integration environment. Resolve any issues before you deploy to Staging or Production.
 
 For more information on Composer, see [Composer in Cloud]({{ page.baseurl }}/cloud/reference/cloud-composer.html).

--- a/_includes/cloud/sens-data-create-config-local.md
+++ b/_includes/cloud/sens-data-create-config-local.md
@@ -1,28 +1,28 @@
 {:.procedure}
 To create and transfer `config.local.php`:
 
-1.  On your local workstation, find the integration server SSH URL.
+1. On your local workstation, find the integration server SSH URL.
 
-    ```bash
-    magento-cloud environment:ssh --pipe
-    ```
+   ```bash
+   magento-cloud environment:ssh --pipe
+   ```
 
-1.  Create the `config.local.php` file on the integration server.
+1. Create the `config.local.php` file on the integration server.
 
-    ```bash
-    ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
-    ```
+   ```bash
+   ssh server@ssh.magentosite.cloud "php bin/magento magento-cloud:scd-dump"
+   ```
 
-1.  Change to the project root directory.
+1. Change to the project root directory.
 
-1.  Transfer the `config.local.php` file to your local workstation.
+1. Transfer the `config.local.php` file to your local workstation.
 
-    ```bash
-    rsync server@ssh.magentosite.cloud:app/etc/config.local.php ./app/etc/config.local.php
-    ```
+   ```bash
+   rsync server@ssh.magentosite.cloud:app/etc/config.local.php ./app/etc/config.local.php
+   ```
 
-1.  Test to ensure a successful transfer by importing the configuration file to your local environment.
+1. Test to ensure a successful transfer by importing the configuration file to your local environment.
 
-    ```bash
-    php bin/magento app:config:import
-    ```
+   ```bash
+   php bin/magento app:config:import
+   ```

--- a/_includes/comp-man/checklist.md
+++ b/_includes/comp-man/checklist.md
@@ -4,7 +4,7 @@ Before you continue, to avoid errors during your installation or update, make su
 *  Your [cron jobs](#magento-cron) are set up and running
 *  [File system permissions](#perms) are set properly
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Do not continue without performing these checks. Failure to do so could result in errors.
 
 ### Magento file system owner and group {#magento-owner-group}

--- a/_includes/comp-man/checklist_2.2.md
+++ b/_includes/comp-man/checklist_2.2.md
@@ -5,7 +5,7 @@ Before you continue, to avoid errors during your installation or update, make su
 *  [Set a value for DATA_CONVERTER_BATCH_SIZE](#batch-size)
 *  [File system permissions](#perms) are set properly
 
-{:.bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Do not continue without performing these checks. Failure to do so could result in errors.
 
 ### Set a value for DATA_CONVERTER_BATCH_SIZE {#batch-size}
@@ -37,7 +37,7 @@ After your upgrade completes, you can unset the variable as follows:
 unset DATA_CONVERTER_BATCH_SIZE
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 `DATA_CONVERTER_BATCH_SIZE` requires memory; avoid setting it to a very large value (approximately 1GB) without testing it first.
 
 ### Magento file system owner and group {#magento-owner-group}

--- a/_includes/comp-man/dependency.md
+++ b/_includes/comp-man/dependency.md
@@ -4,9 +4,9 @@
 
 We suggest you try the following solutions in the order shown:
 
-* [Conflicting dependencies](#trouble-depend-conflict)
-* [File system permissions issues](#trouble-depend-permission)
-* [The Component Dependency Check status never changes](#trouble-depend-state)
+*  [Conflicting dependencies](#trouble-depend-conflict)
+*  [File system permissions issues](#trouble-depend-permission)
+*  [The Component Dependency Check status never changes](#trouble-depend-state)
 
 ### Conflicting dependencies {#trouble-depend-conflict}
 
@@ -21,7 +21,7 @@ Following is a sample failure message:
  - magento/sample-data version 0.74.0-beta15. Please try to update it to one of the following package versions: 0.74.0-beta16, 0.74.0-beta14, 0.74.0-beta13, 0.74.0-beta12, 0.74.0-beta11, 0.74.0-beta10, 0.74.0-beta9, 0.74.0-beta8, 0.74.0-beta7
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 The message you see will likely be different.
 
 Typically, component dependency conflicts result from someone manually editing the Magento 2 `composer.json` file. It can also be caused by third-party modules that depend on earlier Magento components than the ones you have installed.

--- a/_includes/comp-man/readiness-check.md
+++ b/_includes/comp-man/readiness-check.md
@@ -5,7 +5,7 @@ After the readiness check completes, see one of the following:
 
 ### Readiness check success {#compman-readiness-success}
 
-The following figure shows an example of a successful readiness check. If all tests passed, click **Next** and continue with the next step.
+The following figure shows an example of a successful readiness check. If all tests passed, click **Next**and continue with the next step.
 
 ![If all readiness checks pass, click Next and continue with the next step]({{ site.baseurl }}/common/images/extensman_readiness-success.png)
 

--- a/_includes/config-guide/custom-logger-handler-examples.md
+++ b/_includes/config-guide/custom-logger-handler-examples.md
@@ -1,7 +1,7 @@
 You can use one of the following approaches for logging into a custom file:
 
-- Set up a custom log file in the `di.xml`
-- Set up a custom file in the custom logger handler class
+-  Set up a custom log file in the `di.xml`
+-  Set up a custom file in the custom logger handler class
 
 ## Set up a custom log file in the `di.xml`
 

--- a/_includes/config/es-elasticsearch-magento.md
+++ b/_includes/config/es-elasticsearch-magento.md
@@ -1,7 +1,7 @@
 This section discusses the minimum settings you must choose to test Elasticsearch with Magento 2.
 For additional details about configuring Elasticsearch, see the [{{site.data.var.ee}} User Guide](http://docs.magento.com/m2/ee/user_guide/catalog/search-elasticsearch.html).
 
-{: .bs-callout .bs-callout-warning}
+{: .bs-callout-warning }
 Magento 2.3.1 adds support for Elasticsearch 6.x, and it is enabled by default.
 Magento still provides modules for Elasticsearch 2.x and 5.x, but these must be enabled in order to use these versions.
 Elasticsearch 2.x is still available but strongly discouraged. Versions 2.x and 5.x are [End of Life](https://www.elastic.co/support/eol).
@@ -48,12 +48,12 @@ or you will see:
 
 If so, try the following:
 
-* Make sure the Elasticsearch server is running.
-* If the Elasticsearch server is on a different host from Magento, log in to the Magento server and ping the Elasticsearch host. Resolve network connectivity issues and test the connection again.
-* Examine the command window in which you started Elasticsearch for stack traces and exceptions. You must resolve those before you continue. In particular, make sure you started Elasticsearch as a user with `root` privileges.
-* Make sure that [UNIX firewall and SELinux]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html#firewall-selinux) are both disabled, or set up rules to enable Elasticsearch and Magento to communicate with each other.
-* Verify the value of the **Elasticsearch Server Hostname** field. Make sure the server is available. You can try the server's IP address instead.
-* Use the command `netstat -an | grep **listen-port**` command to verify that the port specified in the **Elasticsearch Server Port** field is not being used by another process.
+*  Make sure the Elasticsearch server is running.
+*  If the Elasticsearch server is on a different host from Magento, log in to the Magento server and ping the Elasticsearch host. Resolve network connectivity issues and test the connection again.
+*  Examine the command window in which you started Elasticsearch for stack traces and exceptions. You must resolve those before you continue. In particular, make sure you started Elasticsearch as a user with `root` privileges.
+*  Make sure that [UNIX firewall and SELinux]({{ page.baseurl }}/config-guide/elasticsearch/es-overview.html#firewall-selinux) are both disabled, or set up rules to enable Elasticsearch and Magento to communicate with each other.
+*  Verify the value of the **Elasticsearch Server Hostname** field. Make sure the server is available. You can try the server's IP address instead.
+*  Use the command `netstat -an | grep **listen-port**` command to verify that the port specified in the **Elasticsearch Server Port** field is not being used by another process.
 
   For example, to see if Elasticsearch is running on its default port, use the following command:
 
@@ -97,5 +97,5 @@ bin/magento indexer:reindex
 
 1. Wait until reindexing completes.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Unlike the cache, indexers are updated by a cron job. Make sure [cron is enabled]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html) before you start using Elasticsearch.

--- a/_includes/config/install-java.md
+++ b/_includes/config/install-java.md
@@ -10,8 +10,8 @@ If the message `java: command not found` displays, you must install the Java SDK
 
 See one of the following sections:
 
-* [Install the latest JDK on CentOS](#install-prereq-java-centos)
-* [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
+*  [Install the latest JDK on CentOS](#install-prereq-java-centos)
+*  [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
 
 #### Install the JDK on CentOS {#install-prereq-java-centos}
 
@@ -23,7 +23,7 @@ Be sure to install the JDK and *not* the JRE.
 yum -y install java-1.7.0-openjdk
 ```
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Java version 7 might not be available for all operating systems. For example, you can [search the list of available packages for Ubuntu](http://packages.ubuntu.com/).
 
 #### Install the JDK on Ubuntu {#install-prereq-java-ubuntu}

--- a/_includes/config/install-java8.md
+++ b/_includes/config/install-java8.md
@@ -10,8 +10,8 @@ If the message `java: command not found` displays, you must install the Java SDK
 
 See one of the following sections:
 
-* [Install the latest JDK on CentOS](#install-prereq-java-centos)
-* [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
+*  [Install the latest JDK on CentOS](#install-prereq-java-centos)
+*  [Install the latest JDK on Ubuntu](#install-prereq-java-ubuntu)
 
 #### Install the JDK on CentOS   {#install-prereq-java-centos}
 

--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -7,9 +7,9 @@ The Amazon Sales Channel extension installs and adds features to integrate your 
 
 ## Requirements
 
-- **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
-- **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
-- **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
+-  **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
+-  **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
+-  **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
 
 ## Install
 

--- a/extensions/amazon-sales/release-notes/index.md
+++ b/extensions/amazon-sales/release-notes/index.md
@@ -7,15 +7,15 @@ title: Amazon Sales Channel Release Notes
 
 See the following documentation:
 
-- [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
-- [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
-- [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
+-  [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
+-  [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
+-  [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
 
 The release notes include:
 
--   {:.new}New features
--   {:.fix}Fixes and improvements
--   {:.bug}Known issues
+-  {:.new}New features
+-  {:.fix}Fixes and improvements
+-  {:.bug}Known issues
 
 ### v3.0.0
 
@@ -23,9 +23,9 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.new}**Amazon UK Marketplace Now Available**: Users can choose the United Kingdom marketplace when [creating and integrating](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/store-integration.html) an Amazon Sales Channel store. This UK upgrade includes additional support for:
 
-   - [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
+   -  [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
 
-   - [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
+   -  [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
 
 -  {:.new}**Improved Logging**: <!--CHAN-3642, 3672-->Implemented the **Enable Debug Logging** feature to collect additional synchronization data when troubleshooting is needed. See the [Sales Channels Settings](https://docs.magento.com/m2/ce/user_guide/configuration/sales-channels/global-settings.html) topic in the Configuration Reference.
 
@@ -33,31 +33,31 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.fix}**Order Creation**: <!--CHAN-3708-->Corrected an issue preventing Magento from creating orders for an Amazon order that does not match with a Magento catalog product. See [Order Settings](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/order-settings.html).
 
-- {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
+-  {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
 
 ### v2.0.0
 
 Amazon Sales Channel 2.0.0 is compatible with version 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Version 1.0.0 was available in limited release only.
 
-- {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
+-  {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
 
-- {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
+-  {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
 
-- {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
+-  {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
 
-- {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
+-  {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
 
-- {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
+-  {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
 
-- {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
+-  {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
 
--   {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
+-  {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
 
--   {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
+-  {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
 
--   {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
+-  {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
 
--   {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.
+-  {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.

--- a/extensions/b2b/index.md
+++ b/extensions/b2b/index.md
@@ -7,7 +7,7 @@ redirect_from:
  - guides/v2.3/comp-mgr/install-extensions/b2b-installation.html
 ---
 
-{: .bs-callout .bs-callout-warning }
+{: .bs-callout-warning }
 The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
 
 1. Change to your Magento installation directory and enter the following command to update your `composer.json` file and install the {{site.data.var.b2b}} extension:
@@ -49,10 +49,10 @@ The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v
     bin/magento cache:clean
     ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
   Note: In Production mode, you may receive a message to 'Please rerun Magento compile command'.  Enter the commands above. Magento does not prompt you to run the compile command in Developer mode.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 After completing the installation, you must follow the [post-installation steps](#configure-b2b).
 
 ## Configure {#configure-b2b}
@@ -91,7 +91,7 @@ The {{site.data.var.b2b}} extension uses MySQL for message queue management. If 
     bin/magento queue:consumers:start sharedCatalogUpdatePrice
     ```
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Append `&` to the command to run it in the background, return to a prompt, and continue running commands. For example: `bin/magento queue:consumers:start sharedCatalogUpdatePrice &`.
 
 Refer to [Manage message queues]({{ site.baseurl }}/guides/v2.3/config-guide/mq/manage-message-queues.html) for more information.
@@ -109,15 +109,15 @@ You may also add these two message consumers to the cron job (optional). For thi
 
 Depending on your system configuration, to prevent possible issues, you may also need to specify the following parameters when starting the services:
 
-- `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
+-  `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
 
-- `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
+-  `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
 
 ### Enable B2B features in Magento Admin
 
 After installing the {{site.data.var.b2b}} extension and starting message consumers (if you want to enable the **Shared Catalog** module), you must also enable B2B modules in Magento Admin.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 If you enable the **Shared Catalog** module, you must also enable the **Company** module. The **Quick Order** and **Requisition Lists** modules can be enabled/disabled independently.
 
 1. Access the Magento Admin and click **Stores** > **Settings** > **Configuration** > **General** > **B2B Features**.

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -11,6 +11,6 @@ This section tracks and provides installation guides and release notes for Magen
 
 ## Additional information
 
-* [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
-* [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
-* [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)
+*  [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
+*  [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
+*  [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)

--- a/extensions/install/index.md
+++ b/extensions/install/index.md
@@ -11,11 +11,11 @@ Code that extends or customizes Magento behavior is called an extension. You can
 
 Extensions include:
 
-- Modules (extend Magento capabilities)
-- Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
-- Language packages (localize the storefront and Admin)
+-  Modules (extend Magento capabilities)
+-  Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
+-  Language packages (localize the storefront and Admin)
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 This topic explains how to use the command line to install extensions you purchase from the Magento Marketplace. You can use the same procedure to install _any_ extension; all you need is the extension's [Composer](https://glossary.magento.com/composer) name and version. To find it, open the extension's `composer.json` file and note the values for `"name"` and `"version"`.
 
 Prior to installation, you may want to:
@@ -55,7 +55,7 @@ To get the extension's Composer name and version from the Magento Marketplace:
 
     ![Technical details shows the extension's Composer name]({{ site.baseurl }}/common/images/marketplace-extension-technical-details.png){:width="200px"}
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Alternatively, you can find the Composer name and version of _any_ extension (whether you purchased it on Magento Marketplace or somewhere else) in the extension's `composer.json` file.
 
 ## Update your `composer.json` file {#update-composer-json}
@@ -102,7 +102,7 @@ By default, the extension is probably disabled:
   J2t_Payplug
   ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 The extension name is in the format `<VendorName>_<ComponentName>`; it's not the same format as the Composer name. Use this format to enable the extension.
 
 ## Enable the extension
@@ -163,7 +163,7 @@ Some extensions won't work properly unless you clear Magento-generated static vi
 
 1. Configure the extension in Admin as needed.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 If you encounter errors when loading the storefront in a browser, use the following command to clear the cache:
 <br/>
 `bin/magento cache:flush`

--- a/extensions/inventory-management/index.md
+++ b/extensions/inventory-management/index.md
@@ -80,9 +80,9 @@ For more information on configurations, see [Enabling Inventory Management](http
 
 You may need to disable {{site.data.var.im}} modules to:
 
-* Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
-* Use custom or third party inventory and order management modules.
-* Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
+*  Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
+*  Use custom or third party inventory and order management modules.
+*  Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
 
 To disable {{site.data.var.im}}, see the instructions for [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html). When complete, you should see the following modules and values in `<Magento_installation_directory>/app/etc/config.php` (v1.1.2 Beta):
 
@@ -172,13 +172,13 @@ For the latest, update your metapackage version:
 
 See the following guides for more information on upgrades:
 
-* [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
-* [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
+*  [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
+*  [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
 
 ## Additional information
 
 See the following guides for more information on {{site.data.var.im}}:
 
-* [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
-* [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
-* [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information
+*  [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
+*  [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
+*  [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information

--- a/guides/v2.2/advanced-reporting/report-xml.md
+++ b/guides/v2.2/advanced-reporting/report-xml.md
@@ -16,8 +16,8 @@ A report name is the same as the `name` attribute in the `<report>` node as desc
 Report XML does not support the asterisk statement.
 All columns must be declared:
 
-* for the main table — inside the `<source>` node
-* for join tables — inside the `<link-source>` node
+*  for the main table — inside the `<source>` node
+*  for join tables — inside the `<link-source>` node
 
 Columns are added using the `<attribute>` node.
 

--- a/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
@@ -8,12 +8,12 @@ Magento incorporates the core architectural principles of object-oriented, PHP-b
 
 The following discussion focuses on how these topics apply directly to Magento:
 
-* Magento technology stack
-* Magento View Model
-* Extensibility
-* Modularity
-* Event-driven architecture
-* Security
+*  Magento technology stack
+*  Magento View Model
+*  Extensibility
+*  Modularity
+*  Event-driven architecture
+*  Security
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
@@ -18,9 +18,9 @@ Layered software is a popular, widely discussed principle in software developmen
 
 Layered application design offers many advantages, but users of Magento will appreciate:
 
-* Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
+*  Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
 
-* Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
+*  Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
@@ -8,13 +8,13 @@ menu_title: Components
 
 Magento has several core components that are used to build custom websites, applications, and integrated systems. When you change the appearance or behavior of your Magento store, you are inevitably changing one or more of these **core Magento components**, which include **modules**, **themes**, and **language packages**. Together, these core components determine much of server-side and [storefront](https://glossary.magento.com/storefront) (frontend) appearance and behavior.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Throughout the Magento documentation set, we also use the term *component* in its generic sense to mean element or part. However, the term **Magento component** explicitly refers to either a module, theme, or [language package](https://glossary.magento.com/language-package).
 
 For more information about individual Magento components, see:
 
-* [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
+*  [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
 
-* [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
+*  [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
 
-* [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)
+*  [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -14,19 +14,19 @@ For example, if you are invoking a REST web service call, rather than load all t
 
 Magento is organized into these main areas:
 
-* **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
+*  **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
 
-* **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
+*  **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
 
-* **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
+*  **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
 
-* **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
+*  **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
 
 You can also send requests to Magento using the SOAP and REST APIs. These two areas
 
-* **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
+*  **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
 
-* **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
+*  **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
 
 ## How areas work with modules {#m2arch-module-using}
 
@@ -40,11 +40,11 @@ You can enable or disable an area within a module. If this module is enabled, it
 
 ### Module/area interaction guidelines
 
-* Modules should not depend on other modules' areas.
+*  Modules should not depend on other modules' areas.
 
-* Disabling an area does not result in disabling the modules related to it.
+*  Disabling an area does not result in disabling the modules related to it.
 
-* Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
+*  Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
 
 ### Note about Magento request processing
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -24,9 +24,9 @@ A module is a directory that contains the PHP and [XML](https://glossary.magento
 
 Modules typically live in the `vendor` directory of a Magento installation, in a directory with the following PSR-0 compliant format: `vendor/<vendor>/<type>-<module-name>`, where `<type>` can be one of the following values:
 
-- **`module`** - for modules (`module-customer-import-export`)
-- **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
-- **`language`** - for language packs (`language-de_de`)
+-  **`module`** - for modules (`module-customer-import-export`)
+-  **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
+-  **`language`** - for language packs (`language-de_de`)
 
 For example, the Customer Import/Export module of Magento can be found at `vendor/magento/module-customer-import-export`.
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -10,15 +10,15 @@ Understanding how one [module](https://glossary.magento.com/module) relates to a
 
 A single module can have the following types of relationships with another module:
 
-* **uses**: module A uses module B if it invokes behavior of module B
+*  **uses**: module A uses module B if it invokes behavior of module B
 
-* **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
+*  **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
 
-* **customizes**: module A customizes module B if it modifies the behavior of module B
+*  **customizes**: module A customizes module B if it modifies the behavior of module B
 
-* **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
+*  **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
 
-* **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
+*  **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
 
 ## Relationship types and scenarios
 

--- a/guides/v2.2/architecture/archi_perspectives/framework.md
+++ b/guides/v2.2/architecture/archi_perspectives/framework.md
@@ -11,7 +11,7 @@ The Magento Framework controls how application components interact, including re
 This primarily [PHP](https://glossary.magento.com/php) software component is organized into logical groups called *libraries*, which all modules can call.  Most of the framework code sits under the domain layer or encloses the presentation, service, and domain layers. The framework contains no business logic.
 (Although the Magento Framework does not contain resource models, it does contain a [library](https://glossary.magento.com/library) of code to help implement a resource model.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Don't confuse the Magento Framework with the Zend web application framework that ships with Magento.
 
 You should never modify Framework files, although if you are extending Magento, you must know how to call Framework libraries. Modules you create will typically inherit from classes and interfaces defined in the Framework directories.
@@ -22,11 +22,11 @@ The Magento Framework provides libraries that help reduce the effort of creating
 
 The Framework is responsible for operations that are useful for potentially all modules, including:
 
-* handling HTTP protocols
+*  handling HTTP protocols
 
-* interacting with the database and filesystem
+*  interacting with the database and filesystem
 
-* rendering content
+*  rendering content
 
 ## Organization
 
@@ -42,13 +42,13 @@ lib/
     ../web
 ```
 
-* `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
+*  `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
 
-* `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
+*  `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
 
-* `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
+*  `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 The `vendor/magento/framework` directory maps to the `Magento\Framework` [namespace](https://glossary.magento.com/namespace).
 
 ## Highlights of Magento Framework

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 

--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -34,9 +34,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -11,13 +11,13 @@ This is implemented using *service contracts*, which are defined using [PHP](htt
 
 In general, the service layer:
 
-* Resides below the presentation layer and above the domain layer.
+*  Resides below the presentation layer and above the domain layer.
 
-* Contains service contracts, which define how the implementation will behave.
+*  Contains service contracts, which define how the implementation will behave.
 
-* Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
+*  Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
 
-* Provides a stable API for other modules to call into.
+*  Provides a stable API for other modules to call into.
 
 ## Who accesses the service layer?
 
@@ -30,11 +30,11 @@ Once implemented, a web service can make a single API call and return an informa
 
 [Service contract](https://glossary.magento.com/service-contract) clients include:
 
-* Controllers (initiated by actions of users of the storefront)
+*  Controllers (initiated by actions of users of the storefront)
 
-* Web services (SOAP and REST API calls)
+*  Web services (SOAP and REST API calls)
 
-* Other Magento modules through service contracts
+*  Other Magento modules through service contracts
 
 ## Service contract anatomy
 
@@ -42,20 +42,20 @@ The service contract of a [module](https://glossary.magento.com/module) is defin
 
 This directory contains:
 
-* Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
+*  Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
 
-* Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
-  Data entities* are data structures passed to and returned from service interfaces.
+*  Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
+   Data entities* are data structures passed to and returned from service interfaces.
 
-  Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
+   Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
 
 Typically, service contracts provide three distinct types of interfaces:
 
-* Repository interfaces
+*  Repository interfaces
 
-* Management interfaces
+*  Management interfaces
 
-* [Metadata](https://glossary.magento.com/metadata) interfaces
+*  [Metadata](https://glossary.magento.com/metadata) interfaces
 
 However, there is no requirement that service contracts conform to all three patterns.
 

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -69,11 +69,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide][] for information about using attributes.
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -16,11 +16,11 @@ Merchants are encouraged to use Magento components and themes to extend and tran
 
 Magento provides several tools to help you significantly jumpstart the storefront customization process:
 
-* Magento Blank [Theme](https://glossary.magento.com/theme)
+*  Magento Blank [Theme](https://glossary.magento.com/theme)
 
-* [Overview of UI components][]
+*  [Overview of UI components][]
 
-* [Magento Admin Pattern Library][]
+*  [Magento Admin Pattern Library][]
 
 See the [Frontend Developer Guide][] for information on creating your themes.
 
@@ -32,8 +32,8 @@ The Magento blank theme template provides a launchpad for storefront customizati
 
 Using Magento standard coding and styling tools can help:
 
-* enforce for consistency in design across your storefronts
-* simplify (and speed up) the design process
+*  enforce for consistency in design across your storefronts
+*  simplify (and speed up) the design process
 
 This component [library](https://glossary.magento.com/library) contains standard reusable components for form features, such as fields and buttons, and navigation elements. The Magento UI library is a set of generic web components and Magento-specific patterns, which simplifies the process of Magento theme creation and customization.
 
@@ -45,11 +45,11 @@ A *pattern library* is a collection of user interface (UI) design patterns that 
 
 Form elements included in the [Magento Admin](https://glossary.magento.com/magento-admin) pattern library include:
 
-* address form
-* button bar
-* container
-* tabs
-* sign-in form
+*  address form
+*  button bar
+*  container
+*  tabs
+*  sign-in form
 
 Users of the default Magento storefront encounter examples of these form elements throughout the product. These patterns provide a valuable language of software components (and indirectly, user experiences) for [extension](https://glossary.magento.com/extension) developers and administrators.
 

--- a/guides/v2.2/architecture/gdpr/magento-1x.md
+++ b/guides/v2.2/architecture/gdpr/magento-1x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -274,26 +274,26 @@ Table | Column | Data type
 
 Other tables that reference Customer:
 
-* `catalog_compare_item`
-* `downloadable_link_purchased`
-* `enterprise_customerbalance`
-* `enterprise_customersegment_customer`
-* `enterprise_giftregistry_entity`
-* `enterprise_reminder_rule_log`
-* `enterprise_reward`
-* `log_customer`
-* `log_visitor_online`
-* `oauth_token`
-* `product_alert_price`
-* `product_alert_stock`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `sales_billing_agreement`
-* `sales_flat_shipment`
-* `sales_recurring_profile`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `tag`
-* `tag_relation`
-* `wishlist`
+*  `catalog_compare_item`
+*  `downloadable_link_purchased`
+*  `enterprise_customerbalance`
+*  `enterprise_customersegment_customer`
+*  `enterprise_giftregistry_entity`
+*  `enterprise_reminder_rule_log`
+*  `enterprise_reward`
+*  `log_customer`
+*  `log_visitor_online`
+*  `oauth_token`
+*  `product_alert_price`
+*  `product_alert_stock`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `sales_billing_agreement`
+*  `sales_flat_shipment`
+*  `sales_recurring_profile`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `tag`
+*  `tag_relation`
+*  `wishlist`

--- a/guides/v2.2/architecture/gdpr/magento-2x.md
+++ b/guides/v2.2/architecture/gdpr/magento-2x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this GDPR compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -49,14 +49,14 @@ Magento 2 primarily stores customer-specific information in customer, address, o
 
 Magento 2 stores these customer attributes:
 
-* Date of Birth
-* Email
-* First Name
-* Gender
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
+*  Date of Birth
+*  Email
+*  First Name
+*  Gender
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
 
 #### `customer_entity` and reference tables
 
@@ -110,21 +110,21 @@ Column | Data type
 
 Magento 2 stores these customer attributes:
 
-* City
-* Company
-* Country
-* Fax
-* First Name
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
-* Phone Number
-* State/Province
-* State/Province ID
-* Street Address
-* VAT Number
-* Zip/Postal Code
+*  City
+*  Company
+*  Country
+*  Fax
+*  First Name
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
+*  Phone Number
+*  State/Province
+*  State/Province ID
+*  Street Address
+*  VAT Number
+*  Zip/Postal Code
 
 #### `customer_address_entity` and reference tables
 
@@ -309,21 +309,21 @@ Column | Data type
 
 The following tables contain a `customer_id` column:
 
-* `catalog_compare_item`
-* `catalog_product_frontend_action`
-* `downloadable_link_purchased`
-* `magento_customerbalance`
-* `magento_customersegment_customer`
-* `magento_reward`
-* `magento_rma`
-* `oauth_token`
-* `paypal_billing_agreement`
-* `persistent_session`
-* `product_alert_price`
-* `product_stock_alert`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `wishlist`
+*  `catalog_compare_item`
+*  `catalog_product_frontend_action`
+*  `downloadable_link_purchased`
+*  `magento_customerbalance`
+*  `magento_customersegment_customer`
+*  `magento_reward`
+*  `magento_rma`
+*  `oauth_token`
+*  `paypal_billing_agreement`
+*  `persistent_session`
+*  `product_alert_price`
+*  `product_stock_alert`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `wishlist`

--- a/guides/v2.2/architecture/global_extensibility_features.md
+++ b/guides/v2.2/architecture/global_extensibility_features.md
@@ -4,13 +4,13 @@ title: Global features that support extensibility
 menu_title: Global features that support extensibility
 ---
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
 
 The concept of the *module* is the heart of Magento [extension](https://glossary.magento.com/extension) development, and modular design of software components (in particular, modules, themes, and language packages) is a core architectural principle of the product. Self-contained modules of discrete code are organized by feature, thereby reducing each module's external dependencies.
 
@@ -63,11 +63,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.2/architecture/security_intro.md
+++ b/guides/v2.2/architecture/security_intro.md
@@ -34,9 +34,9 @@ A simple [Magento Admin](https://glossary.magento.com/magento-admin) [URL](https
 
 You can change this Admin URI in three ways:
 
-- The `bin/magento setup:config:set --backend-frontname=<value>` command
-- The `env.php` file
-- The Admin panel
+-  The `bin/magento setup:config:set --backend-frontname=<value>` command
+-  The `env.php` file
+-  The Admin panel
 
 Although the use of a non-default admin URL will not secure the site, its use will help prevent large-scale automated attacks. See [Display or change the Admin URI]({{page.baseurl}}/install-gde/install/cli/install-cli-adminurl.html) in Configuration Guide for more information.
 

--- a/guides/v2.2/architecture/tech-stack.md
+++ b/guides/v2.2/architecture/tech-stack.md
@@ -14,48 +14,48 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache storage
 
-* Redis
-* Memcache
+*  Redis
+*  Memcache
 
 ### Search
 
-* Solr ({{site.data.var.ee}})
-* Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
+*  Solr ({{site.data.var.ee}})
+*  Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Solr (search engine)
-* Elasticsearch (search engine)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Solr (search engine)
+*  Elasticsearch (search engine)
 
 Magento 2.2 and above only supports PHP7+ and is no longer compatible with HipHop Virtual Machine(HHVM).
 

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -50,9 +50,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.3/architecture/global_extensibility_features.md
+++ b/guides/v2.3/architecture/global_extensibility_features.md
@@ -7,14 +7,14 @@ title: Global features that support extensibility
 
 Essential qualities foster extensibility throughout the entire set of Magento components. This discussion focuses on:
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
-* Declarative schema
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
+*  Declarative schema
 
 ### Modularity
 
@@ -52,11 +52,11 @@ Extension | No
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.3/architecture/tech-stack.md
+++ b/guides/v2.3/architecture/tech-stack.md
@@ -11,12 +11,12 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 {:.bs-callout .bs-callout-info }
 Magento, with assistance from our community, is implementing PHP 7.2 compatibility for our upcoming 2.3.0 release. Any backward-incompatibility issues will be resolved in this release, and all 3rd party libraries now support PHP 7.2. Fully tested 7.2 support will be delivered in following patch releases.
@@ -25,37 +25,37 @@ If you are interested in participating in Magento Community projects we welcome 
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache Storage
 
-* Redis
+*  Redis
 
 ### Search
 
-* Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
+*  Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Elasticsearch (search engine)
-* RabbitMQ (message queue)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Elasticsearch (search engine)
+*  RabbitMQ (message queue)
 
 Magento 2.2+ does not support HipHop Virtual Machine (HHVM).
 

--- a/guides/v2.3/graphql/mutations/change-customer-password.md
+++ b/guides/v2.3/graphql/mutations/change-customer-password.md
@@ -57,6 +57,16 @@ The `changeCustomerPassword` mutation returns the `customer` object.
 
 {% include graphql/customer-output.md %}
 
+## Errors
+
+Error | Description
+--- | ---
+`The current customer isn't authorized.` | The customer's token does not exist in the `oauth_token` table.
+`Invalid login or password.` | The password specified in the `currentPassword` attribute is not valid.
+`Specify the "currentPassword" value.` | The password specified in the `currentPassword` attribute is empty.
+`Specify the "newPassword" value.` | The password specified in the `newPassword` attribute is empty.
+`The account is locked.` | The customer's password cannot be changed because the account is locked.
+
 ## Related topics
 
 * [customer query]({{page.baseurl}}/graphql/queries/customer.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the following folders:
- `guides/v2.2/architecture`
- `guides/v2.3/architecture`

## Affected DevDocs pages

- ...

## Links to Magento source code

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
