### PR TITLE
Markdown linting: Spaces after list markers (MD030)

### DIFF
--- a/guides/v2.2/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -34,9 +34,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -11,13 +11,13 @@ This is implemented using *service contracts*, which are defined using [PHP](htt
 
 In general, the service layer:
 
-* Resides below the presentation layer and above the domain layer.
+*  Resides below the presentation layer and above the domain layer.
 
-* Contains service contracts, which define how the implementation will behave.
+*  Contains service contracts, which define how the implementation will behave.
 
-* Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
+*  Provides an easy way to access the REST/SOAP [API](https://glossary.magento.com/api) framework code (which also resides above the service contracts). You can bind service contracts to web service APIs in configuration files --- no coding required.
 
-* Provides a stable API for other modules to call into.
+*  Provides a stable API for other modules to call into.
 
 ## Who accesses the service layer?
 
@@ -30,11 +30,11 @@ Once implemented, a web service can make a single API call and return an informa
 
 [Service contract](https://glossary.magento.com/service-contract) clients include:
 
-* Controllers (initiated by actions of users of the storefront)
+*  Controllers (initiated by actions of users of the storefront)
 
-* Web services (SOAP and REST API calls)
+*  Web services (SOAP and REST API calls)
 
-* Other Magento modules through service contracts
+*  Other Magento modules through service contracts
 
 ## Service contract anatomy
 
@@ -42,20 +42,20 @@ The service contract of a [module](https://glossary.magento.com/module) is defin
 
 This directory contains:
 
-* Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
+*  Service interfaces in the `/Api` [namespace](https://glossary.magento.com/namespace) of the module ([Catalog API][catalog-api]).
 
-* Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
-  Data entities* are data structures passed to and returned from service interfaces.
+*  Data (or *entity*) interfaces in the `Api/Data` directory ([Catalog API/Data][catalog-api-data][]).
+   Data entities* are data structures passed to and returned from service interfaces.
 
-  Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
+   Files in the data directory contain `get()` and `set()` methods for entries in the entity table and extension attributes.
 
 Typically, service contracts provide three distinct types of interfaces:
 
-* Repository interfaces
+*  Repository interfaces
 
-* Management interfaces
+*  Management interfaces
 
-* [Metadata](https://glossary.magento.com/metadata) interfaces
+*  [Metadata](https://glossary.magento.com/metadata) interfaces
 
 However, there is no requirement that service contracts conform to all three patterns.
 

--- a/guides/v2.2/architecture/extensibility.md
+++ b/guides/v2.2/architecture/extensibility.md
@@ -69,11 +69,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide][] for information about using attributes.
 

--- a/guides/v2.2/architecture/frontend_custom_strategies.md
+++ b/guides/v2.2/architecture/frontend_custom_strategies.md
@@ -16,11 +16,11 @@ Merchants are encouraged to use Magento components and themes to extend and tran
 
 Magento provides several tools to help you significantly jumpstart the storefront customization process:
 
-* Magento Blank [Theme](https://glossary.magento.com/theme)
+*  Magento Blank [Theme](https://glossary.magento.com/theme)
 
-* [Overview of UI components][]
+*  [Overview of UI components][]
 
-* [Magento Admin Pattern Library][]
+*  [Magento Admin Pattern Library][]
 
 See the [Frontend Developer Guide][] for information on creating your themes.
 
@@ -32,8 +32,8 @@ The Magento blank theme template provides a launchpad for storefront customizati
 
 Using Magento standard coding and styling tools can help:
 
-* enforce for consistency in design across your storefronts
-* simplify (and speed up) the design process
+*  enforce for consistency in design across your storefronts
+*  simplify (and speed up) the design process
 
 This component [library](https://glossary.magento.com/library) contains standard reusable components for form features, such as fields and buttons, and navigation elements. The Magento UI library is a set of generic web components and Magento-specific patterns, which simplifies the process of Magento theme creation and customization.
 
@@ -45,11 +45,11 @@ A *pattern library* is a collection of user interface (UI) design patterns that 
 
 Form elements included in the [Magento Admin](https://glossary.magento.com/magento-admin) pattern library include:
 
-* address form
-* button bar
-* container
-* tabs
-* sign-in form
+*  address form
+*  button bar
+*  container
+*  tabs
+*  sign-in form
 
 Users of the default Magento storefront encounter examples of these form elements throughout the product. These patterns provide a valuable language of software components (and indirectly, user experiences) for [extension](https://glossary.magento.com/extension) developers and administrators.
 

--- a/guides/v2.2/architecture/gdpr/magento-1x.md
+++ b/guides/v2.2/architecture/gdpr/magento-1x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -274,26 +274,26 @@ Table | Column | Data type
 
 Other tables that reference Customer:
 
-* `catalog_compare_item`
-* `downloadable_link_purchased`
-* `enterprise_customerbalance`
-* `enterprise_customersegment_customer`
-* `enterprise_giftregistry_entity`
-* `enterprise_reminder_rule_log`
-* `enterprise_reward`
-* `log_customer`
-* `log_visitor_online`
-* `oauth_token`
-* `product_alert_price`
-* `product_alert_stock`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `sales_billing_agreement`
-* `sales_flat_shipment`
-* `sales_recurring_profile`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `tag`
-* `tag_relation`
-* `wishlist`
+*  `catalog_compare_item`
+*  `downloadable_link_purchased`
+*  `enterprise_customerbalance`
+*  `enterprise_customersegment_customer`
+*  `enterprise_giftregistry_entity`
+*  `enterprise_reminder_rule_log`
+*  `enterprise_reward`
+*  `log_customer`
+*  `log_visitor_online`
+*  `oauth_token`
+*  `product_alert_price`
+*  `product_alert_stock`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `sales_billing_agreement`
+*  `sales_flat_shipment`
+*  `sales_recurring_profile`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `tag`
+*  `tag_relation`
+*  `wishlist`

--- a/guides/v2.2/architecture/gdpr/magento-2x.md
+++ b/guides/v2.2/architecture/gdpr/magento-2x.md
@@ -8,8 +8,8 @@ The European Union (EU) enacted [General Data Protection Regulation](https://www
 
 We are publishing this GDPR compliance information to help our merchants and their system integrators with GDPR compliance. A system integrator can use the data flow diagrams and database information to build scripts to resolve use cases similar to the following:
 
-* A shopper asks for a copy of the data the merchant has stored about her
-* A shopper requests that all information about him be deleted
+*  A shopper asks for a copy of the data the merchant has stored about her
+*  A shopper requests that all information about him be deleted
 
 See the corporate [Magento website](https://magento.com/gdpr) for more information about how Magento helps merchants comply with GDPR.
 
@@ -49,14 +49,14 @@ Magento 2 primarily stores customer-specific information in customer, address, o
 
 Magento 2 stores these customer attributes:
 
-* Date of Birth
-* Email
-* First Name
-* Gender
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
+*  Date of Birth
+*  Email
+*  First Name
+*  Gender
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
 
 #### `customer_entity` and reference tables
 
@@ -110,21 +110,21 @@ Column | Data type
 
 Magento 2 stores these customer attributes:
 
-* City
-* Company
-* Country
-* Fax
-* First Name
-* Last Name
-* Middle Name/Initial
-* Name Prefix
-* Name Suffix
-* Phone Number
-* State/Province
-* State/Province ID
-* Street Address
-* VAT Number
-* Zip/Postal Code
+*  City
+*  Company
+*  Country
+*  Fax
+*  First Name
+*  Last Name
+*  Middle Name/Initial
+*  Name Prefix
+*  Name Suffix
+*  Phone Number
+*  State/Province
+*  State/Province ID
+*  Street Address
+*  VAT Number
+*  Zip/Postal Code
 
 #### `customer_address_entity` and reference tables
 
@@ -309,21 +309,21 @@ Column | Data type
 
 The following tables contain a `customer_id` column:
 
-* `catalog_compare_item`
-* `catalog_product_frontend_action`
-* `downloadable_link_purchased`
-* `magento_customerbalance`
-* `magento_customersegment_customer`
-* `magento_reward`
-* `magento_rma`
-* `oauth_token`
-* `paypal_billing_agreement`
-* `persistent_session`
-* `product_alert_price`
-* `product_stock_alert`
-* `report_compared_product_index`
-* `report_viewed_product_index`
-* `review_detail`
-* `salesrule_coupon_usage`
-* `salesrule_customer`
-* `wishlist`
+*  `catalog_compare_item`
+*  `catalog_product_frontend_action`
+*  `downloadable_link_purchased`
+*  `magento_customerbalance`
+*  `magento_customersegment_customer`
+*  `magento_reward`
+*  `magento_rma`
+*  `oauth_token`
+*  `paypal_billing_agreement`
+*  `persistent_session`
+*  `product_alert_price`
+*  `product_stock_alert`
+*  `report_compared_product_index`
+*  `report_viewed_product_index`
+*  `review_detail`
+*  `salesrule_coupon_usage`
+*  `salesrule_customer`
+*  `wishlist`

--- a/guides/v2.2/architecture/global_extensibility_features.md
+++ b/guides/v2.2/architecture/global_extensibility_features.md
@@ -4,13 +4,13 @@ title: Global features that support extensibility
 menu_title: Global features that support extensibility
 ---
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
 
 The concept of the *module* is the heart of Magento [extension](https://glossary.magento.com/extension) development, and modular design of software components (in particular, modules, themes, and language packages) is a core architectural principle of the product. Self-contained modules of discrete code are organized by feature, thereby reducing each module's external dependencies.
 
@@ -63,11 +63,11 @@ You can enhance your storefront by adding unique attributes to the default produ
 
 Attribute types fall into three general categories:
 
-* <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  <b>EAV (Entity-Attribute-Value) attributes</b> are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.2/architecture/security_intro.md
+++ b/guides/v2.2/architecture/security_intro.md
@@ -34,9 +34,9 @@ A simple [Magento Admin](https://glossary.magento.com/magento-admin) [URL](https
 
 You can change this Admin URI in three ways:
 
-- The `bin/magento setup:config:set --backend-frontname=<value>` command
-- The `env.php` file
-- The Admin panel
+-  The `bin/magento setup:config:set --backend-frontname=<value>` command
+-  The `env.php` file
+-  The Admin panel
 
 Although the use of a non-default admin URL will not secure the site, its use will help prevent large-scale automated attacks. See [Display or change the Admin URI]({{page.baseurl}}/install-gde/install/cli/install-cli-adminurl.html) in Configuration Guide for more information.
 

--- a/guides/v2.2/architecture/tech-stack.md
+++ b/guides/v2.2/architecture/tech-stack.md
@@ -14,48 +14,48 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache storage
 
-* Redis
-* Memcache
+*  Redis
+*  Memcache
 
 ### Search
 
-* Solr ({{site.data.var.ee}})
-* Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
+*  Solr ({{site.data.var.ee}})
+*  Elasticsearch ({{site.data.var.ee}} - 2.1.x only)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (Less [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Solr (search engine)
-* Elasticsearch (search engine)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Solr (search engine)
+*  Elasticsearch (search engine)
 
 Magento 2.2 and above only supports PHP7+ and is no longer compatible with HipHop Virtual Machine(HHVM).
 

--- a/guides/v2.3/architecture/archi_perspectives/present_layer.md
+++ b/guides/v2.3/architecture/archi_perspectives/present_layer.md
@@ -13,11 +13,11 @@ The presentation layer contains both view elements **(layouts, blocks, templates
 
 Magento uses *areas* to efficiently make web service calls, loading only the dependent code that is required for the particular type of user. Three types of Magento users interact with presentation layer code:
 
-* **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
+*  **Web users** interact with the storefront, where they can see the View model of data displayed by Magento and interact with product UI elements to request data for view and manipulation. These users work within the `frontend` area.
 
-* **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
+*  **System administrators** customizing a [storefront](https://glossary.magento.com/storefront) can indirectly manipulate the presentation layer by, for example, adding themes or widgets to the frontend.
 
-* **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
+*  **Web [API](https://glossary.magento.com/api) calls** can be made through HTTP just like browser requests, and can be made via AJAX calls from the user interface.
 
 ## Presentation layer components
 
@@ -50,9 +50,9 @@ Magento generates the [HTML](https://glossary.magento.com/html) for a page to di
 
 View elements fall into two main categories: blocks and containers.
 
-* **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
+*  **Blocks** can generate [dynamic content](https://glossary.magento.com/dynamic-content) and can contain named child view elements that are similar to arguments being passed in. (The `as` attribute holds the child view element names for the parent block to reference them)
 
-* **Containers** collect an ordered group of children view elements.
+*  **Containers** collect an ordered group of children view elements.
 
 The browser forms a product web page by asking the view element tree to render itself into HTML.
 Containers and blocks emit HTML that encloses their children appropriately.

--- a/guides/v2.3/architecture/global_extensibility_features.md
+++ b/guides/v2.3/architecture/global_extensibility_features.md
@@ -7,14 +7,14 @@ title: Global features that support extensibility
 
 Essential qualities foster extensibility throughout the entire set of Magento components. This discussion focuses on:
 
-* Modularity
-* Reliance on popular design patterns
-* Coding standards
-* Flexible attribute types
-* Web APIs
-* Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
-* Plug-ins
-* Declarative schema
+*  Modularity
+*  Reliance on popular design patterns
+*  Coding standards
+*  Flexible attribute types
+*  Web APIs
+*  Service contracts and [dependency injection](https://glossary.magento.com/dependency-injection)
+*  Plug-ins
+*  Declarative schema
 
 ### Modularity
 
@@ -52,11 +52,11 @@ Extension | No
 
 Attribute types fall into three general categories:
 
-* **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
+*  **EAV (Entity-Attribute-Value) attributes** are site-specific attributes that you can define for a local site using the [Magento Admin](https://glossary.magento.com/magento-admin).
 
-* **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
+*  **Custom attributes** are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The Customer and [Catalog](https://glossary.magento.com/catalog) modules use EAV attributes.
 
-* **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
+*  **Extension attributes** often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the storefront. Extension attributes are introduced by modules.
 
 See [PHP Developer Guide]({{page.baseurl}}/extension-dev-guide/bk-extension-dev-guide.html) for information about using attributes.
 

--- a/guides/v2.3/architecture/tech-stack.md
+++ b/guides/v2.3/architecture/tech-stack.md
@@ -11,12 +11,12 @@ Magento's highly modular structure includes the following open-source technologi
 
 ### Web servers
 
-* Apache
-* [nginx](https://glossary.magento.com/nginx)
+*  Apache
+*  [nginx](https://glossary.magento.com/nginx)
 
 ### PHP
 
-* [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
+*  [Composer](https://glossary.magento.com/composer) (dependency management package for PHP)
 
 {:.bs-callout .bs-callout-info }
 Magento, with assistance from our community, is implementing PHP 7.2 compatibility for our upcoming 2.3.0 release. Any backward-incompatibility issues will be resolved in this release, and all 3rd party libraries now support PHP 7.2. Fully tested 7.2 support will be delivered in following patch releases.
@@ -25,37 +25,37 @@ If you are interested in participating in Magento Community projects we welcome 
 
 ### Database
 
-* MySQL
-* MySQL Percona
+*  MySQL
+*  MySQL Percona
 
 ### HTTP accelerator
 
-* Varnish
+*  Varnish
 
 ### Cache Storage
 
-* Redis
+*  Redis
 
 ### Search
 
-* Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
+*  Elasticsearch ({{site.data.var.ee}} versions 2.1.x and 2.2.x, and Magento Open Source version 2.3.x)
 
 ### Additional technologies
 
-* HTML5
-* CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
-* [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
-* RequireJS (library that helps load JavaScript resources on demand)
-* Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
-* Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
-* Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
+*  HTML5
+*  CSS3 (LESS [CSS](https://glossary.magento.com/css) pre-processor)
+*  [jQuery](https://glossary.magento.com/jquery) (primary [JavaScript](https://glossary.magento.com/javascript) library)
+*  RequireJS (library that helps load JavaScript resources on demand)
+*  Knockout.js (simplifies JavaScript UIs with the Model-View-View Model pattern)
+*  Third-party libraries (Zend Framework 1, Zend Framework 2, Symfony)
+*  Coding standards PSR-0 (autoloading standard), PSR-1 (basic coding standards), and PSR-2 (coding style guide), PSR-3, PSR-4
 
 ### Optional stack components
 
-* Varnish (caching)
-* Redis (used for page caching)
-* Elasticsearch (search engine)
-* RabbitMQ (message queue)
+*  Varnish (caching)
+*  Redis (used for page caching)
+*  Elasticsearch (search engine)
+*  RabbitMQ (message queue)
 
 Magento 2.2+ does not support HipHop Virtual Machine (HHVM).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the following folders:
- `guides/v2.2/architecture`
- `guides/v2.3/architecture`

## Affected DevDocs pages

- ...

## Links to Magento source code

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
