### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/rest/tutorials/orders/order-add-items.md
+++ b/guides/v2.2/rest/tutorials/orders/order-add-items.md
@@ -204,10 +204,10 @@ We now know the values for `option_value` for `size` and `color` are `168` and `
 
 The sample data provides one bundled product, the Sprite Yoga Companion Kit (`sku`: `24-WG080`). The kit contains the following items:
 
-* Sprite Statis Ball in sizes 55 cm (`sku`: `24-WG081-blue`), 65 cm (`sku`: `24-WG082-blue`), or 75 cm (`sku`: `24-WG083-blue`)
-* Sprite Foam Yoga brick (`sku`: `24-WG084`)
-* Sprite Yoga Strap in lengths 6 ft (`sku`: `24-WG085`), 8 ft (`sku`: `24-WG086`), or 10 ft (`sku`: `24-WG087`)
-* Sprite Foam Roller (`sku`: `24-WG088`)
+*  Sprite Statis Ball in sizes 55 cm (`sku`: `24-WG081-blue`), 65 cm (`sku`: `24-WG082-blue`), or 75 cm (`sku`: `24-WG083-blue`)
+*  Sprite Foam Yoga brick (`sku`: `24-WG084`)
+*  Sprite Yoga Strap in lengths 6 ft (`sku`: `24-WG085`), 8 ft (`sku`: `24-WG086`), or 10 ft (`sku`: `24-WG087`)
+*  Sprite Foam Roller (`sku`: `24-WG088`)
 
 To add a bundle product to a cart, you must specify the `sku` of the bundle product, but not the individual items. You add individual items to the bundle product by specifying the `id` defined in the item's `product_links` object. The `product_links` object primarily describes the ordering and placement of options on the customization page, but it also links an item's `sku` and `id` to the `sku` of the bundle product.
 
@@ -312,10 +312,10 @@ The `GET <host>/rest/<store_code>/V1/bundle-products/24-WG080/options/all` call 
 
 For this example, we'll configure the Sprite Yoga Companion Kit as follows:
 
-* 65 cm Sprite Stasis Ball (`id`: `2`)
-* Sprite Foam Yoga Brick (`id`: `4`)
-* 8 ft Sprite Yoga strap (`id`: `6`)
-* Sprite Foam Roller (`id`: `8`)
+*  65 cm Sprite Stasis Ball (`id`: `2`)
+*  Sprite Foam Yoga Brick (`id`: `4`)
+*  8 ft Sprite Yoga strap (`id`: `6`)
+*  Sprite Foam Roller (`id`: `8`)
 
 **Endpoint**
 

--- a/guides/v2.2/rest/tutorials/orders/order-create-quote.md
+++ b/guides/v2.2/rest/tutorials/orders/order-create-quote.md
@@ -19,20 +19,20 @@ functional_areas:
 
 When a customer adds an item to their [shopping cart](https://glossary.magento.com/shopping-cart) for the first time, Magento creates a [quote](https://glossary.magento.com/quote). Magento uses a quote to perform tasks such as
 
-* Track each item the customer wants to buy, including the quantity and base cost
-* Gather information about the customer, including billing and shipping addresses
-* Determine shipping costs
-* Calculate the subtotal, add costs (shipping fees, taxes, etc.) and apply coupons to determine the grand total
-* Determine the [payment method](https://glossary.magento.com/payment-method)
-* Place the order so that the merchant can fulfill it.
+*  Track each item the customer wants to buy, including the quantity and base cost
+*  Gather information about the customer, including billing and shipping addresses
+*  Determine shipping costs
+*  Calculate the subtotal, add costs (shipping fees, taxes, etc.) and apply coupons to determine the grand total
+*  Determine the [payment method](https://glossary.magento.com/payment-method)
+*  Place the order so that the merchant can fulfill it.
 
 ### Types of carts {#cart-types}
 
 Magento identifies three types of users that can create a shopping cart:
 
-* An [admin](https://glossary.magento.com/admin) user can create a cart on behalf of a customer. For all admin requests, you must provide an admin [authorization](https://glossary.magento.com/authorization) token in the call's authorization header.
-* A logged-in customer. Calls to create a cart and add items must contain the customer's authorization token in the authorization header.
-* A guest user. These users could be customers who haven't logged in yet, or they could be users who have no intention of creating an account. An anonymous user's cart is called a guest cart.
+*  An [admin](https://glossary.magento.com/admin) user can create a cart on behalf of a customer. For all admin requests, you must provide an admin [authorization](https://glossary.magento.com/authorization) token in the call's authorization header.
+*  A logged-in customer. Calls to create a cart and add items must contain the customer's authorization token in the authorization header.
+*  A guest user. These users could be customers who haven't logged in yet, or they could be users who have no intention of creating an account. An anonymous user's cart is called a guest cart.
 
 ### Create a cart for a logged-in customer {#create-cart}
 

--- a/guides/v2.2/rest/tutorials/orders/order-prepare-checkout.md
+++ b/guides/v2.2/rest/tutorials/orders/order-prepare-checkout.md
@@ -18,8 +18,8 @@ functional_areas:
 
 Now that all the items have been added to the cart, we can prepare the order for [checkout](https://glossary.magento.com/checkout). This process includes the following steps:
 
-* Estimate shipping costs
-* Set shipping and billing information
+*  Estimate shipping costs
+*  Set shipping and billing information
 
 ### Estimate shipping costs {#estimate-shipping}
 

--- a/guides/v2.2/test/integration/annotations/magento-app-isolation.md
+++ b/guides/v2.2/test/integration/annotations/magento-app-isolation.md
@@ -66,8 +66,8 @@ Test class ancestors                                 | Test case (class) | Test 
 
 You can use non-isolated tests unless they do not modify or utilize the same application areas such as:
 
-- same attributes of an application object.
-- same paths in a current configuration or current scope (for example "store").
+-  same attributes of an application object.
+-  same paths in a current configuration or current scope (for example "store").
 
 {:.bs-callout .bs-callout-tip}
 Set up application isolation if any application objects were intentionally modified within the test case.

--- a/guides/v2.2/test/unit/writing_testable_code.md
+++ b/guides/v2.2/test/unit/writing_testable_code.md
@@ -24,8 +24,8 @@ The fewer dependencies a class has and the more obvious they are, the easier it 
 
 We strongly recommend you do *not*:
 
-* Use `new` to instantiate new objects, because that removes the flexibility the Magento dependency configuration offers.
-* Use the `ObjectManager` directly in production code.
+*  Use `new` to instantiate new objects, because that removes the flexibility the Magento dependency configuration offers.
+*  Use the `ObjectManager` directly in production code.
 
 There always is a better alternative, usually a [generated]({{ page.baseurl }}/extension-dev-guide/code-generation.html) `Factory` class, or a [`Locator`](https://thephp.cc/news/2015/09/dependencies-in-disguise){:target="_blank"} class of sorts.
 
@@ -46,19 +46,19 @@ Whenever your code requires access to some part of the environment, try to use a
 
 For example, if you need...
 
-* file system access?
+*  file system access?
 
   Use [`\Magento\Framework\Filesystem\Io\IoInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Filesystem/Io/IoInterface.php){:target="_blank"} instead of `fopen()`, `dir()` or other native methods.
 
-* the current time?
+*  the current time?
 
    Inject a [`\DateTimeInterface`](http://php.net/manual/en/refs.calendar.php){:target="_blank"} instance (for example `\DateTimeImmutable`) and use that.
 
-* the remote IP?
+*  the remote IP?
 
   Use [`\Magento\Framework\HTTP\PhpEnvironment\RemoteAddress`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/HTTP/PhpEnvironment/RemoteAddress.php){:target="_blank"}.
 
-* access to `$_SERVER`?
+*  access to `$_SERVER`?
 
   Consider using [`\Magento\Framework\HTTP\PhpEnvironment\Request::getServerValue()`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php){:target="_blank"}.
 
@@ -139,8 +139,8 @@ If `getParams()` had been called, the class `MyClass` would have instantly depen
 
 If cannot avoid using `getParams()`, you can do any of the following:
 
-* Add the `getParams()` method to `RequestInterface`
-* Make `MyClass` dependent on `HttpRequest` directly instead of using `RequestInterface` as a constructor argument
+*  Add the `getParams()` method to `RequestInterface`
+*  Make `MyClass` dependent on `HttpRequest` directly instead of using `RequestInterface` as a constructor argument
 
 The benefit *interfaces* offer is that interfaces keep code decoupled from implementation details. This means that future changes will not cause your code to fail unless the interface is changed too.
 
@@ -251,9 +251,9 @@ function extractMatchingDocuments(Document $searchDoc, array $documents)
 
 The [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter){:target="_blank"} principle is sometimes stated as "Talk to friends only" or "Do not talk to strangers." It states that code can call methods only on objects that it received in one of the following ways:
 
-* Objects received as constructor arguments
-* Objects received as arguments to the current method
-* Objects instantiated in the current method
+*  Objects received as constructor arguments
+*  Objects received as arguments to the current method
+*  Objects instantiated in the current method
 
 The principle explicitly states that no method can be called on objects that are the return value of another method call. Calling method calls on returned objects introduces a hidden dependency on the returned object type.
 
@@ -281,10 +281,10 @@ Almost as a side effect, those classes are very easy to test.
 
 ## For more information
 
-* [Rules of simple software design](http://martinfowler.com/bliki/BeckDesignRules.html){:target="_blank"} by Kent Beck
-* [Clean Code](https://books.google.com/books/about/Clean_Code.html?id=dwSfGQAACAAJ){:target="_blank"} by Robert C. Martin
-* [Refactoring](http://martinfowler.com/books/refactoring.html){:target="_blank"} by Martin Fowler
-* [Growing Object Oriented Software Guided by Tests](http://www.growing-object-oriented-software.com){:target="_blank"} by Steve Freeman and Nat Pryce
+*  [Rules of simple software design](http://martinfowler.com/bliki/BeckDesignRules.html){:target="_blank"} by Kent Beck
+*  [Clean Code](https://books.google.com/books/about/Clean_Code.html?id=dwSfGQAACAAJ){:target="_blank"} by Robert C. Martin
+*  [Refactoring](http://martinfowler.com/books/refactoring.html){:target="_blank"} by Martin Fowler
+*  [Growing Object Oriented Software Guided by Tests](http://www.growing-object-oriented-software.com){:target="_blank"} by Steve Freeman and Nat Pryce
 
 <!-- Link definitions -->
 [single-responsibility-principle]: https://en.wikipedia.org/wiki/Single_responsibility_principle

--- a/guides/v2.2/ui_comp_guide/components/ui-sizes.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-sizes.md
@@ -73,4 +73,4 @@ The Sizes component defines the maximum number of displayed records in a table (
 
 Extends [`UiElement`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/paging/sizes.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/paging/sizes.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/paging/sizes.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/paging/sizes.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-thumbnailcolumn.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-thumbnailcolumn.md
@@ -32,4 +32,4 @@ The ThumbnailColumn component implements a column containing images associated w
 
 Extends [`Column`]({{ page.baseurl }}/ui_comp_guide/components/ui-column.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js)

--- a/guides/v2.2/ui_comp_guide/components/ui-toolbar.md
+++ b/guides/v2.2/ui_comp_guide/components/ui-toolbar.md
@@ -44,4 +44,4 @@ The Toolbar component implements a container for the listing-related elements li
 
 Extends [`UiCollection`]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uicollection_concept.html):
 
-- [app/code/Magento/Ui/view/base/web/js/grid/toolbar.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js)
+-  [app/code/Magento/Ui/view/base/web/js/grid/toolbar.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js)

--- a/guides/v2.3/rest/tutorials/orders/order-intro.md
+++ b/guides/v2.3/rest/tutorials/orders/order-intro.md
@@ -25,18 +25,18 @@ The **10-step tutorial** generally takes **30 minutes**.
 
 Complete the following prerequisites:
 
-* Install a Magento 2.1.3 (or later) instance with sample data.
+*  Install a Magento 2.1.3 (or later) instance with sample data.
 
   The sample data defines a functional store, called Luma, that sells fitness clothing and accessories. The store does not provide any sandbox accounts for testing credit card payments, so transactions will be simulated using an offline [payment method](https://glossary.magento.com/payment-method).
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
 
-* Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/redoc/{{page.guide_version}}/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
+*  Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/redoc/{{page.guide_version}}/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
 
-* Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}} 2.1](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
+*  Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}} 2.1](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
 
 ### Other resources
 
-* [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.

--- a/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.3/rest/tutorials/orders/order-issue-refund.md
@@ -81,7 +81,7 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 {:.ref-header}
 Related topics
 
-* [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
-* [Create a configurable product Tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html)
-* [REST API Reference Overview]({{ page.baseurl }}/rest/bk-rest.html)
-* [REST API documentation]({{site.baseurl}}/redoc/{{page.guide_version}}/)
+*  [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
+*  [Create a configurable product Tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html)
+*  [REST API Reference Overview]({{ page.baseurl }}/rest/bk-rest.html)
+*  [REST API documentation]({{site.baseurl}}/redoc/{{page.guide_version}}/)

--- a/guides/v2.3/security/google-recaptcha.md
+++ b/guides/v2.3/security/google-recaptcha.md
@@ -7,8 +7,8 @@ functional_areas:
 
 Google reCAPTCHA provides a greater level of security for both the storefront and Admin UI than is available with standard CAPTCHA, and gives you the ability to:
 
-- Verify when customers create accounts, retrieve passwords, log in to their accounts, or contact your company.
-- Enhance security when Admin users log in.
+-  Verify when customers create accounts, retrieve passwords, log in to their accounts, or contact your company.
+-  Enhance security when Admin users log in.
 
 Google reCAPTCHA reduces potential user error when entering a Captcha code and encourages cart conversion without adding hurdles during checkout.
 

--- a/guides/v2.3/soap/bk-soap.md
+++ b/guides/v2.3/soap/bk-soap.md
@@ -15,9 +15,9 @@ functional_areas:
 
 The value of `store_code` can be one of the following:
 
-* `default`
-* The assigned store code
-* `all`. This value only applies to the [CMS](https://glossary.magento.com/cms) and Product modules. If this value is specified, the [API](https://glossary.magento.com/api) call affects all the merchant's stores.
+*  `default`
+*  The assigned store code
+*  `all`. This value only applies to the [CMS](https://glossary.magento.com/cms) and Product modules. If this value is specified, the [API](https://glossary.magento.com/api) call affects all the merchant's stores.
 
 ## List of Service Names per Module
 

--- a/guides/v2.3/test/integration/annotations/magento-db-isolation.md
+++ b/guides/v2.3/test/integration/annotations/magento-db-isolation.md
@@ -6,9 +6,9 @@ title: Database isolation annotation
 To isolate database changes between tests, the Integration testing framework (ITF) implements the `@magentoDbIsolation` annotation.
 When the `@magentoDbIsolation` is enabled, the ITF:
 
-- starts a database transaction before the test/test case.
-- avoids a database commit during the test/test case.
-- restores the database after the test/test case.
+-  starts a database transaction before the test/test case.
+-  avoids a database commit during the test/test case.
+-  restores the database after the test/test case.
 
 ## Format
 

--- a/guides/v2.3/test/integration/integration_test_execution.md
+++ b/guides/v2.3/test/integration/integration_test_execution.md
@@ -37,9 +37,9 @@ See [Running Integration Tests in PhpStorm][phpstorm run].
 Before you can use the Magento integration test framework, you must prepare the test environment.
 Prerequisites for the test environment include the following:
 
-- A dedicated integration test database
-- The test framework database configuration
-- The PHPUnit configuration matches the purpose of the integration test execution
+-  A dedicated integration test database
+-  The test framework database configuration
+-  The PHPUnit configuration matches the purpose of the integration test execution
 
 ## Integration test database
 
@@ -331,14 +331,14 @@ The root folder for the Magento integration tests suite —`<magento_root>/dev/t
 
 This folder contains the following sub-folders and files:
 
-- `framework/` – Integration testing framework scripts, configuration files and classes.
-- `Magento/` – A set of classes that implement the Magento integration tests framework.
-- `bootstrap.php` – The PHPUnit bootstrap script.
-- `etc/install-config-<db_vendor>.php` – A configuration file that provides values for installing the Magento application.
-- `testsuite/` – The test suite.
-- `tmp/` – A writable directory for storing temporary data during test execution.
-- `sandbox-<hash>/` – The folder where each Magento instance stores temporary and configuration data.
-- `phpunit.xml.dist` – A PHPUnit configuration file.
+-  `framework/` – Integration testing framework scripts, configuration files and classes.
+-  `Magento/` – A set of classes that implement the Magento integration tests framework.
+-  `bootstrap.php` – The PHPUnit bootstrap script.
+-  `etc/install-config-<db_vendor>.php` – A configuration file that provides values for installing the Magento application.
+-  `testsuite/` – The test suite.
+-  `tmp/` – A writable directory for storing temporary data during test execution.
+-  `sandbox-<hash>/` – The folder where each Magento instance stores temporary and configuration data.
+-  `phpunit.xml.dist` – A PHPUnit configuration file.
 
 <!-- LINK DEFINITIONS -->
 

--- a/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
+++ b/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
@@ -199,5 +199,5 @@ class MyLink implements ConfigInterface
 
 Magento provides the ability to use two link types by default:
 
-* `Magento\Catalog\Ui\Component\UrlInput\Category` for category
-* `Magento\Catalog\Ui\Component\UrlInput\Product` for product
+*  `Magento\Catalog\Ui\Component\UrlInput\Category` for category
+*  `Magento\Catalog\Ui\Component\UrlInput\Product` for product


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:
- `guides/v2.3/ui_comp_guide`
- `guides/v2.3/test`
- `guides/v2.3/soap`
- `guides/v2.3/security`
- `guides/v2.3/rest`