### PR TITLE
MD030 architecture folder part 2

### DIFF
--- a/extensions/amazon-sales/index.md
+++ b/extensions/amazon-sales/index.md
@@ -7,9 +7,9 @@ The Amazon Sales Channel extension installs and adds features to integrate your 
 
 ## Requirements
 
-- **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
-- **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
-- **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
+-  **Magento Instance**: Amazon Sales Channel can be installed on instances with {{site.data.var.ce}} and {{site.data.var.ee}} versions 2.2.4+ and 2.3.X. We do not support the extension on Magento 2.1 or Magento 1.
+-  **Magento Web Account**: You should have a Magento web account, which is used to create and track an API key.
+-  **API Key**: Get a Amazon Sales Channel API key through your Magento web account. The following instructions include these steps.
 
 ## Install
 

--- a/extensions/amazon-sales/release-notes/index.md
+++ b/extensions/amazon-sales/release-notes/index.md
@@ -7,15 +7,15 @@ title: Amazon Sales Channel Release Notes
 
 See the following documentation:
 
-- [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
-- [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
-- [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
+-  [Amazon Sales Channel](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/amazon-sales-channel.html) for merchant information and instructions
+-  [Amazon Sales Channel install]({{site.baseurl}}/extensions/amazon-sales/) for installation and API key information
+-  [Amazon Sales Channel Marketplace](http://marketplace.magento.com/magento-module-amazon.html)
 
 The release notes include:
 
--   {:.new}New features
--   {:.fix}Fixes and improvements
--   {:.bug}Known issues
+-  {:.new}New features
+-  {:.fix}Fixes and improvements
+-  {:.bug}Known issues
 
 ### v3.0.0
 
@@ -23,9 +23,9 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.new}**Amazon UK Marketplace Now Available**: Users can choose the United Kingdom marketplace when [creating and integrating](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/store-integration.html) an Amazon Sales Channel store. This UK upgrade includes additional support for:
 
-   - [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
+   -  [Amazon VAT Calculation Service](https://services.amazon.co.uk/vat-calculation-service.html)
 
-   - [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
+   -  [Product Tax Code](https://sellercentral.amazon.com/gp/help/help.html?itemID=G200794510&language=en_US) information.
 
 -  {:.new}**Improved Logging**: <!--CHAN-3642, 3672-->Implemented the **Enable Debug Logging** feature to collect additional synchronization data when troubleshooting is needed. See the [Sales Channels Settings](https://docs.magento.com/m2/ce/user_guide/configuration/sales-channels/global-settings.html) topic in the Configuration Reference.
 
@@ -33,31 +33,31 @@ Amazon Sales Channel 3.0.0 is compatible with versions 2.2.4+ and 2.3.x of {{sit
 
 -  {:.fix}**Order Creation**: <!--CHAN-3708-->Corrected an issue preventing Magento from creating orders for an Amazon order that does not match with a Magento catalog product. See [Order Settings](https://docs.magento.com/m2/ce/user_guide/sales-channels/amazon/order-settings.html).
 
-- {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
+-  {:.bug}**Duplicate Amazon Listings**: <!--CHAN-3593-->This issue causes the catalog to create a new item for an imported listing, using the same SKU but with a region code added on the end. Amazon then processes the modified SKU as a new item and creates a new listing. This issue will be addressed in an future release.
 
 ### v2.0.0
 
 Amazon Sales Channel 2.0.0 is compatible with version 2.2.4+ and 2.3.x of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
-{:.bs-callout .bs-callout-info}
+{: .bs-callout-info }
 Version 1.0.0 was available in limited release only.
 
-- {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
+-  {:.new} **Simplified Onboarding and Maintenance**: Add and integrate with your Amazon Seller account through a step-by-step process with detailed instructions available through the Magento Admin. Maintain your stores, accounts, and listed products through one dashboard.
 
-- {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
+-  {:.new} **Multiple Account Support**: Manage and monitor multiple Amazon brands and marketplace regions through the Magento Admin.
 
-- {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
+-  {:.new} **Intelligent Pricing**: Set automated repricing rules to increase your chances for the coveted Buy Box. Set prices to dynamically adjust to the current Buy Box price, or lowest competitor pricing. Set limits to repricing to protect your margin.
 
-- {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
+-  {:.new} **Listing Management**: Automate product listings and sync your Magento catalog to the Amazon Marketplace using listing rules. Add specific overrides to finely control your offerings. Monitor and manage all your listings directly from the Magento Admin.
 
-- {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
+-  {:.new} **Consistent Inventory Management**: Keep your Magento and Amazon inventory quantities in constant synchronization.
 
-- {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
+-  {:.new} **Order and Fulfillment Management**: Track Amazon orders through the dashboard, with seamless communication and inventory updates. Complete and track order shipments as fulfilled by Amazon, merchant fulfilled, or a mix of methods.
 
--   {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
+-  {:.bug} You may encounter longer wait times to update product quantities. Updates for product quantity may take ~2 hours to sync.
 
--   {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
+-  {:.bug} Imported orders may have a type of Prime or Premium orders. You may need to verify these orders in your Amazon Seller Account.
 
--   {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
+-  {:.bug} Ineligible bundled products may display as Eligible for listing on Amazon. One of the products within the bundled product may not be eligible. If you encounter issues, check the eligibility status for bundled products items.
 
--   {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.
+-  {:.bug} When using [Inventory Management](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) for Magento 2.3.x, a partial stock reindex may not trigger when an order is created. The salable quantity recalculates hourly, which may cause overselling during this update interval.

--- a/extensions/b2b/index.md
+++ b/extensions/b2b/index.md
@@ -7,7 +7,7 @@ redirect_from:
  - guides/v2.3/comp-mgr/install-extensions/b2b-installation.html
 ---
 
-{: .bs-callout .bs-callout-warning }
+{: .bs-callout-warning }
 The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v2.2.0 or later. You must install it after installing {{site.data.var.ee}}.
 
 1. Change to your Magento installation directory and enter the following command to update your `composer.json` file and install the {{site.data.var.b2b}} extension:
@@ -49,10 +49,10 @@ The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v
     bin/magento cache:clean
     ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
   Note: In Production mode, you may receive a message to 'Please rerun Magento compile command'.  Enter the commands above. Magento does not prompt you to run the compile command in Developer mode.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 After completing the installation, you must follow the [post-installation steps](#configure-b2b).
 
 ## Configure {#configure-b2b}
@@ -91,7 +91,7 @@ The {{site.data.var.b2b}} extension uses MySQL for message queue management. If 
     bin/magento queue:consumers:start sharedCatalogUpdatePrice
     ```
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Append `&` to the command to run it in the background, return to a prompt, and continue running commands. For example: `bin/magento queue:consumers:start sharedCatalogUpdatePrice &`.
 
 Refer to [Manage message queues]({{ site.baseurl }}/guides/v2.3/config-guide/mq/manage-message-queues.html) for more information.
@@ -109,15 +109,15 @@ You may also add these two message consumers to the cron job (optional). For thi
 
 Depending on your system configuration, to prevent possible issues, you may also need to specify the following parameters when starting the services:
 
-- `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
+-  `--max-messages`: manages the consumer's lifetime and allows you to specify the maximum number of messages processed by the consumer. The best practice for a PHP application is to restart long-running processes to prevent possible memory leaks.
 
-- `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
+-  `--batch-size`: allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.
 
 ### Enable B2B features in Magento Admin
 
 After installing the {{site.data.var.b2b}} extension and starting message consumers (if you want to enable the **Shared Catalog** module), you must also enable B2B modules in Magento Admin.
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 If you enable the **Shared Catalog** module, you must also enable the **Company** module. The **Quick Order** and **Requisition Lists** modules can be enabled/disabled independently.
 
 1. Access the Magento Admin and click **Stores** > **Settings** > **Configuration** > **General** > **B2B Features**.

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -11,6 +11,6 @@ This section tracks and provides installation guides and release notes for Magen
 
 ## Additional information
 
-* [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
-* [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
-* [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)
+*  [Run the Module Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/module-man/compman-checklist.html)
+*  [Run the Extension Manager]({{ site.baseurl }}/guides/v2.3/comp-mgr/extens-man/extensman-checklist.html)
+*  [Magento Marketplace Support](https://marketplacesupport.magento.com/hc/en-us)

--- a/extensions/install/index.md
+++ b/extensions/install/index.md
@@ -11,11 +11,11 @@ Code that extends or customizes Magento behavior is called an extension. You can
 
 Extensions include:
 
-- Modules (extend Magento capabilities)
-- Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
-- Language packages (localize the storefront and Admin)
+-  Modules (extend Magento capabilities)
+-  Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
+-  Language packages (localize the storefront and Admin)
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 This topic explains how to use the command line to install extensions you purchase from the Magento Marketplace. You can use the same procedure to install _any_ extension; all you need is the extension's [Composer](https://glossary.magento.com/composer) name and version. To find it, open the extension's `composer.json` file and note the values for `"name"` and `"version"`.
 
 Prior to installation, you may want to:
@@ -55,7 +55,7 @@ To get the extension's Composer name and version from the Magento Marketplace:
 
     ![Technical details shows the extension's Composer name]({{ site.baseurl }}/common/images/marketplace-extension-technical-details.png){:width="200px"}
 
-{: .bs-callout .bs-callout-tip }
+{: .bs-callout-tip }
 Alternatively, you can find the Composer name and version of _any_ extension (whether you purchased it on Magento Marketplace or somewhere else) in the extension's `composer.json` file.
 
 ## Update your `composer.json` file {#update-composer-json}
@@ -102,7 +102,7 @@ By default, the extension is probably disabled:
   J2t_Payplug
   ```
 
-{: .bs-callout .bs-callout-info }
+{: .bs-callout-info }
 The extension name is in the format `<VendorName>_<ComponentName>`; it's not the same format as the Composer name. Use this format to enable the extension.
 
 ## Enable the extension
@@ -163,7 +163,7 @@ Some extensions won't work properly unless you clear Magento-generated static vi
 
 1. Configure the extension in Admin as needed.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 If you encounter errors when loading the storefront in a browser, use the following command to clear the cache:
 <br/>
 `bin/magento cache:flush`

--- a/extensions/inventory-management/index.md
+++ b/extensions/inventory-management/index.md
@@ -80,9 +80,9 @@ For more information on configurations, see [Enabling Inventory Management](http
 
 You may need to disable {{site.data.var.im}} modules to:
 
-* Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
-* Use custom or third party inventory and order management modules.
-* Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
+*  Speed up the upgrade process for merchants migrating from 2.0.x, 2.1.x, or 2.2.x to 2.3.x.
+*  Use custom or third party inventory and order management modules.
+*  Use [Magento Order Management](https://omsdocs.magento.com) for inventory and order management. The current Order Management connector does not support {{site.data.var.im}} interfaces. We plan to support this integration in a later release.
 
 To disable {{site.data.var.im}}, see the instructions for [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html). When complete, you should see the following modules and values in `<Magento_installation_directory>/app/etc/config.php` (v1.1.2 Beta):
 
@@ -172,13 +172,13 @@ For the latest, update your metapackage version:
 
 See the following guides for more information on upgrades:
 
-* [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
-* [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
+*  [Software Update Guide]({{site.baseurl}}/guides/v2.3/comp-mgr/bk-compman-upgrade-guide.html)
+*  [Enable or disable modules]({{site.baseurl}}/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html)
 
 ## Additional information
 
 See the following guides for more information on {{site.data.var.im}}:
 
-* [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
-* [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
-* [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information
+*  [Release Notes]({{site.baseurl}}/guides/v2.3/inventory/release-notes.html)
+*  [Inventory Management]({{site.baseurl}}/guides/v2.3/inventory/index.html) overview for developer resources
+*  [Managing Inventory](https://docs.magento.com/m2/ce/user_guide/catalog/inventory-management.html) in the Magento 2 User Guides for merchant information

--- a/guides/v2.2/advanced-reporting/report-xml.md
+++ b/guides/v2.2/advanced-reporting/report-xml.md
@@ -16,8 +16,8 @@ A report name is the same as the `name` attribute in the `<report>` node as desc
 Report XML does not support the asterisk statement.
 All columns must be declared:
 
-* for the main table — inside the `<source>` node
-* for join tables — inside the `<link-source>` node
+*  for the main table — inside the `<source>` node
+*  for join tables — inside the `<link-source>` node
 
 Columns are added using the `<attribute>` node.
 

--- a/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ABasics_intro.md
@@ -8,12 +8,12 @@ Magento incorporates the core architectural principles of object-oriented, PHP-b
 
 The following discussion focuses on how these topics apply directly to Magento:
 
-* Magento technology stack
-* Magento View Model
-* Extensibility
-* Modularity
-* Event-driven architecture
-* Security
+*  Magento technology stack
+*  Magento View Model
+*  Extensibility
+*  Modularity
+*  Event-driven architecture
+*  Security
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/ALayers_intro.md
@@ -18,9 +18,9 @@ Layered software is a popular, widely discussed principle in software developmen
 
 Layered application design offers many advantages, but users of Magento will appreciate:
 
-* Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
+*  Stringent separation of business logic from presentation logic simplifies the customization process. For example, you can alter your storefront appearance without affecting any of the [backend](https://glossary.magento.com/backend) business logic.
 
-* Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
+*  Clear organization of code predictably points [extension](https://glossary.magento.com/extension) developers to code location.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/AComponents.md
@@ -8,13 +8,13 @@ menu_title: Components
 
 Magento has several core components that are used to build custom websites, applications, and integrated systems. When you change the appearance or behavior of your Magento store, you are inevitably changing one or more of these **core Magento components**, which include **modules**, **themes**, and **language packages**. Together, these core components determine much of server-side and [storefront](https://glossary.magento.com/storefront) (frontend) appearance and behavior.
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Throughout the Magento documentation set, we also use the term *component* in its generic sense to mean element or part. However, the term **Magento component** explicitly refers to either a module, theme, or [language package](https://glossary.magento.com/language-package).
 
 For more information about individual Magento components, see:
 
-* [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
+*  [Modules]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)
 
-* [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
+*  [Themes]({{page.baseurl}}/frontend-dev-guide/themes/theme-overview.html)
 
-* [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)
+*  [Language packages]({{page.baseurl}}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack)

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -14,19 +14,19 @@ For example, if you are invoking a REST web service call, rather than load all t
 
 Magento is organized into these main areas:
 
-* **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
+*  **Magento Admin** (`adminhtml`): entry point for this area is `index.php` or `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
 
-* **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
+*  **Storefront** (`frontend`): entry point for this area is `index.php` or `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
 
-* **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
+*  **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
 
-* **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
+*  **Cron** (`crontab`): In `cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
 
 You can also send requests to Magento using the SOAP and REST APIs. These two areas
 
-* **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
+*  **Web API REST** (`webapi_rest`): entry point for this area is `index.php` or `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
 
-* **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
+*  **Web API SOAP** (`webapi_soap`): entry point for this area is `index.php` or `pub/index.php`.
 
 ## How areas work with modules {#m2arch-module-using}
 
@@ -40,11 +40,11 @@ You can enable or disable an area within a module. If this module is enabled, it
 
 ### Module/area interaction guidelines
 
-* Modules should not depend on other modules' areas.
+*  Modules should not depend on other modules' areas.
 
-* Disabling an area does not result in disabling the modules related to it.
+*  Disabling an area does not result in disabling the modules related to it.
 
-* Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
+*  Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
 
 ### Note about Magento request processing
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_intro.md
@@ -24,9 +24,9 @@ A module is a directory that contains the PHP and [XML](https://glossary.magento
 
 Modules typically live in the `vendor` directory of a Magento installation, in a directory with the following PSR-0 compliant format: `vendor/<vendor>/<type>-<module-name>`, where `<type>` can be one of the following values:
 
-- **`module`** - for modules (`module-customer-import-export`)
-- **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
-- **`language`** - for language packs (`language-de_de`)
+-  **`module`** - for modules (`module-customer-import-export`)
+-  **`theme`** - for frontend and admin themes (`theme-frontend-luma` or `theme-adminhtml-backend`)
+-  **`language`** - for language packs (`language-de_de`)
 
 For example, the Customer Import/Export module of Magento can be found at `vendor/magento/module-customer-import-export`.
 

--- a/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
+++ b/guides/v2.2/architecture/archi_perspectives/components/modules/mod_relationships.md
@@ -10,15 +10,15 @@ Understanding how one [module](https://glossary.magento.com/module) relates to a
 
 A single module can have the following types of relationships with another module:
 
-* **uses**: module A uses module B if it invokes behavior of module B
+*  **uses**: module A uses module B if it invokes behavior of module B
 
-* **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
+*  **reacts to**: module A reacts to module B if its behavior is triggered by an [event](https://glossary.magento.com/event) in module B without module B knowing about module A
 
-* **customizes**: module A customizes module B if it modifies the behavior of module B
+*  **customizes**: module A customizes module B if it modifies the behavior of module B
 
-* **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
+*  **implements**: module A implements module B if it implements some, not necessarily all, behavior that is defined in module B
 
-* **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
+*  **replaces**: module A replaces module B if it provides its own version of the [API](https://glossary.magento.com/api) exposed and implemented by module B
 
 ## Relationship types and scenarios
 

--- a/guides/v2.2/architecture/archi_perspectives/framework.md
+++ b/guides/v2.2/architecture/archi_perspectives/framework.md
@@ -11,7 +11,7 @@ The Magento Framework controls how application components interact, including re
 This primarily [PHP](https://glossary.magento.com/php) software component is organized into logical groups called *libraries*, which all modules can call.  Most of the framework code sits under the domain layer or encloses the presentation, service, and domain layers. The framework contains no business logic.
 (Although the Magento Framework does not contain resource models, it does contain a [library](https://glossary.magento.com/library) of code to help implement a resource model.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 Don't confuse the Magento Framework with the Zend web application framework that ships with Magento.
 
 You should never modify Framework files, although if you are extending Magento, you must know how to call Framework libraries. Modules you create will typically inherit from classes and interfaces defined in the Framework directories.
@@ -22,11 +22,11 @@ The Magento Framework provides libraries that help reduce the effort of creating
 
 The Framework is responsible for operations that are useful for potentially all modules, including:
 
-* handling HTTP protocols
+*  handling HTTP protocols
 
-* interacting with the database and filesystem
+*  interacting with the database and filesystem
 
-* rendering content
+*  rendering content
 
 ## Organization
 
@@ -42,13 +42,13 @@ lib/
     ../web
 ```
 
-* `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
+*  `/vendor/magento/framework`  contains only PHP code. These are libraries of code plus the application entry point that routes requests to modules (that in turn call the Framework libraries). For example,  libraries in the Framework help implement a resource model (base classes and interfaces to inherit from) but not the resource models themselves. Certain libraries also support [CSS](https://glossary.magento.com/css) rendering.
 
-* `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
+*  `/lib/internal` contains some non-PHP as well as PHP components. Non-PHP framework libraries includes [JavaScript](https://glossary.magento.com/javascript) and LESS/CSS.
 
-* `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
+*  `/lib/web` contains JavaScript and CSS/LESS files. These files reside  under `web` and not `internal` because they are accessible from a web browser, while the PHP code under `internal` is not. (Any code that a web browser must access should be under `web`, while everything else under `internal`.)
 
-{:.bs-callout .bs-callout-tip}
+{: .bs-callout-tip }
 The `vendor/magento/framework` directory maps to the `Magento\Framework` [namespace](https://glossary.magento.com/namespace).
 
 ## Highlights of Magento Framework

--- a/guides/v2.2/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 

--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -34,9 +34,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -11,13 +11,13 @@ This is implemented using *service contracts*, which are defined using [PHP](htt
 
 In general, the service layer:
 
-* Resides below the presentation layer and above the domain layer.
+*  Resides below the presentation layer and above the domain layer.
 
-* Contains service contracts, which define how the implementation will behave.
+*  Contains service contracts, which define how the implementation will behave.
 
-* Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
+*  Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
 
-* Provides a stable API for other modules to call into.
+*  Provides a stable API for other modules to call into.
 
 ## Who accesses the service layer?
 
@@ -30,11 +30,11 @@ Once implemented, a web service can make a single API call and return an informa
 
 [Service contract](https://glossary.magento.com/service-contract) clients include:
 
-* Controllers (initiated by actions of users of the storefront)
+*  Controllers (initiated by actions of users of the storefront)
 
-* Web services (SOAP and REST API calls)
+*  Web services (SOAP and REST API calls)
 
-* Other Magento modules through service contracts
+*  Other Magento modules through service contracts
 
 ## Service contract anatomy
 
@@ -42,20 +42,20 @@ The service contract of a [module](https://glossary.magento.com/module) is defin
 
 This directory contains:
 
-* Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
+*  Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
 
-* Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
-  Data entities* are data structures passed to and returned from service interfaces.
+*  Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
+   Data entities* are data structures passed to and returned from service interfaces.
 
-  Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
+   Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
 
 Typically, service contracts provide three distinct types of interfaces:
 
-* Repository interfaces
+*  Repository interfaces
 
-* Management interfaces
+*  Management interfaces
 
-* [Metadata](https://glossary.magento.com/metadata) interfaces
+*  [Metadata](https://glossary.magento.com/metadata) interfaces
 
 However, there is no requirement that service contracts conform to all three patterns.
 

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -69,11 +69,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide][] for information about using attributes.
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -16,11 +16,11 @@ Merchants are encouraged to use Magento components and themes to extend and tran
 
 Magento provides several tools to help you significantly jumpstart the storefront customization process:
 
-* Magento Blank [Theme](https://glossary.magento.com/theme)
+*  Magento Blank [Theme](https://glossary.magento.com/theme)
 
-* [Overview of UI components][]
+*  [Overview of UI components][]
 
-* [Magento Admin Pattern Library][]
+*  [Magento Admin Pattern Library][]
 
 See the [Frontend Developer Guide][] for information on creating your themes.
 
@@ -32,8 +32,8 @@ The Magento blank theme template provides a launchpad for storefront customizati
 
 Using Magento standard coding and styling tools can help:
 
-* enforce for consistency in design across your storefronts
-* simplify (and speed up) the design process
+*  enforce for consistency in design across your storefronts
+*  simplify (and speed up) the design process
 
 This component [library](https://glossary.magento.com/library) contains standard reusable components for form features, such as fields and buttons, and navigation elements. The Magento UI library is a set of generic web components and Magento-specific patterns, which simplifies the process of Magento theme creation and customization.
 
@@ -45,11 +45,11 @@ A *pattern library* is a collection of user interface (UI) design patterns that 
 
 Form elements included in the [Magento Admin](https://glossary.magento.com/magento-admin) pattern library include:
 
-* address form
-* button bar
-* container
-* tabs
-* sign-in form
+*  address form
+*  button bar
+*  container
+*  tabs
+*  sign-in form
 
 Users of the default Magento storefront encounter examples of these form elements throughout the product. These patterns provide a valuable language of software components (and indirectly, user experiences) for [extension](https://glossary.magento.com/extension) developers and administrators.
 

--- a/guides/v2.2/architecture/gdpr/magento-1x.md
+++ b/guides/v2.2/architecture/gdpr/magento-1x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -274,26 +274,26 @@ Table | Column | Data type
 
 Other tables that reference Customer:
 
-* `catalog_compare_item`
-* `downloadable_link_purchased`
-* `enterprise_customerbalance`
-* `enterprise_customersegment_customer`
-* `enterprise_giftregistry_entity`
-* `enterprise_reminder_rule_log`
-* `enterprise_reward`
-* `log_customer`
-* `log_visitor_online`
-* `oauth_token`
-* `product_alert_price`
-* `product_alert_stock`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `sales_billing_agreement`
-* `sales_flat_shipment`
-* `sales_recurring_profile`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `tag`
-* `tag_relation`
-* `wishlist`
+*  `catalog_compare_item`
+*  `downloadable_link_purchased`
+*  `enterprise_customerbalance`
+*  `enterprise_customersegment_customer`
+*  `enterprise_giftregistry_entity`
+*  `enterprise_reminder_rule_log`
+*  `enterprise_reward`
+*  `log_customer`
+*  `log_visitor_online`
+*  `oauth_token`
+*  `product_alert_price`
+*  `product_alert_stock`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `sales_billing_agreement`
+*  `sales_flat_shipment`
+*  `sales_recurring_profile`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `tag`
+*  `tag_relation`
+*  `wishlist`

--- a/guides/v2.2/architecture/gdpr/magento-2x.md
+++ b/guides/v2.2/architecture/gdpr/magento-2x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this GDPR compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -49,14 +49,14 @@ Magento 2 primarily stores customer-specific information in customer, address, o
 
 Magento 2 stores these customer attributes:
 
-* Date of Birth
-* Email
-* First Name
-* Gender
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
+*  Date of Birth
+*  Email
+*  First Name
+*  Gender
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
 
 #### `customer_entity` and reference tables
 
@@ -110,21 +110,21 @@ Column | Data type
 
 Magento 2 stores these customer attributes:
 
-* City
-* Company
-* Country
-* Fax
-* First Name
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
-* Phone Number
-* State/Province
-* State/Province ID
-* Street Address
-* VAT Number
-* Zip/Postal Code
+*  City
+*  Company
+*  Country
+*  Fax
+*  First Name
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
+*  Phone Number
+*  State/Province
+*  State/Province ID
+*  Street Address
+*  VAT Number
+*  Zip/Postal Code
 
 #### `customer_address_entity` and reference tables
 
@@ -309,21 +309,21 @@ Column | Data type
 
 The following tables contain a `customer_id` column:
 
-* `catalog_compare_item`
-* `catalog_product_frontend_action`
-* `downloadable_link_purchased`
-* `magento_customerbalance`
-* `magento_customersegment_customer`
-* `magento_reward`
-* `magento_rma`
-* `oauth_token`
-* `paypal_billing_agreement`
-* `persistent_session`
-* `product_alert_price`
-* `product_stock_alert`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `wishlist`
+*  `catalog_compare_item`
+*  `catalog_product_frontend_action`
+*  `downloadable_link_purchased`
+*  `magento_customerbalance`
+*  `magento_customersegment_customer`
+*  `magento_reward`
+*  `magento_rma`
+*  `oauth_token`
+*  `paypal_billing_agreement`
+*  `persistent_session`
+*  `product_alert_price`
+*  `product_stock_alert`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `wishlist`

--- a/guides/v2.2/architecture/global_extensibility_features.md
+++ b/guides/v2.2/architecture/global_extensibility_features.md
@@ -4,13 +4,13 @@ title: Global features that support extensibility
 menu_title: Global features that support extensibility
 ---
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
 
 The concept of the *module* is the heart of Magento [extension](https://glossary.magento.com/extension) development, and modular design of software components (in particular, modules, themes, and language packages) is a core architectural principle of the product. Self-contained modules of discrete code are organized by feature, thereby reducing each module's external dependencies.
 
@@ -63,11 +63,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.2/architecture/security_intro.md
+++ b/guides/v2.2/architecture/security_intro.md
@@ -34,9 +34,9 @@ A simple [Magento Admin](https://glossary.magento.com/magento-admin) [URL](https
 
 You can change this Admin URI in three ways:
 
-- The `bin/magento setup:config:set --backend-frontname=<value>` command
-- The `env.php` file
-- The Admin panel
+-  The `bin/magento setup:config:set --backend-frontname=<value>` command
+-  The `env.php` file
+-  The Admin panel
 
 Although the use of a non-default admin URL will not secure the site, its use will help prevent large-scale automated attacks. See [Display or change the Admin URI]({{page.baseurl}}/install-gde/install/cli/install-cli-adminurl.html) in Configuration Guide for more information.
 

--- a/guides/v2.2/architecture/tech-stack.md
+++ b/guides/v2.2/architecture/tech-stack.md
@@ -14,48 +14,48 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache storage
 
-* Redis
-* Memcache
+*  Redis
+*  Memcache
 
 ### Search
 
-* Solr ({{site.data.var.ee}})
-* Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
+*  Solr ({{site.data.var.ee}})
+*  Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Solr (search engine)
-* Elasticsearch (search engine)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Solr (search engine)
+*  Elasticsearch (search engine)
 
 Magento 2.2 and above only supports PHP7+ and is no longer compatible with HipHop Virtual Machine(HHVM).
 

--- a/guides/v2.3/architecture/archi_perspectives/persist_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/persist_layer.md
@@ -5,9 +5,9 @@ title: Persistence layer
 
 Magento uses an active record pattern strategy for persistence. In this system, the model object contains a *resource model* that maps an object to one or more database rows. A resource model is responsible for performing functions such as:
 
-* Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
+*  Executing all CRUD (create, read, update, delete) requests. The resource model contains the SQL code for completing these requests.
 
-* Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
+*  Performing additional business logic. For example, a resource model could perform data validation, start processes before or after data is saved, or perform other database operations.
 
 If you expect to return multiple items from a database query, then you would implement a special type of resource model known as a *collection*. A collection is a class that loads multiple models into an array-like structure based on a set of rules. This is similar to a SQL `WHERE` clause.
 

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -50,9 +50,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.3/architecture/global_extensibility_features.md
+++ b/guides/v2.3/architecture/global_extensibility_features.md
@@ -7,14 +7,14 @@ title: Global features that support extensibility
 
 Essential qualities foster extensibility throughout the entire set of Magento components. This discussion focuses on:
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
-* Declarative schema
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
+*  Declarative schema
 
 ### Modularity
 
@@ -52,11 +52,11 @@ Extension | No
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.3/architecture/tech-stack.md
+++ b/guides/v2.3/architecture/tech-stack.md
@@ -11,12 +11,12 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 {:.bs-callout .bs-callout-info }
 Magento, with assistance from our community, is implementing PHP 7.2 compatibility for our upcoming 2.3.0 release. Any backward-incompatibility issues will be resolved in this release, and all 3rd party libraries now support PHP 7.2. Fully tested 7.2 support will be delivered in following patch releases.
@@ -25,37 +25,37 @@ If you are interested in participating in Magento Community projects we welcome 
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache Storage
 
-* Redis
+*  Redis
 
 ### Search
 
-* Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
+*  Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Elasticsearch (search engine)
-* RabbitMQ (message queue)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Elasticsearch (search engine)
+*  RabbitMQ (message queue)
 
 Magento 2.2+ does not support HipHop Virtual Machine (HHVM).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the following folders:
- `guides/v2.2/architecture`
- `guides/v2.3/architecture`

## Affected DevDocs pages

- ...

## Links to Magento source code

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
