### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - cloud. Part 03.

### DIFF
--- a/guides/v2.2/cloud/env/variables-global.md
+++ b/guides/v2.2/cloud/env/variables-global.md
@@ -78,8 +78,8 @@ stage:
 
 Enables or disables copying static view files to the `<magento_root>/init/` directory at the end of the build stage. If set to `true` files are not copied and HTML minification is available on request. Set this value to `true` to reduce downtime when deploying to Staging and Production environments.
 
--   **`false`**—Copies the `view_preprocessed` directory to the `<magento_root>/init/` directory at the end of the build phase, and restores the directory in the `<magento_root>/var` directory at the beginning of the deploy phase.
--   **`true`**—Enables on-demand HTML minification; does *not* copy the `<magento_root>var/view_preprocessed` to the `<magento_root>/init/` directory at the end of the build phase.
+-  **`false`**—Copies the `view_preprocessed` directory to the `<magento_root>/init/` directory at the end of the build phase, and restores the directory in the `<magento_root>/var` directory at the beginning of the deploy phase.
+-  **`true`**—Enables on-demand HTML minification; does *not* copy the `<magento_root>var/view_preprocessed` to the `<magento_root>/init/` directory at the end of the build phase.
 
 Add the `SKIP_HTML_MINIFICATION` environment variable to the `global` stage in the `.magento.env.yaml` file:
 

--- a/guides/v2.2/cloud/env/variables-intro.md
+++ b/guides/v2.2/cloud/env/variables-intro.md
@@ -8,12 +8,12 @@ functional_areas:
 
 {{site.data.var.ece}} enables you to assign environment variables to override configuration options:
 
--   [ADMIN]({{ page.baseurl }}/cloud/env/environment-vars_magento.html)—variables override project ADMIN variables
--   [Global]({{ page.baseurl }}/cloud/env/variables-global.html)—variables affect each stage
--   [Build]({{ page.baseurl }}/cloud/env/variables-build.html)—variables control build actions
--   [Cloud]({{ page.baseurl }}/cloud/env/variables-cloud.html)—variables specific to {{site.data.var.ece}}
--   [Deploy]({{ page.baseurl }}/cloud/env/variables-deploy.html)—variables control deploy actions
--   [Post-deploy]({{ page.baseurl }}/cloud/env/variables-post-deploy.html)—variables control actions after deploy
+-  [ADMIN]({{ page.baseurl }}/cloud/env/environment-vars_magento.html)—variables override project ADMIN variables
+-  [Global]({{ page.baseurl }}/cloud/env/variables-global.html)—variables affect each stage
+-  [Build]({{ page.baseurl }}/cloud/env/variables-build.html)—variables control build actions
+-  [Cloud]({{ page.baseurl }}/cloud/env/variables-cloud.html)—variables specific to {{site.data.var.ece}}
+-  [Deploy]({{ page.baseurl }}/cloud/env/variables-deploy.html)—variables control deploy actions
+-  [Post-deploy]({{ page.baseurl }}/cloud/env/variables-post-deploy.html)—variables control actions after deploy
 
 Variables are _hierarchical_, which means that if a variable is not overridden, it is inherited from the parent environment.
 

--- a/guides/v2.2/cloud/env/working-with-variables.md
+++ b/guides/v2.2/cloud/env/working-with-variables.md
@@ -9,16 +9,16 @@ Environment variables apply to a specific environment or branch. An environment 
 
 The following demonstrates a specific case for preventing a variable from being seen or inherited. You can only specify these options in the CLI. This case does not pertain to all available environment variables. When using the CLI, you must set variables using one of the following methods:
 
--   **Project-specific variables**—To set the same value for all environments in your project, use the `magento-cloud project:variable:set` command. These variables are available at build and runtime in all environments.
--   **Environment-specific variables**—To set a unique value for a specific environment, use the `magento-cloud variable:set` command. These variables are available at runtime and are inherited by child environments. You should specify the environment in your command using the `-e` option.
+-  **Project-specific variables**—To set the same value for all environments in your project, use the `magento-cloud project:variable:set` command. These variables are available at build and runtime in all environments.
+-  **Environment-specific variables**—To set a unique value for a specific environment, use the `magento-cloud variable:set` command. These variables are available at runtime and are inherited by child environments. You should specify the environment in your command using the `-e` option.
 
 {: .bs-callout-info }
 After setting project-specific variables, you must manually redeploy the remote environment for the change to take effect. Push the new commits to trigger a redeploy. Setting environment-specific variables in the Project Web Interface automatically redeploys the environment.
 
 Use the following options to prevent a variable from being seen or inherited:
 
--   `--inheritable false`—disables inheritance for child environments. This is useful for setting production-only values on the master branch and allowing all other environments to use a project-level variable of the same name.
--   `--sensitive true`—marks the variable as _non-readable_ in the Project Web Interface. You can not view the variable in the user interface; however, you can view the variable from the application container, like any other variable.
+-  `--inheritable false`—disables inheritance for child environments. This is useful for setting production-only values on the master branch and allowing all other environments to use a project-level variable of the same name.
+-  `--sensitive true`—marks the variable as _non-readable_ in the Project Web Interface. You can not view the variable in the user interface; however, you can view the variable from the application container, like any other variable.
 
 ```bash
 magento-cloud variable:create --name <VARIABLE_NAME> --value <VARIABLE_VALUE> --inheritable false --sensitive true

--- a/guides/v2.2/cloud/howtos/custom-theme.md
+++ b/guides/v2.2/cloud/howtos/custom-theme.md
@@ -51,8 +51,8 @@ To install a theme manually:
 
 1. Confirm the theme copied to the correct place.
 
-   * Storefront theme: `ls <Magento root dir>/app/design/frontend`
-   * Admin theme: `ls <Magento root dir>/app/design/adminhtml`
+   *  Storefront theme: `ls <Magento root dir>/app/design/frontend`
+   *  Admin theme: `ls <Magento root dir>/app/design/adminhtml`
 
    A sample follows:
 

--- a/guides/v2.2/cloud/howtos/debug.md
+++ b/guides/v2.2/cloud/howtos/debug.md
@@ -24,10 +24,10 @@ To run and use Xdebug, you will need the environment's SSH URL. You can locate t
 
 To configure Xdebug, you need to do the following:
 
-* [Work in a branch](#branch) to push file updates
-* [Enable Xdebug for environments](#enable)
-* Configure your IDE, like [PhpStorm](#phpstorm)
-* [Set up port forwarding](#port)
+*  [Work in a branch](#branch) to push file updates
+*  [Enable Xdebug for environments](#enable)
+*  Configure your IDE, like [PhpStorm](#phpstorm)
+*  [Set up port forwarding](#port)
 
 For configuring on Pro plan Staging and Production, you need to enter a [ticket for Staging and Production](#pro).
 
@@ -97,26 +97,26 @@ You need to configure [PhpStorm](https://www.jetbrains.com/phpstorm/) to properl
 1. Open your PhpStorm project.
 1. Open the settings for PhpStorm.
 
-   * On Mac, select **File** > **Preferences**.
-   * On Windows/Linux, select **File** > **Settings**.
+   *  On Mac, select **File** > **Preferences**.
+   *  On Windows/Linux, select **File** > **Settings**.
 
 1. Expand and locate **Languages & Frameworks** > **PHP** > **Servers** section in settings.
 1. Add a server configuration. Click the + to add a server. Notice at the top, it will show the project name in grey, just for reference. This will create a "server" configuration. This will be used to listen to port 9000 locally, which will be [forwarded](#port).
 1. Configure settings for the new server:
 
-   * **Name**: enter the same as the hostname. This value is used in and must match the value for `PHP_IDE_CONFIG` variable in [Debug CLI commands](#debugcli).
-   * **Host**: enter `localhost`
-   * **Port**: enter 80
-   * **Debugger**: set to Xdebug in the drop-down
+   *  **Name**: enter the same as the hostname. This value is used in and must match the value for `PHP_IDE_CONFIG` variable in [Debug CLI commands](#debugcli).
+   *  **Host**: enter `localhost`
+   *  **Port**: enter 80
+   *  **Debugger**: set to Xdebug in the drop-down
 
 1. Select the **Use path mappings** option. In the files/directories, the root of the project displays that you opened for the added server.
 1. In the **Absolute path on the server** column, click ![Edit]({{ site.baseurl }}/common/images/install_docker_php-storm-edit.png){:width="15px"} (**Edit**) and add a setting based on the environment:
 
-   * For all Starter environments and Pro Integration environments, the remote path is `/app`.
-   * For Pro Staging and Production environments:
+   *  For all Starter environments and Pro Integration environments, the remote path is `/app`.
+   *  For Pro Staging and Production environments:
 
-      * Production: `/app/<project_code>/`
-      * Staging:  `/app/<project_code>_stg/`
+      *  Production: `/app/<project_code>/`
+      *  Staging:  `/app/<project_code>_stg/`
 
 ### Set up port forwarding {#port}
 
@@ -124,8 +124,8 @@ You need to set up port forwarding. This is necessary to map the XDEBUG connecti
 
 To do any type of debugging, you must forward port 9000 from your {{site.data.var.ece}} server to your local machine. See one of the following sections:
 
-* [Port forwarding on Mac or UNIX](#portmac)
-* [Port forwarding on Windows](#portwindows)
+*  [Port forwarding on Mac or UNIX](#portmac)
+*  [Port forwarding on Windows](#portwindows)
 
 #### Port forwarding on Mac or UNIX {#portmac}
 
@@ -148,9 +148,9 @@ To troubleshoot the connection:
 1. Enter `who` to view a list of SSH sessions.
 1. View existing SSH sessions by user. Be careful to not affect a user other than yourself!
 
-   * Integration: usernames are similar to `dd2q5ct7mhgus`
-   * Staging: usernames are similar to `dd2q5ct7mhgus_stg`
-   * Production: usernames are similar to `dd2q5ct7mhgus`
+   *  Integration: usernames are similar to `dd2q5ct7mhgus`
+   *  Staging: usernames are similar to `dd2q5ct7mhgus_stg`
+   *  Production: usernames are similar to `dd2q5ct7mhgus`
 
 1. For a user session that is older than yours, find the pseudo-terminal (PTS) value. For example, `pts/0`.
 1. Kill the process ID (PID) corresponding to the PTS value using the following commands:
@@ -183,17 +183,17 @@ To set up an SSH tunnel on Windows using Putty:
 1. In the Category pane, click **Session**.
 1. Enter the following information:
 
-   * **Hostname (or IP address)** field: Enter your Cloud server's [SSH URL]({{ page.baseurl }}/cloud/env/environments-ssh.html)
-   * **Port** field: Enter `22`
+   *  **Hostname (or IP address)** field: Enter your Cloud server's [SSH URL]({{ page.baseurl }}/cloud/env/environments-ssh.html)
+   *  **Port** field: Enter `22`
 
    ![Set up Putty]({{ site.baseurl }}/common/images/cloud-xdebug_putty-session.png){:width="350px"}
 
 1. In the Category pane, click **Connection** > **SSH** > **Tunnels**.
 1. Enter the following information:
 
-   * **Source port** field: Enter `9000`
-   * **Destination** field: Enter `127.0.0.1:9000`
-   * Click **Remote**
+   *  **Source port** field: Enter `9000`
+   *  **Destination** field: Enter `127.0.0.1:9000`
+   *  Click **Remote**
 
 1. Click **Add**.
 
@@ -209,8 +209,8 @@ To set up an SSH tunnel on Windows using Putty:
 
 If an "unable to connect" error displays, verify all of the following:
 
-* All Putty settings are correct
-* You are running Putty on the machine on which your private {{site.data.var.ece}} SSH keys are located
+*  All Putty settings are correct
+*  You are running Putty on the machine on which your private {{site.data.var.ece}} SSH keys are located
 
 ### Configure Pro Staging and Production {#pro}
 
@@ -246,8 +246,8 @@ To use Xdebug specifically on Pro plan Staging and Production environment, you c
 
 You need the following:
 
-* SSH commands for accessing the environments. You can get this information, through the [Project Web Interface]({{ page.baseurl }}/cloud/project/projects.html) and your project spreadsheet.
-* The `xdebug_key` value we set when configuring the Staging and Pro environments
+*  SSH commands for accessing the environments. You can get this information, through the [Project Web Interface]({{ page.baseurl }}/cloud/project/projects.html) and your project spreadsheet.
+*  The `xdebug_key` value we set when configuring the Staging and Pro environments
 
 Set up an SSH tunnel to Staging or Production environment:
 
@@ -344,15 +344,15 @@ Due to your environments being read-only, you need to pull code locally from an 
 
 The method you choose is up to you. You have the following options:
 
-* Check out code from Git and run `composer install`
+*  Check out code from Git and run `composer install`
 
    This method works unless `composer.json` references packages in private repositories to which you do not have access. This method results in getting the entire Magento codebase.
 
-* Copy the `vendor`, `app`, `pub`, `lib`, and `setup` directories
+*  Copy the `vendor`, `app`, `pub`, `lib`, and `setup` directories
 
    This method results in your having all code you can possibly test. Depending on how many static assets you have, it could result in a long transfer with a large volume of files.
 
-* Copy the `vendor` directory only
+*  Copy the `vendor` directory only
 
    Because most Magento and third-party code is in the `vendor` directory, this method is likely to result in good testing although you won't be testing the entire codebase.
 
@@ -395,9 +395,9 @@ Due to not having access to manually restart the nginx server, you need to locat
 1. Enter `who` to view a list of SSH sessions.
 1. View existing SSH sessions by user. Be careful to not affect a user other than yourself!
 
-   * Integration: usernames are similar to `dd2q5ct7mhgus`
-   * Staging: usernames are similar to `dd2q5ct7mhgus_stg`
-   * Production: usernames are similar to `dd2q5ct7mhgus`
+   *  Integration: usernames are similar to `dd2q5ct7mhgus`
+   *  Staging: usernames are similar to `dd2q5ct7mhgus_stg`
+   *  Production: usernames are similar to `dd2q5ct7mhgus`
 
 1. For a user session that is older than yours, find the pseudo-terminal (PTS) value. For example, `pts/0`.
 1. Kill the process ID (PID) corresponding to the PTS value using the following commands:

--- a/guides/v2.2/cloud/howtos/environment-tutorial-env-merge.md
+++ b/guides/v2.2/cloud/howtos/environment-tutorial-env-merge.md
@@ -71,8 +71,8 @@ You must be a [project administrator]({{ page.baseurl }}/cloud/project/user-admi
 
 This section discusses how to optionally delete an environment in the following ways:
 
-* Make the environment *inactive* but let it remain in the project
-* Delete the environment entirely and remove it from the project
+*  Make the environment *inactive* but let it remain in the project
+*  Delete the environment entirely and remove it from the project
 
 To delete a environment:
 

--- a/guides/v2.2/cloud/howtos/how-to.md
+++ b/guides/v2.2/cloud/howtos/how-to.md
@@ -17,13 +17,13 @@ Have suggestions? Open [an issue](https://github.com/magento/devdocs/issues) or 
 
 Current topics:
 
-* Install components, upgrade, update
+*  Install components, upgrade, update
 
-   * [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
-   * [Test a Magento patch before deploying it]({{ page.baseurl }}/cloud/project/project-upgrade.html)
+   *  [Install, manage, and upgrade modules]({{ page.baseurl }}/cloud/howtos/install-components.html)
+   *  [Test a Magento patch before deploying it]({{ page.baseurl }}/cloud/project/project-upgrade.html)
 
-* Environments
+*  Environments
 
-   * [Merge and delete an environment]({{ page.baseurl }}/cloud/howtos/environment-tutorial-env-merge.html)
+   *  [Merge and delete an environment]({{ page.baseurl }}/cloud/howtos/environment-tutorial-env-merge.html)
 
-* [Install optional sample data]({{ page.baseurl }}/cloud/howtos/sample-data.html)
+*  [Install optional sample data]({{ page.baseurl }}/cloud/howtos/sample-data.html)

--- a/guides/v2.2/cloud/howtos/install-components.md
+++ b/guides/v2.2/cloud/howtos/install-components.md
@@ -14,9 +14,9 @@ When adding extensions to {{site.data.var.ece}}, you should add the code to a Gi
 
 Extensions include the following:
 
-* Modules to extend Magento capabilities, with options through Magento Marketplace and directly through company sites
-* Themes to change the look and feel of your storefronts
-* Language packages to localize the storefront and Admin
+*  Modules to extend Magento capabilities, with options through Magento Marketplace and directly through company sites
+*  Themes to change the look and feel of your storefronts
+*  Language packages to localize the storefront and Admin
 
 These instructions walk through extension installation purchased from Magento Marketplace. You can use the same procedure to install any extension with the extension's Composer name. To find it, open the extension's `composer.json` file and note the values for `"name"` and `"version"`.
 
@@ -31,11 +31,11 @@ We recommend using a branch for adding or updating, configuring, and testing you
 ## Install an extension {#install}
 [Extension installation](#install) uses the following steps:
 
-1.  Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com) or another site.
-1.  [Create a branch](#getstarted) to work with the files.
-1.  [Get the extension's Composer name](#compose) and version from your purchase history.
-1.  In your local {{site.data.var.ece}} project, [update the Magento `composer.json`](#update) file with the name and version of the extension and add the code to Git. The code builds, deploys, and is available through the environment.
-1.  [Verify](#verify) the extension installed properly.
+1. Purchase an extension or module from [Magento Marketplace](https://marketplace.magento.com) or another site.
+1. [Create a branch](#getstarted) to work with the files.
+1. [Get the extension's Composer name](#compose) and version from your purchase history.
+1. In your local {{site.data.var.ece}} project, [update the Magento `composer.json`](#update) file with the name and version of the extension and add the code to Git. The code builds, deploys, and is available through the environment.
+1. [Verify](#verify) the extension installed properly.
 
 ### Step 1: Get the extension's Composer name and version {#compose}
 
@@ -49,8 +49,8 @@ When adding the module to `composer.json`, the file [`app/etc/config.php`]({{ pa
 
 To update `composer.json`:
 
-1.  If you haven't done so already, change to your environment root directory.
-1.  Enter the following commands to update it:
+1. If you haven't done so already, change to your environment root directory.
+1. Enter the following commands to update it:
 
     ```bash
     composer require <component-name>:<version> --no-update
@@ -70,8 +70,8 @@ To update `composer.json`:
     composer update
     ```
 
-1.  Wait for project dependencies to update.
-1.  Enter the following commands in the order shown to commit your changes, including `composer.lock`:
+1. Wait for project dependencies to update.
+1. Enter the following commands in the order shown to commit your changes, including `composer.lock`:
 
     ```bash
     git add -A
@@ -94,15 +94,15 @@ When installing and adding the module, you must add the `composer.lock` to your 
 
 To verify the extension installed properly, you can check its functionality in the Magento Admin or you can view enabled modules using the CLI:
 
-1.  Open a terminal.
-1.  [Checkout the branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) where the module is installed.
-1.  List all enabled modules:
+1. Open a terminal.
+1. [Checkout the branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) where the module is installed.
+1. List all enabled modules:
 
     ```bash
     php bin/magento module:status
     ```
 
-1.  Verify the extension is listed.
+1. Verify the extension is listed.
 
 The extension name is in the format `<VendorName>_<ComponentName>`. It will not be in the same format as the Composer name.
 
@@ -116,34 +116,34 @@ To enable or disable extensions, you must begin those changes on your local in a
 
 Trying to enable and disable extensions not following this method can lead to permissions and other issues.
 
-1.  [Work in a branch](#getstarted) to update `config.php`.
-1.  In a terminal, access your local development environment.
-1.  List all module.
+1. [Work in a branch](#getstarted) to update `config.php`.
+1. In a terminal, access your local development environment.
+1. List all module.
 
     ```bash
     php bin/magento module:status
     ```
 
-1.  Enable a module.This command updates the `config.php` file with the enabled status of the module.
+1. Enable a module.This command updates the `config.php` file with the enabled status of the module.
 
     ```bash
     php bin/magento module:enable <module name>
     ```
 
-1.  Disable a module. This command updates the `config.php` file with the disable status of the module.
+1. Disable a module. This command updates the `config.php` file with the disable status of the module.
 
     ```bash
     php bin/magento module:disable <module name>
     ```
 
-1.  Verify the status of a module:
+1. Verify the status of a module:
 
     ```bash
     php bin/magento module:status
     ```
 
-1.  Push your updates to the Git branch.
-1.  [Complete deployment]({{ page.baseurl }}/cloud/live/stage-prod-live.html) to Integration for testing, then Staging for testing, and finally Production.
+1. Push your updates to the Git branch.
+1. [Complete deployment]({{ page.baseurl }}/cloud/live/stage-prod-live.html) to Integration for testing, then Staging for testing, and finally Production.
 
 ### Modify configurations {#configure}
 
@@ -153,22 +153,22 @@ You update configurations according to [Configuration Management]({{ site.baseur
 
 You should have a branch to work in when updating your extension. These instructions use composer to update the files. Before you continue, you must:
 
-* Know the extension's Composer name and version
-* Know the extension is compatible with your project and {{site.data.var.ece}} version. In particular, check the required PHP version.
+*  Know the extension's Composer name and version
+*  Know the extension is compatible with your project and {{site.data.var.ece}} version. In particular, check the required PHP version.
 
 To update an extension:
 
-1.  If you haven't done so already, change to your environment root directory.
-1.  Open `composer.json` in a text editor.
-1.  Locate your extension and update the version.
-1.  Save your changes to `composer.json` and exit the text editor.
-1.  Update project dependencies:
+1. If you haven't done so already, change to your environment root directory.
+1. Open `composer.json` in a text editor.
+1. Locate your extension and update the version.
+1. Save your changes to `composer.json` and exit the text editor.
+1. Update project dependencies:
 
     ```bash
     composer update
     ```
 
-1.  Enter the following commands in the order to commit the changes and deploy the project, including `composer.lock`:
+1. Enter the following commands in the order to commit the changes and deploy the project, including `composer.lock`:
 
     ```bash
     git add -A
@@ -176,6 +176,6 @@ To update an extension:
     git push origin <environment ID>
     ```
 
-1.  Wait for the project to deploy and verify in your environment.
+1. Wait for the project to deploy and verify in your environment.
 
 If there are errors, see [Component deployment failure]({{ page.baseurl }}/cloud/trouble/trouble_comp-deploy-fail.html).

--- a/guides/v2.2/cloud/integrations/github-integration.md
+++ b/guides/v2.2/cloud/integrations/github-integration.md
@@ -26,37 +26,37 @@ You must be a member of a group with write-access to the GitHub repository, so t
 
 You need to clone your {{site.data.var.ece}} project from an existing environment and migrate the project branches to a new, empty GitHub repository, preserving the same branch names. It is **critical** to retain an identical Git tree, so that you do not lose any existing environments or branches in your {{site.data.var.ece}} project.
 
-1.  From the terminal, log in to your {{site.data.var.ece}} project.
+1. From the terminal, log in to your {{site.data.var.ece}} project.
 
     ```bash
     magento-cloud login
     ```
 
-1.  List your projects and copy the project ID.
+1. List your projects and copy the project ID.
 
     ```bash
     magento-cloud project:list
     ```
 
-1.  Clone the project to your local environment.
+1. Clone the project to your local environment.
 
     ```bash
     magento-cloud project:get <project-ID>
     ```
 
-1.  Add your GitHub repository as a remote.
+1. Add your GitHub repository as a remote.
 
     ```bash
     git remote add origin git@github.com:<user-name>/<repo-name>.git
     ```
 
-1.  Delete the default `magento` remote.
+1. Delete the default `magento` remote.
 
     ```bash
     git remote remove magento
     ```
 
-1.  Verify that you added the GitHub remote correctly.
+1. Verify that you added the GitHub remote correctly.
 
     ```bash
     git remote -v
@@ -70,7 +70,7 @@ You need to clone your {{site.data.var.ece}} project from an existing environmen
     ```
     {: .no-copy}
 
-1.  Push the project files to your new GitHub repository. Remember to keep all branch names the same.
+1. Push the project files to your new GitHub repository. Remember to keep all branch names the same.
 
     ```bash
     git push -u origin master
@@ -78,7 +78,7 @@ You need to clone your {{site.data.var.ece}} project from an existing environmen
 
     If you are starting with a new GitHub repository, you may have to use the `-f` option, because the remote repository does not match your local copy.
 
-1.  Verify that your GitHub repository contains all of your project files.
+1. Verify that your GitHub repository contains all of your project files.
 
 ## Enable the GitHub integration
 

--- a/guides/v2.2/cloud/live/go-live-checklist.md
+++ b/guides/v2.2/cloud/live/go-live-checklist.md
@@ -29,20 +29,20 @@ This does not work for an [apex domain](https://blog.cloudflare.com/zone-apex-na
 
 The following list contains examples of DNS providers for informational purposes. Use your preferred DNS provider.
 
-* CNAME with ALIAS record from [Dyn](http://dyn.com)
-* ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
-* ANAME at [easyDNS](https://www.easydns.com)
-* ACNAME at [CloudFlare](https://www.cloudflare.com)
-* ALIAS at [PointDNS](https://pointhq.com)
+*  CNAME with ALIAS record from [Dyn](http://dyn.com)
+*  ANAME record on [DNS Made Easy](http://www.dnsmadeeasy.com)
+*  ANAME at [easyDNS](https://www.easydns.com)
+*  ACNAME at [CloudFlare](https://www.cloudflare.com)
+*  ALIAS at [PointDNS](https://pointhq.com)
 
 Many other DNS providers also offer workarounds to accomplish this goal. The most common is to add a CNAME record for the `www` host on the domain and then use the DNS provider's redirect service to redirect the apex over to the `www` version of the domain. Consult your DNS provider for more information.
 
 Another option for apex domain is to add A records, which maps a domain name to the Fastly IP addresses:
 
-* `151.101.1.124`
-* `151.101.65.124`
-* `151.101.129.124`
-* `151.101.193.124`
+*  `151.101.1.124`
+*  `151.101.65.124`
+*  `151.101.129.124`
+*  `151.101.193.124`
 
 ### TLS and Fastly {#fastly-tls}
 
@@ -56,22 +56,22 @@ Make a final pass for any Production configurations in the store(s). If you need
 
 The following are recommended changes and checks:
 
-* Outgoing email has been tested
-* Base URL and Base Admin URL are set correctly
-* Change the default Magento Admin password
+*  Outgoing email has been tested
+*  Base URL and Base Admin URL are set correctly
+*  Change the default Magento Admin password
 
    See [Configuring Admin Security](http://docs.magento.com/m2/ee/user_guide/stores/security-admin.html) for further information on Admin configurations.
 
-* Optimize all images for the web
-* [Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html) for JS, CSS, and HTTP
+*  Optimize all images for the web
+*  [Enable minification](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html) for JS, CSS, and HTTP
 
 ## Verify Fastly caching {#verifyfastly}
 
 Test and verify Fastly caching is correctly working in Production. For detailed tests and checks, see [Fastly testing]({{ page.baseurl }}/cloud/live/stage-prod-test.html#fastly).
 
-* Make sure that pages are being correctly cached in the page cache and Fastly
-* Make sure the Fastly Extension is up-to-date
-* Make sure the Fastly VCL is up-to-date
+*  Make sure that pages are being correctly cached in the page cache and Fastly
+*  Make sure the Fastly Extension is up-to-date
+*  Make sure the Fastly VCL is up-to-date
 
 ## Performance testing {#performance}
 
@@ -79,11 +79,11 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 You can also test using the following 3rd party options:
 
-* [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
-* [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
-* [New Relic](https://support.newrelic.com/) (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
-* [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks in depth: process, method call, query, load, and so on.
-* [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
+*  [Siege](https://www.joedog.org/siege-home/): Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+*  [Jmeter](http://jmeter.apache.org/): Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+*  [New Relic](https://support.newrelic.com/) (provided): Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
+*  [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) (provided): Helps track through the issues New Relic finds and helps you dig deeper into the issue for specifics. Blackfire profiles the environment and helps locate bottlenecks in depth: process, method call, query, load, and so on.
+*  [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/): Real-time analysis of your site pages load time with different origin locations. Pingdom may cost a fee. WebPageTest is a free tool.
 
 {:.ref-header}
 Next step

--- a/guides/v2.2/cloud/live/live-prot.md
+++ b/guides/v2.2/cloud/live/live-prot.md
@@ -20,18 +20,18 @@ Outdated software often contains exploits we protect against by partially blocki
 
 We analyze the code of your application:
 
-* When you push new code to Git
-* When new vulnerabilities are added to our database
+*  When you push new code to Git
+*  When new vulnerabilities are added to our database
 
 If a critical vulnerability is detected in your application, it rejects the Git push.
 
 We run two types of blocks:
 
-* For development websites, we run complete blocks.
+*  For development websites, we run complete blocks.
 
    The error message accompanying `git push` provides detailed information about the vulnerability.
 
-* For production websites, we run a "partial block" that allows the site to stay mostly online.
+*  For production websites, we run a "partial block" that allows the site to stay mostly online.
 
    Depending on the nature of the vulnerability, parts of a request, such as a query string, cookies or any additional headers, might be removed from GET requests. All other requests may be blocked entirely&mdash;this could apply to logging in, form submission, or product [checkout](https://glossary.magento.com/checkout).
 

--- a/guides/v2.2/cloud/live/live-sanity-check.md
+++ b/guides/v2.2/cloud/live/live-sanity-check.md
@@ -10,9 +10,9 @@ Before pushing your code to your [Starter]({{ page.baseurl }}/cloud/basic-inform
 
 These tasks walk through:
 
-* Complete development on your local
-* Complete a full build and deploy process on your local (deploys to the associated active development environment)
-* Test fully before continuing deployment to Staging
+*  Complete development on your local
+*  Complete a full build and deploy process on your local (deploys to the associated active development environment)
+*  Test fully before continuing deployment to Staging
 
 For more information on the full five step process, see the [Deployment process]({{ page.baseurl }}/cloud/reference/discover-deploy.html).
 
@@ -27,11 +27,11 @@ If you modified your `composer.json` file to add modules, we recommend running t
 
 Your Git branch must have the following files for building and deploying to your local, Integration, Staging, and Production environments:
 
-* `auth.json` in the root Magento directory. This file includes the Magento authentication keys entered when creating the project. If you need to verify the file and settings, see [Troubleshoot deployment]({{ page.baseurl }}/cloud/trouble/troubleshoot-deployment.html).
-* `config.php` if you use [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) to manage Magento configuration settings
-* [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html) is updated and saved in the root directory
-* [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) is updated and saved in `magento/`
-* [`routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html) is updated and saved in `magento/`
+*  `auth.json` in the root Magento directory. This file includes the Magento authentication keys entered when creating the project. If you need to verify the file and settings, see [Troubleshoot deployment]({{ page.baseurl }}/cloud/trouble/troubleshoot-deployment.html).
+*  `config.php` if you use [Configuration Management]({{ page.baseurl }}/cloud/live/sens-data-over.html) to manage Magento configuration settings
+*  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html) is updated and saved in the root directory
+*  [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html) is updated and saved in `magento/`
+*  [`routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html) is updated and saved in `magento/`
 
 ## Test build your code locally before pushing {#test-build}
 
@@ -76,16 +76,16 @@ To push code to your remote environment:
    git push origin <branch name>
    ```
 
-1.  The build and deploy phases begin. Wait for the deployment to complete.
+1. The build and deploy phases begin. Wait for the deployment to complete.
 
 ## Build phase {#build}
 
 During the [build phase]({{page.baseurl}}/cloud/reference/discover-deploy.html#cloud-deploy-over-phases-build), we perform the following tasks:
 
-* Apply patches distributed to all {{site.data.var.ece}} accounts
-* Apply patches we provided specifically to you
-* Enable modules to build
-* Compile code and the [dependency injection](https://glossary.magento.com/dependency-injection) configuration
+*  Apply patches distributed to all {{site.data.var.ece}} accounts
+*  Apply patches we provided specifically to you
+*  Enable modules to build
+*  Compile code and the [dependency injection](https://glossary.magento.com/dependency-injection) configuration
 
 The build also checks for a [configuration file]({{ page.baseurl }}/cloud/live/sens-data-over.html). If the file exists, the static file deployment is also completed during the build stage. If not, it is completed in the deployment stage.
 
@@ -171,10 +171,10 @@ We strongly recommend you complete your testing in an Integration or Staging env
 
 We highly recommend having Magento already installed prior to deployment. During the [deployment phase]({{ page.baseurl }}/cloud/reference/discover-deploy.html#cloud-deploy-over-phases-hook), we perform the following tasks:
 
-* Install the Magento application if needed
-* If the Magento application is installed, upgrade components
-* Clear the [cache](https://glossary.magento.com/cache)
-* Set the Magento application for [`production`]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode) mode
+*  Install the Magento application if needed
+*  If the Magento application is installed, upgrade components
+*  Clear the [cache](https://glossary.magento.com/cache)
+*  Set the Magento application for [`production`]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode) mode
 
 {:.procedure}
 To deploy your site:

--- a/guides/v2.2/cloud/live/sens-data-initial.md
+++ b/guides/v2.2/cloud/live/sens-data-initial.md
@@ -16,19 +16,19 @@ This example shows how to use the [recommended procedure]({{ page.baseurl }}/clo
 1. Verify your settings are not editable in the Admin panel. Any configurations exported to `config.php` make those fields in the Admin panel read-only and disabled for edits.
 1. Update and modify configurations again in Integration, update the file, and check it into Git:
 
-   * Change configuration settings on the Integration environment.
-   * To add new configurations, run the command to create `config.php` again. New configurations are appended to the file.
-   * To remove or edit existing configurations, manually edit the file.
-   * Commit and push to Git.
+   *  Change configuration settings on the Integration environment.
+   *  To add new configurations, run the command to create `config.php` again. New configurations are appended to the file.
+   *  To remove or edit existing configurations, manually edit the file.
+   *  Commit and push to Git.
 
 <!-- {:.bs-callout .bs-callout-info}
 This example shows how you can set and lock configuration values for everything _except_ sensitive settings. You must set sensitive settings either as configuration variables or in the [Magento Admin](https://glossary.magento.com/magento-admin). For more information, see [Sensitive and system-specific]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
 -->
 For example, you may want to set the following settings:
 
-* Disable [locale](https://glossary.magento.com/locale) and static file optimization settings in your Integration environment
-* Enable static file optimization in Staging and Production environments
-* Configure Fastly in Staging and Production with specific credentials for each
+*  Disable [locale](https://glossary.magento.com/locale) and static file optimization settings in your Integration environment
+*  Enable static file optimization in Staging and Production environments
+*  Configure Fastly in Staging and Production with specific credentials for each
 
 _Static file optimization_ means merging and minifying [JavaScript](https://glossary.magento.com/javascript) and Cascading Style Sheets, and minifying [HTML](https://glossary.magento.com/html) templates.
 
@@ -36,12 +36,12 @@ _Static file optimization_ means merging and minifying [JavaScript](https://glos
 
 To complete these configuration management tasks, you need the following:
 
-* Minimum a project reader role with [environment administrator]({{ page.baseurl }}/cloud/project/user-admin.html#cloud-role-env) privileges
-* Magento Admin panel URL and credentials for Integration, Staging, and Production environments
-* Push all updated code to your Integration environment:
+*  Minimum a project reader role with [environment administrator]({{ page.baseurl }}/cloud/project/user-admin.html#cloud-role-env) privileges
+*  Magento Admin panel URL and credentials for Integration, Staging, and Production environments
+*  Push all updated code to your Integration environment:
 
-   * For Starter: To an Integration branch and environment
-   * For Pro: To the Integration `master` branch and environment
+   *  For Starter: To an Integration branch and environment
+   *  For Pro: To the Integration `master` branch and environment
 
 ## Configure Magento through the Integration Admin panel {#configure}
 

--- a/guides/v2.2/cloud/live/stage-prod-live.md
+++ b/guides/v2.2/cloud/live/stage-prod-live.md
@@ -52,9 +52,9 @@ For Pro, locate your Git and SSH URLs from the OneDrive onboarding document you 
 
 After you know these URLs, you can access those environments without further intervention.
 
-* Use the URLs to access the store as a customer.
-* Use the URL /admin to access the Admin panel.
-* (Pro) Use SSH access and Git CLI commands to deploy updated code to Staging or Production. Magento Cloud CLI commands are not available in Staging and Production.
+*  Use the URLs to access the store as a customer.
+*  Use the URL /admin to access the Admin panel.
+*  (Pro) Use SSH access and Git CLI commands to deploy updated code to Staging or Production. Magento Cloud CLI commands are not available in Staging and Production.
 
 For more information, see [SSH and sFTP]({{ page.baseurl }}/cloud/env/environments-ssh.html).
 
@@ -64,20 +64,20 @@ You should always deploy code by pushing your local Git branch to your environme
 
 Always update your code in a branch on your local environment, push to Git, and complete the full deployment when you need to do the following:
 
-* Add extensions
-* Add 3rd party integrations
-* Fix issues and check errors
+*  Add extensions
+*  Add 3rd party integrations
+*  Fix issues and check errors
 
 {:.ref-header}
 Related topics
 
 To learn more, check the following:
 
-* [Deployment process]({{ page.baseurl }}/cloud/reference/discover-deploy.html)
-* [Continuous integration]({{ page.baseurl }}/cloud/deploy/continuous-deployment.html)
-* [Protective block]({{ page.baseurl }}/cloud/live/live-prot.html)
-* [Build and deploy to your local]({{ page.baseurl }}/cloud/live/live-sanity-check.html)
-* [Prepare to deploy]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html)
-* [Migrate and deploy]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html)
-* [Test deployment]({{ page.baseurl }}/cloud/live/stage-prod-test.html)
-* [Go live and launch]({{ page.baseurl }}/cloud/live/live.html)
+*  [Deployment process]({{ page.baseurl }}/cloud/reference/discover-deploy.html)
+*  [Continuous integration]({{ page.baseurl }}/cloud/deploy/continuous-deployment.html)
+*  [Protective block]({{ page.baseurl }}/cloud/live/live-prot.html)
+*  [Build and deploy to your local]({{ page.baseurl }}/cloud/live/live-sanity-check.html)
+*  [Prepare to deploy]({{ page.baseurl }}/cloud/live/stage-prod-migrate-prereq.html)
+*  [Migrate and deploy]({{ page.baseurl }}/cloud/live/stage-prod-migrate.html)
+*  [Test deployment]({{ page.baseurl }}/cloud/live/stage-prod-test.html)
+*  [Go live and launch]({{ page.baseurl }}/cloud/live/live.html)

--- a/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
+++ b/guides/v2.2/cloud/live/stage-prod-migrate-prereq.md
@@ -28,18 +28,18 @@ You can deploy to Starter environments from the Project Web Interface or using C
 
 **Prerequisites**
 
-1.  Get your [access URLs and SSH](#starter-urls) information.
-1.  [Add your public SSH key](#add-public-ssh-key) to your project.
+1. Get your [access URLs and SSH](#starter-urls) information.
+1. [Add your public SSH key](#add-public-ssh-key) to your project.
 
 ### Get your Starter access URLs and SSH information {#starter-urls}
 
 You can find URLs and SSH connection information from the Project Web Interface. For each selected environment or branch, you have an Access Site link. Your initial project is provisioned with a `Master` environment, which is Production, and any additional branches you create, including Staging (recommended) and development branches for custom code.
 
-1.  Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
+1. Log in to [your {{site.data.var.ece}} account](https://accounts.magento.cloud).
 
-1.  Select an environment.
+1. Select an environment.
 
-1.  Click **Access site** to display the URL and SSH information.
+1. Click **Access site** to display the URL and SSH information.
 
     ![Access your project]({{ site.baseurl }}/common/images/cloud/cloud-starter-project-access.png)
    {:width="500px"}
@@ -50,11 +50,11 @@ For Pro plan projects, you must merge your completed development code to the `In
 
 For **first time setup** to migrate your database and deploy code to Staging or Production, complete the following steps:
 
-1.  Create a support ticket to [migrate deployment hooks](#pro-yaml). In this ticket, include your public SSH keys to add to Staging and Production.
+1. Create a support ticket to [migrate deployment hooks](#pro-yaml). In this ticket, include your public SSH keys to add to Staging and Production.
 
-1.  Get your [access URLs and SSH](#pro-urls) for Staging and Production.
+1. Get your [access URLs and SSH](#pro-urls) for Staging and Production.
 
-1.  [Add your public SSH key](#add-public-ssh-key) to your {{ site.data.var.ece }} project environments.
+1. [Add your public SSH key](#add-public-ssh-key) to your {{ site.data.var.ece }} project environments.
 
 If you have not done so already, set up [Fastly CDN services]({{ page.baseurl }}/cloud/cdn/cloud-fastly.html) on your Staging and Production environments. See [Fastly set up]({{ page.baseurl }}/cloud/cdn/configure-fastly.html#upload-vcl-snippets).
 
@@ -79,8 +79,8 @@ You can locate your URLs through the Project Web Interface. There is an _Access 
 
 -  SSH access:
 
-   - Staging: `ssh <node>.ent-<project ID>-staging-<system ID>@ssh.<region>.magento.cloud`
-   - Production: `ssh <node>.ent-<project ID>-production-<system ID>@ssh.<region>.magento.cloud`
+   -  Staging: `ssh <node>.ent-<project ID>-staging-<system ID>@ssh.<region>.magento.cloud`
+   -  Production: `ssh <node>.ent-<project ID>-production-<system ID>@ssh.<region>.magento.cloud`
 
 -  Web URL format:
 
@@ -91,27 +91,27 @@ You can locate your URLs through the Project Web Interface. There is an _Access 
 
 Add your SSH public key to {{ site.data.var.ece }} environments:
 
-- Starter–Add to Master (Production) and any environments you create by branching from Master
-- Pro–Add to the Master Integration, Staging, and Production environments
+-  Starter–Add to Master (Production) and any environments you create by branching from Master
+-  Pro–Add to the Master Integration, Staging, and Production environments
 
 {:.procedure}
 To add an SSH key using the Project Web Interface:
 
-1.  Copy your SSH public key to the clipboard.
+1. Copy your SSH public key to the clipboard.
 
     If you do not already have SSH keys on that machine, see the [GitHub documentation](https://help.github.com/articles/generating-an-ssh-key) to create them.
 
-1.  Login and access your project through the [Project Web Interface](https://accounts.magento.cloud).
+1. Login and access your project through the [Project Web Interface](https://accounts.magento.cloud).
 
-1.  In your selected branch, an icon displays if you do not have an SSH key added.
+1. In your selected branch, an icon displays if you do not have an SSH key added.
 
     ![No SSH key]({{ site.baseurl }}/common/images/cloud_ssh-key-install.png)
 
-1.  Copy and paste the content of your public SSH key in the screen.
+1. Copy and paste the content of your public SSH key in the screen.
 
     ![Add SSH key]({{ site.baseurl }}/common/images/cloud_ssh-key-add.png)
 
-1.  Follow the prompts on your screen to complete the task.
+1. Follow the prompts on your screen to complete the task.
 
 You can also add an SSH key using the {{site.data.var.ece}} CLI. See [Add an SSH key using the CLI]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html#add-key-cli).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/cloud` folder.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
