### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - comp-mgr

### DIFF
--- a/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
+++ b/guides/v2.2/comp-mgr/bk-compman-upgrade-guide.md
@@ -14,29 +14,29 @@ functional_areas:
 
 This topic discusses the ways you can:
 
-* Upgrade (that is, *patch*) the Magento software from version {{ page.guide_version }}.0 to {{ page.guide_version }}.1, for example
-* Update any of the following:
+*  Upgrade (that is, *patch*) the Magento software from version {{ page.guide_version }}.0 to {{ page.guide_version }}.1, for example
+*  Update any of the following:
 
-   * Modules (also referred to as *extensions*; extend Magento capabilities)
-   * Themes (change the look and feel of your storefront and Admin)
-   * Language packages (localize the storefront and Admin)
+   *  Modules (also referred to as *extensions*; extend Magento capabilities)
+   *  Themes (change the look and feel of your storefront and Admin)
+   *  Language packages (localize the storefront and Admin)
 
-* Uninstall extensions
+*  Uninstall extensions
 
 ## Upgrade the Magento application
 
 The way you upgrade (that is, patch) the Magento application depends on how you installed it:
 
-* {{ce}} and {{ee}}: If you used [Composer] to install the Magento application or if you downloaded an [archive], use the [System Upgrade utility] or the [command line].
-* {{ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{ce}} codebase, [upgrade the software manually].
-* If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
-   * For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
+*  {{ce}} and {{ee}}: If you used [Composer] to install the Magento application or if you downloaded an [archive], use the [System Upgrade utility] or the [command line].
+*  {{ce}} only: If you cloned the Magento 2 GitHub repository because you are contributing code to the {{ce}} codebase, [upgrade the software manually].
+*  If your Magento root directory is `<your Magento install directory/pub>`, you can upgrade in any of the following ways:
+   *  For the upgrade, create another subdomain or docroot that uses the Magento installation directory as its root.
 
    Run the System Upgrade utility as discussed in this topic using that subdomain or docroot.
 
-   * Upgrade the Magento software using the [command line].
+   *  Upgrade the Magento software using the [command line].
 
-* To upgrade from {{ce}} to {{ee}}, see [Upgrade from Open Source to Commerce].
+*  To upgrade from {{ce}} to {{ee}}, see [Upgrade from Open Source to Commerce].
 
 {: .bs-callout-info }
 __System upgrade__ refers to updating the Magento 2.x core modules and other installed modules.

--- a/guides/v2.2/comp-mgr/extens-man/extensman-backup.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-backup.md
@@ -18,7 +18,7 @@ Related topics
 
 After your backup is complete, continue with any of the following:
 
-* Installing extensions: [Step 3. Install]({{ page.baseurl }}/comp-mgr/extens-man/extensman-new-purchase.html)
-* Updating extensions: [Step 3. Extension Update]({{ page.baseurl }}/comp-mgr/extens-man/extensman-update.html)
-* Uninstalling extensions: [Step 3. Data Option]({{ page.baseurl }}/comp-mgr/extens-man/extensman-uninst-data.html)
+*  Installing extensions: [Step 3. Install]({{ page.baseurl }}/comp-mgr/extens-man/extensman-new-purchase.html)
+*  Updating extensions: [Step 3. Extension Update]({{ page.baseurl }}/comp-mgr/extens-man/extensman-update.html)
+*  Uninstalling extensions: [Step 3. Data Option]({{ page.baseurl }}/comp-mgr/extens-man/extensman-uninst-data.html)
 

--- a/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-checklist.md
@@ -13,9 +13,9 @@ functional_areas:
 
 The [Extension](https://glossary.magento.com/extension) Manager enables you to install, uninstall, and update extensions, including those you purchase from Magento Marketplace. The term *extension* means:
 
-* Modules (extend Magento capabilities)
-* Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
-* Language packages (localize the storefront and Admin)
+*  Modules (extend Magento capabilities)
+*  Themes (change the look and feel of your [storefront](https://glossary.magento.com/storefront) and Admin)
+*  Language packages (localize the storefront and Admin)
 
 {: .bs-callout-warning }
 If you installed the Magento application by [cloning the GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html), you *cannot* use the Extension Manager to update components. Instead, you must [update them manually]({{ page.baseurl }}/install-gde/install/cli/dev_options.html).

--- a/guides/v2.2/comp-mgr/extens-man/extensman-main-pg.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-main-pg.md
@@ -34,10 +34,10 @@ You must use the same authentication keys you used to install the Magento softwa
 
 See one of the following sections:
 
-* [Choose what to install, uninstall, or update](#extens-choose)
-* [Install extensions](#extensman-install)
-* [Uninstall extensions](#extensman-uninstall)
-* [Update extensions](#extensman-update)
+*  [Choose what to install, uninstall, or update](#extens-choose)
+*  [Install extensions](#extensman-install)
+*  [Uninstall extensions](#extensman-uninstall)
+*  [Update extensions](#extensman-update)
 
 ## Choose what to install, uninstall, or update {#extens-choose}
 
@@ -45,9 +45,9 @@ After you log in to the Extension Manager, a list displays as follows:
 
 ![Choose what to install, update, or uninstall]({{ site.baseurl }}/common/images/extens_mgr_updates.png){:width="500px"}
 
-* **Updates Available** displays the number of extensions you can update.
-* **Extensions Ready to Install** displays the number of extensions you can install.
-* **Last Refresh** displays the last time you refreshed the list of extensions on Magento Marketplace.
+*  **Updates Available** displays the number of extensions you can update.
+*  **Extensions Ready to Install** displays the number of extensions you can install.
+*  **Last Refresh** displays the last time you refreshed the list of extensions on Magento Marketplace.
 
    Click **Refresh** to update the information, such as after you purchase new extensions.
 
@@ -63,18 +63,18 @@ The following figure shows how types display in the Extension Manager.
 
 Following is a definition of types:
 
-* `module` for a module (that is, PHP code that modifies Magento behavior)
-* `language` for a language package used to translate the Magento storefront and Admin
-* `theme` for a collection of styles that affect the look of the storefront or Admin
-* `library` for a library&mdash;such as a shared third-party library
-* `component` for any type of component that must be installed in the Magento root directory (this is a relatively uncommon type)
+*  `module` for a module (that is, PHP code that modifies Magento behavior)
+*  `language` for a language package used to translate the Magento storefront and Admin
+*  `theme` for a collection of styles that affect the look of the storefront or Admin
+*  `library` for a library&mdash;such as a shared third-party library
+*  `component` for any type of component that must be installed in the Magento root directory (this is a relatively uncommon type)
 
 Actions are further divided between those available for *metapackages* (that is, an installable package that contains a group of different types) or *non-metapackages* (that is, a single type).
 
 The following sections provide details:
 
-* [Actions available for non-metapackages](#extensman-access-types-non-meta)
-* [Actions available for metapackages](#extensman-access-types-meta)
+*  [Actions available for non-metapackages](#extensman-access-types-non-meta)
+*  [Actions available for metapackages](#extensman-access-types-meta)
 
 #### Actions available for non-metapackages {#extensman-access-types-non-meta}
 
@@ -222,12 +222,12 @@ The New Updates page displays all extensions that can be updated.
 
 You have the following options:
 
-* To update one extension, click **Update** at the end of its row.
-* To update more than one extension, select its checkbox and click **Update**, as the following figure shows.
+*  To update one extension, click **Update** at the end of its row.
+*  To update more than one extension, select its checkbox and click **Update**, as the following figure shows.
 
    ![Update selected extensions]({{ site.baseurl }}/common/images/extensman_update-selected.png){:width="500px"}
 
-* To update all extensions, click **Select All** from the list and click **Update**, as the following figure shows.
+*  To update all extensions, click **Select All** from the list and click **Update**, as the following figure shows.
 
    ![Update all extensions]({{ site.baseurl }}/common/images/extensman_update-all.png)
 

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-fail.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-fail.md
@@ -16,9 +16,9 @@ If you're updating multiple extensions, see [Readiness check with multiple exten
 
 In the [event](https://glossary.magento.com/event) of failure, see one of the following sections:
 
-* [Updater check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
-* [Cron script check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
-* [Component dependency check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
-* [PHP version readiness check issues]({{ page.baseurl }}/comp-mgr/trouble/cman/php-version.html)
-* [PHP settings errors]({{ page.baseurl }}/install-gde/trouble/php/tshoot_php-set.html)
-* [PHP extensions check failure]({{ page.baseurl }}/install-gde/system-requirements.html)
+*  [Updater check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
+*  [Cron script check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
+*  [Component dependency check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
+*  [PHP version readiness check issues]({{ page.baseurl }}/comp-mgr/trouble/cman/php-version.html)
+*  [PHP settings errors]({{ page.baseurl }}/install-gde/trouble/php/tshoot_php-set.html)
+*  [PHP extensions check failure]({{ page.baseurl }}/install-gde/system-requirements.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness-multi.md
@@ -17,9 +17,9 @@ If you're updating multiple extensions, the readiness check displays success and
 
 You have the following options:
 
-* Click **Update** or **Next** to continue to [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html) with no changes
-* To update the extension to a different version, select the desired version from the list
-* To remove the extension from the list and *not* update it, click ![Remove extension from the list]({{ site.baseurl }}/common/images/extensman_delete.png) (delete)
+*  Click **Update** or **Next** to continue to [Step 2. Backup]({{ page.baseurl }}/comp-mgr/extens-man/extensman-backup.html) with no changes
+*  To update the extension to a different version, select the desired version from the list
+*  To remove the extension from the list and *not* update it, click ![Remove extension from the list]({{ site.baseurl }}/common/images/extensman_delete.png) (delete)
 
 If you make changes, click **Try Again**.
 
@@ -35,9 +35,9 @@ If the readiness check fails because of version conflicts, you must resolve the 
 
 You have the following options:
 
-* Click **Back** and select different extensions to update
-* From the list, click different versions of the selected extensions
-* To remove the extension from the list and *not* update it, click ![Remove extension from the list]({{ site.baseurl }}/common/images/extensman_delete.png) (delete)
+*  Click **Back** and select different extensions to update
+*  From the list, click different versions of the selected extensions
+*  To remove the extension from the list and *not* update it, click ![Remove extension from the list]({{ site.baseurl }}/common/images/extensman_delete.png) (delete)
 
 After you make your changes, click **Try Again**. Repeat the process as necessary to resolve the conflicts.
 
@@ -53,12 +53,12 @@ Messages similar to the following display if a readiness check fails.
 
 In the event of failure, see one of the following sections:
 
-* [Updater check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
-* [Cron script check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
-* [Component dependency check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
-* [PHP version readiness check issues]({{ page.baseurl }}/comp-mgr/trouble/cman/php-version.html)
-* [PHP settings errors]({{ page.baseurl }}/install-gde/trouble/php/tshoot_php-set.html)
-* [PHP extensions check failure]({{ page.baseurl }}/install-gde/system-requirements.html)
+*  [Updater check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
+*  [Cron script check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
+*  [Component dependency check failure]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
+*  [PHP version readiness check issues]({{ page.baseurl }}/comp-mgr/trouble/cman/php-version.html)
+*  [PHP settings errors]({{ page.baseurl }}/install-gde/trouble/php/tshoot_php-set.html)
+*  [PHP extensions check failure]({{ page.baseurl }}/install-gde/system-requirements.html)
 
 {% endcollapsible %}
 

--- a/guides/v2.2/comp-mgr/extens-man/extensman-readiness.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-readiness.md
@@ -15,6 +15,6 @@ To start, click either **Start Readiness Check** or **Next**. A sample follows.
 
 After the readiness check completes, see one of the following:
 
-* [Readiness check success]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-success.html)
-* [Readiness check failure]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-fail.html)
-* [Readiness check with multiple extension updates]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-multi.html)
+*  [Readiness check success]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-success.html)
+*  [Readiness check failure]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-fail.html)
+*  [Readiness check with multiple extension updates]({{ page.baseurl }}/comp-mgr/extens-man/extensman-readiness-multi.html)

--- a/guides/v2.2/comp-mgr/extens-man/extensman-uninst-data.md
+++ b/guides/v2.2/comp-mgr/extens-man/extensman-uninst-data.md
@@ -23,8 +23,8 @@ If the extension has data to remove, a page similar to the following displays.
 
 Click one of the following:
 
-* **Keep data**: Click to keep the data in the database.
-* **Remove data**: Click to remove data from the database.
+*  **Keep data**: Click to keep the data in the database.
+*  **Remove data**: Click to remove data from the database.
 
    You can click **Back** to back up the database first if you did not do so already.
 

--- a/guides/v2.2/comp-mgr/module-man/compman-start.md
+++ b/guides/v2.2/comp-mgr/module-man/compman-start.md
@@ -23,8 +23,8 @@ To upgrade Magento system software instead, see [Run System Upgrade]({{ page.bas
 
 See one of the following sections:
 
-* [About the Module Manager](#modman-about)
-* [Enable or disable a module](#modman-about-endis)
+*  [About the Module Manager](#modman-about)
+*  [Enable or disable a module](#modman-about-endis)
 
 ## About the Module Manager {#modman-about}
 

--- a/guides/v2.2/comp-mgr/prereq/prereq_compman.md
+++ b/guides/v2.2/comp-mgr/prereq/prereq_compman.md
@@ -13,12 +13,12 @@ functional_areas:
 
 Before running the [Module](https://glossary.magento.com/module) Manager, [Extension](https://glossary.magento.com/extension) Manager, or System Upgrade, complete the following tasks:
 
-* [Set up cron]({{ page.baseurl }}/comp-mgr/prereq/prereq_cron.html)
-* [Set `ulimit` for the web server user]({{ page.baseurl }}/comp-mgr/prereq/prereq_compman-ulimit.html)
-* [Checklist]({{ page.baseurl }}/comp-mgr/prereq/prereq_compman-checklist.html)
+*  [Set up cron]({{ page.baseurl }}/comp-mgr/prereq/prereq_cron.html)
+*  [Set `ulimit` for the web server user]({{ page.baseurl }}/comp-mgr/prereq/prereq_compman-ulimit.html)
+*  [Checklist]({{ page.baseurl }}/comp-mgr/prereq/prereq_compman-checklist.html)
 
 After you've completed all prerequisites, continue with:
 
-* [Module Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)
-* [Extension Manager]({{ page.baseurl }}/comp-mgr/extens-man/extensman-main-pg.html)
-* [System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
+*  [Module Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)
+*  [Extension Manager]({{ page.baseurl }}/comp-mgr/extens-man/extensman-main-pg.html)
+*  [System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)

--- a/guides/v2.2/comp-mgr/trouble/cman/cron.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/cron.md
@@ -11,19 +11,19 @@ functional_areas:
 
 Following are symptoms of cron issues:
 
-* Your update or upgrade never runs; it stays in a `pending` state
-* An error message about the [PHP](https://glossary.magento.com/php) setting `$HTTP_RAW_POST_DATA` displays even though it's set properly
-* The cron readiness check fails
+*  Your update or upgrade never runs; it stays in a `pending` state
+*  An error message about the [PHP](https://glossary.magento.com/php) setting `$HTTP_RAW_POST_DATA` displays even though it's set properly
+*  The cron readiness check fails
 
    Possible errors include non-writable paths and cron not set up. An example follows:
 
    <img src="{{ site.baseurl }}/common/images/upgr-tshoot-no-cron2.png">
 
-* The PHP readiness check doesn't display the PHP version as the following figure shows.
+*  The PHP readiness check doesn't display the PHP version as the following figure shows.
 
    <img src="{{ site.baseurl }}/common/images/upgr-tshoot-no-cron.png">
 
-* The following error displays in the Magento Admin:
+*  The following error displays in the Magento Admin:
 
    ![cron isn't running]({{ site.baseurl }}/common/images/compman-cron-not-running.png)
 

--- a/guides/v2.2/comp-mgr/trouble/cman/maint-mode.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/maint-mode.md
@@ -18,16 +18,16 @@ You must perform the tasks in this section as a user with `root` privileges.
 
 See one of the following sections for more information:
 
-* [Create the custom maintenance page](#compman-trouble-maint-create)
-* [Custom maintenance page for Apache](#compman-trouble-maint-apache)
-* [Custom maintenance page for nginx](#compman-trouble-maint-nginx)
+*  [Create the custom maintenance page](#compman-trouble-maint-create)
+*  [Custom maintenance page for Apache](#compman-trouble-maint-apache)
+*  [Custom maintenance page for nginx](#compman-trouble-maint-nginx)
 
 ## Create the custom maintenance page {#compman-trouble-maint-create}
 
 To create a maintenance page and redirect to it, first create a maintenance page named:
 
-* Apache: `<web server docroot>/maintenance.html`
-* nginx: `<magento_root>/maintenance.html`
+*  Apache: `<web server docroot>/maintenance.html`
+*  nginx: `<magento_root>/maintenance.html`
 
 Add to it the following contents:
 
@@ -61,15 +61,15 @@ This section discusses how to create a custom maintenance page and how to redire
 
 The example in this section shows how to modify the following files, which is one way to set up your maintenance page:
 
-* Apache 2.4: `/etc/apache2/sites-available/000-default.conf`
-* Apache 2.2: `/etc/apache2/sites-available/default` (Ubuntu), `/etc/httpd/conf/httpd.conf` (CentOS)
+*  Apache 2.4: `/etc/apache2/sites-available/000-default.conf`
+*  Apache 2.2: `/etc/apache2/sites-available/default` (Ubuntu), `/etc/httpd/conf/httpd.conf` (CentOS)
 
 To redirect traffic to a custom maintenance page:
 
 1. Update your Apache configuration to do the following:
 
-   * Redirect all traffic to the maintenance page
-   * Whitelist certain IPs so an administrator can run the System Upgrade utility to upgrade the Magento software.
+   *  Redirect all traffic to the maintenance page
+   *  Whitelist certain IPs so an administrator can run the System Upgrade utility to upgrade the Magento software.
 
     The following example whitelists 192.0.2.110.
 
@@ -88,8 +88,8 @@ To redirect traffic to a custom maintenance page:
 
 1. Restart Apache:
 
-   * CentOS: `service httpd restart`
-   * Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
 
 1. Enter the following command:
 

--- a/guides/v2.2/comp-mgr/trouble/cman/out-of-memory.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/out-of-memory.md
@@ -39,14 +39,14 @@ The following are suggestions only; other options might be available. Consult a 
 
 Use the `fallocate` command as discussed in these references:
 
-* [How To Add Swap on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04){:target="_blank"}
-* [How To Add Swap Space on Ubuntu 16.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04){:target="_blank"}
-* [SwapFaq (help.ubuntu.com)](https://help.ubuntu.com/community/SwapFaq){:target="_blank"}
+*  [How To Add Swap on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04){:target="_blank"}
+*  [How To Add Swap Space on Ubuntu 16.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04){:target="_blank"}
+*  [SwapFaq (help.ubuntu.com)](https://help.ubuntu.com/community/SwapFaq){:target="_blank"}
 
 #### Swap file on CentOS
 
 Use the `mkswap` command as discussed in these references:
 
-* [How To Add Swap on CentOS 6 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-centos-6){:target="_blank"}
-* [How To Add Swap on CentOS 7 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-centos-7){:target="_blank"}
-* [Swap Space (RedHat customer portal)](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Storage_Administration_Guide/ch-swapspace.html){:target="_blank"}
+*  [How To Add Swap on CentOS 6 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-centos-6){:target="_blank"}
+*  [How To Add Swap on CentOS 7 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-centos-7){:target="_blank"}
+*  [Swap Space (RedHat customer portal)](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Storage_Administration_Guide/ch-swapspace.html){:target="_blank"}

--- a/guides/v2.2/comp-mgr/trouble/cman/tshoot_backup.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/tshoot_backup.md
@@ -11,9 +11,9 @@ functional_areas:
 
 A backup can fail for any of the following reasons:
 
-* [Insufficient disk space](#trouble-backup-space)
-* [An operating system error](#trouble-backup-os)
-* [Backup fails](#trouble-backup-all)
+*  [Insufficient disk space](#trouble-backup-space)
+*  [An operating system error](#trouble-backup-os)
+*  [Backup fails](#trouble-backup-all)
 
 ## Backup disabled
 
@@ -36,17 +36,17 @@ For additional information on backups, see [Back up and roll back the file syste
 
 If the backup failed because of insufficient disk space, you should typically free up disk space by moving some files to another storage device or drive. However, there might be other ways to resolve the issue. See one of the following resources for tips:
 
-* [8 Tips to Solve Linux & Unix Systems Hard Disk Problems Like Disk Full Or Can’t Write to the Disk](http://www.cyberciti.biz/datacenter/linux-unix-bsd-osx-cannot-write-to-hard-disk){:target="_blank"}
-* [serverfault: df says disk is full, but it is not](http://serverfault.com/questions/315181/df-says-disk-is-full-but-it-is-not){:target="_blank"}
-* [unix.stackexchange.com: Tracking down where disk space has gone on Linux?](http://unix.stackexchange.com/questions/125429/tracking-down-where-disk-space-has-gone-on-linux){:target="_blank"}
+*  [8 Tips to Solve Linux & Unix Systems Hard Disk Problems Like Disk Full Or Can’t Write to the Disk](http://www.cyberciti.biz/datacenter/linux-unix-bsd-osx-cannot-write-to-hard-disk){:target="_blank"}
+*  [serverfault: df says disk is full, but it is not](http://serverfault.com/questions/315181/df-says-disk-is-full-but-it-is-not){:target="_blank"}
+*  [unix.stackexchange.com: Tracking down where disk space has gone on Linux?](http://unix.stackexchange.com/questions/125429/tracking-down-where-disk-space-has-gone-on-linux){:target="_blank"}
 
 ## Operating system error {#trouble-backup-os}
 
 Unfortunately, we can't recommend anything specific because of the variety of errors you might encounter. We can suggest, however, you:
 
-* Contact your system administrator
-* Search public forums like [Stack Exchange](http://unix.stackexchange.com){:target="_blank"} or [Stack Overflow](http://stackoverflow.com){:target="_blank"}
-* Open a [GitHub issue](https://github.com/magento/magento2/issues){:target="_blank"} and we'll try to help
+*  Contact your system administrator
+*  Search public forums like [Stack Exchange](http://unix.stackexchange.com){:target="_blank"} or [Stack Overflow](http://stackoverflow.com){:target="_blank"}
+*  Open a [GitHub issue](https://github.com/magento/magento2/issues){:target="_blank"} and we'll try to help
 
 ## Backup fails {#trouble-backup-all}
 

--- a/guides/v2.2/comp-mgr/trouble/cman/were-sorry.md
+++ b/guides/v2.2/comp-mgr/trouble/cman/were-sorry.md
@@ -15,9 +15,9 @@ The following error might display at the start of your upgrade:
 
 See one of the following sections for possible solutions:
 
-* [Problem: you're not authenticated](#not-auth)
-* [Problem: the updater application isn't initialized](#updater)
-* [Problem: you cloned the Magento GitHub repository](#git-clone)
+*  [Problem: you're not authenticated](#not-auth)
+*  [Problem: the updater application isn't initialized](#updater)
+*  [Problem: you cloned the Magento GitHub repository](#git-clone)
 
 ### Problem: you're not authenticated {#not-auth}
 

--- a/guides/v2.2/comp-mgr/trouble/tshoot.md
+++ b/guides/v2.2/comp-mgr/trouble/tshoot.md
@@ -13,12 +13,12 @@ The following topics discuss Component Manager and System Upgrade errors and sug
 
 ### Both Component Manager and System Upgrade
 
-* [Troubleshoot cron]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
-* [Troubleshoot component dependencies]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
-* [Troubleshoot the updater application]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
-* [Troubleshoot backup]({{ page.baseurl }}/comp-mgr/trouble/cman/tshoot_backup.html)
+*  [Troubleshoot cron]({{ page.baseurl }}/comp-mgr/trouble/cman/cron.html)
+*  [Troubleshoot component dependencies]({{ page.baseurl }}/comp-mgr/trouble/cman/component-depend.html)
+*  [Troubleshoot the updater application]({{ page.baseurl }}/comp-mgr/trouble/cman/updater.html)
+*  [Troubleshoot backup]({{ page.baseurl }}/comp-mgr/trouble/cman/tshoot_backup.html)
 
 ### System Upgrade only
 
-* ["Sorry, we can't take that action right now"]({{ page.baseurl }}/comp-mgr/trouble/cman/were-sorry.html)
-* [Roll back after upgrade failure]({{ page.baseurl }}/comp-mgr/trouble/cman/update-fail.html)
+*  ["Sorry, we can't take that action right now"]({{ page.baseurl }}/comp-mgr/trouble/cman/were-sorry.html)
+*  [Roll back after upgrade failure]({{ page.baseurl }}/comp-mgr/trouble/cman/update-fail.html)

--- a/guides/v2.2/comp-mgr/upgrader/ce-ee-upgrade-start.md
+++ b/guides/v2.2/comp-mgr/upgrader/ce-ee-upgrade-start.md
@@ -58,13 +58,13 @@ After the upgrade completes:
 
 ### Errors
 
-* The following error can indicate one of several issues, including that you haven't entered your [authentication keys] in the Magento Admin:
+*  The following error can indicate one of several issues, including that you haven't entered your [authentication keys] in the Magento Admin:
 
    ![Sorry we can't take that action right now]
 
    For suggested solutions to other causes indicated by this message, see [troubleshooting].
 
-* The following error might display:
+*  The following error might display:
 
    ```terminal
    [2016-01-19 23:33:24 UTC] An error occurred while executing job

--- a/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade-checklist.md
@@ -15,11 +15,11 @@ This section discusses how to start System Upgrade, which upgrades the version o
 
 You can upgrade in any of the following ways:
 
-* Using the System Upgrade utility, a wizard that walks you through the upgrade step by step; continue with this topic.
+*  Using the System Upgrade utility, a wizard that walks you through the upgrade step by step; continue with this topic.
 
    Use this method if you don't have a to the Magento server's file system or if you're a non-technical user.
 
-* Using the [command line]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html).
+*  Using the [command line]({{ page.baseurl }}/comp-mgr/cli/cli-upgrade.html).
 
  This upgrade method is more advanced and it requires access to the Magento server's file system.
 
@@ -28,8 +28,8 @@ _System upgrade_ refers to updating the Magento 2.x core components and other in
 
 {: .bs-callout-warning }
 
-* Authorization keys from a [shared account](http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html) _cannot_ be used for upgrade. You must get your authorization keys from `magento.com` account owner.
-* If you installed the Magento application by [cloning the GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html), you _cannot_ use the System Upgrade utility to upgrade the software. Instead, you must [update it manually]({{ page.baseurl }}/install-gde/install/cli/dev_options.html).
+*  Authorization keys from a [shared account](http://docs.magento.com/m2/ce/user_guide/magento/magento-account-share.html) _cannot_ be used for upgrade. You must get your authorization keys from `magento.com` account owner.
+*  If you installed the Magento application by [cloning the GitHub repository]({{ page.baseurl }}/install-gde/prereq/dev_install.html), you _cannot_ use the System Upgrade utility to upgrade the software. Instead, you must [update it manually]({{ page.baseurl }}/install-gde/install/cli/dev_options.html).
 
 ## System Upgrade checklist
 {% include comp-man/checklist_2.2.md %}

--- a/guides/v2.2/comp-mgr/upgrader/upgrade-start.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade-start.md
@@ -65,5 +65,5 @@ For suggested solutions to other causes indicated by this message, see [troubles
 
 The System Upgrade utility installs sample data for you but doesn't display it, if you:
 
-* Used the [`magento sampledata:deploy`]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-composer.html) command to download, but not installed sample data
-* You chose to update components at the same time as the Magento system software
+*  Used the [`magento sampledata:deploy`]({{ page.baseurl }}/install-gde/install/cli/install-cli-sample-data-composer.html) command to download, but not installed sample data
+*  You chose to update components at the same time as the Magento system software

--- a/guides/v2.2/comp-mgr/upgrader/upgrade.md
+++ b/guides/v2.2/comp-mgr/upgrader/upgrade.md
@@ -63,11 +63,11 @@ Then access your [storefront](https://glossary.magento.com/storefront) and verif
 
 After you finish your upgrade, errors might display.
 
-* On the main storefront page, the following error might display.
+*  On the main storefront page, the following error might display.
 
    _We're sorry, an error has occurred while generating this email._
 
-* On a [category](https://glossary.magento.com/category) page, the following error might display:
+*  On a [category](https://glossary.magento.com/category) page, the following error might display:
 
    _We can't find products matching the selection._
 

--- a/guides/v2.2/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-dirs.md
@@ -17,8 +17,8 @@ Specify an associative array where keys are constants from [\\Magento\\App\\File
 
 You can set `MAGE_DIRS` in any of the following ways:
 
-* [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html)
-* Use a custom entry point script such as the following:
+*  [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html)
+*  Use a custom entry point script such as the following:
 
    ```php
    use Magento\Framework\App\Filesystem\DirectoryList;


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the folders:
- `guides/v2.2/comp-mgr`
- `guides/v2.3/comp-mgr`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
