### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - config-guide. Part 01.

### DIFF
--- a/guides/v2.2/config-guide/bootstrap/mage-dirs.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-dirs.md
@@ -17,8 +17,8 @@ Specify an associative array where keys are constants from [\\Magento\\App\\File
 
 You can set `MAGE_DIRS` in any of the following ways:
 
-* [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html)
-* Use a custom entry point script such as the following:
+*  [Set the value of bootstrap parameters]({{ page.baseurl }}/config-guide/bootstrap/magento-how-to-set.html)
+*  Use a custom entry point script such as the following:
 
    ```php
    use Magento\Framework\App\Filesystem\DirectoryList;

--- a/guides/v2.2/config-guide/bootstrap/mage-profiler.md
+++ b/guides/v2.2/config-guide/bootstrap/mage-profiler.md
@@ -9,11 +9,11 @@ functional_areas:
 
 Magento profiling enables you to:
 
-- Enable a built-in profiler.
+-  Enable a built-in profiler.
 
    You can use a built-in profiler with Magento to perform tasks such as analyzing performance. The nature of profiling depends on the analytical tools you use. We support multiple formats, including HTML. When you enable the profiler, a `var/profiler.flag` file generates indicating the profiler is enabled and configurations. When disabled, this file is deleted.
 
-- Display dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
+-  Display dependency graphs on a Magento page. A *dependency graph* is a list of object dependencies and all of their all their dependencies, and all the dependencies for those dependencies, and so on.
 
    You should be particularly interested in the list of *unused dependencies*, which are objects that were created because they were requested in some constructor, but were never used (that is, none of their methods were called). As a result, processor time and memory spent to create these dependencies are wasted.
 
@@ -27,14 +27,14 @@ You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set th
 
 `MAGE_PROFILER` supports the following values:
 
-- `1` to enable a specific profiler's output.
+-  `1` to enable a specific profiler's output.
 
    You can also use one of the following values to enable a specific profiler:
 
-      - `csvfile` which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Csvfile]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Csvfile.php)
-      - Any other value (except `2`), including an empty value, which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Html]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Html.php)
+   -  `csvfile` which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Csvfile]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Csvfile.php)
+   -  Any other value (except `2`), including an empty value, which uses [Magento\\Framework\\Profiler\\Driver\\Standard\\Output\\Html]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Html.php)
 
-- `2` to enable dependency graphs.
+-  `2` to enable dependency graphs.
 
    Dependency graphs typically display at the bottom of a page. The following figure shows portion of the output:
 
@@ -44,8 +44,8 @@ You can set the value of `MAGE_PROFILER` in any of the ways discussed in [Set th
 
 You can enable or disable the profiler using CLI commands:
 
-- `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
-- `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
+-  `dev:profiler:enable <type>` enables the profiler with `type` of `html` (default) or `csvfile`. When enabled, a flagfile `var/profiler.flag` is created.
+-  `dev:profiler:disable` disables the profiler. When disabled, the flagfile `var/profiler.flag` is removed.
 
 To enable dependency graphs, use the variable option.
 

--- a/guides/v2.2/config-guide/bootstrap/magento-how-to-set.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-how-to-set.md
@@ -20,8 +20,8 @@ The following table discusses the bootstrap parameters you can set:
 
 {:.bs-callout-info}
 
-* Not all bootstrap parameters are documented at this time.
-* You now set the Magento mode (developer, default, production) using the [`magento deploy:mode:set {mode}`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html) command.
+*  Not all bootstrap parameters are documented at this time.
+*  You now set the Magento mode (developer, default, production) using the [`magento deploy:mode:set {mode}`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html) command.
 
 ## Specifying a parameter value using an environment variable {#mode-specify-var}
 
@@ -54,9 +54,9 @@ This section discusses how to specify the mode for either Apache or [nginx](http
 
 See one of the following sections for more information:
 
-* [Specify a variable using an nginx setting](#mode-specify-web-nginx)
-* [Specify a variable using .htaccess (Apache only)](#mode-specify-web-htaccess)
-* [Specify a variable using an Apache setting](#mode-specify-web-apache)
+*  [Specify a variable using an nginx setting](#mode-specify-web-nginx)
+*  [Specify a variable using .htaccess (Apache only)](#mode-specify-web-htaccess)
+*  [Specify a variable using an Apache setting](#mode-specify-web-apache)
 
 ### Specify a variable using an nginx setting {#mode-specify-web-nginx}
 
@@ -68,8 +68,8 @@ One way to set the Magento mode is by editing `.htaccess`. This way, you don't h
 
 You can modify `.htaccess` in any of the following locations, depending on your entry point to the Magento application:
 
-* `<magento_root>/.htaccess`
-* `<magento_root>/pub/.htaccess`
+*  `<magento_root>/.htaccess`
+*  `<magento_root>/pub/.htaccess`
 
 To set a variable:
 
@@ -99,8 +99,8 @@ The Apache `mod_env` directive is slightly different in [version 2.2](http://htt
 
 The procedures that follows show how to set the Magento mode in an Apache virtual host. This is not the only way to use `mod_env` directives; consult the Apache documentation for details.
 
-* [Specify a bootstrap variable for Apache on Ubuntu](#mode-specify-ubuntu)
-* [Specify a bootstrap variable for Apache on CentOS](#mode-specify-centos)
+*  [Specify a bootstrap variable for Apache on Ubuntu](#mode-specify-ubuntu)
+*  [Specify a bootstrap variable for Apache on CentOS](#mode-specify-centos)
 
 #### Specify a bootstrap variable for Apache on Ubuntu {#mode-specify-ubuntu}
 
@@ -112,8 +112,8 @@ To set a Magento bootstrap variable using your web server's environment:
 
    For example, if your virtual host is named `my.magento`,
 
-   * Apache 2.4: `vim /etc/apache2/sites-available/my.magento.conf`
-   * Apache 2.2: `vim /etc/apache2/sites-available/my.magento`
+   *  Apache 2.4: `vim /etc/apache2/sites-available/my.magento.conf`
+   *  Apache 2.2: `vim /etc/apache2/sites-available/my.magento`
 
 1. Anywhere in the virtual host configuration, add the following line:
 
@@ -142,8 +142,8 @@ To set a Magento bootstrap variable using your web server's environment:
 
 1. Restart the web server:
 
-   * Ubuntu: `service apache2 restart`
-   * CentOS: `service httpd restart`
+   *  Ubuntu: `service apache2 restart`
+   *  CentOS: `service httpd restart`
 
 #### Specify a bootstrap variable for Apache on CentOS {#mode-specify-centos}
 
@@ -169,12 +169,12 @@ To set a Magento bootstrap variable using your web server's environment:
 
 After setting the mode, restart the web server:
 
-* Ubuntu: `service apache2 restart`
-* CentOS: `service httpd restart`
+*  Ubuntu: `service apache2 restart`
+*  CentOS: `service httpd restart`
 
 {:.ref-header}
 Related topics
 
-* [Customize base directory paths (MAGE_DIRS)]({{ page.baseurl }}/config-guide/bootstrap/mage-dirs.html)
-* [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html)
-* [Enable an dependency graphs and built-in profiler (MAGE_PROFILER)]({{ page.baseurl }}/config-guide/bootstrap/mage-profiler.html)
+*  [Customize base directory paths (MAGE_DIRS)]({{ page.baseurl }}/config-guide/bootstrap/mage-dirs.html)
+*  [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html)
+*  [Enable an dependency graphs and built-in profiler (MAGE_PROFILER)]({{ page.baseurl }}/config-guide/bootstrap/mage-profiler.html)

--- a/guides/v2.2/config-guide/bootstrap/magento-modes.md
+++ b/guides/v2.2/config-guide/bootstrap/magento-modes.md
@@ -67,9 +67,9 @@ To deploy the Magento application on more than one server or to optimize it for 
 
 In default mode:
 
-- Errors are logged to the file reports at server, and never shown to a user
-- Static view files are cached
-- Default mode is not optimized for a production environment, primarily because of the adverse performance impact of [static files](https://glossary.magento.com/static-files) being dynamically generated rather than [materialized](https://en.wikipedia.org/wiki/Materialized_view). In other words, creating static files and caching them has a greater performance impact than generating them using the static files creation tool.
+-  Errors are logged to the file reports at server, and never shown to a user
+-  Static view files are cached
+-  Default mode is not optimized for a production environment, primarily because of the adverse performance impact of [static files](https://glossary.magento.com/static-files) being dynamically generated rather than [materialized](https://en.wikipedia.org/wiki/Materialized_view). In other words, creating static files and caching them has a greater performance impact than generating them using the static files creation tool.
 
 For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
 
@@ -79,11 +79,11 @@ Run Magento in developer mode when you are extending or customizing it.
 
 In developer mode:
 
-- Static view files are not cached; they are written to the Magento `pub/static` directory every time they're called
-- Uncaught exceptions display in the browser
-- System logging in `var/report` is verbose
-- An [exception](https://glossary.magento.com/exception) is thrown in the error handler, rather than being logged
-- An exception is thrown when an [event](https://glossary.magento.com/event) subscriber cannot be invoked
+-  Static view files are not cached; they are written to the Magento `pub/static` directory every time they're called
+-  Uncaught exceptions display in the browser
+-  System logging in `var/report` is verbose
+-  An [exception](https://glossary.magento.com/exception) is thrown in the error handler, rather than being logged
+-  An exception is thrown when an [event](https://glossary.magento.com/event) subscriber cannot be invoked
 
 For more information, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
 
@@ -95,9 +95,9 @@ This improves performance by providing all necessary static files at deployment 
 
 In production mode:
 
-- Static view files are not materialized, and URLs for them are composed on the fly. Static view files are served from the [cache](https://glossary.magento.com/cache) only.
-- Errors are logged to the file system and are never displayed to the user.
-- You can enable and disable cache types only using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en).
+-  Static view files are not materialized, and URLs for them are composed on the fly. Static view files are served from the [cache](https://glossary.magento.com/cache) only.
+-  Errors are logged to the file system and are never displayed to the user.
+-  You can enable and disable cache types only using the [command line]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-en).
 
    You _cannot_ enable or disable cache types using the Magento Admin
 
@@ -112,6 +112,6 @@ If you are using {{site.data.var.ece}}, the Magento application runs in maintena
 {:.ref-header}
 Related topics
 
-- To set a mode, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
+-  To set a mode, see [Set the Magento mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html).
 
-- To generate static view files for production mode, see [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html)
+-  To generate static view files for production mode, see [Deploy static view files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html)

--- a/guides/v2.2/config-guide/cache/cache-options.md
+++ b/guides/v2.2/config-guide/cache/cache-options.md
@@ -19,9 +19,9 @@ Magento extends [Zend_Cache_Core](http://framework.zend.com/manual/1.12/en/zend.
 
 In general, the Magento application works with any backend cache that [Zend_Cache Backends](http://framework.zend.com/manual/1.12/en/zend.cache.backends.html){:target="_blank"} supports. However, this guide covers only the following low-level backend caches:
 
-*   [Redis]({{ page.baseurl }}/config-guide/redis/config-redis.html)
-*   [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
-*   File system (default): No configuration is necessary to use file system caching.
+*  [Redis]({{ page.baseurl }}/config-guide/redis/config-redis.html)
+*  [Database]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/database-caching.html)
+*  File system (default): No configuration is necessary to use file system caching.
 
 [Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html) doesn't require setting up a low-level [cache backend](https://glossary.magento.com/cache-backend).
 

--- a/guides/v2.2/config-guide/cache/cache-types.md
+++ b/guides/v2.2/config-guide/cache/cache-types.md
@@ -64,12 +64,12 @@ You can specify frontend and [backend](https://glossary.magento.com/backend) cac
 
 where
 
-*   `<frontend_type>` is the low-level frontend [cache type](https://glossary.magento.com/cache-type). Specify the name of a class that is compatible with [Zend\Cache\Core](http://framework.zend.com/apidoc/1.7/Zend_Cache/Zend_Cache_Core.html){:target="_blank"}.
+*  `<frontend_type>` is the low-level frontend [cache type](https://glossary.magento.com/cache-type). Specify the name of a class that is compatible with [Zend\Cache\Core](http://framework.zend.com/apidoc/1.7/Zend_Cache/Zend_Cache_Core.html){:target="_blank"}.
 
     If you omit `<frontend_type>`, [Magento\Framework\Cache\Core]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Cache/Core.php){:target="_blank"} is used.
-*   `<frontend_option>`, `<frontend_option_value>` are the name and value of options the Magento framework passes as an associative array to the frontend cache upon its creation.
-*   `<backend_type>` is the low-level backend cache type. Specify the name of a class that is compatible with [Zend_Cache_Backend](http://framework.zend.com/apidoc/1.7/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend.html){:target="_blank"} and that implements [Zend_Cache_Backend_Interface](http://framework.zend.com/apidoc/1.6/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend_Interface.html){:target="_blank"}.
-*   `<backend_option>`, `<backend_option_value>` are the name and value of options the Magento framework passes as an associative array to backend cache upon its creation.
+*  `<frontend_option>`, `<frontend_option_value>` are the name and value of options the Magento framework passes as an associative array to the frontend cache upon its creation.
+*  `<backend_type>` is the low-level backend cache type. Specify the name of a class that is compatible with [Zend_Cache_Backend](http://framework.zend.com/apidoc/1.7/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend.html){:target="_blank"} and that implements [Zend_Cache_Backend_Interface](http://framework.zend.com/apidoc/1.6/Zend_Cache/Zend_Cache_Backend/Zend_Cache_Backend_Interface.html){:target="_blank"}.
+*  `<backend_option>`, `<backend_option_value>` are the name and value of options the Magento framework passes as an associative array to backend cache upon its creation.
 
 {:.ref-header}
 Related topics

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-cache.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-cache.md
@@ -166,14 +166,14 @@ Enabling a [cache type](https://glossary.magento.com/cache-type) automatically c
 
 To purge out-of-date items from the cache, you can *clean* or *flush* cache types:
 
-- Cleaning a cache type deletes all items from enabled Magento cache types only. In other words, this option does not affect other processes or applications because it cleans only the cache that Magento uses.
+-  Cleaning a cache type deletes all items from enabled Magento cache types only. In other words, this option does not affect other processes or applications because it cleans only the cache that Magento uses.
 
    Disabled cache types are not cleaned.
 
    {: .bs-callout-tip }
    Always clean the cache after upgrading versions of {{site.data.var.ce}} or {{site.data.var.ee}}, upgrading from {{site.data.var.ce}} to {{site.data.var.ee}}, or installing {{site.data.var.b2b}} or any module.
 
-- Flushing a cache type purges the cache storage, which might affect other processes applications that are using the same storage.
+-  Flushing a cache type purges the cache storage, which might affect other processes applications that are using the same storage.
 
 Flush cache types if you've already tried cleaning the cache and you're still having issues that you cannot isolate.
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-compiler.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-compiler.md
@@ -11,12 +11,12 @@ functional_areas:
 
 Code compilation includes the following (in no particular order):
 
--   Application code generation (factories, proxies)
--   Area configuration aggregation (optimized [dependency injection](https://glossary.magento.com/dependency-injection) configurations per area)
--   Interceptor generation (optimized code generation of interceptors)
--   Interception [cache](https://glossary.magento.com/cache) generation
--   Repositories code generation (generated code for APIs)
--   Service data attributes generation (generated [extension](https://glossary.magento.com/extension) classes for data objects)
+-  Application code generation (factories, proxies)
+-  Area configuration aggregation (optimized [dependency injection](https://glossary.magento.com/dependency-injection) configurations per area)
+-  Interceptor generation (optimized code generation of interceptors)
+-  Interception [cache](https://glossary.magento.com/cache) generation
+-  Repositories code generation (generated code for APIs)
+-  Service data attributes generation (generated [extension](https://glossary.magento.com/extension) classes for data objects)
 
 You can find code compilation classes in the [\Magento\Setup\Module\Di\App\Task\Operation]({{ site.mage2bloburl }}/{{ page.guide_version }}/setup/src/Magento/Setup/Module/Di/App/Task/Operation) [namespace](https://glossary.magento.com/namespace).
 
@@ -37,7 +37,7 @@ Generated code and dependency injection configuration successfully.
 
 In some cases, you might want to compile code before you install the Magento application.
 
-1.  Enable the modules.
+1. Enable the modules.
 
     ```bash
     bin/magento module:enable --all [-c|--clear-static-content]
@@ -47,7 +47,7 @@ In some cases, you might want to compile code before you install the Magento app
 
     See [Enable modules]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html).
 
-1.  Compile the code.
+1. Compile the code.
 
     ```bash
     bin/magento setup:di:compile

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-export.md
@@ -23,8 +23,8 @@ bin/magento app:config:dump scopes themes
 
 As a result of the command execution, the following configuration files are updated:
 
--   [`app/etc/config.php`](#app-etc-config-php)
--   [`app/etc/env.php`](#app-etc-env-php)
+-  [`app/etc/config.php`](#app-etc-config-php)
+-  [`app/etc/env.php`](#app-etc-env-php)
 
 ## `app/etc/config.php` {#app-etc-config-php}
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-import.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-import.md
@@ -69,15 +69,15 @@ When we import backend models, we don't save the configuration values.
 We import the following types of configurations.
 (These configurations are under the `scopes` array in `config.php`.)
 
-*   `websites`: websites related configuration
-*   `groups`: stores related configuration
-*   `stores`: store views related configuration
+*  `websites`: websites related configuration
+*  `groups`: stores related configuration
+*  `stores`: store views related configuration
 
 The preceding configurations can be imported in the following modes:
 
-*   `create`: `config.php` contains new entities (`websites`, `groups`, `stores`) that are absent in the production environment
-*   `update`: `config.php` contains entities (`websites`, `groups`, `stores`) that are different from the production environment
-*   `delete`: `config.php` does _not_ contain entities (`websites`, `groups`, `stores`) that are present on production environment
+*  `create`: `config.php` contains new entities (`websites`, `groups`, `stores`) that are absent in the production environment
+*  `update`: `config.php` contains entities (`websites`, `groups`, `stores`) that are different from the production environment
+*  `delete`: `config.php` does _not_ contain entities (`websites`, `groups`, `stores`) that are present on production environment
 
 {:.bs-callout .bs-callout-info}
 We don't import the root [category](https://glossary.magento.com/category) associated with stores. You must associate a root category with a store using the Magento [Admin](https://glossary.magento.com/admin).
@@ -113,11 +113,11 @@ Full example:
 
 {:.bs-callout .bs-callout-info}
 
-*   _Theme registration_. If a theme data is defined in `config.php` but the theme's source code is  not present in the file system, the theme is ignored (that is, not registered).
-*   _Theme removal_. If a theme is not present in `config.php` but the source code is present on the file system, the theme is not removed.
+*  _Theme registration_. If a theme data is defined in `config.php` but the theme's source code is  not present in the file system, the theme is ignored (that is, not registered).
+*  _Theme removal_. If a theme is not present in `config.php` but the source code is present on the file system, the theme is not removed.
 
 {:.ref-header}
 Related topics
 
-*   [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)
-*   [`bin/magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html)
+*  [Deployment general overview]({{ page.baseurl }}/config-guide/deployment/pipeline/)
+*  [`bin/magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html)

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
@@ -11,38 +11,38 @@ functional_areas:
 
 This topic discusses advanced configuration commands you can use to:
 
-*   Set any configuration option from the command line.
-*   Optionally lock any configuration option so its value cannot be changed in the Magento Admin.
-*   Change a configuration option that is locked in the Magento Admin.
+*  Set any configuration option from the command line.
+*  Optionally lock any configuration option so its value cannot be changed in the Magento Admin.
+*  Change a configuration option that is locked in the Magento Admin.
 
 You can use these commands to set the Magento configuration manually or using scripts. Set configuration options using a _configuration path_, which is a `/`-delimited string that uniquely identifies that configuration option.
 
 Find configuration paths in the following references:
 
-*   [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
-*   [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*   [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*   [{{site.data.var.ee}} B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [{{site.data.var.ee}} B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
 
 Set values:
 
-*   Before you install Magento. You can set configuration values for the default scope only.
+*  Before you install Magento. You can set configuration values for the default scope only.
 
     Before you install Magento, the default scope is the only valid scope.
-*   After you install Magento. You can set configuration values for any [website](https://glossary.magento.com/website) or [store view](https://glossary.magento.com/store-view) scope.
+*  After you install Magento. You can set configuration values for any [website](https://glossary.magento.com/website) or [store view](https://glossary.magento.com/store-view) scope.
 
 Use the following commands:
 
-*   `bin/magento config:set` sets any non-sensitive configuration value by its configuration path.
-*   `bin/magento config:sensitive:set` sets any sensitive configuration value by its configuration path.
-*   `bin/magento config:show` shows saved configuration values; values of encrypted settings are displayed as asterisks.
+*  `bin/magento config:set` sets any non-sensitive configuration value by its configuration path.
+*  `bin/magento config:sensitive:set` sets any sensitive configuration value by its configuration path.
+*  `bin/magento config:show` shows saved configuration values; values of encrypted settings are displayed as asterisks.
 
 ## Prerequisites
 
 To set a configuration value, you must know at least one of the following:
 
-*   The configuration path
-*   The scope code, to set a configuration value for a particular scope
+*  The configuration path
+*  The scope code, to set a configuration value for a particular scope
 
     To set a configuration value for the default scope, you don't need to do anything.
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-depen.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-depen.md
@@ -13,9 +13,9 @@ functional_areas:
 
 You can run the following types of reports:
 
--   [**Module**](https://glossary.magento.com/module) dependencies: Shows the total number of dependencies between modules and whether the dependencies are hard or soft.
--   **Circular dependencies:** Shows the total number of dependency chains and the number and list of circular dependencies for each module.
--   **Framework dependencies:** Shows the total number of dependencies on the Magento framework by module (including the total number of framework entries for each library).
+-  [**Module**](https://glossary.magento.com/module) dependencies: Shows the total number of dependencies between modules and whether the dependencies are hard or soft.
+-  **Circular dependencies:** Shows the total number of dependency chains and the number and list of circular dependencies for each module.
+-  **Framework dependencies:** Shows the total number of dependencies on the Magento framework by module (including the total number of framework entries for each library).
 
 A dependency in a comment is also a dependency.
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-index.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-index.md
@@ -158,7 +158,7 @@ MAGE_INDEXER_THREADS_COUNT=3 php -f bin/magento indexer:reindex catalogsearch_fu
 Use this command to set the following indexer options:
 
 *  **Update on save (`realtime`)** - Indexed data is updated as soon as a change is made in the [Admin](https://glossary.magento.com/admin). (For example, the [category](https://glossary.magento.com/category) products index is reindex after products are added to a category in the Admin.) This is the default.
-* **Update by schedule (`schedule`)** - Data is indexed according to the schedule set by your Magento cron job.
+*  **Update by schedule (`schedule`)** - Data is indexed according to the schedule set by your Magento cron job.
 
 [Learn more about indexing]({{ page.baseurl }}/extension-dev-guide/indexing.html).
 

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-layout-xml.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-layout-xml.md
@@ -15,8 +15,8 @@ Use this command to update your [layout](https://glossary.magento.com/layout) [X
 
 For more information about layout XML files, see:
 
--   [Layout instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html)
--   [Layout file types]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-types.html)
+-  [Layout instructions]({{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html)
+-  [Layout file types]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-types.html)
 
 ## Convert layout XML files
 
@@ -28,6 +28,6 @@ bin/magento dev:xml:convert [-o|--overwrite] {xml file} {xslt stylesheet}
 
 here:
 
--   **`{xml file}`** is the full path and file name of a layout XML file to convert (required)
--   **`{xslt stylesheet}`** is the full path and file name of an XSLT stylesheet file to use for [conversion](https://glossary.magento.com/conversion) (required)
--   **`-o|--overwrite`** include this option to overwrite the existing XML file
+-  **`{xml file}`** is the full path and file name of a layout XML file to convert (required)
+-  **`{xslt stylesheet}`** is the full path and file name of an XSLT stylesheet file to use for [conversion](https://glossary.magento.com/conversion) (required)
+-  **`-o|--overwrite`** include this option to overwrite the existing XML file

--- a/guides/v2.2/config-guide/cli/config-cli-subcommands-spt-util.md
+++ b/guides/v2.2/config-guide/cli/config-cli-subcommands-spt-util.md
@@ -45,9 +45,9 @@ bin/magento support:backup:code [--name=<file name>] [-o|--output=<path>] [-l|--
 
 Where:
 
-- **`--name`** specifies the dump file name (optional). If you omit this parameter, the dump file is time and date-stamped.
-- **`-o|--output=<path>`** is the absolute file system path to store the backup (required).
-- **`-l|--logs`** includes log files (optional).
+-  **`--name`** specifies the dump file name (optional). If you omit this parameter, the dump file is time and date-stamped.
+-  **`-o|--output=<path>`** is the absolute file system path to store the backup (required).
+-  **`-l|--logs`** includes log files (optional).
 
 For example, to create a code backup named `/var/www/html/magento2/var/log/mycodebackup.tar.gz`:
 
@@ -71,10 +71,10 @@ bin/magento support:backup:db [--name=<name>] [-o|--output=<path>] [-l|--logs] [
 
 Where:
 
-- **`--name`** specifies the dump file name (optional). If you omit this parameter, the dump file is time and date-stamped.
-- **`-o|--output=<path>` is the absolute file system path to store the backup (required).
-- **`-l|--logs`** includes log files (optional).
-- **`-i|--ignore-sanitize`** means that data is preserved; omit the flag to hash [sensitive data](#sens-data) stored in the database when creating the backup (optional).
+-  **`--name`** specifies the dump file name (optional). If you omit this parameter, the dump file is time and date-stamped.
+-  **`-o|--output=<path>` is the absolute file system path to store the backup (required).
+-  **`-l|--logs`** includes log files (optional).
+-  **`-i|--ignore-sanitize`** means that data is preserved; omit the flag to hash [sensitive data](#sens-data) stored in the database when creating the backup (optional).
 
 After the command completes, provide the database backup to Magento Support.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/config-guide` folder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
