### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - cloud. Part 05.

### DIFF
--- a/guides/v2.2/cloud/reference/git-integration.md
+++ b/guides/v2.2/cloud/reference/git-integration.md
@@ -8,15 +8,15 @@ redirect_from:
 
 Git is the center of all code management, build, and deployment for your {{site.data.var.ece}} stores and sites. We use Git to provide source control for your code:
 
-* Git supports branch development that merges upstream (or to a parent branch) before deploying across your environments. Multiple developers can work together on small to large code updates through Git branch management.
-* When you push Git branches, we automatically kick off build and deploy scripts to completely build and verify your code, generate and update a virtual environment, and deploy to the environment for ease of testing.
-* Every active Git branch has an associated environment. We use specific .yaml files in {{site.data.var.ece}} code with your customizations to define environment configurations, services, database, and more.
+*  Git supports branch development that merges upstream (or to a parent branch) before deploying across your environments. Multiple developers can work together on small to large code updates through Git branch management.
+*  When you push Git branches, we automatically kick off build and deploy scripts to completely build and verify your code, generate and update a virtual environment, and deploy to the environment for ease of testing.
+*  Every active Git branch has an associated environment. We use specific .yaml files in {{site.data.var.ece}} code with your customizations to define environment configurations, services, database, and more.
 
 If you need help understand Git, you can review the following resources:
 
-* [Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
-* [Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
-* [Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
+*  [Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
+*  [Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
+*  [Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
 
 ## Git CLI and clients {#clients}
 You can interact with Git using [CLI commands](https://git-scm.com/documentation) or using a Git client. Git provides a [Git client](https://git-scm.com/downloads) option, or you can use other clients such as installed on your computer to be able to interact with {{site.data.var.ece}}.
@@ -27,15 +27,15 @@ Not everyone remembers [Git](https://git-scm.com/docs) commands with ease. If yo
 
 In addition to Git's requirements for [valid branch names](https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html), {{site.data.var.ece}} adds two additional requirements:
 
-* The `/` character isn't allowed in a branch name.
-* Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`. A branch name of `Sprint2` and `sprint2` are just fine.
+*  The `/` character isn't allowed in a branch name.
+*  Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`. A branch name of `Sprint2` and `sprint2` are just fine.
 
 ## Git branching {#branching}
 
 For specifics on creating Git branches, see the following topics:
 
-* [Manage branches with the Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-branch.html)
-* [Manage branches with the CLI]({{ page.baseurl }}/cloud/env/environments-start.html)
+*  [Manage branches with the Project Web Interface]({{ page.baseurl }}/cloud/project/project-webint-branch.html)
+*  [Manage branches with the CLI]({{ page.baseurl }}/cloud/env/environments-start.html)
 
 ## .gitignore file {#gitignore}
 Depending on your {{site.data.var.ece}} version, you may need different information added to or commented out in your `.gitignore` file. Git uses this file to determine which files and directories to ignore, before you make a commit to your branches. A .gitignore file should be committed into your root Magento in the repository, in order to share the ignore rules with any other users that clone the repository.

--- a/guides/v2.2/cloud/release-notes/cloud-tools.md
+++ b/guides/v2.2/cloud/release-notes/cloud-tools.md
@@ -436,13 +436,13 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
 -  {:.fix}<!-- MAGECLOUD-1607 -->**Cron-specific Improvements**—Re-worked the cron implementation:
 
-   - Fixed an issue that caused the cron queue to fill quickly. Now it clears the outdated cron jobs in a more reliable way.
+   -  Fixed an issue that caused the cron queue to fill quickly. Now it clears the outdated cron jobs in a more reliable way.
 
-   - Re-organized the sequence of cron jobs so that all jobs in separate threads launch prior to the general group.
+   -  Re-organized the sequence of cron jobs so that all jobs in separate threads launch prior to the general group.
 
-   - Improved logging to better assist in debugging cron issues.
+   -  Improved logging to better assist in debugging cron issues.
 
-   - **NOTE**—This release addresses many cron-related issues. If you currently use some cron-related patches in _m2-hotfixes_, remove them.
+   -  **NOTE**—This release addresses many cron-related issues. If you currently use some cron-related patches in _m2-hotfixes_, remove them.
 
 -  {:.fix}**SCD-specific improvements**—
 

--- a/guides/v2.2/cloud/requirements/cloud-requirements.md
+++ b/guides/v2.2/cloud/requirements/cloud-requirements.md
@@ -12,19 +12,19 @@ This topic describes technologies, knowledge, accounts, and steps to complete wh
 
 The following technologies are requirements for developing and deploying your store code:
 
-* Git
-* Composer
-* Magento 2
-* Continuous Integration
-* Architectures including Starter or Pro architecture
+*  Git
+*  Composer
+*  Magento 2
+*  Continuous Integration
+*  Architectures including Starter or Pro architecture
 
 Here are some advanced technologies we recommend getting familiar with:
 
-* [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html) for CDN and caching (based on Varnish)
-* [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) for performance testing
-* [New Relic]({{ page.baseurl }}/cloud/project/new-relic.html) for performance testing
-* [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html) if you need a Git repo
-* [Bitbucket]({{ page.baseurl }}/cloud/integrations/bitbucket-integration.html) if you need a Git repo
+*  [Fastly]({{ page.baseurl }}/cloud/basic-information/cloud-fastly.html) for CDN and caching (based on Varnish)
+*  [Blackfire Profiler]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) for performance testing
+*  [New Relic]({{ page.baseurl }}/cloud/project/new-relic.html) for performance testing
+*  [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html) if you need a Git repo
+*  [Bitbucket]({{ page.baseurl }}/cloud/integrations/bitbucket-integration.html) if you need a Git repo
 
 {% include cloud/split-db-nosupport.md %}
 
@@ -34,9 +34,9 @@ Git is the heart of all your code in repositories. It acts as a version control 
 
 We hope you have a good working knowledge of Git. Need some help? Don't worry, we have you covered with some of our favorite links and information. We'll also include a Git guide to branching and developing soon.
 
-* [Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
-* [Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
-* [Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
+*  [Git documentation](https://git-scm.com/documentation) and [videos](https://git-scm.com/videos) from the makers of Git
+*  [Git cheatsheet](http://rogerdudler.github.io/git-guide/files/git_cheat_sheet.pdf) and [quick guide](http://rogerdudler.github.io/git-guide/) from Roger Dudler
+*  [Git video](https://www.youtube.com/watch?v=8KCQe9Pm1kg) with DevForge to understand how people use the repo and commands with a fun story
 
 To get started with Git, you should have [Git installed](https://git-scm.com/downloads) on your local.
 
@@ -49,16 +49,16 @@ You must use Secure Shell (SSH) and not HTTPS to connect to the Git repository. 
 ## Supported software versions {#cloud-arch-software}
 {{site.data.var.ece}} uses:
 
-* Operating system: Debian GNU/Linux 8 (jessie)
-* Web server: [nginx](https://glossary.magento.com/nginx) 1.8
+*  Operating system: Debian GNU/Linux 8 (jessie)
+*  Web server: [nginx](https://glossary.magento.com/nginx) 1.8
 
 You cannot upgrade the software, but you can configure the following services:
 
-* [PHP]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
-* [MySQL]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html)
-* [Redis]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
-* [RabbitMQ]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
-* [Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
+*  [PHP]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
+*  [MySQL]({{ page.baseurl }}/cloud/project/project-conf-files_services-mysql.html)
+*  [Redis]({{ page.baseurl }}/cloud/project/project-conf-files_services-redis.html)
+*  [RabbitMQ]({{ page.baseurl }}/cloud/project/project-conf-files_services-rabbit.html)
+*  [Elasticsearch]({{ page.baseurl }}/cloud/project/project-conf-files_services-elastic.html)
 
 {: .bs-callout-info }
 See [Magento technology stack requirements]({{ page.baseurl }}/install-gde/system-requirements-tech.html) for the latest software version requirements.
@@ -67,17 +67,17 @@ For Staging and Production environments, you use the Fastly CDN module for Magen
 
 For information about configuring the software versions to use in your implementation, see the following {{ site.data.var.ece }} configuration files:
 
-* [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
-* [`routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)
-* [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)
+*  [`.magento.app.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_magento-app.html)
+*  [`routes.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_routes.html)
+*  [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html)
 
 ## Requirements to get started {#requirements}
 
 To get started as a developer in a {{site.data.var.ece}} project, you need to set up the following:
 
-* Set up a [local development environment]({{ page.baseurl }}/cloud/before/before-workspace.html). Your local workspace works best as a virtual system (VM or container) with all prerequisites installed and the project `master` Git branch cloned. You'll develop in branches to add modules, extensions, 3rd party integrations, and configurations. We recommend reading over develop and deploy process for your [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html) or [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html) plan.
-* Get [`repo.magento.com` credentials]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) in your account.
-* Get a [project invitation]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#users) from the Project Owner or a super user.
+*  Set up a [local development environment]({{ page.baseurl }}/cloud/before/before-workspace.html). Your local workspace works best as a virtual system (VM or container) with all prerequisites installed and the project `master` Git branch cloned. You'll develop in branches to add modules, extensions, 3rd party integrations, and configurations. We recommend reading over develop and deploy process for your [Starter]({{ page.baseurl }}/cloud/basic-information/starter-develop-deploy-workflow.html) or [Pro]({{ page.baseurl }}/cloud/architecture/pro-develop-deploy-workflow.html) plan.
+*  Get [`repo.magento.com` credentials]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) in your account.
+*  Get a [project invitation]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#users) from the Project Owner or a super user.
 
 We walk you through everything you need to do and know.
 
@@ -85,15 +85,15 @@ We walk you through everything you need to do and know.
 
 Before you test any custom code in your local {{site.data.var.ee}} environment, you must do all of the following:
 
-* For Pro, set the database [`auto_increment_increment` to 3]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html#database)
-* Test with the correct file permissions in [PRODUCTION mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
+*  For Pro, set the database [`auto_increment_increment` to 3]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html#database)
+*  Test with the correct file permissions in [PRODUCTION mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
 
    Correct permissions only allow write access to `var`, `pub/static, pub/media`, and `app/etc`
 
-* Test with minification for HTML, JavaScript, and [CSS](https://glossary.magento.com/css) enabled
-* Test with [Redis enabled for page cache and session cache]({{ page.baseurl }}/config-guide/redis/config-redis.html)
-* Install and configure [Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html)
-* Test using [Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html) for the page [cache](https://glossary.magento.com/cache)
+*  Test with minification for HTML, JavaScript, and [CSS](https://glossary.magento.com/css) enabled
+*  Test with [Redis enabled for page cache and session cache]({{ page.baseurl }}/config-guide/redis/config-redis.html)
+*  Install and configure [Fastly]({{ page.baseurl }}/cloud/cdn/configure-fastly.html)
+*  Test using [Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html) for the page [cache](https://glossary.magento.com/cache)
 
 {: .bs-callout-info }
 {{ site.data.var.ece }} supports production and maintenance modes only.
@@ -102,19 +102,19 @@ Before you test any custom code in your local {{site.data.var.ee}} environment, 
 
 For development and testing, we recommend the following:
 
-* Test your site in an Integration (development) and Staging (near-production) environment as you complete modifications
+*  Test your site in an Integration (development) and Staging (near-production) environment as you complete modifications
 
    You can enable and test individual features, new extensions, and 3rd party integration on different environments prior to merging into a single environment.
 
-* Verify [`magento setup:install`]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html) and [`magento setup:upgrade`]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html) commands work during the build and deploy process and that any extensions and customizations compile correctly in [Production mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
+*  Verify [`magento setup:install`]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html) and [`magento setup:upgrade`]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html) commands work during the build and deploy process and that any extensions and customizations compile correctly in [Production mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
 
    You can set an environment variable or enter a CLI command for this specific mode.
 
-* Fully [test your site]({{ page.baseurl }}/cloud/live/stage-prod-test.html) in Staging as a merchant and customer prior to Production deployment
-* Verify the Fastly VCL is uploaded to Fastly
-* Send a ticket with all storefront domains when going live (to be added to the shared SSL (HTTPS) certificate)
-* For custom deploy hooks in Integration, open a Support ticket to have them added to the Staging and Production deployment process
-* Profile key flows and customizations using Blackfire.io
+*  Fully [test your site]({{ page.baseurl }}/cloud/live/stage-prod-test.html) in Staging as a merchant and customer prior to Production deployment
+*  Verify the Fastly VCL is uploaded to Fastly
+*  Send a ticket with all storefront domains when going live (to be added to the shared SSL (HTTPS) certificate)
+*  For custom deploy hooks in Integration, open a Support ticket to have them added to the Staging and Production deployment process
+*  Profile key flows and customizations using Blackfire.io
 
 ## License and authentication requirements
 
@@ -122,13 +122,13 @@ The Account Owner creates the initial {{site.data.var.ece}} account with a purch
 
 To work with and deploy stores, you need the following:
 
-* [{{site.data.var.ece}} account]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#cloud-first-acct) already created or created via an invitation
-* [Project invitation]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#users) for contributing developers from the Account Owner or a super user
-* [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) for each user who contributes to the project
+*  [{{site.data.var.ece}} account]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#cloud-first-acct) already created or created via an invitation
+*  [Project invitation]({{ page.baseurl }}/cloud/onboarding/onboarding-tasks.html#users) for contributing developers from the Account Owner or a super user
+*  [Magento authentication keys]({{ page.baseurl }}/install-gde/prereq/connect-auth.html) for each user who contributes to the project
 
 Your {{site.data.var.ee}} account must *authenticate* using any of the following:
 
-* GitHub
-* Bitbucket
-* Google
-* Create your own Cloud account
+*  GitHub
+*  Bitbucket
+*  Google
+*  Create your own Cloud account

--- a/guides/v2.2/cloud/setup/first-time-deploy.md
+++ b/guides/v2.2/cloud/setup/first-time-deploy.md
@@ -21,10 +21,10 @@ After fully setting up your local workspace, for **Pro** you should have the clo
 
 This initial push provides the following benefits:
 
-* Fully installs Magento in each environment
-* Allows the build/deploy scripts to use the `setup:upgrade` command instead of `setup:install` (important for adding extensions)
-* Pushes the Magento encryption key across all environments
-* Protects against errors and failures when installing with added modules and extensions
+*  Fully installs Magento in each environment
+*  Allows the build/deploy scripts to use the `setup:upgrade` command instead of `setup:install` (important for adding extensions)
+*  Pushes the Magento encryption key across all environments
+*  Protects against errors and failures when installing with added modules and extensions
 
   Not all extensions are correctly tested with the setup:install command and application modes. If you initially install Magento code with added 3rd party extensions or custom code, you may receive errors and build/deploy failures. By deploying the unmodified Magento template, all future deployments to Staging and Production typically do not encounter installation issues from 3rd party and custom code.
 
@@ -32,9 +32,9 @@ This initial push provides the following benefits:
 
 To deploy, you need the following:
 
-* A project with an unmodified {{site.data.var.ee}} template `master` branch (projects created using the import option may encounter issues)
-* Staging and Production environments provisioned
-* SSH access to Staging and Production environments
+*  A project with an unmodified {{site.data.var.ee}} template `master` branch (projects created using the import option may encounter issues)
+*  Staging and Production environments provisioned
+*  SSH access to Staging and Production environments
 
 ## Enter a ticket {#ticket}
 
@@ -64,20 +64,20 @@ If you prefer to use CLI for deploying, you will need to configure additional SS
 
 You'll need the SSH and Git with your project ID. The formats are as follows:
 
-* Git URL format:
+*  Git URL format:
 
-   * Staging: `git@git.ent.magento.cloud:<project ID>_stg.git`
-   * Production: `git@git.ent.magento.cloud:<project ID>.git`
+   *  Staging: `git@git.ent.magento.cloud:<project ID>_stg.git`
+   *  Production: `git@git.ent.magento.cloud:<project ID>.git`
 
-* SSH URL format:
+*  SSH URL format:
 
-   * Staging: `<project ID>_stg@<project ID>.ent.magento.cloud`
-   * Production: `<project ID>@<project ID>.ent.magento.cloud`
+   *  Staging: `<project ID>_stg@<project ID>.ent.magento.cloud`
+   *  Production: `<project ID>@<project ID>.ent.magento.cloud`
 
 As part of pushing the code, you may need to:
 
-* [Set up remote Git repos](#cloud-live-migrate-git)
-* [Set up the SSH agent](#cloud-live-migrate-agent) on environments
+*  [Set up remote Git repos](#cloud-live-migrate-git)
+*  [Set up the SSH agent](#cloud-live-migrate-agent) on environments
 
 After that is set up, you can SSH into the environment and use Git commands to push the branches.
 
@@ -118,11 +118,11 @@ To set up an SSH agent:
 
    One of the following messages displays:
 
-   * Working SSH agent: `2048 ab:de:56:94:e3:1e:71:c3:4f:df:e1:62:8d:29:a5:c0 /home/magento_user/.ssh/id_rsa (RSA)`
+   *  Working SSH agent: `2048 ab:de:56:94:e3:1e:71:c3:4f:df:e1:62:8d:29:a5:c0 /home/magento_user/.ssh/id_rsa (RSA)`
 
       Skip the next step and continue with step 4.
 
-   * SSH agent not started: `Could not open a connection to your authentication agent.`
+   *  SSH agent not started: `Could not open a connection to your authentication agent.`
 
       Continue with step 3.
 
@@ -152,8 +152,8 @@ For more information on setting up SSH, see [Enable SSH keys]({{ page.baseurl }}
 
 1. Open an SSH connection to your Staging or Production environment:
 
-   * Staging: `ssh -A <project ID>_stg@<project ID>.ent.magento.cloud`
-   * Production: `ssh -A <project ID>@<project ID>.ent.magento.cloud`
+   *  Staging: `ssh -A <project ID>_stg@<project ID>.ent.magento.cloud`
+   *  Production: `ssh -A <project ID>@<project ID>.ent.magento.cloud`
 
 1. Pull the `master` branch to the server.
 

--- a/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-first-steps.md
@@ -18,12 +18,12 @@ You can create a {{site.data.var.ece}} project from a blank template or by impor
 
 Before you begin, do the following:
 
-- Add the existing {{site.data.var.ee}} code to a Git repository. We recommend using [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html).
-- Set up your [local development environment]({{ page.baseurl }}/cloud/setup/first-time-setup.html).
-- Gather required information:
+-  Add the existing {{site.data.var.ee}} code to a Git repository. We recommend using [GitHub]({{ page.baseurl }}/cloud/integrations/github-integration.html).
+-  Set up your [local development environment]({{ page.baseurl }}/cloud/setup/first-time-setup.html).
+-  Gather required information:
 
-   - [SSH access link](#ssh) to the target environment
-   - [Database credentials](#db-creds)
+   -  [SSH access link](#ssh) to the target environment
+   -  [Database credentials](#db-creds)
 
 ### SSH access to cloud environments {#ssh}
 

--- a/guides/v2.2/cloud/setup/first-time-setup-import-import.md
+++ b/guides/v2.2/cloud/setup/first-time-setup-import-import.md
@@ -18,35 +18,35 @@ When you force push code from an existing Git branch to your {{site.data.var.ece
 
 You need the following information to import code into your project:
 
-- [Encryption key]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html) from your {{site.data.var.ee}} system
+-  [Encryption key]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html) from your {{site.data.var.ee}} system
 
-- SSH or HTTPS [URL](https://glossary.magento.com/url) for your {{site.data.var.ee}} installation Git repository.
+-  SSH or HTTPS [URL](https://glossary.magento.com/url) for your {{site.data.var.ee}} installation Git repository.
 
 ## Create a remote Git reference {#cloud-import-ref}
 
 Create a remote Git reference from your Cloud Git repository to the repository containing your {{site.data.var.ee}} installation so you can pull the {{site.data.var.ee}} code into your project.
 
-1.  Log in to your local {{site.data.var.ece}} development machine as, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
+1. Log in to your local {{site.data.var.ece}} development machine as, or switch to, the [Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html).
 
-1.  Copy `composer.json` to a _non-tracked directory_ so it does not get overwritten.
+1. Copy `composer.json` to a _non-tracked directory_ so it does not get overwritten.
 
     ```
     cp composer.json ../composer.json.cloud
     ```
 
-1.  Rename your Cloud Git remote from `origin` to `cloud-project` to make it clear which repository is which:
+1. Rename your Cloud Git remote from `origin` to `cloud-project` to make it clear which repository is which:
 
     ```
     git remote rename origin cloud-project
     ```
 
-1.  Add a remote upstream for your existing {{site.data.var.ee}} installation:
+1. Add a remote upstream for your existing {{site.data.var.ee}} installation:
 
     ```
     git remote add prev-project <git url>
     ```
 
-1.  Review the remote branch configuration.
+1. Review the remote branch configuration.
 
     ```
     git remote -v
@@ -63,13 +63,13 @@ Create a remote Git reference from your Cloud Git repository to the repository c
     prev-project    git@github.com:mygitusername/myeereponame.git (push)
     ```
 
-1.  Checkout the Cloud project `master` branch.
+1. Checkout the Cloud project `master` branch.
 
     ```
     magento-cloud environment:checkout master
     ```
 
-1.  Set the `cloud-project` branch as an upstream tracking branch for `master`.
+1. Set the `cloud-project` branch as an upstream tracking branch for `master`.
 
     ```
     git fetch cloud-project
@@ -80,19 +80,19 @@ Create a remote Git reference from your Cloud Git repository to the repository c
 
 After you have completed the git reference configuration, you can import the {{site.data.var.ee}} code.
 
-1.  Fetch the {{site.data.var.ee}} branch.
+1. Fetch the {{site.data.var.ee}} branch.
 
     ```
     git fetch prev-project
     ```
 
-1.  Reset your Cloud `master` branch to contain the code and the commit history of your {{site.data.var.ee}} branch.
+1. Reset your Cloud `master` branch to contain the code and the commit history of your {{site.data.var.ee}} branch.
 
     ```
     git reset --hard prev-project/<branch name>
     ```
 
-1.  Push code from your {{site.data.var.ee}} project to your {{site.data.var.ece}} project, overwriting the previous contents and commit history with that of your project.
+1. Push code from your {{site.data.var.ee}} project to your {{site.data.var.ece}} project, overwriting the previous contents and commit history with that of your project.
 
     ```
     git push -f cloud-project master
@@ -119,8 +119,8 @@ Before you can use your existing {{site.data.var.ee}} code in {{site.data.var.ec
 
 You need the following information to complete this task:
 
--   [SSH URL]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html#ssh) for the {{site.data.var.ece}} environment
--   The database name, username, and password for the [Cloud database]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html#db-creds)
+-  [SSH URL]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html#ssh) for the {{site.data.var.ece}} environment
+-  The database name, username, and password for the [Cloud database]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html#db-creds)
 
 {:.bs-callout .bs-callout-info}
 This topic discusses how to import the Integration environment database. The database connection information is different for Staging and Production environments.
@@ -129,33 +129,33 @@ When importing data, you will need to drop and create a new database. If you hav
 
 To drop and re-create the Cloud database:
 
-1.  SSH to the Integration environment.
+1. SSH to the Integration environment.
 
     ```
     magento-cloud ssh
     ```
 
-1.  Connect to the database.
+1. Connect to the database.
 
     ```
     mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
     ```
 
-1.  Drop the database. At the `MariaDB [main]>` prompt, enter:
+1. Drop the database. At the `MariaDB [main]>` prompt, enter:
 
     ```
     drop database main;
     ```
 
-1.  Re-create the database:
+1. Re-create the database:
 
     ```
     create database main;
     ```
 
-1.  At the `MariaDB [main]>` prompt, enter `exit`.
+1. At the `MariaDB [main]>` prompt, enter `exit`.
 
-1.  At the shell command prompt, enter the following command to re-create the database.
+1. At the shell command prompt, enter the following command to re-create the database.
 
     ```
     zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
@@ -175,19 +175,19 @@ The following example shows how to change _only_ the insecure URL but you can us
 
 To update the unsecure base URL:
 
-1.  If you haven't already done so, SSH to the Cloud integration server.
+1. If you haven't already done so, SSH to the Cloud integration server.
 
     ```
     magento-cloud ssh
     ```
 
-1.  Connect to the database.
+1. Connect to the database.
 
     ```
     mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
     ```
 
-1.  Show the contents of the `core_config_data` table.
+1. Show the contents of the `core_config_data` table.
 
     ```
     SELECT * from core_config_data;
@@ -195,7 +195,7 @@ To update the unsecure base URL:
 
     Note the `path` of `web/unsecure/base_url`; this is the value you'll change.
 
-1.  Enter the following command to change the value of `path` to your integration server's unsecure base URL:
+1. Enter the following command to change the value of `path` to your integration server's unsecure base URL:
 
     ```
     UPDATE core_config_data SET value='<Cloud unsecure base URL>' WHERE path='web/unsecure/base_url';
@@ -204,14 +204,14 @@ To update the unsecure base URL:
     {:.bs-callout .bs-callout-warning}
     The base URL _must_ end with a `/` character.
 
-1.  Confirm the change by entering the following command:
+1. Confirm the change by entering the following command:
 
     ```
     SELECT * from core_config_data;
     ```
 
-1.  If the change was successful, enter `exit` to exit the `[Maria DB]` prompt.
-1.  Continue with the next section.
+1. If the change was successful, enter `exit` to exit the `[Maria DB]` prompt.
+1. Continue with the next section.
 
 {:.bs-callout .bs-callout-info}
 For your system to be fully functional, you must also set unsecure and secure URLs for the default scope as well as for all websites, stores, and store views.
@@ -224,14 +224,14 @@ You copied the key in a [previous step]({{ page.baseurl }}/cloud/setup/first-tim
 
 To add your {{site.data.var.ee}} encryption key:
 
-1.  If you haven't done so already, SSH to the Cloud environment.
+1. If you haven't done so already, SSH to the Cloud environment.
 
     ```
     magento-cloud environment:ssh
     ```
 
-1.  Open `app/etc/env.php` in a text editor.
-1.  Replace the existing value of `key` with your [{{site.data.var.ee}} key]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html#encryption-key).
+1. Open `app/etc/env.php` in a text editor.
+1. Replace the existing value of `key` with your [{{site.data.var.ee}} key]({{ page.baseurl }}/cloud/setup/first-time-setup-import-prepare.html#encryption-key).
 
     ```php
     return array (
@@ -242,7 +242,7 @@ To add your {{site.data.var.ee}} encryption key:
     );
     ```
 
-1.  Save your changes to `env.php` and exit the text editor.
+1. Save your changes to `env.php` and exit the text editor.
 
     {:.bs-callout .bs-callout-info}
     You must add this key to the `env.php` file for all environments: Integration, Staging, and Production.
@@ -251,19 +251,19 @@ To add your {{site.data.var.ee}} encryption key:
 
 To import media files into your Cloud environment:
 
-1.  If you haven't done so already, SSH to the Cloud environment.
+1. If you haven't done so already, SSH to the Cloud environment.
 
     ```
     magento-cloud ssh -p <project ID> -e <environment ID>
     ```
 
-1.  Enter the following command to clear existing media files:
+1. Enter the following command to clear existing media files:
 
     ```
     rm -rf pub/media/*
     ```
 
-1.  Enter the following command to extract the media files to the `pub/media` directory:
+1. Enter the following command to extract the media files to the `pub/media` directory:
 
     ```
     tar -xzf var/media.tgz pub/media
@@ -291,14 +291,14 @@ After the [cache](https://glossary.magento.com/cache) flushes, enter `exit` to c
 
 To verify everything imported properly, perform the following tasks in your local Cloud development environment:
 
-1.  On your Cloud environment, enter the following commands to find the information to log in to the [Magento Admin](https://glossary.magento.com/magento-admin) and to view the storefront:
+1. On your Cloud environment, enter the following commands to find the information to log in to the [Magento Admin](https://glossary.magento.com/magento-admin) and to view the storefront:
 
     ```
     magento-cloud environment:url
     ```
 
-1.  Log in to the Magento [Admin](https://glossary.magento.com/admin) using the username and password of your {{site.data.var.ee}} system.
-1.  Verify that the settings in the Admin are the same as your {{site.data.var.ee}} system.
-1.  Access the [storefront](https://glossary.magento.com/storefront).
-1.  Confirm that categories, products, and other content display as expected.
-1.  Test everything thoroughly.
+1. Log in to the Magento [Admin](https://glossary.magento.com/admin) using the username and password of your {{site.data.var.ee}} system.
+1. Verify that the settings in the Admin are the same as your {{site.data.var.ee}} system.
+1. Access the [storefront](https://glossary.magento.com/storefront).
+1. Confirm that categories, products, and other content display as expected.
+1. Test everything thoroughly.

--- a/guides/v2.2/cloud/setup/first-time-setup.md
+++ b/guides/v2.2/cloud/setup/first-time-setup.md
@@ -38,12 +38,12 @@ You can use the Docker environment to emulate the {{site.data.var.ece}} Integrat
 
 You can manually add a virtual machine (VM) and install {{site.data.var.ee}}. The environment closely matches the cloud environments. The following steps walk-through manually preparing your local environment, installing Magento, and starting development:
 
-1.  [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
-1.  [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
-1.  [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)
-1.  [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html) (optional)
-1.  [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)
-1.  [Install Magento]({{ page.baseurl }}/cloud/before/before-setup-env-install.html)
-1.  [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html)
+1. [Prepare for local environment setup]({{ page.baseurl }}/cloud/before/before-workspace.html)
+1. [Install Magento prerequisites]({{ page.baseurl }}/cloud/before/before-workspace-magento-prereqs.html)
+1. [Enable SSH keys]({{ page.baseurl }}/cloud/before/before-workspace-ssh.html)
+1. [Set up the Magento file system owner]({{ page.baseurl }}/cloud/before/before-workspace-file-sys-owner.html) (optional)
+1. [Clone and branch the project]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html)
+1. [Install Magento]({{ page.baseurl }}/cloud/before/before-setup-env-install.html)
+1. [First time deployment]({{ page.baseurl }}/cloud/setup/first-time-deploy.html)
 
 You can import existing Magento custom code. See [First steps for importing {{site.data.var.ee}}]({{ page.baseurl }}/cloud/setup/first-time-setup-import-first-steps.html).

--- a/guides/v2.2/cloud/trouble/reset-cron-jobs.md
+++ b/guides/v2.2/cloud/trouble/reset-cron-jobs.md
@@ -12,9 +12,9 @@ Sometimes, Magento cron jobs do not finish executing and persist in a `running` 
 
 Symptoms of cron jobs that must be reset include:
 
-*   Large quantity of jobs appear in the `cron_schedule` queue
-*   Site performance starts to degrade
-*   Jobs fail to execute on schedule
+*  Large quantity of jobs appear in the `cron_schedule` queue
+*  Site performance starts to degrade
+*  Jobs fail to execute on schedule
 
 ## Solution
 
@@ -23,35 +23,35 @@ To resolve this issue, you must reset the cron job(s) using the `cron:unlock` co
 {:.bs-callout .bs-callout-warning}
 Running this command without the `--job-code` option resets _all_ cron jobs, including those currently running, so we recommend using it only in exceptional cases, such as after you have verified that all cron jobs must be reset. Re-deployment runs this command by default to reset cron jobs, so they recover appropriately after the environment is back up. Avoid using this solution when indexers are running.
 
-1.  Open a terminal and use your [SSH]({{ page.baseurl }}/cloud/env/environments-ssh.html#ssh) keys to connect to the affected environment.
+1. Open a terminal and use your [SSH]({{ page.baseurl }}/cloud/env/environments-ssh.html#ssh) keys to connect to the affected environment.
 
-1.  Get the MySQL database credentials:
+1. Get the MySQL database credentials:
 
     ```shell
     echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | json_pp
     ```
 
-1.  Connect to the database using `mysql`:
+1. Connect to the database using `mysql`:
 
     ```shell
     mysql -hdatabase.internal -uuser -ppassword main
     ```
 
-1.  Select the `main` database:
+1. Select the `main` database:
 
     ```shell
     use main
     ```
 
-1.  Find all running cron jobs:
+1. Find all running cron jobs:
 
     ```shell
     SELECT * FROM cron_schedule WHERE status = 'running';
     ```
 
-1.  Copy the `schedule_id` of any job running longer than usual.
+1. Copy the `schedule_id` of any job running longer than usual.
 
-1.  Use the schedule IDs from the previous step to unlock specific cron jobs:
+1. Use the schedule IDs from the previous step to unlock specific cron jobs:
 
     ```shell
     ./vendor/bin/ece-tools cron:unlock --job-code=<schedule_id> --job-code=<schedule_id>

--- a/guides/v2.2/cloud/trouble/site-availability.md
+++ b/guides/v2.2/cloud/trouble/site-availability.md
@@ -30,8 +30,8 @@ Static content deployment in the build phase also reduces downtime. The deploy p
 
 ### Symptoms
 
-- Your site is not functioning at all. HTTP requests result in 50x errors.
-- Your site is functioning normally, but fails to refresh static assets.
+-  Your site is not functioning at all. HTTP requests result in 50x errors.
+-  Your site is functioning normally, but fails to refresh static assets.
 
 ### Solution
 

--- a/guides/v2.2/cloud/trouble/theme-troubleshooting.md
+++ b/guides/v2.2/cloud/trouble/theme-troubleshooting.md
@@ -13,15 +13,15 @@ This issue can occur in all environments during any deployment.
 
 To resolve, you need the SSH information and store URL available through the [Project Web Interface]({{ page.baseurl }}/cloud/project/projects.html) or your noted access.
 
-1.  Open a terminal application.
-1.  [Checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) that corresponds to the environment where you are experiencing the issue.
-1.  Regenerate the image cache:
+1. Open a terminal application.
+1. [Checkout a branch]({{ page.baseurl }}/cloud/before/before-setup-env-2_clone.html#branch) that corresponds to the environment where you are experiencing the issue.
+1. Regenerate the image cache:
 
     ```bash
     php bin/magento catalog:images:resize
     ```
 
-1.  Test the category pages through the store URL.
+1. Test the category pages through the store URL.
 
 ## Locate blocks in themes that make them uncacheable {#uncache}
 

--- a/guides/v2.2/cloud/trouble/trouble.md
+++ b/guides/v2.2/cloud/trouble/trouble.md
@@ -8,10 +8,10 @@ functional_areas:
 
 The troubleshooting topics help to resolve specific issues with your {{site.data.var.ece}} project. Before submitting a Support ticket, check the following:
 
-- Verify your [credentials]({{ page.baseurl }}/cloud/trouble/trouble_ce-creds.html)
-- Review the [log files]({{ page.baseurl }}/cloud/live/stage-prod-test.html)
-- Search for relevant content in the {{site.data.var.ece}} documentation
-- Search the [Magento Help Center](https://support.magento.com/hc/en-us) troubleshooting articles, FAQ, and Tech resources
+-  Verify your [credentials]({{ page.baseurl }}/cloud/trouble/trouble_ce-creds.html)
+-  Review the [log files]({{ page.baseurl }}/cloud/live/stage-prod-test.html)
+-  Search for relevant content in the {{site.data.var.ece}} documentation
+-  Search the [Magento Help Center](https://support.magento.com/hc/en-us) troubleshooting articles, FAQ, and Tech resources
 
 If you still require technical support, you can create a Support ticket through the Project Web Interface:
 

--- a/guides/v2.2/cloud/trouble/trouble_comp-deploy-fail.md
+++ b/guides/v2.2/cloud/trouble/trouble_comp-deploy-fail.md
@@ -14,8 +14,8 @@ This topic discusses how to recover from a failed component deployment. Typical 
 
 You can recover from a failed deployment in any of the following ways:
 
-*   [Restore a snapshot]({{ page.baseurl }}/cloud/project/project-webint-snap.html) if you have one
-*   Remove the component from your environment's `composer.json` and redeploy the environment
+*  [Restore a snapshot]({{ page.baseurl }}/cloud/project/project-webint-snap.html) if you have one
+*  Remove the component from your environment's `composer.json` and redeploy the environment
 
 ## Remove the component from `composer.json` and redeploy
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/cloud` folder.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
