### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - cloud. Part 02.

### DIFF
--- a/guides/v2.2/cloud/configure/setup-cron-jobs.md
+++ b/guides/v2.2/cloud/configure/setup-cron-jobs.md
@@ -11,9 +11,9 @@ Magento uses cron jobs for numerous features to schedule activities. This topic 
 
 The `.magento.app.yaml` file specifies the configuration for the default Magento cron jobs as well as any custom crons that you add to the following environments.
 
-- Starter plan–All environments including `Master`
+-  Starter plan–All environments including `Master`
 
-- Pro plan–Integration, Staging, and Production environments including `Master`
+-  Pro plan–Integration, Staging, and Production environments including `Master`
 
 The `.magento.app.yaml` file includes the following default crons configuration, which runs the default Magento cron jobs:
 
@@ -170,6 +170,6 @@ You can review cron processing information in the application-level log files fo
 
 See the following Magento Support articles for help troubleshooting cron-related problems:
 
-- [Cron tasks lock tasks from other groups](https://support.magento.com/hc/en-us/articles/360029219812-Cron-tasks-lock-tasks-from-other-groups)
+-  [Cron tasks lock tasks from other groups](https://support.magento.com/hc/en-us/articles/360029219812-Cron-tasks-lock-tasks-from-other-groups)
 
-- [Reset stuck cron jobs manually on the cloud](https://support.magento.com/hc/en-us/articles/360000097713-Reset-stuck-Magento-cron-jobs-manually-on-Cloud)
+-  [Reset stuck cron jobs manually on the cloud](https://support.magento.com/hc/en-us/articles/360000097713-Reset-stuck-Magento-cron-jobs-manually-on-Cloud)

--- a/guides/v2.2/cloud/deploy/continuous-deployment.md
+++ b/guides/v2.2/cloud/deploy/continuous-deployment.md
@@ -14,38 +14,38 @@ Following your branching and development methodologies, you can easily develop n
 
 Both Starter and Pro plan environments support continuous integration for constant updates. This workflow supports releases multiple times a day or on a set schedule according to your business needs.
 
-* Create development branches with future features and changes
-* Test the code in your development environments
-* Deploy and test in Staging
-* Deploy to Production
+*  Create development branches with future features and changes
+*  Test the code in your development environments
+*  Deploy and test in Staging
+*  Deploy to Production
 
 We recommend the following best practices for {{site.data.var.ece}} environments.
 
 ## Development best practices
 
-* Keep your branches updated with the latest code for all developers to access and pull
-* Maintain commit comments to share with your developers and track branch work
-* Keep Staging as close to Production as possible with configurations, code, services, and data
-* Do not overfill a branch of development work, keep it streamlined to carefully implement and test code, extensions, etc
-* Keep track of the order you follow for adding extensions to your code. Some extensions require very specific installation orders.
-* Do not push all of your extensions at once into Staging and Production. Add, push, and test extensions in groups to ensure they are stable.
-* Use Magento Configuration Management to ensure configuration consistency
+*  Keep your branches updated with the latest code for all developers to access and pull
+*  Maintain commit comments to share with your developers and track branch work
+*  Keep Staging as close to Production as possible with configurations, code, services, and data
+*  Do not overfill a branch of development work, keep it streamlined to carefully implement and test code, extensions, etc
+*  Keep track of the order you follow for adding extensions to your code. Some extensions require very specific installation orders.
+*  Do not push all of your extensions at once into Staging and Production. Add, push, and test extensions in groups to ensure they are stable.
+*  Use Magento Configuration Management to ensure configuration consistency
 
 ## Deployment best practices
 
-* Fully deploy the base {{site.data.var.ece}} site initially to ensure all environments are stable with Magento installed. Some extensions will throw errors during build and deploy if they are added during an install. These work best during an update.
-* Run a local build prior to fully deploying
-* Ensure all files are correctly added to the Git branch before pushing
+*  Fully deploy the base {{site.data.var.ece}} site initially to ensure all environments are stable with Magento installed. Some extensions will throw errors during build and deploy if they are added during an install. These work best during an update.
+*  Run a local build prior to fully deploying
+*  Ensure all files are correctly added to the Git branch before pushing
 
 ## Testing best practices
 
-* Fully test Administrator and customer features in your code. Your staff may encounter issues, for example when refunding an order or sending notifications.
-* Heavily test extensions with the correct credentials per environment
-* Perform all Fastly tests against Staging and Production
+*  Fully test Administrator and customer features in your code. Your staff may encounter issues, for example when refunding an order or sending notifications.
+*  Heavily test extensions with the correct credentials per environment
+*  Perform all Fastly tests against Staging and Production
 
 ## Data best practices
 
-* Create a backup of your database and snapshot on a schedule or before pushing major updates. We provide snapshots of the Pro Production environment according to a [progressive schedule]({{ page.baseurl }}/cloud/architecture/pro-architecture.html#backup-and-disaster-recovery), but you may need to backup your Staging environment for constant iterations.
-* Pull a data dump of your Production data into the Staging environment for extensive testing
-* Consider running scripts or pulling only specific tables to sanitize customer data from non-Production environments Staging
+*  Create a backup of your database and snapshot on a schedule or before pushing major updates. We provide snapshots of the Pro Production environment according to a [progressive schedule]({{ page.baseurl }}/cloud/architecture/pro-architecture.html#backup-and-disaster-recovery), but you may need to backup your Staging environment for constant iterations.
+*  Pull a data dump of your Production data into the Staging environment for extensive testing
+*  Consider running scripts or pulling only specific tables to sanitize customer data from non-Production environments Staging
 

--- a/guides/v2.2/cloud/deploy/reduce-downtime.md
+++ b/guides/v2.2/cloud/deploy/reduce-downtime.md
@@ -13,25 +13,25 @@ During the deployment process, all connections queue for up to 5 minutes preserv
 
 Use the following steps to reduce the amount of time it takes your store to deploy an update to Production:
 
-1.  [Upgrade to the `{{site.data.var.ct}}` package]({{page.baseurl}}/cloud/project/ece-tools-upgrade-project.html) or [update the `{{site.data.var.ct}}` version]({{page.baseurl}}/cloud/project/ece-tools-update.html)
-    Your {{site.data.var.ece}} project must have the latest `{{site.data.var.ct}}` package so that you have the tools available to configure an optimal deployment. If you have the latest `{{site.data.var.ct}}`, continue to the next step.
+1. [Upgrade to the `{{site.data.var.ct}}` package]({{page.baseurl}}/cloud/project/ece-tools-upgrade-project.html) or [update the `{{site.data.var.ct}}` version]({{page.baseurl}}/cloud/project/ece-tools-update.html)
+   Your {{site.data.var.ece}} project must have the latest `{{site.data.var.ct}}` package so that you have the tools available to configure an optimal deployment. If you have the latest `{{site.data.var.ct}}`, continue to the next step.
 
-    {:.bs-callout .bs-callout-info}
-    Even though it is a best practice to use the latest `{{site.data.var.ct}}` package, the zero-downtime deployment method works with `{{site.data.var.ct}}` [version 2002.0.13]({{page.baseurl}}/cloud/release-notes/cloud-tools.html#v2002013) and later.
+   {:.bs-callout .bs-callout-info}
+   Even though it is a best practice to use the latest `{{site.data.var.ct}}` package, the zero-downtime deployment method works with `{{site.data.var.ct}}` [version 2002.0.13]({{page.baseurl}}/cloud/release-notes/cloud-tools.html#v2002013) and later.
 
-1.  [Configure static content deployment]({{page.baseurl}}/cloud/deploy/static-content-deployment.html)
-    If static content deployment fails in the deploy phase, your site gets stuck in maintenance mode. When a failure occurs during the build phase, the process avoids downtime because it never begins the deploy phase. [Generating static content during the build phase with minified HTML]({{page.baseurl}}/cloud/deploy/static-content-deployment.html#setting-the-scd-on-build), also known as the ideal state, is the optimal configuration for zero-downtime deployments and _prevents_ downtime if a failure occurs.
+1. [Configure static content deployment]({{page.baseurl}}/cloud/deploy/static-content-deployment.html)
+   If static content deployment fails in the deploy phase, your site gets stuck in maintenance mode. When a failure occurs during the build phase, the process avoids downtime because it never begins the deploy phase. [Generating static content during the build phase with minified HTML]({{page.baseurl}}/cloud/deploy/static-content-deployment.html#setting-the-scd-on-build), also known as the ideal state, is the optimal configuration for zero-downtime deployments and _prevents_ downtime if a failure occurs.
 
-1.  [Configure the post-deploy hook]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks)
-    You must configure the post-deploy hook to clean and warm the cache. By default, cache clean occurs during the deploy phase when the site is down. Moving the cache clean to the post-deploy phase means that your cache remains live until the deploy phase is complete, and then you can safely clean the cache.
+1. [Configure the post-deploy hook]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks)
+   You must configure the post-deploy hook to clean and warm the cache. By default, cache clean occurs during the deploy phase when the site is down. Moving the cache clean to the post-deploy phase means that your cache remains live until the deploy phase is complete, and then you can safely clean the cache.
 
-    Customize the list of pages used to preload the cache with the [WARM_UP_PAGES environment variable]({{page.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages).
+   Customize the list of pages used to preload the cache with the [WARM_UP_PAGES environment variable]({{page.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages).
 
-1.  [Reduce theme files]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_matrix)
-    You can reduce the amount of unnecessary theme files by configuring the SCD\_MATRIX environment variable.
+1. [Reduce theme files]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_matrix)
+   You can reduce the amount of unnecessary theme files by configuring the SCD\_MATRIX environment variable.
 
-1.  [Speed up static content deployment]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_threads)
-    You can speed up the deployment process by updating the  SCD\_THREADS environment variable to increase the number of threads for static content deployment.
+1. [Speed up static content deployment]({{page.baseurl}}/cloud/env/variables-deploy.html#scd_threads)
+   You can speed up the deployment process by updating the  SCD\_THREADS environment variable to increase the number of threads for static content deployment.
 
 {:.bs-callout .bs-callout-info}
 You can validate your project configuration for optimal deployment by [running the ideal state wizard]({{page.baseurl}}/cloud/deploy/smart-wizards.html#verifying-an-ideal-configuration).

--- a/guides/v2.2/cloud/deploy/smart-wizards.md
+++ b/guides/v2.2/cloud/deploy/smart-wizards.md
@@ -61,28 +61,28 @@ Ideal state is not configured
 
 Based on the output, you need to make the following corrections to your configuration:
 
-1.  Enable the Skip HTML minification variable.
+1. Enable the Skip HTML minification variable.
 
-    > .magento.env.yaml
+   > .magento.env.yaml
 
-    ```yaml
-    stage:
-      global:
-        SKIP_HTML_MINIFICATION: true
-    ```
+   ```yaml
+   stage:
+     global:
+       SKIP_HTML_MINIFICATION: true
+   ```
 
-1.  Configure the post-deploy hook.
+1. Configure the post-deploy hook.
 
-    > .magento.app.yaml
+   > .magento.app.yaml
 
-    ```yaml
-        post_deploy: |
-            php ./vendor/bin/ece-tools post-deploy
-    ```
+   ```yaml
+       post_deploy: |
+           php ./vendor/bin/ece-tools post-deploy
+   ```
 
-1.  Push your code changes and run the test again. When your configuration is _ideal_, you receive the following message.
+1. Push your code changes and run the test again. When your configuration is _ideal_, you receive the following message.
 
-    ```terminal
-    Ideal state is configured
-    ```
-    {: .no-copy}
+   ```terminal
+   Ideal state is configured
+   ```
+   {: .no-copy}

--- a/guides/v2.2/cloud/deploy/static-content-deployment.md
+++ b/guides/v2.2/cloud/deploy/static-content-deployment.md
@@ -34,21 +34,21 @@ Generating static content requires access to themes and locales. Magento stores 
 {:.procedure}
 To configure your project to generate SCD on build:
 
-1.  Log in to your Cloud environment using SSH and move locales to the file system, then update the [`config.php` file]({{site.baseurl}}/guides/v2.2/cloud/project/project-upgrade.html#create-a-new-configphp-file).
+1. Log in to your Cloud environment using SSH and move locales to the file system, then update the [`config.php` file]({{site.baseurl}}/guides/v2.2/cloud/project/project-upgrade.html#create-a-new-configphp-file).
 
-1.  The `.magento.env.yaml` configuration file should contain the following values:
+1. The `.magento.env.yaml` configuration file should contain the following values:
 
-    -  [SKIP_HTML_MINIFICATION]({{page.baseurl}}/cloud/env/variables-global.html#skip_html_minification) is `true`
-    -  [SKIP_SCD]({{page.baseurl}}/cloud/env/variables-build.html#skip_scd) on build stage is `false`
-    -  [SCD_STRATEGY]({{site.baseurl}}/guides/v2.2/cloud/env/variables-build.html#scd_strategy) is `compact`
+   -  [SKIP_HTML_MINIFICATION]({{page.baseurl}}/cloud/env/variables-global.html#skip_html_minification) is `true`
+   -  [SKIP_SCD]({{page.baseurl}}/cloud/env/variables-build.html#skip_scd) on build stage is `false`
+   -  [SCD_STRATEGY]({{site.baseurl}}/guides/v2.2/cloud/env/variables-build.html#scd_strategy) is `compact`
 
-1.  Verify configuration of the [Post-deploy hook]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks) in the `.magento.app.yaml` file.
+1. Verify configuration of the [Post-deploy hook]({{page.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks) in the `.magento.app.yaml` file.
 
-1.  Verify your settings by running the [Smart wizard for the ideal state]({{page.baseurl}}/cloud/deploy/smart-wizards.html).
+1. Verify your settings by running the [Smart wizard for the ideal state]({{page.baseurl}}/cloud/deploy/smart-wizards.html).
 
-    ```bash
-    php ./vendor/bin/ece-tools wizard:ideal-state
-    ```
+   ```bash
+   php ./vendor/bin/ece-tools wizard:ideal-state
+   ```
 
 ### Setting the SCD on demand
 

--- a/guides/v2.2/cloud/docker/docker-config.md
+++ b/guides/v2.2/cloud/docker/docker-config.md
@@ -18,8 +18,8 @@ _Mode_ is an additional configuration option for the Docker configuration genera
 
 You can launch your Docker environment in one of the following modes:
 
--   **production**—Production mode is the default configuration setting for launching the Docker environment with read-only filesystem permissions. This option builds the Docker environment in production mode and verifies configured service versions.
--   **developer**—Developer mode supports an active development environment with full, writable filesystem permissions. This option builds the Docker environment in developer mode and verifies configured service versions. System performance is slower in developer mode because of additional file synchronization operations.
+-  **production**—Production mode is the default configuration setting for launching the Docker environment with read-only filesystem permissions. This option builds the Docker environment in production mode and verifies configured service versions.
+-  **developer**—Developer mode supports an active development environment with full, writable filesystem permissions. This option builds the Docker environment in developer mode and verifies configured service versions. System performance is slower in developer mode because of additional file synchronization operations.
 
 For example, the following command starts the Docker configuration generator for the developer mode:
 

--- a/guides/v2.2/cloud/docker/docker-database.md
+++ b/guides/v2.2/cloud/docker/docker-database.md
@@ -29,62 +29,62 @@ return [
 {:.procedure}
 To connect to the database using Docker commands:
 
-1.  Connect to the CLI container.
+1. Connect to the CLI container.
 
     ```bash
     docker-compose run deploy bash
     ```
 
-1.  Connect to the database with a username and password.
+1. Connect to the database with a username and password.
 
-    ```bash
-    mysql --host=db --user=magento2 --password=magento2
-    ```
+   ```bash
+   mysql --host=db --user=magento2 --password=magento2
+   ```
 
-1.  Verify the version of the database service.
+1. Verify the version of the database service.
 
-    ```mysql
-    SELECT VERSION();
-    +--------------------------+
-    | VERSION()                |
-    +--------------------------+
-    | 10.0.38-MariaDB-1~xenial |
-    +--------------------------+
-    ```
-    {: .no-copy}
+   ```mysql
+   SELECT VERSION();
+   +--------------------------+
+   | VERSION()                |
+   +--------------------------+
+   | 10.0.38-MariaDB-1~xenial |
+   +--------------------------+
+   ```
+   {: .no-copy}
 
 {:.procedure}
 To connect to the database:
 
-1.  Find the port used by the database. The port may change each time you restart Docker.
+1. Find the port used by the database. The port may change each time you restart Docker.
 
-    ```bash
-    docker-compose ps
-    ```
+   ```bash
+   docker-compose ps
+   ```
 
-    Sample response:
+   Sample response:
 
-    ```terminal
-              Name                         Command               State               Ports
-    --------------------------------------------------------------------------------------------------
-    mc-master_db_1              docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp
-    ```
-    {: .no-copy}
+   ```terminal
+             Name                         Command               State               Ports
+   --------------------------------------------------------------------------------------------------
+   mc-master_db_1              docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp
+   ```
+   {: .no-copy}
 
-1.  Connect to the database with port information from the previous step.
+1. Connect to the database with port information from the previous step.
 
-    ```bash
-    mysql -h127.0.0.1 -p32769 -umagento2 -pmagento2
-    ```
+   ```bash
+   mysql -h127.0.0.1 -p32769 -umagento2 -pmagento2
+   ```
 
-1.  Verify the version of the database service.
+1. Verify the version of the database service.
 
-    ```mysql
-    SELECT VERSION();
-    +--------------------------+
-    | VERSION()                |
-    +--------------------------+
-    | 10.0.38-MariaDB-1~xenial |
-    +--------------------------+
-    ```
-    {: .no-copy}
+   ```mysql
+   SELECT VERSION();
+   +--------------------------+
+   | VERSION()                |
+   +--------------------------+
+   | 10.0.38-MariaDB-1~xenial |
+   +--------------------------+
+   ```
+   {: .no-copy}

--- a/guides/v2.2/cloud/docker/docker-development-testing.md
+++ b/guides/v2.2/cloud/docker/docker-development-testing.md
@@ -15,19 +15,19 @@ For testing the Magento application, see the [Magento Functional Testing Framewo
 
 Before you run functional tests, you must prepare your environment with the following steps.
 
-1.  Clone the {{site.data.var.ct}} GitHub repository.
+1. Clone the {{site.data.var.ct}} GitHub repository.
 
     ```bash
     git clone git@github.com:magento/ece-tools.git
     ```
 
-1.  Stop all services that use the following ports:
+1. Stop all services that use the following ports:
 
     -  `80`—varnish
     -  `443`—web, tls
     -  `3306`—apache, mysql
 
-1.  Update the hosts file.
+1. Update the hosts file.
 
     Before you begin, you must add the following hostname to your `/etc/hosts` file:
 
@@ -41,15 +41,15 @@ Before you run functional tests, you must prepare your environment with the foll
     echo "127.0.0.1 web" | sudo tee -a /etc/hosts
     ```
 
-1.  Switch to the preferred PHP version for running tests.
+1. Switch to the preferred PHP version for running tests.
 
-1.  Update the project dependencies.
+1. Update the project dependencies.
 
     ```bash
     composer update
     ```
 
-1.  Add credentials to the Docker environment.
+1. Add credentials to the Docker environment.
 
     ```bash
     echo "COMPOSER_MAGENTO_USERNAME=your_public_key" >> ./.docker/composer.env

--- a/guides/v2.2/cloud/env/environments-ssh.md
+++ b/guides/v2.2/cloud/env/environments-ssh.md
@@ -15,14 +15,14 @@ SSH, or Secure Shell, is a common protocol used to securely log into remote serv
 
 To use SSH, you need to:
 
-* Generate your SSH public and private keys
-* Add your SSH public key to your remote server either through CLI commands or the Project Web Interface
-* Use Magento Cloud CLI or Git commands to [SSH](#ssh) to an environment
+*  Generate your SSH public and private keys
+*  Add your SSH public key to your remote server either through CLI commands or the Project Web Interface
+*  Use Magento Cloud CLI or Git commands to [SSH](#ssh) to an environment
 
 You create an SSH key pair including a public and private key:
 
-* The _public key_ is safe to provide for accessing a site, [SSH](#ssh), and [sFTP](#sftp).
-* The _private key_ should remain private on your workspace that you use for remote accessing environments. **Never share your private key.** Do not add it to a ticket, copy it to a chat, or attach it to emails.
+*  The _public key_ is safe to provide for accessing a site, [SSH](#ssh), and [sFTP](#sftp).
+*  The _private key_ should remain private on your workspace that you use for remote accessing environments. **Never share your private key.** Do not add it to a ticket, copy it to a chat, or attach it to emails.
 
 ## How SSH keys work {#work}
 
@@ -34,16 +34,16 @@ When you enter an SSH command to connect your client to the remote host, the hos
 
 You can connect using SSH in any of the following ways:
 
-* [SSH using Magento Cloud CLI](#magento-cli)
-* [Locate the SSH command in the Project Web Interface](#web-interface)
-* [Git SSH commands for Pro Staging and Production](#pro)
+*  [SSH using Magento Cloud CLI](#magento-cli)
+*  [Locate the SSH command in the Project Web Interface](#web-interface)
+*  [Git SSH commands for Pro Staging and Production](#pro)
 
 ### SSH using Magento Cloud CLI {#magento-cli}
 
 Magento Cloud CLI commands can only be used in environments with the software installed. These environments include:
 
-* Starter environments
-* Pro Integration environments
+*  Starter environments
+*  Pro Integration environments
 
 To SSH to an environment using the Magento Cloud command line:
 
@@ -100,8 +100,8 @@ With your SSH keys added to those servers, you can use a terminal application, t
 
 For the URLs, see the following:
 
-* Staging: `ssh <project ID>_stg@<project ID>.ent.magento.cloud`
-* Production: `ssh <project ID>@<project ID>.ent.magento.cloud`
+*  Staging: `ssh <project ID>_stg@<project ID>.ent.magento.cloud`
+*  Production: `ssh <project ID>@<project ID>.ent.magento.cloud`
 
 For example, to log in to the Staging environment, use the following command: `ssh abcdefghij_stg@abcdefghij.ent.magento.cloud`. For production: `ssh abcdefghij@abcdefghij.ent.magento.cloud`
 
@@ -115,15 +115,15 @@ Typically, you want to use SSH for secure access to your environments and [migra
 
 You need the following requirements to sFTP into cloud environments:
 
-* You need to use a client that supports SSH key authentication for sFTP and use your SSH public key.
-* Your public SSH key must be added to the target environment. For Starter environments and Pro Integration environments, you can add it through the Project Web Interface. For Pro Staging and Production, you must enter a [Support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) with your public key attached. **Never provide your private SSH key.**
+*  You need to use a client that supports SSH key authentication for sFTP and use your SSH public key.
+*  Your public SSH key must be added to the target environment. For Starter environments and Pro Integration environments, you can add it through the Project Web Interface. For Pro Staging and Production, you must enter a [Support ticket]({{ page.baseurl }}/cloud/trouble/trouble.html) with your public key attached. **Never provide your private SSH key.**
 
 When configuring sFTP, use your SSH public key and the following information for access:
 
-* Username: All content before the `@` in your public SSH key.
-* Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
-* Host: All content after the `@` in your public SSH key.
-* Port: 22, which is the default SSH port.
+*  Username: All content before the `@` in your public SSH key.
+*  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
+*  Host: All content after the `@` in your public SSH key.
+*  Port: 22, which is the default SSH port.
 
 To add your SSH public key information to your client:
 

--- a/guides/v2.2/cloud/env/environments-start.md
+++ b/guides/v2.2/cloud/env/environments-start.md
@@ -47,15 +47,15 @@ To begin, create a new branch.
 
 After completing development, you can merge this branch to the parent:
 
-1.  Complete code in your local branch.
+1. Complete code in your local branch.
 
-1.  Add, commit, and push changes to the environment.
+1. Add, commit, and push changes to the environment.
 
     ```bash
     git add -A && git commit -m "Commit message" && git push origin <branch-name>
     ```
 
-1.  Merge with the parent environment:
+1. Merge with the parent environment:
 
     ```bash
     magento-cloud environment:merge <environment-ID>
@@ -75,15 +75,15 @@ When you delete an environment, the environment is set to _inactive_. The code i
 {:.procedure}
 To delete an environment:
 
-1.  Open a terminal and navigate to your project.
+1. Open a terminal and navigate to your project.
 
-1.  Fetch updates from the remote server.
+1. Fetch updates from the remote server.
 
     ```bash
     git fetch
     ```
 
-1.  Delete the environment branch.
+1. Delete the environment branch.
 
     ```bash
     magento-cloud environment:delete <environment-ID>
@@ -95,7 +95,7 @@ To delete an environment:
     magento-cloud environment:delete <environment-1-ID> <environment-2-ID>
     ```
 
-1.  Respond to the prompts to delete the local environment and the corresponding remote environment.
+1. Respond to the prompts to delete the local environment and the corresponding remote environment.
 
     ```terminal
     The environment <environment-ID> is currently active: deleting it will delete all associated data.
@@ -111,7 +111,7 @@ To delete an environment:
 
     Deleting the remote Git branch removes the environment from the project.
 
-1.  Wait for the environment to delete.
+1. Wait for the environment to delete.
 
     ```terminal
     Deleting environment <environment-ID>

--- a/guides/v2.2/cloud/env/environments.md
+++ b/guides/v2.2/cloud/env/environments.md
@@ -11,9 +11,9 @@ After fully configuring your store, you need to configure your environments. Env
 
 You can configure application settings, routes, build and deploy actions, and notifications to support your project environments using the following configuration files:
 
-- [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)—defines how to build and deploy Magento, including services, hooks, and cron jobs.
-- [`.magento.env.yaml`]({{ page.baseurl }}/cloud/project/magento-env-yaml.html)—centralizes the management of build and deploy actions across all of your environments, including Pro Staging and Production, using environment variables.
-- [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)—configure caching, redirects, and server-side includes.
-- [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)—defines the services Magento uses by name and version. For example, this file may include versions of MySQL, PHP extensions, Redis, RabbitMQ, and Elasticsearch. You must open a support ticket to push these changes to Pro plan Staging and Production environments.
+-  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)—defines how to build and deploy Magento, including services, hooks, and cron jobs.
+-  [`.magento.env.yaml`]({{ page.baseurl }}/cloud/project/magento-env-yaml.html)—centralizes the management of build and deploy actions across all of your environments, including Pro Staging and Production, using environment variables.
+-  [`.magento/routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)—configure caching, redirects, and server-side includes.
+-  [`.magento/services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)—defines the services Magento uses by name and version. For example, this file may include versions of MySQL, PHP extensions, Redis, RabbitMQ, and Elasticsearch. You must open a support ticket to push these changes to Pro plan Staging and Production environments.
 
 When you push code changes, the active environment provisions container updates using the YAML configuration files.

--- a/guides/v2.2/cloud/env/log-handlers.md
+++ b/guides/v2.2/cloud/env/log-handlers.md
@@ -52,11 +52,11 @@ log:
 
 Log levels determine the level of detail in notification messages. The following log level categories include every log level below it. For example, a `debug` level includes logging from every level, whereas an `alert` level only shows alerts and emergencies.
 
--   **debug**—detailed debug information
--   **info**—interesting events, such as a user login or SQL log
--   **notice**—normal, but significant events
--   **warning**—exceptional occurrences that are not errors, such as the use of a deprecated API or poor use of an API
--   **error**—run-time errors that do not require immediate action
--   **critical**—critical conditions, such as an unavailable application component or an unexpected exception
--   **alert**—immediate action required—such as a website is down or the database is unavailable—that triggers an SMS alert
--   **emergency**—system is unusable
+-  **debug**—detailed debug information
+-  **info**—interesting events, such as a user login or SQL log
+-  **notice**—normal, but significant events
+-  **warning**—exceptional occurrences that are not errors, such as the use of a deprecated API or poor use of an API
+-  **error**—run-time errors that do not require immediate action
+-  **critical**—critical conditions, such as an unavailable application component or an unexpected exception
+-  **alert**—immediate action required—such as a website is down or the database is unavailable—that triggers an SMS alert
+-  **emergency**—system is unusable

--- a/guides/v2.2/cloud/env/setup-notifications.md
+++ b/guides/v2.2/cloud/env/setup-notifications.md
@@ -15,9 +15,9 @@ For example, you could send a Slack message to alert a group of people when a de
 
 Before you configure notifications, consider the following:
 
--   What kind of notifications do you want to receive (Slack messages, email, both)?
--   How much detail do you want to see in the logs?
--   Where do you want to set up notifications (Integration, Staging, Production)?
+-  What kind of notifications do you want to receive (Slack messages, email, both)?
+-  How much detail do you want to see in the logs?
+-  Where do you want to set up notifications (Integration, Staging, Production)?
 
 For example, during initial development you may prefer email notifications that show detailed logs about your Integration environment to help you debug issues before deploying to the Staging environment. When you are ready to deploy to the Staging or Production environment, you may prefer a Slack message that contains less detailed information.
 
@@ -28,8 +28,8 @@ The configuration file used to set up notifications is at the root of your proje
 
 To configure notifications:
 
-1.  Open a terminal and [checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) in your local environment.
-1.  In the `.magento.env.yaml` file in your project root, add your messaging system settings, including preferred notification [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels).
+1. Open a terminal and [checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) in your local environment.
+1. In the `.magento.env.yaml` file in your project root, add your messaging system settings, including preferred notification [Log levels]({{page.baseurl}}/cloud/env/log-handlers.html#log-levels).
 
     For example, to configure both Slack _and_ email configurations, use the following:
 
@@ -73,10 +73,10 @@ log:
     min_level: "info"
 ```
 
--   `token`—Your Slack [user token](https://api.slack.com/docs/token-types#user). Your user token authorizes {{site.data.var.ece}} to send messages.
--   `channel`—Name of the Slack channel {{site.data.var.ece}} sends notifications.
--   `username`—Username {{site.data.var.ece}} uses to send notification messages in Slack.
--   `min_level`—Minimum log level for notification messages. We recommend using `info`.
+-  `token`—Your Slack [user token](https://api.slack.com/docs/token-types#user). Your user token authorizes {{site.data.var.ece}} to send messages.
+-  `channel`—Name of the Slack channel {{site.data.var.ece}} sends notifications.
+-  `username`—Username {{site.data.var.ece}} uses to send notification messages in Slack.
+-  `min_level`—Minimum log level for notification messages. We recommend using `info`.
 
 ### Example email configuration
 
@@ -94,7 +94,7 @@ log:
     min_level: "notice"
 ```
 
--   `to`—Email address {{site.data.var.ece}} sends notification messages.
--   `from`—Email address for sending notification messages to recipients.
--   `subject`—Description of the email.
--   `min_level`—Minimum log level for notification messages. We recommend using `notice` or `warning`.
+-  `to`—Email address {{site.data.var.ece}} sends notification messages.
+-  `from`—Email address for sending notification messages to recipients.
+-  `subject`—Description of the email.
+-  `min_level`—Minimum log level for notification messages. We recommend using `notice` or `warning`.

--- a/guides/v2.2/cloud/env/variables-build.md
+++ b/guides/v2.2/cloud/env/variables-build.md
@@ -21,8 +21,8 @@ You can still use the `build_options.ini` file, but we recommend using the `.mag
 
 The following variables were removed in v2.2:
 
--   `skip_di_clearing`
--   `skip_di_compilation`
+-  `skip_di_clearing`
+-  `skip_di_compilation`
 
 ### `SCD_COMPRESSION_LEVEL`
 

--- a/guides/v2.2/cloud/env/variables-deploy.md
+++ b/guides/v2.2/cloud/env/variables-deploy.md
@@ -111,9 +111,9 @@ The following command returns a list of message queue consumers:
 
 Configure how consumers process messages from the message queue by choosing one of the following options:
 
-- `false`—Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `max_messages` value specified in the `CRON_CONSUMERS_RUNNER` deploy variable.
+-  `false`—Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `max_messages` value specified in the `CRON_CONSUMERS_RUNNER` deploy variable.
 
-- `true`—Consumers continue to process messages from the message queue until reaching the maximum number of messages (`max_messages`) specified in the `CRON_CONSUMERS_RUNNER` deploy variable before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `max_messages`, the consumer waits for more messages to arrive.
+-  `true`—Consumers continue to process messages from the message queue until reaching the maximum number of messages (`max_messages`) specified in the `CRON_CONSUMERS_RUNNER` deploy variable before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `max_messages`, the consumer waits for more messages to arrive.
 
 {: .bs-callout .bs-callout-warning}
 If you use workers to run consumers instead of using a cron job, set this variable to true.


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/cloud` folder.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
