### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - cloud. Part 01.

### DIFF
--- a/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
+++ b/guides/v2.2/cloud/basic-information/starter-develop-deploy-workflow.md
@@ -7,9 +7,9 @@ The {{site.data.var.ece}} includes a single Git repository with a master branch 
 
 For your environments, we recommend following a Development > Staging > Production workflow to develop and deploy your site.
 
-* **Production environment (live site)**—Provides a full Production environment with all services built and deployed from the code on the `master` branch.
-* **Staging environment**—Provides a full Staging environment that matches the Production environment with all services built and deployed from a `staging` branch that you create by cloning from `master`.
-* **Integration environments**—Provides up to two active development environments that you create from the `staging` branch. The Integration environment does not support third-party services like Fastly and New Relic.
+*  **Production environment (live site)**—Provides a full Production environment with all services built and deployed from the code on the `master` branch.
+*  **Staging environment**—Provides a full Staging environment that matches the Production environment with all services built and deployed from a `staging` branch that you create by cloning from `master`.
+*  **Integration environments**—Provides up to two active development environments that you create from the `staging` branch. The Integration environment does not support third-party services like Fastly and New Relic.
 
 For your branches, you can follow any development methodology. For example, you can follow an Agile methodology such as scrum to create branches for every sprint.
 
@@ -21,18 +21,18 @@ Development and deployment on Starter plans begin with your initial project. You
 
 The development workflow uses the following process:
 
-* [Clone and branch](#clone-branch) from the `master` to create `staging` and development branches
-* [Develop code](#dev-code) and install extensions locally in a development branch
-* [Configure](#configure-store) your store and extension settings
-* [Generate configuration](#config-management) management files
-* [Push code](#push-code) and configuration to build and deploy to the Staging and Production environments
+*  [Clone and branch](#clone-branch) from the `master` to create `staging` and development branches
+*  [Develop code](#dev-code) and install extensions locally in a development branch
+*  [Configure](#configure-store) your store and extension settings
+*  [Generate configuration](#config-management) management files
+*  [Push code](#push-code) and configuration to build and deploy to the Staging and Production environments
 
 ![Develop and deploy workflow]({{ site.baseurl }}/common/images/cloud_workflow-starter.png)
 
 You also have a few optional steps to help develop and test your code and your store data:
 
-* [Install sample data](#sample-data) to your store
-* [Pull production store data](#prod-data) down to environments
+*  [Install sample data](#sample-data) to your store
+*  [Pull production store data](#prod-data) down to environments
 
 This process assumes that you have set up your [local developer workspace]({{ page.baseurl }}/cloud/setup/first-time-setup.html).
 
@@ -71,12 +71,12 @@ It's the time you have been waiting for...writing code. Using this base branch o
 
 We recommend using a branching strategy with your development work. Using one branch to do all of your work all at once might make testing difficult. For example, you could follow continuous integration and sprint methodologies to work:
 
-* Add a few extensions and configure them with your first branch
-* Push this code, test, and merge to Staging then Production
-* Fully configure your services in `services.yaml` and add a theme
-* Push this code, test, and merge to Staging then Production
-* Integrate with a 3rd party service
-* Push this code, test, and merge to Staging then Production
+*  Add a few extensions and configure them with your first branch
+*  Push this code, test, and merge to Staging then Production
+*  Fully configure your services in `services.yaml` and add a theme
+*  Push this code, test, and merge to Staging then Production
+*  Integrate with a 3rd party service
+*  Push this code, test, and merge to Staging then Production
 
 And so on until you have your store fully built, configured, and ready to go live. But keep reading, we have even better options for your store and code configuration!
 
@@ -92,11 +92,11 @@ Configure your store settings from the Magento Admin panel for the Integration e
 
 For the best information on configurations, review the documentation for {{site.data.var.ee}} and the installed extensions. Here are some links and ideas to help you get kickstarted:
 
-* [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
-* [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html) for store admin access, name, languages, currencies, branding, sites, store views and more
-* [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html) for your look and feel of the site and stores including CSS and layouts
-* [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html) for roles, tools, notifications, and your encryption key for your database
-* Extension settings using their documentation
+*  [Best practices for store configuration]({{ page.baseurl }}/cloud/configure/configure-best-practices.html) for specific best practices in the cloud
+*  [Basic configuration](http://docs.magento.com/m2/ee/user_guide/configuration/configuration-basic.html) for store admin access, name, languages, currencies, branding, sites, store views and more
+*  [Theme](http://docs.magento.com/m2/ee/user_guide/design/design-theme.html) for your look and feel of the site and stores including CSS and layouts
+*  [System configuration](http://docs.magento.com/m2/ee/user_guide/system/system.html) for roles, tools, notifications, and your encryption key for your database
+*  Extension settings using their documentation
 
 Beyond just store settings, you can further configure multiple sites and stores, configured services, and more. See [Configure Magento Commerce]({{ page.baseurl }}/cloud/configure/configuration-overview.html).
 
@@ -108,8 +108,8 @@ If you are familiar with Magento, you may be concerned about how to get your con
 
 {{site.data.var.ece}} provides a set of two [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) commands that export configuration settings from your environment into a file. These commands are only available for **{{site.data.var.ece}} 2.2 and later**.
 
-* `php .vendor/bin/m2-ece-scd-dump`: Recommended. Exports only the configuration settings you have entered or modified from defaults into a configuration file.
-* `php bin/magento app:config:dump`: Exports every configuration setting, including modified and default, into a configuration file.
+*  `php .vendor/bin/m2-ece-scd-dump`: Recommended. Exports only the configuration settings you have entered or modified from defaults into a configuration file.
+*  `php bin/magento app:config:dump`: Exports every configuration setting, including modified and default, into a configuration file.
 
 The generated file is `app/etc/config.php`.
 
@@ -117,11 +117,11 @@ You generate the file in the Integration environment where you configured Magent
 
 **Important notes** on Configuration Management:
 
-* Any configuration setting included in the file generated from the `app:config:dump` command is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using the `.vendor/bin/m2-ece-scd-dump` command.
+*  Any configuration setting included in the file generated from the `app:config:dump` command is locked from editing, or read-only, in the deployed environment. This is one reason we recommend using the `.vendor/bin/m2-ece-scd-dump` command.
 
-  For example, we will have you install a module for Fastly in your development environment. You can only configure this module in the Staging and Production environment. Using the `.vendor/bin/m2-ece-scd-dump` command keeps those default fields editable when you deploy your development changes to the Staging and Production environment.
+   For example, we will have you install a module for Fastly in your development environment. You can only configure this module in the Staging and Production environment. Using the `.vendor/bin/m2-ece-scd-dump` command keeps those default fields editable when you deploy your development changes to the Staging and Production environment.
 
-* The generated file can be long depending on the size of your deployment. The `.vendor/bin/m2-ece-scd-dump` command generates a much smaller file than the file generated by the `app:config:dump` command.
+*  The generated file can be long depending on the size of your deployment. The `.vendor/bin/m2-ece-scd-dump` command generates a much smaller file than the file generated by the `app:config:dump` command.
 
 ![Generate configuration management file]({{ site.baseurl }}/common/images/cloud_workflow-config-mgmt.png)
 
@@ -175,19 +175,19 @@ When you push branched code from your local environment to the remote branch, a 
 
 Build scripts:
 
-* Your site on the target environment continue running during a build
-* Check and run {{site.data.var.ece}} patches and hotfixes
-* Compile your code with a build and deploy log
-* Check for Configuration Management, if there static content deploy occurs during this phase
-* Create or use a slug of unchanged code to speed up the process
-* Provision all backend services and applications
+*  Your site on the target environment continue running during a build
+*  Check and run {{site.data.var.ece}} patches and hotfixes
+*  Compile your code with a build and deploy log
+*  Check for Configuration Management, if there static content deploy occurs during this phase
+*  Create or use a slug of unchanged code to speed up the process
+*  Provision all backend services and applications
 
 Deploy scripts:
 
-* Puts your site on the target environment in Maintenance mode
-* Deploys static content if not completed during Build
-* Installs or updates {{site.data.var.ece}}
-* Configure routing for traffic
+*  Puts your site on the target environment in Maintenance mode
+*  Deploys static content if not completed during Build
+*  Installs or updates {{site.data.var.ece}}
+*  Configure routing for traffic
 
 When fully completed, your store comes back online, live, with all of your updated code and configurations.
 
@@ -218,9 +218,9 @@ Following your branching and development methodologies, you can easily develop n
 
 {{site.data.var.ece}} environments support continuous integration for constant updates. This workflow supports releases multiple times a day or on a set schedule according to your business needs.
 
-* Create development branches with future features and changes
-* Test the code in your development environments
-* Deploy and test in Staging
-* Deploy to Production
+*  Create development branches with future features and changes
+*  Test the code in your development environments
+*  Deploy and test in Staging
+*  Deploy to Production
 
 For more information, see [Continuous integration]({{ page.baseurl }}/cloud/deploy/continuous-deployment.html).

--- a/guides/v2.2/cloud/before/before-setup-env-2_clone.md
+++ b/guides/v2.2/cloud/before/before-setup-env-2_clone.md
@@ -148,8 +148,8 @@ To add variables using the Project Web Interface:
 
 After cloning your project and updating the Magento administrator account configuration, you can branch for development. As stated earlier, you must create an environment using the `magento-cloud environment:branch <branch-name>` command or the Project Web Interface for the environment to become _active_.
 
-- For [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html#clone-branch), consider creating a branch for `staging`, then create a development branch based on the `staging` branch.
-- For [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html), create development branches based on the Integration environment.
+-  For [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html#clone-branch), consider creating a branch for `staging`, then create a development branch based on the `staging` branch.
+-  For [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html), create development branches based on the Integration environment.
 
 {:.procedure}
 To branch from master:

--- a/guides/v2.2/cloud/before/before-setup-env-install.md
+++ b/guides/v2.2/cloud/before/before-setup-env-install.md
@@ -21,9 +21,9 @@ With your workspace prepared, install Magento on your local to verify custom cod
 
 To customize the Magento software on your local workstation, prepare the following:
 
-* Hostname or IP address of your machine
-* Admin username, password, and URL created earlier
-* Magento authentication keys for installing Magento
+*  Hostname or IP address of your machine
+*  Admin username, password, and URL created earlier
+*  Magento authentication keys for installing Magento
 
 ### List the Magento Admin environment variables
 
@@ -105,8 +105,8 @@ Prior to installing, you should [Update installation dependencies]({{ page.baseu
 
 Be ready to install Magento using one of the following options:
 
-* [Install the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
-* [Install the Magento software using the Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
+*  [Install the Magento software using the command line]({{ page.baseurl }}/install-gde/install/cli/install-cli.html)
+*  [Install the Magento software using the Web Setup Wizard]({{ page.baseurl }}/install-gde/install/web/install-web.html)
 
 {:.procedure}
 To install Magento using the command line:
@@ -181,17 +181,17 @@ Optionally, if you used Vagrant with the _hostmanager_ plugin, update the hosts 
 
 For development and testing in an environment as close to Integration as possible, you may also want to install additional tools, software, and services. These services are configured using [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html).
 
-* [Redis]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
-* [ElasticSearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
-* [RabbitMQ]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
-* [Additional software]({{ page.baseurl }}/install-gde/prereq/optional.html) for Magento
+*  [Redis]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
+*  [ElasticSearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
+*  [RabbitMQ]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
+*  [Additional software]({{ page.baseurl }}/install-gde/prereq/optional.html) for Magento
 
 ## Verify your local workspace
 
 To verify the local, access the store using the URL you passed in the install command. For this example, you can access the local Magento store using the following URL formats:
 
-* `http://magento.local/`
-* `http://magento.local/admin`
+*  `http://magento.local/`
+*  `http://magento.local/admin`
 
 To change the URI for the Admin panel, use this command to locate it:
 
@@ -205,12 +205,12 @@ To verify the Integration master branch environment, log into the Project Web In
 
 With these steps completed, you should have:
 
-* A {{site.data.var.ee}} account and initial project setup and master branch
-* A local workspace configured with installations of required software, Magento Cloud CLI, and Magento
-* SSH keys set up
-* The Magento file system owner configured
-* Your initial code branch
-* Magento authentication keys set up and configured in the project and local
+*  A {{site.data.var.ee}} account and initial project setup and master branch
+*  A local workspace configured with installations of required software, Magento Cloud CLI, and Magento
+*  SSH keys set up
+*  The Magento file system owner configured
+*  Your initial code branch
+*  Magento authentication keys set up and configured in the project and local
 
 {:.ref-header}
 Next step

--- a/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
+++ b/guides/v2.2/cloud/before/before-workspace-file-sys-owner.md
@@ -55,7 +55,7 @@ Because the point of creating this user is to provide added security, it is esse
 
 To find the web server user's group:
 
-* CentOS:
+*  CentOS:
 
    ```bash
    grep -E -i '^user|^group' /etc/httpd/conf/httpd.conf
@@ -69,7 +69,7 @@ To find the web server user's group:
 
    Typically, the user and group name are both `apache`
 
-* Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group
+*  Ubuntu: `ps aux | grep apache` to find the apache user, then `groups <apache user>` to find the group
 
    Typically, the username and the group name are both `www-data`
 
@@ -77,8 +77,8 @@ To find the web server user's group:
 
 Assuming the typical Apache group name for CentOS and Ubuntu, enter the following command as a user with `root` privileges:
 
-* CentOS: `usermod -g apache <username>`
-* Ubuntu: `usermod -g www-data <username>`
+*  CentOS: `usermod -g apache <username>`
+*  Ubuntu: `usermod -g www-data <username>`
 
 For example, to add the user `magento_user` to the `apache` primary group on CentOS:
 
@@ -100,8 +100,8 @@ magento_user : apache
 
 To complete the task, restart the web server:
 
-* Ubuntu: `service apache2 restart`
-* CentOS: `service httpd restart`
+*  Ubuntu: `service apache2 restart`
+*  CentOS: `service httpd restart`
 
 {:.ref-header}
 Next step

--- a/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
+++ b/guides/v2.2/cloud/before/before-workspace-magento-prereqs.md
@@ -30,15 +30,15 @@ To best develop and manage your host, we recommend using a virtual machine. The 
 
 For your VM, we recommend installing one of the following:
 
-* [Vagrant](https://www.vagrantup.com/docs/) for a virtual machine
-* [Docker](https://docs.docker.com/) for a container
+*  [Vagrant](https://www.vagrantup.com/docs/) for a virtual machine
+*  [Docker](https://docs.docker.com/) for a container
 
 When using Vagrant, we also recommend the package [hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) and using [VirtualBox](https://www.virtualbox.org/wiki/Documentation) to manage the environment. VirtualBox extends support and features across all OS and platforms to create and manage multiple VMs and operating systems on your local.
 
 ## Development tools {#devtools}
 
-* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host. For more information, see [How Cloud uses Git]({{ page.baseurl }}/cloud/reference/git-integration.html).
-* [Composer](https://getcomposer.org/download/) - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM. For more information, see [How Cloud uses Composer]({{ page.baseurl }}/cloud/reference/cloud-composer.html).
+*  [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Provides code branching and management for accessing {{site.data.var.ee}} and your code repositories. Use Git command-line commands or applications of your choice to work with Git. You can install this on your local VM or on your host. For more information, see [How Cloud uses Git]({{ page.baseurl }}/cloud/reference/git-integration.html).
+*  [Composer](https://getcomposer.org/download/) - Used for dependency management. Composer enables us to manage the Magento components and their dependencies. Install on your local VM. For more information, see [How Cloud uses Composer]({{ page.baseurl }}/cloud/reference/cloud-composer.html).
 
 ## Web server (local) {#webserver}
 
@@ -50,18 +50,18 @@ Install [PHP](https://glossary.magento.com/php) on your local workstation. For i
 
 The following packages may also be helpful for your PHP installation:
 
-* [bcmath](http://php.net/manual/en/book.bc.php)
-* [curl](http://php.net/manual/en/book.curl.php)
-* ext-dom
-* [fpm](https://php-fpm.org/)
-* [gd](http://php.net/manual/en/book.image.php)
-* [intl](http://php.net/manual/en/book.intl.php)
-* [json](http://php.net/manual/en/ref.json.php)
-* [mbstring](http://php.net/manual/en/book.mbstring.php)
-* [mcrypt](http://php.net/manual/en/book.mcrypt.php) (for PHP 7.1 and earlier only)
-* [mysql](http://php.net/manual/en/set.mysqlinfo.php)
-* [xml](http://php.net/manual/en/book.xml.php)
-* [zip](http://php.net/manual/en/book.zip.php)
+*  [bcmath](http://php.net/manual/en/book.bc.php)
+*  [curl](http://php.net/manual/en/book.curl.php)
+*  ext-dom
+*  [fpm](https://php-fpm.org/)
+*  [gd](http://php.net/manual/en/book.image.php)
+*  [intl](http://php.net/manual/en/book.intl.php)
+*  [json](http://php.net/manual/en/ref.json.php)
+*  [mbstring](http://php.net/manual/en/book.mbstring.php)
+*  [mcrypt](http://php.net/manual/en/book.mcrypt.php) (for PHP 7.1 and earlier only)
+*  [mysql](http://php.net/manual/en/set.mysqlinfo.php)
+*  [xml](http://php.net/manual/en/book.xml.php)
+*  [zip](http://php.net/manual/en/book.zip.php)
 
 ### Set up PHP memory limit {#cloud-first-php}
 
@@ -85,10 +85,10 @@ To set a memory limit:
 1. Save your changes to `php.ini` and exit the text editor.
 1. Restart your web server:
 
-   * Apache:
-      * CentOS: `service httpd restart`
-      * Ubuntu: `service apache2 restart`
-   * Nginx: `service nginx restart`
+   *  Apache:
+      *  CentOS: `service httpd restart`
+      *  Ubuntu: `service apache2 restart`
+   *  Nginx: `service nginx restart`
 
 ## Database (local) {#database}
 
@@ -219,8 +219,8 @@ To install the Magento Cloud CLI:
 
 The requirements listed in this topic are specific to {{site.data.var.ece}} environments. You will also install {{site.data.var.ee}} on your VM or Docker container. For that installation, you should also review the following:
 
-* [{{site.data.var.ee}} requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
-* [(Integrator) Integrator installation]({{ page.baseurl }}/install-gde/composer.html)
+*  [{{site.data.var.ee}} requirements]({{ page.baseurl }}/install-gde/system-requirements.html)
+*  [(Integrator) Integrator installation]({{ page.baseurl }}/install-gde/composer.html)
 
 ## Additional options
 

--- a/guides/v2.2/cloud/before/before-workspace-ssh.md
+++ b/guides/v2.2/cloud/before/before-workspace-ssh.md
@@ -17,8 +17,8 @@ The [SSH protocol](https://en.wikipedia.org/wiki/Secure_Shell) is designed to ma
 
 When initially setting up your local environment, you need to add the SSH keys to the following specific environments:
 
-* Starter: Add to Master (Production) and any environments you create by branching from Master
-* Pro: Add to Master Integration environment. After your Staging and Production environments are provisioned, you can add the SSH keys to those environments through the Project Web Interface or via SSH and CLI commands.
+*  Starter: Add to Master (Production) and any environments you create by branching from Master
+*  Pro: Add to Master Integration environment. After your Staging and Production environments are provisioned, you can add the SSH keys to those environments through the Project Web Interface or via SSH and CLI commands.
 
 {% include cloud/enable-ssh.md %}
 

--- a/guides/v2.2/cloud/cdn/cloud-fastly-custom-response.md
+++ b/guides/v2.2/cloud/cdn/cloud-fastly-custom-response.md
@@ -20,23 +20,23 @@ You can update your {{ site.var.data.ee }} store configuration to replace some d
 
 Currently, you can customize the following Fastly response pages for your {{ site.data.var.ece }} project through the Magento Admin UI.
 
-- [Timeout or site maintenance outages (503 Service Unavailable)](#customize-the-503-error-page)
-- [WAF blocking events that occur when the WAF detects suspicious request traffic (403 Forbidden)](#customize-the-waf-error-page)
+-  [Timeout or site maintenance outages (503 Service Unavailable)](#customize-the-503-error-page)
+-  [WAF blocking events that occur when the WAF detects suspicious request traffic (403 Forbidden)](#customize-the-waf-error-page)
 
 **HTML coding requirements:**
 
 The HTML code for the custom page must meet the following requirements:
 
-- Content can contain up to 65,535 characters.
-- Specify all CSS inline in the HTML source.
-- Bundle images in the HTML page using base64 so that they display even if Fastly is offline. See [Data URIs on the css-tricks site](https://css-tricks.com/data-uris/).
+-  Content can contain up to 65,535 characters.
+-  Specify all CSS inline in the HTML source.
+-  Bundle images in the HTML page using base64 so that they display even if Fastly is offline. See [Data URIs on the css-tricks site](https://css-tricks.com/data-uris/).
 
 ## Customize the 503 error page
 
 Customers see the default 503 error page in the following cases:
 
-- When a request to the Fastly origin returns a response status great than 500.
-- When the Fastly origin is down, for example due to a timeout, maintenance activity, or health issues.
+-  When a request to the Fastly origin returns a response status great than 500.
+-  When the Fastly origin is down, for example due to a timeout, maintenance activity, or health issues.
 
 You can customize the default page by adapting the following HTML code to include styling to match your {{ site.data.var.ee }} store theme and modifying the title and messaging as needed.
 
@@ -77,9 +77,9 @@ To add the custom response page to the Fastly configuration:
 
 1. Refresh the cache.
 
-   - In the notification at the top of the page, click the *Cache Management* link.
+   -  In the notification at the top of the page, click the *Cache Management* link.
 
-   - On the Cache Management page, click **Flush Magento Cache**.
+   -  On the Cache Management page, click **Flush Magento Cache**.
 
 ## Customize the WAF error page
 
@@ -139,9 +139,9 @@ To edit the WAF error page:
 
 1. Refresh the cache.
 
-   - In the notification at the top of the page, click the **Cache Management** link.
+   -  In the notification at the top of the page, click the **Cache Management** link.
 
-   - On the Cache Management page, click **Flush Magento Cache**.
+   -  On the Cache Management page, click **Flush Magento Cache**.
 
 <!-- Link definitions -->
 

--- a/guides/v2.2/cloud/cdn/configure-fastly.md
+++ b/guides/v2.2/cloud/cdn/configure-fastly.md
@@ -20,10 +20,10 @@ For VCL snippets, experience developing that code is required for advanced confi
 
 The process for configuring Fastly includes:
 
-- Get Fastly credentials for Staging and Production environments
-- Enable Fastly CDN caching in your environment
-- Upload Fastly VCL snippets
-- Advanced configurations including VCL snippets, as needed for your {{ site.data.var.ee }} sites
+-  Get Fastly credentials for Staging and Production environments
+-  Enable Fastly CDN caching in your environment
+-  Upload Fastly VCL snippets
+-  Advanced configurations including VCL snippets, as needed for your {{ site.data.var.ee }} sites
 
 ## Get Fastly credentials {#cloud-fastly-creds}
 
@@ -36,19 +36,19 @@ Use the following methods to find and save the Fastly service ID and API token f
 {:.procedure}
 To view your Fastly credentials:
 
-- IaaS-mounted shared directory—On Pro projects, use SSH to connect to your server and get the Fastly credentials from the `/mnt/shared/fastly_tokens.txt` file.
+-  IaaS-mounted shared directory—On Pro projects, use SSH to connect to your server and get the Fastly credentials from the `/mnt/shared/fastly_tokens.txt` file.
 
-- Local workspace—From the command line, use the Magento Cloud CLI to [list and review]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html) Fastly environment variables.
+-  Local workspace—From the command line, use the Magento Cloud CLI to [list and review]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html) Fastly environment variables.
 
    ```bash
    magento-cloud variable:get -e <environment ID>
    ```
 
-- Project Web UI—Check the following environment variables in the *[Environment configuration variables]({{ page.baseurl }}/cloud/project/projects.html#environment-configuration-variables)* section.
+-  Project Web UI—Check the following environment variables in the *[Environment configuration variables]({{ page.baseurl }}/cloud/project/projects.html#environment-configuration-variables)* section.
 
-   - `CONFIG__DEFAULT__SYSTEM__FULL_PAGE_CACHE__FASTLY__FASTLY_API_TOKEN`
+   -  `CONFIG__DEFAULT__SYSTEM__FULL_PAGE_CACHE__FASTLY__FASTLY_API_TOKEN`
 
-   - `CONFIG__DEFAULT__SYSTEM__FULL_PAGE_CACHE__FASTLY__FASTLY_SERVICE_ID`
+   -  `CONFIG__DEFAULT__SYSTEM__FULL_PAGE_CACHE__FASTLY__FASTLY_SERVICE_ID`
 
 {: .bs-callout-info }
 If you cannot find the Fastly credentials for the Staging or Production environments, contact your Magento Technical Account Manager.
@@ -57,9 +57,9 @@ If you cannot find the Fastly credentials for the Staging or Production environm
 
 **Prerequisites:**
 
-- Latest version of the [Fastly CDN for Magento 2 module]({{ page.baseurl }}/cloud/cdn/cloud-fastly.html#fastly-cdn-module-for-magento-2) installed in the Staging and Production environments. See [Upgrade Fastly](#upgrade).
+-  Latest version of the [Fastly CDN for Magento 2 module]({{ page.baseurl }}/cloud/cdn/cloud-fastly.html#fastly-cdn-module-for-magento-2) installed in the Staging and Production environments. See [Upgrade Fastly](#upgrade).
 
-- [Fastly credentials](#cloud-fastly-creds) for {{ site.data.var.ece }} Staging and Production environments
+-  [Fastly credentials](#cloud-fastly-creds) for {{ site.data.var.ece }} Staging and Production environments
 
 {:.procedure}
 To enable Fastly CDN caching in Staging and Production:
@@ -127,9 +127,9 @@ Before adding [custom](#custom-configuration) or advanced configuration settings
 
 Configure the following features as needed:
 
-- [Configure backends and Origin shielding](#backend)
-- [Customize response pages]({{ page.baseurl }}/cloud/cdn/cloud-fastly-custom-response.html)
-- [Enable additional Fastly configuration options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#further-configuration-options)
+-  [Configure backends and Origin shielding](#backend)
+-  [Customize response pages]({{ page.baseurl }}/cloud/cdn/cloud-fastly-custom-response.html)
+-  [Enable additional Fastly configuration options](https://github.com/fastly/fastly-magento2/blob/master/Documentation/CONFIGURATION.md#further-configuration-options)
 
 ### Configure backends and Origin shielding {#backend}
 
@@ -156,23 +156,23 @@ To review the backend settings configuration:
 
    The following list shows which Fastly shield locations to use based an AWS region:
 
-   - ap-east-1 => hongkong-hk
-   - ap-northeast-1 => tyo-tokyo-jp, hnd-tokyo-jp
-   - ap-northeast-2 => tyo-tokyo-jp, hnd-tokyo-jp
-   - ap-southeast-1 => singapore-sg
-   - ap-southeast-2 => sydney-au
-   - ap-south-1 => singapore-sg
-   - ca-central-1 => yul-montreal-ca, iad-va-us, dca-dc-us, bwi-va-us
-   - eu-central-1 => frankfurt-de, hhn-frankfurt-de
-   - eu-north-1 => stockholm-bma
-   - eu-west-1 => london-uk, london_city-uk
-   - eu-west-2 => london-uk, london_city-uk
-   - eu-west-3 => cdg-par-fr
-   - sa-east-1 => gru-br-sa
-   - us-east-1 => iad-va-us, dca-dc-us, bwi-va-us
-   - us-east-2 => iad-va-us, dca-dc-us, bwi-va-us
-   - us-west-1 => sjc-ca-us, pao-ca-us
-   - us-west-2 => sea-wa-us
+   -  ap-east-1 => hongkong-hk
+   -  ap-northeast-1 => tyo-tokyo-jp, hnd-tokyo-jp
+   -  ap-northeast-2 => tyo-tokyo-jp, hnd-tokyo-jp
+   -  ap-southeast-1 => singapore-sg
+   -  ap-southeast-2 => sydney-au
+   -  ap-south-1 => singapore-sg
+   -  ca-central-1 => yul-montreal-ca, iad-va-us, dca-dc-us, bwi-va-us
+   -  eu-central-1 => frankfurt-de, hhn-frankfurt-de
+   -  eu-north-1 => stockholm-bma
+   -  eu-west-1 => london-uk, london_city-uk
+   -  eu-west-2 => london-uk, london_city-uk
+   -  eu-west-3 => cdg-par-fr
+   -  sa-east-1 => gru-br-sa
+   -  us-east-1 => iad-va-us, dca-dc-us, bwi-va-us
+   -  us-east-2 => iad-va-us, dca-dc-us, bwi-va-us
+   -  us-west-1 => sjc-ca-us, pao-ca-us
+   -  us-west-2 => sea-wa-us
 
 1. Modify the timeout values (in microseconds) for the connection to the shield, time between bytes, and time for the first byte. We recommend keeping the default timeout settings.
 
@@ -190,10 +190,10 @@ Fastly provides multiple types of purge options on your Magento Cache Management
 
 The options include:
 
-- **Purge category**: Purges product category content (not product content) when you add and update a single product. You may want to keep this disabled and enable purge product, which purges products and product categories.
-- **Purge product**: Purges all product and product category content when saving a single modification to a product. Enabling purge product can be helpful to immediately get updates to customers when changing a price, adding a product option, and when product inventory is out-of-stock.
-- **Purge CMS page**: Purges page content when updating and adding pages to the Magento CMS. For example, you may want to purge when updating your Terms and Conditions or Return policy. If you rarely make these changes, you could disable automatic purging.
-- **Soft purge**: Sets changed content to stale and purges according to the stale timing. In combination with the stale timings your customers will be served stale content very fast while Fastly is updating the content in the background.
+-  **Purge category**: Purges product category content (not product content) when you add and update a single product. You may want to keep this disabled and enable purge product, which purges products and product categories.
+-  **Purge product**: Purges all product and product category content when saving a single modification to a product. Enabling purge product can be helpful to immediately get updates to customers when changing a price, adding a product option, and when product inventory is out-of-stock.
+-  **Purge CMS page**: Purges page content when updating and adding pages to the Magento CMS. For example, you may want to purge when updating your Terms and Conditions or Return policy. If you rarely make these changes, you could disable automatic purging.
+-  **Soft purge**: Sets changed content to stale and purges according to the stale timing. In combination with the stale timings your customers will be served stale content very fast while Fastly is updating the content in the background.
 
 ![Configure purge options]({{ site.baseurl }}/common/images/cloud_fastly-purgeoptions.png){:width="650px"}
 
@@ -252,9 +252,9 @@ Fastly also provides a series of [geolocation-related VCL features](https://docs
 
 To enable Fastly caching on your Staging and Production sites, you need make the following changes to the DNS configuration for your site:
 
-- Set all necessary redirects, especially if you are migrating from an existing site
-- Set the zone’s root resource record to address the hostname
-- Lower the value for the Time-to-Live (TTL) to refresh DNS information to point customers to the correct Production store
+-  Set all necessary redirects, especially if you are migrating from an existing site
+-  Set the zone’s root resource record to address the hostname
+-  Lower the value for the Time-to-Live (TTL) to refresh DNS information to point customers to the correct Production store
 
 We recommend a significantly lower TTL value when switching the DNS record. This value tells the DNS how long to cache the DNS record. When shortened, it refreshes the DNS faster. For example, you can change the TTL value from 3 days to 10 minutes when you are testing your site. Be advised that shortening the TTL value  adds load to the web server.
 
@@ -263,10 +263,10 @@ After checking with your registrar about where to change your DNS settings, add 
 CNAME records cannot be set for apex domains, also referred to as a naked or base domains. You must use `A` records for this.
 `A` records map a domain name to the following Fastly IP addresses:
 
-- `151.101.1.124`
-- `151.101.65.124`
-- `151.101.129.124`
-- `151.101.193.124`
+-  `151.101.1.124`
+-  `151.101.65.124`
+-  `151.101.129.124`
+-  `151.101.193.124`
 
 Refer to [Go live checklist]({{ page.baseurl }}/cloud/live/go-live-checklist.html) for more information.
 

--- a/guides/v2.2/cloud/cdn/fastly-image-optimization.md
+++ b/guides/v2.2/cloud/cdn/fastly-image-optimization.md
@@ -9,10 +9,10 @@ functional_areas:
 
 Fastly image optimization (Fastly IO) provides real-time image manipulation and optimization to speed up image delivery and simplify maintenance of image source sets for responsive web applications. Once configured Fastly IO provides the following image optimization features:
 
-- Force lossy conversion
-- Deep image optimization
-- Adaptive pixel ratios
-- Support for common image formats: PNG, JPEG, and GIF
+-  Force lossy conversion
+-  Deep image optimization
+-  Adaptive pixel ratios
+-  Support for common image formats: PNG, JPEG, and GIF
 
 You must set up your Fastly service and configure Origin shielding before you can enable and configure the Fastly IO option.
 
@@ -24,8 +24,8 @@ You can enable Fastly image optimization (Fastly IO) from the Admin panel by upl
 
 **Prerequisites**
 
-- Install or upgrade to Fastly module version 1.2.62 or later
-- [Configure Fastly Origin shield and backend]({{ page.baseurl }}/cloud/cdn/configure-fastly.html#backend)
+-  Install or upgrade to Fastly module version 1.2.62 or later
+-  [Configure Fastly Origin shield and backend]({{ page.baseurl }}/cloud/cdn/configure-fastly.html#backend)
 
 {:.procedure}
 To enable Fastly IO:
@@ -49,9 +49,9 @@ To enable Fastly IO:
 
 You can review and update the default IO configuration settings for image optimization as needed. For example, you might want to change WebP and JPEG quality levels for lossy formats or change the format for serving JPEG images to *Progressive* or *Baseline*. Also, you can use Fastly IO for more granular image optimization features, such as:
 
-- Force lossy conversion
-- Deep image optimization
-- Adaptive pixel ratios
+-  Force lossy conversion
+-  Deep image optimization
+-  Adaptive pixel ratios
 
 {:.procedure}
 To update Fastly IO:
@@ -94,8 +94,8 @@ To update Fastly IO:
 
    ![Enable Fastly IO adaptive pixel ratios]({{ site.baseurl }}/common/images/cloud_fastly-io-config-adaptive-pixel.png){:width="650px"}
 
-   - In the _Enable adaptive device pixel ratios_ field, select **Yes**.
-   - In the _Device pixel ratios_ field, accept the default setting, or click the **System Input** check box to remove the setting. Then, select the desired ratio. A higher Device Pixel Ratio setting delivers larger images.
+   -  In the _Enable adaptive device pixel ratios_ field, select **Yes**.
+   -  In the _Device pixel ratios_ field, accept the default setting, or click the **System Input** check box to remove the setting. Then, select the desired ratio. A higher Device Pixel Ratio setting delivers larger images.
 
 1. Click **Save Configuration**.
 

--- a/guides/v2.2/cloud/cdn/fastly-vcl-badreferer.md
+++ b/guides/v2.2/cloud/cdn/fastly-vcl-badreferer.md
@@ -16,11 +16,11 @@ We recommend adding custom VCL configurations to a Staging environment where you
 
 **Prerequisites**
 
-- Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
+-  Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
 
-- Get Admin credentials for your {{ site.data.var.ece }} environment.
+-  Get Admin credentials for your {{ site.data.var.ece }} environment.
 
-- Review your site logs for fake referral URLs and make a list of domains to block.
+-  Review your site logs for fake referral URLs and make a list of domains to block.
 
 ## Create a referrer block list
 
@@ -34,7 +34,7 @@ Edge Dictionaries create key-value pairs accessible to VCL functions during VCL 
 
 1. Create the Dictionary container:
 
-   - Click **Add container**.
+   -  Click **Add container**.
 
    -  On the *Container* page, enter a **Dictionary name**—`referrer_blocklist`.
 
@@ -74,15 +74,15 @@ The following custom VCL snippet code (JSON format) checks incoming requests and
 
 Review the example code and change values as needed:
 
-- `name` — Name for the VCL snippet. For this example, we used `block_bad_referrer`.
+-  `name` — Name for the VCL snippet. For this example, we used `block_bad_referrer`.
 
-- `dynamic` — Value 0 indicates a [regular snippet](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) to upload to the versioned VCL for the Fastly configuration.
+-  `dynamic` — Value 0 indicates a [regular snippet](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) to upload to the versioned VCL for the Fastly configuration.
 
-- `priority` — Determines when the VCL snippet runs. The priority  is `5` to run this snippet code before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
+-  `priority` — Determines when the VCL snippet runs. The priority  is `5` to run this snippet code before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
 
-- `type` — Specifies a location to insert the snippet in the VCL version. In this example, the VCL snippet is a `recv` snippet. When the snippet is inserted into the VCL version, it is added to the `vcl_recv` subroutine,  below the default Fastly VCL code and above any objects.
+-  `type` — Specifies a location to insert the snippet in the VCL version. In this example, the VCL snippet is a `recv` snippet. When the snippet is inserted into the VCL version, it is added to the `vcl_recv` subroutine,  below the default Fastly VCL code and above any objects.
 
-- `content` — The snippet of VCL code to run in one line, without line breaks.
+-  `content` — The snippet of VCL code to run in one line, without line breaks.
 
 In this example, the VCL code logic captures the host of a referrer website into a header, and then compares the host name to the list of URLs in the `referrer_blocklist` dictionary.
 
@@ -104,13 +104,13 @@ Add the custom VCL snippet to your Fastly service configuration from the Magento
 
 1. Add the VCL snippet values:
 
-   - **Name** — `block_bad_referrer`
+   -  **Name** — `block_bad_referrer`
 
-   - **Type** — `recv`
+   -  **Type** — `recv`
 
-   - **Priority** — `5`
+   -  **Priority** — `5`
 
-   - **VCL** snippet content —
+   -  **VCL** snippet content —
 
       ```
       set req.http.Referer-Host = regsub(req.http.Referer,

--- a/guides/v2.2/cloud/cdn/fastly-vcl-whitelist.md
+++ b/guides/v2.2/cloud/cdn/fastly-vcl-whitelist.md
@@ -13,11 +13,11 @@ The following example shows how to use a custom VCL snippet with a [Fastly Acces
 
 **Prerequisites**
 
-- Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
+-  Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
 
-- Get Magento Admin UI credentials for your {{ site.data.var.ece }} environment.
+-  Get Magento Admin UI credentials for your {{ site.data.var.ece }} environment.
 
-- List of client IP addresses allowed to access the Magento Admin UI.
+-  List of client IP addresses allowed to access the Magento Admin UI.
 
 ## Create Edge ACL for allowing client IPs {#edge-acl}
 
@@ -31,7 +31,7 @@ Edge ACLs create IP address lists for managing access to your site. In this exam
 
 1. Create the ACL container:
 
-   - Click **Add ACL**.
+   -  Click **Add ACL**.
 
    -  On the *ACL Container* page, enter a **ACL name**—`allowlist`.
 
@@ -69,13 +69,13 @@ Create an `allowlist.json` file with the following JSON content:
 
 Review the following values for the code to determine if you need to make changes:
 
-- `name` — Name for the VCL snippet. For this example, `allowlist`.
+-  `name` — Name for the VCL snippet. For this example, `allowlist`.
 
-- `priority` — Determines when the VCL snippet runs. The priority  is `5` to immediately run and check whether a Magento Admin UI requests are coming from an allowed IP address. The snippet runs before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
+-  `priority` — Determines when the VCL snippet runs. The priority  is `5` to immediately run and check whether a Magento Admin UI requests are coming from an allowed IP address. The snippet runs before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
 
-- `type` — Specifies Specifies a location to insert the snippet in the versioned VCL code. This VCL is a `recv` snippet type which adds the snippet code to the `vcl_recv` subroutine below the default Fastly VCL code and above any objects.
+-  `type` — Specifies Specifies a location to insert the snippet in the versioned VCL code. This VCL is a `recv` snippet type which adds the snippet code to the `vcl_recv` subroutine below the default Fastly VCL code and above any objects.
 
-- `content` — The snippet of VCL code to run. In this example, the code filters requests to the Magento Admin UI and allows access if the client IP address matches an address in the `allowlist` ACL. If the address doesn't match the request is blocked with a `403 Forbidden` error.
+-  `content` — The snippet of VCL code to run. In this example, the code filters requests to the Magento Admin UI and allows access if the client IP address matches an address in the `allowlist` ACL. If the address doesn't match the request is blocked with a `403 Forbidden` error.
 
    If the URL for your Magento Admin UI was changed, replace the sample value `/admin` with the URL for your environment. For example, `/company-admin`.
 

--- a/guides/v2.2/cloud/cdn/fastly-vcl-wordpress.md
+++ b/guides/v2.2/cloud/cdn/fastly-vcl-wordpress.md
@@ -16,17 +16,17 @@ We recommend adding custom VCL configurations to a Staging environment where you
 
 **Prerequisites**
 
-- Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
+-  Configure the {{ site.var.data.ece }} environment for Fastly services. See [Set up Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
 
-- Get credentials to access both the Fastly API and the Magento Admin UI for your {{ site.data.var.ece }} environment.
+-  Get credentials to access both the Fastly API and the Magento Admin UI for your {{ site.data.var.ece }} environment.
 
-- Identify the URL paths to redirect to the WordPress backend.
+-  Identify the URL paths to redirect to the WordPress backend.
 
-- Submit a support ticket requesting the following Fastly service configuration changes required to use the custom VCL snippet for the WordPress redirects:
+-  Submit a support ticket requesting the following Fastly service configuration changes required to use the custom VCL snippet for the WordPress redirects:
 
-   - Add the WordPress host to the Fastly backend configuration. Include the domain name for the WordPress host.
+   -  Add the WordPress host to the Fastly backend configuration. Include the domain name for the WordPress host.
 
-   - Attach the following request condition to the Wordpress backend.
+   -  Attach the following request condition to the Wordpress backend.
 
       ```json
       req.http.X-WP == “1”
@@ -46,7 +46,7 @@ Edge Dictionaries create key-value pairs accessible to VCL functions during VCL 
 
 1. Create the Dictionary container:
 
-   - Click **Add container**.
+   -  Click **Add container**.
 
    -  On the *Container* page, enter a **Dictionary name**—`wordpress_urls`.
 
@@ -56,15 +56,15 @@ Edge Dictionaries create key-value pairs accessible to VCL functions during VCL 
 
 1. Add the list of URLs for redirection to the the `wordpress_urls` dictionary:
 
-   - Click the Settings icon for the `wordpress_urls` dictionary.
+   -  Click the Settings icon for the `wordpress_urls` dictionary.
 
       ![Configure Edge Dictionary]
 
-   - Add and save key-value pairs in the new dictionary. For this example, each **Key** is a URL path to redirect to the WordPress backend, and the **Value** is 1.
+   -  Add and save key-value pairs in the new dictionary. For this example, each **Key** is a URL path to redirect to the WordPress backend, and the **Value** is 1.
 
       ![Add Edge Dictionary Items]
 
-   - Click **Cancel** to return to the system configuration page.
+   -  Click **Cancel** to return to the system configuration page.
 
 1. Click **Save Config**.
 
@@ -88,15 +88,15 @@ The following custom VCL snippet code (JSON format) evaluates incoming requests 
 
 Review the example code and change values as needed:
 
-- `name` — Name for the VCL snippet. For this example, we used `wordpress_redirect`.
+-  `name` — Name for the VCL snippet. For this example, we used `wordpress_redirect`.
 
-- `dynamic` — Value 0 indicates a [regular snippet](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) to upload to the versioned VCL for the Fastly configuration.
+-  `dynamic` — Value 0 indicates a [regular snippet](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) to upload to the versioned VCL for the Fastly configuration.
 
-- `priority` — Determines when the VCL snippet runs. The priority  is `5` to run this snippet code runs before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
+-  `priority` — Determines when the VCL snippet runs. The priority  is `5` to run this snippet code runs before any of the default Magento VCL snippets (`magentomodule_*`) assigned a priority of 50.
 
-- `type` — Specifies a location to insert the snippet in the versioned VCL code. This VCL is a `recv` snippet type which adds the snippet code to the `vcl_recv` subroutine below the default Fastly VCL code and above any objects.
+-  `type` — Specifies a location to insert the snippet in the versioned VCL code. This VCL is a `recv` snippet type which adds the snippet code to the `vcl_recv` subroutine below the default Fastly VCL code and above any objects.
 
-- `content` — The snippet of VCL code to run in one line, without line breaks.
+-  `content` — The snippet of VCL code to run in one line, without line breaks.
 
    In this example, the VCL code logic extracts the first segment of the path `/mypath/someotherpath`, and then compares the path (`mypath`) to the paths in the `wordpress_urls` dictionary. Requests with matching paths are redirected to the WordPress backend. See the [Fastly VCL reference](https://docs.fastly.com/vcl/reference/) for information about creating Fastly VCL code snippets.
 
@@ -114,13 +114,13 @@ Add the custom VCL snippet to your Fastly service configuration from the Admin U
 
 1. Add the VCL snippet values:
 
-   - **Name** — `wordpress_redirect`
+   -  **Name** — `wordpress_redirect`
 
-   - **Type** — `recv`
+   -  **Type** — `recv`
 
-   - **Priority** — `5`
+   -  **Priority** — `5`
 
-   - **VCL** snippet content:
+   -  **VCL** snippet content:
 
       ```
       if ( req.url.path ~ "^/?([^/?]+)")

--- a/guides/v2.2/cloud/composer-packages/patch-notes.md
+++ b/guides/v2.2/cloud/composer-packages/patch-notes.md
@@ -11,10 +11,10 @@ The release information in this section relates to [Composer packages]({{ site.b
 
 Use this section to learn about updates to the following Composer packages:
 
--   `vendor/magento/magento-cloud-metapackage`
--   [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/composer-packages/ece-patches.html)
--   [`vendor/magento/ece-tools`]({{ site.baseurl }}/guides/v2.2/cloud/release-notes/cloud-tools.html)
--   `vendor/magento/product-enterprise-edition`
+-  `vendor/magento/magento-cloud-metapackage`
+-  [`vendor/magento/ece-patches`]({{ site.baseurl }}/guides/v2.2/cloud/composer-packages/ece-patches.html)
+-  [`vendor/magento/ece-tools`]({{ site.baseurl }}/guides/v2.2/cloud/release-notes/cloud-tools.html)
+-  `vendor/magento/product-enterprise-edition`
 
 {:.bs-callout .bs-callout-info}
 You must [update these packages]({{ site.baseurl }}/guides/v2.2/cloud/project/project-patch.html) to get new features and fixes.

--- a/guides/v2.2/cloud/configure/configuration-overview.md
+++ b/guides/v2.2/cloud/configure/configuration-overview.md
@@ -18,31 +18,31 @@ You can set up [multiple websites and stores]({{ page.baseurl }}/cloud/project/p
 
 The following options, tools, and features can be set up and configured in your store:
 
-* [Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html) for caching and CDN in Staging and Production environments
-* [PayPal On-Boarding tool]({{ page.baseurl }}/cloud/live/paypal-onboarding.html) provides PayPal payment gateway checkout by connecting to your PayPal merchant account
-* [Magento B2B module]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-b2b.html) for Business to Business features, Pro plan only
-* [cron jobs]({{ page.baseurl }}/cloud/configure/setup-cron-jobs.html) details how to create and configure Magento cron jobs in all environments
-* [Multiple websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html) details how to create and configure multi-sites for your store, for example multiple locales including English, French, and Spanish
-* [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
-* [Install a theme]({{ page.baseurl }}/cloud/howtos/custom-theme.html) for your site and store
-* Install Magento security extensions including [Google reCAPTCHA]({{ page.baseurl }}/security/google-recaptcha.html) and [Two-Factor Authentication]({{ page.baseurl }}/security/two-factor-authentication.html) to enhance secure access to the Magento Admin UI and storefront
+*  [Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html) for caching and CDN in Staging and Production environments
+*  [PayPal On-Boarding tool]({{ page.baseurl }}/cloud/live/paypal-onboarding.html) provides PayPal payment gateway checkout by connecting to your PayPal merchant account
+*  [Magento B2B module]({{ site.baseurl }}/guides/v2.2/cloud/configure/setup-b2b.html) for Business to Business features, Pro plan only
+*  [cron jobs]({{ page.baseurl }}/cloud/configure/setup-cron-jobs.html) details how to create and configure Magento cron jobs in all environments
+*  [Multiple websites or stores]({{ page.baseurl }}/cloud/project/project-multi-sites.html) details how to create and configure multi-sites for your store, for example multiple locales including English, French, and Spanish
+*  [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
+*  [Install a theme]({{ page.baseurl }}/cloud/howtos/custom-theme.html) for your site and store
+*  Install Magento security extensions including [Google reCAPTCHA]({{ page.baseurl }}/security/google-recaptcha.html) and [Two-Factor Authentication]({{ page.baseurl }}/security/two-factor-authentication.html) to enhance secure access to the Magento Admin UI and storefront
 
 ## Configure your deploy: build hooks, services, and routes {#deploy}
 
 After fully configuring your store, you should configure your deployment. This includes specific files to manage builds, deployments, services, and routes:
 
-* [.magento.app.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html) configures how the Magento application is built and deployed including services, hooks, cron jobs, and more
-* [routes.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html) configures how Magento processes an incoming URL for your Integration environment
-* [services.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) configures the services you use in your stores and sites including name, version, and allocated disk space
+*  [.magento.app.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html) configures how the Magento application is built and deployed including services, hooks, cron jobs, and more
+*  [routes.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html) configures how Magento processes an incoming URL for your Integration environment
+*  [services.yaml]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) configures the services you use in your stores and sites including name, version, and allocated disk space
 
 ## Configure integrations {#integrations}
 
 We also provide integrations with:
 
-* [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) configuration for tracking and investigating issues for bottleneck issues in processes, method calls, queries, loads, and so on
-* [New Relic]({{ page.baseurl }}/cloud/project/new-relic.html) configuration for application and performance analysis
-* [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html) configuration for CDN and caching
-* [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html) for managing your Git branches and code
+*  [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) configuration for tracking and investigating issues for bottleneck issues in processes, method calls, queries, loads, and so on
+*  [New Relic]({{ page.baseurl }}/cloud/project/new-relic.html) configuration for application and performance analysis
+*  [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html) configuration for CDN and caching
+*  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html) for managing your Git branches and code
 
 ## Configuration management {#config-mgmt}
 

--- a/guides/v2.2/cloud/configure/import-url-rewrites.md
+++ b/guides/v2.2/cloud/configure/import-url-rewrites.md
@@ -82,8 +82,8 @@ To import URL Rewrites:
 
 1. Select the **Behavior**.
 
-   - `Add/Update` — adds new URL rewrite and updates existing URL Rewrites
-   - `Delete` — removes existing URL rewrites
+   -  `Add/Update` — adds new URL rewrite and updates existing URL Rewrites
+   -  `Delete` — removes existing URL rewrites
 
 1. Click **Import**.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/cloud` folder.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
