### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - config-guide. Part 03.

### DIFF
--- a/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
@@ -20,8 +20,8 @@ The reason the proxy is not secured in this example is it's easier to set up and
 
 See one of the following sections for more information:
 
-* [Step 1: Specify additional configuration files in your global `nginx.conf`](#es-ws-secure-nginx-conf)
-* [Step 2: Set up nginx as a proxy](#es-ws-secure-nginx-proxy)
+*  [Step 1: Specify additional configuration files in your global `nginx.conf`](#es-ws-secure-nginx-conf)
+*  [Step 2: Set up nginx as a proxy](#es-ws-secure-nginx-proxy)
 
 ### Step 1: Specify additional configuration files in your global `nginx.conf` {#es-ws-secure-nginx-conf}
 
@@ -90,16 +90,16 @@ Because nginx natively supports HTTP Basic authentication, we recommend it over,
 
 Additional resources:
 
-* [How To Set Up Password Authentication with Nginx on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-password-authentication-with-nginx-on-ubuntu-14-04)
-* [Basic HTTP Authentication With Nginx (HowtoForge)](https://www.howtoforge.com/basic-http-authentication-with-nginx)
-* [Example Nginx Configurations for Elasticsearch](https://gist.github.com/karmi/b0a9b4c111ed3023a52d)
+*  [How To Set Up Password Authentication with Nginx on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-password-authentication-with-nginx-on-ubuntu-14-04)
+*  [Basic HTTP Authentication With Nginx (HowtoForge)](https://www.howtoforge.com/basic-http-authentication-with-nginx)
+*  [Example Nginx Configurations for Elasticsearch](https://gist.github.com/karmi/b0a9b4c111ed3023a52d)
 
 See the following sections for more information:
 
-* [Step 1: Create passwords](#es-ws-secure-nginx-pwd)
-* [Step 2: Set up access to nginx](#es-ws-secure-nginx-access)
-* [Step 3: Set up a restricted context for Elasticsearch](#es-ws-secure-nginx-context)
-* [Verify communication is secure](#es-ws-secure-verify)
+*  [Step 1: Create passwords](#es-ws-secure-nginx-pwd)
+*  [Step 2: Set up access to nginx](#es-ws-secure-nginx-access)
+*  [Step 3: Set up a restricted context for Elasticsearch](#es-ws-secure-nginx-context)
+*  [Verify communication is secure](#es-ws-secure-verify)
 
 ### Step 1: Create a password {#es-ws-secure-nginx-pwd}
 
@@ -117,8 +117,8 @@ To create a password:
 
 1. If necessary, install `htpasswd`:
 
-   * Ubuntu: `apt-get -y install apache2-utils`
-   * CentOS: `yum -y install httpd-tools`
+   *  Ubuntu: `apt-get -y install apache2-utils`
+   *  CentOS: `yum -y install httpd-tools`
 
 1. Create a `/etc/nginx/passwd` directory to store passwords:
 

--- a/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
+++ b/guides/v2.2/config-guide/elasticsearch/es-config-nginx.md
@@ -20,8 +20,8 @@ The reason the proxy is not secured in this example is it's easier to set up and
 
 See one of the following sections for more information:
 
-*  [Step 1: Specify additional configuration files in your global `nginx.conf`](#es-ws-secure-nginx-conf)
-*  [Step 2: Set up nginx as a proxy](#es-ws-secure-nginx-proxy)
+* [Step 1: Specify additional configuration files in your global `nginx.conf`](#es-ws-secure-nginx-conf)
+* [Step 2: Set up nginx as a proxy](#es-ws-secure-nginx-proxy)
 
 ### Step 1: Specify additional configuration files in your global `nginx.conf` {#es-ws-secure-nginx-conf}
 
@@ -90,16 +90,16 @@ Because nginx natively supports HTTP Basic authentication, we recommend it over,
 
 Additional resources:
 
-*  [How To Set Up Password Authentication with Nginx on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-password-authentication-with-nginx-on-ubuntu-14-04)
-*  [Basic HTTP Authentication With Nginx (HowtoForge)](https://www.howtoforge.com/basic-http-authentication-with-nginx)
-*  [Example Nginx Configurations for Elasticsearch](https://gist.github.com/karmi/b0a9b4c111ed3023a52d)
+* [How To Set Up Password Authentication with Nginx on Ubuntu 14.04 (Digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-password-authentication-with-nginx-on-ubuntu-14-04)
+* [Basic HTTP Authentication With Nginx (HowtoForge)](https://www.howtoforge.com/basic-http-authentication-with-nginx)
+* [Example Nginx Configurations for Elasticsearch](https://gist.github.com/karmi/b0a9b4c111ed3023a52d)
 
 See the following sections for more information:
 
-*  [Step 1: Create passwords](#es-ws-secure-nginx-pwd)
-*  [Step 2: Set up access to nginx](#es-ws-secure-nginx-access)
-*  [Step 3: Set up a restricted context for Elasticsearch](#es-ws-secure-nginx-context)
-*  [Verify communication is secure](#es-ws-secure-verify)
+* [Step 1: Create passwords](#es-ws-secure-nginx-pwd)
+* [Step 2: Set up access to nginx](#es-ws-secure-nginx-access)
+* [Step 3: Set up a restricted context for Elasticsearch](#es-ws-secure-nginx-context)
+* [Verify communication is secure](#es-ws-secure-verify)
 
 ### Step 1: Create a password {#es-ws-secure-nginx-pwd}
 
@@ -117,8 +117,8 @@ To create a password:
 
 1. If necessary, install `htpasswd`:
 
-   *  Ubuntu: `apt-get -y install apache2-utils`
-   *  CentOS: `yum -y install httpd-tools`
+   * Ubuntu: `apt-get -y install apache2-utils`
+   * CentOS: `yum -y install httpd-tools`
 
 1. Create a `/etc/nginx/passwd` directory to store passwords:
 

--- a/guides/v2.2/config-guide/log/log-db.md
+++ b/guides/v2.2/config-guide/log/log-db.md
@@ -9,8 +9,8 @@ functional_areas:
 
 The following example shows how to log database activity using the [`Magento\Framework\DB\LoggerInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/LoggerInterface.php), which has two implementations:
 
-*  Logs nothing (default): [`Magento\Framework\DB\Logger\Quiet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/Quiet.php)
-*  Logs to the Magento `var/log` directory: [`Magento\Framework\DB\Logger\File`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/File.php)
+*   Logs nothing (default): [`Magento\Framework\DB\Logger\Quiet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/Quiet.php)
+*   Logs to the Magento `var/log` directory: [`Magento\Framework\DB\Logger\File`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/File.php)
 
 {:.bs-callout .bs-callout-info}
 You can also use the Magento CLI to [enable and disable database logging]({{page.baseurl}}/config-guide/cli/logging.html#database-logging).

--- a/guides/v2.2/config-guide/log/log-db.md
+++ b/guides/v2.2/config-guide/log/log-db.md
@@ -9,8 +9,8 @@ functional_areas:
 
 The following example shows how to log database activity using the [`Magento\Framework\DB\LoggerInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/LoggerInterface.php), which has two implementations:
 
-*   Logs nothing (default): [`Magento\Framework\DB\Logger\Quiet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/Quiet.php)
-*   Logs to the Magento `var/log` directory: [`Magento\Framework\DB\Logger\File`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/File.php)
+*  Logs nothing (default): [`Magento\Framework\DB\Logger\Quiet`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/Quiet.php)
+*  Logs to the Magento `var/log` directory: [`Magento\Framework\DB\Logger\File`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Logger/File.php)
 
 {:.bs-callout .bs-callout-info}
 You can also use the Magento CLI to [enable and disable database logging]({{page.baseurl}}/config-guide/cli/logging.html#database-logging).

--- a/guides/v2.2/config-guide/log/log-intro.md
+++ b/guides/v2.2/config-guide/log/log-intro.md
@@ -15,9 +15,9 @@ This topic focuses on file-based logging, although Magento provides the flexibil
 
 We recommend using centralized application logging for the following reasons:
 
-*  It allows storage of logs on a server other than the application server and decreases disk I/O operations, simplifying support of the application server.
+* It allows storage of logs on a server other than the application server and decreases disk I/O operations, simplifying support of the application server.
 
-*  It makes processing of logs data more effective by using special tools without impact to a production server (for example, [logstash](https://www.elastic.co/products/logstash), [logplex](https://devcenter.heroku.com/articles/logplex), or [fluentd](http://www.fluentd.org)).
+* It makes processing of logs data more effective by using special tools without impact to a production server (for example, [logstash](https://www.elastic.co/products/logstash), [logplex](https://devcenter.heroku.com/articles/logplex), or [fluentd](http://www.fluentd.org)).
 
 {:.bs-callout .bs-callout-info}
 Magento does not recommend or endorse any particular logging solution.

--- a/guides/v2.2/config-guide/log/log-intro.md
+++ b/guides/v2.2/config-guide/log/log-intro.md
@@ -15,9 +15,9 @@ This topic focuses on file-based logging, although Magento provides the flexibil
 
 We recommend using centralized application logging for the following reasons:
 
-* It allows storage of logs on a server other than the application server and decreases disk I/O operations, simplifying support of the application server.
+*  It allows storage of logs on a server other than the application server and decreases disk I/O operations, simplifying support of the application server.
 
-* It makes processing of logs data more effective by using special tools without impact to a production server (for example, [logstash](https://www.elastic.co/products/logstash), [logplex](https://devcenter.heroku.com/articles/logplex), or [fluentd](http://www.fluentd.org)).
+*  It makes processing of logs data more effective by using special tools without impact to a production server (for example, [logstash](https://www.elastic.co/products/logstash), [logplex](https://devcenter.heroku.com/articles/logplex), or [fluentd](http://www.fluentd.org)).
 
 {:.bs-callout .bs-callout-info}
 Magento does not recommend or endorse any particular logging solution.

--- a/guides/v2.2/config-guide/memcache/memcache.md
+++ b/guides/v2.2/config-guide/memcache/memcache.md
@@ -19,5 +19,5 @@ Refer to [Why Redis is better]({{ page.baseurl }}/config-guide/redis/config-redi
 {:.ref-header}
 Related topics
 
-*  [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
-*  [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)
+* [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
+* [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)

--- a/guides/v2.2/config-guide/memcache/memcache.md
+++ b/guides/v2.2/config-guide/memcache/memcache.md
@@ -19,5 +19,5 @@ Refer to [Why Redis is better]({{ page.baseurl }}/config-guide/redis/config-redi
 {:.ref-header}
 Related topics
 
-* [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
-* [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)
+*  [Install, configure, verify memcached on Ubuntu]({{ page.baseurl }}/config-guide/memcache/memcache_ubuntu.html)
+*  [Install, configure, verify memcached on CentOS]({{ page.baseurl }}/config-guide/memcache/memcache_centos.html)

--- a/guides/v2.2/config-guide/mq/manage-message-queues.md
+++ b/guides/v2.2/config-guide/mq/manage-message-queues.md
@@ -36,9 +36,9 @@ You can also use a process manager such as [Supervisor](http://supervisord.org/i
 
 #### Behavior by default
 
-* Cron job `consumers_runner` is enabled
-* Cron job `consumers_runner` runs all defined consumers
-* Each consumer processes 10000 messages and then terminates
+*  Cron job `consumers_runner` is enabled
+*  Cron job `consumers_runner` runs all defined consumers
+*  Each consumer processes 10000 messages and then terminates
 
 #### Specific configuration
 
@@ -57,9 +57,9 @@ Edit */app/etc/env.php* file for configure cron job `consumers_runner`
 ...
 ```
 
-* `cron_run` - A boolean value that enables or disables the `consumers_runner` cron job (default = `true`).
-* `max_messages` - The maximum number of messages each consumer must process before terminating (default = `10000`). Although we do not recommend it, you can use 0 to prevent the consumer from terminating.
-* `consumers` - An array of strings specifying which consumer(s) to run. An empty array runs *all* consumers.
+*  `cron_run` - A boolean value that enables or disables the `consumers_runner` cron job (default = `true`).
+*  `max_messages` - The maximum number of messages each consumer must process before terminating (default = `10000`). Although we do not recommend it, you can use 0 to prevent the consumer from terminating.
+*  `consumers` - An array of strings specifying which consumer(s) to run. An empty array runs *all* consumers.
 
 ## Command line interface
 
@@ -71,15 +71,15 @@ Use the `magento` command to start message queue consumers. You can start multip
 
 Where:
 
-*   `<consumer_name>` is the consumer to start.
+*  `<consumer_name>` is the consumer to start.
 
-*   `--max-messages=<value>` specifies the maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously.
+*  `--max-messages=<value>` specifies the maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously.
 
-*   `--batch-size=<value>` specifies the number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
+*  `--batch-size=<value>` specifies the number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
 
-*   `--pid-file-path=<value>` the file path for saving PID of consumer process.
+*  `--pid-file-path=<value>` the file path for saving PID of consumer process.
 
-*   `--area-code=<value>` the area code preferred for consumer process.
+*  `--area-code=<value>` the area code preferred for consumer process.
 
 After consuming all available messages, the command terminates. You can run the command again manually or with a cron job. You can also run multiple instances of the `magento queue:consumers:start` command to process large message queues. For example, you can append `&` to the command to run it in the background, return to a prompt, and continue running commands (e.g., `bin/magento queue:consumers:start <consumer_name> &`).
 
@@ -91,7 +91,7 @@ Use the following command to return a list of message queue consumers:
 
 #### Related Topics
 
-*   [Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
-*   [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)
-*   [Command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
-*   [Message Queues]({{ page.baseurl }}/extension-dev-guide/message-queues/message-queues.html)
+*  [Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
+*  [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)
+*  [Command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
+*  [Message Queues]({{ page.baseurl }}/extension-dev-guide/message-queues/message-queues.html)

--- a/guides/v2.2/config-guide/mq/manage-message-queues.md
+++ b/guides/v2.2/config-guide/mq/manage-message-queues.md
@@ -36,9 +36,9 @@ You can also use a process manager such as [Supervisor](http://supervisord.org/i
 
 #### Behavior by default
 
-*  Cron job `consumers_runner` is enabled
-*  Cron job `consumers_runner` runs all defined consumers
-*  Each consumer processes 10000 messages and then terminates
+* Cron job `consumers_runner` is enabled
+* Cron job `consumers_runner` runs all defined consumers
+* Each consumer processes 10000 messages and then terminates
 
 #### Specific configuration
 
@@ -57,9 +57,9 @@ Edit */app/etc/env.php* file for configure cron job `consumers_runner`
 ...
 ```
 
-*  `cron_run` - A boolean value that enables or disables the `consumers_runner` cron job (default = `true`).
-*  `max_messages` - The maximum number of messages each consumer must process before terminating (default = `10000`). Although we do not recommend it, you can use 0 to prevent the consumer from terminating.
-*  `consumers` - An array of strings specifying which consumer(s) to run. An empty array runs *all* consumers.
+* `cron_run` - A boolean value that enables or disables the `consumers_runner` cron job (default = `true`).
+* `max_messages` - The maximum number of messages each consumer must process before terminating (default = `10000`). Although we do not recommend it, you can use 0 to prevent the consumer from terminating.
+* `consumers` - An array of strings specifying which consumer(s) to run. An empty array runs *all* consumers.
 
 ## Command line interface
 
@@ -71,15 +71,15 @@ Use the `magento` command to start message queue consumers. You can start multip
 
 Where:
 
-*  `<consumer_name>` is the consumer to start.
+*   `<consumer_name>` is the consumer to start.
 
-*  `--max-messages=<value>` specifies the maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously.
+*   `--max-messages=<value>` specifies the maximum number of messages to consume per invocation. If the number of queued messages is less than the specified max, the consumer polls for new messages until it has processed the max. If you don't specify `--max-messages`, the process runs continuously.
 
-*  `--batch-size=<value>` specifies the number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
+*   `--batch-size=<value>` specifies the number of messages to consume per batch. If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
 
-*  `--pid-file-path=<value>` the file path for saving PID of consumer process.
+*   `--pid-file-path=<value>` the file path for saving PID of consumer process.
 
-*  `--area-code=<value>` the area code preferred for consumer process.
+*   `--area-code=<value>` the area code preferred for consumer process.
 
 After consuming all available messages, the command terminates. You can run the command again manually or with a cron job. You can also run multiple instances of the `magento queue:consumers:start` command to process large message queues. For example, you can append `&` to the command to run it in the background, return to a prompt, and continue running commands (e.g., `bin/magento queue:consumers:start <consumer_name> &`).
 
@@ -91,7 +91,7 @@ Use the following command to return a list of message queue consumers:
 
 #### Related Topics
 
-*  [Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
-*  [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)
-*  [Command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
-*  [Message Queues]({{ page.baseurl }}/extension-dev-guide/message-queues/message-queues.html)
+*   [Message Queues Overview]({{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html)
+*   [Configure and run cron]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html)
+*   [Command-line configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands.html)
+*   [Message Queues]({{ page.baseurl }}/extension-dev-guide/message-queues/message-queues.html)

--- a/guides/v2.2/config-guide/mq/rabbitmq-overview.md
+++ b/guides/v2.2/config-guide/mq/rabbitmq-overview.md
@@ -10,19 +10,19 @@ The following diagram illustrates the Message Queue Framework.
 
 ![]({{ site.baseurl }}/common/images/mq.png)
 
-*  A [publisher](https://glossary.magento.com/publisher-subscriber-pattern) is a component that sends messages to an exchange. It knows which exchange to publish to and the format of the messages it sends.
+* A [publisher](https://glossary.magento.com/publisher-subscriber-pattern) is a component that sends messages to an exchange. It knows which exchange to publish to and the format of the messages it sends.
 
-*  An exchange receives messages from publishers and sends them to queues. Although RabbitMQ supports multiple types of exchanges, Magento uses topic exchanges only. A topic includes a routing key, which contains text strings separated by dots. The format for a topic name is <code><i>string1</i>.<i>string2</i></code>..., for example, `customer.created` or `customer.sent.email`.
+* An exchange receives messages from publishers and sends them to queues. Although RabbitMQ supports multiple types of exchanges, Magento uses topic exchanges only. A topic includes a routing key, which contains text strings separated by dots. The format for a topic name is <code><i>string1</i>.<i>string2</i></code>..., for example, `customer.created` or `customer.sent.email`.
 
    The broker allows you to use wildcards when setting rules for forwarding messages.  You can use an asterisk (`*`) to replace _one_ string or a pound sign (`#`) to replace 0 or more strings. For example, `customer.*` would filter on `customer.create` and `customer.delete`, but not `customer.sent.email`. However `customer.#` would filter on `customer.create`,  `customer.delete`, and`customer.sent.email`.
 
-*  A queue is a buffer that stores messages.
+* A queue is a buffer that stores messages.
 
-*  A consumer receives messages. It knows which queue to consume. It can map processors of the message to a specific queue.
+* A consumer receives messages. It knows which queue to consume. It can map processors of the message to a specific queue.
 
 A basic message queue system can also be set up without using RabbitMQ. In this system, a MySQL [adapter](https://glossary.magento.com/adapter) stores messages in the database. Three database tables (`queue`, `queue_message`, and `queue_message_status`) manage the message queue workload. Cron jobs ensure the consumers are able to receive messages. This solution is not very scalable. RabbitMQ should be used whenever possible.
 
 #### Related Topics
 
-*  [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)
-*  [Install RabbitMQ]({{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html)
+* [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)
+* [Install RabbitMQ]({{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html)

--- a/guides/v2.2/config-guide/mq/rabbitmq-overview.md
+++ b/guides/v2.2/config-guide/mq/rabbitmq-overview.md
@@ -10,19 +10,19 @@ The following diagram illustrates the Message Queue Framework.
 
 ![]({{ site.baseurl }}/common/images/mq.png)
 
-* A [publisher](https://glossary.magento.com/publisher-subscriber-pattern) is a component that sends messages to an exchange. It knows which exchange to publish to and the format of the messages it sends.
+*  A [publisher](https://glossary.magento.com/publisher-subscriber-pattern) is a component that sends messages to an exchange. It knows which exchange to publish to and the format of the messages it sends.
 
-* An exchange receives messages from publishers and sends them to queues. Although RabbitMQ supports multiple types of exchanges, Magento uses topic exchanges only. A topic includes a routing key, which contains text strings separated by dots. The format for a topic name is <code><i>string1</i>.<i>string2</i></code>..., for example, `customer.created` or `customer.sent.email`.
+*  An exchange receives messages from publishers and sends them to queues. Although RabbitMQ supports multiple types of exchanges, Magento uses topic exchanges only. A topic includes a routing key, which contains text strings separated by dots. The format for a topic name is <code><i>string1</i>.<i>string2</i></code>..., for example, `customer.created` or `customer.sent.email`.
 
    The broker allows you to use wildcards when setting rules for forwarding messages.  You can use an asterisk (`*`) to replace _one_ string or a pound sign (`#`) to replace 0 or more strings. For example, `customer.*` would filter on `customer.create` and `customer.delete`, but not `customer.sent.email`. However `customer.#` would filter on `customer.create`,  `customer.delete`, and`customer.sent.email`.
 
-* A queue is a buffer that stores messages.
+*  A queue is a buffer that stores messages.
 
-* A consumer receives messages. It knows which queue to consume. It can map processors of the message to a specific queue.
+*  A consumer receives messages. It knows which queue to consume. It can map processors of the message to a specific queue.
 
 A basic message queue system can also be set up without using RabbitMQ. In this system, a MySQL [adapter](https://glossary.magento.com/adapter) stores messages in the database. Three database tables (`queue`, `queue_message`, and `queue_message_status`) manage the message queue workload. Cron jobs ensure the consumers are able to receive messages. This solution is not very scalable. RabbitMQ should be used whenever possible.
 
 #### Related Topics
 
-* [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)
-* [Install RabbitMQ]({{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html)
+*  [Manage message queues]({{ page.baseurl }}/config-guide/mq/manage-mysql.html)
+*  [Install RabbitMQ]({{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html)

--- a/guides/v2.2/config-guide/multi-master/multi-master_slavedb.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_slavedb.md
@@ -10,9 +10,9 @@ functional_areas:
 
 Setting up database replication provides the following benefits:
 
-* Provides data backup
-* Enables data analysis without affecting the master database
-* Scalability
+*  Provides data backup
+*  Enables data analysis without affecting the master database
+*  Scalability
 
 MySQL databases replicate asynchronously, which means slaves do not need to be connected permanently to receive updates from the master.
 
@@ -20,8 +20,8 @@ MySQL databases replicate asynchronously, which means slaves do not need to be c
 
 An in-depth discussion of database replication is beyond the scope of this guide. To set it up, you can consult a resource like:
 
-* [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/replication.html)
-* [How To Set Up Master Slave Replication in MySQL (digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-master-slave-replication-in-mysql)
+*  [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/replication.html)
+*  [How To Set Up Master Slave Replication in MySQL (digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-master-slave-replication-in-mysql)
 
 Magento provides sample MySQL configurations for your slave databases. A simple configuration is provided with the `ResourceConnections` class `README.md`.
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_slavedb.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_slavedb.md
@@ -10,9 +10,9 @@ functional_areas:
 
 Setting up database replication provides the following benefits:
 
-*  Provides data backup
-*  Enables data analysis without affecting the master database
-*  Scalability
+* Provides data backup
+* Enables data analysis without affecting the master database
+* Scalability
 
 MySQL databases replicate asynchronously, which means slaves do not need to be connected permanently to receive updates from the master.
 
@@ -20,8 +20,8 @@ MySQL databases replicate asynchronously, which means slaves do not need to be c
 
 An in-depth discussion of database replication is beyond the scope of this guide. To set it up, you can consult a resource like:
 
-*  [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/replication.html)
-*  [How To Set Up Master Slave Replication in MySQL (digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-master-slave-replication-in-mysql)
+* [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/replication.html)
+* [How To Set Up Master Slave Replication in MySQL (digitalocean)](https://www.digitalocean.com/community/tutorials/how-to-set-up-master-slave-replication-in-mysql)
 
 Magento provides sample MySQL configurations for your slave databases. A simple configuration is provided with the `ResourceConnections` class `README.md`.
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_verify.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_verify.md
@@ -10,9 +10,9 @@ functional_areas:
 
 After configuration, the master databases are configured as follows:
 
--  Main magento database: 369 tables
--  Magento [quote](https://glossary.magento.com/quote) database: 11 tables
--  Magento sales database: 55 tables
+-   Main magento database: 369 tables
+-   Magento [quote](https://glossary.magento.com/quote) database: 11 tables
+-   Magento sales database: 55 tables
 
 To verify your split databases are working properly, perform the following tasks and verify that data is added to the database tables using a database tool like [phpmyadmin]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin):
 

--- a/guides/v2.2/config-guide/multi-master/multi-master_verify.md
+++ b/guides/v2.2/config-guide/multi-master/multi-master_verify.md
@@ -10,9 +10,9 @@ functional_areas:
 
 After configuration, the master databases are configured as follows:
 
--   Main magento database: 369 tables
--   Magento [quote](https://glossary.magento.com/quote) database: 11 tables
--   Magento sales database: 55 tables
+-  Main magento database: 369 tables
+-  Magento [quote](https://glossary.magento.com/quote) database: 11 tables
+-  Magento sales database: 55 tables
 
 To verify your split databases are working properly, perform the following tasks and verify that data is added to the database tables using a database tool like [phpmyadmin]({{ page.baseurl }}/install-gde/prereq/optional.html#install-optional-phpmyadmin):
 

--- a/guides/v2.2/config-guide/prod/config-reference-b2b.md
+++ b/guides/v2.2/config-guide/prod/config-reference-b2b.md
@@ -14,8 +14,8 @@ This reference lists _only_ configuration paths unique to Magento Enterprise B2B
 
 For those configuration paths, see:
 
-*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-b2b.md
+++ b/guides/v2.2/config-guide/prod/config-reference-b2b.md
@@ -14,8 +14,8 @@ This reference lists _only_ configuration paths unique to Magento Enterprise B2B
 
 For those configuration paths, see:
 
-* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-gitignore.md
+++ b/guides/v2.2/config-guide/prod/config-reference-gitignore.md
@@ -12,8 +12,8 @@ This reference shows suggested `.gitignore` files to use in a development system
 ## .gitignore for development
 We recommend you use the `.gitignore` provided with Magento in a development system with the following changes&mdash;comment out the following so they are included in source control:
 
-*  `pub/media/*`
-*  `pub/media/wysiwyg/*.*`
+* `pub/media/*`
+* `pub/media/wysiwyg/*.*`
 
 {% collapsible Show `.gitignore` for development %}
 
@@ -89,10 +89,10 @@ You should use the same `.gitignore` in both your build and production systems s
 
 Changes compared to the default `.gitignore`:
 
-*  The `/pub/media/*.*` directory is included in source control
-*  The `/pub/media/wysiwyg` directory is included in source control
-*  The `/pub/static/*.*` directory is included in source control
-*  The `/generated` directory and subdirectories are included in source control
+* The `/pub/media/*.*` directory is included in source control
+* The `/pub/media/wysiwyg` directory is included in source control
+* The `/pub/static/*.*` directory is included in source control
+* The `/generated` directory and subdirectories are included in source control
 
 {% collapsible Show .gitignore for build and production %}
 

--- a/guides/v2.2/config-guide/prod/config-reference-gitignore.md
+++ b/guides/v2.2/config-guide/prod/config-reference-gitignore.md
@@ -12,8 +12,8 @@ This reference shows suggested `.gitignore` files to use in a development system
 ## .gitignore for development
 We recommend you use the `.gitignore` provided with Magento in a development system with the following changes&mdash;comment out the following so they are included in source control:
 
-* `pub/media/*`
-* `pub/media/wysiwyg/*.*`
+*  `pub/media/*`
+*  `pub/media/wysiwyg/*.*`
 
 {% collapsible Show `.gitignore` for development %}
 
@@ -89,10 +89,10 @@ You should use the same `.gitignore` in both your build and production systems s
 
 Changes compared to the default `.gitignore`:
 
-* The `/pub/media/*.*` directory is included in source control
-* The `/pub/media/wysiwyg` directory is included in source control
-* The `/pub/static/*.*` directory is included in source control
-* The `/generated` directory and subdirectories are included in source control
+*  The `/pub/media/*.*` directory is included in source control
+*  The `/pub/media/wysiwyg` directory is included in source control
+*  The `/pub/static/*.*` directory is included in source control
+*  The `/generated` directory and subdirectories are included in source control
 
 {% collapsible Show .gitignore for build and production %}
 

--- a/guides/v2.2/config-guide/prod/config-reference-most.md
+++ b/guides/v2.2/config-guide/prod/config-reference-most.md
@@ -11,8 +11,8 @@ This topic lists all configuration paths _except_ payment variables, sensitive v
 
 For those configuration paths, see:
 
-*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-most.md
+++ b/guides/v2.2/config-guide/prod/config-reference-most.md
@@ -11,8 +11,8 @@ This topic lists all configuration paths _except_ payment variables, sensitive v
 
 For those configuration paths, see:
 
-* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-payment.md
+++ b/guides/v2.2/config-guide/prod/config-reference-payment.md
@@ -11,8 +11,8 @@ This topic lists payment-related configuration paths that are neither sensitive 
 
 For a list of other configuration paths, see:
 
-*  [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+* [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-payment.md
+++ b/guides/v2.2/config-guide/prod/config-reference-payment.md
@@ -11,8 +11,8 @@ This topic lists payment-related configuration paths that are neither sensitive 
 
 For a list of other configuration paths, see:
 
-* [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
 
 To optionally override any configuration settings or to set sensitive settings, see [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 

--- a/guides/v2.2/config-guide/prod/config-reference-sens.md
+++ b/guides/v2.2/config-guide/prod/config-reference-sens.md
@@ -9,15 +9,15 @@ functional_areas:
 
 This topic lists configuration paths for system-specific and sensitive settings:
 
-* The [`magento app:config:dump` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.
-* The [`magento config:sensitive:set` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) writes sensitive settings to `app/etc/env.php`.
+*  The [`magento app:config:dump` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.
+*  The [`magento config:sensitive:set` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) writes sensitive settings to `app/etc/env.php`.
 
    You can also set sensitive values using configuration variables as discussed in [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 
 For a list of other configuration paths, see:
 
-* [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html).
+*  [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html).
 
 {:.bs-callout .bs-callout-info}
 All configuration paths listed in this topic are sensitive. The `System-specific?` column shows which values are also system-specific.

--- a/guides/v2.2/config-guide/prod/config-reference-sens.md
+++ b/guides/v2.2/config-guide/prod/config-reference-sens.md
@@ -9,15 +9,15 @@ functional_areas:
 
 This topic lists configuration paths for system-specific and sensitive settings:
 
-*  The [`magento app:config:dump` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.
-*  The [`magento config:sensitive:set` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) writes sensitive settings to `app/etc/env.php`.
+* The [`magento app:config:dump` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.
+* The [`magento config:sensitive:set` command]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html) writes sensitive settings to `app/etc/env.php`.
 
    You can also set sensitive values using configuration variables as discussed in [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html).
 
 For a list of other configuration paths, see:
 
-*  [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
-*  [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html).
+* [All configuration paths except payments]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+* [Payment configuration paths]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html).
 
 {:.bs-callout .bs-callout-info}
 All configuration paths listed in this topic are sensitive. The `System-specific?` column shows which values are also system-specific.

--- a/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
+++ b/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
@@ -13,15 +13,15 @@ This topic focuses on Magento development and production systems. If you are ins
 
 The sections that follow discuss requirements for one or two Magento file system owners. That means:
 
-* One user: Typically necessary on shared hosting providers, which allow you to access only one user on the server This user can log in, transfer files using FTP, and this user also runs the web server.
+*  One user: Typically necessary on shared hosting providers, which allow you to access only one user on the server This user can log in, transfer files using FTP, and this user also runs the web server.
 
-* Two users: We recommend two users if you run your own Magento server: one to transfer files and run command-line utilities, and a separate user for the web server software. When possible, this is preferable because it's more secure.
+*  Two users: We recommend two users if you run your own Magento server: one to transfer files and run command-line utilities, and a separate user for the web server software. When possible, this is preferable because it's more secure.
 
    Instead, you have separate users:
 
-   * The web server user, which runs the Magento Admin (including Setup Wizard) and storefront.
+   *  The web server user, which runs the Magento Admin (including Setup Wizard) and storefront.
 
-   * A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
+   *  A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
 
 <p id="mage-owner-one"></p>{% collapsibleh2 Production file system ownership for shared hosting (one user) %}
 To use the one-owner setup, you must log in to your Magento server as the same user that runs the web server. This is typical for shared hosting.
@@ -32,14 +32,14 @@ Because having one file system owner is less secure, we recommend you deploy Mag
 
 In default or developer mode, the following directories must be writable by the user:
 
-* `vendor`
-* `app/etc`
-* `pub/static`
-* `var`
-* Any other static resources
-* `generated/code`
-* `generated/metadata`
-* `var/view_preprocessed`
+*  `vendor`
+*  `app/etc`
+*  `pub/static`
+*  `var`
+*  Any other static resources
+*  `generated/code`
+*  `generated/metadata`
+*  `var/view_preprocessed`
 
 You can set these permissions using either the command line or a file manager application provided by your shared hosting provider.
 
@@ -47,14 +47,14 @@ You can set these permissions using either the command line or a file manager ap
 
 When you are ready to deploy your site to production, you should remove write access from files in the following directories for improved security:
 
-* `vendor`
-* `app/code`
-* `app/etc`
-* `pub/static`
-* Any other static resources
-* `generated/code`
-* `generated/metadata`
-* `var/view_preprocessed`
+*  `vendor`
+*  `app/code`
+*  `app/etc`
+*  `pub/static`
+*  Any other static resources
+*  `generated/code`
+*  `generated/metadata`
+*  `var/view_preprocessed`
 
 To update components, install new components, or to upgrade the Magento software, all of the preceding directories must be read-write.
 
@@ -99,11 +99,11 @@ To make files and directories writable so you can update components and upgrade 
 <p id="mage-owner-two"></p>{% collapsibleh2 Production file system ownership for private hosting (two users) %}
 If you use your own server (including a hosting provider's private server setup), there are two users:
 
-* The web server user, which runs the Magento Admin (including the Setup Wizard) and storefront.
+*  The web server user, which runs the Magento Admin (including the Setup Wizard) and storefront.
 
    Linux systems typically do not provide a shell for this user; you cannot log in to the Magento server as, or switch to, the web server user.
 
-* The command-line user, which you log in to your Magento server as or switch to.
+*  The command-line user, which you log in to your Magento server as or switch to.
 
    Magento uses this user to run Magento CLI commands and cron.
 
@@ -114,18 +114,18 @@ Because these users require access to the same files, we recommend you create a 
 
 See one of the following sections:
 
-* [Two Magento file system owners in developer or default mode](#mage-owner-two-devel)
-* [Two Magento file system owners in production mode](#mage-owner-two-prod)
+*  [Two Magento file system owners in developer or default mode](#mage-owner-two-devel)
+*  [Two Magento file system owners in production mode](#mage-owner-two-prod)
 
 ### Set up two owners for default or developer mode {#mage-owner-two-devel}
 
 Files in the following directories must be writable by both users in developer and default mode:
 
-* `var`
-* `generated`
-* `pub/static`
-* `pub/media`
-* `app/etc`
+*  `var`
+*  `generated`
+*  `pub/static`
+*  `pub/media`
+*  `app/etc`
 
 Set the [`setgid`](http://linuxg.net/how-to-set-the-setuid-and-setgid-bit-for-files-in-linux-and-unix/) bit on directories so permissions always inherit from the parent directory.
 
@@ -157,15 +157,15 @@ To set `setgid` and permissions for developer mode:
 
 When you are ready to deploy your site to production, you should remove write access from files in the following directories for improved security:
 
-* `vendor`
-* `app/code`
-* `app/etc`
-* `lib`
-* `pub/static`
-* Any other static resources
-* `generated/code`
-* `generated/metadata`
-* `var/view_preprocessed`
+*  `vendor`
+*  `app/code`
+*  `app/etc`
+*  `lib`
+*  `pub/static`
+*  Any other static resources
+*  `generated/code`
+*  `generated/metadata`
+*  `var/view_preprocessed`
 
 #### Make code files and directories read-only {#make-files-readable-two-owners}
 

--- a/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
+++ b/guides/v2.2/config-guide/prod/prod_file-sys-perms.md
@@ -13,15 +13,15 @@ This topic focuses on Magento development and production systems. If you are ins
 
 The sections that follow discuss requirements for one or two Magento file system owners. That means:
 
-*  One user: Typically necessary on shared hosting providers, which allow you to access only one user on the server This user can log in, transfer files using FTP, and this user also runs the web server.
+* One user: Typically necessary on shared hosting providers, which allow you to access only one user on the server This user can log in, transfer files using FTP, and this user also runs the web server.
 
-*  Two users: We recommend two users if you run your own Magento server: one to transfer files and run command-line utilities, and a separate user for the web server software. When possible, this is preferable because it's more secure.
+* Two users: We recommend two users if you run your own Magento server: one to transfer files and run command-line utilities, and a separate user for the web server software. When possible, this is preferable because it's more secure.
 
    Instead, you have separate users:
 
-   *  The web server user, which runs the Magento Admin (including Setup Wizard) and storefront.
+   * The web server user, which runs the Magento Admin (including Setup Wizard) and storefront.
 
-   *  A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
+   * A *command-line user*, which is a local user account you can use to log in to the server. This user runs Magento cron jobs and command-line utilities.
 
 <p id="mage-owner-one"></p>{% collapsibleh2 Production file system ownership for shared hosting (one user) %}
 To use the one-owner setup, you must log in to your Magento server as the same user that runs the web server. This is typical for shared hosting.
@@ -32,14 +32,14 @@ Because having one file system owner is less secure, we recommend you deploy Mag
 
 In default or developer mode, the following directories must be writable by the user:
 
-*  `vendor`
-*  `app/etc`
-*  `pub/static`
-*  `var`
-*  Any other static resources
-*  `generated/code`
-*  `generated/metadata`
-*  `var/view_preprocessed`
+* `vendor`
+* `app/etc`
+* `pub/static`
+* `var`
+* Any other static resources
+* `generated/code`
+* `generated/metadata`
+* `var/view_preprocessed`
 
 You can set these permissions using either the command line or a file manager application provided by your shared hosting provider.
 
@@ -47,14 +47,14 @@ You can set these permissions using either the command line or a file manager ap
 
 When you are ready to deploy your site to production, you should remove write access from files in the following directories for improved security:
 
-*  `vendor`
-*  `app/code`
-*  `app/etc`
-*  `pub/static`
-*  Any other static resources
-*  `generated/code`
-*  `generated/metadata`
-*  `var/view_preprocessed`
+* `vendor`
+* `app/code`
+* `app/etc`
+* `pub/static`
+* Any other static resources
+* `generated/code`
+* `generated/metadata`
+* `var/view_preprocessed`
 
 To update components, install new components, or to upgrade the Magento software, all of the preceding directories must be read-write.
 
@@ -99,11 +99,11 @@ To make files and directories writable so you can update components and upgrade 
 <p id="mage-owner-two"></p>{% collapsibleh2 Production file system ownership for private hosting (two users) %}
 If you use your own server (including a hosting provider's private server setup), there are two users:
 
-*  The web server user, which runs the Magento Admin (including the Setup Wizard) and storefront.
+* The web server user, which runs the Magento Admin (including the Setup Wizard) and storefront.
 
    Linux systems typically do not provide a shell for this user; you cannot log in to the Magento server as, or switch to, the web server user.
 
-*  The command-line user, which you log in to your Magento server as or switch to.
+* The command-line user, which you log in to your Magento server as or switch to.
 
    Magento uses this user to run Magento CLI commands and cron.
 
@@ -114,18 +114,18 @@ Because these users require access to the same files, we recommend you create a 
 
 See one of the following sections:
 
-*  [Two Magento file system owners in developer or default mode](#mage-owner-two-devel)
-*  [Two Magento file system owners in production mode](#mage-owner-two-prod)
+* [Two Magento file system owners in developer or default mode](#mage-owner-two-devel)
+* [Two Magento file system owners in production mode](#mage-owner-two-prod)
 
 ### Set up two owners for default or developer mode {#mage-owner-two-devel}
 
 Files in the following directories must be writable by both users in developer and default mode:
 
-*  `var`
-*  `generated`
-*  `pub/static`
-*  `pub/media`
-*  `app/etc`
+* `var`
+* `generated`
+* `pub/static`
+* `pub/media`
+* `app/etc`
 
 Set the [`setgid`](http://linuxg.net/how-to-set-the-setuid-and-setgid-bit-for-files-in-linux-and-unix/) bit on directories so permissions always inherit from the parent directory.
 
@@ -157,15 +157,15 @@ To set `setgid` and permissions for developer mode:
 
 When you are ready to deploy your site to production, you should remove write access from files in the following directories for improved security:
 
-*  `vendor`
-*  `app/code`
-*  `app/etc`
-*  `lib`
-*  `pub/static`
-*  Any other static resources
-*  `generated/code`
-*  `generated/metadata`
-*  `var/view_preprocessed`
+* `vendor`
+* `app/code`
+* `app/etc`
+* `lib`
+* `pub/static`
+* Any other static resources
+* `generated/code`
+* `generated/metadata`
+* `var/view_preprocessed`
 
 #### Make code files and directories read-only {#make-files-readable-two-owners}
 

--- a/guides/v2.2/config-guide/redis/config-redis.md
+++ b/guides/v2.2/config-guide/redis/config-redis.md
@@ -9,11 +9,11 @@ functional_areas:
 
 Redis features include:
 
-* Redis can also be used for [PHP](https://glossary.magento.com/php) session storage.
+*  Redis can also be used for [PHP](https://glossary.magento.com/php) session storage.
 
-* The backend supports tag-based cache cleanup without `foreach` loops.
+*  The backend supports tag-based cache cleanup without `foreach` loops.
 
-* Redis supports on-disk save and master/slave replication.
+*  Redis supports on-disk save and master/slave replication.
 
 {:.bs-callout .bs-callout-info}
 Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
@@ -22,19 +22,19 @@ Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseu
 
 Installing and configuring the Redis software is beyond the scope of this guide. Consult resources such as:
 
-* [Download Redis page](http://redis.io/download)
-* [Redis quick start](http://redis.io/topics/quickstart)
-* [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
-* [Redis documentation page](http://redis.io/documentation)
+*  [Download Redis page](http://redis.io/download)
+*  [Redis quick start](http://redis.io/topics/quickstart)
+*  [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
+*  [Redis documentation page](http://redis.io/documentation)
 
 ## For more information
 
 You can find more information about configuring Redis from the following:
 
-* [David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
-* [TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
+*  [David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
+*  [TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
 
 ## Next
 
-* [Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
-* [Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)
+*  [Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+*  [Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)

--- a/guides/v2.2/config-guide/redis/config-redis.md
+++ b/guides/v2.2/config-guide/redis/config-redis.md
@@ -9,11 +9,11 @@ functional_areas:
 
 Redis features include:
 
-*  Redis can also be used for [PHP](https://glossary.magento.com/php) session storage.
+* Redis can also be used for [PHP](https://glossary.magento.com/php) session storage.
 
-*  The backend supports tag-based cache cleanup without `foreach` loops.
+* The backend supports tag-based cache cleanup without `foreach` loops.
 
-*  Redis supports on-disk save and master/slave replication.
+* Redis supports on-disk save and master/slave replication.
 
 {:.bs-callout .bs-callout-info}
 Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
@@ -22,19 +22,19 @@ Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseu
 
 Installing and configuring the Redis software is beyond the scope of this guide. Consult resources such as:
 
-*  [Download Redis page](http://redis.io/download)
-*  [Redis quick start](http://redis.io/topics/quickstart)
-*  [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
-*  [Redis documentation page](http://redis.io/documentation)
+* [Download Redis page](http://redis.io/download)
+* [Redis quick start](http://redis.io/topics/quickstart)
+* [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
+* [Redis documentation page](http://redis.io/documentation)
 
 ## For more information
 
 You can find more information about configuring Redis from the following:
 
-*  [David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
-*  [TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
+* [David Alger](http://davidalger.com/development/magento/configuring-magento-2-to-use-redis-cache-backend/)
+* [TechyTalk](http://www.techytalk.info/configuring-cache-storage-backends-magento-2-redis/)
 
 ## Next
 
-*  [Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
-*  [Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)
+* [Use Redis for the Magento page and default cache]({{ page.baseurl }}/config-guide/redis/redis-pg-cache.html)
+* [Use Redis for session storage]({{ page.baseurl }}/config-guide/redis/redis-session.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the `guides/v2.2/config-guide` folder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
