### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - coding-standards

### DIFF
--- a/guides/v2.2/coding-standards/bk-coding-standards.md
+++ b/guides/v2.2/coding-standards/bk-coding-standards.md
@@ -16,11 +16,11 @@ Like many large projects, Magento has coding standards.
 
 Use Magento's coding standards when you contribute to Magento's codebase or create extensions.
 
-- [Code demarcation standard]({{ page.baseurl }}/coding-standards/code-standard-demarcation.html)
-- [PHP coding standard]({{ page.baseurl }}/coding-standards/code-standard-php.html)
-- [JavaScript coding standard]({{ page.baseurl }}/coding-standards/code-standard-javascript.html)
-- [jQuery widget coding standard]({{ page.baseurl }}/coding-standards/code-standard-jquery-widgets.html)
-- [DocBlock standard]({{ page.baseurl }}/coding-standards/docblock-standard-general.html)
-- [JavaScript DocBlock standard]({{ page.baseurl }}/coding-standards/docblock-standard-javascript.html)
-- [LESS coding standard]({{ page.baseurl }}/coding-standards/code-standard-less.html)
-- [HTML style guide]({{ page.baseurl }}/coding-standards/code-standard-html.html)
+-  [Code demarcation standard]({{ page.baseurl }}/coding-standards/code-standard-demarcation.html)
+-  [PHP coding standard]({{ page.baseurl }}/coding-standards/code-standard-php.html)
+-  [JavaScript coding standard]({{ page.baseurl }}/coding-standards/code-standard-javascript.html)
+-  [jQuery widget coding standard]({{ page.baseurl }}/coding-standards/code-standard-jquery-widgets.html)
+-  [DocBlock standard]({{ page.baseurl }}/coding-standards/docblock-standard-general.html)
+-  [JavaScript DocBlock standard]({{ page.baseurl }}/coding-standards/docblock-standard-javascript.html)
+-  [LESS coding standard]({{ page.baseurl }}/coding-standards/code-standard-less.html)
+-  [HTML style guide]({{ page.baseurl }}/coding-standards/code-standard-html.html)

--- a/guides/v2.2/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.2/coding-standards/code-standard-demarcation.md
@@ -105,21 +105,21 @@ The following list will help you make a distinction between the actual meaning o
 
 **Content (Semantics)** includes:
 
-- logic
-- information
-- data
-- model
-- outline
-- message
+-  logic
+-  information
+-  data
+-  model
+-  outline
+-  message
 
 **Presentation** includes:
 
-- aesthetic
-- graphics
-- design
-- style
-- visualization
-- view
+-  aesthetic
+-  graphics
+-  design
+-  style
+-  visualization
+-  view
 
 ### You must use semantic HTML markup only, and must not use presentation markup.
 
@@ -180,9 +180,9 @@ include note.html
 type='info'
 content='Exception: CSS attributes where values must be calculated beyond the css-topics/LESS code.
 
-- Simplifies change of the default look and feel by adding CSS classes to and removing them from elements.
-- Improves style extensibility.
-- Reduces long-term maintenance efforts by containing CSS styles in a single place.'
+-  Simplifies change of the default look and feel by adding CSS classes to and removing them from elements.
+-  Improves style extensibility.
+-  Reduces long-term maintenance efforts by containing CSS styles in a single place.'
 
 %}
 
@@ -362,7 +362,7 @@ $fieldset->addField('new_category_parent', 'text', array(
 ### You must not hard-code inline JavaScript in PHP classes
 
 -  Reduces long term maintenance by having frontend business logic stored in one place.
-- Reduces the number of files to be modified.
+-  Reduces the number of files to be modified.
 
 **Acceptable PHP file**
 

--- a/guides/v2.2/coding-standards/code-standard-html.md
+++ b/guides/v2.2/coding-standards/code-standard-html.md
@@ -17,9 +17,9 @@ The guide is based on the [Google HTML/CSS Style Guide](https://google.github.io
 
 Use only spaces for indentation:
 
-* Tab size: 4 spaces
-* Indent size: 4 spaces
-* Continuation indent: 4 spaces
+*  Tab size: 4 spaces
+*  Indent size: 4 spaces
+*  Continuation indent: 4 spaces
 
 **Recommended**
 

--- a/guides/v2.2/coding-standards/code-standard-javascript.md
+++ b/guides/v2.2/coding-standards/code-standard-javascript.md
@@ -21,8 +21,8 @@ Use [ESLint][eslint] and [JSCS][jscs] to ensure the quality of your JavaScript c
 ESLint is a community-driven tool that detects errors and potential problems in JavaScript code.
 It can use custom rules to enforce specific coding standards.
 
-* [Magento ESLint Rules][eslint-rules]
-* [Magento JSCS Rules][jscs-rules]
+*  [Magento ESLint Rules][eslint-rules]
+*  [Magento JSCS Rules][jscs-rules]
 
 ## Additional formatting standards
 
@@ -90,9 +90,9 @@ Use sparingly and in general where required by the syntax and semantics.
 
 Never use parentheses for:
 
-* Unary operators (e.g. `delete`, `typeof`, and `void`)
-* After keywords such as `return`, `throw`
-* For `case`, `in`, or `new`, and others keywords like them
+*  Unary operators (e.g. `delete`, `typeof`, and `void`)
+*  After keywords such as `return`, `throw`
+*  For `case`, `in`, or `new`, and others keywords like them
 
 ### Blocks
 
@@ -187,21 +187,21 @@ var msg = '<span class="text">Hello World!</div>';
 
 ### General naming conventions
 
-* Avoid underscores and numbers in names.
-* Variables or methods should have names that accurately describe their purpose or behavior.
-* Object methods or variables that are declared `private` or `protected` should start with an underscore(`_`).
+*  Avoid underscores and numbers in names.
+*  Variables or methods should have names that accurately describe their purpose or behavior.
+*  Object methods or variables that are declared `private` or `protected` should start with an underscore(`_`).
 
 ### Functions and methods
 
-* Class method names should start with an English verb in its infinitive form that describes the method.
-* Names for accessors for instance or static variables should always have the `get` or `set` prefix.
-* In [design pattern](https://glossary.magento.com/design-pattern) classes, implementation method names should contain the pattern name where practical to provide better behavior description.
-* Methods that return status flags or Boolean values should have the `has` or `is` prefix.
+*  Class method names should start with an English verb in its infinitive form that describes the method.
+*  Names for accessors for instance or static variables should always have the `get` or `set` prefix.
+*  In [design pattern](https://glossary.magento.com/design-pattern) classes, implementation method names should contain the pattern name where practical to provide better behavior description.
+*  Methods that return status flags or Boolean values should have the `has` or `is` prefix.
 
 ### Variables and properties
 
-* Do not use short variable names such as `i` or `n` except in small loop contexts
-* If a loop contains more than 20 lines of code, the index variables should have more descriptive names.
+*  Do not use short variable names such as `i` or `n` except in small loop contexts
+*  If a loop contains more than 20 lines of code, the index variables should have more descriptive names.
 
 ## Additional coding construct standards
 

--- a/guides/v2.2/coding-standards/code-standard-less.md
+++ b/guides/v2.2/coding-standards/code-standard-less.md
@@ -21,9 +21,9 @@ This coding standard is optional for third-party Magento developers.
 
 Use only spaces for indentation:
 
-* Tab size: 4 spaces
-* Indent size: 4 spaces
-* Continuation indent: 4 spaces
+*  Tab size: 4 spaces
+*  Indent size: 4 spaces
+*  Continuation indent: 4 spaces
 
 **Correct**:
 
@@ -611,9 +611,9 @@ margin-left: 0.5rem;
 
 ### Hexadecimal notation
 
-* Use lowercase only.
-* Use three-character hexadecimal notation where possible.
-* Avoid using hexadecimal values for color in properties, use only variables instead.
+*  Use lowercase only.
+*  Use three-character hexadecimal notation where possible.
+*  Avoid using hexadecimal values for color in properties, use only variables instead.
 
 **Correct**:
 

--- a/guides/v2.2/coding-standards/code-standard-php.md
+++ b/guides/v2.2/coding-standards/code-standard-php.md
@@ -13,16 +13,16 @@ The Magento core development team uses the [Magento Coding Standard](https://git
 
 The Magento Coding Standard provides a set of rules that covers the following:
 
-* [PSR-1]{:target="_blank"} and [PSR-2]{:target="_blank"} compliance
-* The use of insecure functions
-* Unescaped output
-* The use of deprecated PHP functions
-* PHP code syntax
-* Naming convention
-* The use of PHP superglobals
-* Empty code blocks
-* Improper exception handling
-* Raw SQL queries and many other general PHP and Magento-specific code issues.
+*  [PSR-1]{:target="_blank"} and [PSR-2]{:target="_blank"} compliance
+*  The use of insecure functions
+*  Unescaped output
+*  The use of deprecated PHP functions
+*  PHP code syntax
+*  Naming convention
+*  The use of PHP superglobals
+*  Empty code blocks
+*  Improper exception handling
+*  Raw SQL queries and many other general PHP and Magento-specific code issues.
 
 ### Coding standard compliance
 
@@ -38,10 +38,10 @@ Learn more about using rule sets with PHP CodeSniffer [ruleset]{:target="_blank"
 For class name resolution, use the [`::class`](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class){:target="_blank"} [keyword](https://glossary.magento.com/keyword) instead of a string literal for every class name reference outside of that class.
 This includes references to:
 
-* Fully qualified class name
-* Imported/non-imported class name
-* [Namespace](https://glossary.magento.com/namespace) relative class name
-* Import relative class name
+*  Fully qualified class name
+*  Imported/non-imported class name
+*  [Namespace](https://glossary.magento.com/namespace) relative class name
+*  Import relative class name
 
 Examples:
 

--- a/guides/v2.2/coding-standards/docblock-standard-javascript.md
+++ b/guides/v2.2/coding-standards/docblock-standard-javascript.md
@@ -28,9 +28,9 @@ It is recommended to avoid sentence fragments in documentation blocks. Use sente
 
 JSDoc comments requirements:
 
-* A JSDoc comment should begin with a slash (/) and two asterisks (*).
-* Inline tags should be enclosed in braces: `{ @code this }`.
-* `@desc` Block tags should always start on their own line.
+*  A JSDoc comment should begin with a slash (/) and two asterisks (*).
+*  Inline tags should be enclosed in braces: `{ @code this }`.
+*  `@desc` Block tags should always start on their own line.
 
 Example:
 

--- a/guides/v2.2/coding-standards/technical-vision/index.md
+++ b/guides/v2.2/coding-standards/technical-vision/index.md
@@ -13,5 +13,5 @@ Technical vision documents are targeting architects and developers to **guide** 
 
 In contrast,
 
-* **specifications** are documents that describe current implementation of the system. Though they are also targeting architects and developers, they help with initial investigation, but may be insufficient to make decisions that improve the system.
-* **Technical Guidelines** is a low-level document that provides specific recommendations for a developer in their every day work.
+*  **specifications** are documents that describe current implementation of the system. Though they are also targeting architects and developers, they help with initial investigation, but may be insufficient to make decisions that improve the system.
+*  **Technical Guidelines** is a low-level document that provides specific recommendations for a developer in their every day work.

--- a/guides/v2.2/coding-standards/technical-vision/webapi.md
+++ b/guides/v2.2/coding-standards/technical-vision/webapi.md
@@ -77,8 +77,8 @@ Any new design related to Web API must satisfy the following constraints to keep
 1. Authentication must be done via `\Magento\Authorization\Model\UserContextInterface`.
 1. Customer-specific identifiers (such as customer ID or cart ID) must be deducted from the record of the successfully authenticated customer. They must not be accepted via request parameters.
 1. All new web API endpoints must be covered with web API functional tests.
-    * For REST and SOAP, by default, the same test will be executed in the scope of different continuous integration jobs. The base class for REST and SOAP tests is `\Magento\TestFramework\TestCase\WebapiAbstract`
-    * The base class for GraphQL tests is: `\Magento\TestFramework\TestCase\GraphQlAbstract`
+    *  For REST and SOAP, by default, the same test will be executed in the scope of different continuous integration jobs. The base class for REST and SOAP tests is `\Magento\TestFramework\TestCase\WebapiAbstract`
+    *  The base class for GraphQL tests is: `\Magento\TestFramework\TestCase\GraphQlAbstract`
 1. Web API requests must be processed by custom front controllers with optimized routing to prevent the admin and storefront areas from executing routers.
 1. Web API schema should be strictly typed. (All complex types should eventually be resolved to scalar types.)
 1. Authentication parameters must be passed via headers.

--- a/guides/v2.3/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.3/coding-standards/code-standard-demarcation.md
@@ -17,10 +17,10 @@ Some parts of Magento code might not comply with the standard, but we are workin
 
 The standard was developed in the scope of our efforts to ensure the following:
 
-- Decouple visual (CSS) layer from the functional (JavaScript) layer.
-- Decouple functional (JavaScript) layer from the [markup](https://glossary.magento.com/markup) (HTML).
-- Reinstate emphasis on using of [jQuery](https://glossary.magento.com/jquery) templates.
-- Reinstate emphasis on decoupling HTML, [CSS](https://glossary.magento.com/css) and JS from [PHP](https://glossary.magento.com/php) classes.
+-  Decouple visual (CSS) layer from the functional (JavaScript) layer.
+-  Decouple functional (JavaScript) layer from the [markup](https://glossary.magento.com/markup) (HTML).
+-  Reinstate emphasis on using of [jQuery](https://glossary.magento.com/jquery) templates.
+-  Reinstate emphasis on decoupling HTML, [CSS](https://glossary.magento.com/css) and JS from [PHP](https://glossary.magento.com/php) classes.
 
 Use [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt) to interpret the "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" keywords.
 
@@ -28,7 +28,7 @@ Use [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt) to interpret the "MUST," "MU
 
 ### For attribute names and values you must use meaningful unabbreviated lowercase words comprised of Latin characters concatenated with a hyphen (`-`)
 
-- Helps simplify and unify naming conventions that are used to apply visual styles to page elements.
+-  Helps simplify and unify naming conventions that are used to apply visual styles to page elements.
 
 **Acceptable**
 
@@ -56,8 +56,8 @@ Use [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt) to interpret the "MUST," "MU
 
 ### Semantic representation may rely on ID attribute
 
-- Forces engineers to think about reusable page components instead of unique singleton components.
-- Reduces long-term maintenance efforts.
+-  Forces engineers to think about reusable page components instead of unique singleton components.
+-  Reduces long-term maintenance efforts.
 
 **Acceptable [PHTML](https://glossary.magento.com/phtml) template**
 
@@ -109,21 +109,21 @@ The following list will help you make a distinction between the actual meaning o
 
 **Content (Semantics)** includes:
 
-- logic
-- information
-- data
-- model
-- outline
-- message
+-  logic
+-  information
+-  data
+-  model
+-  outline
+-  message
 
 **Presentation** includes:
 
-- aesthetic
-- graphics
-- design
-- style
-- visualization
-- view
+-  aesthetic
+-  graphics
+-  design
+-  style
+-  visualization
+-  view
 
 ### You must use semantic HTML markup only, and must not use presentation markup
 
@@ -147,10 +147,10 @@ The following list will help you make a distinction between the actual meaning o
 
 As the first option, you are required to use [HTML](https://glossary.magento.com/html) class attributes. In case this option is not applicable then it is recommended to use HTML tags and form element's type attribute.
 
-- Enforces clean, strict separation between visual and business logic layers.
-- Allows [frontend](https://glossary.magento.com/frontend) and [backend](https://glossary.magento.com/backend) teams to work independently.
-- Allows changing look and feel without affecting business functionality, and vice versa.
-- Enables frontend teams to clean up old styles quickly and easily when refactoring.
+-  Enforces clean, strict separation between visual and business logic layers.
+-  Allows [frontend](https://glossary.magento.com/frontend) and [backend](https://glossary.magento.com/backend) teams to work independently.
+-  Allows changing look and feel without affecting business functionality, and vice versa.
+-  Enables frontend teams to clean up old styles quickly and easily when refactoring.
 
 **Acceptable CSS selectors**
 
@@ -184,9 +184,9 @@ include note.html
 type='info'
 content='Exception: CSS attributes where values must be calculated beyond the css-topics/LESS code.
 
-- Simplifies change of the default look and feel by adding CSS classes to and removing them from elements.
-- Improves style extensibility.
-- Reduces long-term maintenance efforts by containing CSS styles in a single place.'
+-  Simplifies change of the default look and feel by adding CSS classes to and removing them from elements.
+-  Improves style extensibility.
+-  Reduces long-term maintenance efforts by containing CSS styles in a single place.'
 
 %}
 
@@ -221,9 +221,9 @@ this.element.on('click', function() {
 
 ### You must not use inline CSS styles inside HTML tags
 
-- Improves style extensibility allowing engineers to overload styles easier by toggling classes.
-- Enforces clean, strict separation between visual presentation and markup.
-- Enables frontend teams quickly and easily clean up old styles.
+-  Improves style extensibility allowing engineers to overload styles easier by toggling classes.
+-  Enforces clean, strict separation between visual presentation and markup.
+-  Enables frontend teams quickly and easily clean up old styles.
 
 **Acceptable PHTML template**
 
@@ -241,9 +241,9 @@ this.element.on('click', function() {
 
 ### Business logic must rely on only the form, form element name attributes, or data attributes
 
-- Enforces clean, strict separation between visual and business logic layers.
-- Allows frontend and backend teams to work independently.
-- Allows changing business logic without affecting styling and vice versa.
+-  Enforces clean, strict separation between visual and business logic layers.
+-  Allows frontend and backend teams to work independently.
+-  Allows changing business logic without affecting styling and vice versa.
 
 **Acceptable PHTML template**
 
@@ -307,7 +307,7 @@ HTML helper class names added in JavaScript REQUIRE underscore symbol ("_") at t
 
 ### You must not select DOM elements based on HTML structure
 
-- Allows frontend teams to modify markup and themes without affecting business logic.
+-  Allows frontend teams to modify markup and themes without affecting business logic.
 
 **Acceptable JavaScript file**
 
@@ -325,17 +325,17 @@ this.element.parent().find('[data-action="edit"]').data('entity_id');
 
 ### You must use jQuery templates to insert recurring markup into DOM structure
 
-- Reinstates emphasis on jQuery templates. For more information, see JavaScript Coding Best Practices.
-- Reduces long-term maintenance efforts by having markup code stored in one place.
-- Simplifies frontend debugging efforts.
+-  Reinstates emphasis on jQuery templates. For more information, see JavaScript Coding Best Practices.
+-  Reduces long-term maintenance efforts by having markup code stored in one place.
+-  Simplifies frontend debugging efforts.
 
 ## PHTML templates and PHP files
 
 ### You must not hard-code inline CSS styles in PHP classes
 
-- Reduces long-term maintenance efforts by having styles stored in one place.
-- Simplifies debugging and reduces number of files to be modified.
-- Makes styles more extensible and easier to override when needed.
+-  Reduces long-term maintenance efforts by having styles stored in one place.
+-  Simplifies debugging and reduces number of files to be modified.
+-  Makes styles more extensible and easier to override when needed.
 
 **Acceptable PHP file**
 
@@ -365,8 +365,8 @@ $fieldset->addField('new_category_parent', 'text', array(
 
 ### You must not hard-code inline JavaScript in PHP classes
 
-- Reduces long term maintenance by having frontend business logic stored in one place.
-- Reduces the number of files to be modified.
+-  Reduces long term maintenance by having frontend business logic stored in one place.
+-  Reduces the number of files to be modified.
 
 **Acceptable PHP file**
 
@@ -425,8 +425,8 @@ jQuery('#{$htmlId}-suggest').treeSuggest({$selectorOptions});
 
 ### You must not hard-code HTML markup (used in the `<body>` tag) in PHP classes
 
-- Reduces long-term maintenance efforts by having markup stored in one place.
-- Reduces the number of files to be modified.
+-  Reduces long-term maintenance efforts by having markup stored in one place.
+-  Reduces the number of files to be modified.
 
 **Acceptable PHP file**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folders:
- `guides/v2.2/coding-standards`
- `guides/v2.3/coding-standards`


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
