### PR TITLE
Refactors MD030 issues

### DIFF
--- a/guides/v2.2/ui_comp_guide/components/ui-columns.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-columns.md
@@ -32,4 +32,4 @@ The Columns component is a collection of columns. It renders the `<table>` eleme
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [`Magento/Ui/view/base/web/js/grid/listing.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/listing.js)
+-  [`Magento/Ui/view/base/web/js/grid/listing.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/listing.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-datecolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-datecolumn.md
@@ -26,4 +26,4 @@ The DateColumn component implements a table column that displays dates.
 
 Extends [`Column`]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html):
 
-- [`app/code/Magento/Ui/view/base/web/js/grid/columns/date.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js)
+-  [`app/code/Magento/Ui/view/base/web/js/grid/columns/date.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-draganddrop.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-draganddrop.md
@@ -18,4 +18,4 @@ The DragAndDrop component is an [extension](https://glossary.magento.com/extensi
 
 Extends [`UiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [`app/code/Magento/Ui/view/base/web/js/grid/dnd.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/dnd.js)
+-  [`app/code/Magento/Ui/view/base/web/js/grid/dnd.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/dnd.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-expandable-column.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-expandable-column.md
@@ -62,16 +62,16 @@ This component has a dependency on the Column component, `<Magento_Ui_module_dir
 
 ## Source files
 
-- [`<Magento_Ui_module_dir>/view/base/web/js/grid/columns/expandable.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/expandable.js)
-- [`<Magento_Ui_module_dir>/view/base/web/templates/grid/cells/expandable.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/expandable.html)
-- [`<Magento_Ui_module_dir>/view/base/web/templates/grid/cells/expandable/content.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/expandable/content.html)
+-  [`<Magento_Ui_module_dir>/view/base/web/js/grid/columns/expandable.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/expandable.js)
+-  [`<Magento_Ui_module_dir>/view/base/web/templates/grid/cells/expandable.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/expandable.html)
+-  [`<Magento_Ui_module_dir>/view/base/web/templates/grid/cells/expandable/content.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/grid/cells/expandable/content.html)
 
 ### Methods and events
 
 The following [API](https://glossary.magento.com/api) methods are available:
 
-- `getFullLabel()` - gets a label from a full list of options.
-- `getShortLabel()` - gets a label from a list of options limited by `visibeItemsLimit` value.
-- `getLabelsArray()` - extracts an array of labels associated with provided values and sorts these labels alphabetically.
-- `isExpandable()` - checks if the amount of options associated with a record is greater than a `visibeItemsLimit` value.
-- `flatOptions()` - transforms the tree options structure to a linear array.
+-  `getFullLabel()` - gets a label from a full list of options.
+-  `getShortLabel()` - gets a label from a list of options limited by `visibeItemsLimit` value.
+-  `getLabelsArray()` - extracts an array of labels associated with provided values and sorts these labels alphabetically.
+-  `isExpandable()` - checks if the amount of options associated with a record is greater than a `visibeItemsLimit` value.
+-  `flatOptions()` - transforms the tree options structure to a linear array.

--- a/guides/v2.2/ui_comp_guide/components/ui-fieldset.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-fieldset.md
@@ -26,7 +26,7 @@ The Fieldset component implements a container for visually-grouped form elements
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html) and `collapsible`:
 
-- [`Magento/Ui/Component/Form/Fieldset.php`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/Component/Form/Fieldset.php)
-- [`Magento/Ui/view/base/web/js/form/components/fieldset.js`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js)
-- [`Magento/Ui/view/base/web/templates/form/fieldset.html`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/templates/form/fieldset.html)
-- [`Magento/Ui/view/base/ui_component/etc/definition/fieldset.xsd`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/ui_component/etc/definition/fieldset.xsd)
+-  [`Magento/Ui/Component/Form/Fieldset.php`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/Component/Form/Fieldset.php)
+-  [`Magento/Ui/view/base/web/js/form/components/fieldset.js`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js)
+-  [`Magento/Ui/view/base/web/templates/form/fieldset.html`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/templates/form/fieldset.html)
+-  [`Magento/Ui/view/base/ui_component/etc/definition/fieldset.xsd`]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/ui_component/etc/definition/fieldset.xsd)

--- a/guides/v2.2/ui_comp_guide/components/ui-fileuploader.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-fileuploader.md
@@ -227,7 +227,7 @@ Here is an example of how File Uploader component integrates with [Form]({{ page
 
 Extends `abstract`:
 
-- [`<Magento_Ui_module_dir>/view/base/web/js/form/element/file-uploader.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js)
-- [`jquery/fileUploader/jquery.fileupload-fp`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/jquery/fileUploader/jquery.fileupload-fp.js)
-- [`<Magento_Ui_module_dir>/view/base/web/templates/form/element/uploader/uploader.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/form/element/uploader/uploader.html)
-- [`<Magento_Ui_module_dir>/view/base/web/templates/form/element/uploader/preview.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/form/element/uploader/preview.html)
+-  [`<Magento_Ui_module_dir>/view/base/web/js/form/element/file-uploader.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js)
+-  [`jquery/fileUploader/jquery.fileupload-fp`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/jquery/fileUploader/jquery.fileupload-fp.js)
+-  [`<Magento_Ui_module_dir>/view/base/web/templates/form/element/uploader/uploader.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/form/element/uploader/uploader.html)
+-  [`<Magento_Ui_module_dir>/view/base/web/templates/form/element/uploader/preview.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/form/element/uploader/preview.html)

--- a/guides/v2.2/ui_comp_guide/components/ui-filterschips.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-filterschips.md
@@ -28,4 +28,4 @@ The FiltersChips component provides UI controls that allows users to remove the 
 
 Extends [`uiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/filters/chips.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/chips.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/filters/chips.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/chips.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-htmlcontent.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-htmlcontent.md
@@ -83,5 +83,5 @@ All blocks inside HtmlContent are integrated into the layout, so external blocks
 
 Extends `uiComponent`:
 
-- [app/code/Magento/Ui/view/base/web/js/form/components/html.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/components/html.js)
-- [app/code/Magento/Ui/view/base/web/templates/content/content.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/content/content.html)
+-  [app/code/Magento/Ui/view/base/web/js/form/components/html.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/components/html.js)
+-  [app/code/Magento/Ui/view/base/web/templates/content/content.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/content/content.html)

--- a/guides/v2.2/ui_comp_guide/components/ui-linkcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-linkcolumn.md
@@ -20,4 +20,4 @@ Constructor: [app/code/Magento/Ui/view/base/web/js/grid/columns/link.js]({{ site
 
 Extends [Column component]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html)
 
-- [`app/code/Magento/Ui/view/base/web/js/grid/columns/link.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/link.js)
+-  [`app/code/Magento/Ui/view/base/web/js/grid/columns/link.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/link.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-listing-grid.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-listing-grid.md
@@ -66,4 +66,4 @@ The listing component requires the data source to be properly configured and ass
 
 ## Source files
 
-- [app/code/Magento/Ui/view/base/web/js/lib/core/collection.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/collection.js)
+-  [app/code/Magento/Ui/view/base/web/js/lib/core/collection.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/collection.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-onoffcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-onoffcolumn.md
@@ -18,4 +18,4 @@ The OnOffColumn component is a decorator for [MultiselectColumn]({{ page.baseurl
 
 Extends [`MultiselectColumn`]({{ page.baseurl }}/ui_comp_guide/components/ui-multiselectcolumn.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/columns/onoff.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/onoff.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/columns/onoff.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/onoff.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-paging.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-paging.md
@@ -47,4 +47,4 @@ The Paging component implements pagination in grids implemented using [Listing](
 
 Extends [`UiElement`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/paging/paging.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/paging/paging.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/paging/paging.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/paging/paging.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-range.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-range.md
@@ -32,4 +32,4 @@ The Range component implements the range for filtering rows in a grid. Visually,
 
 Extends [`Multiline`]({{ page.baseurl }}/ui_comp_guide/components/ui-multiline.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/filters/range.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/filters/range.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-search.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-search.md
@@ -89,4 +89,4 @@ The Search component allows searching through the grid records. It is a generic 
 
 Extends [`UiElement`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/search/search.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/search/search.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/search/search.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/search/search.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-selectcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-selectcolumn.md
@@ -91,4 +91,4 @@ The SelectColumn component receives an array of values and displays the column w
 
 Extends [`Column`]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/columns/select.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/columns/select.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:
- `guides/v2.3/ui_comp_guide`