### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.md
@@ -21,12 +21,12 @@ This **5-step tutorial** generally takes **45 minutes**.
 ### Before you begin
 {:.tutorial-before}
 
-* Install a Magento 2.2 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
+*  Install a Magento 2.2 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
+*  Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
 
 ### Other resources
 
-* [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.

--- a/guides/v2.2/rest/tutorials/configurable-product/create-configurable-product.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-configurable-product.md
@@ -205,8 +205,8 @@ Before you using this code sample, verify that the attribute values are the same
 
 ## Verify this step
 
-* Log in to the Luma website and select **Catalog > Products**. The product appears in the grid.
+*  Log in to the Luma website and select **Catalog > Products**. The product appears in the grid.
 
   ![Product page with configurable product]({{ page.baseurl }}/rest/images/products-page.png)
 
-* On the Luma storefront page, search for `Champ`. No results are returned.
+*  On the Luma storefront page, search for `Champ`. No results are returned.

--- a/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-personalization-option.md
@@ -58,11 +58,11 @@ The `product_sku` is the `sku` of the configurable product. The `sku` specified 
 
 ## Verify this step
 
-* Log in to the Luma website and select **Catalog > Products**. Click on the **Champ Tee** configurable product and expand the **Customizable Options** section.
+*  Log in to the Luma website and select **Catalog > Products**. Click on the **Champ Tee** configurable product and expand the **Customizable Options** section.
 
   ![Product page with configurable and simple products]({{ page.baseurl }}/rest/images/options-section.png)
 
-* On the Luma storefront page, search for `Champ`. Then click on the Champ Tee product.
+*  On the Luma storefront page, search for `Champ`. Then click on the Champ Tee product.
 
   ![Search results]({{ page.baseurl }}/rest/images/add-your-name.png)
 

--- a/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/create-simple-products.md
@@ -15,11 +15,11 @@ functional_areas:
 
 The payloads for creating a simple product and a configurable product are identical, with the following exceptions:
 
-* The simple product `sku` appends the configurable option (the size in this tutorial) to the configurable product `sku`.
-* The `name` indicates the size.
-* The `type_id` is set to `simple`.
-* The `visibility` is set to `1`, indicating the simple product should not be displayed on the store.
-* The `price` and `size` attributes are specified.
+*  The simple product `sku` appends the configurable option (the size in this tutorial) to the configurable product `sku`.
+*  The `name` indicates the size.
+*  The `type_id` is set to `simple`.
+*  The `visibility` is set to `1`, indicating the simple product should not be displayed on the store.
+*  The `price` and `size` attributes are specified.
 
 Although it's not required, the simple product payload also includes `stock_item` information. By default, the Luma store hides out-of-stock items, so adding stock will make the Champ Tee visible on the website.
 
@@ -230,8 +230,8 @@ Attribute | Medium Value | Large Value
 
 ## Verify this step
 
-* Log in to the Luma website and select <b>Catalog > Products</b>. The product appears in the grid.
+*  Log in to the Luma website and select <b>Catalog > Products</b>. The product appears in the grid.
 
   ![Product page with configurable and simple products]({{ page.baseurl }}/rest/images/products-page-all.png)
 
-* On the Luma storefront page, search for `Champ`. No results are returned.
+*  On the Luma storefront page, search for `Champ`. No results are returned.

--- a/guides/v2.2/rest/tutorials/configurable-product/define-config-product-options.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/define-config-product-options.md
@@ -69,15 +69,15 @@ The call to link a simple (child) product to the configurable product accepts on
 
 ## Verify this step
 
-* Log in to the Luma website and select **Catalog > Products**. Click on the **Champ Tee** configurable product and expand the **Configurations** section.
+*  Log in to the Luma website and select **Catalog > Products**. Click on the **Champ Tee** configurable product and expand the **Configurations** section.
 
 ![Product page with configurable and simple products]({{ page.baseurl }}/rest/images/configurations-section.png)
 
-* On the Luma storefront page, search for `Champ`.
+*  On the Luma storefront page, search for `Champ`.
 
 ![Search results]({{ page.baseurl }}/rest/images/search-results.png)
 
-* Call `GET /V1/products/MS-Champ`. The response includes the `configurable_product_options` and `configurable_product_links` arrays.
+*  Call `GET /V1/products/MS-Champ`. The response includes the `configurable_product_options` and `configurable_product_links` arrays.
 
 ```json
 ...

--- a/guides/v2.2/rest/tutorials/configurable-product/plan-product.md
+++ b/guides/v2.2/rest/tutorials/configurable-product/plan-product.md
@@ -15,9 +15,9 @@ functional_areas:
 
 To create a configurable product programmatically, you'll need to know the following:
 
-* The attribute names and values defined in the attribute set assigned to the configurable product.
-* The categories numbers assigned to the configurable product.
-* Which attributes to use as the configuration options.
+*  The attribute names and values defined in the attribute set assigned to the configurable product.
+*  The categories numbers assigned to the configurable product.
+*  Which attributes to use as the configuration options.
 
 Since this tutorial uses the sample data, we can take advantage of the options that the Top attribute set provides. This attribute set contains attributes that describe the fabric, sleeve length, and other characteristics that are specific to clothing. It also includes EAV attributes such as size and color, which are commonly available to all types of physical products.
 
@@ -134,9 +134,9 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gte
 
 Note that women's tops and tees have different ids than men's tops and tees. The values for men's clothing are:
 
-* Men - `11`
-* Tops - `12`
-* Tees - `16`
+*  Men - `11`
+*  Tops - `12`
+*  Tees - `16`
 
 ## Verify this step
 

--- a/guides/v2.2/rest/tutorials/grouped-product/create-and-manage-grouped-products.md
+++ b/guides/v2.2/rest/tutorials/grouped-product/create-and-manage-grouped-products.md
@@ -11,15 +11,15 @@ This tutorial describes how you can use the Magento REST API to create and manag
 
 ### Before you begin
 
-* Install a Magento 2.2 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
+*  Install a Magento 2.2 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
+*  Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
 
 ### Other resources
 
-* [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
 
 ## 1. Create an empty grouped product
 

--- a/guides/v2.3/rest/retrieve-filtered-responses.md
+++ b/guides/v2.3/rest/retrieve-filtered-responses.md
@@ -10,10 +10,10 @@ This feature is not available for SOAP, because SOAP does not allow partial resp
 
 You can append `?fields=<field_or_object1>,<field_or_object2>,...` to any GET, POST, or PUT operation to filter unimportant information from the response. `<field_or_object>` can be any of the following:
 
-* Simple top-level field
-* Top-level object that includes all fields
-* Top-level object with selected fields
-* Nested objects
+*  Simple top-level field
+*  Top-level object that includes all fields
+*  Top-level object with selected fields
+*  Nested objects
 
 Separate each field or object with a comma.
 
@@ -88,9 +88,9 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 
 This example returns only the following:
 
-* The product's `sku` and `name`
-* The entire `category_links` object, which is defined in `extension_attributes`
-* The `item_id` and `qty` fields of the `stock_item` object, which is also defined in `extension_attributes`
+*  The product's `sku` and `name`
+*  The entire `category_links` object, which is defined in `extension_attributes`
+*  The `item_id` and `qty` fields of the `stock_item` object, which is also defined in `extension_attributes`
 
 `GET <host>/rest/<store_code>/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
@@ -191,4 +191,4 @@ The following query returns only the `sku` and `name` parameters for product ite
 {:.ref-header}
 Related topics
 
-* [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)
+*  [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.3/rest/tutorials/bulk-configurable-product/config-product-intro.md
+++ b/guides/v2.3/rest/tutorials/bulk-configurable-product/config-product-intro.md
@@ -25,13 +25,13 @@ A system integrator can use Magento REST bulk APIs to perform actions on a large
 ### Before you begin
 {:.tutorial-before}
 
-* Install a Magento 2.3 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
-* Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
-* Use the `bin/magento queue:consumers:start async.operations.all` command to enable bulk endpoint processing.
+*  Install a Magento 2.3 (or later) instance with sample data. The sample data defines a functional store, called Luma, that sells fitness clothing and accessories.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Obtain an admin authorization token. All calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
+*  Use the `bin/magento queue:consumers:start async.operations.all` command to enable bulk endpoint processing.
 
 ### Other resources
 
-* [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
-* [Asynchronous web endpoints]({{ page.baseurl }}/rest/asynchronous-web-endpoints.html) provides information about how to use Magento Asynchronous API
-* [Bulk endpoints]({{ page.baseurl }}/rest/bulk-endpoints.html) provides information about how to use Magento Bulk API
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
+*  [Asynchronous web endpoints]({{ page.baseurl }}/rest/asynchronous-web-endpoints.html) provides information about how to use Magento Asynchronous API
+*  [Bulk endpoints]({{ page.baseurl }}/rest/bulk-endpoints.html) provides information about how to use Magento Bulk API

--- a/guides/v2.3/rest/tutorials/bulk-configurable-product/create-configurable-simple-products.md
+++ b/guides/v2.3/rest/tutorials/bulk-configurable-product/create-configurable-simple-products.md
@@ -21,19 +21,19 @@ By providing configurable and simple product information, you can use the bulk A
 
 Some notes about the configurable product payload example:
 
-* We have the information we need to create the Champ Tee configurable product.
-* The sample payload does not contain the price or the size, as these are defined in the simple products section.
-* The `visibility` attribute is set to 4, which allows customers to find the product by browsing or searching. Each simple product defined in the payload can override the `visibility` attribute.
+*  We have the information we need to create the Champ Tee configurable product.
+*  The sample payload does not contain the price or the size, as these are defined in the simple products section.
+*  The `visibility` attribute is set to 4, which allows customers to find the product by browsing or searching. Each simple product defined in the payload can override the `visibility` attribute.
 
 ### Simple products
 
  The payloads for creating a simple product and a configurable product are identical, with the following exceptions:
 
-* The simple product `sku` appends the configurable option (the size in this tutorial) to the configurable product `sku`.
-* The `name` indicates the size.
-* The `type_id` is set to `simple`.
-* The `visibility` is set to `1`, indicating the simple product should not be displayed on the store.
-* The `price` and `size` attributes are specified.
+*  The simple product `sku` appends the configurable option (the size in this tutorial) to the configurable product `sku`.
+*  The `name` indicates the size.
+*  The `type_id` is set to `simple`.
+*  The `visibility` is set to `1`, indicating the simple product should not be displayed on the store.
+*  The `price` and `size` attributes are specified.
 
  Although it's not required, the simple product payload also includes `stock_item` information. By default, the Luma store hides out-of-stock items, so adding stock will make the Champ Tee visible on the website.
 

--- a/guides/v2.3/rest/tutorials/bulk-configurable-product/plan-product.md
+++ b/guides/v2.3/rest/tutorials/bulk-configurable-product/plan-product.md
@@ -17,9 +17,9 @@ contributor_link: http://comwrap.com/
 
  To create a configurable product programmatically, you'll need to know the following:
 
-* The attribute names and values defined in the attribute set assigned to the configurable product.
-* The category numbers assigned to the configurable product.
-* Which attributes to use as the configuration options.
+*  The attribute names and values defined in the attribute set assigned to the configurable product.
+*  The category numbers assigned to the configurable product.
+*  Which attributes to use as the configuration options.
 
  Since this tutorial uses the sample data, we can take advantage of the options that the Top attribute set provides. This attribute set contains attributes that describe the fabric, sleeve length, and other characteristics that are specific to clothing. It also includes EAV attributes such as size and color, which are commonly available to all types of physical products.
 
@@ -136,9 +136,9 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gte
 
  Note that women's tops and tees have different ids than men's tops and tees. The values for men's clothing are:
 
-* Men - `11`
-* Tops - `12`
-* Tees - `16`
+*  Men - `11`
+*  Tops - `12`
+*  Tees - `16`
 
 ## Verify this step
 

--- a/guides/v2.3/rest/tutorials/index.md
+++ b/guides/v2.3/rest/tutorials/index.md
@@ -9,31 +9,31 @@ functional_areas:
 
 The REST tutorials provide an introduction to Magento web APIs. In general, the tutorials guide you through commonly-performed complex tasks:
 
-* The [**order processing** tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html) demonstrates the lifecycle of an order. Major steps include creating a quote, converting it to an order, issuing an invoice, and shipping the order.
+*  The [**order processing** tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html) demonstrates the lifecycle of an order. Major steps include creating a quote, converting it to an order, issuing an invoice, and shipping the order.
 
-* The [**order processing with Inventory Management**]({{ page.baseurl }}/rest/tutorials/inventory/index.html) tutorial builds upon the original order processing tutorial. It also configures sources and stocks and other Inventory Management features.
+*  The [**order processing with Inventory Management**]({{ page.baseurl }}/rest/tutorials/inventory/index.html) tutorial builds upon the original order processing tutorial. It also configures sources and stocks and other Inventory Management features.
 
-* The [**configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html) helps you plan then create a configurable product and its component simple products.
+*  The [**configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html) helps you plan then create a configurable product and its component simple products.
 
-* The [**bulk API configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/bulk-configurable-product/config-product-intro.html) demonstrates how to create configurable products using bulk APIs.
+*  The [**bulk API configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/bulk-configurable-product/config-product-intro.html) demonstrates how to create configurable products using bulk APIs.
 
-* The [**grouped products** tutorial]({{ page.baseurl }}/rest/tutorials/grouped-product/create-and-manage-grouped-products.html) demonstrates how to create and manage grouped products.
+*  The [**grouped products** tutorial]({{ page.baseurl }}/rest/tutorials/grouped-product/create-and-manage-grouped-products.html) demonstrates how to create and manage grouped products.
 
 ## Complete these prerequisites
 
 Before you begin any tutorial, make sure you know the basics about {{site.data.var.ce}}
 
-* Install a Magento 2.3 (or later) instance with sample data.
+*  Install a Magento 2.3 (or later) instance with sample data.
 
   The sample data defines a functional store, called Luma, that sells fitness clothing and accessories. The store does not provide any sandbox accounts for testing credit card payments, so transactions will be simulated using an offline [payment method](https://glossary.magento.com/payment-method).
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
 
-* Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{site.baseurl}}/redoc/{{page.guide_version}}/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
+*  Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{site.baseurl}}/redoc/{{page.guide_version}}/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
 
-* Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}}](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
+*  Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}}](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
 
 ## Performing steps
 

--- a/guides/v2.3/rest/tutorials/inventory/bulk-transfer-products.md
+++ b/guides/v2.3/rest/tutorials/inventory/bulk-transfer-products.md
@@ -77,6 +77,6 @@ Use the same endpoint to bulk transfer the product to Austin.
 
 In Admin, click **Catalog** > **Products**. Scroll down to the Driven Backpack row.
 
-* The stock has been transferred from Berlin to Baltimore. The Baltimore warehouse now has 32 units.
-* The Austin warehouse now has 7 units.
-* The **Salable Quantity** column no longer lists European stock.
+*  The stock has been transferred from Berlin to Baltimore. The Baltimore warehouse now has 32 units.
+*  The Austin warehouse now has 7 units.
+*  The **Salable Quantity** column no longer lists European stock.

--- a/guides/v2.3/rest/tutorials/inventory/index.md
+++ b/guides/v2.3/rest/tutorials/inventory/index.md
@@ -23,14 +23,14 @@ This **13-step tutorial** generally takes **1 hour**.
 
 ### Complete these prerequisites
 
-* Install Magento 2.3.0 or later.
+*  Install Magento 2.3.0 or later.
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
 
-* Obtain an admin authorization token. Multiple calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
+*  Obtain an admin authorization token. Multiple calls in this tutorial require administrator privileges. See [Generate the admin token]({{ page.baseurl }}/rest/tutorials/prerequisite-tasks/create-admin-token.html) for more information.
 
 ### Other resources
 
-* Magento uses [Swagger](https://swagger.io) to provide REST API documentation on local instances of Magento. See [Generate a local API reference]({{ page.baseurl }}/rest/generate-local.html) for more information. You can view the [static REST API documentation]({{site.baseurl}}/redoc/{{page.guide_version}}/), which displays reference information using ReDoc.
+*  Magento uses [Swagger](https://swagger.io) to provide REST API documentation on local instances of Magento. See [Generate a local API reference]({{ page.baseurl }}/rest/generate-local.html) for more information. You can view the [static REST API documentation]({{site.baseurl}}/redoc/{{page.guide_version}}/), which displays reference information using ReDoc.

--- a/guides/v2.3/rest/tutorials/inventory/prepare-for-checkout.md
+++ b/guides/v2.3/rest/tutorials/inventory/prepare-for-checkout.md
@@ -14,8 +14,8 @@ functional_areas:
 
 Now that all the items have been added to the cart, we can prepare the quote for [checkout](https://glossary.magento.com/checkout). This process includes the following steps:
 
-* Estimate shipping costs
-* Set shipping and billing information
+*  Estimate shipping costs
+*  Set shipping and billing information
 
 ### Estimate shipping costs {#estimate-shipping}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.3/rest`