### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - config-guide. Part 02.

### DIFF
--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-static-deploy-strategies.md
@@ -12,9 +12,9 @@ functional_areas:
 
 When [deploying static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html), you can choose one of the three available strategies. Each of them provides optimal deployment results for different use cases:
 
-*   [Standard](#static-file-standard): the regular deployment process.
-*   [Quick](#static-file-quick) (_default_): minimizes the time required for deployment when files for more than one [locale](https://glossary.magento.com/locale) are deployed.
-*   [Compact](#static-file-compact): minimizes the space taken by the published view files.
+*  [Standard](#static-file-standard): the regular deployment process.
+*  [Quick](#static-file-quick) (_default_): minimizes the time required for deployment when files for more than one [locale](https://glossary.magento.com/locale) are deployed.
+*  [Compact](#static-file-compact): minimizes the space taken by the published view files.
 
 The following sections describe the implementation details and features of each strategy.
 
@@ -32,7 +32,7 @@ The quick strategy performs the following actions:
 1. For all other locales of the theme:
 
    1. Files that override the deployed locale are defined and deployed.
-   1.  All other files are considered similar for all locales, and are copied from the deployed locale.
+   1. All other files are considered similar for all locales, and are copied from the deployed locale.
 
 {: .bs-callout-info }
 By _similar_, we mean files that are independent of the locale, theme, or area. These files might include CSS, images, and fonts.
@@ -122,8 +122,8 @@ The files are deployed to these subdirectories according to the following patter
 
 The approach to deployment used in the compact strategy means that files are inherited from base themes and locales. This inheritance relations are stored in the map files for each combination of area, [theme](https://glossary.magento.com/theme) and locale. There are separate map files for [PHP](https://glossary.magento.com/php) and JS:
 
-* `map.php`
-* `requirejs-map.js`
+*  `map.php`
+*  `requirejs-map.js`
 
 `map.php` is used by [`Magento\Framework\View\Asset\Repository`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/View/Asset/Repository.php) to build correct URLs.
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-test.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-test.md
@@ -17,13 +17,13 @@ This command runs a set of tests defined in the Magento 2 code base. You can eit
 
 Before you run this command, all of the following must be true:
 
--   The `Magento_Developer` [module](https://glossary.magento.com/module) must be enabled. You can enable it as follows:
+-  The `Magento_Developer` [module](https://glossary.magento.com/module) must be enabled. You can enable it as follows:
 
         bin/magento module:enable [--force] Magento_Developer
 
     Use the `--force` option only if it's necessary.
 
--   Your system must be set up to run the desired tests.
+-  Your system must be set up to run the desired tests.
 
 For example, to run integration tests, you should copy `dev/tests/integration/etc/install-config-mysql.php.dist` to `dev/tests/integration/etc/install-config-mysql.php` and modify it to suit your environment.
 

--- a/guides/v2.2/config-guide/config/config-create.md
+++ b/guides/v2.2/config-guide/config/config-create.md
@@ -21,27 +21,27 @@ Your new `events.xml` is automatically collected from your module and merged wit
 
 To create new configuration type, you must add at minimum:
 
-* [XML](https://glossary.magento.com/xml) configuration files
-* XSD validation schema
-* A loader
+*  [XML](https://glossary.magento.com/xml) configuration files
+*  XSD validation schema
+*  A loader
 
 For example, to introduce an [adapter](https://glossary.magento.com/adapter) for a new search server that enables extensions to configure how its entities are indexed in that server, create:
 
-* A loader.
-* An XSD schema.
-* Any other classes required for your new type to work.
-* An appropriately named configuration file. For example, `search.xml`. This file is read and validated against your schema.
+*  A loader.
+*  An XSD schema.
+*  Any other classes required for your new type to work.
+*  An appropriately named configuration file. For example, `search.xml`. This file is read and validated against your schema.
 
    If other modules have a `search.xml` file, they are merged with your file when it loads.
 
 To create a new configuration type, extend the `\Magento\Framework\Config\ReaderInterface`, which is [Magento\Framework\Config\Reader\Filesystem]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/Reader/Filesystem.php) to provide the following parameters:
 
-* `$fileResolver`. Implements [\Magento\Framework\Config\FileResolverInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/FileResolverInterface.php). This parameter lists the files containing the configurations of your custom type.
-* `$converter`. Implements [\Magento\Framework\Config\ConverterInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ConverterInterface.php). This parameter converts the XML into the internal array representation of the configurations.
-* `$schemaLocator`. Implements [\Magento\Framework\Config\SchemaLocatorInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/SchemaLocatorInterface.php). This parameter provides the full path to file(s) containing schema(s) for validation of the individual and merged configuration files.
-* `$validationState`. Implements [\Magento\Framework\Config\ValidationStateInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ValidationStateInterface.php). This parameter defines whether a configuration file should be validated.
-* `$fileName`. Name of a configuration file. The Reader looks for the file names specified by this parameter in modules' `etc` directories.
-* `$idAttributes`. Array of node attribute IDs.
+*  `$fileResolver`. Implements [\Magento\Framework\Config\FileResolverInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/FileResolverInterface.php). This parameter lists the files containing the configurations of your custom type.
+*  `$converter`. Implements [\Magento\Framework\Config\ConverterInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ConverterInterface.php). This parameter converts the XML into the internal array representation of the configurations.
+*  `$schemaLocator`. Implements [\Magento\Framework\Config\SchemaLocatorInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/SchemaLocatorInterface.php). This parameter provides the full path to file(s) containing schema(s) for validation of the individual and merged configuration files.
+*  `$validationState`. Implements [\Magento\Framework\Config\ValidationStateInterface]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Config/ValidationStateInterface.php). This parameter defines whether a configuration file should be validated.
+*  `$fileName`. Name of a configuration file. The Reader looks for the file names specified by this parameter in modules' `etc` directories.
+*  `$idAttributes`. Array of node attribute IDs.
 
     For example, to merge the XML files:
 
@@ -50,7 +50,7 @@ To create a new configuration type, extend the `\Magento\Framework\Config\Reader
          '</path/to/other/node>' => '<identifierAttributeName>',
        }
 
-* `$defaultScope`. Defines the configuration scope to be read by default. The default value for this parameter is global scope.
+*  `$defaultScope`. Defines the configuration scope to be read by default. The default value for this parameter is global scope.
 
  After you customize `ReaderInterface`, you can use it to collect, merge, validate, and convert the configuration files to an internal array representation.
 
@@ -60,8 +60,8 @@ Each configuration file is validated against a schema specific to its configurat
 
 Configuration files can be validated both before (optional) and after any merge of multiple files affecting the same configuration type. Unless the validation rules for the individual and merged files are identical, you should provide two schemas for validating the configuration files:
 
-* Schema to validate an individual
-* Schema to validate a merged file
+*  Schema to validate an individual
+*  Schema to validate a merged file
 
 New configuration files must be accompanied by XSD validation schemas. An XML configuration file and its XSD validation file must have the same name.
 
@@ -78,5 +78,5 @@ Your IDE can validate your configuration files at both runtime and during develo
 {:.ref-header}
 Related topics
 
-* [Module configuration files]({{ page.baseurl }}/config-guide/config/config-php.html)
-* [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)
+*  [Module configuration files]({{ page.baseurl }}/config-guide/config/config-php.html)
+*  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)

--- a/guides/v2.2/config-guide/config/config-magento.md
+++ b/guides/v2.2/config-guide/config/config-magento.md
@@ -11,6 +11,6 @@ Magento provides configuration files that enable you to easily customize a compo
 
 See the following topics for details:
 
-*   [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)
-*   [Module configuration files]({{ page.baseurl }}/config-guide/config/config-files.html)
-*   [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
+*  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)
+*  [Module configuration files]({{ page.baseurl }}/config-guide/config/config-files.html)
+*  [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)

--- a/guides/v2.2/config-guide/config/config-php.md
+++ b/guides/v2.2/config-guide/config/config-php.md
@@ -11,7 +11,7 @@ functional_areas:
 
 Magento's deployment configuration consists of the shared and system-specific configuration for your installation. Magento's deployment configuration is divided between [`app/etc/config.php`][config-php] and [`app/etc/env.php`][env-php].
 
-* `app/etc/config.php` is the _shared_ configuration file.
+*  `app/etc/config.php` is the _shared_ configuration file.
   This file contains the list of installed modules, themes, and language packages; and shared configuration settings.
 
   Check this file in to source control and use it in your development, staging, and production systems.
@@ -19,7 +19,7 @@ Magento's deployment configuration consists of the shared and system-specific co
   As of the 2.2 release, the `app/etc/config.php` file is no longer an entry in the `.gitignore` file.
   This was done to facilitate [pipeline deployment][pipeline-deployment].
 
-* `app/etc/env.php` contains settings that are specific to the installation environment.
+*  `app/etc/env.php` contains settings that are specific to the installation environment.
 
 Together, `config.php` and `env.php` are referred to as Magento's _deployment configuration_ because they are created during installation and are required to start Magento.
 
@@ -39,18 +39,18 @@ On the next hierarchy level, items in each segment are ordered according to the 
 
 The following sections discusses the structure and contents of the deployment configuration&mdash;`config.php` and `env.php`.
 
-* [Manage installed modules](#config-php-contents-config-php)
-* [System-specific configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html#app-etc-env-php)
+*  [Manage installed modules](#config-php-contents-config-php)
+*  [System-specific configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html#app-etc-env-php)
 
 ## Manage installed modules {#config-php-contents-config-php}
 `config.php` lists your installed modules. Magento provides both command-line and web-based utilities to manage modules (install, uninstall, enable, disable, or upgrade).
 
 Examples:
 
-* Uninstall components: [`bin/magento setup:uninstall`]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall.html)
-* Enable or disable components: [`bin/magento module:disable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable), [`bin/magento module:enable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable).
-* [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)
-* [System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
+*  Uninstall components: [`bin/magento setup:uninstall`]({{ page.baseurl }}/install-gde/install/cli/install-cli-uninstall.html)
+*  Enable or disable components: [`bin/magento module:disable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable), [`bin/magento module:enable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html#instgde-cli-subcommands-enable-disable).
+*  [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html)
+*  [System Upgrade]({{ page.baseurl }}/comp-mgr/upgrader/upgrade-start.html)
 
 `config.php` snippet:
 

--- a/guides/v2.2/config-guide/config/disable-module-output.md
+++ b/guides/v2.2/config-guide/config/disable-module-output.md
@@ -17,8 +17,8 @@ If a merchant used the Admin to disable a module's output in a previous release,
 
 The Output disabling is performed in following classes:
 
-- [\Magento\Framework\View\Element\AbstractBlock::toHtml]({{ site.mage2bloburl }}/36097739bbb0b8939ad9a2a0dadee64318153dca/lib/internal/Magento/Framework/View/Element/AbstractBlock.php#L651){:target="_blank"}
-- [\Magento\Backend\Block\Template::isOutputEnabled]({{ site.mage2bloburl }}/0c786907ffe03d0e2990612eec16ee58b00379c5/app/code/Magento/Backend/Block/Template.php#L96){:target="_blank"}
+-  [\Magento\Framework\View\Element\AbstractBlock::toHtml]({{ site.mage2bloburl }}/36097739bbb0b8939ad9a2a0dadee64318153dca/lib/internal/Magento/Framework/View/Element/AbstractBlock.php#L651){:target="_blank"}
+-  [\Magento\Backend\Block\Template::isOutputEnabled]({{ site.mage2bloburl }}/0c786907ffe03d0e2990612eec16ee58b00379c5/app/code/Magento/Backend/Block/Template.php#L96){:target="_blank"}
 
 {:.bs-callout .bs-callout-warning}
 Please note that by disabling the module's output, the module is still enabled and keeps working, but no block, page or field is rendered on the frontend or backend.
@@ -45,9 +45,9 @@ To disable module output in the pipeline deployment or any other deployment, wit
 
 Here:
 
-- `<modules_disable_output>` contains a list of modules.
-- `<Magento_Newsletter></Magento_Newsletter>` specifies which module to disable output for.
-- `1` is the flag that disables output for the `Magento_Newsletter` module.
+-  `<modules_disable_output>` contains a list of modules.
+-  `<Magento_Newsletter></Magento_Newsletter>` specifies which module to disable output for.
+-  `1` is the flag that disables output for the `Magento_Newsletter` module.
 
 As a sample result of this configuration, customers can no longer sign up to receive newsletters.
 

--- a/guides/v2.2/config-guide/cron/custom-cron.md
+++ b/guides/v2.2/config-guide/cron/custom-cron.md
@@ -13,13 +13,13 @@ If you use a Magento-provided cron group, you don't have to define a custom cron
 
 The Magento application provides the following cron groups:
 
-* `default`, which contains most cron jobs
-* `index`, which refreshes [indexers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html)
-* These topics are available in {{site.data.var.ee}} only
-   * `staging`, which runs [Staging-related](http://docs.magento.com/m2/ee/user_guide/cms/content-staging.html) tasks
-   * `catalog_event`, which runs tasks for target and shopping cart rules
+*  `default`, which contains most cron jobs
+*  `index`, which refreshes [indexers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html)
+*  These topics are available in {{site.data.var.ee}} only
+   *  `staging`, which runs [Staging-related](http://docs.magento.com/m2/ee/user_guide/cms/content-staging.html) tasks
+   *  `catalog_event`, which runs tasks for target and shopping cart rules
 
 See the following topics for details:
 
-* [Custom cron job and cron group reference]({{ page.baseurl }}/config-guide/cron/custom-cron-ref.html)
-* [Configure a custom cron job and cron group (tutorial)]({{ page.baseurl }}/config-guide/cron/custom-cron-tut.html)
+*  [Custom cron job and cron group reference]({{ page.baseurl }}/config-guide/cron/custom-cron-ref.html)
+*  [Configure a custom cron job and cron group (tutorial)]({{ page.baseurl }}/config-guide/cron/custom-cron-tut.html)

--- a/guides/v2.2/config-guide/db-profiler/db-profiler.md
+++ b/guides/v2.2/config-guide/db-profiler/db-profiler.md
@@ -57,9 +57,9 @@ Configure the output in your Magento application boostrap file; this might be `<
 
 The following example displays results in a three-column table:
 
-* Total time (displays the total amount of time to run all queries on the page)
-* SQL (displays all SQL queries; the row header displays the count of queries)
-* Query Params (displays the parameters for each SQL query)
+*  Total time (displays the total amount of time to run all queries on the page)
+*  SQL (displays all SQL queries; the row header displays the count of queries)
+*  Query Params (displays the parameters for each SQL query)
 
 To configure the output, add the following after the `$bootstrap->run($app);` line in your bootstrap file:
 

--- a/guides/v2.2/config-guide/deployment/index.md
+++ b/guides/v2.2/config-guide/deployment/index.md
@@ -14,28 +14,28 @@ If you deploy Magento on a single machine and can tolerate some downtime during 
 
 The following topics are organized to help you get started quickly. If you're new to Magento or not familiar with the technical details, start by reading the overviews.
 
-* Overview of deployment
+*  Overview of deployment
 
-   * [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)
-   * [Deployment technical overview (implementation details)]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html)
+   *  [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)
+   *  [Deployment technical overview (implementation details)]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html)
 
-* Set up your pipeline deployment systems: development, build, and production
+*  Set up your pipeline deployment systems: development, build, and production
 
-   * [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
-   * [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
-   * [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
+   *  [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
+   *  [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
+   *  [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
 
-* Step-by-step examples of using pipeline deployment
+*  Step-by-step examples of using pipeline deployment
 
-   * [Simple example&mdash;manage the shared configuration]({{ page.baseurl }}/config-guide/deployment/pipeline/example/shared-configuration.html)
+   *  [Simple example&mdash;manage the shared configuration]({{ page.baseurl }}/config-guide/deployment/pipeline/example/shared-configuration.html)
 
-* Reference information
+*  Reference information
 
-   * [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-   * [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-   * [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-   * [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
-   * [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html)
-   * [.gitignore reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html)
-   * [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html)
-   * [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html)
+   *  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+   *  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+   *  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+   *  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+   *  [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html)
+   *  [.gitignore reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html)
+   *  [config.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-configphp.html)
+   *  [env.php reference]({{ page.baseurl }}/config-guide/prod/config-reference-envphp.html)

--- a/guides/v2.2/config-guide/deployment/pipeline/development-system.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/development-system.md
@@ -10,18 +10,18 @@ functional_areas:
 
 You can have any number of development systems, provided the following is true of all of them:
 
-* They all run Magento 2.2 or later
-* All Magento code is under source control in the same repository as the build and production systems
-* Each development system should use either [default mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#default-mode) or [developer mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#developer-mode)
-* It has Magento file system ownership and permissions set as discussed in [Prerequisite for your development, build, and production systems]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html#config-deploy-prereq).
-* Make sure all of the following are _excluded_ from source control:
+*  They all run Magento 2.2 or later
+*  All Magento code is under source control in the same repository as the build and production systems
+*  Each development system should use either [default mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#default-mode) or [developer mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#developer-mode)
+*  It has Magento file system ownership and permissions set as discussed in [Prerequisite for your development, build, and production systems]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html#config-deploy-prereq).
+*  Make sure all of the following are _excluded_ from source control:
 
-   * `vendor` directory (and subdirectories)
-   * `generated` directory (and subdirectories)
-   * `pub/static` directory (and subdirectories)
-   * `app/etc/env.php` file
+   *  `vendor` directory (and subdirectories)
+   *  `generated` directory (and subdirectories)
+   *  `pub/static` directory (and subdirectories)
+   *  `app/etc/env.php` file
 
-* Make sure `app/etc/config.php` is _included_ in source control
+*  Make sure `app/etc/config.php` is _included_ in source control
 
 If you use Git, Magento's `.gitignore` provides most of the preceding. See the [`.gitignore` reference]({{ page.baseurl }}/config-guide/prod/config-reference-gitignore.html) for more information.
 

--- a/guides/v2.2/config-guide/deployment/pipeline/example/environment-variables.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/example/environment-variables.md
@@ -16,15 +16,15 @@ VAT Number and Store Name from **Stores** > Settings > **Configuration** > Gener
 
 These configuration settings are either system-specific or sensitive, as indicated:
 
-* Send Emails To (sensitive) from **Stores** > Settings > **Configuration** > General > **Contacts**
-* Default Email Domain (system-specific) from **Stores** > Settings > **Configuration** > Customers > **Customer Configuration** > **Create New Account Options**
+*  Send Emails To (sensitive) from **Stores** > Settings > **Configuration** > General > **Contacts**
+*  Default Email Domain (system-specific) from **Stores** > Settings > **Configuration** > Customers > **Customer Configuration** > **Create New Account Options**
 
 You can use the same procedure to configure any settings in the following references:
 
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-* [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ## Before you begin
 
@@ -36,9 +36,9 @@ This topic provides an example of modifying the production system configuration.
 
 For the purposes of this example, we assume the following:
 
-* You use Git source control
-* The development system is available in a Git remote repository named `mconfig`
-* Your Git working branch is named `m2.2_deploy`
+*  You use Git source control
+*  The development system is available in a Git remote repository named `mconfig`
+*  Your Git working branch is named `m2.2_deploy`
 
 ## Step 1: Set the configuration in the development system {#deploy-sens-setconfig}
 
@@ -88,19 +88,19 @@ Now that you've committed your changes to the shared configuration to source con
 
 The last step in the process is to update your production system. You must do it in two parts:
 
-* [Update the sensitive and system-specific settings](#config-split-verify-sens)
-* [Update the shared settings](#config-split-verify-shared)
+*  [Update the sensitive and system-specific settings](#config-split-verify-sens)
+*  [Update the shared settings](#config-split-verify-shared)
 
 ### Update the sensitive and system-specific settings {#config-split-verify-sens}
 
 To set the sensitive and system-specific settings using environment variables, you must know the following:
 
-*   Each setting's scope
+*  Each setting's scope
 
    If you followed the instructions in [Step 1](#deploy-sens-setconfig), the scope for Send Emails To is global (that is, the Default Config scope) and the scope for Default Email Domain is website.
 
    You must know the website's code to set the Default Email Domain configuration value. See [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html) for more information on finding it.
-*   Each setting's configuration path
+*  Each setting's configuration path
 
    The configuration paths used in this example follow:
 

--- a/guides/v2.2/config-guide/deployment/pipeline/example/shared-configuration.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/example/shared-configuration.md
@@ -10,16 +10,16 @@ functional_areas:
 
 This example shows how to change the following settings in your development system, update the shared configuration file, `config.php`, in your build system, and implement the same settings in your production system:
 
-* Timezone
-* Weight unit
+*  Timezone
+*  Weight unit
 
 These settings are available in the Magento Admin in **Stores** > Settings > **Configuration** > General > **General**.
 
 You can use the same procedure to configure any non-sensitive, non-system-specific settings in the following references:
 
-* [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 ## Before you begin
 
@@ -31,9 +31,9 @@ This topic provides an example of modifying the production system configuration.
 
 For the purposes of this example, we assume the following:
 
-* You use Git source control
-* The development system is available in a Git remote repository named `mconfig`
-* Your Git working branch is named `m2.2_deploy`
+*  You use Git source control
+*  The development system is available in a Git remote repository named `mconfig`
+*  Your Git working branch is named `m2.2_deploy`
 
 ## Step 1: Set the configuration in the development system
 

--- a/guides/v2.2/config-guide/deployment/pipeline/production-system.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/production-system.md
@@ -12,17 +12,17 @@ functional_areas:
 
 You can have one production system. All of the following must be true:
 
-* All Magento code is in source control in the same repository as the development and build systems
-* Make sure all of the following are _included_ in source control:
+*  All Magento code is in source control in the same repository as the development and build systems
+*  Make sure all of the following are _included_ in source control:
 
-   * `app/etc/config.php`
-   * `generated` directory (and subdirectories)
-   * `pub/media` directory
-   * `pub/media/wysiwyg` directory (and subdirectories)
-   * `pub/static` directory (and subdirectories)
+   *  `app/etc/config.php`
+   *  `generated` directory (and subdirectories)
+   *  `pub/media` directory
+   *  `pub/media/wysiwyg` directory (and subdirectories)
+   *  `pub/static` directory (and subdirectories)
 
-* Magento 2.2 or later must be installed and set for [production mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
-* It has Magento file system ownership and permissions set as discussed in [Prerequisite for your development, build, and production systems]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html#config-deploy-prereq).
+*  Magento 2.2 or later must be installed and set for [production mode]({{ page.baseurl }}/config-guide/bootstrap/magento-modes.html#production-mode)
+*  It has Magento file system ownership and permissions set as discussed in [Prerequisite for your development, build, and production systems]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html#config-deploy-prereq).
 
 ## Set up a production machine
 

--- a/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
+++ b/guides/v2.2/config-guide/deployment/pipeline/technical-details.md
@@ -70,7 +70,7 @@ We changed the following behavior in the Magento Admin in production mode:
    *  Merge CSS and JavaScript
    *  Server-side or client-side LESS compilation
    *  Inline translations
-   * As discussed previously, any configuration setting in `config.php` or `env.php` is locked and cannot be edited in the Admin.
+   *  As discussed previously, any configuration setting in `config.php` or `env.php` is locked and cannot be edited in the Admin.
    *  You can change the Admin locale only to languages used by deployed themes
 
    The following figure shows an example of the **Account Setting**> **Interface Locale** list in the Admin showing only two deployed locales:

--- a/guides/v2.2/config-guide/elasticsearch/es-config-apache.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-apache.md
@@ -20,8 +20,8 @@ The reason the proxy is not secured in this example is it's easier to set up and
 
 See one of the following sections:
 
-* [Set up a proxy for Apache 2.4](#es-apache-proxy-24)
-* [Set up a proxy for Apache 2.2](#es-apache-proxy-22)
+*  [Set up a proxy for Apache 2.4](#es-apache-proxy-24)
+*  [Set up a proxy for Apache 2.2](#es-apache-proxy-22)
 
 ### Set up a proxy for Apache 2.4 {#es-apache-proxy-24}
 
@@ -104,8 +104,8 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 1. Restart Apache:
 
-   * CentOS: `service httpd restart`
-   * Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
 
 1. Verify the proxy works by entering the following command:
 
@@ -139,14 +139,14 @@ This section discusses how to configure an Elasticsearch proxy using a virtual h
 
 This section discusses how to secure communication between Apache and Elasticsearch using [HTTP Basic](http://tools.ietf.org/html/rfc2617) authentication with Apache. For more options, consult one of the following resources:
 
-* [Apache 2.2 authentication and authorization tutorial](http://httpd.apache.org/docs/2.2/howto/auth.html)
-* [Apache 2.4 authentication and authorization tutorial](http://httpd.apache.org/docs/2.4/howto/auth.html)
+*  [Apache 2.2 authentication and authorization tutorial](http://httpd.apache.org/docs/2.2/howto/auth.html)
+*  [Apache 2.4 authentication and authorization tutorial](http://httpd.apache.org/docs/2.4/howto/auth.html)
 
 See one of the following sections:
 
-* [Step 1: Create a password file](#es-ws-secure-apache-pwd)
-* [Step 2: Configure your secure virtual host](#es-ws-secure-finish)
-* [Verify communication is secure](#es-ws-secure-verify)
+*  [Step 1: Create a password file](#es-ws-secure-apache-pwd)
+*  [Step 2: Configure your secure virtual host](#es-ws-secure-finish)
+*  [Verify communication is secure](#es-ws-secure-verify)
 
 ### Step 1: Create a password {#es-ws-secure-apache-pwd}
 
@@ -160,9 +160,9 @@ This section discusses how to specify who can access the Apache server.
 
 1. Use a text editor to add the following contents to your secure virtual host.
 
-   * Apache 2.2: Depending on how you set up SSL, the Apache 2.2 SSL configuration might be located in `/etc/httpd/conf/httpd.conf` or `/etc/httpd/conf.d/ssl.conf`.
+   *  Apache 2.2: Depending on how you set up SSL, the Apache 2.2 SSL configuration might be located in `/etc/httpd/conf/httpd.conf` or `/etc/httpd/conf.d/ssl.conf`.
 
-   * Apache 2.4: Edit `/etc/apache2/sites-available/default-ssl.conf`
+   *  Apache 2.4: Edit `/etc/apache2/sites-available/default-ssl.conf`
 
       ```conf
       <Proxy *>
@@ -185,8 +185,8 @@ This section discusses how to specify who can access the Apache server.
 1. If you added the preceding to your secure virtual host, remove `Listen 8080` and the `<VirtualHost *:8080>` directives you added earlier to your unsecure virtual host.
 1. Save your changes, exit the text editor, and restart Apache:
 
-   * CentOS: `service httpd restart`
-   * Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
 
 {% include config/es-verify-proxy.md %}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/config-guide` folder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
