### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/rest/modules/catalog-pricing.md
+++ b/guides/v2.2/rest/modules/catalog-pricing.md
@@ -15,10 +15,10 @@ The  `SpecialPriceStorageInterface` service provides the means to efficiently sc
 
 The `POST /V1/products/special-price` call sets special prices for the following product types:
 
-* Simple
-* Bundle
-* Virtual
-* Downloadable
+*  Simple
+*  Bundle
+*  Virtual
+*  Downloadable
 
 **Service Name**
 
@@ -417,10 +417,10 @@ Name | Description | Format | Requirements
 
 The `POST /V1/products/base-price` call can set base prices for the following types of products:
 
-* Simple
-* Virtual
-* Downloadable
-* Bundle (fixed price type only)
+*  Simple
+*  Virtual
+*  Downloadable
+*  Bundle (fixed price type only)
 
 The following example sets the base price for a simple and a downloadable product.
 
@@ -511,9 +511,9 @@ Name | Description | Format | Requirements
 
 The `POST /V1/products/cost` call can set the cost values for the following types of products:
 
-* Simple
-* Virtual
-* Downloadable
+*  Simple
+*  Virtual
+*  Downloadable
 
 The following example sets the cost value for a simple and a downloadable product.
 

--- a/guides/v2.2/rest/modules/sales/refunds.md
+++ b/guides/v2.2/rest/modules/sales/refunds.md
@@ -14,11 +14,11 @@ With this service, you can initiate and process a refund based on an invoice ID,
 
 The `salesRefundInvoice` service allows you to:
 
-* Create a credit memo (complete or partial) for an invoice
-* Add details about the refunded items to the order
-* Change status and state of an order according to performed actions
-* Notify a customer about the performed refund operation
-* Designate whether the returned items are returned to stock
+*  Create a credit memo (complete or partial) for an invoice
+*  Add details about the refunded items to the order
+*  Change status and state of an order according to performed actions
+*  Notify a customer about the performed refund operation
+*  Designate whether the returned items are returned to stock
 
 ### Endpoint
 
@@ -42,5 +42,5 @@ If you try to apply the service to an invoice created using an online payment m
 
 While Magento recommends you use the `Refund` services, Magento also provides the following `CreditmemoManagement` services you can use to issue a credit:
 
-* `salesCreditmemoManagement`
-* `salesCreditmemoRepository`
+*  `salesCreditmemoManagement`
+*  `salesCreditmemoRepository`

--- a/guides/v2.2/rest/performing-searches.md
+++ b/guides/v2.2/rest/performing-searches.md
@@ -15,9 +15,9 @@ searchCriteria[filter_groups][<index>][filters][<index>][condition_type]=<operat
 
 where:
 
-* `field` is an attribute name.
-* `value` specifies the value to search for.
-* `condition_type` is one of the following values:
+*  `field` is an attribute name.
+*  `value` specifies the value to search for.
+*  `condition_type` is one of the following values:
 
 Condition | Notes
 --- | ---
@@ -45,10 +45,10 @@ The `filter_groups` array defines one or more `filters`. Each filter defines a s
 
 When constructing a search, keep the following in mind:
 
-* To perform a logical OR, specify multiple `filters` within a `filter_groups`.
-* To perform a logical AND, specify multiple `filter_groups`.
-* You cannot perform a logical OR across different `filter_groups`, such as `(A AND B) OR (X AND Y)`. ORs can be performed only within the context of a single `filter_groups`.
-* You can only search top-level attributes.
+*  To perform a logical OR, specify multiple `filters` within a `filter_groups`.
+*  To perform a logical AND, specify multiple `filter_groups`.
+*  You cannot perform a logical OR across different `filter_groups`, such as `(A AND B) OR (X AND Y)`. ORs can be performed only within the context of a single `filter_groups`.
+*  You can only search top-level attributes.
 
 The following sections provide examples of each type of search. These examples use the {{site.data.var.ce}} sample data.
 
@@ -197,10 +197,10 @@ The query returns 37 items.
 
 The following searchCriteria can be used to determine the sort order and the number of items to return.
 
-* `searchCriteria[sortOrders][<index>][field]=<field-name>` - Specifies the field to sort on. By default, search results are returned in descending order. You can sort on multiple fields. For example, to sort on `price` first and then by `name`, call `searchCriteria[sortOrders][0][field]=price&searchCriteria[sortOrders][1][field]=name`.
+*  `searchCriteria[sortOrders][<index>][field]=<field-name>` - Specifies the field to sort on. By default, search results are returned in descending order. You can sort on multiple fields. For example, to sort on `price` first and then by `name`, call `searchCriteria[sortOrders][0][field]=price&searchCriteria[sortOrders][1][field]=name`.
 
-* `searchCriteria[sortOrders][<index>][direction]=ASC | DESC` - Specifies whether to return results in ascending (ASC) or descending (DESC) order. To expand the previous example and sort the `price` fields in descending order and the `name` fields in ascending order, call `searchCriteria[sortOrders][0][field]=price&searchCriteria[sortOrders][1][field]=name&searchCriteria[sortOrders][1][direction]=ASC`.
+*  `searchCriteria[sortOrders][<index>][direction]=ASC | DESC` - Specifies whether to return results in ascending (ASC) or descending (DESC) order. To expand the previous example and sort the `price` fields in descending order and the `name` fields in ascending order, call `searchCriteria[sortOrders][0][field]=price&searchCriteria[sortOrders][1][field]=name&searchCriteria[sortOrders][1][direction]=ASC`.
 
-* `searchCriteria[pageSize]` - Specifies the maximum number of items to return. The value must be an integer. If the `pageSize` is not specified, the system returns all matches.
+*  `searchCriteria[pageSize]` - Specifies the maximum number of items to return. The value must be an integer. If the `pageSize` is not specified, the system returns all matches.
 
-* `searchCriteria[currentPage]` - Returns the current page.
+*  `searchCriteria[currentPage]` - Returns the current page.

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.md
@@ -32,34 +32,34 @@ Look for the following highlights in this release:
 
 This release includes extensive security enhancements:
 
-* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.2) have been ported to 2.2.9, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+*  **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.2) have been ported to 2.2.9, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
-* **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
+*  **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
 
 {:.bs-callout .bs-callout-note}
 Starting with the release of Magento Commerce 2.3.2, Magento will  assign and publish indexed Common Vulnerabilities and Exposures (CVE) numbers with each security bug reported to us by external parties. This  will allows users of Magento Commerce to more easily identify unaddressed vulnerabilities in their deployment.
 
 ### Performance boosts
 
-* **Redesign of checkout page to support customers working with many addresses**. The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is  disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).   <!--- MC-5681--->
+*  **Redesign of checkout page to support customers working with many addresses**. The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is  disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).   <!--- MC-5681--->
 
-* **Significant improvement to storefront page response time**. The page response times for the catalog, search, and advanced search pages have been significantly improved under high load. <!--- MAGETWO-95294--->
+*  **Significant improvement to storefront page response time**. The page response times for the catalog, search, and advanced search pages have been significantly improved under high load. <!--- MAGETWO-95294--->
 
-* **Improved concurrent access to block cache storage**. We have optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.  <!--- MC-6273-->
+*  **Improved concurrent access to block cache storage**. We have optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.  <!--- MC-6273-->
 
-* **Product page gallery load optimization**. Product images are now loaded as quickly as other page content. In previous releases, although the product page loaded quickly, product images needed two to four additional seconds to load completely. <!--- MC-15440-->
+*  **Product page gallery load optimization**. Product images are now loaded as quickly as other page content. In previous releases, although the product page loaded quickly, product images needed two to four additional seconds to load completely. <!--- MC-15440-->
 
-* **Improved page rendering through deferred loading and parsing of storefront JavaScript**. All non-critical JavaScript code has been relocated to the bottom of storefront pages, which speeds up page rendering and allows users to see the complete page sooner while nonessential elements remain inactive. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.   <!--- MC-15439-->
+*  **Improved page rendering through deferred loading and parsing of storefront JavaScript**. All non-critical JavaScript code has been relocated to the bottom of storefront pages, which speeds up page rendering and allows users to see the complete page sooner while nonessential elements remain inactive. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.   <!--- MC-15439-->
 
 ### Infrastructure improvements
 
 This release contains 130 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements:
 
-* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.<!--- MAGETWO-98424-->
+*  **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.<!--- MAGETWO-98424-->
 
-* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for information about using the UPS shipment method. Shipping method configuration settings are described in  [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
+*  **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for information about using the UPS shipment method. Shipping method configuration settings are described in  [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
 
-* **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts).
+*  **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts).
 
 ### Merchant tool enhancements
 
@@ -136,316 +136,316 @@ We have fixed hundreds of issues in the Magento 2.3.2 core code.
 
 <!--- ENGCOM-4602-->
 
-* The `configFactory` `scope` and `scope_code` values are now passed to `configFactory` as data arrays. *Fix submitted by ochnygosch in pull request [22012](https://github.com/magento/magento2/pull/22012)*. [GitHub-21993](https://github.com/magento/magento2/issues/21993)
+*  The `configFactory` `scope` and `scope_code` values are now passed to `configFactory` as data arrays. *Fix submitted by ochnygosch in pull request [22012](https://github.com/magento/magento2/pull/22012)*. [GitHub-21993](https://github.com/magento/magento2/issues/21993)
 
 <!--- ENGCOM-4582-->
 
-* Magento now renders the value of configuration variables (such as `{{unsecure_base_url}}`) as they are entered in  configuration files rather than saving the resolved value. Previously, Magento resolved the variable to its actual value, which lead to the overwriting the value in the database when the configuration was saved instead of storing the value in the variable. *Fix submitted by Pieter Hoste in pull request [18067](https://github.com/magento/magento2/pull/18067)*. [GitHub-15972](https://github.com/magento/magento2/issues/15972)
+*  Magento now renders the value of configuration variables (such as `{{unsecure_base_url}}`) as they are entered in  configuration files rather than saving the resolved value. Previously, Magento resolved the variable to its actual value, which lead to the overwriting the value in the database when the configuration was saved instead of storing the value in the variable. *Fix submitted by Pieter Hoste in pull request [18067](https://github.com/magento/magento2/pull/18067)*. [GitHub-15972](https://github.com/magento/magento2/issues/15972)
 
 <!--- ENGCOM-4751-->
 
-* Magento no longer throws an error when you use  `app:config:import` to import configuration settings. Previously, the import failed, and Magento threw the following error even when the imported file contained only minor changes to password or URL values: `Please specify the admin custom URL`. *Fix submitted by David Alger in pull request [22281](https://github.com/magento/magento2/pull/22281)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
+*  Magento no longer throws an error when you use  `app:config:import` to import configuration settings. Previously, the import failed, and Magento threw the following error even when the imported file contained only minor changes to password or URL values: `Please specify the admin custom URL`. *Fix submitted by David Alger in pull request [22281](https://github.com/magento/magento2/pull/22281)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
 
 <!--- MAGETWO-95675-->
 
-* Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`.
+*  Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`.
 
 <!--- ENGCOM-4794-->
 
-* Magento no longer throws an error during catalog set up when you run `bin/magento setup:upgrade`. Previously, set up failed, and Magento threw the following error even though no problems existed with your catalog, `Magento\Catalog\Setup\Media does not exist`. *Fix submitted by Pieter Hoste in pull request [22446](https://github.com/magento/magento2/pull/22446)*. [GitHub-22124](https://github.com/magento/magento2/issues/22124)
+*  Magento no longer throws an error during catalog set up when you run `bin/magento setup:upgrade`. Previously, set up failed, and Magento threw the following error even though no problems existed with your catalog, `Magento\Catalog\Setup\Media does not exist`. *Fix submitted by Pieter Hoste in pull request [22446](https://github.com/magento/magento2/pull/22446)*. [GitHub-22124](https://github.com/magento/magento2/issues/22124)
 
 <!--- ENGCOM-4815-->
 
-* All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by Keyur Kanani in pull request [22475](https://github.com/magento/magento2/pull/22475)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
+*  All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by Keyur Kanani in pull request [22475](https://github.com/magento/magento2/pull/22475)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
 
 <!--- ENGCOM-4753-->
 
-* Updated the email template stylesheet for the Magento default and Luma themes to correctly specify the `.no-link` selector. This update fixes the following less compilation error that displayed when compiling the `email-inline.less` file using less.js compiler v2.73: `extend '.no-link a' has no matches`. *Fix submitted by Pieter Hoste in pull request [22332](https://github.com/magento/magento2/pull/22332)*. [GitHub-22330](https://github.com/magento/magento2/issues/22330)
+*  Updated the email template stylesheet for the Magento default and Luma themes to correctly specify the `.no-link` selector. This update fixes the following less compilation error that displayed when compiling the `email-inline.less` file using less.js compiler v2.73: `extend '.no-link a' has no matches`. *Fix submitted by Pieter Hoste in pull request [22332](https://github.com/magento/magento2/pull/22332)*. [GitHub-22330](https://github.com/magento/magento2/issues/22330)
 
 ### AdminGWS
 
 <!--- MAGETWO-99034-->
 
-* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to.
+*  The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to.
 
 <!--- MAGETWO-98389-->
 
-* Administrators with access to only one website in a multisite deployments can now access the reports page for that website as expected. Previously, only administrators with access to all websites could access reports.
+*  Administrators with access to only one website in a multisite deployments can now access the reports page for that website as expected. Previously, only administrators with access to all websites could access reports.
 
 ### Backend
 
 <!--- MAGETWO-98183-->
 
-* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
+*  The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
 
 <!--- ENGCOM-4270-->
 
-* The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by Eduard Chitoraga in pull request [21197](https://github.com/magento/magento2/pull/21197)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+*  The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by Eduard Chitoraga in pull request [21197](https://github.com/magento/magento2/pull/21197)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
 <!--- ENGCOM-3924-->
 
-* Form fields of type multiline now work as expected on Admin forms. *Fix submitted by Vivek Kumar in pull request [20371](https://github.com/magento/magento2/pull/20371)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086),  [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+*  Form fields of type multiline now work as expected on Admin forms. *Fix submitted by Vivek Kumar in pull request [20371](https://github.com/magento/magento2/pull/20371)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086),  [GitHub-18115](https://github.com/magento/magento2/issues/18115)
 
 <!--- ENGCOM-3885-->
 
-* Fixed display of **Option Title** label on **Catalog** > **Product** > **Customizable Options** > **Add Option**.  *Fix submitted by Arvinda kumar in pull request [20339](https://github.com/magento/magento2/pull/20339)*. [GitHub-20337](https://github.com/magento/magento2/issues/20337)
+*  Fixed display of **Option Title** label on **Catalog** > **Product** > **Customizable Options** > **Add Option**.  *Fix submitted by Arvinda kumar in pull request [20339](https://github.com/magento/magento2/pull/20339)*. [GitHub-20337](https://github.com/magento/magento2/issues/20337)
 
 <!--- ENGCOM-4377-->
 
-* Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by Shikha Mishra in pull request [21443](https://github.com/magento/magento2/pull/21443)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by Shikha Mishra in pull request [21443](https://github.com/magento/magento2/pull/21443)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
 
 <!--- ENGCOM-3664-->
 
-* Fixed alignment of the **Marketing** > **Cart Price Rules** > **Store View Specific** Labels on the Admin. *Fix submitted by Kajal Solanki in pull request [19637](https://github.com/magento/magento2/pull/19637)*. [GitHub-19632](https://github.com/magento/magento2/issues/19632)
+*  Fixed alignment of the **Marketing** > **Cart Price Rules** > **Store View Specific** Labels on the Admin. *Fix submitted by Kajal Solanki in pull request [19637](https://github.com/magento/magento2/pull/19637)*. [GitHub-19632](https://github.com/magento/magento2/issues/19632)
 
 <!--- ENGCOM-4336-->
 
-* The Change Status option of the mass actions dropdown menu (available on the products and sales pages) now works as expected. *Fix submitted by Ananth Iyer in pull request [20938](https://github.com/magento/magento2/pull/20938)*. [GitHub-20928](https://github.com/magento/magento2/issues/20928)
+*  The Change Status option of the mass actions dropdown menu (available on the products and sales pages) now works as expected. *Fix submitted by Ananth Iyer in pull request [20938](https://github.com/magento/magento2/pull/20938)*. [GitHub-20928](https://github.com/magento/magento2/issues/20928)
 
 <!--- ENGCOM-4373-->
 
-* The option type dropdown on the Admin Customizable Options page now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [21371](https://github.com/magento/magento2/pull/21371)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+*  The option type dropdown on the Admin Customizable Options page now works as expected. *Fix submitted by Oleksandr Miroshnichenko in pull request [21371](https://github.com/magento/magento2/pull/21371)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
 <!--- ENGCOM-4452-->
 
-* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by Ananth Iyer in pull request [21444](https://github.com/magento/magento2/pull/21444)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+*  The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by Ananth Iyer in pull request [21444](https://github.com/magento/magento2/pull/21444)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
 
 <!--- ENGCOM-4655-->
 
-* Magento retains the filter settings you enter on the **Admin** > **System** > **Permissions** > **All Users** list when you click on an item in the filtered list, then return to the list. Previously, if you navigated away from the list and then returned, all filter parameters were lost. *Fix submitted by Jay Ghosh in pull request [22128](https://github.com/magento/magento2/pull/22128)*. [GitHub-21824](https://github.com/magento/magento2/issues/21824)
+*  Magento retains the filter settings you enter on the **Admin** > **System** > **Permissions** > **All Users** list when you click on an item in the filtered list, then return to the list. Previously, if you navigated away from the list and then returned, all filter parameters were lost. *Fix submitted by Jay Ghosh in pull request [22128](https://github.com/magento/magento2/pull/22128)*. [GitHub-21824](https://github.com/magento/magento2/issues/21824)
 
 <!--- ENGCOM-4711-->
 
-* The web setup wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by JeroenVanLeusden in pull request [20182](https://github.com/magento/magento2/pull/20182)*. [GitHub-7623](https://github.com/magento/magento2/issues/7623), [GitHub-11892](https://github.com/magento/magento2/issues/11892)
+*  The web setup wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by JeroenVanLeusden in pull request [20182](https://github.com/magento/magento2/pull/20182)*. [GitHub-7623](https://github.com/magento/magento2/issues/7623), [GitHub-11892](https://github.com/magento/magento2/issues/11892)
 
 <!--- ENGCOM-4397-->
 
-* Magento now redirects to you the Admin home page or a 404 page as expected when you try to access a nonexisting Admin page and **Stores** > **Configuration** > **Advanced** > **Admin** > **Security** > **Add Secret Key to URLs** is enabled. Previously,  redirects did not work properly, and Magento displayed the following message, `The page isn’t redirecting properly`. *Fix submitted by Jitheesh V O in pull request [21455](https://github.com/magento/magento2/pull/21455)*. [GitHub-21454](https://github.com/magento/magento2/issues/21454)
+*  Magento now redirects to you the Admin home page or a 404 page as expected when you try to access a nonexisting Admin page and **Stores** > **Configuration** > **Advanced** > **Admin** > **Security** > **Add Secret Key to URLs** is enabled. Previously,  redirects did not work properly, and Magento displayed the following message, `The page isn’t redirecting properly`. *Fix submitted by Jitheesh V O in pull request [21455](https://github.com/magento/magento2/pull/21455)*. [GitHub-21454](https://github.com/magento/magento2/issues/21454)
 
 ### Back up
 
 <!--- ENGCOM-4782-->
 
-* Magento now creates the `var/.maintenance.flag`  file as expected when you start a database backup  (**System** > **Tools** > **Backups** > **Database Backup**). Previously, Magento did not create this  file, but instead displayed the following error: `Error: You need more permissions to activate maintenance mode right now. To create the backup, please deselect "Put store into maintenance mode" or update your permissions`. *Fix submitted by Hiren Pandya in pull request [19993](https://github.com/magento/magento2/pull/19993)*. [GitHub-19825](https://github.com/magento/magento2/issues/19825)
+*  Magento now creates the `var/.maintenance.flag`  file as expected when you start a database backup  (**System** > **Tools** > **Backups** > **Database Backup**). Previously, Magento did not create this  file, but instead displayed the following error: `Error: You need more permissions to activate maintenance mode right now. To create the backup, please deselect "Put store into maintenance mode" or update your permissions`. *Fix submitted by Hiren Pandya in pull request [19993](https://github.com/magento/magento2/pull/19993)*. [GitHub-19825](https://github.com/magento/magento2/issues/19825)
 
 ### Bundle
 
 <!--- ENGCOM-4507-->
 
-* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by Adarsh Khatri in pull request [21469](https://github.com/magento/magento2/pull/21469)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+*  Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by Adarsh Khatri in pull request [21469](https://github.com/magento/magento2/pull/21469)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
 <!--- MAGETWO-98603-->
 
-* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly and did not display any informative messages about tier pricing on the category and product pages.
+*  Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly and did not display any informative messages about tier pricing on the category and product pages.
 
 ### B2B
 
 <!--- MAGETWO-98791-->
 
-* You can now add backordered products to the cart when backorders are enabled.
+*  You can now add backordered products to the cart when backorders are enabled.
 
 <!--- MAGETWO-99023-->
 
-* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter the product collection.
+*  Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter the product collection.
 
 <!--- MAGETWO-98290-->
 
-* Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
+*  Magento now displays the correct price on the storefront  for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
 
 <!--- MAGETWO-98563-->
 
-* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog.
+*  The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog.
 
 ### Cache
 
 <!--- ENGCOM-4745-->
 
-* CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by Marius Strajeru in pull request [22302](https://github.com/magento/magento2/pull/22302)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
+*  CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by Marius Strajeru in pull request [22302](https://github.com/magento/magento2/pull/22302)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
 
 ### Cart and checkout
 
 <!--- MAGETWO-97968-->
 
-* Magento now correctly updates the minicart if a selected product is disabled during the shopping session.
+*  Magento now correctly updates the minicart if a selected product is disabled during the shopping session.
 
 <!--- MAGETWO-98255-->
 
-* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
+*  You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
 <!--- MAGETWO-98620-->
 
-* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
+*  Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
 
 <!--- ENGCOM-3477-->
 
-* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by Nazar Klovanych in pull request [19191](https://github.com/magento/magento2/pull/19191)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
+*  Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by Nazar Klovanych in pull request [19191](https://github.com/magento/magento2/pull/19191)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
 
 <!--- ENGCOM-4237-->
 
-* Guests can now complete checkout when a custom shipping carrier with underscores in the carrier code is used. Previously, Magento threw the following exception under these conditions: `Please specify a shipping method`. *Fix submitted by vovsky in pull request [19505](https://github.com/magento/magento2/pull/19505)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
+*  Guests can now complete checkout when a custom shipping carrier with underscores in the carrier code is used. Previously, Magento threw the following exception under these conditions: `Please specify a shipping method`. *Fix submitted by vovsky in pull request [19505](https://github.com/magento/magento2/pull/19505)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
 
 <!--- ENGCOM-3900-->
 
-* Fixed alignment of the **Update** button on the payment page of the checkout workflow. *Fix submitted by Govind Sharma in pull request [20307](https://github.com/magento/magento2/pull/20307)*. [GitHub-20305](https://github.com/magento/magento2/issues/20305)
+*  Fixed alignment of the **Update** button on the payment page of the checkout workflow. *Fix submitted by Govind Sharma in pull request [20307](https://github.com/magento/magento2/pull/20307)*. [GitHub-20305](https://github.com/magento/magento2/issues/20305)
 
 <!--- ENGCOM-3849-->
 
-* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18503](https://github.com/magento/magento2/pull/18503)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+*  Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by Ihor Sviziev in pull request [18503](https://github.com/magento/magento2/pull/18503)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
 <!--- ENGCOM-4355-->
 
-* Magento now displays an error message as expected when a customer clicks on **Add to cart*without selecting at least one product from the recently ordered  product list. *Fix submitted by Prince Patel in pull request [21401](https://github.com/magento/magento2/pull/21401)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
+*  Magento now displays an error message as expected when a customer clicks on **Add to cart*without selecting at least one product from the recently ordered  product list. *Fix submitted by Prince Patel in pull request [21401](https://github.com/magento/magento2/pull/21401)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
 <!--- ENGCOM-4376-->
 
-* The **Cancel** button on the checkout page now works as expected. *Fix submitted by Jitheesh V O in pull request [21356](https://github.com/magento/magento2/pull/21356)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+*  The **Cancel** button on the checkout page now works as expected. *Fix submitted by Jitheesh V O in pull request [21356](https://github.com/magento/magento2/pull/21356)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
 <!--- MAGETWO-96851-->
 
-* Magento now provides an option to remove store credit from the Payment page of checkout.
+*  Magento now provides an option to remove store credit from the Payment page of checkout.
 
 <!--- ENGCOM-4362-->
 
-* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by Wojtek Naruniec in pull request [21295](https://github.com/magento/magento2/pull/21295)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
+*  Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by Wojtek Naruniec in pull request [21295](https://github.com/magento/magento2/pull/21295)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
 <!--- MAGETWO-70996-->
 
-* Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
+*  Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
 <!--- ENGCOM-4783-->
 
-* Magento now validates the shipping information section of checkout as expected. Previously, a customer could proceed to the Payment Details section of checkout without having added valid shipping details. *Fix submitted by Nirav Patel in pull request [22405](https://github.com/magento/magento2/pull/22405)*. [GitHub-21596](https://github.com/magento/magento2/issues/21596)
+*  Magento now validates the shipping information section of checkout as expected. Previously, a customer could proceed to the Payment Details section of checkout without having added valid shipping details. *Fix submitted by Nirav Patel in pull request [22405](https://github.com/magento/magento2/pull/22405)*. [GitHub-21596](https://github.com/magento/magento2/issues/21596)
 
 <!--- ENGCOM-4414-->
 
-* The `label` elements  on the checkout address input fields are now readable by screen readers. Previously, the  address input fields did not have a `label` element with a valid value, which prevented screen readers from reading the values. *Fix submitted by Scott Buchanan in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+*  The `label` elements  on the checkout address input fields are now readable by screen readers. Previously, the  address input fields did not have a `label` element with a valid value, which prevented screen readers from reading the values. *Fix submitted by Scott Buchanan in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 <!--- ENGCOM-4691-->
 
-* New downloadable products now show up in a customer's My Downloadable products list after a customer who completed a purchase as a guest then creates an account. *Fix submitted by Jitheesh V O in pull request [21711](https://github.com/magento/magento2/pull/21711)*. [GitHub-21702](https://github.com/magento/magento2/issues/21702)
+*  New downloadable products now show up in a customer's My Downloadable products list after a customer who completed a purchase as a guest then creates an account. *Fix submitted by Jitheesh V O in pull request [21711](https://github.com/magento/magento2/pull/21711)*. [GitHub-21702](https://github.com/magento/magento2/issues/21702)
 
 <!--- MC-5681-->
 
-* The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).
+*  The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).
 
 ### Cart Price rules
 
 <!--- MAGETWO-98680-->
 
-* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
+*  Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
 ### Catalog
 
 <!--- MAGETWO-57934-->
 
-* You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+*  You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
 <!--- MAGETWO-96429-->
 
-* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
+*  Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
 
 {:.bs-callout .bs-callout-note}
 This fix can degrade performance in deployments that implement flat catalogs. To avoid this potential performance degradation, consider disabling flat catalogs.
 
 <!--- MAGETWO-96416-->
 
-* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
+*  Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
 
 <!--- ENGCOM-3252-->
 
-* The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by Patrick McLain in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
+*  The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by Patrick McLain in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
 
 <!--- MAGETWO-96127-->
 
-* Magento now maintains correct pagination when a Catalog list has multiple pages of products.  Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
+*  Magento now maintains correct pagination when a Catalog list has multiple pages of products.  Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
 
 <!--- MAGETWO-64260-->
 
-* We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
+*  We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
 
 <!--- MAGETWO-98246-->
 
-* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level.
+*  Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level.
 
 <!--- MAGETWO-98335-->
 
-* You can now use storeview-level attributes to filter products on the products list.
+*  You can now use storeview-level attributes to filter products on the products list.
 
 <!--- MAGETWO-97966-->
 
-* Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty.
+*  Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty.
 
 <!--- ENGCOM-3767-->
 
-* A product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously, the price in this metatag was always calculated in the base currency. *Fix submitted by Milind Singh in pull request [20011](https://github.com/magento/magento2/pull/20011)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+*  A product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously, the price in this metatag was always calculated in the base currency. *Fix submitted by Milind Singh in pull request [20011](https://github.com/magento/magento2/pull/20011)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
 <!--- ENGCOM-4217-->
 
-* Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price incorrectly. *Fix submitted by Emipro Technologies Pvt Ltd in pull request [19608](https://github.com/magento/magento2/pull/19608)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price incorrectly. *Fix submitted by Emipro Technologies Pvt Ltd in pull request [19608](https://github.com/magento/magento2/pull/19608)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
 
 <!--- ENGCOM-4065-->
 
-* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by Lisovyi Yevhenii in pull request [20617](https://github.com/magento/magento2/pull/20617)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+*  The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by Lisovyi Yevhenii in pull request [20617](https://github.com/magento/magento2/pull/20617)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
 <!--- ENGCOM-4360-->
 
-* Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator applied the tax twice when calculating the minimal price. *Fix submitted by Jitheesh V O in pull request [21395](https://github.com/magento/magento2/pull/21395)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator applied the tax twice when calculating the minimal price. *Fix submitted by Jitheesh V O in pull request [21395](https://github.com/magento/magento2/pull/21395)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
 <!--- ENGCOM-4342-->
 
-* The Admin product grid now displays default values when no filter is set. *Fix submitted by Eduard Chitoraga in pull request [21363](https://github.com/magento/magento2/pull/21363)*. [GitHub-13338](https://github.com/magento/magento2/issues/13338)
+*  The Admin product grid now displays default values when no filter is set. *Fix submitted by Eduard Chitoraga in pull request [21363](https://github.com/magento/magento2/pull/21363)*. [GitHub-13338](https://github.com/magento/magento2/issues/13338)
 
 <!--- ENGCOM-3252-->
 
-* The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by Patrick McLain in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
+*  The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by Patrick McLain in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
 
 <!--- ENGCOM-4400-->
 
-* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by Leandro F. L. in pull request [21509](https://github.com/magento/magento2/pull/21509)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
+*  Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by Leandro F. L. in pull request [21509](https://github.com/magento/magento2/pull/21509)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
 <!--- ENGCOM-4451-->
 
-* Fixed issue with excessive white space on  the related, cross sell and upsell product grids. *Fix submitted by Amol Chaudhari in pull request [21582](https://github.com/magento/magento2/pull/21582)*. [GitHub-21541](https://github.com/magento/magento2/issues/21541)
+*  Fixed issue with excessive white space on  the related, cross sell and upsell product grids. *Fix submitted by Amol Chaudhari in pull request [21582](https://github.com/magento/magento2/pull/21582)*. [GitHub-21541](https://github.com/magento/magento2/issues/21541)
 
 <!--- ENGCOM-4405-->
 
-* You can now sort the Admin product list by website. *Fix submitted by Ievgenii Gryshkun in pull request [20512](https://github.com/magento/magento2/pull/20512)*. [GitHub-20511](https://github.com/magento/magento2/issues/20511)
+*  You can now sort the Admin product list by website. *Fix submitted by Ievgenii Gryshkun in pull request [20512](https://github.com/magento/magento2/pull/20512)*. [GitHub-20511](https://github.com/magento/magento2/issues/20511)
 
 <!--- MAGETWO-53037-->
 
-* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the same attribute values.
+*  Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the same attribute values.
 
 <!--- MAGETWO-58219-->
 
-* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed r options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+*  During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed r options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
 <!--- MAGETWO-98522-->
 
-* You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
+*  You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
 
 <!--- ENGCOM-4749-->
 
-* The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Oleg Volkov in pull request [22318](https://github.com/magento/magento2/pull/22318)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
+*  The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Oleg Volkov in pull request [22318](https://github.com/magento/magento2/pull/22318)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
 
 <!--- MAGETWO-98366-->
 
-* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in.
+*  Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in.
 
 <!--- MAGETWO-98831-->
 
-* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed the following message: `The SKU was not found in the catalog`.
+*  You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product this way, Magento displayed the following message: `The SKU was not found in the catalog`.
 
 <!--- MAGETWO-72204-->
 
-* Tax recalculation has been moved out of the translation into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
+*  Tax recalculation has been moved out of the translation into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
 
 <!--- ENGCOM-4207-->
 
-* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by Govind Sharma in pull request [20115](https://github.com/magento/magento2/pull/20115)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+*  The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by Govind Sharma in pull request [20115](https://github.com/magento/magento2/pull/20115)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
 <!--- ENGCOM-4669-->
 
-* Magento now increments product quantity correctly when you add products to your cart first as a guest user, and then logged in. Previously, Magento added items separately instead. *Fix submitted by Jitheesh V O in pull request [21501](https://github.com/magento/magento2/pull/21501)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
+*  Magento now increments product quantity correctly when you add products to your cart first as a guest user, and then logged in. Previously, Magento added items separately instead. *Fix submitted by Jitheesh V O in pull request [21501](https://github.com/magento/magento2/pull/21501)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
 
 <!--- ENGCOM-4180-->
 
@@ -473,7 +473,7 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-4490-->
 
-* We have fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
+*  We have fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
 
 has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.)
 *Fix submitted by VitaliyBoyko in pull request [21731](https://github.com/magento/magento2/pull/21731)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
@@ -482,129 +482,129 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
 <!--- ENGCOM-4386-->
 
-* URL rewrites are no longer overwritten in multisite deployments. *Fix submitted by Anshu Mishra in pull request [21462](https://github.com/magento/magento2/pull/21462)*. [GitHub-21329](https://github.com/magento/magento2/issues/21329)
+*  URL rewrites are no longer overwritten in multisite deployments. *Fix submitted by Anshu Mishra in pull request [21462](https://github.com/magento/magento2/pull/21462)*. [GitHub-21329](https://github.com/magento/magento2/issues/21329)
 
 ### Cleanup and simple code refactoring
 
 <!--- ENGCOM-4249-->
 
-* Corrected the overlapping **Rating** field and **Add to cart** button on the cart page. *Fix submitted by Kajal Solanki in pull request [21178](https://github.com/magento/magento2/pull/21178)*. [GitHub-21177](https://github.com/magento/magento2/issues/21177)
+*  Corrected the overlapping **Rating** field and **Add to cart** button on the cart page. *Fix submitted by Kajal Solanki in pull request [21178](https://github.com/magento/magento2/pull/21178)*. [GitHub-21177](https://github.com/magento/magento2/issues/21177)
 
 <!--- ENGCOM-3824-->
 
-* Corrected length of the customer login page input field in tablet view. *Fix submitted by Nainesh Waghale in pull request [20173](https://github.com/magento/magento2/pull/20173)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+*  Corrected length of the customer login page input field in tablet view. *Fix submitted by Nainesh Waghale in pull request [20173](https://github.com/magento/magento2/pull/20173)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
 <!--- ENGCOM-3642-->
 
-* Fixed misalignment of the checkbox in the fields enclosure on **Admin** > **System** > **Export**. *Fix submitted by suryakant-krish in pull request [19631](https://github.com/magento/magento2/pull/19631)*. [GitHub-19630](https://github.com/magento/magento2/issues/19630)
+*  Fixed misalignment of the checkbox in the fields enclosure on **Admin** > **System** > **Export**. *Fix submitted by suryakant-krish in pull request [19631](https://github.com/magento/magento2/pull/19631)*. [GitHub-19630](https://github.com/magento/magento2/issues/19630)
 
 <!--- ENGCOM-4174-->
 
-* Corrected misalignment of the products in category checkboxes on the Admin catalog categories page. *Fix submitted by priti2jcommerce in pull request [21022](https://github.com/magento/magento2/pull/21022)*. [GitHub-21021](https://github.com/magento/magento2/issues/21021)
+*  Corrected misalignment of the products in category checkboxes on the Admin catalog categories page. *Fix submitted by priti2jcommerce in pull request [21022](https://github.com/magento/magento2/pull/21022)*. [GitHub-21021](https://github.com/magento/magento2/issues/21021)
 
 <!--- ENGCOM-4069-->
 
-* Corrected misalignment of the order item details label in mobile view. *Fix submitted by priti2jcommerce in pull request [20466](https://github.com/magento/magento2/pull/20466)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+*  Corrected misalignment of the order item details label in mobile view. *Fix submitted by priti2jcommerce in pull request [20466](https://github.com/magento/magento2/pull/20466)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
 <!--- ENGCOM-4154-->
 
-* Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by Arvinda kumar in pull request [21009](https://github.com/magento/magento2/pull/21009)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by Arvinda kumar in pull request [21009](https://github.com/magento/magento2/pull/21009)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
 <!--- ENGCOM-4202-->
 
-* You can now open a product's details page from the compare products side bar. *Fix submitted by Eduard Chitoraga in pull request [21102](https://github.com/magento/magento2/pull/21102)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+*  You can now open a product's details page from the compare products side bar. *Fix submitted by Eduard Chitoraga in pull request [21102](https://github.com/magento/magento2/pull/21102)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
 
 <!--- ENGCOM-4262-->
 
-* Added padding to the `shippingAddress` telephone tool tip on the shipping page of checkout. *Fix submitted by Abrar Pathan in pull request [20839](https://github.com/magento/magento2/pull/20839)*. [GitHub-20838](https://github.com/magento/magento2/issues/20838)
+*  Added padding to the `shippingAddress` telephone tool tip on the shipping page of checkout. *Fix submitted by Abrar Pathan in pull request [20839](https://github.com/magento/magento2/pull/20839)*. [GitHub-20838](https://github.com/magento/magento2/issues/20838)
 
 <!--- ENGCOM-4269-->
 
-* Corrected misalignment of product prices in the order summary block of the checkout page in tablet view. *Fix submitted by dipti2jcommerce in pull request [20856](https://github.com/magento/magento2/pull/20856)*. [GitHub-20855](https://github.com/magento/magento2/issues/20855)
+*  Corrected misalignment of product prices in the order summary block of the checkout page in tablet view. *Fix submitted by dipti2jcommerce in pull request [20856](https://github.com/magento/magento2/pull/20856)*. [GitHub-20855](https://github.com/magento/magento2/issues/20855)
 
 <!--- ENGCOM-4318-->
 
-* Corrected size of the pagination drop-down on **Admin** > **Content** > **Blocks**. *Fix submitted by Pratik Oza in pull request [21298](https://github.com/magento/magento2/pull/21298)*. [GitHub-21296](https://github.com/magento/magento2/issues/21296)
+*  Corrected size of the pagination drop-down on **Admin** > **Content** > **Blocks**. *Fix submitted by Pratik Oza in pull request [21298](https://github.com/magento/magento2/pull/21298)*. [GitHub-21296](https://github.com/magento/magento2/issues/21296)
 
 <!--- ENGCOM-4250-->
 
-* Corrected a tabbing issue on the product page. *Fix submitted by Prakash Gunthe in pull request [21079](https://github.com/magento/magento2/pull/21079)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
+*  Corrected a tabbing issue on the product page. *Fix submitted by Prakash Gunthe in pull request [21079](https://github.com/magento/magento2/pull/21079)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
 
 <!--- ENGCOM-4161-->
 
-* Corrected alignment of page elements on the  Recent Orders section of the My Accounts page in mobile view. *Fix submitted by Nainesh Waghale in pull request [20429](https://github.com/magento/magento2/pull/20429)*. [GitHub-20414](https://github.com/magento/magento2/issues/20414)
+*  Corrected alignment of page elements on the  Recent Orders section of the My Accounts page in mobile view. *Fix submitted by Nainesh Waghale in pull request [20429](https://github.com/magento/magento2/pull/20429)*. [GitHub-20414](https://github.com/magento/magento2/issues/20414)
 
 <!--- ENGCOM-4461-->
 
-* Corrected formatting of the Advance Search link in page footers. *Fix submitted by Amol Chaudhari in pull request [21611](https://github.com/magento/magento2/pull/21611)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
+*  Corrected formatting of the Advance Search link in page footers. *Fix submitted by Amol Chaudhari in pull request [21611](https://github.com/magento/magento2/pull/21611)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 <!--- ENGCOM-4457-->
 
-* Corrected alignment of the minicart search logo. *Fix submitted by Amol Chaudhari in pull request [21638](https://github.com/magento/magento2/pull/21638)*. [GitHub-20905](https://github.com/magento/magento2/issues/20905)
+*  Corrected alignment of the minicart search logo. *Fix submitted by Amol Chaudhari in pull request [21638](https://github.com/magento/magento2/pull/21638)*. [GitHub-20905](https://github.com/magento/magento2/issues/20905)
 
 <!--- ENGCOM-4475-->
 
-* Added missing asterisk adjacent to the Checkout Agreements checkbox. *Fix submitted by Karla Saaremäe in pull request [21649](https://github.com/magento/magento2/pull/21649)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
+*  Added missing asterisk adjacent to the Checkout Agreements checkbox. *Fix submitted by Karla Saaremäe in pull request [21649](https://github.com/magento/magento2/pull/21649)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 <!--- ENGCOM-4595-->
 
-* Removed unnecessary white space between `li` tags in the product table. *Fix submitted by Akhilesh Singh Shrinet in pull request [21948](https://github.com/magento/magento2/pull/20092)*. [GitHub-21244](https://github.com/magento/magento2/issues/21244), [GitHub-20140](https://github.com/magento/magento2/issues/20140)
+*  Removed unnecessary white space between `li` tags in the product table. *Fix submitted by Akhilesh Singh Shrinet in pull request [21948](https://github.com/magento/magento2/pull/20092)*. [GitHub-21244](https://github.com/magento/magento2/issues/21244), [GitHub-20140](https://github.com/magento/magento2/issues/20140)
 
 <!--- ENGCOM-4629-->
 
-* The documentation for Travis CI static tests has been improved. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18386](https://github.com/magento/magento2/pull/18386)*. [GitHub-13951](https://github.com/magento/magento2/issues/13951)
+*  The documentation for Travis CI static tests has been improved. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18386](https://github.com/magento/magento2/pull/18386)*. [GitHub-13951](https://github.com/magento/magento2/issues/13951)
 
 <!--- ENGCOM-4606-->
 
-* Corrected typos on the Admin sales shipment and credit memo pages. *Fix submitted by Vishal Sutariya in pull request [22031](https://github.com/magento/magento2/pull/22031)*. [GitHub-22030](https://github.com/magento/magento2/issues/22030)
+*  Corrected typos on the Admin sales shipment and credit memo pages. *Fix submitted by Vishal Sutariya in pull request [22031](https://github.com/magento/magento2/pull/22031)*. [GitHub-22030](https://github.com/magento/magento2/issues/22030)
 
 <!--- ENGCOM-4637-->
 
-* The **Equalize product count** operation in Layered Navigation now works as expected. *Fix submitted by Nazar Klovanych in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715)
+*  The **Equalize product count** operation in Layered Navigation now works as expected. *Fix submitted by Nazar Klovanych in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715)
 
 <!--- ENGCOM-4744-->
 
-* Corrected misalignment of page elements on the pop-up window that Magento displays when you edit an order that contains a downloadable product when the **Links can be purchased separately** option is enabled. *Fix submitted by ansari-krish in pull request [22298](https://github.com/magento/magento2/pull/22298)*. [GitHub-20917](https://github.com/magento/magento2/issues/20917)
+*  Corrected misalignment of page elements on the pop-up window that Magento displays when you edit an order that contains a downloadable product when the **Links can be purchased separately** option is enabled. *Fix submitted by ansari-krish in pull request [22298](https://github.com/magento/magento2/pull/22298)*. [GitHub-20917](https://github.com/magento/magento2/issues/20917)
 
 <!--- ENGCOM-4594-->
 
-* Fixed misalignment of the shipping method block on Order pages that are accessed through **Sales** > **Orders**. *Fix submitted by Vishal Sutariya in pull request [21963](https://github.com/magento/magento2/pull/21963)*. [GitHub-21962](https://github.com/magento/magento2/issues/21962)
+*  Fixed misalignment of the shipping method block on Order pages that are accessed through **Sales** > **Orders**. *Fix submitted by Vishal Sutariya in pull request [21963](https://github.com/magento/magento2/pull/21963)*. [GitHub-21962](https://github.com/magento/magento2/issues/21962)
 
 <!--- ENGCOM-4797-->
 
-* In the Conditions section of the New Cart Price Rule page in the Admin, the arrow for the `If ALL of these conditions are TRUE` dropdown list field now points in the correct direction. *Fix submitted by Hiren Pandya in pull request [22456](https://github.com/magento/magento2/pull/22456)*. [GitHub-20366](https://github.com/magento/magento2/issues/22434)
+*  In the Conditions section of the New Cart Price Rule page in the Admin, the arrow for the `If ALL of these conditions are TRUE` dropdown list field now points in the correct direction. *Fix submitted by Hiren Pandya in pull request [22456](https://github.com/magento/magento2/pull/22456)*. [GitHub-20366](https://github.com/magento/magento2/issues/22434)
 
 ### Company
 
 <!--- MAGETWO-98590-->
 
-* Magento no longer throws an error when you try to export a customer report with a description filter.
+*  Magento no longer throws an error when you try to export a customer report with a description filter.
 
 <!--- MAGETWO--98665-->
 
-* Magento now sorts media directories alphabetically during image upload.
+*  Magento now sorts media directories alphabetically during image upload.
 
 <!--- MAGETWO-98698-->
 
-* Magento now correctly adds Company users when the database prefix schedule contains an underscore. Previously, Magento threw an SQL error and did not add the users.
+*  Magento now correctly adds Company users when the database prefix schedule contains an underscore. Previously, Magento threw an SQL error and did not add the users.
 
 ### Configurable products
 
 <!--- MAGETWO-98013-->
 
-* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
+*  Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
 <!--- ENGCOM-3963-->
 
-* Corrected the position of the labels in the configurable product variations table. *Fix submitted by Burlacu Vasilii in pull request [20528](https://github.com/magento/magento2/pull/20528)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
+*  Corrected the position of the labels in the configurable product variations table. *Fix submitted by Burlacu Vasilii in pull request [20528](https://github.com/magento/magento2/pull/20528)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
 <!--- MAGETWO-98088-->
 
-* Configurable products can no longer be added as a variation of another configurable product in the Admin.
+*  Configurable products can no longer be added as a variation of another configurable product in the Admin.
 
 <!--- ENGCOM-4809-->
 
-* The configurable product page's attribute dropdown menu shows an accurate price and tax is rendered correctly in the final price at the top of the page. Previously, configurable products that had only one configurable attribute displayed a price increase in the dropdown of the tax amount. This affected stores when prices were entered excluding tax and configurable products with only one configurable attribute. *Fix submitted by Daniel Farmer in pull request [22466](https://github.com/magento/magento2/pull/22466)*. [GitHub-22270](https://github.com/magento/magento2/issues/22270)
+*  The configurable product page's attribute dropdown menu shows an accurate price and tax is rendered correctly in the final price at the top of the page. Previously, configurable products that had only one configurable attribute displayed a price increase in the dropdown of the tax amount. This affected stores when prices were entered excluding tax and configurable products with only one configurable attribute. *Fix submitted by Daniel Farmer in pull request [22466](https://github.com/magento/magento2/pull/22466)*. [GitHub-22270](https://github.com/magento/magento2/issues/22270)
 
 <!--- ENGCOM-4188-->
 
@@ -632,335 +632,335 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
 <!--- MAGETWO-93628-->
 
-* Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
+*  Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
 
 <!--- MAGETWO-97549-->
 
-* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
+*  Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
 
 <!--- ENGCOM-4146-->
 
-* The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by Shikha Mishra in pull request [20896](https://github.com/magento/magento2/pull/20896)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+*  The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by Shikha Mishra in pull request [20896](https://github.com/magento/magento2/pull/20896)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
 <!--- ENGCOM-4309-->
 
-* Fixed a horizontal scrolling issue that affected the address book display in mobile view. *Fix submitted by Pratik Oza in pull request [21272](https://github.com/magento/magento2/pull/21272)*. [GitHub-21271](https://github.com/magento/magento2/issues/21271)
+*  Fixed a horizontal scrolling issue that affected the address book display in mobile view. *Fix submitted by Pratik Oza in pull request [21272](https://github.com/magento/magento2/pull/21272)*. [GitHub-21271](https://github.com/magento/magento2/issues/21271)
 
 <!--- ENGCOM-4413-->
 
-* The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by Jitheesh V O in pull request [21498](https://github.com/magento/magento2/pull/21498)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+*  The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by Jitheesh V O in pull request [21498](https://github.com/magento/magento2/pull/21498)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
 <!--- ENGCOM-4047-->
 
-* The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by Lisovyi Yevhenii in pull request [20583](https://github.com/magento/magento2/pull/20583)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
+*  The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by Lisovyi Yevhenii in pull request [20583](https://github.com/magento/magento2/pull/20583)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
 <!--- MAGETWO-91523-->
 
-* An admin user with full permissions for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an admin with full permission could not see it.
+*  An admin user with full permissions for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an admin with full permission could not see it.
 
 <!--- MAGETWO-98087-->
 
-* Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
+*  Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
 
 <!--- MAGETWO-98087-->
 
-* Customer groups can now be successfully reassigned during order creation in the Admin.
+*  Customer groups can now be successfully reassigned during order creation in the Admin.
 
 <!--- ENGCOM-4678-->
 
-* Customer accounts are now confirmed when a customer clicks the email activation link. Previously, Magento confirmed the customer account even when the customer did not click on the email activation link. *Fix submitted by Shikha Mishra in pull request [22147](https://github.com/magento/magento2/pull/22147)*. [GitHub-22052](https://github.com/magento/magento2/issues/22052)
+*  Customer accounts are now confirmed when a customer clicks the email activation link. Previously, Magento confirmed the customer account even when the customer did not click on the email activation link. *Fix submitted by Shikha Mishra in pull request [22147](https://github.com/magento/magento2/pull/22147)*. [GitHub-22052](https://github.com/magento/magento2/issues/22052)
 
 ### Dashboard
 
 <!--- ENGCOM-4601-->
 
-* Magento no longer throws a 404 error when you click the Most viewed products on the Admin dashboard. *Fix submitted by Vishal Sutariya in pull request [22002](https://github.com/magento/magento2/pull/22002)*. [GitHub-22001](https://github.com/magento/magento2/issues/22001)
+*  Magento no longer throws a 404 error when you click the Most viewed products on the Admin dashboard. *Fix submitted by Vishal Sutariya in pull request [22002](https://github.com/magento/magento2/pull/22002)*. [GitHub-22001](https://github.com/magento/magento2/issues/22001)
 
 ### Downloadable
 
 <!--- ENGCOM-4399-->
 
-* Product prices are no longer duplicated on the Downloadable products page.  *Fix submitted by Govinda Sharma in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
+*  Product prices are no longer duplicated on the Downloadable products page.  *Fix submitted by Govinda Sharma in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
 
 <!--- ENGCOM-3979-->
 
-* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by Govind Sharma in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
+*  Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by Govind Sharma in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
 
 <!--- ENGCOM-4684-->
 
-* You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message. *Fix submitted by Ravi chandra in pull request [19806](https://github.com/magento/magento2/pull/19806)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
+*  You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message. *Fix submitted by Ravi chandra in pull request [19806](https://github.com/magento/magento2/pull/19806)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
 
 <!--- ENGCOM-4685-->
 
-* A logged-in user's My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by James in pull request [22073](https://github.com/magento/magento2/pull/22073)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
+*  A logged-in user's My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by James in pull request [22073](https://github.com/magento/magento2/pull/22073)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
 
 <!--- ENGCOM-4345-->
 
-* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by Mahesh Singh in pull request [21279](https://github.com/magento/magento2/pull/21279)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+*  Added missing sort order to columns on Downloadable Product links page. *Fix submitted by Mahesh Singh in pull request [21279](https://github.com/magento/magento2/pull/21279)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
 
 ### EAV
 
 <!--- ENGCOM-4246-->
 
-* Attribute code validation (specifically, maximum characters allowed) has been improved during attribute creation. *Fix submitted by Eduard Chitoraga in pull request [20526](https://github.com/magento/magento2/pull/20526)*. [GitHub-20766](https://github.com/magento/magento2/issues/20766), [GitHub-20943](https://github.com/magento/magento2/issues/20943)
+*  Attribute code validation (specifically, maximum characters allowed) has been improved during attribute creation. *Fix submitted by Eduard Chitoraga in pull request [20526](https://github.com/magento/magento2/pull/20526)*. [GitHub-20766](https://github.com/magento/magento2/issues/20766), [GitHub-20943](https://github.com/magento/magento2/issues/20943)
 
 <!--- ENGCOM-4583-->
 
-* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by Wojtek Naruniec in pull request [21135](https://github.com/magento/magento2/pull/21135)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+*  Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by Wojtek Naruniec in pull request [21135](https://github.com/magento/magento2/pull/21135)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
 <!--- ENGCOM-4553-->
 
-* The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the  `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by Lorenzo Stramaccia in pull request [21869](https://github.com/magento/magento2/pull/21869)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
+*  The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the  `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by Lorenzo Stramaccia in pull request [21869](https://github.com/magento/magento2/pull/21869)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
 
 <!--- ENGCOM-3793-->
 
-* You can now retrieve product attribute values for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by Shikha Mishra in pull request [20071](https://github.com/magento/magento2/pull/20071)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
+*  You can now retrieve product attribute values for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by Shikha Mishra in pull request [20071](https://github.com/magento/magento2/pull/20071)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
 
 <!--- ENGCOM-4152-->
 
-* You can now programmatically upload an image for the customer attribute. Previously, Magento threw the following error:  `error: Base64 is not defined`. *Fix submitted by Nazar Klovanych in pull request [19988](https://github.com/magento/magento2/pull/19988)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+*  You can now programmatically upload an image for the customer attribute. Previously, Magento threw the following error:  `error: Base64 is not defined`. *Fix submitted by Nazar Klovanych in pull request [19988](https://github.com/magento/magento2/pull/19988)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
 <!--- MAGETWO-98621-->
 
-* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty.
+*  Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty.
 
 <!--- ENGCOM-3810-->
 
-* Added an `is_array` parameter value check to the `getOptionText($value)` function in `app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php` to fix an error that caused Magento to throw a UI error when you make the `_quantity_and_stock_status (Qty)_` product attribute visible in the storefront properties. Previously, the `getOptionText($value)` function expected integer or string input and failed because the `quantity_and_stock_status (Qty)` configuration parameters were passed as an array.` *Fix submitted by Aditi Singh in pull request [20001](https://github.com/magento/magento2/pull/20001)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
+*  Added an `is_array` parameter value check to the `getOptionText($value)` function in `app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php` to fix an error that caused Magento to throw a UI error when you make the `_quantity_and_stock_status (Qty)_` product attribute visible in the storefront properties. Previously, the `getOptionText($value)` function expected integer or string input and failed because the `quantity_and_stock_status (Qty)` configuration parameters were passed as an array.` *Fix submitted by Aditi Singh in pull request [20001](https://github.com/magento/magento2/pull/20001)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 ### Email
 
 <!--- ENGCOM-4512-->
 
-* Magento no longer sends via asynchronous email sending any sales-related emails  that were created when email sending was disabled once email sending is enabled. *Fix submitted by Serhiy Zhovnir in pull request [21788](https://github.com/magento/magento2/pull/21788)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
+*  Magento no longer sends via asynchronous email sending any sales-related emails  that were created when email sending was disabled once email sending is enabled. *Fix submitted by Serhiy Zhovnir in pull request [21788](https://github.com/magento/magento2/pull/21788)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
 
 <!--- ENGCOM-4812-->
 
-* The Insert variable pop-up window that is accessed from the Email Template Information window is now populated as expected. *Fix submitted by Bartłomiej Szubert in pull request [22469](https://github.com/magento/magento2/pull/22469)*. [GitHub-20111](https://github.com/magento/magento2/issues/20111)
+*  The Insert variable pop-up window that is accessed from the Email Template Information window is now populated as expected. *Fix submitted by Bartłomiej Szubert in pull request [22469](https://github.com/magento/magento2/pull/22469)*. [GitHub-20111](https://github.com/magento/magento2/issues/20111)
 
 ### Frameworks
 
 <!--- MC-15440-->
 
-* The performance of product image loading has been significantly improved. [GitHub-14667](https://github.com/magento/magento2/issues/14667)
+*  The performance of product image loading has been significantly improved. [GitHub-14667](https://github.com/magento/magento2/issues/14667)
 
 <!--- ENGCOM-3794-->
 
-* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. Previously, when you clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by Shikha Mishra in pull request [19996](https://github.com/magento/magento2/pull/19996)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+*  You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. Previously, when you clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by Shikha Mishra in pull request [19996](https://github.com/magento/magento2/pull/19996)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
 
 <!--- ENGCOM-3932-->
 
-* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by Burlacu Vasilii in pull request [20495](https://github.com/magento/magento2/pull/20495)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+*  Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by Burlacu Vasilii in pull request [20495](https://github.com/magento/magento2/pull/20495)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
 
 <!--- ENGCOM-4212-->
 
-* Corrected misalignment of the Admin success message icon. *Fix submitted by Kajal Solanki in pull request [21069](https://github.com/magento/magento2/pull/21069)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+*  Corrected misalignment of the Admin success message icon. *Fix submitted by Kajal Solanki in pull request [21069](https://github.com/magento/magento2/pull/21069)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
 <!--- ENGCOM-3543-->
 
-* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by Jaimin Sutariya in pull request [19274](https://github.com/magento/magento2/pull/19274)*. [GitHub-19359](https://github.com/magento/magento2/issues/19359)
+*  The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by Jaimin Sutariya in pull request [19274](https://github.com/magento/magento2/pull/19274)*. [GitHub-19359](https://github.com/magento/magento2/issues/19359)
 
 <!--- ENGCOM-4223-->
 
-* The module ranking in the `app/etc/config` now remains consistent when a new module is added without any other changes. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by Alexandre Jardin in pull request [21020](https://github.com/magento/magento2/pull/21020)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479)
+*  The module ranking in the `app/etc/config` now remains consistent when a new module is added without any other changes. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by Alexandre Jardin in pull request [21020](https://github.com/magento/magento2/pull/21020)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479)
 
 <!--- ENGCOM-4104-->
 
-* Magento now logs exceptions during autoloading instead of throwing them. This conforms with PSR-4 guidelines. *Fix submitted by Vinai Kopp in pull request [20950](https://github.com/magento/magento2/pull/20950)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
+*  Magento now logs exceptions during autoloading instead of throwing them. This conforms with PSR-4 guidelines. *Fix submitted by Vinai Kopp in pull request [20950](https://github.com/magento/magento2/pull/20950)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 <!--- ENGCOM-4333-->
 
-* Running the `php bin/magento setup:upgrade` command on modules that have a `db_schema.xml` without an `indexType` now creates the index, and subsequent runs result in no modifications as expected. Previously, running this command multiple times resulted in index creation followed by an error. *Fix submitted by Milind Singh in pull request [21328](https://github.com/magento/magento2/pull/21328)*. [GitHub-21322](https://github.com/magento/magento2/issues/21322)
+*  Running the `php bin/magento setup:upgrade` command on modules that have a `db_schema.xml` without an `indexType` now creates the index, and subsequent runs result in no modifications as expected. Previously, running this command multiple times resulted in index creation followed by an error. *Fix submitted by Milind Singh in pull request [21328](https://github.com/magento/magento2/pull/21328)*. [GitHub-21322](https://github.com/magento/magento2/issues/21322)
 
 #### Cache framework
 
 <!--- ENGCOM-3470-->
 
-* The purge cache feature in `\Magento\CacheInvalidate\Model\PurgeCache::sendPurgeRequest` has been updated to flush the cache on all hosts even if a Varnish server is offline. Magento also displays a warning message about unresponsive cache hosts. Previously, the `bin/magento cache:flush full_page` operation stopped as soon as it encountered a host that was offline. *Fix submitted by Wiard van Rij in pull request [18852](https://github.com/magento/magento2/pull/18852)*. [GitHub-18056](https://github.com/magento/magento2/issues/18056)
+*  The purge cache feature in `\Magento\CacheInvalidate\Model\PurgeCache::sendPurgeRequest` has been updated to flush the cache on all hosts even if a Varnish server is offline. Magento also displays a warning message about unresponsive cache hosts. Previously, the `bin/magento cache:flush full_page` operation stopped as soon as it encountered a host that was offline. *Fix submitted by Wiard van Rij in pull request [18852](https://github.com/magento/magento2/pull/18852)*. [GitHub-18056](https://github.com/magento/magento2/issues/18056)
 
 #### JavaScript framework
 
 <!--- ENGCOM-4546-->
 
-* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by Roman Kis in pull request [21776](https://github.com/magento/magento2/pull/21776)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+*  JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by Roman Kis in pull request [21776](https://github.com/magento/magento2/pull/21776)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 ### General fixes
 
 <!--- MAGETWO-96983-->
 
-* The Sodium crypto adapter now consistently returns a `string` in accordance with the strict return type on its signature. Previously, the adapter sometimes did not return a `string`, which resulted in exceptions and a failure to bootstrap Magento. [GitHub-19590](https://github.com/magento/magento2/issues/19590)
+*  The Sodium crypto adapter now consistently returns a `string` in accordance with the strict return type on its signature. Previously, the adapter sometimes did not return a `string`, which resulted in exceptions and a failure to bootstrap Magento. [GitHub-19590](https://github.com/magento/magento2/issues/19590)
 
 <!--- MAGETWO-98317-->
 
-* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks.
+*  Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks.
 
 <!--- ENGCOM-4378-->
 
-* Watermarks now appear on product images as expected. *Fix submitted by Yevhenii Dumskyi in pull request [21338](https://github.com/magento/magento2/pull/21338)*. [GitHub-21154](https://github.com/magento/magento2/issues/21154)
+*  Watermarks now appear on product images as expected. *Fix submitted by Yevhenii Dumskyi in pull request [21338](https://github.com/magento/magento2/pull/21338)*. [GitHub-21154](https://github.com/magento/magento2/issues/21154)
 
 <!--- ENGCOM-4521-->
 
-* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed the following error: `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by Nirav Patel in pull request [21376](https://github.com/magento/magento2/pull/21376)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+*  You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed the following error: `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by Nirav Patel in pull request [21376](https://github.com/magento/magento2/pull/21376)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
 <!--- ENGCOM-4523-->
 
-* The pagination count of **My Account** > **My addresses** > **Additional Address Data Table** is now correct. *Fix submitted by Dharmesh Vaja in pull request [21399](https://github.com/magento/magento2/pull/21399)*. [GitHub-21396](https://github.com/magento/magento2/issues/21396)
+*  The pagination count of **My Account** > **My addresses** > **Additional Address Data Table** is now correct. *Fix submitted by Dharmesh Vaja in pull request [21399](https://github.com/magento/magento2/pull/21399)*. [GitHub-21396](https://github.com/magento/magento2/issues/21396)
 
 <!--- ENGCOM-4696-->
 
-* The `fatalErrorHandler` now returns `500` only on fatal errors. Previously, simple deprecation warnings on the page triggered an internal server error, which was invalid. *Fix submitted by WEXO team in pull request [22200](https://github.com/magento/magento2/pull/22200)*. [GitHub-22199](https://github.com/magento/magento2/issues/22199)
+*  The `fatalErrorHandler` now returns `500` only on fatal errors. Previously, simple deprecation warnings on the page triggered an internal server error, which was invalid. *Fix submitted by WEXO team in pull request [22200](https://github.com/magento/magento2/pull/22200)*. [GitHub-22199](https://github.com/magento/magento2/issues/22199)
 
 <!--- ENGCOM-4774-->
 
-* CodeSniffer no longer marks correctly aligned `DocBlock` elements as code style violations. *Fix submitted by p-bystritsky in pull request [22321](https://github.com/magento/magento2/pull/22321)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
+*  CodeSniffer no longer marks correctly aligned `DocBlock` elements as code style violations. *Fix submitted by p-bystritsky in pull request [22321](https://github.com/magento/magento2/pull/22321)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
 
 <!--- ENGCOM-4631-->
 
-* The Adminhtml `textarea` field now accepts the `maxlength` attribute. *Fix submitted by Roman Kis in pull request [21816](https://github.com/magento/magento2/pull/21816)*. [GitHub-21779](https://github.com/magento/magento2/issues/21779)
+*  The Adminhtml `textarea` field now accepts the `maxlength` attribute. *Fix submitted by Roman Kis in pull request [21816](https://github.com/magento/magento2/pull/21816)*. [GitHub-21779](https://github.com/magento/magento2/issues/21779)
 
 <!--- ENGCOM-4695-->
 
-* The Reporting Security Issues section of the [Magento 2 README](https://github.com/magento/magento2/blob/2.3-develop/README.md) file has been updated to reflect use of HackerOne for the Magento 2 Bug Bounty program. *Fix submitted by Andreas Mautz in pull request [22195](https://github.com/magento/magento2/pull/22195)*. [GitHub-22166](https://github.com/magento/magento2/issues/22166)
+*  The Reporting Security Issues section of the [Magento 2 README](https://github.com/magento/magento2/blob/2.3-develop/README.md) file has been updated to reflect use of HackerOne for the Magento 2 Bug Bounty program. *Fix submitted by Andreas Mautz in pull request [22195](https://github.com/magento/magento2/pull/22195)*. [GitHub-22166](https://github.com/magento/magento2/issues/22166)
 
 <!--- ENGCOM-4654-->
 
-* You can now save an inactive admin user token by navigating to **System** > **Permissions** -> **All Users**, and clicking **Save User** on an inactive Admin user. Previously, if you tried to save an inactive Admin user token fom the Admin using this method, Magento threw an error and did not save the token. *Fix submitted by Pratik Oza in pull request [20772](https://github.com/magento/magento2/pull/20772)*. [GitHub-16513](https://github.com/magento/magento2/issues/16513)
+*  You can now save an inactive admin user token by navigating to **System** > **Permissions** -> **All Users**, and clicking **Save User** on an inactive Admin user. Previously, if you tried to save an inactive Admin user token fom the Admin using this method, Magento threw an error and did not save the token. *Fix submitted by Pratik Oza in pull request [20772](https://github.com/magento/magento2/pull/20772)*. [GitHub-16513](https://github.com/magento/magento2/issues/16513)
 
 <!--- ENGCOM-4706-->
 
-* We updated `Magento\Msrp\Pricing\MsrpPriceCalculator` to add the `$msrpPriceCalculators` argument. Previously, this argument was missing, which caused Magento to throw a `MsrpPriceCalculator` exception after an upgrade. *Fix submitted by Leandro F. L. in pull request [22197](https://github.com/magento/magento2/pull/22197)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-22090](https://github.com/magento/magento2/issues/22090)
+*  We updated `Magento\Msrp\Pricing\MsrpPriceCalculator` to add the `$msrpPriceCalculators` argument. Previously, this argument was missing, which caused Magento to throw a `MsrpPriceCalculator` exception after an upgrade. *Fix submitted by Leandro F. L. in pull request [22197](https://github.com/magento/magento2/pull/22197)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-22090](https://github.com/magento/magento2/issues/22090)
 
 <!--- ENGCOM-4681-->
 
-* The `stream_wrapper_unregister('phar')` function in `app/boostrap.php` is now run only when a stream wrapper is registered. Previously, calling `stream_wrapper_unregister('phar')` without checking to see if it was registered triggered a warning. *Fix submitted by Antoine Daudenthun in pull request [22171](https://github.com/magento/magento2/pull/22171)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-21973](https://github.com/magento/magento2/issues/21973)
+*  The `stream_wrapper_unregister('phar')` function in `app/boostrap.php` is now run only when a stream wrapper is registered. Previously, calling `stream_wrapper_unregister('phar')` without checking to see if it was registered triggered a warning. *Fix submitted by Antoine Daudenthun in pull request [22171](https://github.com/magento/magento2/pull/22171)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-21973](https://github.com/magento/magento2/issues/21973)
 
 <!--- ENGCOM-4055-->
 
-* The sitemap generation `cron` job no longer flushes the entire cache. A dummy cache tag has been added to the frontend for sitemap and robots generation to prevent the default and `page_cache` from being dropped completely. Previously, the sitemap generation cron job flushed the entire cache. *Fix submitted by David Führ in pull request [20818](https://github.com/magento/magento2/pull/20818)*. [GitHub-14857](https://github.com/magento/magento2/issues/14857)
+*  The sitemap generation `cron` job no longer flushes the entire cache. A dummy cache tag has been added to the frontend for sitemap and robots generation to prevent the default and `page_cache` from being dropped completely. Previously, the sitemap generation cron job flushed the entire cache. *Fix submitted by David Führ in pull request [20818](https://github.com/magento/magento2/pull/20818)*. [GitHub-14857](https://github.com/magento/magento2/issues/14857)
 
 <!--- ENGCOM-4454-->
 
-* Magento now sets an accurate `CURRENT_TIMESTAMP` on `updated_at` fields in the database schema. Previously, this timestamp displayed `0000-00-00 00:00:00`. *Fix submitted by Danny Verkade in pull request [21486](https://github.com/magento/magento2/pull/21486)*. [GitHub-21477](https://github.com/magento/magento2/issues/21477)
+*  Magento now sets an accurate `CURRENT_TIMESTAMP` on `updated_at` fields in the database schema. Previously, this timestamp displayed `0000-00-00 00:00:00`. *Fix submitted by Danny Verkade in pull request [21486](https://github.com/magento/magento2/pull/21486)*. [GitHub-21477](https://github.com/magento/magento2/issues/21477)
 
 <!--- ENGCOM-4733-->
 
-* The `grunt watch` command no longer triggers `livereload` twice. *Fix submitted by Torben Höhn in pull request [22276](https://github.com/magento/magento2/pull/22276)*. [GitHub-19544](https://github.com/magento/magento2/issues/19544)
+*  The `grunt watch` command no longer triggers `livereload` twice. *Fix submitted by Torben Höhn in pull request [22276](https://github.com/magento/magento2/pull/22276)*. [GitHub-19544](https://github.com/magento/magento2/issues/19544)
 
 <!--- ENGCOM-4776-->
 
-* You can now duplicate a product with translated url keys over multiple store views without generating non-unique keys. Previously, when a product was duplicated, only one URL key was used and set for all store views. *Fix submitted by Vechirko Yurii in pull request [22178](https://github.com/magento/magento2/pull/22178)*. [GitHub-21737](https://github.com/magento/magento2/issues/21737)
+*  You can now duplicate a product with translated url keys over multiple store views without generating non-unique keys. Previously, when a product was duplicated, only one URL key was used and set for all store views. *Fix submitted by Vechirko Yurii in pull request [22178](https://github.com/magento/magento2/pull/22178)*. [GitHub-21737](https://github.com/magento/magento2/issues/21737)
 
 ### Gift cards accounts
 
 <!--- MAGETWO-98112-->
 
-* Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
+*  Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
 
 ### Google Analytics
 
 <!--- ENGCOM-4313-->
 
-* The Google Analytics `Anonymize Ip` feature is no longer enabled by default. *Fix submitted by Nazar Klovanych in pull request [21303](https://github.com/magento/magento2/pull/21303)*. [GitHub-21292](https://github.com/magento/magento2/issues/21292)
+*  The Google Analytics `Anonymize Ip` feature is no longer enabled by default. *Fix submitted by Nazar Klovanych in pull request [21303](https://github.com/magento/magento2/pull/21303)*. [GitHub-21292](https://github.com/magento/magento2/issues/21292)
 
 <!--- MAGETWO-98421-->
 
-* The Google Tag Manager snippet is now correctly placed in the HTML `head` section. Previously, this snippet was incorrectly positioned lower in the `head` section, which generated HTML validation errors.
+*  The Google Tag Manager snippet is now correctly placed in the HTML `head` section. Previously, this snippet was incorrectly positioned lower in the `head` section, which generated HTML validation errors.
 
 ### Google Chart API
 
 <!--- MAGETWO-98584 -->
 
-* The Google chart API has been updated to use Image-Charts. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). [GitHub-21599](https://github.com/magento/magento2/issues/21599)
+*  The Google chart API has been updated to use Image-Charts. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). [GitHub-21599](https://github.com/magento/magento2/issues/21599)
 
 ### Import/export
 
 <!--- MAGETWO-95313-->
 
-* Magento now imports existing products that have a price change and unchanged url-key with no unnecessary updates. Previously, the product's price was updated as expected, but its unchanged url-key was deleted.
+*  Magento now imports existing products that have a price change and unchanged url-key with no unnecessary updates. Previously, the product's price was updated as expected, but its unchanged url-key was deleted.
 
 <!--- MAGETWO-70232-->
 
-* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
+*  Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
 <!--- ENGCOM-4281-->
 
-* The import process  `replace` method now works as expected. *Fix submitted by Denys Saltanakhmedov in pull request [21189](https://github.com/magento/magento2/pull/21189)*. [GitHub-18761](https://github.com/magento/magento2/issues/18761)
+*  The import process  `replace` method now works as expected. *Fix submitted by Denys Saltanakhmedov in pull request [21189](https://github.com/magento/magento2/pull/21189)*. [GitHub-18761](https://github.com/magento/magento2/issues/18761)
 
 <!--- ENGCOM-4772-->
 
-* The import process now imports product quantity as expected.  *Fix submitted by Nazar Klovanych in pull request [22382](https://github.com/magento/magento2/pull/22382)*. [GitHub-22355](https://github.com/magento/magento2/issues/22355)
+*  The import process now imports product quantity as expected.  *Fix submitted by Nazar Klovanych in pull request [22382](https://github.com/magento/magento2/pull/22382)*. [GitHub-22355](https://github.com/magento/magento2/issues/22355)
 
 <!--- ENGCOM-3761-->
 
-* Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Jaimin Sutariya in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
+*  Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Jaimin Sutariya in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 <!--- ENGCOM-4600-->
 
-* The `_coreConfig` field in `Magento/ImportExport/Model/Import` is no longer declared dynamically. *Fix submitted by Roman Kis in pull request [21999](https://github.com/magento/magento2/pull/21999)*. [GitHub-21998](https://github.com/magento/magento2/issues/21998)
+*  The `_coreConfig` field in `Magento/ImportExport/Model/Import` is no longer declared dynamically. *Fix submitted by Roman Kis in pull request [21999](https://github.com/magento/magento2/pull/21999)*. [GitHub-21998](https://github.com/magento/magento2/issues/21998)
 
 <!--- ENGCOM-4722-->
 
-* Tooltip styles now use the appropriate variables for mobile view. *Fix submitted by Nazar Klovanych in pull request [22382](https://github.com/magento/magento2/pull/22355)*. [GitHub-22246](https://github.com/magento/magento2/issues/22355)
+*  Tooltip styles now use the appropriate variables for mobile view. *Fix submitted by Nazar Klovanych in pull request [22382](https://github.com/magento/magento2/pull/22355)*. [GitHub-22246](https://github.com/magento/magento2/issues/22355)
 
 <!--- ENGCOM-4428-->
 
-* Magento now displays the correct import status data for an import that is created using **System** > **Import** > **Advanced Pricing** > **Add/Update**. *Fix submitted by Denys Saltanakhmedov in pull request [21476](https://github.com/magento/magento2/pull/21476)*. [GitHub-21192](https://github.com/magento/magento2/issues/21192)
+*  Magento now displays the correct import status data for an import that is created using **System** > **Import** > **Advanced Pricing** > **Add/Update**. *Fix submitted by Denys Saltanakhmedov in pull request [21476](https://github.com/magento/magento2/pull/21476)*. [GitHub-21192](https://github.com/magento/magento2/issues/21192)
 
 <!--- ENGCOM-3993-->
 
-* When you export product data into a CSV file, the `store_view_code` column now contains data from the chosen product store. Previously, Magento did not populate the `store_view_code` column. *Fix submitted by Valant13 in pull request [19395](https://github.com/magento/magento2/pull/19395)*. [GitHub-17784](https://github.com/magento/magento2/issues/17784), [GitHub-19786](https://github.com/magento/magento2/issues/19786)
+*  When you export product data into a CSV file, the `store_view_code` column now contains data from the chosen product store. Previously, Magento did not populate the `store_view_code` column. *Fix submitted by Valant13 in pull request [19395](https://github.com/magento/magento2/pull/19395)*. [GitHub-17784](https://github.com/magento/magento2/issues/17784), [GitHub-19786](https://github.com/magento/magento2/issues/19786)
 
 ### Index
 
 <!--- ENGCOM-4440-->
 
-* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the indexer list for an Admin, Magento threw a fatal error. *Fix submitted by Cristiano Casciotti in pull request [21575](https://github.com/magento/magento2/pull/21575)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+*  You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the indexer list for an Admin, Magento threw a fatal error. *Fix submitted by Cristiano Casciotti in pull request [21575](https://github.com/magento/magento2/pull/21575)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
 
 <!--- ENGCOM-3761-->
 
-* Magento now validates CSV files that are created by custom adapters when you click **Check Data** if column and data are available. Previously, Magento threw an error.
+*  Magento now validates CSV files that are created by custom adapters when you click **Check Data** if column and data are available. Previously, Magento threw an error.
 
 *Fix submitted by Jaimin Sutariya in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 ### Infrastructure
 
-* The default behavior of view models has changed in this release. Instances of view models are now shared by default. As a result, you must add the `attribute shared="false"` on the argument node of the `layout.xml` file if you want a new instance of a view model.
+*  The default behavior of view models has changed in this release. Instances of view models are now shared by default. As a result, you must add the `attribute shared="false"` on the argument node of the `layout.xml` file if you want a new instance of a view model.
 
 <!--- ENGCOM-4474-->
 
-* The `FrontController` now explicitly requires actions to specify if they respond to `HEAD` requests. `HEAD` action mapping has also been changed to the  `GET` action interface, which results in `HEAD` requests returning `200` instead of `404`. *Fix submitted by Matti Vapa in pull request [21378](https://github.com/magento/magento2/pull/21378)*. [GitHub-21299](https://github.com/magento/magento2/issues/21299)
+*  The `FrontController` now explicitly requires actions to specify if they respond to `HEAD` requests. `HEAD` action mapping has also been changed to the  `GET` action interface, which results in `HEAD` requests returning `200` instead of `404`. *Fix submitted by Matti Vapa in pull request [21378](https://github.com/magento/magento2/pull/21378)*. [GitHub-21299](https://github.com/magento/magento2/issues/21299)
 
 <!--- ENGCOM-4482-->
 
-* We removed the Logic class from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class continued logic. *Fix submitted by Bartłomiej Szubert in pull request [21693](https://github.com/magento/magento2/pull/21693)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692), [GitHub-21752](https://github.com/magento/magento2/issues/21752)
+*  We removed the Logic class from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class continued logic. *Fix submitted by Bartłomiej Szubert in pull request [21693](https://github.com/magento/magento2/pull/21693)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692), [GitHub-21752](https://github.com/magento/magento2/issues/21752)
 
 <!--- ENGCOM-4543-->
 
-* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by Roman Kis in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+*  The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by Roman Kis in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
 <!--- ENGCOM-4562-->
 
-* The `errors/local.xml` and error page templates are no longer publicly accessible. *Fix submitted by Fabian Schmengler in pull request [20212](https://github.com/magento/magento2/pull/20212)*. [GitHub-20209](https://github.com/magento/magento2/issues/20209)
+*  The `errors/local.xml` and error page templates are no longer publicly accessible. *Fix submitted by Fabian Schmengler in pull request [20212](https://github.com/magento/magento2/pull/20212)*. [GitHub-20209](https://github.com/magento/magento2/issues/20209)
 
 <!--- ENGCOM-3498-->
 
-* We added the missing  attributes `validated_country_code` and `validated_vat_number` to `quote_address`. *Fix submitted by Erik Pellikka in pull request [19265](https://github.com/magento/magento2/pull/19265)*. [GitHub-17658](https://github.com/magento/magento2/issues/17658)
+*  We added the missing  attributes `validated_country_code` and `validated_vat_number` to `quote_address`. *Fix submitted by Erik Pellikka in pull request [19265](https://github.com/magento/magento2/pull/19265)*. [GitHub-17658](https://github.com/magento/magento2/issues/17658)
 
 <!--- ENGCOM-4147-->
 
-* We added Type casting to \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes() to improve  validation. *Fix submitted by Mudit Shukla in pull request [20898](https://github.com/magento/magento2/pull/20898)*. [GitHub-13319](https://github.com/magento/magento2/issues/13319)
+*  We added Type casting to \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes() to improve  validation. *Fix submitted by Mudit Shukla in pull request [20898](https://github.com/magento/magento2/pull/20898)*. [GitHub-13319](https://github.com/magento/magento2/issues/13319)
 
 <!--- ENGCOM-4170-->
 
-* Widget parameters can now contain multidimensional arrays. *Fix submitted by Eduard Chitoraga in pull request [21008](https://github.com/magento/magento2/pull/21008)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
+*  Widget parameters can now contain multidimensional arrays. *Fix submitted by Eduard Chitoraga in pull request [21008](https://github.com/magento/magento2/pull/21008)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
 
 <!--- ENGCOM-4627-->
 
-* The `phpcs` linter plugin now reports all errors and warnings in the terminal as expected. Previously, `phpcs` threw an error instead of reporting errors under certain circumstances. *Fix submitted by Nazar Klovanych in pull request [22081](https://github.com/magento/magento2/pull/22081)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
+*  The `phpcs` linter plugin now reports all errors and warnings in the terminal as expected. Previously, `phpcs` threw an error instead of reporting errors under certain circumstances. *Fix submitted by Nazar Klovanych in pull request [22081](https://github.com/magento/magento2/pull/22081)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
 
 <!--- ENGCOM-4527-->
 
-* The `getSize()` method in `\Magento\Framework\Data\Collection` now returns results that reflect added filters as expected when the `clear()` method is called after `getSize()`. Previously, this method returned results that always remained the same after the first call and the `clear()` method was ignored.*Fix submitted by Sergey Nezbritskiy in pull request [21670](https://github.com/magento/magento2/pull/21670)*. [GitHub-21654](https://github.com/magento/magento2/issues/21654)
+*  The `getSize()` method in `\Magento\Framework\Data\Collection` now returns results that reflect added filters as expected when the `clear()` method is called after `getSize()`. Previously, this method returned results that always remained the same after the first call and the `clear()` method was ignored.*Fix submitted by Sergey Nezbritskiy in pull request [21670](https://github.com/magento/magento2/pull/21670)*. [GitHub-21654](https://github.com/magento/magento2/issues/21654)
 
 <!--- ENGCOM-4545-->
 
@@ -986,221 +986,221 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
 <!--- ENGCOM-4504-->
 
-* Use of the Yes/No attribute in the Layered Navigation filter no longer degrades filter performance. *Fix submitted by Stephan Kechedzhi in pull request [21772](https://github.com/magento/magento2/pull/21772)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283), [GitHub-21771](https://github.com/magento/magento2/issues/21771)
+*  Use of the Yes/No attribute in the Layered Navigation filter no longer degrades filter performance. *Fix submitted by Stephan Kechedzhi in pull request [21772](https://github.com/magento/magento2/pull/21772)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283), [GitHub-21771](https://github.com/magento/magento2/issues/21771)
 
 <!--- ENGCOM-4458-->
 
-* Magento now retrieves the configuration value (store ID)  that is  based on the current store scope in multistore deployments. Previously, Magento occasionally returned an incorrect configuration scope ID when attempting to resolve a scope ID set to null. *Fix submitted by Pratik Oza in pull request [21633](https://github.com/magento/magento2/pull/21633)*. [GitHub-16939](https://github.com/magento/magento2/issues/16939)
+*  Magento now retrieves the configuration value (store ID)  that is  based on the current store scope in multistore deployments. Previously, Magento occasionally returned an incorrect configuration scope ID when attempting to resolve a scope ID set to null. *Fix submitted by Pratik Oza in pull request [21633](https://github.com/magento/magento2/pull/21633)*. [GitHub-16939](https://github.com/magento/magento2/issues/16939)
 
 ### Logging
 
 <!--- MAGETWO--98102 -->
 
-* The `support_report.log` and `system.log` files no longer contain duplicate records.
+*  The `support_report.log` and `system.log` files no longer contain duplicate records.
 
 <!--- ENGCOM-4505-->
 
-* Magento now creates a log entry if an observer does not implement `ObserverInterface` in modes other than developer mode.  Previously, Magento created a log entry when in developer mode only. *Fix submitted by Nazar Klovanych in pull request [21767](https://github.com/magento/magento2/pull/21767)*. [GitHub-21755](https://github.com/magento/magento2/issues/21755)
+*  Magento now creates a log entry if an observer does not implement `ObserverInterface` in modes other than developer mode.  Previously, Magento created a log entry when in developer mode only. *Fix submitted by Nazar Klovanych in pull request [21767](https://github.com/magento/magento2/pull/21767)*. [GitHub-21755](https://github.com/magento/magento2/issues/21755)
 
 ### Magento Shipping
 
-* Fixed issue with the event stream cron job.
+*  Fixed issue with the event stream cron job.
 
-* Fixed issue with retrieving shipping labels from some AWS environments.
+*  Fixed issue with retrieving shipping labels from some AWS environments.
 
 ### New Relic reporting
 
 <!--- MAGETWO-98853-->
 
-* Improved performance of New Relic queries. The New Relic Reporting module now cleans the Magento 2.x report data to prevent the reporting data store from growing too large and slowing query performance.
+*  Improved performance of New Relic queries. The New Relic Reporting module now cleans the Magento 2.x report data to prevent the reporting data store from growing too large and slowing query performance.
 
 <!--- ENGCOM-4634-->
 
-* Magento 2.x CLI command names are now reported in the transaction names in the New Relic APM Monitoring Data. The transaction name is based on the Magento CLI command name, for example `cli app:config:import`, `cli indexer:reindex`, and `cli cache:flush`. In previous releases, the New Relic transaction names for CLI commands initiated by Magento 2.x CLI command names was missing and reported as unknown. *Fix submitted by Lukasz Bajsarowicz in pull request [22059](https://github.com/magento/magento2/pull/22059)*. [GitHub-22047](https://github.com/magento/magento2/issues/22047)
+*  Magento 2.x CLI command names are now reported in the transaction names in the New Relic APM Monitoring Data. The transaction name is based on the Magento CLI command name, for example `cli app:config:import`, `cli indexer:reindex`, and `cli cache:flush`. In previous releases, the New Relic transaction names for CLI commands initiated by Magento 2.x CLI command names was missing and reported as unknown. *Fix submitted by Lukasz Bajsarowicz in pull request [22059](https://github.com/magento/magento2/pull/22059)*. [GitHub-22047](https://github.com/magento/magento2/issues/22047)
 
 ### Newsletter
 
 <!--- MAGETWO-98617-->
 
-* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page.
+*  You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page.
 
 <!--- ENGCOM-3992-->
 
-* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by Arvinda kumar in pull request [20165](https://github.com/magento/magento2/pull/20165)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
+*  The newsletter subscription input box now displays all text in mobile view. *Fix submitted by Arvinda kumar in pull request [20165](https://github.com/magento/magento2/pull/20165)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
 ### Orders
 
 <!--- MAGETWO-98368-->
 
-* The quick order form now handles the SKU codes that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the simple product which typically returned a 404 page.
+*  The quick order form now handles the SKU codes that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the simple product which typically returned a 404 page.
 
 <!--- ENGCOM-4673-->
 
-* Order status is now maintained as expected after a partial refund. Previously, Magento reset order status  to default  after a partial refund. *Fix submitted by Malyovanets Nickolas in pull request [20378](https://github.com/magento/magento2/pull/20378)*. [GitHub-12386](https://github.com/magento/magento2/issues/12386)
+*  Order status is now maintained as expected after a partial refund. Previously, Magento reset order status  to default  after a partial refund. *Fix submitted by Malyovanets Nickolas in pull request [20378](https://github.com/magento/magento2/pull/20378)*. [GitHub-12386](https://github.com/magento/magento2/issues/12386)
 
 <!--- ENGCOM-4739-->
 
-* Programmatically created invoices now include all items as expected when both simple products and bundled products are mixed in an order. Previously, when  `Magento\Sales\Model\Service\InvoiceService::prepareInvoice` was called without a specified quantity, the function did not discard items as expected after bundled items were processed, which resulted in a partial invoice. *Fix submitted by Ryan Palmer in pull request [22263](https://github.com/magento/magento2/pull/22263)*. [GitHub-22246](https://github.com/magento/magento2/issues/22246)
+*  Programmatically created invoices now include all items as expected when both simple products and bundled products are mixed in an order. Previously, when  `Magento\Sales\Model\Service\InvoiceService::prepareInvoice` was called without a specified quantity, the function did not discard items as expected after bundled items were processed, which resulted in a partial invoice. *Fix submitted by Ryan Palmer in pull request [22263](https://github.com/magento/magento2/pull/22263)*. [GitHub-22246](https://github.com/magento/magento2/issues/22246)
 
 <!--- ENGCOM-4524-->
 
-* When you create new extension attributes for orders, these attributes are now correctly joined when querying orders. *Fix submitted by Oleksandr Kravchuk in pull request [21797](https://github.com/magento/magento2/pull/21797)*. [GitHub-8035](https://github.com/magento/magento2/issues/8035)
+*  When you create new extension attributes for orders, these attributes are now correctly joined when querying orders. *Fix submitted by Oleksandr Kravchuk in pull request [21797](https://github.com/magento/magento2/pull/21797)*. [GitHub-8035](https://github.com/magento/magento2/issues/8035)
 
 ### Page cache
 
 <!--- MAGETWO-91607-->
 
-* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode.
+*  Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintenance mode.
 
 ### Payment methods
 
 <!--- MAGETWO-99307-->
 
-* Magento no longer throws an error indicating that a transaction was declined when Authorize.net successfully processes the order. Previously, orders were successfully created but Authorize.net indicated that the transaction had been declined.  [GitHub-22373](https://github.com/magento/magento2/issues/22373)
+*  Magento no longer throws an error indicating that a transaction was declined when Authorize.net successfully processes the order. Previously, orders were successfully created but Authorize.net indicated that the transaction had been declined.  [GitHub-22373](https://github.com/magento/magento2/issues/22373)
 
 <!--- MAGETWO-99094-->
 
-* Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.
+*  Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.
 
 <!--- ENGCOM-4192-->
 
-* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by Patrick McLain in pull request [21090](https://github.com/magento/magento2/pull/21090)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+*  Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by Patrick McLain in pull request [21090](https://github.com/magento/magento2/pull/21090)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
 ### Performance
 
 <!--- MAGETWO-95294-->
 
-* Improved catalog/search/advanced search pages response time: We have optimized the products load flow on storefront, which result in significant improvement of category, product, checkout and search result pages response time. There is minimum a five times improvement for page response time under high load.
+*  Improved catalog/search/advanced search pages response time: We have optimized the products load flow on storefront, which result in significant improvement of category, product, checkout and search result pages response time. There is minimum a five times improvement for page response time under high load.
 
 <!--- MC-16005-->
 
-* Client-side performance has been optimized by moving non-critical JavaScript code to the bottom of the page along with the corresponding deferred parsing and evaluation of this code. This means that users can see rendered pages faster. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.
+*  Client-side performance has been optimized by moving non-critical JavaScript code to the bottom of the page along with the corresponding deferred parsing and evaluation of this code. This means that users can see rendered pages faster. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.
 
 <!--- MAGETWO-96138-->
 
-* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+*  The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
 
 <!--- MAGETWO-98424-->
 
-* The multishipping checkout flow now supports the Braintree payment method.
+*  The multishipping checkout flow now supports the Braintree payment method.
 
 <!--- ENGCOM-4650-->
 
-* Magento no longer disables the **Place order** button in the checkout workflow after the customer has supplied the requested email address for orders created with Braintree. *Fix submitted by Roman Kis in pull request [21936](https://github.com/magento/magento2/pull/21936)* [GitHub-21907](https://github.com/magento/magento2/issues/21907)
+*  Magento no longer disables the **Place order** button in the checkout workflow after the customer has supplied the requested email address for orders created with Braintree. *Fix submitted by Roman Kis in pull request [21936](https://github.com/magento/magento2/pull/21936)* [GitHub-21907](https://github.com/magento/magento2/issues/21907)
 
 <!--- MC-6273-->
 
-* We have optimized the logic of concurrent access to the block cache, which has improved the response of storefront pages under high load by approximately 20%.
+*  We have optimized the logic of concurrent access to the block cache, which has improved the response of storefront pages under high load by approximately 20%.
 
 ### Quote
 
 <!--- ENGCOM-4520-->
 
-* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`.  *Fix submitted by David Führ in pull request [21697](https://github.com/magento/magento2/pull/21697)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
+*  `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`.  *Fix submitted by David Führ in pull request [21697](https://github.com/magento/magento2/pull/21697)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
 <!--- ENGCOM-4712-->
 
-* The `x_forwarded_for` field of the Quote Management service now contains the value from `$_SERVER['HTTP_X_FORWARDED_FOR']`. Previously, this field was always empty. This change will permit administrators to see their customer's actual IP addresses (as opposed to 127.0.0.1), which can help identify potentially fraudulent orders. *Fix submitted by Christian Münch in pull request [21787](https://github.com/magento/magento2/pull/21787)*. [GitHub-](https://github.com/magento/magento2/issues/)
+*  The `x_forwarded_for` field of the Quote Management service now contains the value from `$_SERVER['HTTP_X_FORWARDED_FOR']`. Previously, this field was always empty. This change will permit administrators to see their customer's actual IP addresses (as opposed to 127.0.0.1), which can help identify potentially fraudulent orders. *Fix submitted by Christian Münch in pull request [21787](https://github.com/magento/magento2/pull/21787)*. [GitHub-](https://github.com/magento/magento2/issues/)
 
 ### Reports
 
 <!--- MAGETWO-97848-->
 
-* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.
+*  Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.
 
 <!--- ENGCOM-3808-->
 
-* The date range in reports no longer displays the same start and end dates. *Fix submitted by Milind Singh in pull request [20129](https://github.com/magento/magento2/pull/20129)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
+*  The date range in reports no longer displays the same start and end dates. *Fix submitted by Milind Singh in pull request [20129](https://github.com/magento/magento2/pull/20129)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
 <!--- ENGCOM-4302-->
 
-* Magento now includes the amount of a credit memo's refunded discount in its calculation of the value displayed in the total column under **Last Orders** listing on the Admin dashboard. *Fix submitted by rav-redchamps in pull request [21283](https://github.com/magento/magento2/pull/21283)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+*  Magento now includes the amount of a credit memo's refunded discount in its calculation of the value displayed in the total column under **Last Orders** listing on the Admin dashboard. *Fix submitted by rav-redchamps in pull request [21283](https://github.com/magento/magento2/pull/21283)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
 
 <!--- ENGCOM-4747-->
 
-* The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by Shikha Mishra in pull request [22291](https://github.com/magento/magento2/pull/22291)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
+*  The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by Shikha Mishra in pull request [22291](https://github.com/magento/magento2/pull/22291)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
 
 ### Reviews
 
 <!--- ENGCOM-4560-->
 
-* The text for review-related headers under **User Content** on the Admin dashboard has been edited for clarity.  *Fix submitted by Vishal Gelani in pull request [21621](https://github.com/magento/magento2/pull/21621)*. [GitHub-21620](https://github.com/magento/magento2/issues/21620)
+*  The text for review-related headers under **User Content** on the Admin dashboard has been edited for clarity.  *Fix submitted by Vishal Gelani in pull request [21621](https://github.com/magento/magento2/pull/21621)*. [GitHub-21620](https://github.com/magento/magento2/issues/21620)
 
 ### Return Merchandise Authorizations (RMA)
 
 <!--- MAGETWO-97852-->
 
-* Product-level RMA disabling now works as expected.
+*  Product-level RMA disabling now works as expected.
 
 ### Sales
 
 <!--- ENGCOM-4101-->
 
-* Corrected problems with the disabling and enabling order-related emails. *Fix submitted by Serhiy Zhovnir in pull request [20953](https://github.com/magento/magento2/pull/20953)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+*  Corrected problems with the disabling and enabling order-related emails. *Fix submitted by Serhiy Zhovnir in pull request [20953](https://github.com/magento/magento2/pull/20953)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
 <!--- ENGCOM-4197-->
 
-* Fixed display of the Luma theme My Account Order status tabs in mobile view.*Fix submitted by Abrar Pathan in pull request [21071](https://github.com/magento/magento2/pull/21071)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
+*  Fixed display of the Luma theme My Account Order status tabs in mobile view.*Fix submitted by Abrar Pathan in pull request [21071](https://github.com/magento/magento2/pull/21071)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
 
 <!--- ENGCOM-4241-->
 
-* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by gauravagarwal1001 in pull request [21145](https://github.com/magento/magento2/pull/21145)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162), [GitHub-7974](https://github.com/magento/magento2/issues/7974), [GitHub-21144](https://github.com/magento/magento2/issues/21144)
+*  You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by gauravagarwal1001 in pull request [21145](https://github.com/magento/magento2/pull/21145)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162), [GitHub-7974](https://github.com/magento/magento2/issues/7974), [GitHub-21144](https://github.com/magento/magento2/issues/21144)
 
 <!--- ENGCOM-4321-->
 
-* You can now successfully re-order a virtual product. *Fix submitted by Shikha Mishra in pull request [21335](https://github.com/magento/magento2/pull/21335)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
+*  You can now successfully re-order a virtual product. *Fix submitted by Shikha Mishra in pull request [21335](https://github.com/magento/magento2/pull/21335)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
 
 <!--- MAGETWO-97423-->
 
-* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column  contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
+*  When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column  contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
 
 <!--- ENGCOM-4238-->
 
-* Form validation now works as expected for fields in the Admin order address edit forms. Previously, when you entered invalid data, Magento did not display an error message and displayed the data. *Fix submitted by Ievgenii Gryshkun in pull request [20840](https://github.com/magento/magento2/pull/20840)*. [GitHub-19360](https://github.com/magento/magento2/issues/19360)
+*  Form validation now works as expected for fields in the Admin order address edit forms. Previously, when you entered invalid data, Magento did not display an error message and displayed the data. *Fix submitted by Ievgenii Gryshkun in pull request [20840](https://github.com/magento/magento2/pull/20840)*. [GitHub-19360](https://github.com/magento/magento2/issues/19360)
 
 <!--- ENGCOM-3910-->
 
-* If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 ### SalesRule
 
 <!--- ENGCOM-4215-->
 
-* We updated the DataProvider and Save Controller files to improve persistence of form data in cart price rules. *Fix submitted by Aditya Yadav in pull request [20895](https://github.com/magento/magento2/pull/20895)*. [GitHub-20888](https://github.com/magento/magento2/issues/2088)
+*  We updated the DataProvider and Save Controller files to improve persistence of form data in cart price rules. *Fix submitted by Aditya Yadav in pull request [20895](https://github.com/magento/magento2/pull/20895)*. [GitHub-20888](https://github.com/magento/magento2/issues/2088)
 
 <!--- ENGCOM-4406-->
 
-* Added a condition `type _Subtotal (Excl. Tax)` to the Cart Price Rule configuration so that you can configure a cart price discount rule discount based on minimum purchase amount that excludes tax. Previously, the subtotal was calculated only with tax included. *Fix submitted by AleksLi in pull request [21288](https://github.com/magento/magento2/pull/21288)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
+*  Added a condition `type _Subtotal (Excl. Tax)` to the Cart Price Rule configuration so that you can configure a cart price discount rule discount based on minimum purchase amount that excludes tax. Previously, the subtotal was calculated only with tax included. *Fix submitted by AleksLi in pull request [21288](https://github.com/magento/magento2/pull/21288)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
 
 ### Search
 
 <!--- MAGETWO-58764-->
 
-* Catalog search **Minimal Query Length** values are now enforced as expected.
+*  Catalog search **Minimal Query Length** values are now enforced as expected.
 
 <!--- MAGETWO-97209-->
 
-* The count of products in layered navigation now equals the number of  products found by search in deployments that run B2B. Previously, fewer products were identified by search than by layered navigation.
+*  The count of products in layered navigation now equals the number of  products found by search in deployments that run B2B. Previously, fewer products were identified by search than by layered navigation.
 
 <!--- MAGETWO-97830-->
 
-* Elasticsearch quick search now works as expected when the default attribute set contains a `date` attribute that has been set to **Search = Yes**. Previously, the search page threw an exception and crashed.
+*  Elasticsearch quick search now works as expected when the default attribute set contains a `date` attribute that has been set to **Search = Yes**. Previously, the search page threw an exception and crashed.
 
 <!--- ENGCOM-4109-->
 
-* The performance of layered navigation queries has been improved. *Fix submitted by Mads Nielsen in pull request [20971](https://github.com/magento/magento2/pull/20971)*. [GitHub-20969](https://github.com/magento/magento2/issues/20969)
+*  The performance of layered navigation queries has been improved. *Fix submitted by Mads Nielsen in pull request [20971](https://github.com/magento/magento2/pull/20971)*. [GitHub-20969](https://github.com/magento/magento2/issues/20969)
 
 <!--- ENGCOM-4481-->
 
-* The search REST API now returns the correct `total_count` of result items. Previously, the value of `total_count`  equaled `searchCriteria[pageSize]`,  not the total count of the search result items. *Fix submitted by Ronak Patel in pull request [21713](https://github.com/magento/magento2/pull/21713)*. [GitHub-17295](https://github.com/magento/magento2/issues/17295)
+*  The search REST API now returns the correct `total_count` of result items. Previously, the value of `total_count`  equaled `searchCriteria[pageSize]`,  not the total count of the search result items. *Fix submitted by Ronak Patel in pull request [21713](https://github.com/magento/magento2/pull/21713)*. [GitHub-17295](https://github.com/magento/magento2/issues/17295)
 
 <!--- ENGCOM-4761-->
 
-* The search icon on Admin page headers now works as expected. *Fix submitted by Nirav Patel in pull request [22154](https://github.com/magento/magento2/pull/22154)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
+*  The search icon on Admin page headers now works as expected. *Fix submitted by Nirav Patel in pull request [22154](https://github.com/magento/magento2/pull/22154)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
 
 <!--- ENGCOM-4620-->
 
-* Magento now checks concrete class while applying plugins. Previously, when  the pluginized class was virtual-typed by a class with name ending with an autogenerated suffix and without the implementation of the base concrete class, the `di:compile` process failed.
+*  Magento now checks concrete class while applying plugins. Previously, when  the pluginized class was virtual-typed by a class with name ending with an autogenerated suffix and without the implementation of the base concrete class, the `di:compile` process failed.
 
 *Fix submitted by Riccardo Tempesta in pull request [22046](https://github.com/magento/magento2/pull/22046)*. [GitHub-21916](https://github.com/magento/magento2/issues/21916), [GitHub-21976](https://github.com/magento/magento2/issues/21976)
 
@@ -1208,187 +1208,187 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
 <!--- ENGCOM-4266-->
 
-* UPS (non XML) endpoints are now HTTPS instead of  HTTP. *Fix submitted by Josh in pull request [21511](https://github.com/magento/magento2/pull/21511)*.
+*  UPS (non XML) endpoints are now HTTPS instead of  HTTP. *Fix submitted by Josh in pull request [21511](https://github.com/magento/magento2/pull/21511)*.
 
 <!--- ENGCOM-3601-->
 
-* Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**. *Fix submitted by gwharton in pull request [19487](https://github.com/magento/magento2/pull/19487)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
+*  Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**. *Fix submitted by gwharton in pull request [19487](https://github.com/magento/magento2/pull/19487)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
 
 <!--- MAGETWO-98947-->
 
-* The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS).
+*  The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS).
 
 <!--- MAGETWO-98328-->
 
-* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
+*  The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 ### Sitemap
 
 <!--- ENGCOM-3683-->
 
-* Images in the XML sitemap are no longer linked to the base store in a multistore deployment when scheduling start times and daily frequency. *Fix submitted by Nazar Klovanych in pull request [19598](https://github.com/magento/magento2/pull/15012)*. [GitHub-19596](https://github.com/magento/magento2/issues/19596)
+*  Images in the XML sitemap are no longer linked to the base store in a multistore deployment when scheduling start times and daily frequency. *Fix submitted by Nazar Klovanych in pull request [19598](https://github.com/magento/magento2/pull/15012)*. [GitHub-19596](https://github.com/magento/magento2/issues/19596)
 
 <!--- ENGCOM-3844-->
 
-* Magento now validates sitemap file names to ensure that file names do not exceed length limits. Previously, Magento simply truncated excessively long file names. *Fix submitted by Rajneesh Gupta in pull request [20044](https://github.com/magento/magento2/pull/20044)*. [GitHub-13937](https://github.com/magento/magento2/issues/13937)
+*  Magento now validates sitemap file names to ensure that file names do not exceed length limits. Previously, Magento simply truncated excessively long file names. *Fix submitted by Rajneesh Gupta in pull request [20044](https://github.com/magento/magento2/pull/20044)*. [GitHub-13937](https://github.com/magento/magento2/issues/13937)
 
 ### Staging
 
 <!--- MAGETWO-97866-->
 
-* Products are now marked as new on the storefront when you set a product "As New" in the product page or from a scheduled update. Previously, dates shown in database did not match the dates in the update on the store in deployments running the `en_GB` locale.
+*  Products are now marked as new on the storefront when you set a product "As New" in the product page or from a scheduled update. Previously, dates shown in database did not match the dates in the update on the store in deployments running the `en_GB` locale.
 
 ### Swatches
 
 <!--- ENGCOM-4347-->
 
-* Corrected `blackground` to `background` in `Magento_Swatches _module.less`. *Fix submitted by Amol Chaudhari in pull request [21368](https://github.com/magento/magento2/pull/21368)*. [GitHub-21365](https://github.com/magento/magento2/issues/21365)
+*  Corrected `blackground` to `background` in `Magento_Swatches _module.less`. *Fix submitted by Amol Chaudhari in pull request [21368](https://github.com/magento/magento2/pull/21368)*. [GitHub-21365](https://github.com/magento/magento2/issues/21365)
 
 <!--- ENGCOM-4296-->
 
-* You can now successfully preselect a configurable product swatch that contains an image. Previously, Magento tried to load the image into the product gallery before initialization completed and threw a JavaScript error. *Fix submitted by Nirav Patel in pull request [19635](https://github.com/magento/magento2/pull/19635)*. [GitHub-18017](https://github.com/magento/magento2/issues/18017)
+*  You can now successfully preselect a configurable product swatch that contains an image. Previously, Magento tried to load the image into the product gallery before initialization completed and threw a JavaScript error. *Fix submitted by Nirav Patel in pull request [19635](https://github.com/magento/magento2/pull/19635)*. [GitHub-18017](https://github.com/magento/magento2/issues/18017)
 
 ### Tax
 
 <!--- MAGETWO-97396-->
 
-* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
+*  The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
 <!--- ENGCOM-4022-->
 
-* The shopping cart full tax summary now displays total tax as expected instead of  individual tax values. *Fix submitted by Nirav Patel in pull request [20682](https://github.com/magento/magento2/pull/20682)*. [GitHub-11358](https://github.com/magento/magento2/issues/11358), [GitHub-19701](https://github.com/magento/magento2/issues/19701)
+*  The shopping cart full tax summary now displays total tax as expected instead of  individual tax values. *Fix submitted by Nirav Patel in pull request [20682](https://github.com/magento/magento2/pull/20682)*. [GitHub-11358](https://github.com/magento/magento2/issues/11358), [GitHub-19701](https://github.com/magento/magento2/issues/19701)
 
 <!--- ENGCOM-4359-->
 
-* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by Nick de Kleijn in pull request [20316](https://github.com/magento/magento2/pull/20316)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+*  The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by Nick de Kleijn in pull request [20316](https://github.com/magento/magento2/pull/20316)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
 <!--- MAGETWO-98028-->
 
-* The tax that is applied to a simple child product is now based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
+*  The tax that is applied to a simple child product is now based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
 
 <!--- ENGCOM-4480-->
 
-* You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw a MySQL error. *Fix submitted by Tuyen Nguyen in pull request [21701](https://github.com/magento/magento2/pull/21701)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw a MySQL error. *Fix submitted by Tuyen Nguyen in pull request [21701](https://github.com/magento/magento2/pull/21701)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
 ### Testing
 
 <!--- ENGCOM-4300-->
 
-* The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by Maksym Novik in pull request [21275](https://github.com/magento/magento2/pull/21275)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
+*  The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by Maksym Novik in pull request [21275](https://github.com/magento/magento2/pull/21275)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 <!--- ENGCOM-4554-->
 
-* Added missing parameters to failing unit tests for `FormatTests`. *Fix submitted by Kamil Degórski in pull request [21880](https://github.com/magento/magento2/pull/21880)*. [GitHub-21001](https://github.com/magento/magento2/issues/21001)
+*  Added missing parameters to failing unit tests for `FormatTests`. *Fix submitted by Kamil Degórski in pull request [21880](https://github.com/magento/magento2/pull/21880)*. [GitHub-21001](https://github.com/magento/magento2/issues/21001)
 
 ### Theme
 
 <!--- MAGETWO-98319-->
 
-* Editing a theme now creates an entry in the Admin action log as expected.
+*  Editing a theme now creates an entry in the Admin action log as expected.
 
 <!--- ENGCOM-3799-->
 
-* Logo files for transactional emails can now be uploaded successfully using the **Content** > **Configuration** > **Edit theme** > **Transactional Emails** option. Previously, Magento did not upload the logo, and displayed the following error instead: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.` *Fix submitted by chaplynsky in pull request [20092](https://github.com/magento/magento2/pull/20092)*. [GitHub-20091](https://github.com/magento/magento2/issues/20091)
+*  Logo files for transactional emails can now be uploaded successfully using the **Content** > **Configuration** > **Edit theme** > **Transactional Emails** option. Previously, Magento did not upload the logo, and displayed the following error instead: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.` *Fix submitted by chaplynsky in pull request [20092](https://github.com/magento/magento2/pull/20092)*. [GitHub-20091](https://github.com/magento/magento2/issues/20091)
 
 <!--- ENGCOM-4338-->
 
-* The horizontal scroll widget on the storefront search results page now works as expected when displaying very long search strings. *Fix submitted by Prince Patel in pull request [21360](https://github.com/magento/magento2/pull/21360)*. [GitHub-21359](https://github.com/magento/magento2/issues/21359)
+*  The horizontal scroll widget on the storefront search results page now works as expected when displaying very long search strings. *Fix submitted by Prince Patel in pull request [21360](https://github.com/magento/magento2/pull/21360)*. [GitHub-21359](https://github.com/magento/magento2/issues/21359)
 
 <!--- ENGCOM-4541-->
 
-* Checkboxes and radio buttons are now highlighted on focus while you navigate a form using the keyboard.  This change is a reversion of an earlier fix (20861), which inadvertently violated accessibility standards for keyboard  navigation. *Fix submitted by Roman Kis in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+*  Checkboxes and radio buttons are now highlighted on focus while you navigate a form using the keyboard.  This change is a reversion of an earlier fix (20861), which inadvertently violated accessibility standards for keyboard  navigation. *Fix submitted by Roman Kis in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
 <!--- ENGCOM-4800-->
 
-* Magento now successfully uploads files from the theme config edit form page when you click the **Select from Gallery** button for the **Logo Image** field. *Fix submitted by Vechirko Yurii in pull request [22132](https://github.com/magento/magento2/pull/22132)*. [GitHub-21032](https://github.com/magento/magento2/issues/21032)
+*  Magento now successfully uploads files from the theme config edit form page when you click the **Select from Gallery** button for the **Logo Image** field. *Fix submitted by Vechirko Yurii in pull request [22132](https://github.com/magento/magento2/pull/22132)*. [GitHub-21032](https://github.com/magento/magento2/issues/21032)
 
 ### Translation and locales
 
 <!--- ENGCOM-4503-->
 
-* Product attribute labels are no longer translated. *Fix submitted by Karla Saaremäe in pull request [21751](https://github.com/magento/magento2/pull/21751)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
+*  Product attribute labels are no longer translated. *Fix submitted by Karla Saaremäe in pull request [21751](https://github.com/magento/magento2/pull/21751)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
 ### UI
 
 <!--- ENGCOM-3937-->
 
-* You can no longer upload images when the **Use Default Value** setting on the Admin Content tab is enabled. Previously, you could drag an image to this tab even when this setting was enabled. *Fix submitted by Mahesh Singh in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  You can no longer upload images when the **Use Default Value** setting on the Admin Content tab is enabled. Previously, you could drag an image to this tab even when this setting was enabled. *Fix submitted by Mahesh Singh in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 <!--- ENGCOM-4148-->
 
-* The Date field associated with a page on the  Admin Pages table now displays the correct date, not the current date. *Fix submitted by Satya Prakash in pull request [20902](https://github.com/magento/magento2/pull/20902)*. [GitHub-17564](https://github.com/magento/magento2/issues/17564)
+*  The Date field associated with a page on the  Admin Pages table now displays the correct date, not the current date. *Fix submitted by Satya Prakash in pull request [20902](https://github.com/magento/magento2/pull/20902)*. [GitHub-17564](https://github.com/magento/magento2/issues/17564)
 
 <!--- ENGCOM-3898-->
 
-* Postcodes and zip code fields on the checkout page are empty and invalidated on page load as expected. Previously, Magento validated postcodes and zip codes on the checkout page when the page loaded. *Fix submitted by Danny Verkade in pull request [18633](https://github.com/magento/magento2/pull/18633)*. [GitHub-18630](https://github.com/magento/magento2/issues/18630)
+*  Postcodes and zip code fields on the checkout page are empty and invalidated on page load as expected. Previously, Magento validated postcodes and zip codes on the checkout page when the page loaded. *Fix submitted by Danny Verkade in pull request [18633](https://github.com/magento/magento2/pull/18633)*. [GitHub-18630](https://github.com/magento/magento2/issues/18630)
 
 <!--- ENGCOM-4522-->
 
-* Buttons on the Admin **System** > **Backups** page no longer flicker when the page is reloaded. *Fix submitted by Oleg Volkov in pull request [21791](https://github.com/magento/magento2/pull/21791)*. [GitHub-19835](https://github.com/magento/magento2/issues/19835)
+*  Buttons on the Admin **System** > **Backups** page no longer flicker when the page is reloaded. *Fix submitted by Oleg Volkov in pull request [21791](https://github.com/magento/magento2/pull/21791)*. [GitHub-19835](https://github.com/magento/magento2/issues/19835)
 
 <!--- ENGCOM-4414-->
 
-* Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by Scott Buchanan in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+*  Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by Scott Buchanan in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 <!--- ENGCOM-4596-->
 
-* Product gallery images no longer open unexpectedly when you move a product image while moving to another page element. *Fix submitted by Denis Kopylov in pull request [21790](https://github.com/magento/magento2/pull/21790)*. [GitHub-21789](https://github.com/magento/magento2/issues/21789)
+*  Product gallery images no longer open unexpectedly when you move a product image while moving to another page element. *Fix submitted by Denis Kopylov in pull request [21790](https://github.com/magento/magento2/pull/21790)*. [GitHub-21789](https://github.com/magento/magento2/issues/21789)
 
 <!--- ENGCOM-4703-->
 
-* Magento now cancels previous scrolling actions as expected when you click **Add to cart** on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked  **Add to cart**. *Fix submitted by Vechirko Yurii in pull request [22117](https://github.com/magento/magento2/pull/22117)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
+*  Magento now cancels previous scrolling actions as expected when you click **Add to cart** on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked  **Add to cart**. *Fix submitted by Vechirko Yurii in pull request [22117](https://github.com/magento/magento2/pull/22117)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
 
 <!--- ENGCOM-4666-->
 
-* Magento no longer displays the customer name twice in the welcome message on the log in page after a customer logs in. *Fix submitted by priti2jcommerce in pull request [20832](https://github.com/magento/magento2/pull/20832)*. [GitHub-20830](https://github.com/magento/magento2/issues/20830)
+*  Magento no longer displays the customer name twice in the welcome message on the log in page after a customer logs in. *Fix submitted by priti2jcommerce in pull request [20832](https://github.com/magento/magento2/pull/20832)*. [GitHub-20830](https://github.com/magento/magento2/issues/20830)
 
 <!--- ENGCOM-4762-->
 
-* Magento now updates the `created_at` and `updated_at` columns in the `ui_bookmark` table as expected. *Fix submitted by Shikha Mishra in pull request [22340](https://github.com/magento/magento2/pull/22340)*. [GitHub-18557](https://github.com/magento/magento2/issues/18557)
+*  Magento now updates the `created_at` and `updated_at` columns in the `ui_bookmark` table as expected. *Fix submitted by Shikha Mishra in pull request [22340](https://github.com/magento/magento2/pull/22340)*. [GitHub-18557](https://github.com/magento/magento2/issues/18557)
 
 <!--- ENGCOM-4775-->
 
-* Scrolling now works as expected in pop-up windows on devices running iOS. *Fix submitted by priti2jcommerce in pull request [21150](https://github.com/magento/magento2/pull/21150)*. [GitHub-21147](https://github.com/magento/magento2/issues/21147)
+*  Scrolling now works as expected in pop-up windows on devices running iOS. *Fix submitted by priti2jcommerce in pull request [21150](https://github.com/magento/magento2/pull/21150)*. [GitHub-21147](https://github.com/magento/magento2/issues/21147)
 
 <!--- ENGCOM-3803-->
 
-* Magento now displays warning messages when validation fails on a form field that has a validation rule associated with it. Previously,  Magento displayed the following error: `Javascript Error: Uncaught TypeError: msg.replace is not a function`, if validation failed on a form field. *Fix submitted by Seth Daugherty in pull request [20079](https://github.com/magento/magento2/pull/20079)*. [GitHub-20078](https://github.com/magento/magento2/issues/20078)
+*  Magento now displays warning messages when validation fails on a form field that has a validation rule associated with it. Previously,  Magento displayed the following error: `Javascript Error: Uncaught TypeError: msg.replace is not a function`, if validation failed on a form field. *Fix submitted by Seth Daugherty in pull request [20079](https://github.com/magento/magento2/pull/20079)*. [GitHub-20078](https://github.com/magento/magento2/issues/20078)
 
 <!--- ENGCOM-3937-->
 
-* Magento no longer uploads images to the Category page unless the **Use Default Value** attribute is enabled. *Fix submitted by Serhiy Zhovnir in pull request [20461](https://github.com/magento/magento2/pull/20461)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
+*  Magento no longer uploads images to the Category page unless the **Use Default Value** attribute is enabled. *Fix submitted by Serhiy Zhovnir in pull request [20461](https://github.com/magento/magento2/pull/20461)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
 ### URL rewrites
 
 <!--- ENGCOM-4357-->
 
-* Added a feature to manage URL rewrites when the product visibility attribute changes. If the product is made invisible, Magento deletes the URL rewrite. If you change the visibility attribute to true, Magento creates a URL rewrite rule. Previously, changing the visibility attribute sometimes created duplicate product URLs. *Fix submitted by VitaliyBoyko in pull request [20774](https://github.com/magento/magento2/pull/20774)*. [GitHub-20434](https://github.com/magento/magento2/issues/20434)
+*  Added a feature to manage URL rewrites when the product visibility attribute changes. If the product is made invisible, Magento deletes the URL rewrite. If you change the visibility attribute to true, Magento creates a URL rewrite rule. Previously, changing the visibility attribute sometimes created duplicate product URLs. *Fix submitted by VitaliyBoyko in pull request [20774](https://github.com/magento/magento2/pull/20774)*. [GitHub-20434](https://github.com/magento/magento2/issues/20434)
 
 <!--- MAGETWO-98643-->
 
-* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
+*  URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
 
 <!--- ENGCOM-4586-->
 
-* Magento now retains filter terms after you apply a filter to the Admin `url_rewrites` table, and subsequently click the back button. *Fix submitted by Vaibhav Bhalerao in pull request [21834](https://github.com/magento/magento2/pull/21834)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+*  Magento now retains filter terms after you apply a filter to the Admin `url_rewrites` table, and subsequently click the back button. *Fix submitted by Vaibhav Bhalerao in pull request [21834](https://github.com/magento/magento2/pull/21834)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 ### Web API
 
 <!--- ENGCOM-4771-->
 
-* You can now use REST in scope `all` to save an existing category that does not have a `name` attribute. Previously, Magento threw this exception, `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by Nirav Patel in pull request [22362](https://github.com/magento/magento2/pull/22362)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
+*  You can now use REST in scope `all` to save an existing category that does not have a `name` attribute. Previously, Magento threw this exception, `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by Nirav Patel in pull request [22362](https://github.com/magento/magento2/pull/22362)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
 
 <!--- ENGCOM-4674-->
 
-* The REST-API locale now matches the appropriate store view in multistore deployments. Previously, Magento used the default scope for each store view. *Fix submitted by Julian Wundrak in pull request [19913](https://github.com/magento/magento2/pull/19913)*. [GitHub-19908](https://github.com/magento/magento2/issues/19908)
+*  The REST-API locale now matches the appropriate store view in multistore deployments. Previously, Magento used the default scope for each store view. *Fix submitted by Julian Wundrak in pull request [19913](https://github.com/magento/magento2/pull/19913)*. [GitHub-19908](https://github.com/magento/magento2/issues/19908)
 
 <!--- ENGCOM-4173-->
 
-* You can now use the `/rest/all/V1/products/` API to update a product's `category_ids` through `custom_attribute` when the product has no custom attributes. Previously, the `update` command reported success, but categories were not updated. *Fix submitted by Yaroslav Gyryn in pull request [20842](https://github.com/magento/magento2/pull/20842)*. [GitHub-20481](https://github.com/magento/magento2/issues/20481)
+*  You can now use the `/rest/all/V1/products/` API to update a product's `category_ids` through `custom_attribute` when the product has no custom attributes. Previously, the `update` command reported success, but categories were not updated. *Fix submitted by Yaroslav Gyryn in pull request [20842](https://github.com/magento/magento2/pull/20842)*. [GitHub-20481](https://github.com/magento/magento2/issues/20481)
 
 <!--- ENGCOM-4786-->
 
-* The `PUT /V1/products/:sku/media/:entryId` API operation now updates product images as expected. Previously, this operation updated the label, types, and disabled settings, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`.
+*  The `PUT /V1/products/:sku/media/:entryId` API operation now updates product images as expected. Previously, this operation updated the label, types, and disabled settings, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`.
 
 *Fix submitted by Nazar Klovanych in pull request [22424](https://github.com/magento/magento2/pull/22424)*. [GitHub-22402](https://github.com/magento/magento2/issues/22402)
 
@@ -1396,31 +1396,31 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
 <!--- ENGCOM-4460-->
 
-* Customer wishlists now include review summaries for included products. *Fix submitted by Denis Kopylov in pull request [21420](https://github.com/magento/magento2/pull/21420)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
+*  Customer wishlists now include review summaries for included products. *Fix submitted by Denis Kopylov in pull request [21420](https://github.com/magento/magento2/pull/21420)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 <!--- MAGETWO-62113-->
 
-* All phrases in wishlist modal windows are now translated as expected.
+*  All phrases in wishlist modal windows are now translated as expected.
 
 <!--- MAGETWO-62728-->
 
-* The wish list quantity field now has limits on both the type and number of characters that you can enter. Previously, you could enter an extremely large quantity of both number and letters into this field, which resulted in undesirable and inaccurate quantity changes.
+*  The wish list quantity field now has limits on both the type and number of characters that you can enter. Previously, you could enter an extremely large quantity of both number and letters into this field, which resulted in undesirable and inaccurate quantity changes.
 
 <!--- ENGCOM-3715-->
 
-* Magento now alerts you to the expected minimum quantity of product when you try to add a lesser product quantity to your shopping cart from the wishlist. *Fix submitted by khodu in pull request [19653](https://github.com/magento/magento2/pull/19653)*. [GitHub-9155](https://github.com/magento/magento2/issues/9155)
+*  Magento now alerts you to the expected minimum quantity of product when you try to add a lesser product quantity to your shopping cart from the wishlist. *Fix submitted by khodu in pull request [19653](https://github.com/magento/magento2/pull/19653)*. [GitHub-9155](https://github.com/magento/magento2/issues/9155)
 
 ### WYSIWYG
 
 <!--- ENGCOM-4664-->
 
-* You can now insert widgets that contain a WYSIWYG field into a form. Previously, when you tried to insert a widget with a `WYSIWYG` parameter into a form, the operation failed. *Fix submitted by James Dinsdale in pull request [20174](https://github.com/magento/magento2/pull/20174)*. [GitHub-19742](https://github.com/magento/magento2/issues/19742)
+*  You can now insert widgets that contain a WYSIWYG field into a form. Previously, when you tried to insert a widget with a `WYSIWYG` parameter into a form, the operation failed. *Fix submitted by James Dinsdale in pull request [20174](https://github.com/magento/magento2/pull/20174)*. [GitHub-19742](https://github.com/magento/magento2/issues/19742)
 
 ## Known issues
 
-* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
+*  **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 
-* **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions.
+*  **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions.
 
   {:.bs-callout-warning}
   {{site.data.var.ece}} customers must submit a support ticket to upgrade the libsodium package on Pro Production and Staging environments prior to upgrading to {{site.data.var.ee}} 2.3.2. Currently, you cannot upgrade Starter environments to {{site.data.var.ee}} 2.3.2.
@@ -1429,9 +1429,9 @@ has been changed to `<argument name="resourceStockItem" xsi:type="object">Magent
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### Partner contributions
 

--- a/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
+++ b/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.md
@@ -36,46 +36,46 @@ Look for the following highlights in this release:
 
 This release is focused on substantial security enhancements:
 
-* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.2) have been ported to 2.2.9, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+*  **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.2) have been ported to 2.2.9, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
-* **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
+*  **Google reCAPTCHA module for PayPal Payflow checkout**. The new PaypalRecaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form.  This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html).  <!--- MC-15427-->
 
 {:.bs-callout .bs-callout-note}
 Starting with the release of Magento Commerce 2.3.2, Magento will  assign and publish indexed Common Vulnerabilities and Exposures (CVE) numbers with each security bug reported to us by external parties. This  will allows users of Magento Commerce to more easily identify unaddressed vulnerabilities in their deployment.
 
 ### Performance boosts
 
-* **Significant improvement to storefront page response time**. The page response times for the catalog, search, and advanced search pages have been significantly improved under high load. <!--- MAGETWO-95294--->
+*  **Significant improvement to storefront page response time**. The page response times for the catalog, search, and advanced search pages have been significantly improved under high load. <!--- MAGETWO-95294--->
 
-* **Improved concurrent access to block cache storage**. We have optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.  <!--- MC-6273-->
+*  **Improved concurrent access to block cache storage**. We have optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.  <!--- MC-6273-->
 
-* **Product page gallery load optimization**.  Product images are now loaded as quickly as other page content. In previous releases, although the product page loaded quickly, product images needed two to four additional seconds to load completely. <!--- MC-15440-->
+*  **Product page gallery load optimization**.  Product images are now loaded as quickly as other page content. In previous releases, although the product page loaded quickly, product images needed two to four additional seconds to load completely. <!--- MC-15440-->
 
-* **Improved page rendering through deferred loading and parsing of storefront JavaScript**. All non-critical JavaScript code has been relocated to the bottom of storefront pages, which speeds up page rendering and allows users to see the complete page sooner while nonessential elements remain inactive. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.   <!--- MC-15439-->
+*  **Improved page rendering through deferred loading and parsing of storefront JavaScript**. All non-critical JavaScript code has been relocated to the bottom of storefront pages, which speeds up page rendering and allows users to see the complete page sooner while nonessential elements remain inactive. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.   <!--- MC-15439-->
 
 ### Infrastructure improvements
 
 This release contains 130 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements:
 
-* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.<!---MAGETWO-98424-->
+*  **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.<!---MAGETWO-98424-->
 
-* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for information about using the UPS shipment method. Shipping method configuration settings are described in  [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
+*  **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated  from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for information about using the UPS shipment method. Shipping method configuration settings are described in  [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98947-->
 
-* **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
+*  **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 ### Merchant tool enhancements
 
 Magento now performs the following tasks as **asynchronous background processes** and sends system messages to alert Admin users when tasks complete. Moving these common administrative tasks to the background frees administrators to work on other tasks while the initial tasks are processing.
 
-* Discount coupon generation. See [Coupon Code](https://docs.magento.com/m2/ee/user_guide/marketing/price-rules-cart-coupon.html).
+*  Discount coupon generation. See [Coupon Code](https://docs.magento.com/m2/ee/user_guide/marketing/price-rules-cart-coupon.html).
 
 <!--- MC-13615-->
 
-* Mass editing of products.
+*  Mass editing of products.
 
 <!--- MC-13613-->
 
-* Data export. Previously, connection timeouts occurred during export of large data sets (for example, the export of 200,000 products). See [Export](https://docs.magento.com/m2/b2b/user_guide/system/data-export.html) for more information.
+*  Data export. Previously, connection timeouts occurred during export of large data sets (for example, the export of 200,000 products). See [Export](https://docs.magento.com/m2/b2b/user_guide/system/data-export.html) for more information.
 
  <!--- MC-5953-->
 
@@ -95,292 +95,292 @@ We've fixed hundreds of issues in the Magento 2.3.2 core code.
 
 <!--- ENGCOM-4602-->
 
-* `configFactory` `scope` and `scope_code` values are now passed to `configFactory`   as data arrays. *Fix submitted by [ochnygosch](https://github.com/ochnygosch) in pull request [22012](https://github.com/magento/magento2/pull/22012)*. [GitHub-21993](https://github.com/magento/magento2/issues/21993)
+*  `configFactory` `scope` and `scope_code` values are now passed to `configFactory`   as data arrays. *Fix submitted by [ochnygosch](https://github.com/ochnygosch) in pull request [22012](https://github.com/magento/magento2/pull/22012)*. [GitHub-21993](https://github.com/magento/magento2/issues/21993)
 
 <!--- ENGCOM-4582-->
 
-* Magento now renders the value of configuration variables (such as `{{unsecure_base_url}}`) as they are entered in  configuration files rather than saving the resolved value. Previously, Magento resolved the variable to its actual value, which lead to the overwriting the value in the database when the configuration was saved instead of storing the value in the variable. *Fix submitted by [Pieter Hoste ](https://github.com/hostep) in pull request [18067](https://github.com/magento/magento2/pull/18067)*. [GitHub-15972](https://github.com/magento/magento2/issues/15972)
+*  Magento now renders the value of configuration variables (such as `{{unsecure_base_url}}`) as they are entered in  configuration files rather than saving the resolved value. Previously, Magento resolved the variable to its actual value, which lead to the overwriting the value in the database when the configuration was saved instead of storing the value in the variable. *Fix submitted by [Pieter Hoste ](https://github.com/hostep) in pull request [18067](https://github.com/magento/magento2/pull/18067)*. [GitHub-15972](https://github.com/magento/magento2/issues/15972)
 
 <!--- ENGCOM-4751-->
 
-* Magento no longer throws an error when you use  `app:config:import` to import configuration settings. Previously, the import failed, and Magento threw the following error even when the imported file contained only minor changes to password or URL values: `Please specify the admin custom URL`. *Fix submitted by [David Alger](https://github.com/davidalger) in pull request [22281](https://github.com/magento/magento2/pull/22281)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
+*  Magento no longer throws an error when you use  `app:config:import` to import configuration settings. Previously, the import failed, and Magento threw the following error even when the imported file contained only minor changes to password or URL values: `Please specify the admin custom URL`. *Fix submitted by [David Alger](https://github.com/davidalger) in pull request [22281](https://github.com/magento/magento2/pull/22281)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
 
 <!--- MAGETWO-95675-->
 
-* Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`.
+*  Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`.
 
 <!--- ENGCOM-4794-->
 
-* Magento no longer throws an error during catalog set up when you run `bin/magento setup:upgrade`. Previously, set up failed, and Magento threw the following error even though no problems existed with your catalog, `Magento\Catalog\Setup\Media does not exist`. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [22446](https://github.com/magento/magento2/pull/22446)*. [GitHub-22124](https://github.com/magento/magento2/issues/22124)
+*  Magento no longer throws an error during catalog set up when you run `bin/magento setup:upgrade`. Previously, set up failed, and Magento threw the following error even though no problems existed with your catalog, `Magento\Catalog\Setup\Media does not exist`. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [22446](https://github.com/magento/magento2/pull/22446)*. [GitHub-22124](https://github.com/magento/magento2/issues/22124)
 
 <!--- ENGCOM-4815-->
 
-* All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by [Keyur Kanani](https://github.com/keyuremipro) in pull request [22475](https://github.com/magento/magento2/pull/22475)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
+*  All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by [Keyur Kanani](https://github.com/keyuremipro) in pull request [22475](https://github.com/magento/magento2/pull/22475)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
 
 <!--- ENGCOM-4753-->
 
-* Updated the email template stylesheet for the Magento default and Luma themes to correctly specify the `.no-link` selector. This update fixes the following less compilation error that displayed when compiling the `email-inline.less` file using less.js compiler v2.73: `extend ' .no-link a' has no matches`. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [22332](https://github.com/magento/magento2/pull/22332)*. [GitHub-22330](https://github.com/magento/magento2/issues/22330)
+*  Updated the email template stylesheet for the Magento default and Luma themes to correctly specify the `.no-link` selector. This update fixes the following less compilation error that displayed when compiling the `email-inline.less` file using less.js compiler v2.73: `extend ' .no-link a' has no matches`. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [22332](https://github.com/magento/magento2/pull/22332)*. [GitHub-22330](https://github.com/magento/magento2/issues/22330)
 
 ### Backend
 
 <!--- MAGETWO-98183-->
 
-* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
+*  The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
 
 <!--- ENGCOM-4270-->
 
-* The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21197](https://github.com/magento/magento2/pull/21197)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+*  The icon that identifies a dropdown menu throughout the product interface now reflects the changing state of the dropdown menu's status (expanded or collapsed). *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21197](https://github.com/magento/magento2/pull/21197)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
 <!--- ENGCOM-3924-->
 
-* Form fields of type multiline now work as expected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [20371](https://github.com/magento/magento2/pull/20371)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086),  [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+*  Form fields of type multiline now work as expected on Admin forms. *Fix submitted by [Vivek Kumar](https://github.com/vivekkumarcedcoss) in pull request [20371](https://github.com/magento/magento2/pull/20371)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086),  [GitHub-18115](https://github.com/magento/magento2/issues/18115)
 
 <!--- ENGCOM-3885-->
 
-* Fixed display of **Option Title** label on **Catalog** > **Product** > **Customizable Options** > **Add Option**.  *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [20339](https://github.com/magento/magento2/pull/20339)*. [GitHub-20337](https://github.com/magento/magento2/issues/20337)
+*  Fixed display of **Option Title** label on **Catalog** > **Product** > **Customizable Options** > **Add Option**.  *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [20339](https://github.com/magento/magento2/pull/20339)*. [GitHub-20337](https://github.com/magento/magento2/issues/20337)
 
 <!--- ENGCOM-4377-->
 
-* Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21443](https://github.com/magento/magento2/pull/21443)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21443](https://github.com/magento/magento2/pull/21443)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
 
 <!--- ENGCOM-3664-->
 
-* Fixed alignment of the **Marketing** > **Cart Price Rules** > **Store View Specific** Labels on the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19637](https://github.com/magento/magento2/pull/19637)*. [GitHub-19632](https://github.com/magento/magento2/issues/19632)
+*  Fixed alignment of the **Marketing** > **Cart Price Rules** > **Store View Specific** Labels on the Admin. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19637](https://github.com/magento/magento2/pull/19637)*. [GitHub-19632](https://github.com/magento/magento2/issues/19632)
 
 <!--- ENGCOM-4336-->
 
-* The Change Status option of the mass actions dropdown menu (available on the products and sales pages) now works as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [20938](https://github.com/magento/magento2/pull/20938)*. [GitHub-20928](https://github.com/magento/magento2/issues/20928)
+*  The Change Status option of the mass actions dropdown menu (available on the products and sales pages) now works as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [20938](https://github.com/magento/magento2/pull/20938)*. [GitHub-20928](https://github.com/magento/magento2/issues/20928)
 
 <!--- ENGCOM-4373-->
 
-* The option type dropdown on the Admin Customizable Options page now works as expected. *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [21371](https://github.com/magento/magento2/pull/21371)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+*  The option type dropdown on the Admin Customizable Options page now works as expected. *Fix submitted by [Oleksandr Miroshnichenko](https://github.com/omiroshnichenko) in pull request [21371](https://github.com/magento/magento2/pull/21371)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
 <!--- ENGCOM-4452-->
 
-* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21444](https://github.com/magento/magento2/pull/21444)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+*  The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by [Ananth Iyer](https://github.com/ananth-iyer) in pull request [21444](https://github.com/magento/magento2/pull/21444)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
 
 <!--- ENGCOM-4655-->
 
-* Magento retains the filter settings you enter on the **Admin** > **System** > **Permissions** > **All Users** list when you click on an item in the filtered list, then return to the list. Previously, if you navigated away from the list and then returned, all filter parameters were lost. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [22128](https://github.com/magento/magento2/pull/22128)*. [GitHub-21824](https://github.com/magento/magento2/issues/21824)
+*  Magento retains the filter settings you enter on the **Admin** > **System** > **Permissions** > **All Users** list when you click on an item in the filtered list, then return to the list. Previously, if you navigated away from the list and then returned, all filter parameters were lost. *Fix submitted by [Jay Ghosh](https://github.com/jayankaghosh) in pull request [22128](https://github.com/magento/magento2/pull/22128)*. [GitHub-21824](https://github.com/magento/magento2/issues/21824)
 
 <!--- ENGCOM-4711-->
 
-* The web setup wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by [Jeroen ](https://github.com/JeroenVanLeusden) in pull request [20182](https://github.com/magento/magento2/pull/20182)*. [GitHub-7623](https://github.com/magento/magento2/issues/7623), [GitHub-11892](https://github.com/magento/magento2/issues/11892)
+*  The web setup wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by [Jeroen ](https://github.com/JeroenVanLeusden) in pull request [20182](https://github.com/magento/magento2/pull/20182)*. [GitHub-7623](https://github.com/magento/magento2/issues/7623), [GitHub-11892](https://github.com/magento/magento2/issues/11892)
 
 <!--- ENGCOM-4397-->
 
-* Magento now redirects to you the Admin home page or a 404 page as expected when you try to access a nonexisting Admin page and **Stores** > **Configuration** > **Advanced** > **Admin** > **Security** > **Add Secret Key to URLs** is enabled. Previously,  redirects did not work properly, and Magento displayed the following message, `The page isn’t redirecting properly`. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21455](https://github.com/magento/magento2/pull/21455)*. [GitHub-21454](https://github.com/magento/magento2/issues/21454)
+*  Magento now redirects to you the Admin home page or a 404 page as expected when you try to access a nonexisting Admin page and **Stores** > **Configuration** > **Advanced** > **Admin** > **Security** > **Add Secret Key to URLs** is enabled. Previously,  redirects did not work properly, and Magento displayed the following message, `The page isn’t redirecting properly`. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21455](https://github.com/magento/magento2/pull/21455)*. [GitHub-21454](https://github.com/magento/magento2/issues/21454)
 
 ### Back up
 
 <!--- ENGCOM-4782-->
 
-* Magento now creates the `var/.maintenance.flag`  file as expected when you start a database backup  (**System** > **Tools** > **Backups** > **Database Backup**). Previously, Magento did not create this  file, but instead displayed the following error: `Error: You need more permissions to activate maintenance mode right now. To create the backup, please deselect "Put store into maintenance mode" or update your permissions`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [19993](https://github.com/magento/magento2/pull/19993)*. [GitHub-19825](https://github.com/magento/magento2/issues/19825)
+*  Magento now creates the `var/.maintenance.flag`  file as expected when you start a database backup  (**System** > **Tools** > **Backups** > **Database Backup**). Previously, Magento did not create this  file, but instead displayed the following error: `Error: You need more permissions to activate maintenance mode right now. To create the backup, please deselect "Put store into maintenance mode" or update your permissions`. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [19993](https://github.com/magento/magento2/pull/19993)*. [GitHub-19825](https://github.com/magento/magento2/issues/19825)
 
 ### Bundle
 
 <!--- ENGCOM-4507-->
 
-* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Adarsh Khatri](https://github.com/adarshkhatri) in pull request [21469](https://github.com/magento/magento2/pull/21469)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+*  Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by [Adarsh Khatri](https://github.com/adarshkhatri) in pull request [21469](https://github.com/magento/magento2/pull/21469)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
 <!--- MAGETWO-98603-->
 
-* Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly and did not display any informative messages about tier pricing on the category and product pages.
+*  Tier pricing for bundle products now works as expected: Magento displays the correct  price in the cart, and reminds customers that they can buy a specific quantity of the  product for a discount. Previously, Magento did not calculate the price correctly and did not display any informative messages about tier pricing on the category and product pages.
 
 ### Cache
 
 <!--- ENGCOM-4745-->
 
-* CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by [Marius Strajeru](https://github.com/tzyganu) in pull request [22302](https://github.com/magento/magento2/pull/22302)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
+*  CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by [Marius Strajeru](https://github.com/tzyganu) in pull request [22302](https://github.com/magento/magento2/pull/22302)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
 
 ### Cart and checkout
 
 <!--- MAGETWO-97968-->
 
-* Magento now correctly updates the mini cart if a selected product is disabled during the shopping session.
+*  Magento now correctly updates the mini cart if a selected product is disabled during the shopping session.
 
 <!--- MAGETWO-98620-->
 
-* Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
+*  Magento now persists the shipping quote in the shopping cart for guest customers when **Persistent Shopping Cart** is enabled.
 
 <!--- ENGCOM-3477-->
 
-* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19191](https://github.com/magento/magento2/pull/19191)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
+*  Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null during account creation after checkout. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19191](https://github.com/magento/magento2/pull/19191)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
 
 <!--- ENGCOM-4237-->
 
-* Guests can now complete checkout when a custom shipping carrier with underscores in the carrier code is used. Previously, Magento threw the following exception under these conditions: `Please specify a shipping method`. *Fix submitted by [vovsky](https://github.com/vovsky) in pull request [19505](https://github.com/magento/magento2/pull/19505)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
+*  Guests can now complete checkout when a custom shipping carrier with underscores in the carrier code is used. Previously, Magento threw the following exception under these conditions: `Please specify a shipping method`. *Fix submitted by [vovsky](https://github.com/vovsky) in pull request [19505](https://github.com/magento/magento2/pull/19505)*. [GitHub-5021](https://github.com/magento/magento2/issues/5021)
 
 <!--- ENGCOM-3900-->
 
-* Fixed alignment of the **Update** button on the payment page of the checkout workflow. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20307](https://github.com/magento/magento2/pull/20307)*. [GitHub-20305](https://github.com/magento/magento2/issues/20305)
+*  Fixed alignment of the **Update** button on the payment page of the checkout workflow. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20307](https://github.com/magento/magento2/pull/20307)*. [GitHub-20305](https://github.com/magento/magento2/issues/20305)
 
 <!--- ENGCOM-3849-->
 
-* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18503](https://github.com/magento/magento2/pull/18503)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+*  Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by [Ihor Sviziev](https://github.com/ihor-sviziev) in pull request [18503](https://github.com/magento/magento2/pull/18503)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
 <!--- ENGCOM-4355-->
 
-* Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21401](https://github.com/magento/magento2/pull/21401)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
+*  Magento now displays an error message as expected when a customer clicks on **Add to cart**  without selecting at least one product from the recently ordered  product list. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21401](https://github.com/magento/magento2/pull/21401)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
 <!--- ENGCOM-4376-->
 
-* The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21356](https://github.com/magento/magento2/pull/21356)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+*  The **Cancel** button on the checkout page now works as expected. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21356](https://github.com/magento/magento2/pull/21356)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
 <!--- ENGCOM-4362-->
 
-* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21295](https://github.com/magento/magento2/pull/21295)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
+*  Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by [Wojtek Naruniec](https://github.com/wojtekn) in pull request [21295](https://github.com/magento/magento2/pull/21295)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
 <!--- MAGETWO-70996-->
 
-* Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
+*  Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
 <!--- ENGCOM-4783-->
 
-* Magento now validates the shipping information section of checkout as expected. Previously, a customer could proceed to the Payment Details section of checkout without having added valid shipping details. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22405](https://github.com/magento/magento2/pull/22405)*. [GitHub-21596](https://github.com/magento/magento2/issues/21596)
+*  Magento now validates the shipping information section of checkout as expected. Previously, a customer could proceed to the Payment Details section of checkout without having added valid shipping details. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22405](https://github.com/magento/magento2/pull/22405)*. [GitHub-21596](https://github.com/magento/magento2/issues/21596)
 
 <!--- ENGCOM-4414-->
 
-* The `label` elements  on the checkout address input fields are now readable by screen readers. Previously, the  address input fields did not have a `label` element with a valid value, which prevented screen readers from reading the values. *Fix submitted by [Scott Buchanan ](https://github.com/scottsb) in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+*  The `label` elements  on the checkout address input fields are now readable by screen readers. Previously, the  address input fields did not have a `label` element with a valid value, which prevented screen readers from reading the values. *Fix submitted by [Scott Buchanan ](https://github.com/scottsb) in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 <!--- ENGCOM-4691-->
 
-* New downloadable products now show up in a customer's My Downloadable products list after a customer who completed a purchase as a guest then creates an account. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21711](https://github.com/magento/magento2/pull/21711)*. [GitHub-21702](https://github.com/magento/magento2/issues/21702)
+*  New downloadable products now show up in a customer's My Downloadable products list after a customer who completed a purchase as a guest then creates an account. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21711](https://github.com/magento/magento2/pull/21711)*. [GitHub-21702](https://github.com/magento/magento2/issues/21702)
 
 <!--- MC-5681-->
 
-* The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).
+*  The checkout page now provides the ability to search addresses instead of listing addresses only on the Select shipping and Billing address steps. This new search feature can substantially increase checkout performance for customers with thousands of addresses. It is disabled by default and  must be enabled from Admin.  See [Checkout](https://docs.magento.com/m2/ee/user_guide/configuration/sales/checkout.html#Checkout).
 
 ### Cart Price rules
 
 <!--- MAGETWO-98680-->
 
-* Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
+*  Magento now displays the Cart Price Rule code on an order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
 ### Catalog
 
 <!--- MAGETWO-57934-->
 
-* You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+*  You can now use the term **configurable** as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
 <!--- MAGETWO-96429-->
 
-* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
+*  Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
 
 {:.bs-callout .bs-callout-note}
 This fix can degrade performance in deployments that implement flat catalogs. To avoid this potential performance degradation, consider disabling flat catalogs.
 
 <!--- MAGETWO-96416-->
 
-* Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
+*  Clicking on a store's root category now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
 
 <!--- MAGETWO-96127-->
 
-* Magento now maintains correct pagination when a Catalog list has multiple pages of products.  Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
+*  Magento now maintains correct pagination when a Catalog list has multiple pages of products.  Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
 
 <!--- MAGETWO-64260-->
 
-* We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
+*  We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
 
 <!--- MAGETWO-98335-->
 
-* You can now use storeview-level attributes to filter products on the products list.
+*  You can now use storeview-level attributes to filter products on the products list.
 
 <!--- MAGETWO-97966-->
 
-* Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty.
+*  Magento does not display the Country of Manufacture field under the More Information tab of the product page when this value is empty.
 
 <!--- ENGCOM-3767-->
 
-* A product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously, the price in this metatag was always calculated in the base currency. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20011](https://github.com/magento/magento2/pull/20011)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+*  A product's  `product:price:amount` metatag now contains the price converted to the appropriate base currency in multistore deployments with stores using different base currencies. Previously, the price in this metatag was always calculated in the base currency. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20011](https://github.com/magento/magento2/pull/20011)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
 <!--- ENGCOM-4217-->
 
-* Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price incorrectly. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [19608](https://github.com/magento/magento2/pull/19608)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. Previously, when the multi-currency custom option was set to a percentage price type, Magento calculated the price incorrectly. *Fix submitted by [Emipro Technologies Pvt Ltd](https://github.com/emiprotech) in pull request [19608](https://github.com/magento/magento2/pull/19608)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
 
 <!--- ENGCOM-4065-->
 
-* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [20617](https://github.com/magento/magento2/pull/20617)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+*  The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [20617](https://github.com/magento/magento2/pull/20617)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
 <!--- ENGCOM-4360-->
 
-* Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator applied the tax twice when calculating the minimal price. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21395](https://github.com/magento/magento2/pull/21395)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously, MinimalTierPriceCalculator applied the tax twice when calculating the minimal price. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21395](https://github.com/magento/magento2/pull/21395)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
 <!--- ENGCOM-4342-->
 
-* The Admin product grid now displays default values when no filter is set. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21363](https://github.com/magento/magento2/pull/21363)*. [GitHub-13338](https://github.com/magento/magento2/issues/13338)
+*  The Admin product grid now displays default values when no filter is set. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21363](https://github.com/magento/magento2/pull/21363)*. [GitHub-13338](https://github.com/magento/magento2/issues/13338)
 
 <!--- ENGCOM-3252-->
 
-* The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by [Patrick McLain](https://github.com/pmclain) in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
+*  The Magento implementation of the `CategoryManagementInterface::getTree($rootCategoryId)` now provides a tree that is populated with children instead of an empty array. *Fix submitted by [Patrick McLain](https://github.com/pmclain) in pull request [18705](https://github.com/magento/magento2/pull/18705)*. [GitHub-17297](https://github.com/magento/magento2/issues/17297)
 
 <!--- ENGCOM-4400-->
 
-* Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21509](https://github.com/magento/magento2/pull/21509)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
+*  Magento no longer empties the shopping cart when you click **Enter** after changing a product's quantity. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [21509](https://github.com/magento/magento2/pull/21509)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
 <!--- ENGCOM-4451-->
 
-* Fixed issue with excessive white space on  the related, cross sell and upsell product grids. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21582](https://github.com/magento/magento2/pull/21582)*. [GitHub-21541](https://github.com/magento/magento2/issues/21541)
+*  Fixed issue with excessive white space on  the related, cross sell and upsell product grids. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21582](https://github.com/magento/magento2/pull/21582)*. [GitHub-21541](https://github.com/magento/magento2/issues/21541)
 
 <!--- ENGCOM-4405-->
 
-* You can now sort the Admin product list by website. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20512](https://github.com/magento/magento2/pull/20512)*. [GitHub-20511](https://github.com/magento/magento2/issues/20511)
+*  You can now sort the Admin product list by website. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20512](https://github.com/magento/magento2/pull/20512)*. [GitHub-20511](https://github.com/magento/magento2/issues/20511)
 
 <!--- MAGETWO-53037-->
 
-* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the same attribute values.
+*  Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, magento duplicated a product, but both products had the same attribute values.
 
 <!--- MAGETWO-58219-->
 
-* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed r options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+*  During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed r options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
 <!--- MAGETWO-98522-->
 
-* You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
+*  You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
 
 <!--- ENGCOM-4749-->
 
-* The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by [Oleg Volkov](https://github.com/OlehWolf) in pull request [22318](https://github.com/magento/magento2/pull/22318)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
+*  The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by [Oleg Volkov](https://github.com/OlehWolf) in pull request [22318](https://github.com/magento/magento2/pull/22318)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
 
 <!--- MAGETWO-98366-->
 
-* Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in.
+*  Magento now applies the correct tier price for a product after a customer who is assigned to a customer group logs in after first adding items to their cart as a guest. Previously, Magento did not apply the tier price after the customer logged in.
 
 <!--- ENGCOM-4207-->
 
-* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20115](https://github.com/magento/magento2/pull/20115)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+*  The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20115](https://github.com/magento/magento2/pull/20115)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
 <!--- ENGCOM-4669-->
 
-* Magento now increments product quantity correctly when you add products to your cart first as a guest user, and then logged in. Previously, Magento added items separately instead. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21501](https://github.com/magento/magento2/pull/21501)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
+*  Magento now increments product quantity correctly when you add products to your cart first as a guest user, and then logged in. Previously, Magento added items separately instead. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21501](https://github.com/magento/magento2/pull/21501)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
 
 <!--- ENGCOM-4180-->
 
-* **Meta Keywords** and **Meta Description** are now defined as `textarea` throughout  product forms. *Fix submitted by Amit Vishvakarma in pull request [20556](https://github.com/magento/magento2/pull/20556)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
+*  **Meta Keywords** and **Meta Description** are now defined as `textarea` throughout  product forms. *Fix submitted by Amit Vishvakarma in pull request [20556](https://github.com/magento/magento2/pull/20556)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
 
 <!--- MAGETWO-99027-->
 
-* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prices were not saved on the store-view level when Catalog Price Scope was to **Global**.
+*  Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**. Previously, customizable option prices were not saved on the store-view level when Catalog Price Scope was to **Global**.
 
 <!--- MAGETWO-99817-->
 
-* We have modified the required permissions for updating the `design` fieldset of categories, products, and CMS pages:
+*  We have modified the required permissions for updating the `design` fieldset of categories, products, and CMS pages:
 
-   * Existing roles that have **save** permission for these entities can save everything.
+   *  Existing roles that have **save** permission for these entities can save everything.
 
-   * New roles will need to be granted permission to edit design manually.
+   *  New roles will need to be granted permission to edit design manually.
 
    If you do not have permission to edit the `design` fieldset or use web API endpoints to update a category, Magento does not save your changes and the design properties remain unchanged
 
 <!--- ENGCOM-3608-->
 
-* When you configure a price rule for configurable products with swatches, Magento now a shows the special price for products that match the price rule. Previously, Magento displayed both the old price and the special price for the matching configurable products. *Fix submitted by [Sarfaraz Bheda](https://github.com/sarfarazbheda) in pull request [19376](https://github.com/magento/magento2/pull/19376)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
+*  When you configure a price rule for configurable products with swatches, Magento now a shows the special price for products that match the price rule. Previously, Magento displayed both the old price and the special price for the matching configurable products. *Fix submitted by [Sarfaraz Bheda](https://github.com/sarfarazbheda) in pull request [19376](https://github.com/magento/magento2/pull/19376)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
 
 ### CatalogInventory
 
 <!--- ENGCOM-4490-->
 
-* We have fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>` has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.)
+*  We have fixed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>` has been changed to `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`.)
 
 *Fix submitted by [Vitaliy](https://github.com/VitaliyBoyko) in pull request [21731](https://github.com/magento/magento2/pull/21731)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
 
@@ -388,135 +388,135 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-4386-->
 
-* URL rewrites are no longer overwritten in multisite deployments. *Fix submitted by [Anshu Mishra](https://github.com/AnshuMishra17) in pull request [21462](https://github.com/magento/magento2/pull/21462)*. [GitHub-21329](https://github.com/magento/magento2/issues/21329)
+*  URL rewrites are no longer overwritten in multisite deployments. *Fix submitted by [Anshu Mishra](https://github.com/AnshuMishra17) in pull request [21462](https://github.com/magento/magento2/pull/21462)*. [GitHub-21329](https://github.com/magento/magento2/issues/21329)
 
 ### Cleanup and simple code refactoring
 
 <!--- ENGCOM-4249-->
 
-* Corrected overlapping **Rating** field and **Add to cart** button on the cart page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [21178](https://github.com/magento/magento2/pull/21178)*. [GitHub-21177](https://github.com/magento/magento2/issues/21177)
+*  Corrected overlapping **Rating** field and **Add to cart** button on the cart page. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [21178](https://github.com/magento/magento2/pull/21178)*. [GitHub-21177](https://github.com/magento/magento2/issues/21177)
 
 <!--- ENGCOM-3824-->
 
-* Corrected length of the customer login page input field in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20173](https://github.com/magento/magento2/pull/20173)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+*  Corrected length of the customer login page input field in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20173](https://github.com/magento/magento2/pull/20173)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
 <!--- ENGCOM-3642-->
 
-* Fixed misalignment of the checkbox in the fields enclosure on **Admin** > **System** > **Export**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19631](https://github.com/magento/magento2/pull/19631)*. [GitHub-19630](https://github.com/magento/magento2/issues/19630)
+*  Fixed misalignment of the checkbox in the fields enclosure on **Admin** > **System** > **Export**. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19631](https://github.com/magento/magento2/pull/19631)*. [GitHub-19630](https://github.com/magento/magento2/issues/19630)
 
 <!--- ENGCOM-4174-->
 
-* Corrected misalignment of the products in category checkboxes on the Admin catalog categories page. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [21022](https://github.com/magento/magento2/pull/21022)*. [GitHub-21021](https://github.com/magento/magento2/issues/21021)
+*  Corrected misalignment of the products in category checkboxes on the Admin catalog categories page. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [21022](https://github.com/magento/magento2/pull/21022)*. [GitHub-21021](https://github.com/magento/magento2/issues/21021)
 
 <!--- ENGCOM-4069-->
 
-* Corrected misalignment of the order item details label  in mobile view. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [20466](https://github.com/magento/magento2/pull/20466)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+*  Corrected misalignment of the order item details label  in mobile view. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [20466](https://github.com/magento/magento2/pull/20466)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
 <!--- ENGCOM-4154-->
 
-* Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [21009](https://github.com/magento/magento2/pull/21009)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+*  Corrected misalignment of page elements on the Admin product reorder page. *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [21009](https://github.com/magento/magento2/pull/21009)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
 <!--- ENGCOM-4202-->
 
-* You can now open a product's details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21102](https://github.com/magento/magento2/pull/21102)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+*  You can now open a product's details page from the compare products side bar. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21102](https://github.com/magento/magento2/pull/21102)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
 
 <!--- ENGCOM-4262-->
 
-* Added padding to the `shippingAddress` telephone tool tip on the shipping page of checkout. *Fix submitted by [Abrar Pathan](https://github.com/abrarpathan19) in pull request [20839](https://github.com/magento/magento2/pull/20839)*. [GitHub-20838](https://github.com/magento/magento2/issues/20838)
+*  Added padding to the `shippingAddress` telephone tool tip on the shipping page of checkout. *Fix submitted by [Abrar Pathan](https://github.com/abrarpathan19) in pull request [20839](https://github.com/magento/magento2/pull/20839)*. [GitHub-20838](https://github.com/magento/magento2/issues/20838)
 
 <!--- ENGCOM-4269-->
 
-* Corrected misalignment of product prices in the order summary block of the checkout page in tablet view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20856](https://github.com/magento/magento2/pull/20856)*. [GitHub-20855](https://github.com/magento/magento2/issues/20855)
+*  Corrected misalignment of product prices in the order summary block of the checkout page in tablet view. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20856](https://github.com/magento/magento2/pull/20856)*. [GitHub-20855](https://github.com/magento/magento2/issues/20855)
 
 <!--- ENGCOM-4318-->
 
-* Corrected size of the pagination drop-down on **Admin** > **Content** > **Blocks**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21298](https://github.com/magento/magento2/pull/21298)*. [GitHub-21296](https://github.com/magento/magento2/issues/21296)
+*  Corrected size of the pagination drop-down on **Admin** > **Content** > **Blocks**. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21298](https://github.com/magento/magento2/pull/21298)*. [GitHub-21296](https://github.com/magento/magento2/issues/21296)
 
 <!--- ENGCOM-4250-->
 
-* Corrected a tabbing issue on the product page. *Fix submitted by [Prakash Gunthe](https://github.com/prakash2jcommerce) in pull request [21079](https://github.com/magento/magento2/pull/21079)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
+*  Corrected a tabbing issue on the product page. *Fix submitted by [Prakash Gunthe](https://github.com/prakash2jcommerce) in pull request [21079](https://github.com/magento/magento2/pull/21079)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
 
 <!--- ENGCOM-4161-->
 
-* Corrected alignment of page elements on the  Recent Orders section of the My Accounts page in mobile view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20429](https://github.com/magento/magento2/pull/20429)*. [GitHub-20414](https://github.com/magento/magento2/issues/20414)
+*  Corrected alignment of page elements on the  Recent Orders section of the My Accounts page in mobile view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20429](https://github.com/magento/magento2/pull/20429)*. [GitHub-20414](https://github.com/magento/magento2/issues/20414)
 
 <!--- ENGCOM-4461-->
 
-* Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21611](https://github.com/magento/magento2/pull/21611)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
+*  Corrected formatting of the Advance Search link in page footers. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21611](https://github.com/magento/magento2/pull/21611)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 <!--- ENGCOM-4457-->
 
-* Corrected alignment of the minicart search logo. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21638](https://github.com/magento/magento2/pull/21638)*. [GitHub-20905](https://github.com/magento/magento2/issues/20905)
+*  Corrected alignment of the minicart search logo. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21638](https://github.com/magento/magento2/pull/21638)*. [GitHub-20905](https://github.com/magento/magento2/issues/20905)
 
 <!--- ENGCOM-4475-->
 
-* Added missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [21649](https://github.com/magento/magento2/pull/21649)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
+*  Added missing asterix adjacent to the Checkout Agreements checkbox. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [21649](https://github.com/magento/magento2/pull/21649)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 <!--- ENGCOM-4595-->
 
-* Removed unneccessary white space between `li` tags in the product table. *Fix submitted by [Akhilesh Singh Shrinet](https://github.com/shrinet) in pull request [21948](https://github.com/magento/magento2/pull/20092)*. [GitHub-21244](https://github.com/magento/magento2/issues/21244), [GitHub-20140](https://github.com/magento/magento2/issues/20140)
+*  Removed unneccessary white space between `li` tags in the product table. *Fix submitted by [Akhilesh Singh Shrinet](https://github.com/shrinet) in pull request [21948](https://github.com/magento/magento2/pull/20092)*. [GitHub-21244](https://github.com/magento/magento2/issues/21244), [GitHub-20140](https://github.com/magento/magento2/issues/20140)
 
 <!--- ENGCOM-4629-->
 
-* The documentation for Travis CI static tests has been improved. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18386](https://github.com/magento/magento2/pull/18386)*. [GitHub-13951](https://github.com/magento/magento2/issues/13951)
+*  The documentation for Travis CI static tests has been improved. *Fix submitted by [Francesco Haymar d'Ettory](https://github.com/Thundar) in pull request [18386](https://github.com/magento/magento2/pull/18386)*. [GitHub-13951](https://github.com/magento/magento2/issues/13951)
 
 <!--- ENGCOM-4606-->
 
-* Corrected typos on the Admin sales shipment and credit memo pages. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [22031](https://github.com/magento/magento2/pull/22031)*. [GitHub-22030](https://github.com/magento/magento2/issues/22030)
+*  Corrected typos on the Admin sales shipment and credit memo pages. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [22031](https://github.com/magento/magento2/pull/22031)*. [GitHub-22030](https://github.com/magento/magento2/issues/22030)
 
 <!--- ENGCOM-4637-->
 
-* The **Equalize product count** operation in Layered Navigation now works as expected. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715)
+*  The **Equalize product count** operation in Layered Navigation now works as expected. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715)
 
 <!--- ENGCOM-4744-->
 
-* Corrected misalignment of page elements on the popup window that Magento displays when you edit an order that contains a downloadable product when **Links can be purchased separately** is enabled. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [22298](https://github.com/magento/magento2/pull/22298)*. [GitHub-20917](https://github.com/magento/magento2/issues/20917)
+*  Corrected misalignment of page elements on the popup window that Magento displays when you edit an order that contains a downloadable product when **Links can be purchased separately** is enabled. *Fix submitted by [Ansari](https://github.com/ansari-krish) in pull request [22298](https://github.com/magento/magento2/pull/22298)*. [GitHub-20917](https://github.com/magento/magento2/issues/20917)
 
 <!--- ENGCOM-4594-->
 
-* Fixed misalignment of the shipping method block on Order pages that are accessed through **Sales** > **Orders**. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [21963](https://github.com/magento/magento2/pull/21963)*. [GitHub-21962](https://github.com/magento/magento2/issues/21962)
+*  Fixed misalignment of the shipping method block on Order pages that are accessed through **Sales** > **Orders**. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [21963](https://github.com/magento/magento2/pull/21963)*. [GitHub-21962](https://github.com/magento/magento2/issues/21962)
 
 <!--- ENGCOM-4797-->
 
-* In the Conditions section of the New Cart Price Rule page in the  Admin, the dropdown arrow in the `_If ALL of these conditions are TRUE _ field` now points in the correct direction. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [22456](https://github.com/magento/magento2/pull/22456)*. [GitHub-20366](https://github.com/magento/magento2/issues/22434)
+*  In the Conditions section of the New Cart Price Rule page in the  Admin, the dropdown arrow in the `_If ALL of these conditions are TRUE _ field` now points in the correct direction. *Fix submitted by [Hiren Pandya](https://github.com/hiren0241) in pull request [22456](https://github.com/magento/magento2/pull/22456)*. [GitHub-20366](https://github.com/magento/magento2/issues/22434)
 
 ### Configurable products
 
 <!--- MAGETWO-98013-->
 
-* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
+*  Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
 <!--- ENGCOM-3963-->
 
-* Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [20528](https://github.com/magento/magento2/pull/20528)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
+*  Corrected the position of the labels in the configurable product variations table. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [20528](https://github.com/magento/magento2/pull/20528)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
 <!--- MAGETWO-98088-->
 
-* Configurable products can no longer be added as a variation of another configurable product in the Admin.
+*  Configurable products can no longer be added as a variation of another configurable product in the Admin.
 
 <!--- ENGCOM-4809-->
 
-* The configurable product page's attribute dropdown menu shows an accurate price and tax is rendered correctly in the final price at the top of the page. Previously, configurable products that had only one configurable attribute displayed a price increase in the dropdown of the tax amount. This affected stores when prices were entered excluding tax and configurable products with only one configurable attribute. *Fix submitted by [Daniel Farmer](https://github.com/danielpfarmer) in pull request [22466](https://github.com/magento/magento2/pull/22466)*. [GitHub-22270](https://github.com/magento/magento2/issues/22270)
+*  The configurable product page's attribute dropdown menu shows an accurate price and tax is rendered correctly in the final price at the top of the page. Previously, configurable products that had only one configurable attribute displayed a price increase in the dropdown of the tax amount. This affected stores when prices were entered excluding tax and configurable products with only one configurable attribute. *Fix submitted by [Daniel Farmer](https://github.com/danielpfarmer) in pull request [22466](https://github.com/magento/magento2/pull/22466)*. [GitHub-22270](https://github.com/magento/magento2/issues/22270)
 
 <!--- ENGCOM-4188-->
 
-* Configurable products can now be successfully updated through the bulk API (specifically, this API endpoint: `rest/async/bulk/V1/configurable-products/bySku/child`). *Fix submitted by [Pedro Sousa ](https://github.com/pedrosousa13) in pull request [21083](https://github.com/magento/magento2/pull/21083)*. [GitHub-20366](https://github.com/magento/magento2/issues/20366)
+*  Configurable products can now be successfully updated through the bulk API (specifically, this API endpoint: `rest/async/bulk/V1/configurable-products/bySku/child`). *Fix submitted by [Pedro Sousa ](https://github.com/pedrosousa13) in pull request [21083](https://github.com/magento/magento2/pull/21083)*. [GitHub-20366](https://github.com/magento/magento2/issues/20366)
 
 ### cron
 
 <!--- MAGETWO-98151-->
 
-* Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We have also added new options to configure locks during installation:
+*  Added support for [Zookeeper](https://php.net/manual/en/book.zookeeper.php) and flock lock providers. We have also added new options to configure locks during installation:
 
-   * `--lock-provider=LOCK-PROVIDER`—Lock provider name
+   *  `--lock-provider=LOCK-PROVIDER`—Lock provider name
 
-   * `--lock-db-prefix=LOCK-DB-PREFIX`—Installation specific lock prefix to avoid lock conflicts
+   *  `--lock-db-prefix=LOCK-DB-PREFIX`—Installation specific lock prefix to avoid lock conflicts
 
-   * `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`  —Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181
+   *  `--lock-zookeeper-host=LOCK-ZOOKEEPER-HOST`  —Host and port to connect to Zookeeper cluster. For example, 127.0.0.1:2181
 
-   * `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH`— The path where Zookeeper will save locks. The default path is /magento/locks
+   *  `--lock-zookeeper-path=LOCK-ZOOKEEPER-PATH`— The path where Zookeeper will save locks. The default path is /magento/locks
 
-   * `--lock-file-path=LOCK-FILE-PATH`—The path where file locks will be saved.
+   *  `--lock-file-path=LOCK-FILE-PATH`—The path where file locks will be saved.
 
    See [Install]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html).
 
@@ -524,35 +524,35 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- MAGETWO-93628-->
 
-* Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
+*  Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
 
 <!--- MAGETWO-97549-->
 
-* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
+*  Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
 
 <!--- ENGCOM-4146-->
 
-* The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20896](https://github.com/magento/magento2/pull/20896)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+*  The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20896](https://github.com/magento/magento2/pull/20896)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
 <!--- ENGCOM-4309-->
 
-* Fixed a horizontal scrolling issue that affected the address book display in mobile view. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21272](https://github.com/magento/magento2/pull/21272)*. [GitHub-21271](https://github.com/magento/magento2/issues/21271)
+*  Fixed a horizontal scrolling issue that affected the address book display in mobile view. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21272](https://github.com/magento/magento2/pull/21272)*. [GitHub-21271](https://github.com/magento/magento2/issues/21271)
 
 <!--- ENGCOM-4413-->
 
-* The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21498](https://github.com/magento/magento2/pull/21498)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+*  The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by [Jitheesh V O](https://github.com/Jitheesh) in pull request [21498](https://github.com/magento/magento2/pull/21498)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
 <!--- ENGCOM-4047-->
 
-* The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [20583](https://github.com/magento/magento2/pull/20583)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
+*  The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [20583](https://github.com/magento/magento2/pull/20583)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
 <!--- MAGETWO-91523-->
 
-* An admin user with full permissions for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an admin with full permission could not see it.
+*  An admin user with full permissions for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an admin with full permission could not see it.
 
 <!--- MAGETWO-98087-->
 
-* Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
+*  Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
 
 <!--- MAGETWO-98087-->
 
@@ -560,13 +560,13 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-4678-->
 
-* Customer accounts are now confirmed when a customer clicks the email activation link. Previously, Magento confirmed the customer account even when the customer did not click on the email activation link. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22147](https://github.com/magento/magento2/pull/22147)*. [GitHub-22052](https://github.com/magento/magento2/issues/22052)
+*  Customer accounts are now confirmed when a customer clicks the email activation link. Previously, Magento confirmed the customer account even when the customer did not click on the email activation link. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22147](https://github.com/magento/magento2/pull/22147)*. [GitHub-22052](https://github.com/magento/magento2/issues/22052)
 
 ### Dashboard
 
 <!--- ENGCOM-4601-->
 
-* Magento no longer throws a  404 error when you click the Most viewed products on the Admin dashboard. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [22002](https://github.com/magento/magento2/pull/22002)*. [GitHub-22001](https://github.com/magento/magento2/issues/22001)
+*  Magento no longer throws a  404 error when you click the Most viewed products on the Admin dashboard. *Fix submitted by [Vishal Sutariya](https://github.com/vishal-7037) in pull request [22002](https://github.com/magento/magento2/pull/22002)*. [GitHub-22001](https://github.com/magento/magento2/issues/22001)
 
 ### Downloadable
 
@@ -576,275 +576,275 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-3979-->
 
-* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
+*  Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by [Govind Sharma](https://github.com/GovindaSharma) in pull request [20239](https://github.com/magento/magento2/pull/20239)*. [GitHub-20187](https://github.com/magento/magento2/issues/20187)
 
 <!--- ENGCOM-4684-->
 
-* You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [19806](https://github.com/magento/magento2/pull/19806)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
+*  You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [19806](https://github.com/magento/magento2/pull/19806)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
 
 <!--- ENGCOM-4685-->
 
-* A logged-in user's My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by [James](https://github.com/crankycyclops) in pull request [22073](https://github.com/magento/magento2/pull/22073)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
+*  A logged-in user's My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by [James](https://github.com/crankycyclops) in pull request [22073](https://github.com/magento/magento2/pull/22073)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
 
 <!--- ENGCOM-4345-->
 
-* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [21279](https://github.com/magento/magento2/pull/21279)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+*  Added missing sort order to columns on Downloadable Product links page. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [21279](https://github.com/magento/magento2/pull/21279)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
 
 ### EAV
 
 <!--- ENGCOM-4246-->
 
-* Attribute code validation (specifically, maximum characters allowed) has been improved during attribute creation. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20526](https://github.com/magento/magento2/pull/20526)*. [GitHub-20766](https://github.com/magento/magento2/issues/20766), [GitHub-20943](https://github.com/magento/magento2/issues/20943)
+*  Attribute code validation (specifically, maximum characters allowed) has been improved during attribute creation. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [20526](https://github.com/magento/magento2/pull/20526)*. [GitHub-20766](https://github.com/magento/magento2/issues/20766), [GitHub-20943](https://github.com/magento/magento2/issues/20943)
 
 <!--- ENGCOM-4583-->
 
-* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec ](https://github.com/wojtekn) in pull request [21135](https://github.com/magento/magento2/pull/21135)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+*  Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw  an `Invalid argument supplied for foreach()` warning. *Fix submitted by [Wojtek Naruniec ](https://github.com/wojtekn) in pull request [21135](https://github.com/magento/magento2/pull/21135)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
 <!--- ENGCOM-4553-->
 
-* The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the  `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by [Lorenzo Stramaccia](https://github.com/slackerzz) in pull request [21869](https://github.com/magento/magento2/pull/21869)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
+*  The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the  `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by [Lorenzo Stramaccia](https://github.com/slackerzz) in pull request [21869](https://github.com/magento/magento2/pull/21869)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
 
 <!--- ENGCOM-3793-->
 
-* You can now retrieve product attribute values for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20071](https://github.com/magento/magento2/pull/20071)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
+*  You can now retrieve product attribute values for store-view scope types in the product collection that is loaded for a specific store. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20071](https://github.com/magento/magento2/pull/20071)*. [GitHub-18374](https://github.com/magento/magento2/issues/18374)
 
 <!--- ENGCOM-4152-->
 
-* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw the following error:  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19988](https://github.com/magento/magento2/pull/19988)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+*  You can now programmmatically upload an image for the customer attribute. Previously, Magento threw the following error:  `error: Base64 is not defined`. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19988](https://github.com/magento/magento2/pull/19988)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
 <!--- MAGETWO-98621-->
 
-* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty.
+*  Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave leave special prices empty.
 
 <!--- ENGCOM-3810-->
 
-* Added an `is_array` parameter value check to the `getOptionText($value)` function in `app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php` to fix an error that caused Magento to throw a UI error when you make the `_quantity_and_stock_status (Qty)_` product attribute visible in the storefront properties. Previously, the `getOptionText($value)` function expected integer or string input and failed because the `quantity_and_stock_status (Qty)` configuration parameters were passed as an array.` *Fix submitted by [Aditi Singh](https://github.com/aditisinghcedcoss) in pull request [20001](https://github.com/magento/magento2/pull/20001)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
+*  Added an `is_array` parameter value check to the `getOptionText($value)` function in `app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php` to fix an error that caused Magento to throw a UI error when you make the `_quantity_and_stock_status (Qty)_` product attribute visible in the storefront properties. Previously, the `getOptionText($value)` function expected integer or string input and failed because the `quantity_and_stock_status (Qty)` configuration parameters were passed as an array.` *Fix submitted by [Aditi Singh](https://github.com/aditisinghcedcoss) in pull request [20001](https://github.com/magento/magento2/pull/20001)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 ### Email
 
 <!--- ENGCOM-4512-->
 
-* Magento no longer sends via asynchronous email sending any sales-related emails  that were created when email sending was disabled once email sending is enabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [21788](https://github.com/magento/magento2/pull/21788)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
+*  Magento no longer sends via asynchronous email sending any sales-related emails  that were created when email sending was disabled once email sending is enabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [21788](https://github.com/magento/magento2/pull/21788)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
 
 <!--- ENGCOM-4812-->
 
-* The Insert variable popup window that is accessed from the Email Template Information window is now populated as expected. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [22469](https://github.com/magento/magento2/pull/22469)*. [GitHub-20111](https://github.com/magento/magento2/issues/20111)
+*  The Insert variable popup window that is accessed from the Email Template Information window is now populated as expected. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [22469](https://github.com/magento/magento2/pull/22469)*. [GitHub-20111](https://github.com/magento/magento2/issues/20111)
 
 ### Frameworks
 
 <!--- MC-15440-->
 
-* The performance of product image loading has been significantly improved. [GitHub-14667](https://github.com/magento/magento2/issues/14667)
+*  The performance of product image loading has been significantly improved. [GitHub-14667](https://github.com/magento/magento2/issues/14667)
 
 <!--- ENGCOM-3794-->
 
-* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. Previously, when you clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19996](https://github.com/magento/magento2/pull/19996)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+*  You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. Previously, when you clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [19996](https://github.com/magento/magento2/pull/19996)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
 
 <!--- ENGCOM-3932-->
 
-* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [20495](https://github.com/magento/magento2/pull/20495)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+*  Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [20495](https://github.com/magento/magento2/pull/20495)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
 
 <!--- ENGCOM-4212-->
 
-* Corrected misalignment of the Admin success message icon. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [21069](https://github.com/magento/magento2/pull/21069)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+*  Corrected misalignment of the Admin success message icon. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [21069](https://github.com/magento/magento2/pull/21069)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
 <!--- ENGCOM-3543-->
 
-* The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Jaimin Sutariya](https://github.com/jaimin-ktpl) in pull request [19274](https://github.com/magento/magento2/pull/19274)*. [GitHub-19359](https://github.com/magento/magento2/issues/19359)
+*  The use of the `SessionManagerInterface` class has replaced the direct use of  `SessionManager`. *Fix submitted by [Jaimin Sutariya](https://github.com/jaimin-ktpl) in pull request [19274](https://github.com/magento/magento2/pull/19274)*. [GitHub-19359](https://github.com/magento/magento2/issues/19359)
 
 <!--- ENGCOM-4223-->
 
-* The module ranking in the `app/etc/config` now remains consistent when a new module is added without any other changes. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Alexandre Jardin](https://github.com/ajardin) in pull request [21020](https://github.com/magento/magento2/pull/21020)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479)
+*  The module ranking in the `app/etc/config` now remains consistent when a new module is added without any other changes. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by [Alexandre Jardin](https://github.com/ajardin) in pull request [21020](https://github.com/magento/magento2/pull/21020)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479)
 
 <!--- ENGCOM-4104-->
 
-* Magento now logs exceptions during autoloading instead of throwing them. This conforms with PSR-4 guidelines. *Fix submitted by [Vinai Kopp](https://github.com/Vinai) in pull request [20950](https://github.com/magento/magento2/pull/20950)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
+*  Magento now logs exceptions during autoloading instead of throwing them. This conforms with PSR-4 guidelines. *Fix submitted by [Vinai Kopp](https://github.com/Vinai) in pull request [20950](https://github.com/magento/magento2/pull/20950)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 <!--- ENGCOM-4333-->
 
-* Running the `php bin/magento setup:upgrade` command on modules that have a `db_schema.xml` without an `indexType` now creates the index, and subsequent runs result in no modifications as expected. Previously, running this command multiple times resulted in index creation followed by an error. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [21328](https://github.com/magento/magento2/pull/21328)*. [GitHub-21322](https://github.com/magento/magento2/issues/21322)
+*  Running the `php bin/magento setup:upgrade` command on modules that have a `db_schema.xml` without an `indexType` now creates the index, and subsequent runs result in no modifications as expected. Previously, running this command multiple times resulted in index creation followed by an error. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [21328](https://github.com/magento/magento2/pull/21328)*. [GitHub-21322](https://github.com/magento/magento2/issues/21322)
 
 #### Cache framework
 
 <!--- ENGCOM-3470-->
 
-* The purge cache feature in `\Magento\CacheInvalidate\Model\PurgeCache::sendPurgeRequest` has been updated to flush the cache on all hosts even when a Varnish servers is offline. Magento also displays a warning message about unresponsive cache hosts.  Previously, the `bin/magento cache:flush full_page` operation stopped as soon as it encountered a host that was offline. *Fix submitted by [Wiard van Rij](https://github.com/wiardvanrij) in pull request [18852](https://github.com/magento/magento2/pull/18852)*. [GitHub-18056](https://github.com/magento/magento2/issues/18056)
+*  The purge cache feature in `\Magento\CacheInvalidate\Model\PurgeCache::sendPurgeRequest` has been updated to flush the cache on all hosts even when a Varnish servers is offline. Magento also displays a warning message about unresponsive cache hosts.  Previously, the `bin/magento cache:flush full_page` operation stopped as soon as it encountered a host that was offline. *Fix submitted by [Wiard van Rij](https://github.com/wiardvanrij) in pull request [18852](https://github.com/magento/magento2/pull/18852)*. [GitHub-18056](https://github.com/magento/magento2/issues/18056)
 
 #### JavaScript framework
 
 <!--- ENGCOM-4546-->
 
-* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21776](https://github.com/magento/magento2/pull/21776)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+*  JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21776](https://github.com/magento/magento2/pull/21776)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 ### General fixes
 
 <!--- MAGETWO-96983-->
 
-* The Sodium crypto adapter now consistently returns a `string` in accordance with the strict return type on its signature. Previously, the adapter sometimes did not return a `string`, which resulted in exceptions and a failure to bootstrap Magento. [GitHub-19590](https://github.com/magento/magento2/issues/19590)
+*  The Sodium crypto adapter now consistently returns a `string` in accordance with the strict return type on its signature. Previously, the adapter sometimes did not return a `string`, which resulted in exceptions and a failure to bootstrap Magento. [GitHub-19590](https://github.com/magento/magento2/issues/19590)
 
 <!--- ENGCOM-4378-->
 
-* Watermarks now appear on product images as expected. *Fix submitted by [Yevhenii Dumskyi](https://github.com/progreg) in pull request [21338](https://github.com/magento/magento2/pull/21338)*. [GitHub-21154](https://github.com/magento/magento2/issues/21154)
+*  Watermarks now appear on product images as expected. *Fix submitted by [Yevhenii Dumskyi](https://github.com/progreg) in pull request [21338](https://github.com/magento/magento2/pull/21338)*. [GitHub-21154](https://github.com/magento/magento2/issues/21154)
 
 <!--- ENGCOM-4521-->
 
-* You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [21376](https://github.com/magento/magento2/pull/21376)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+*  You can now use a period (`.`) for inline CMS content edits. Previously, if you included  a period (`.`) in your edits, Magento displayed this error, `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [21376](https://github.com/magento/magento2/pull/21376)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
 <!--- ENGCOM-4523-->
 
-* The pagination count of **My Account** > **My addresses** > **Additional Address Data Table** is now correct. *Fix submitted by [Dharmesh Vaja](https://github.com/Dharmeshvaja91) in pull request [21399](https://github.com/magento/magento2/pull/21399)*. [GitHub-21396](https://github.com/magento/magento2/issues/21396)
+*  The pagination count of **My Account** > **My addresses** > **Additional Address Data Table** is now correct. *Fix submitted by [Dharmesh Vaja](https://github.com/Dharmeshvaja91) in pull request [21399](https://github.com/magento/magento2/pull/21399)*. [GitHub-21396](https://github.com/magento/magento2/issues/21396)
 
 <!--- ENGCOM-4696-->
 
-* `fatalErrorHandler` now returns `500` only on fatal errors. Previously, simple deprecation warnings on the page triggered an internal server error, which was invalid. *Fix submitted by [WEXO team](https://github.com/wexo-team) in pull request [22200](https://github.com/magento/magento2/pull/22200)*. [GitHub-22199](https://github.com/magento/magento2/issues/22199)
+*  `fatalErrorHandler` now returns `500` only on fatal errors. Previously, simple deprecation warnings on the page triggered an internal server error, which was invalid. *Fix submitted by [WEXO team](https://github.com/wexo-team) in pull request [22200](https://github.com/magento/magento2/pull/22200)*. [GitHub-22199](https://github.com/magento/magento2/issues/22199)
 
 <!--- ENGCOM-4774-->
 
-* CodeSniffer no longer marks correctly aligned `DocBlock` elements as code style violations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [22321](https://github.com/magento/magento2/pull/22321)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
+*  CodeSniffer no longer marks correctly aligned `DocBlock` elements as code style violations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [22321](https://github.com/magento/magento2/pull/22321)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
 
 <!--- ENGCOM-4631-->
 
-* The Adminhtml `textarea` field now accepts the `maxlength` attribute. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21816](https://github.com/magento/magento2/pull/21816)*. [GitHub-21779](https://github.com/magento/magento2/issues/21779)
+*  The Adminhtml `textarea` field now accepts the `maxlength` attribute. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21816](https://github.com/magento/magento2/pull/21816)*. [GitHub-21779](https://github.com/magento/magento2/issues/21779)
 
 <!--- ENGCOM-4695-->
 
-* The Reporting Security Issues section of the Magento 2 README file (https://github.com/magento/magento2/blob/2.3-develop/README.md) has been updated to reflect use of hackerone. *Fix submitted by [Andreas Mautz ](https://github.com/mautz-et-tong) in pull request [22195](https://github.com/magento/magento2/pull/22195)*. [GitHub-22166](https://github.com/magento/magento2/issues/22166)
+*  The Reporting Security Issues section of the Magento 2 README file (https://github.com/magento/magento2/blob/2.3-develop/README.md) has been updated to reflect use of hackerone. *Fix submitted by [Andreas Mautz ](https://github.com/mautz-et-tong) in pull request [22195](https://github.com/magento/magento2/pull/22195)*. [GitHub-22166](https://github.com/magento/magento2/issues/22166)
 
 <!--- ENGCOM-4654-->
 
-* You can now save an inactive admin user token by navigating to **System** > **Permissions** -> **All Users**, and clicking **Save User** on an inactive Admin user. Previously, if you tried to save an inactive Admin user token fom the Admin this way, Magento did not save the token, but threw an error. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20772](https://github.com/magento/magento2/pull/20772)*. [GitHub-16513](https://github.com/magento/magento2/issues/16513)
+*  You can now save an inactive admin user token by navigating to **System** > **Permissions** -> **All Users**, and clicking **Save User** on an inactive Admin user. Previously, if you tried to save an inactive Admin user token fom the Admin this way, Magento did not save the token, but threw an error. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [20772](https://github.com/magento/magento2/pull/20772)*. [GitHub-16513](https://github.com/magento/magento2/issues/16513)
 
 <!--- ENGCOM-4706-->
 
-* The missing `$msrpPriceCalculators` argument for `Magento\Msrp\Pricing\MsrpPriceCalculator` has been added. Previously, Magento threw an `MsrpPriceCalculator` exception after an upgrade. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [22197](https://github.com/magento/magento2/pull/22197)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-22090](https://github.com/magento/magento2/issues/22090)
+*  The missing `$msrpPriceCalculators` argument for `Magento\Msrp\Pricing\MsrpPriceCalculator` has been added. Previously, Magento threw an `MsrpPriceCalculator` exception after an upgrade. *Fix submitted by [Leandro F. L.](https://github.com/lfluvisotto) in pull request [22197](https://github.com/magento/magento2/pull/22197)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-22090](https://github.com/magento/magento2/issues/22090)
 
 <!--- ENGCOM-4681-->
 
-* `stream_wrapper_unregister('phar')` in `app/boostrap.php` is now unregistered only when appropriate. Previously, calling `stream_wrapper_unregister('phar')` without checking to see if it was registered triggered a warning. *Fix submitted by [Antoine Daudenthun](https://github.com/adaudenthun) in pull request [22171](https://github.com/magento/magento2/pull/22171)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-21973](https://github.com/magento/magento2/issues/21973)
+*  `stream_wrapper_unregister('phar')` in `app/boostrap.php` is now unregistered only when appropriate. Previously, calling `stream_wrapper_unregister('phar')` without checking to see if it was registered triggered a warning. *Fix submitted by [Antoine Daudenthun](https://github.com/adaudenthun) in pull request [22171](https://github.com/magento/magento2/pull/22171)*. [GitHub-22190](https://github.com/magento/magento2/issues/22190), [GitHub-21973](https://github.com/magento/magento2/issues/21973)
 
 <!--- ENGCOM-4055-->
 
-* The sitemap generation `cron` job no longer flushes the entire cache. A dummy cache tag has been added to the frontend for sitemap and robots generation to prevent the default and `page_cache` from being dropped completely. Previously, the sitemap generation cron job flushed the entire cache. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [20818](https://github.com/magento/magento2/pull/20818)*. [GitHub-14857](https://github.com/magento/magento2/issues/14857)
+*  The sitemap generation `cron` job no longer flushes the entire cache. A dummy cache tag has been added to the frontend for sitemap and robots generation to prevent the default and `page_cache` from being dropped completely. Previously, the sitemap generation cron job flushed the entire cache. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [20818](https://github.com/magento/magento2/pull/20818)*. [GitHub-14857](https://github.com/magento/magento2/issues/14857)
 
 <!--- ENGCOM-4454-->
 
-* Magento now sets an accurate  `CURRENT_TIMESTAMP` on `updated_at` fields in the database schema. Previously, this timestamp displayed `0000-00-00 00:00:00`. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [21486](https://github.com/magento/magento2/pull/21486)*. [GitHub-21477](https://github.com/magento/magento2/issues/21477)
+*  Magento now sets an accurate  `CURRENT_TIMESTAMP` on `updated_at` fields in the database schema. Previously, this timestamp displayed `0000-00-00 00:00:00`. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [21486](https://github.com/magento/magento2/pull/21486)*. [GitHub-21477](https://github.com/magento/magento2/issues/21477)
 
 <!--- ENGCOM-4733-->
 
-* `grunt watch` no longer triggers `livereload` twice. *Fix submitted by [Torben Höhn](https://github.com/torhoehn) in pull request [22276](https://github.com/magento/magento2/pull/22276)*. [GitHub-19544](https://github.com/magento/magento2/issues/19544)
+*  `grunt watch` no longer triggers `livereload` twice. *Fix submitted by [Torben Höhn](https://github.com/torhoehn) in pull request [22276](https://github.com/magento/magento2/pull/22276)*. [GitHub-19544](https://github.com/magento/magento2/issues/19544)
 
 <!--- ENGCOM-4776-->
 
-* You can now duplicate a product with translated url keys over multiple storeviews without generating non-unique keys. Previously, when a product was duplicated, only one URL key was used and set for all store views. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22178](https://github.com/magento/magento2/pull/22178)*. [GitHub-21737](https://github.com/magento/magento2/issues/21737)
+*  You can now duplicate a product with translated url keys over multiple storeviews without generating non-unique keys. Previously, when a product was duplicated, only one URL key was used and set for all store views. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22178](https://github.com/magento/magento2/pull/22178)*. [GitHub-21737](https://github.com/magento/magento2/issues/21737)
 
 ### Google Analytics
 
 <!--- ENGCOM-4313-->
 
-* Google Analytics `Anonymize Ip` no longer always set to on. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21303](https://github.com/magento/magento2/pull/21303)*. [GitHub-21292](https://github.com/magento/magento2/issues/21292)
+*  Google Analytics `Anonymize Ip` no longer always set to on. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21303](https://github.com/magento/magento2/pull/21303)*. [GitHub-21292](https://github.com/magento/magento2/issues/21292)
 
 ### Google Chart API
 
 <!--- MAGETWO-98584 -->
 
-* The Google chart API has been updated to the Image-Charts. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). [GitHub-21599](https://github.com/magento/magento2/issues/21599)
+*  The Google chart API has been updated to the Image-Charts. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). [GitHub-21599](https://github.com/magento/magento2/issues/21599)
 
 ### Import/export
 
 <!--- MAGETWO-95313-->
 
-* Magento now imports existing products that have a price change and unchanged url-key with no unnecessary updates. Previously, the product's price was updated as expected, but its unchanged url-key was deleted.
+*  Magento now imports existing products that have a price change and unchanged url-key with no unnecessary updates. Previously, the product's price was updated as expected, but its unchanged url-key was deleted.
 
 <!--- MAGETWO-70232-->
 
-* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
+*  Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the newly created product's configurable options to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
 <!--- ENGCOM-4281-->
 
-* The import process  `replace` method now works as expected. *Fix submitted by [Denys Saltanakhmedov](https://github.com/DenisSaltanahmedov) in pull request [21189](https://github.com/magento/magento2/pull/21189)*. [GitHub-18761](https://github.com/magento/magento2/issues/18761)
+*  The import process  `replace` method now works as expected. *Fix submitted by [Denys Saltanakhmedov](https://github.com/DenisSaltanahmedov) in pull request [21189](https://github.com/magento/magento2/pull/21189)*. [GitHub-18761](https://github.com/magento/magento2/issues/18761)
 
 <!--- ENGCOM-4772-->
 
-* The import process now imports product quantity as expected.  *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22382](https://github.com/magento/magento2/pull/22382)*. [GitHub-22355](https://github.com/magento/magento2/issues/22355)
+*  The import process now imports product quantity as expected.  *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22382](https://github.com/magento/magento2/pull/22382)*. [GitHub-22355](https://github.com/magento/magento2/issues/22355)
 
 <!--- ENGCOM-3761-->
 
-* Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by [Jaimin Sutariya](https://github.com/jaimin-ktpl) in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
+*  Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by [Jaimin Sutariya](https://github.com/jaimin-ktpl) in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 <!--- ENGCOM-4600-->
 
-* The `_coreConfig` field in `Magento/ImportExport/Model/Import` is no longer declared dynamically. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21999](https://github.com/magento/magento2/pull/21999)*. [GitHub-21998](https://github.com/magento/magento2/issues/21998)
+*  The `_coreConfig` field in `Magento/ImportExport/Model/Import` is no longer declared dynamically. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21999](https://github.com/magento/magento2/pull/21999)*. [GitHub-21998](https://github.com/magento/magento2/issues/21998)
 
 <!--- ENGCOM-4722-->
 
-* Tooltip styles now use the appropriate variables for mobile view. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22382](https://github.com/magento/magento2/pull/22355)*. [GitHub-22246](https://github.com/magento/magento2/issues/22355)
+*  Tooltip styles now use the appropriate variables for mobile view. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22382](https://github.com/magento/magento2/pull/22355)*. [GitHub-22246](https://github.com/magento/magento2/issues/22355)
 
 <!--- ENGCOM-4428-->
 
-* Magento now displays the correct import status data for an import that is created using **System** > **Import** > **Advanced Pricing** > **Add/Update**. *Fix submitted by [Denys Saltanakhmedov](https://github.com/DenisSaltanahmedov) in pull request [21476](https://github.com/magento/magento2/pull/21476)*. [GitHub-21192](https://github.com/magento/magento2/issues/21192)
+*  Magento now displays the correct import status data for an import that is created using **System** > **Import** > **Advanced Pricing** > **Add/Update**. *Fix submitted by [Denys Saltanakhmedov](https://github.com/DenisSaltanahmedov) in pull request [21476](https://github.com/magento/magento2/pull/21476)*. [GitHub-21192](https://github.com/magento/magento2/issues/21192)
 
 <!--- ENGCOM-3993-->
 
-* The `store_view_code` column now contains data from the chosen product store. Previously, Magento did not populate the `store_view_code` column. *Fix submitted by [Valant13](https://github.com/Valant13) in pull request [19395](https://github.com/magento/magento2/pull/19395)*. [GitHub-17784](https://github.com/magento/magento2/issues/17784), [GitHub-19786](https://github.com/magento/magento2/issues/19786)
+*  The `store_view_code` column now contains data from the chosen product store. Previously, Magento did not populate the `store_view_code` column. *Fix submitted by [Valant13](https://github.com/Valant13) in pull request [19395](https://github.com/magento/magento2/pull/19395)*. [GitHub-17784](https://github.com/magento/magento2/issues/17784), [GitHub-19786](https://github.com/magento/magento2/issues/19786)
 
 ### Index
 
 <!--- ENGCOM-4440-->
 
-* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin's indexer list,  Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21575](https://github.com/magento/magento2/pull/21575)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+*  You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin's indexer list,  Magento threw a fatal error. *Fix submitted by [Cristiano Casciotti](https://github.com/ccasciotti) in pull request [21575](https://github.com/magento/magento2/pull/21575)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
 
 <!--- ENGCOM-3761-->
 
-* Magento now validates CSV files that are created by custom adapters when you click **Check Data** if column and data are available. Previously, Magento threw an error. *Fix submitted by [Jaimin Sutariya ](https://github.com/jaimin-ktpl) in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
+*  Magento now validates CSV files that are created by custom adapters when you click **Check Data** if column and data are available. Previously, Magento threw an error. *Fix submitted by [Jaimin Sutariya ](https://github.com/jaimin-ktpl) in pull request [19765](https://github.com/magento/magento2/pull/19765)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 ### Infrastructure
 
-* The default behavior of view models has changed in this release. Instances of view models are now shared by default. As a result, you must add the `attribute shared="false"` on the argument node of the `layout.xml` file if you want a new instance of a view model.
+*  The default behavior of view models has changed in this release. Instances of view models are now shared by default. As a result, you must add the `attribute shared="false"` on the argument node of the `layout.xml` file if you want a new instance of a view model.
 
 <!--- ENGCOM-4474-->
 
-* The `FrontController` now explicitly requires actions to specify if they respond to `HEAD` requests. `HEAD` action mapping has also been changed to the  `GET` action interface, which results in `HEAD` requests returning `200` instead of `404`. *Fix submitted by [Matti Vapa](https://github.com/mattijv) in pull request [21378](https://github.com/magento/magento2/pull/21378)*. [GitHub-21299](https://github.com/magento/magento2/issues/21299)
+*  The `FrontController` now explicitly requires actions to specify if they respond to `HEAD` requests. `HEAD` action mapping has also been changed to the  `GET` action interface, which results in `HEAD` requests returning `200` instead of `404`. *Fix submitted by [Matti Vapa](https://github.com/mattijv) in pull request [21378](https://github.com/magento/magento2/pull/21378)*. [GitHub-21299](https://github.com/magento/magento2/issues/21299)
 
 <!--- ENGCOM-4482-->
 
-* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contined logic. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21693](https://github.com/magento/magento2/pull/21693)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692), [GitHub-21752](https://github.com/magento/magento2/issues/21752)
+*  Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contined logic. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [21693](https://github.com/magento/magento2/pull/21693)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692), [GitHub-21752](https://github.com/magento/magento2/issues/21752)
 
 <!--- ENGCOM-4543-->
 
-* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+*  The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
 <!--- ENGCOM-4562-->
 
-* The `errors/local.xml` and error page templates are no longer publicly accessible. *Fix submitted by [Fabian Schmengler ](https://github.com/schmengler) in pull request [20212](https://github.com/magento/magento2/pull/20212)*. [GitHub-20209](https://github.com/magento/magento2/issues/20209)
+*  The `errors/local.xml` and error page templates are no longer publicly accessible. *Fix submitted by [Fabian Schmengler ](https://github.com/schmengler) in pull request [20212](https://github.com/magento/magento2/pull/20212)*. [GitHub-20209](https://github.com/magento/magento2/issues/20209)
 
 <!--- ENGCOM-3498-->
 
-* We added the missing  attributes `validated_country_code` and `validated_vat_number` to `quote_address`. *Fix submitted by [Erik Pellikka](https://github.com/ErikPel) in pull request [19265](https://github.com/magento/magento2/pull/19265)*. [GitHub-17658](https://github.com/magento/magento2/issues/17658)
+*  We added the missing  attributes `validated_country_code` and `validated_vat_number` to `quote_address`. *Fix submitted by [Erik Pellikka](https://github.com/ErikPel) in pull request [19265](https://github.com/magento/magento2/pull/19265)*. [GitHub-17658](https://github.com/magento/magento2/issues/17658)
 
 <!--- ENGCOM-4147-->
 
-* We added Type casting to \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes() to improve  validation. *Fix submitted by [Mudit Shukla](https://github.com/cedmudit) in pull request [20898](https://github.com/magento/magento2/pull/20898)*. [GitHub-13319](https://github.com/magento/magento2/issues/13319)
+*  We added Type casting to \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes() to improve  validation. *Fix submitted by [Mudit Shukla](https://github.com/cedmudit) in pull request [20898](https://github.com/magento/magento2/pull/20898)*. [GitHub-13319](https://github.com/magento/magento2/issues/13319)
 
 <!--- ENGCOM-4170-->
 
-* Widget paraneters can now contain multidimensional arrays. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21008](https://github.com/magento/magento2/pull/21008)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
+*  Widget paraneters can now contain multidimensional arrays. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [21008](https://github.com/magento/magento2/pull/21008)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
 
 <!--- ENGCOM-4627-->
 
-* `phpcs` now reports all errors and warnings in the terminal as expected. Previously, `phpcs` threw an error instead of reporting errors under certain circumstances. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22081](https://github.com/magento/magento2/pull/22081)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
+*  `phpcs` now reports all errors and warnings in the terminal as expected. Previously, `phpcs` threw an error instead of reporting errors under certain circumstances. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22081](https://github.com/magento/magento2/pull/22081)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
 
 <!--- ENGCOM-4527-->
 
-* The `getSize()` method in `\Magento\Framework\Data\Collection` now returns results that reflect added filters as expected when the `clear()` method is called after `getSize()`. Previously, this method returned results that always remained the same after the first call and the `clear()` method was ignored.*Fix submitted by [Sergey Nezbritskiy](https://github.com/sergeynezbritskiy) in pull request [21670](https://github.com/magento/magento2/pull/21670)*. [GitHub-21654](https://github.com/magento/magento2/issues/21654)
+*  The `getSize()` method in `\Magento\Framework\Data\Collection` now returns results that reflect added filters as expected when the `clear()` method is called after `getSize()`. Previously, this method returned results that always remained the same after the first call and the `clear()` method was ignored.*Fix submitted by [Sergey Nezbritskiy](https://github.com/sergeynezbritskiy) in pull request [21670](https://github.com/magento/magento2/pull/21670)*. [GitHub-21654](https://github.com/magento/magento2/issues/21654)
 
 <!--- ENGCOM-4545-->
 
-* Magento no longer caches absolute file paths in  the validator factory  (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21856](https://github.com/magento/magento2/pull/21856)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
+*  Magento no longer caches absolute file paths in  the validator factory  (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by [David Führ](https://github.com/david-fuehr) in pull request [21856](https://github.com/magento/magento2/pull/21856)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
 
 <!--- ENGCOM-4679-->
 
-* `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [22149](https://github.com/magento/magento2/pull/22149)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
+*  `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by [Bartłomiej Szubert](https://github.com/Bartlomiejsz) in pull request [22149](https://github.com/magento/magento2/pull/22149)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
 
 <!--- ENGCOM-4585-->
 
@@ -858,374 +858,374 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-4637-->
 
-* Setting **price navigation step calculation** for layered navigation to **Automatic (equalize product counts)** now works as expected. Previously, results were not in the equals range, but omitted products. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-21960](https://github.com/magento/magento2/issues/21960)
+*  Setting **price navigation step calculation** for layered navigation to **Automatic (equalize product counts)** now works as expected. Previously, results were not in the equals range, but omitted products. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [21968](https://github.com/magento/magento2/pull/21968)*. [GitHub-21960](https://github.com/magento/magento2/issues/21960)
 
 <!--- ENGCOM-4504-->
 
-* Use of the Yes/No attribute in the Layered Navigation filter no longer degrades filter performance. *Fix submitted by [Stephan Kechedzhi]](https://github.com/stkec) in pull request [21772](https://github.com/magento/magento2/pull/21772)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283), [GitHub-21771](https://github.com/magento/magento2/issues/21771)
+*  Use of the Yes/No attribute in the Layered Navigation filter no longer degrades filter performance. *Fix submitted by [Stephan Kechedzhi]](https://github.com/stkec) in pull request [21772](https://github.com/magento/magento2/pull/21772)*. [GitHub-3283](https://github.com/magento/magento2/issues/3283), [GitHub-21771](https://github.com/magento/magento2/issues/21771)
 
 <!--- ENGCOM-4458-->
 
-* Magento now retrieves the configuration value (store ID)  that is  based on the current store scope in multistore deployments. Previously, Magento occasionally returned an incorrect configuration scope ID when attempting to resolve a scope ID set to null. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21633](https://github.com/magento/magento2/pull/21633)*. [GitHub-16939](https://github.com/magento/magento2/issues/16939)
+*  Magento now retrieves the configuration value (store ID)  that is  based on the current store scope in multistore deployments. Previously, Magento occasionally returned an incorrect configuration scope ID when attempting to resolve a scope ID set to null. *Fix submitted by [Pratik Oza](https://github.com/mage2pratik) in pull request [21633](https://github.com/magento/magento2/pull/21633)*. [GitHub-16939](https://github.com/magento/magento2/issues/16939)
 
 ### Logging
 
 <!--- ENGCOM-4505-->
 
-* Magento now creates a log entry if an observer does not implement ObserverInterface in modes other than developer mode.  Previously, Magento created a log entry when in developer mode only. *Fix submitted by [Nazar Klovanych ](https://github.com/Nazar65) in pull request [21767](https://github.com/magento/magento2/pull/21767)*. [GitHub-21755](https://github.com/magento/magento2/issues/21755)
+*  Magento now creates a log entry if an observer does not implement ObserverInterface in modes other than developer mode.  Previously, Magento created a log entry when in developer mode only. *Fix submitted by [Nazar Klovanych ](https://github.com/Nazar65) in pull request [21767](https://github.com/magento/magento2/pull/21767)*. [GitHub-21755](https://github.com/magento/magento2/issues/21755)
 
 ### Magento Shipping
 
-* Fixed issue with the event stream cron job.
+*  Fixed issue with the event stream cron job.
 
-* Fixed issue with retrieving shipping labels from some AWS environments.
+*  Fixed issue with retrieving shipping labels from some AWS environments.
 
 ### New Relic reporting
 
 <!--- MAGETWO-98853-->
 
-* Improved performance of New Relic queries. The New Relic Reporting module now cleans the Magento 2.x report data to prevent the reporting data store from growing too large and slowing query performance.
+*  Improved performance of New Relic queries. The New Relic Reporting module now cleans the Magento 2.x report data to prevent the reporting data store from growing too large and slowing query performance.
 
 <!--- ENGCOM-4634-->
 
-* Magento 2.x CLI command names are now reported in the transaction names in the New Relic APM Monitoring Data. The transaction name is based on the Magento CLI command name, for example `cli app:config:import`, `cli indexer:reindex`, and `cli cache:flush`. In previous releases, the New Relic transaction names for CLI commands initiated by Magento 2.x CLI command names was missing and reported as unknown. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [22059](https://github.com/magento/magento2/pull/22059)*. [GitHub-22047](https://github.com/magento/magento2/issues/22047)
+*  Magento 2.x CLI command names are now reported in the transaction names in the New Relic APM Monitoring Data. The transaction name is based on the Magento CLI command name, for example `cli app:config:import`, `cli indexer:reindex`, and `cli cache:flush`. In previous releases, the New Relic transaction names for CLI commands initiated by Magento 2.x CLI command names was missing and reported as unknown. *Fix submitted by [Lukasz Bajsarowicz](https://github.com/lbajsarowicz) in pull request [22059](https://github.com/magento/magento2/pull/22059)*. [GitHub-22047](https://github.com/magento/magento2/issues/22047)
 
 ### Newsletter
 
 <!--- MAGETWO-98617-->
 
-* You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page.
+*  You can now change pages at an expected speed from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Previously, it took excessively long to move off this page.
 
 <!--- ENGCOM-3992-->
 
-* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [20165](https://github.com/magento/magento2/pull/20165)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
+*  The newsletter subscription input box now displays all text in mobile view. *Fix submitted by [Arvinda kumar](https://github.com/cedarvinda) in pull request [20165](https://github.com/magento/magento2/pull/20165)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
 ### Orders
 
 <!--- ENGCOM-4673-->
 
-* The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the simple product which typically returned a 404 page.
+*  The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product, and displayed a link to the simple product which typically returned a 404 page.
 
 <!--- ENGCOM-4739-->
 
-* Programatically created invoices now include all items as expected when both simple products and bundled products are mixed in an order. Previously, when  Magento\Sales\Model\Service\InvoiceService::prepareInvoice was called without a specified quantity, the function did not discards items as expected after bundled items were processed, which resulted in a partial invoice. *Fix submitted by [Ryan Palmer]](https://github.com/ryanpalmerweb) in pull request [22263](https://github.com/magento/magento2/pull/22263)*. [GitHub-22246](https://github.com/magento/magento2/issues/22246)
+*  Programatically created invoices now include all items as expected when both simple products and bundled products are mixed in an order. Previously, when  Magento\Sales\Model\Service\InvoiceService::prepareInvoice was called without a specified quantity, the function did not discards items as expected after bundled items were processed, which resulted in a partial invoice. *Fix submitted by [Ryan Palmer]](https://github.com/ryanpalmerweb) in pull request [22263](https://github.com/magento/magento2/pull/22263)*. [GitHub-22246](https://github.com/magento/magento2/issues/22246)
 
 <!--- ENGCOM-4524-->
 
-* When you create new extension attributes for orders, these attributes are now correctly joined when querying orders. *Fix submitted by [Oleksandr Kravchuk]](https://github.com/swnsma) in pull request [21797](https://github.com/magento/magento2/pull/21797)*. [GitHub-8035](https://github.com/magento/magento2/issues/8035)
+*  When you create new extension attributes for orders, these attributes are now correctly joined when querying orders. *Fix submitted by [Oleksandr Kravchuk]](https://github.com/swnsma) in pull request [21797](https://github.com/magento/magento2/pull/21797)*. [GitHub-8035](https://github.com/magento/magento2/issues/8035)
 
 ### Page cache
 
 <!--- MAGETWO-91607-->
-* Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode.
+*  Page cache is no longer active when maintenance mode is enabled.  Previously, Magento cached  pages from all IP addresses during maintennce mode.
 
 ### Payment methods
 
 <!--- MAGETWO-99307-->
 
-* Magento no longer throws an error indicating that a transaction was declined when Authorize.net successfully processes the order. Previously, orders were successfully created but Authorize.net indicated that the transaction had been declined.  [GitHub-22373](https://github.com/magento/magento2/issues/22373)
+*  Magento no longer throws an error indicating that a transaction was declined when Authorize.net successfully processes the order. Previously, orders were successfully created but Authorize.net indicated that the transaction had been declined.  [GitHub-22373](https://github.com/magento/magento2/issues/22373)
 
 <!--- MAGETWO-99094-->
 
-* Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.
+*  Magento creates an order using PayPal PayflowPro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even though all necessary credit card information has been entered.
 
 <!--- ENGCOM-4192-->
 
-* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to supprt accessibility. *Fix submitted by [Patrick McLain](https://github.com/pmclain) in pull request [21090](https://github.com/magento/magento2/pull/21090)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+*  Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to supprt accessibility. *Fix submitted by [Patrick McLain](https://github.com/pmclain) in pull request [21090](https://github.com/magento/magento2/pull/21090)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
 ### Performance
 
 <!--- MC-16005-->
 
-* Client-side performance has been optimized by moving non-critical JavaScript code to the bottom of the page along with the corresponding deferred parsing and evaluation of this code. This means that users can see  rendered pages faster. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.
+*  Client-side performance has been optimized by moving non-critical JavaScript code to the bottom of the page along with the corresponding deferred parsing and evaluation of this code. This means that users can see  rendered pages faster. To enable this performance enhancement, you must navigate to **Stores** > **Configuration** > **Developer** > **JavaScript Settings** and enable the **Move JS code to the bottom of the page** option.
 
 <!--- MAGETWO-96138-->
 
-* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+*  The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
 
 <!--- MAGETWO-98424-->
 
-* The multishipping checkout flow now supports the Braintree payment method.
+*  The multishipping checkout flow now supports the Braintree payment method.
 
 <!--- ENGCOM-4650-->
 
-* Magento no longer disables the **Place order** button in the checkout workflow after the customer has supplied the requested email address for orders created with Braintree. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21936](https://github.com/magento/magento2/pull/21936)*[GitHub-21907](https://github.com/magento/magento2/issues/21907)
+*  Magento no longer disables the **Place order** button in the checkout workflow after the customer has supplied the requested email address for orders created with Braintree. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21936](https://github.com/magento/magento2/pull/21936)*[GitHub-21907](https://github.com/magento/magento2/issues/21907)
 
 <!--- MC-6273-->
 
-* We've optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.
+*  We've optimized the logic of concurrent access to the block cache, which  has improved the response of storefront pages under high load by approximately 20%.
 
 ### Quote
 
 <!--- ENGCOM-4520-->
 
-* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`.  *Fix submitted by [David Führ ](https://github.com/david-fuehr) in pull request [21697](https://github.com/magento/magento2/pull/21697)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
+*  `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`.  *Fix submitted by [David Führ ](https://github.com/david-fuehr) in pull request [21697](https://github.com/magento/magento2/pull/21697)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
 <!--- ENGCOM-4712-->
 
-* The `x_forwarded_for` field of the Quote Management service now contains the value from `$_SERVER['HTTP_X_FORWARDED_FOR']`. Previously, this field was always empty. This change will permit administrators to see their customer's actual IP addresses (as opposed to 127.0.0.1), which can help identify potentially fraudulent orders. *Fix submitted by [Christian Münch](https://github.com/cmuench) in pull request [21787](https://github.com/magento/magento2/pull/21787)*. [GitHub-](https://github.com/magento/magento2/issues/)
+*  The `x_forwarded_for` field of the Quote Management service now contains the value from `$_SERVER['HTTP_X_FORWARDED_FOR']`. Previously, this field was always empty. This change will permit administrators to see their customer's actual IP addresses (as opposed to 127.0.0.1), which can help identify potentially fraudulent orders. *Fix submitted by [Christian Münch](https://github.com/cmuench) in pull request [21787](https://github.com/magento/magento2/pull/21787)*. [GitHub-](https://github.com/magento/magento2/issues/)
 
 ### Reports
 
 <!--- ENGCOM-3808-->
 
-* The date range in reports no longer displays the same start and end dates. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20129](https://github.com/magento/magento2/pull/20129)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
+*  The date range in reports no longer displays the same start and end dates. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20129](https://github.com/magento/magento2/pull/20129)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
 <!--- ENGCOM-4302-->
 
-* Magento now includes the amount of a credit memo's refunded discount in its calculation of the value displayed in the total column under **Last Orders** listing on the Admin dashboard. *Fix submitted by [Rav ](https://github.com/rav-redchamps) in pull request [21283](https://github.com/magento/magento2/pull/21283)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+*  Magento now includes the amount of a credit memo's refunded discount in its calculation of the value displayed in the total column under **Last Orders** listing on the Admin dashboard. *Fix submitted by [Rav ](https://github.com/rav-redchamps) in pull request [21283](https://github.com/magento/magento2/pull/21283)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
 
 <!--- ENGCOM-4747-->
 
-* The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22291](https://github.com/magento/magento2/pull/22291)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
+*  The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22291](https://github.com/magento/magento2/pull/22291)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
 
 ### Reviews
 
 <!--- ENGCOM-4560-->
 
-* The  text for review-related headers under **User Content** on the Admin dashboard has been edited for clarity.  *Fix submitted by [Vishal Gelani ](https://github.com/gelanivishal) in pull request [21621](https://github.com/magento/magento2/pull/21621)*. [GitHub-21620](https://github.com/magento/magento2/issues/21620)
+*  The  text for review-related headers under **User Content** on the Admin dashboard has been edited for clarity.  *Fix submitted by [Vishal Gelani ](https://github.com/gelanivishal) in pull request [21621](https://github.com/magento/magento2/pull/21621)*. [GitHub-21620](https://github.com/magento/magento2/issues/21620)
 
 ### Sales
 
 <!--- ENGCOM-4101-->
 
-* Corrected problems with the disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20953](https://github.com/magento/magento2/pull/20953)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+*  Corrected problems with the disabling and enabling order-related emails. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20953](https://github.com/magento/magento2/pull/20953)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
 <!--- ENGCOM-4197-->
 
-* Fixed display of the Luma theme My Account Order status tabs in mobile view.*Fix submitted by [Abrar Pathan](https://github.com/abrarpathan19) in pull request [21071](https://github.com/magento/magento2/pull/21071)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
+*  Fixed display of the Luma theme My Account Order status tabs in mobile view.*Fix submitted by [Abrar Pathan](https://github.com/abrarpathan19) in pull request [21071](https://github.com/magento/magento2/pull/21071)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
 
 <!--- ENGCOM-4241-->
 
-* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [gauravagarwal1001](https://github.com/gauravagarwal1001) in pull request [21145](https://github.com/magento/magento2/pull/21145)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162), [GitHub-7974](https://github.com/magento/magento2/issues/7974), [GitHub-21144](https://github.com/magento/magento2/issues/21144)
+*  You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by [gauravagarwal1001](https://github.com/gauravagarwal1001) in pull request [21145](https://github.com/magento/magento2/pull/21145)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162), [GitHub-7974](https://github.com/magento/magento2/issues/7974), [GitHub-21144](https://github.com/magento/magento2/issues/21144)
 
 <!--- ENGCOM-4321-->
 
-* You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21335](https://github.com/magento/magento2/pull/21335)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
+*  You can now successfully re-order a virtual product. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [21335](https://github.com/magento/magento2/pull/21335)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
 
 <!--- MAGETWO-97423-->
 
-* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column  contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
+*  When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column  contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
 
 <!--- ENGCOM-4238-->
 
-* Form validation now works as expected for fields in the Admin order address edit forms. Previously, when you entered invalid data, Magento did not display an error message and displayed the data. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20840](https://github.com/magento/magento2/pull/20840)*. [GitHub-19360](https://github.com/magento/magento2/issues/19360)
+*  Form validation now works as expected for fields in the Admin order address edit forms. Previously, when you entered invalid data, Magento did not display an error message and displayed the data. *Fix submitted by [Ievgenii Gryshkun](https://github.com/XxXgeoXxX) in pull request [20840](https://github.com/magento/magento2/pull/20840)*. [GitHub-19360](https://github.com/magento/magento2/issues/19360)
 
 <!--- ENGCOM-3910-->
 
-* If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 ### SalesRule
 
 <!--- ENGCOM-4215-->
 
-* The DataProvider and Save Controller files have been edited to improve persistence of form data in cart price rules. *Fix submitted by [Aditya Yadav](https://github.com/realadityayadav) in pull request [20895](https://github.com/magento/magento2/pull/20895)*. [GitHub-20888](https://github.com/magento/magento2/issues/20888)
+*  The DataProvider and Save Controller files have been edited to improve persistence of form data in cart price rules. *Fix submitted by [Aditya Yadav](https://github.com/realadityayadav) in pull request [20895](https://github.com/magento/magento2/pull/20895)*. [GitHub-20888](https://github.com/magento/magento2/issues/20888)
 
 <!--- ENGCOM-4406-->
 
-* Added a condition `type _Subtotal (Excl. Tax)` to the Cart Price Rule configuration so that you can configure a cart price discount rule discount based on minimum purchase amount that excludes tax. Previously, the subtotal was calculated only with tax included. *Fix submitted by [AleksLi](https://github.com/AleksLi) in pull request [21288](https://github.com/magento/magento2/pull/21288)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
+*  Added a condition `type _Subtotal (Excl. Tax)` to the Cart Price Rule configuration so that you can configure a cart price discount rule discount based on minimum purchase amount that excludes tax. Previously, the subtotal was calculated only with tax included. *Fix submitted by [AleksLi](https://github.com/AleksLi) in pull request [21288](https://github.com/magento/magento2/pull/21288)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
 
 ### Search
 
 <!--- MAGETWO-58764-->
 
-* Catalog search **Minimal Query Length** values are now enforced as expected.
+*  Catalog search **Minimal Query Length** values are now enforced as expected.
 
 <!--- MAGETWO-97830-->
 
-* Elasticsearch quick search now works as expected when the default attribute set contains a `date` attribute that has been set to **Search = Yes**. Previously, the search page threw an exception and crashed.
+*  Elasticsearch quick search now works as expected when the default attribute set contains a `date` attribute that has been set to **Search = Yes**. Previously, the search page threw an exception and crashed.
 
 <!--- ENGCOM-4109-->
 
-* The performance of layered navigation queries has been improved. *Fix submitted by [Mads Nielsen](https://github.com/k4emic) in pull request [20971](https://github.com/magento/magento2/pull/20971)*. [GitHub-20969](https://github.com/magento/magento2/issues/20969)
+*  The performance of layered navigation queries has been improved. *Fix submitted by [Mads Nielsen](https://github.com/k4emic) in pull request [20971](https://github.com/magento/magento2/pull/20971)*. [GitHub-20969](https://github.com/magento/magento2/issues/20969)
 
 <!--- ENGCOM-4481-->
 
-* The search REST API now returns the correct `total_count` of result items. Previously, the value of `total_count`  equaled `searchCriteria[pageSize]`,  not the total count of the search result items. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [21713](https://github.com/magento/magento2/pull/21713)*. [GitHub-17295](https://github.com/magento/magento2/issues/17295)
+*  The search REST API now returns the correct `total_count` of result items. Previously, the value of `total_count`  equaled `searchCriteria[pageSize]`,  not the total count of the search result items. *Fix submitted by [Ronak Patel](https://github.com/ronak2ram) in pull request [21713](https://github.com/magento/magento2/pull/21713)*. [GitHub-17295](https://github.com/magento/magento2/issues/17295)
 
 <!--- ENGCOM-4761-->
 
-* The search icon on Admin page headers now works as expected. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22154](https://github.com/magento/magento2/pull/22154)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
+*  The search icon on Admin page headers now works as expected. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22154](https://github.com/magento/magento2/pull/22154)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
 
 <!--- ENGCOM-4620-->
 
-* Magento now checks concrete class while applying plugins. Previously, when  the pluginized class was virtual-typed by a class with name ending with an autogenerated suffix and without the implementation of the base concrete class, the `di:compile` process failed.  *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [22046](https://github.com/magento/magento2/pull/22046)*. [GitHub-21916](https://github.com/magento/magento2/issues/21916), [GitHub-21976](https://github.com/magento/magento2/issues/21976)
+*  Magento now checks concrete class while applying plugins. Previously, when  the pluginized class was virtual-typed by a class with name ending with an autogenerated suffix and without the implementation of the base concrete class, the `di:compile` process failed.  *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [22046](https://github.com/magento/magento2/pull/22046)*. [GitHub-21916](https://github.com/magento/magento2/issues/21916), [GitHub-21976](https://github.com/magento/magento2/issues/21976)
 
 ### Shipping
 
 <!--- ENGCOM-4266-->
 
-* UPS (non-XML) endpoints are now HTTPS instead of HTTP. *Fix submitted by [Josh](https://github.com/wsajosh) in pull request [21511](https://github.com/magento/magento2/pull/21511)*.
+*  UPS (non-XML) endpoints are now HTTPS instead of HTTP. *Fix submitted by [Josh](https://github.com/wsajosh) in pull request [21511](https://github.com/magento/magento2/pull/21511)*.
 
 <!--- ENGCOM-3601-->
 
-* Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19487](https://github.com/magento/magento2/pull/19487)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
+*  Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**. *Fix submitted by [gwharton](https://github.com/gwharton) in pull request [19487](https://github.com/magento/magento2/pull/19487)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
 
 <!--- MAGETWO-98947-->
 
-* The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods] (https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS).
+*  The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods] (https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS).
 
 <!--- MAGETWO-98328-->
 
-* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
+*  The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 ### Sitemap
 
 <!--- ENGCOM-3683-->
 
-* Images in the XML sitemap are no longer linked to the base store in a multistore deployment when scheduling start times and daily frequency. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19598](https://github.com/magento/magento2/pull/15012)*. [GitHub-19596](https://github.com/magento/magento2/issues/19596)
+*  Images in the XML sitemap are no longer linked to the base store in a multistore deployment when scheduling start times and daily frequency. *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [19598](https://github.com/magento/magento2/pull/15012)*. [GitHub-19596](https://github.com/magento/magento2/issues/19596)
 
 <!--- ENGCOM-3844-->
 
-* Magento now validates sitemap file names to ensure that file names do not exceed length limits. Previously, Magento simply truncated excessively long file names. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20044](https://github.com/magento/magento2/pull/20044)*. [GitHub-13937](https://github.com/magento/magento2/issues/13937)
+*  Magento now validates sitemap file names to ensure that file names do not exceed length limits. Previously, Magento simply truncated excessively long file names. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20044](https://github.com/magento/magento2/pull/20044)*. [GitHub-13937](https://github.com/magento/magento2/issues/13937)
 
 ### Swatches
 
 <!--- ENGCOM-4347-->
 
-* Corrected `blackground` to `background` in `Magento_Swatches _module.less`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21368](https://github.com/magento/magento2/pull/21368)*. [GitHub-21365](https://github.com/magento/magento2/issues/21365)
+*  Corrected `blackground` to `background` in `Magento_Swatches _module.less`. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [21368](https://github.com/magento/magento2/pull/21368)*. [GitHub-21365](https://github.com/magento/magento2/issues/21365)
 
 <!--- ENGCOM-4296-->
 
-* You can now successfully preselect a configurable product swatch that contains an image. Previously, Magento tried to load the image into the product gallery before initialization completed and threw a JavaScript error. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [19635](https://github.com/magento/magento2/pull/19635)*. [GitHub-18017](https://github.com/magento/magento2/issues/18017)
+*  You can now successfully preselect a configurable product swatch that contains an image. Previously, Magento tried to load the image into the product gallery before initialization completed and threw a JavaScript error. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [19635](https://github.com/magento/magento2/pull/19635)*. [GitHub-18017](https://github.com/magento/magento2/issues/18017)
 
 ### Tax
 
 <!--- MAGETWO-97396-->
 
-* The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
+*  The tax that is applied to a simple child product is now  based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
 <!--- ENGCOM-4022-->
 
-* The shopping cart full tax summary now displays total tax as expected instead of  individual tax values. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20682](https://github.com/magento/magento2/pull/20682)*. [GitHub-11358](https://github.com/magento/magento2/issues/11358), [GitHub-19701](https://github.com/magento/magento2/issues/19701)
+*  The shopping cart full tax summary now displays total tax as expected instead of  individual tax values. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [20682](https://github.com/magento/magento2/pull/20682)*. [GitHub-11358](https://github.com/magento/magento2/issues/11358), [GitHub-19701](https://github.com/magento/magento2/issues/19701)
 
 <!--- ENGCOM-4359-->
 
-* The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Nick de Kleijn](https://github.com/NickdeK) in pull request [20316](https://github.com/magento/magento2/pull/20316)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+*  The value of `product_price_value` in the shopping cart data section  now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by [Nick de Kleijn](https://github.com/NickdeK) in pull request [20316](https://github.com/magento/magento2/pull/20316)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
 <!--- MAGETWO-98028-->
 
-* The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
+*  The tax that is applied to simple child product is now  based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
 
 <!--- ENGCOM-4480-->
 
-* You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21701](https://github.com/magento/magento2/pull/21701)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw an MySQL error. *Fix submitted by [Tuyen Nguyen](https://github.com/tuyennn) in pull request [21701](https://github.com/magento/magento2/pull/21701)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
 ### Testing
 
 <!--- ENGCOM-4300-->
 
-* The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21275](https://github.com/magento/magento2/pull/21275)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
+*  The `Squiz.Operators.ValidLogicalOperators` PHP-CS rule has been added to the static test rules. *Fix submitted by [Maksym Novik](https://github.com/novikor) in pull request [21275](https://github.com/magento/magento2/pull/21275)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 <!--- ENGCOM-4554-->
 
-* Added missing parameters to failing unit tests for `FormatTests`. *Fix submitted by [Kamil Degórski ](https://github.com/kdegorski) in pull request [21880](https://github.com/magento/magento2/pull/21880)*. [GitHub-21001](https://github.com/magento/magento2/issues/21001)
+*  Added missing parameters to failing unit tests for `FormatTests`. *Fix submitted by [Kamil Degórski ](https://github.com/kdegorski) in pull request [21880](https://github.com/magento/magento2/pull/21880)*. [GitHub-21001](https://github.com/magento/magento2/issues/21001)
 
 ### Theme
 
 <!--- ENGCOM-3799-->
 
-* Logo files for transactional emails can now be successfully uploaded  using **Content** > **Configuration** > **Edit theme** > **Transactional Emails**. Previously, Magento did not upload the logo, but displayed this error, `A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.` *Fix submitted by [chaplynsky](https://github.com/chaplynsky) in pull request [20092](https://github.com/magento/magento2/pull/20092)*. [GitHub-20091](https://github.com/magento/magento2/issues/20091)
+*  Logo files for transactional emails can now be successfully uploaded  using **Content** > **Configuration** > **Edit theme** > **Transactional Emails**. Previously, Magento did not upload the logo, but displayed this error, `A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.` *Fix submitted by [chaplynsky](https://github.com/chaplynsky) in pull request [20092](https://github.com/magento/magento2/pull/20092)*. [GitHub-20091](https://github.com/magento/magento2/issues/20091)
 
 <!--- ENGCOM-4338-->
 
-* The horizontal scroll widget on the storefront search results page now works as expected with very long search strings. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21360](https://github.com/magento/magento2/pull/21360)*. [GitHub-21359](https://github.com/magento/magento2/issues/21359)
+*  The horizontal scroll widget on the storefront search results page now works as expected with very long search strings. *Fix submitted by [Prince Patel](https://github.com/mageprince) in pull request [21360](https://github.com/magento/magento2/pull/21360)*. [GitHub-21359](https://github.com/magento/magento2/issues/21359)
 
 <!--- ENGCOM-4541-->
 
-* Checkboxes and radio buttons are now highlighted on focus while you navigate a form using the keyboard.  This change is a reversion of an earlier fix (20861), which inadvertently violated accessibility standards for keyboard  navigation. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+*  Checkboxes and radio buttons are now highlighted on focus while you navigate a form using the keyboard.  This change is a reversion of an earlier fix (20861), which inadvertently violated accessibility standards for keyboard  navigation. *Fix submitted by [Roman Kis](https://github.com/kisroman) in pull request [21820](https://github.com/magento/magento2/pull/21820)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
 <!--- ENGCOM-4800-->
 
-* Magento now successfully uploads files from the theme config edit form page when you click **Select from Gallery** button for the **Logo Image** field. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22132](https://github.com/magento/magento2/pull/22132)*. [GitHub-21032](https://github.com/magento/magento2/issues/21032)
+*  Magento now successfully uploads files from the theme config edit form page when you click **Select from Gallery** button for the **Logo Image** field. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22132](https://github.com/magento/magento2/pull/22132)*. [GitHub-21032](https://github.com/magento/magento2/issues/21032)
 
 ### Translation and locales
 
 <!--- ENGCOM-4503-->
 
-* Product attribute labels are no longer translated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [21751](https://github.com/magento/magento2/pull/21751)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
+*  Product attribute labels are no longer translated. *Fix submitted by [Karla Saaremäe](https://github.com/Karlasa) in pull request [21751](https://github.com/magento/magento2/pull/21751)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
 ### UI
 
 <!--- ENGCOM-3937-->
 
-* You can no longer upload images when the **Use Default Value** setting on the Admin Content tab is enabled. Previously, you could drag an image to this tab even when this setting was enabled. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  You can no longer upload images when the **Use Default Value** setting on the Admin Content tab is enabled. Previously, you could drag an image to this tab even when this setting was enabled. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [20381](https://github.com/magento/magento2/pull/20381)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 <!--- ENGCOM-4148-->
 
-* The Date field associated with a page on the  Admin Pages table now displays the correct date, not the current date. *Fix submitted by [Satya Prakash](https://github.com/satyaprakashpatel) in pull request [20902](https://github.com/magento/magento2/pull/20902)*. [GitHub-17564](https://github.com/magento/magento2/issues/17564)
+*  The Date field associated with a page on the  Admin Pages table now displays the correct date, not the current date. *Fix submitted by [Satya Prakash](https://github.com/satyaprakashpatel) in pull request [20902](https://github.com/magento/magento2/pull/20902)*. [GitHub-17564](https://github.com/magento/magento2/issues/17564)
 
 <!--- ENGCOM-3898-->
 
-* Postcodes/zip code fields on the checkout page are empty and unvalidated on page load as expected. Previously, Magento validated postcodes/zip codes on the checkout page when the page loaded. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [18633](https://github.com/magento/magento2/pull/18633)*. [GitHub-18630](https://github.com/magento/magento2/issues/18630)
+*  Postcodes/zip code fields on the checkout page are empty and unvalidated on page load as expected. Previously, Magento validated postcodes/zip codes on the checkout page when the page loaded. *Fix submitted by [Danny Verkade](https://github.com/dverkade) in pull request [18633](https://github.com/magento/magento2/pull/18633)*. [GitHub-18630](https://github.com/magento/magento2/issues/18630)
 
 <!--- ENGCOM-4522-->
 
-* Buttons on the  Admin **System** > **Backups** page no longer flicker when the page is reloaded. *Fix submitted by [Oleg Volkov](https://github.com/OlehWolf) in pull request [21791](https://github.com/magento/magento2/pull/21791)*. [GitHub-19835](https://github.com/magento/magento2/issues/19835)
+*  Buttons on the  Admin **System** > **Backups** page no longer flicker when the page is reloaded. *Fix submitted by [Oleg Volkov](https://github.com/OlehWolf) in pull request [21791](https://github.com/magento/magento2/pull/21791)*. [GitHub-19835](https://github.com/magento/magento2/issues/19835)
 
 <!--- ENGCOM-4414-->
 
-* Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by [Scott Buchanan](https://github.com/scottsb) in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+*  Screen readers can now identify the `label` elements that are linked to  `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated.  *Fix submitted by [Scott Buchanan](https://github.com/scottsb) in pull request [21484](https://github.com/magento/magento2/pull/21484)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 <!--- ENGCOM-4596-->
 
-* Product gallery images no longer open unexpectedly when you move over a product image while moving to another page element. *Fix submitted by [Denis Kopylov ](https://github.com/Den4ik) in pull request [21790](https://github.com/magento/magento2/pull/21790)*. [GitHub-21789](https://github.com/magento/magento2/issues/21789)
+*  Product gallery images no longer open unexpectedly when you move over a product image while moving to another page element. *Fix submitted by [Denis Kopylov ](https://github.com/Den4ik) in pull request [21790](https://github.com/magento/magento2/pull/21790)*. [GitHub-21789](https://github.com/magento/magento2/issues/21789)
 
 <!--- ENGCOM-4703-->
 
-* Magento now cancels previous scrolling actions as expected when you click **Add to cart** on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked  **Add to cart**. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22117](https://github.com/magento/magento2/pull/22117)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
+*  Magento now cancels previous scrolling actions as expected when you click **Add to cart** on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked  **Add to cart**. *Fix submitted by [Vechirko Yurii](https://github.com/yvechirko) in pull request [22117](https://github.com/magento/magento2/pull/22117)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
 
 <!--- ENGCOM-4666-->
 
-* Magento no longer displays the customer name twice in the welcome message on the log in page after a customer logs in. *Fix submitted by [Priti ](https://github.com/priti2jcommerce) in pull request [20832](https://github.com/magento/magento2/pull/20832)*. [GitHub-20830](https://github.com/magento/magento2/issues/20830)
+*  Magento no longer displays the customer name twice in the welcome message on the log in page after a customer logs in. *Fix submitted by [Priti ](https://github.com/priti2jcommerce) in pull request [20832](https://github.com/magento/magento2/pull/20832)*. [GitHub-20830](https://github.com/magento/magento2/issues/20830)
 
 <!--- ENGCOM-4762-->
 
-* Magento now updates the `created_at` and `updated_at` columns in the `ui_bookmark` table as expected. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22340](https://github.com/magento/magento2/pull/22340)*. [GitHub-18557](https://github.com/magento/magento2/issues/18557)
+*  Magento now updates the `created_at` and `updated_at` columns in the `ui_bookmark` table as expected. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [22340](https://github.com/magento/magento2/pull/22340)*. [GitHub-18557](https://github.com/magento/magento2/issues/18557)
 
 <!--- ENGCOM-4775-->
 
-* Scrolling now works as expected in popup windows on devices running iOS. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [21150](https://github.com/magento/magento2/pull/21150)*. [GitHub-21147](https://github.com/magento/magento2/issues/21147)
+*  Scrolling now works as expected in popup windows on devices running iOS. *Fix submitted by [Priti](https://github.com/priti2jcommerce) in pull request [21150](https://github.com/magento/magento2/pull/21150)*. [GitHub-21147](https://github.com/magento/magento2/issues/21147)
 
 <!--- ENGCOM-3803-->
 
-* Magento now displays warning messages when validation fails on a form field that has a validation rule associated with it. Previously,  Magento displayed this error, `Javascript Error: Uncaught TypeError: msg.replace is not a function`, if validation failed on a form field. *Fix submitted by [Seth Daugherty](https://github.com/floorz) in pull request [20079](https://github.com/magento/magento2/pull/20079)*. [GitHub-20078](https://github.com/magento/magento2/issues/20078)
+*  Magento now displays warning messages when validation fails on a form field that has a validation rule associated with it. Previously,  Magento displayed this error, `Javascript Error: Uncaught TypeError: msg.replace is not a function`, if validation failed on a form field. *Fix submitted by [Seth Daugherty](https://github.com/floorz) in pull request [20079](https://github.com/magento/magento2/pull/20079)*. [GitHub-20078](https://github.com/magento/magento2/issues/20078)
 
 <!--- ENGCOM-3937-->
 
-* Magento no longer uploads images to the Category page unless the **Use Default Value** attribute is enabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20461](https://github.com/magento/magento2/pull/20461)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
+*  Magento no longer uploads images to the Category page unless the **Use Default Value** attribute is enabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20461](https://github.com/magento/magento2/pull/20461)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
 ### URL rewrites
 
 <!--- ENGCOM-4357-->
 
-* Added a feature to manage URL rewrites when the product visibility attribute changes. If the product is made invisible, Magento deletes the URL rewrite. If you change the visibility attribute to true, Magento creates a URL rewrite rule. Previously, changing the visibility attribute sometimes created duplicate product URLs. *Fix submitted by [Vitaliy ](https://github.com/VitaliyBoyko) in pull request [20774](https://github.com/magento/magento2/pull/20774)*. [GitHub-20434](https://github.com/magento/magento2/issues/20434)
+*  Added a feature to manage URL rewrites when the product visibility attribute changes. If the product is made invisible, Magento deletes the URL rewrite. If you change the visibility attribute to true, Magento creates a URL rewrite rule. Previously, changing the visibility attribute sometimes created duplicate product URLs. *Fix submitted by [Vitaliy ](https://github.com/VitaliyBoyko) in pull request [20774](https://github.com/magento/magento2/pull/20774)*. [GitHub-20434](https://github.com/magento/magento2/issues/20434)
 
 <!--- MAGETWO-98643-->
 
-* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
+*  URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
 
 <!--- ENGCOM-4586-->
 
-* Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Vaibhav Bhalerao](https://github.com/vbmagento) in pull request [21834](https://github.com/magento/magento2/pull/21834)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+*  Magento now retains filter terms after you've applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by [Vaibhav Bhalerao](https://github.com/vbmagento) in pull request [21834](https://github.com/magento/magento2/pull/21834)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 ### Web API framework
 
 <!--- ENGCOM-4771-->
 
-* You can now use REST in scope `all` to save an existing category that does not have a `name` attribute. Previously, Magento threw this exception, `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22362](https://github.com/magento/magento2/pull/22362)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
+*  You can now use REST in scope `all` to save an existing category that does not have a `name` attribute. Previously, Magento threw this exception, `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by [Nirav Patel](https://github.com/niravkrish) in pull request [22362](https://github.com/magento/magento2/pull/22362)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
 
 <!--- ENGCOM-4674-->
 
-* The REST-API locale now matches the appropriate store view in multistore deployments. Previously, Magento used the default scope for each store view. *Fix submitted by [Julian Wundrak](https://github.com/jwundrak) in pull request [19913](https://github.com/magento/magento2/pull/19913)*. [GitHub-19908](https://github.com/magento/magento2/issues/19908)
+*  The REST-API locale now matches the appropriate store view in multistore deployments. Previously, Magento used the default scope for each store view. *Fix submitted by [Julian Wundrak](https://github.com/jwundrak) in pull request [19913](https://github.com/magento/magento2/pull/19913)*. [GitHub-19908](https://github.com/magento/magento2/issues/19908)
 
 <!--- ENGCOM-4173-->
 
-* You can now use `/rest/all/V1/products/`  to update a product's `category_ids` through `custom_attribute` when the product has no custom attributes. Previously, the `update` command reported success, but categories were not updated. *Fix submitted by [Yaroslav Gyryn](https://github.com/ygyryn) in pull request [20842](https://github.com/magento/magento2/pull/20842)*. [GitHub-20481](https://github.com/magento/magento2/issues/20481)
+*  You can now use `/rest/all/V1/products/`  to update a product's `category_ids` through `custom_attribute` when the product has no custom attributes. Previously, the `update` command reported success, but categories were not updated. *Fix submitted by [Yaroslav Gyryn](https://github.com/ygyryn) in pull request [20842](https://github.com/magento/magento2/pull/20842)*. [GitHub-20481](https://github.com/magento/magento2/issues/20481)
 
 <!--- ENGCOM-4786-->
 
-* `PUT /V1/products/:sku/media/:entryId` now updates product images as expected. Previously, this call updated label, types and disabled, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`.
+*  `PUT /V1/products/:sku/media/:entryId` now updates product images as expected. Previously, this call updated label, types and disabled, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`.
 
 *Fix submitted by [Nazar Klovanych](https://github.com/Nazar65) in pull request [22424](https://github.com/magento/magento2/pull/22424)*. [GitHub-22402](https://github.com/magento/magento2/issues/22402)
 
@@ -1233,37 +1233,37 @@ This fix can degrade performance in deployments that implement flat catalogs. To
 
 <!--- ENGCOM-4460-->
 
-* Customer wishlists now include review summaries for included products. *Fix submitted by [Denis Kopylov](https://github.com/Den4ik) in pull request [21420](https://github.com/magento/magento2/pull/21420)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
+*  Customer wishlists now include review summaries for included products. *Fix submitted by [Denis Kopylov](https://github.com/Den4ik) in pull request [21420](https://github.com/magento/magento2/pull/21420)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 <!--- MAGETWO-62728-->
 
-* The wishlist quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesirable, inaccurate changes in quantity.
+*  The wishlist quantity field now has limits on both the type and number of characters that can be entered. Previously, you could enter both extremely large number and letters into this field, which resulted in undesirable, inaccurate changes in quantity.
 
 <!--- ENGCOM-3715-->
 
-* Magento now alerts you to the expected minimum quantity of product when you try to add a lesser product quantity to your shopping cart from the wishlist. *Fix submitted by [Khodu](https://github.com/khodu) in pull request [19653](https://github.com/magento/magento2/pull/19653)*. [GitHub-9155](https://github.com/magento/magento2/issues/9155)
+*  Magento now alerts you to the expected minimum quantity of product when you try to add a lesser product quantity to your shopping cart from the wishlist. *Fix submitted by [Khodu](https://github.com/khodu) in pull request [19653](https://github.com/magento/magento2/pull/19653)*. [GitHub-9155](https://github.com/magento/magento2/issues/9155)
 
 ### WYSIWYG
 
 <!--- ENGCOM-4664-->
 
-* You can now insert widgets that contain a WYSIWYG field into a form. Previously, widgets with a `WYSIWYG` parameter failed when inserting them into a WYSIWYG in a form. *Fix submitted by [James Dinsdale](https://github.com/molovo) in pull request [20174](https://github.com/magento/magento2/pull/20174)*. [GitHub-19742](https://github.com/magento/magento2/issues/19742)
+*  You can now insert widgets that contain a WYSIWYG field into a form. Previously, widgets with a `WYSIWYG` parameter failed when inserting them into a WYSIWYG in a form. *Fix submitted by [James Dinsdale](https://github.com/molovo) in pull request [20174](https://github.com/magento/magento2/pull/20174)*. [GitHub-19742](https://github.com/magento/magento2/issues/19742)
 
 ## Known issues
 
-* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
+*  **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future. This issue has been resolved with the Scope parameter for Async/Bulk API patch, which is now available. See [Patch for Magento Framework Message Queue and Store Scopes](https://community.magento.com/t5/Magento-DevBlog/Patch-for-Magento-Framework-Message-Queue-and-Store-Scopes/ba-p/135209) for a full discussion of this scope-related issue and patch contents.
 
-* **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions.
+*  **Issue**: The security enhancements that are part of Magento 2.3.2 require the installation of libsodium version 1.0.13 or higher. You will not be able to successfully install Magento Commerce 2.3.2 without first ensuring that your server runs  version 1.0.13 or higher. See [Libsodium releases](https://github.com/jedisct1/libsodium/releases) for a description of the available releases and installation instructions.
 
-* **Issue**: After upgrade to Magento 2.3.2 Product Flat Data index takes significantly more time to reindex. See [GitHub-23462](https://github.com/magento/magento2/issues/23462) for a full discussion of this issue.
+*  **Issue**: After upgrade to Magento 2.3.2 Product Flat Data index takes significantly more time to reindex. See [GitHub-23462](https://github.com/magento/magento2/issues/23462) for a full discussion of this issue.
 
 ## Community contributions
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### Partner contributions
 

--- a/guides/v2.3/release-notes/component-status.md
+++ b/guides/v2.3/release-notes/component-status.md
@@ -7,9 +7,9 @@ This page shows the status of each component for the Magento 2.3.x release and i
 
 Each status color indicates the severity and amount of 2.3-related issues for a particular component.
 
-- <span class="status red">Red</span> - The module has critical and blocking issues that make this module unstable.
-- <span class="status yellow">Yellow</span> - The module has some issues that may cause problems, but it is still functional.
-- <span class="status green">Green</span> - The module has no significant or outstanding issues.
+-  <span class="status red">Red</span> - The module has critical and blocking issues that make this module unstable.
+-  <span class="status yellow">Yellow</span> - The module has some issues that may cause problems, but it is still functional.
+-  <span class="status green">Green</span> - The module has no significant or outstanding issues.
 
 The issues used to generate the status of these components come from verified internal and GitHub reports for Magento 2.3.
 Issues that are not related to the 2.3 release are not part of this report.

--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -42,9 +42,9 @@ Look for the following highlights in this release:
 
 This release includes the following security enhancements:
 
-* PSD2 compliance to core payment methods
-* Fixes for 75 critical security issues
-* Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
+*  PSD2 compliance to core payment methods
+*  Fixes for 75 critical security issues
+*  Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
 
 #### Core payment methods integrations are now compliant with PSD2 regulations
 
@@ -52,16 +52,16 @@ The European Union recently revised the Payment Services Directive (PSD) regulat
 
 This release contains the following major PSD-related changes:
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**.
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**.
 
 <!--- MAGETWO-99739 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
 
 #### Security enhancements and fixes to core code
 
-* **75 security enhancements**  that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.3) have been ported to 2.2.10, 1.14.4.3, and 1.9.4.3, as appropriate.
+*  **75 security enhancements**  that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.3) have been ported to 2.2.10, 1.14.4.3, and 1.9.4.3, as appropriate.
 
 {:.bs-callout-info}
 Starting with the release of Magento Commerce 2.3.2, Magento will assign and publish indexed Common Vulnerabilities and Exposures (CVE) numbers with each security bug reported to us by external parties. This allows users of Magento Commerce to more easily identify unaddressed vulnerabilities in their deployment.
@@ -71,60 +71,60 @@ Starting with the release of Magento Commerce 2.3.2, Magento will assign and pub
 The following upgrades to core platform components boost platform security and support PCI compliance:
 
 <!--- MC-14862-->
-* Magento 2.3.3 now supports **PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21)**.
+*  Magento 2.3.3 now supports **PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21)**.
 
 <!--- MC-14863-->
-* Magento now supports **Varnish 6.2.0**.
+*  Magento now supports **Varnish 6.2.0**.
 
 <!--- MC-14912-->
-* Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
+*  Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
 
 ### Performance boosts
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-* Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-16046-->
-* Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
+*  Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
 
 ### Infrastructure improvements
 
 This release contains  enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer`, and `Ui`. Here are some additional core enhancements:
 
-* The WYSIWYG editor has been upgraded to TinyMCE v. 4.9.5​.
+*  The WYSIWYG editor has been upgraded to TinyMCE v. 4.9.5​.
 
 ### Merchant tool enhancements
 
 <!--- MC-15298-->
-* As part of our efforts to better understand the Admin user experience and improve product design, Magento is introducing the tracking of user actions and events on the Admin. After you upgrade to Magento 2.3.3, the first administrative user who logs into the Admin will be prompted to **Allow admin usage data collection**. If the user agrees to data collection, the data captured from Admin activity is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See Store Admin for more information.
+*  As part of our efforts to better understand the Admin user experience and improve product design, Magento is introducing the tracking of user actions and events on the Admin. After you upgrade to Magento 2.3.3, the first administrative user who logs into the Admin will be prompted to **Allow admin usage data collection**. If the user agrees to data collection, the data captured from Admin activity is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See Store Admin for more information.
 
 ### Page Builder
 
 Page Builder enhancements for this release include:
 
-* Upgrade to TinyMCE v4.9.5, which improves the experience of editing inline.
-* Admin users can now explicitly define product order.
-* Managing HTML content has been made easier for non-technical users.
+*  Upgrade to TinyMCE v4.9.5, which improves the experience of editing inline.
+*  Admin users can now explicitly define product order.
+*  Managing HTML content has been made easier for non-technical users.
 
 ### Inventory Management enhancements
 
-* Fixes to multiple  bugs. See [Inventory Management release notes](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html).
+*  Fixes to multiple  bugs. See [Inventory Management release notes](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html).
 
 ### GraphQL
 
 Expanded GraphQL functionality and improved coverage for PayPal payment integrations, gift cards, and store credit features. Added mutations and queries that support these tasks:
 
-* Process payments through PayPal Express checkout, Payflow Pro and Link Express Checkout, and other supported PayPal payment methods, Authorize.net, and Braintree
-* Redeem gift cards and convert to store credit balance for logged-in users
-* Update shopping carts for guest users to apply or remove gift cards and check card balance
-* Update shopping carts to apply or remove store credit and check store credit balance
-* Add configurable products to cart
+*  Process payments through PayPal Express checkout, Payflow Pro and Link Express Checkout, and other supported PayPal payment methods, Authorize.net, and Braintree
+*  Redeem gift cards and convert to store credit balance for logged-in users
+*  Update shopping carts for guest users to apply or remove gift cards and check card balance
+*  Update shopping carts to apply or remove store credit and check store credit balance
+*  Add configurable products to cart
 
 See [Release notes](https://devdocs.magento.com/guides/v2.3/graphql/release-notes.html) for a more detailed discussion of recent GraphQL bug fixes.
 
@@ -140,9 +140,9 @@ The Google Shopping ads Channel Marketplace extension is now available as a bund
 
 This release of Magento Shipping includes:
 
-* Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
+*  Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
 
-* Support for bundled products and prepackage options.
+*  Support for bundled products and prepackage options.
 
 See [Magento Shipping](https://docs.magento.com/m2/ee/user_guide/shipping/magento-shipping.html).
 
@@ -156,28 +156,28 @@ Amazon Pay is now compliant with the PSD2 directive for UK and Germany. See [Pay
 
 #### dotdigital
 
-* Improved product catalog sync for bundled and custom products.
+*  Improved product catalog sync for bundled and custom products.
 
-* Enhanced communications for abandoned cart.
+*  Enhanced communications for abandoned cart.
 
 #### Klarna
 
-* Merchants can now disable the sending of customer information.
+*  Merchants can now disable the sending of customer information.
 
-* New options now support B2B transactions in select markets.
+*  New options now support B2B transactions in select markets.
 
-* PayBright, a Canadian payment coverage option, is now supported.
+*  PayBright, a Canadian payment coverage option, is now supported.
 
 See [Klarna](https://docs.magento.com/m2/ee/user_guide/payment/klarna.html).
 
 #### Vertex
 
-* Added support for Vertex Flexible Fields. Vertex flexible fields allow merchants to send additional information to the tax engine, which  can then be used in Tax Assist Rules to refine a product’s applicable tax.
+*  Added support for Vertex Flexible Fields. Vertex flexible fields allow merchants to send additional information to the tax engine, which  can then be used in Tax Assist Rules to refine a product’s applicable tax.
 
-* Several attributes are provided by default, including administrator-created Customer attributes, Address attributes, and Product attributes. Documentation is provided in the module’s README file on how integrators can add additional options to these attributes.
+*  Several attributes are provided by default, including administrator-created Customer attributes, Address attributes, and Product attributes. Documentation is provided in the module’s README file on how integrators can add additional options to these attributes.
 
 <!--- BUNDLE-2151-->
-* You can now add custom fields to the Vertex connector.
+*  You can now add custom fields to the Vertex connector.
 
 #### Yotpo
 
@@ -194,1001 +194,1001 @@ We have fixed hundreds of issues in the Magento 2.3.3 core code.
 ### Installation, upgrade, deployment
 
 <!--- MAGETWO-99616-->
-* Magento font icons now load as expected when deployment optimization is implemented.
+*  Magento font icons now load as expected when deployment optimization is implemented.
 
 <!--- ENGCOM-5056-->
-* The short form versions of the `—lock-env`  and  `—lock-config`  `bin/magento config:set` options now work as expected. *Fix submitted by Satya Prakash in pull request [22720](https://github.com/magento/magento2/pull/22720)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
+*  The short form versions of the `—lock-env`  and  `—lock-config`  `bin/magento config:set` options now work as expected. *Fix submitted by Satya Prakash in pull request [22720](https://github.com/magento/magento2/pull/22720)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
 
 <!--- ENGCOM-5184-->
-* Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [22884](https://github.com/magento/magento2/pull/22884)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
+*  Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [22884](https://github.com/magento/magento2/pull/22884)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
 
 <!--- ENGCOM-5002-->
-* You can now use JSON to  set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [22513](https://github.com/magento/magento2/pull/22513)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
+*  You can now use JSON to  set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [22513](https://github.com/magento/magento2/pull/22513)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
 
 <!--- MC-18052 -->
-* The `\Magento\Setup\SplitDbTest::testUpgradeWithSplitDb` command no longer fails by default.
+*  The `\Magento\Setup\SplitDbTest::testUpgradeWithSplitDb` command no longer fails by default.
 
 <!--- MC-18697-->
-* PHP unit tests no longer fail by default when Magento is installed from Composer.
+*  PHP unit tests no longer fail by default when Magento is installed from Composer.
 
 <!--- ENGCOM-5241-->
-* Removed the obsolete `system.xml` file from the `app/code/Magento/Theme/etc` directory. *Fix submitted by Alexander Taranovsky in pull request [23140](https://github.com/magento/magento2/pull/23140)*. [GitHub-23138](https://github.com/magento/magento2/issues/23138)
+*  Removed the obsolete `system.xml` file from the `app/code/Magento/Theme/etc` directory. *Fix submitted by Alexander Taranovsky in pull request [23140](https://github.com/magento/magento2/pull/23140)*. [GitHub-23138](https://github.com/magento/magento2/issues/23138)
 
 <!--- ENGCOM-5187-->
-* Magento now displays a more informative message when a data patch cannot be applied due to an exception. *Fix submitted by Ash Smith in pull request [23046](https://github.com/magento/magento2/pull/23046)*. [GitHub-23045](https://github.com/magento/magento2/issues/23045)
+*  Magento now displays a more informative message when a data patch cannot be applied due to an exception. *Fix submitted by Ash Smith in pull request [23046](https://github.com/magento/magento2/pull/23046)*. [GitHub-23045](https://github.com/magento/magento2/issues/23045)
 
 <!--- ENGCOM-5264-->
-* The static content deployment progress bar now works as expected. *Fix submitted by Amit Vishvakarma in pull request [23216](https://github.com/magento/magento2/pull/23216)*. [GitHub-23213](https://github.com/magento/magento2/issues/23213)
+*  The static content deployment progress bar now works as expected. *Fix submitted by Amit Vishvakarma in pull request [23216](https://github.com/magento/magento2/pull/23216)*. [GitHub-23213](https://github.com/magento/magento2/issues/23213)
 
 <!--- ENGCOM-5395-->
-* The `setup:upgrade` command now throws an exception if the `app:config:import` command fails. *Fix submitted by Simon Frost in pull request [23310](https://github.com/magento/magento2/pull/23310)*.
+*  The `setup:upgrade` command now throws an exception if the `app:config:import` command fails. *Fix submitted by Simon Frost in pull request [23310](https://github.com/magento/magento2/pull/23310)*.
 
 <!--- ENGCOM-5441-->
-* Fields that have been disabled through configuration settings (**Admin** > **Stores** > **Configuration** > **General** > **General** > **Store Information**) can no longer be overwritten from the Admin. *Fix submitted by Rafael Kassner in pull request [22891](https://github.com/magento/magento2/pull/22891)*. [GitHub-22890](https://github.com/magento/magento2/issues/22890)
+*  Fields that have been disabled through configuration settings (**Admin** > **Stores** > **Configuration** > **General** > **General** > **Store Information**) can no longer be overwritten from the Admin. *Fix submitted by Rafael Kassner in pull request [22891](https://github.com/magento/magento2/pull/22891)*. [GitHub-22890](https://github.com/magento/magento2/issues/22890)
 
 <!--- ENGCOM-4644-->
-* The Magento installation process no longer checks for `dev php` extension dependencies from non-root `composer.json` files. *Fix submitted by Oleksii Lisovyi in pull request [22116](https://github.com/magento/magento2/pull/22116)*  [GitHub-21136](https://github.com/magento/magento2/issues/21136)
+*  The Magento installation process no longer checks for `dev php` extension dependencies from non-root `composer.json` files. *Fix submitted by Oleksii Lisovyi in pull request [22116](https://github.com/magento/magento2/pull/22116)*  [GitHub-21136](https://github.com/magento/magento2/issues/21136)
 
 <!--- ENGCOM-5098-->
-* Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22607](https://github.com/magento/magento2/pull/22607)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852)
+*  Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22607](https://github.com/magento/magento2/pull/22607)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852)
 
 <!--- ENGCOM-5500-->
-* Magento now runs an additional check when determining the password hashing algorithm to use for the libsodium library to see if it supports `argon2id`. The `bin/magento` command did not run successfully if the version of libsodium that you were running did not include `argon2id` support. *Fix submitted by Matei Stefanescu in pull request [23866](https://github.com/magento/magento2/pull/23866)*. [GitHub-23405](https://github.com/magento/magento2/issues/23405)
+*  Magento now runs an additional check when determining the password hashing algorithm to use for the libsodium library to see if it supports `argon2id`. The `bin/magento` command did not run successfully if the version of libsodium that you were running did not include `argon2id` support. *Fix submitted by Matei Stefanescu in pull request [23866](https://github.com/magento/magento2/pull/23866)*. [GitHub-23405](https://github.com/magento/magento2/issues/23405)
 
 ### AdminGWS
 
 <!--- MAGETWO-99801-->
-* An administrator with permission to a website now has access to the theme configuration for the website. Previously, administrators with website permission could update only the theme for the store view that is associated with a website, not the theme for the website itself.
+*  An administrator with permission to a website now has access to the theme configuration for the website. Previously, administrators with website permission could update only the theme for the store view that is associated with a website, not the theme for the website itself.
 
 <!--- MAGETWO-99062-->
-* Administrators with role scope set to **custom** can now view roles and user information.
+*  Administrators with role scope set to **custom** can now view roles and user information.
 
 <!--- MAGETWO-99711-->
-* Administrators with restricted access to Catalog and Content can now mass-update products. Previously, when an administrator tried to mass-update products, Magento did not update the products, and displayed an empty menu for **Stores**.
+*  Administrators with restricted access to Catalog and Content can now mass-update products. Previously, when an administrator tried to mass-update products, Magento did not update the products, and displayed an empty menu for **Stores**.
 
 <!--- MAGETWO-98256-->
-* An administrator with access rights to one website only in a multisite deployment can now mass-update products for that website only. Previously, this administrator could mass-update products on any website in the deployment.
+*  An administrator with access rights to one website only in a multisite deployment can now mass-update products for that website only. Previously, this administrator could mass-update products on any website in the deployment.
 
 <!--- MAGETWO-99411-->
-* An administrator with restricted privileges can now successfully create a catalog price rule. Previously, a restricted administrator could create a catalog price rule, but when they saved it, Magento displayed an error and did not generate any scheduled update to set the new price rule to inactive.
+*  An administrator with restricted privileges can now successfully create a catalog price rule. Previously, a restricted administrator could create a catalog price rule, but when they saved it, Magento displayed an error and did not generate any scheduled update to set the new price rule to inactive.
 
 <!--- MC-17879-->
-* Magento now applies the correct role scope for administrators in multisite deployments. (Post data is now saved in the session and re-rendered for a user only if the validation fails.)  Previously, when you had two administrative roles with different website scopes, and you viewed one role before saving it and opening the second role, the website scope attributed to the second role was incorrectly taken from the first role.
+*  Magento now applies the correct role scope for administrators in multisite deployments. (Post data is now saved in the session and re-rendered for a user only if the validation fails.)  Previously, when you had two administrative roles with different website scopes, and you viewed one role before saving it and opening the second role, the website scope attributed to the second role was incorrectly taken from the first role.
 
 <!--- MC-18148-->
-* Administrators with restricted permissions can now edit companies. Previously, even when the administrator had restricted but appropriate permission to edit companies, Magento displayed this error: `The requested company is not found`.
+*  Administrators with restricted permissions can now edit companies. Previously, even when the administrator had restricted but appropriate permission to edit companies, Magento displayed this error: `The requested company is not found`.
 
 <!--- MC-18070-->
-* Administrators that have access to all websites can now see a complete list of websites, stores, and store views no matter which edit operations  that a administrator with restricted access might perform. Additionally, any edit operation done by another admin user with limited access (for example, limited to one website) will not affect the fully privileged account. Previously, administrators with full access could not see the full list for all websites after an administrator with limited website-level access makes updates.
+*  Administrators that have access to all websites can now see a complete list of websites, stores, and store views no matter which edit operations  that a administrator with restricted access might perform. Additionally, any edit operation done by another admin user with limited access (for example, limited to one website) will not affect the fully privileged account. Previously, administrators with full access could not see the full list for all websites after an administrator with limited website-level access makes updates.
 
 <!--- MAGETWO-97867-->
-* We have improved the Admin login performance for users with limited permissions. Previously, the Admin login process for users with restricted access was significantly slower than it was for users with full administrative access.
+*  We have improved the Admin login performance for users with limited permissions. Previously, the Admin login process for users with restricted access was significantly slower than it was for users with full administrative access.
 
 ### Backend
 
 <!--- MC-17275-->
-* The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
+*  The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
 
 <!--- MC-17675-->
-* The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
+*  The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
 
 <!--- MC-17609-->
-* The store view drop-down menu no longer displays unnecessary symbols.
+*  The store view drop-down menu no longer displays unnecessary symbols.
 
 ### Bundle products
 
 <!--- MAGETWO-99371-->
-* You can now successfully check out bundle products using the Braintree payment method with the payment method set to **Authorize and Capture**.
+*  You can now successfully check out bundle products using the Braintree payment method with the payment method set to **Authorize and Capture**.
 
 <!--- ENGCOM-5360-->
-* Discount coupons now work as expected for bundle products that include both virtual and simple products when the **Ship Bundle Items** setting is set to **Separately**. *Fix submitted by Nikolay Sumrak in pull request [22987](https://github.com/magento/magento2/pull/22987)*.
+*  Discount coupons now work as expected for bundle products that include both virtual and simple products when the **Ship Bundle Items** setting is set to **Separately**. *Fix submitted by Nikolay Sumrak in pull request [22987](https://github.com/magento/magento2/pull/22987)*.
 
 ### B2B
 
 <!--- MAGETWO-99846-->
-* The `Magento_SharedCatalog::manage` role is now defined in the `acl.xml` file.
+*  The `Magento_SharedCatalog::manage` role is now defined in the `acl.xml` file.
 
 <!--- MAGETWO-99325-->
-* Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
+*  Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
 
 <!--- MAGETWO-91614-->
-* You can now successfully filter customer by status in the **Customers** > **All Customers** table. Previously, Magento threw an SQL error and displayed this message: `Something went wrong with processing the default view and we have restored the filter to its original state`.
+*  You can now successfully filter customer by status in the **Customers** > **All Customers** table. Previously, Magento threw an SQL error and displayed this message: `Something went wrong with processing the default view and we have restored the filter to its original state`.
 
 <!--- MAGETWO-99436-->
-* Magento now displays the category tree as expected when you choose **Set Pricing and Structure** on a new shared catalog.
+*  Magento now displays the category tree as expected when you choose **Set Pricing and Structure** on a new shared catalog.
 
 <!--- MAGETWO-99379-->
-* You can now create a new company account from the storefront in the same amount of time it takes to create an account from the Admin. Previously, it took much longer to create a new company account on the storefront.
+*  You can now create a new company account from the storefront in the same amount of time it takes to create an account from the Admin. Previously, it took much longer to create a new company account on the storefront.
 
 <!--- MAGETWO-94004-->
-* You can now successfully configure bundle, grouped, and configurable products from the Admin when shared catalogs are enabled and you have added products to an order by SKU.
+*  You can now successfully configure bundle, grouped, and configurable products from the Admin when shared catalogs are enabled and you have added products to an order by SKU.
 
 <!--- MAGETWO-98825-->
-* Magento now correctly applies category permissions depending upon the scope values you set. Previously, when you enabled shared catalogs for only one website in a multi-site deployment, Magento applied catalog permissions globally instead of to the designated website only.
+*  Magento now correctly applies category permissions depending upon the scope values you set. Previously, when you enabled shared catalogs for only one website in a multi-site deployment, Magento applied catalog permissions globally instead of to the designated website only.
 
 <!--- MC-16245-->
-* Export files now include all columns (including those not visible in the Company list) and their data. Previously, the `State/Province` columns of the exported CSV file were empty.
+*  Export files now include all columns (including those not visible in the Company list) and their data. Previously, the `State/Province` columns of the exported CSV file were empty.
 
 <!--- MC-15524-->
-* Magento no longer displays the **Created/Last Updated from-to** fields for quotes that are not associated with the administrator that is currently logged in.
+*  Magento no longer displays the **Created/Last Updated from-to** fields for quotes that are not associated with the administrator that is currently logged in.
 
 <!--- MC-17642-->
-* Magento now displays an informative message when a customer adds an empty SKU to their shopping cart with Quick Order. Previously, users could not navigate to another page during the process, and Magento did not display a message to the user.
+*  Magento now displays an informative message when a customer adds an empty SKU to their shopping cart with Quick Order. Previously, users could not navigate to another page during the process, and Magento did not display a message to the user.
 
 <!--- MC-18481-->
-* Magento now correctly updates SKU quantities when you use Quick Order and manually enter a SKU in the **Enter Multiple SKUs** field when using Internet Explorer 11.x.
+*  Magento now correctly updates SKU quantities when you use Quick Order and manually enter a SKU in the **Enter Multiple SKUs** field when using Internet Explorer 11.x.
 
 <!--- MC-18565-->
-* Magento now correctly calculates the total product quantity when you enter multiple SKU values in Quick Order.
+*  Magento now correctly calculates the total product quantity when you enter multiple SKU values in Quick Order.
 
 <!--- MAGETWO-97316-->
-* The behavior of the Catalog page Requisition list menu has been corrected
+*  The behavior of the Catalog page Requisition list menu has been corrected
 
 <!--- MAGETWO-99871-->
-* Magento now issues a single request to the server when you change the shipping address for an order to a non-default address. Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
+*  Magento now issues a single request to the server when you change the shipping address for an order to a non-default address. Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
 
 <!--- MAGETWO-99368-->
-* Non-administrative users who have been granted access privileges to catalogs and shared catalogs now also have access to the menu that permits them to manage these catalogs. Previously, these non-Admin users had permission to access the shared catalog, but not the menu that would permit them to manage the shared catalog.
+*  Non-administrative users who have been granted access privileges to catalogs and shared catalogs now also have access to the menu that permits them to manage these catalogs. Previously, these non-Admin users had permission to access the shared catalog, but not the menu that would permit them to manage the shared catalog.
 
 <!--- MAGETWO-99123-->
-* Guests can now access available product options for a configurable product when one of its simple product options is out of stock but the configurable product is listed as in-stock in the shared catalog. Previously, under these circumstances, the options drop-down menu for the configurable product was empty, which prevented guests from ordering available options.
+*  Guests can now access available product options for a configurable product when one of its simple product options is out of stock but the configurable product is listed as in-stock in the shared catalog. Previously, under these circumstances, the options drop-down menu for the configurable product was empty, which prevented guests from ordering available options.
 
 <!--- MAGETWO-99302-->
-* The State/Province drop-down menu available from the Admin Edit Customer form no longer lists duplicate entries for states and provinces.
+*  The State/Province drop-down menu available from the Admin Edit Customer form no longer lists duplicate entries for states and provinces.
 
 <!--- MAGETWO-71835-->
-* The Shared Catalog column tooltip on the Admin product list now sorts values alphabetically
+*  The Shared Catalog column tooltip on the Admin product list now sorts values alphabetically
 
 <!--- MAGETWO-71309-->
-* Magento no longer highlights quote totals on draft quotes.
+*  Magento no longer highlights quote totals on draft quotes.
 
 <!--- MC-17276-->
-* Magento now recalculates cart subtotals as expected when one of the ordered products that belongs to a shared catalog  is disabled from the Admin. Previously, when you reloaded the cart after one of its products had been disabled, Magento reloaded the cart page with this exception: `Exception #0 (Magento\Framework\Exception\NoSuchEntityException): The product that was requested doesn't exist. Verify the product and try again`.
+*  Magento now recalculates cart subtotals as expected when one of the ordered products that belongs to a shared catalog  is disabled from the Admin. Previously, when you reloaded the cart after one of its products had been disabled, Magento reloaded the cart page with this exception: `Exception #0 (Magento\Framework\Exception\NoSuchEntityException): The product that was requested doesn't exist. Verify the product and try again`.
 
 <!--- MC-15900-->
-* Magento now successfully saves customer segments after you have deleted a customer from the Admin. Previously, Magento threw an error and displayed this message: `We can't save the segment right now`.
+*  Magento now successfully saves customer segments after you have deleted a customer from the Admin. Previously, Magento threw an error and displayed this message: `We can't save the segment right now`.
 
 ### Cache
 
 <!--- MC-14863-->
-* Varnish cache support has been upgraded for compatibility with version 6.2.0.
+*  Varnish cache support has been upgraded for compatibility with version 6.2.0.
 
 <!--- MAGETWO-98650-->
-* Full-page cache no longer clears out the checkout session data on uncached pages when the `Magento_Persistent` module is disabled. [GitHub-21614](https://github.com/magento/magento2/issues/21614)
+*  Full-page cache no longer clears out the checkout session data on uncached pages when the `Magento_Persistent` module is disabled. [GitHub-21614](https://github.com/magento/magento2/issues/21614)
 
 <!--- MAGETWO-54438-->
-* Magento now displays simple products on the storefront after the cancellation of an order that contains the bundled simple product. Previously, products did not appear on the storefront after an order containing the bundle product to which the simple product belongs was canceled.
+*  Magento now displays simple products on the storefront after the cancellation of an order that contains the bundled simple product. Previously, products did not appear on the storefront after an order containing the bundle product to which the simple product belongs was canceled.
 
 <!--- ENGCOM-5143-->
-* The Varnish health check no longer fails to the presence of `id_prefix` in `env.php`. Previously, Varnish returned a `503 Backend fetch failed` error. *Fix submitted by Nazar Klovanych in pull request [22307](https://github.com/magento/magento2/pull/22307)*. [GitHub-22143](https://github.com/magento/magento2/issues/22143)
+*  The Varnish health check no longer fails to the presence of `id_prefix` in `env.php`. Previously, Varnish returned a `503 Backend fetch failed` error. *Fix submitted by Nazar Klovanych in pull request [22307](https://github.com/magento/magento2/pull/22307)*. [GitHub-22143](https://github.com/magento/magento2/issues/22143)
 
 ### Cart and checkout
 
 <!--- MAGETWO-97317-->
-* The REST calls for adding an item to a cart (`POST V1/guest-carts/:cartId/items` and `POST V1/guest-carts/:cartId/items`) now include the product price when a call returns the product from an already populated cart. Previously, the item price was not returned if that cart had been emptied before the call was made.
+*  The REST calls for adding an item to a cart (`POST V1/guest-carts/:cartId/items` and `POST V1/guest-carts/:cartId/items`) now include the product price when a call returns the product from an already populated cart. Previously, the item price was not returned if that cart had been emptied before the call was made.
 
 <!--- MAGETWO-99075-->
-* Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
+*  Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
 
 <!--- MAGETWO-48570-->
-* Products added to a shopping cart through REST now display correct product prices. Previously, the shopping cart displayed product prices of zero. [GitHub-2991](https://github.com/magento/magento2/issues/2991)
+*  Products added to a shopping cart through REST now display correct product prices. Previously, the shopping cart displayed product prices of zero. [GitHub-2991](https://github.com/magento/magento2/issues/2991)
 
 <!--- MC-17755-->
-* Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order.
+*  Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order.
 
 <!--- MAGETWO-99370-->
-* You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
+*  You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
 
 <!--- ENGCOM-4126-->
-* Administrators with appropriate permissions can now view the contents of a cart for a registered customer from the Admin customer edit interface. *Fix submitted by Rav in pull request [20918](https://github.com/magento/magento2/pull/20918)*.
+*  Administrators with appropriate permissions can now view the contents of a cart for a registered customer from the Admin customer edit interface. *Fix submitted by Rav in pull request [20918](https://github.com/magento/magento2/pull/20918)*.
 
 <!--- ENGCOM-5071-->
-* Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Karan Shah in pull request [22387](https://github.com/magento/magento2/pull/22387)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
+*  Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Karan Shah in pull request [22387](https://github.com/magento/magento2/pull/22387)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
 
 <!--- MC-17808-->
-* The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
+*  The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
 
 <!--- MC-18281-->
-* The checkout order summary now displays the correct number of ordered items.
+*  The checkout order summary now displays the correct number of ordered items.
 
 <!--- ENGCOM-5357-->
-* The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Geeta Modi in pull request [23394](https://github.com/magento/magento2/pull/23394)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
+*  The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Geeta Modi in pull request [23394](https://github.com/magento/magento2/pull/23394)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
 
 <!--- ENGCOM-5026-->
-* Magento no longer throws an array-to-string conversion error when a customer changes the country setting from one-page checkout. Instead, shipping method, tax values, and payment providers now change according to country selection. Previously, Magento displayed an error about array-to-string conversion. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-12612](https://github.com/magento/magento2/issues/12612)
+*  Magento no longer throws an array-to-string conversion error when a customer changes the country setting from one-page checkout. Instead, shipping method, tax values, and payment providers now change according to country selection. Previously, Magento displayed an error about array-to-string conversion. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-12612](https://github.com/magento/magento2/issues/12612)
 
 <!--- ENGCOM-5026-->
-* Magento now validates the VAT number as expected during checkout when the customer address region field is empty. Previously, Magento threw an informative error: `Internal Error. Details are available in Magento log file` if the `regionId` was not set. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-22556](https://github.com/magento/magento2/issues/22556),
+*  Magento now validates the VAT number as expected during checkout when the customer address region field is empty. Previously, Magento threw an informative error: `Internal Error. Details are available in Magento log file` if the `regionId` was not set. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-22556](https://github.com/magento/magento2/issues/22556),
 
 <!--- ENGCOM-5443-->
-* Magento now creates an invoice for an order that has a zero subtotal when **Automatically Invoice All Items** is set to **yes**. *Fix submitted by Eden Duong in pull request [23688](https://github.com/magento/magento2/pull/23688)*. [GitHub-23211](https://github.com/magento/magento2/issues/23211)
+*  Magento now creates an invoice for an order that has a zero subtotal when **Automatically Invoice All Items** is set to **yes**. *Fix submitted by Eden Duong in pull request [23688](https://github.com/magento/magento2/pull/23688)*. [GitHub-23211](https://github.com/magento/magento2/issues/23211)
 
 ### Cart Price rules
 
 <!--- ENGCOM-5086-->
-* Coupon codes now work as expected. Previously, coupons sent for specific dates in a cart price rule were not applied. *Fix submitted by Adarsh Shukla in pull request [22718](https://github.com/magento/magento2/pull/22718)*. [GitHub-18183](https://github.com/magento/magento2/issues/18183)
+*  Coupon codes now work as expected. Previously, coupons sent for specific dates in a cart price rule were not applied. *Fix submitted by Adarsh Shukla in pull request [22718](https://github.com/magento/magento2/pull/22718)*. [GitHub-18183](https://github.com/magento/magento2/issues/18183)
 
 ### Catalog
 
 <!--- MAGETWO-99890-->
-* You can now use the Select all option when creating a mass-update action when the total number of products exceeds the number of displayed products per page. Previously, Magento only selected and applied mass-update actions to the number of products that were displayed per page. *Fix submitted by Shikha Mishra in pull request [22704](https://github.com/magento/magento2/pull/22704)*. [GitHub-22004](https://github.com/magento/magento2/issues/22004)
+*  You can now use the Select all option when creating a mass-update action when the total number of products exceeds the number of displayed products per page. Previously, Magento only selected and applied mass-update actions to the number of products that were displayed per page. *Fix submitted by Shikha Mishra in pull request [22704](https://github.com/magento/magento2/pull/22704)*. [GitHub-22004](https://github.com/magento/magento2/issues/22004)
 
 <!--- MAGETWO-63599-->
-* Magento no longer throws an error when you run the `php bin/magento catalog:images:resize` command on a  deployment that contains images with a zero byte size. Instead, the operation skips the offending file and updates the log file to indicate where the problematic file resides. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
+*  Magento no longer throws an error when you run the `php bin/magento catalog:images:resize` command on a  deployment that contains images with a zero byte size. Instead, the operation skips the offending file and updates the log file to indicate where the problematic file resides. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
 
 <!--- MAGETWO-98708-->
-* You can now successfully clone a product with a linked product. Previously, cloning  failed and Magento displayed this error:  `The linked products data is invalid. Verify the data and try again`.
+*  You can now successfully clone a product with a linked product. Previously, cloning  failed and Magento displayed this error:  `The linked products data is invalid. Verify the data and try again`.
 
 <!--- MC-17706 -->
-* A product that belongs to a category where the permissions do not allow adding it to cart can now be added to the cart from a different category. Previously, you could not add a product to the cart if one of the categories to which it belongs does not permit adding it the cart.
+*  A product that belongs to a category where the permissions do not allow adding it to cart can now be added to the cart from a different category. Previously, you could not add a product to the cart if one of the categories to which it belongs does not permit adding it the cart.
 
 <!--- MAGETWO-98804 -->
-* Magento now displays the correct currency in the the Admin **Catalog** > **Products**  list  in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
+*  Magento now displays the correct currency in the the Admin **Catalog** > **Products**  list  in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
 
 <!--- MAGETWO-69893-->
-* Magento disables the **New Category** button on the Product page if the user is an administrator with restricted permissions for managing categories. Previously, the button was active, and Magento threw a 403 error if the restricted user clicked the button to create a category.
+*  Magento disables the **New Category** button on the Product page if the user is an administrator with restricted permissions for managing categories. Previously, the button was active, and Magento threw a 403 error if the restricted user clicked the button to create a category.
 
 <!--- MC-17640-->
-* The Items Ordered table (**Admin** > **Sales** > **Orders**) no longer displays bundle option discount amounts with tags.
+*  The Items Ordered table (**Admin** > **Sales** > **Orders**) no longer displays bundle option discount amounts with tags.
 
 <!--- MC-17218-->
-* Magento now creates resized images for all products for which images exist and lists the errors when you run the `php bin/catalog:image:resize` command. Previously, execution halted at the first missing image.
+*  Magento now creates resized images for all products for which images exist and lists the errors when you run the `php bin/catalog:image:resize` command. Previously, execution halted at the first missing image.
 
 <!--- MC-17387-->
-* You can now add a bundle product from a wishlist to your shopping cart. Previously, Magento threw a fatal error.
+*  You can now add a bundle product from a wishlist to your shopping cart. Previously, Magento threw a fatal error.
 
 <!--- MAGETWO-92712-->
-* The `\Magento\Catalog\Model\CategoryList::getList` operation now returns a sorted list of categories as expected.
+*  The `\Magento\Catalog\Model\CategoryList::getList` operation now returns a sorted list of categories as expected.
 
 <!--- MAGETWO-70599-->
-* The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
+*  The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
 
 <!--- MAGETWO-64923-->
-* A duplicated product that has been set to **Is in Stock** and **Enabled** now appears as expected on the storefront.
+*  A duplicated product that has been set to **Is in Stock** and **Enabled** now appears as expected on the storefront.
 
 <!--- MAGETWO-59400-->
-* An invalid join condition in Product Flat Indexer has been refactored, and product relations are now correctly joined by the `entity_id` field. Previously, products were joined incorrectly during catalog re-indexing when staging was enabled.
+*  An invalid join condition in Product Flat Indexer has been refactored, and product relations are now correctly joined by the `entity_id` field. Previously, products were joined incorrectly during catalog re-indexing when staging was enabled.
 
 <!--- MAGETWO-99587-->
-* Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
+*  Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
 
 <!--- MAGETWO-59978-->
-* Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
+*  Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
 
 <!--- MAGETWO-59431-->
-* Sample data now scales correctly when resized in mobile view.
+*  Sample data now scales correctly when resized in mobile view.
 
 <!--- ENGCOM-5371-->
-* Customers no longer receive product alerts after they have unsubscribed from product alerts. Previously, the product alert was not removed from the `product_alert_stock` table as expected, but Magento still displayed this message on the storefront: **You will no longer receive stock alerts for this product**. *Fix submitted by yuriichayka in pull request [23459](https://github.com/magento/magento2/pull/23459)*. [GitHub-22814](https://github.com/magento/magento2/issues/22814)
+*  Customers no longer receive product alerts after they have unsubscribed from product alerts. Previously, the product alert was not removed from the `product_alert_stock` table as expected, but Magento still displayed this message on the storefront: **You will no longer receive stock alerts for this product**. *Fix submitted by yuriichayka in pull request [23459](https://github.com/magento/magento2/pull/23459)*. [GitHub-22814](https://github.com/magento/magento2/issues/22814)
 
 <!--- ENGCOM-5387-->
-* Magento no longer automatically assigns a storeID to a saved product that is not assigned to a store. *Fix submitted by manishgoswamij in pull request [23500](https://github.com/magento/magento2/pull/23500)*. [GitHub-23383](https://github.com/magento/magento2/issues/23383), [GitHub-23500](https://github.com/magento/magento2/issues/23500)
+*  Magento no longer automatically assigns a storeID to a saved product that is not assigned to a store. *Fix submitted by manishgoswamij in pull request [23500](https://github.com/magento/magento2/pull/23500)*. [GitHub-23383](https://github.com/magento/magento2/issues/23383), [GitHub-23500](https://github.com/magento/magento2/issues/23500)
 
 <!--- ENGCOM-5410-->
-* Corrected misspellings in the `lib/web/css/docs/source/_actions-toolbar.less` and  `lib/web/css/docs/source/_layout.less` files. *Fix submitted by Prashant Sharma in pull request [22624](https://github.com/magento/magento2/pull/22624)*.
+*  Corrected misspellings in the `lib/web/css/docs/source/_actions-toolbar.less` and  `lib/web/css/docs/source/_layout.less` files. *Fix submitted by Prashant Sharma in pull request [22624](https://github.com/magento/magento2/pull/22624)*.
 
 <!--- ENGCOM-5067-->
-* Magento now displays the currency code as expected in the Cost column of the Admin catalog product list. *Fix submitted by Vlad Veselov in pull request [22739](https://github.com/magento/magento2/pull/22739)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+*  Magento now displays the currency code as expected in the Cost column of the Admin catalog product list. *Fix submitted by Vlad Veselov in pull request [22739](https://github.com/magento/magento2/pull/22739)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
 <!--- MAGETWO-99489-->
-* The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
+*  The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
 
 <!--- MC-5777-->
-* Catalog rules are now applied as expected in deployments that are running Magento Commerce. Previously, there was a discrepancy between the time zone in which catalog rule staging was set (UTC timezone) and the Magento timezone, which is the time zone that the storefront uses.
+*  Catalog rules are now applied as expected in deployments that are running Magento Commerce. Previously, there was a discrepancy between the time zone in which catalog rule staging was set (UTC timezone) and the Magento timezone, which is the time zone that the storefront uses.
 
 <!--- MC-17020-->
-* We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
+*  We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
 
 <!--- MC-10966-->
-* Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
+*  Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
 
 <!--- MC-17765-->
-* Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
+*  Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
 
 <!--- ENGCOM-5063-->
-* Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22724](https://github.com/magento/magento2/pull/22724)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
+*  Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22724](https://github.com/magento/magento2/pull/22724)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
 
 <!--- ENGCOM-5419-->
-* The catalog products filter now filters on enabled or disabled status as expected. Previously, the SQL generated by the `Magento\Catalog\Ui\DataProvider\Product\ProductCollection` class omitted the `attribute_id` condition, which resulted in any attribute of the same type (`int` or `varchar`, for example) matching the query if the values were the same. *Fix submitted by Matti Vapa in pull request [23444](https://github.com/magento/magento2/pull/23444)*. [GitHub-23435](https://github.com/magento/magento2/issues/23435)
+*  The catalog products filter now filters on enabled or disabled status as expected. Previously, the SQL generated by the `Magento\Catalog\Ui\DataProvider\Product\ProductCollection` class omitted the `attribute_id` condition, which resulted in any attribute of the same type (`int` or `varchar`, for example) matching the query if the values were the same. *Fix submitted by Matti Vapa in pull request [23444](https://github.com/magento/magento2/pull/23444)*. [GitHub-23435](https://github.com/magento/magento2/issues/23435)
 
 <!--- ENGCOM-5134-->
-* `ProductRepository` now updates and saves existing products with changed SKUs as expected. Previously, Magento threw an error, and you were not able to save the product. *Fix submitted by Pavel Bystritsky in pull request [22933](https://github.com/magento/magento2/pull/22933)*. [GitHub-22870](https://github.com/magento/magento2/issues/22870)
+*  `ProductRepository` now updates and saves existing products with changed SKUs as expected. Previously, Magento threw an error, and you were not able to save the product. *Fix submitted by Pavel Bystritsky in pull request [22933](https://github.com/magento/magento2/pull/22933)*. [GitHub-22870](https://github.com/magento/magento2/issues/22870)
 
 <!--- ENGCOM-5439-->
-* You can now change the position of the last two related products in a list of related products that spans multiple pages. Previously, drag and drop functionality allowed you to change only the position of products  on the current page. *Fix submitted by Maxim Tkachuk in pull request [22984](https://github.com/magento/magento2/pull/22984)*. [GitHub-14071](https://github.com/magento/magento2/issues/14071)
+*  You can now change the position of the last two related products in a list of related products that spans multiple pages. Previously, drag and drop functionality allowed you to change only the position of products  on the current page. *Fix submitted by Maxim Tkachuk in pull request [22984](https://github.com/magento/magento2/pull/22984)*. [GitHub-14071](https://github.com/magento/magento2/issues/14071)
 
 <!--- ENGCOM-4591-->
-* The **Select from gallery** button on the category edit page now works as expected. Previously, the image was not saved, and Magento did not display an image in the image preview. *Fix submitted by Bartłomiej Szubert in pull request [21131](https://github.com/magento/magento2/pull/21131)*. [GitHub-19872](https://github.com/magento/magento2/issues/19872), [GitHub-22092](https://github.com/magento/magento2/issues/22092)
+*  The **Select from gallery** button on the category edit page now works as expected. Previously, the image was not saved, and Magento did not display an image in the image preview. *Fix submitted by Bartłomiej Szubert in pull request [21131](https://github.com/magento/magento2/pull/21131)*. [GitHub-19872](https://github.com/magento/magento2/issues/19872), [GitHub-22092](https://github.com/magento/magento2/issues/22092)
 
 ### CatalogInventory
 
 <!--- MAGETWO-99941-->
-* The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
+*  The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
 
 <!--- MAGETWO-99585-->
-* Magento now correctly updates the `qty_backordered` value in the  `sales_order_item` table after you create an order that contains a backordered item.
+*  Magento now correctly updates the `qty_backordered` value in the  `sales_order_item` table after you create an order that contains a backordered item.
 
 <!--- MC-17513-->
-* Stock status records for all products are now added as expected  to the `cataloginventory_stock_status` table after a partial re-indexing.
+*  Stock status records for all products are now added as expected  to the `cataloginventory_stock_status` table after a partial re-indexing.
 
 ### Catalog rule
 
 <!--- MAGETWO-99592-->
-* You can now use Visual Merchandiser to drag and drop products without losing product information. Previously, all discounts for products in the affected category were lost after dragging and dropping products
+*  You can now use Visual Merchandiser to drag and drop products without losing product information. Previously, all discounts for products in the affected category were lost after dragging and dropping products
 
 <!--- MAGETWO-99873-->
-* Coupon expiration dates now match the end date of the staging update the coupons are assigned to.
+*  Coupon expiration dates now match the end date of the staging update the coupons are assigned to.
 
 <!--- MC-17460-->
-* Coupon expiration dates and times now match the `end_date` value set in the staging update. Previously, coupon expiration dates could differ from the expiration date set by the sales rule.
+*  Coupon expiration dates and times now match the `end_date` value set in the staging update. Previously, coupon expiration dates could differ from the expiration date set by the sales rule.
 
 <!--- MC-18254-->
-* The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how  catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento timezone.)
+*  The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how  catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento timezone.)
 
 ### Cleanup and simple code refactoring
 
 <!--- ENGCOM-3817-->
-* Corrected poor positioning  of the Shop By menu on product pages in mobile view on an iPhone 5. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
+*  Corrected poor positioning  of the Shop By menu on product pages in mobile view on an iPhone 5. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
 
 <!--- ENGCOM-4840-->
-* Corrected misalignment of Wishlist and Compare icons on the product page. *Fix submitted by sanjaychouhan-webkul in pull request [22532](https://github.com/magento/magento2/pull/22532)*. [GitHub-22527](https://github.com/magento/magento2/issues/22527)
+*  Corrected misalignment of Wishlist and Compare icons on the product page. *Fix submitted by sanjaychouhan-webkul in pull request [22532](https://github.com/magento/magento2/pull/22532)*. [GitHub-22527](https://github.com/magento/magento2/issues/22527)
 
 <!--- ENGCOM-4788-->
-* Store view-specific labels are no longer truncated in the left navigation menu of the Cart Price Rule Store View Specific Labels window (**Marketing** > **Cart Price rule** > **Labels** ). *Fix submitted by Sudhanshu Bajaj in pull request [22423](https://github.com/magento/magento2/pull/22423)*. [GitHub-22406](https://github.com/magento/magento2/issues/22406)
+*  Store view-specific labels are no longer truncated in the left navigation menu of the Cart Price Rule Store View Specific Labels window (**Marketing** > **Cart Price rule** > **Labels** ). *Fix submitted by Sudhanshu Bajaj in pull request [22423](https://github.com/magento/magento2/pull/22423)*. [GitHub-22406](https://github.com/magento/magento2/issues/22406)
 
 <!--- ENGCOM-5059-->
-* Added missing header to the Customer Sales Order table and corrected multiple typos. *Fix submitted by Vishal Sutariya in pull request [22643](https://github.com/magento/magento2/pull/22643)*. [GitHub-22641](https://github.com/magento/magento2/issues/22641)
+*  Added missing header to the Customer Sales Order table and corrected multiple typos. *Fix submitted by Vishal Sutariya in pull request [22643](https://github.com/magento/magento2/pull/22643)*. [GitHub-22641](https://github.com/magento/magento2/issues/22641)
 
 <!--- ENGCOM-5054-->
-* Improved awkward formatting of the customer account create page in mobile view. *Fix submitted by Arvinda Kumar in pull request [22656](https://github.com/magento/magento2/pull/22656)*. [GitHub-22647](https://github.com/magento/magento2/issues/22647)
+*  Improved awkward formatting of the customer account create page in mobile view. *Fix submitted by Arvinda Kumar in pull request [22656](https://github.com/magento/magento2/pull/22656)*. [GitHub-22647](https://github.com/magento/magento2/issues/22647)
 
 <!--- ENGCOM-5061-->
-* The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Surabhi Srivastava in pull request [22655](https://github.com/magento/magento2/pull/22655)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
+*  The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Surabhi Srivastava in pull request [22655](https://github.com/magento/magento2/pull/22655)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
 
 <!--- ENGCOM-5281-->
-* Corrected typo in CONTRIBUTING.md. *Fix submitted by Raul E Watson in pull request [23244](https://github.com/magento/magento2/pull/23244)*.
+*  Corrected typo in CONTRIBUTING.md. *Fix submitted by Raul E Watson in pull request [23244](https://github.com/magento/magento2/pull/23244)*.
 
 <!--- ENGCOM-5408-->
-* Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Amjad M in pull request [23226](https://github.com/magento/magento2/pull/23226)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
+*  Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Amjad M in pull request [23226](https://github.com/magento/magento2/pull/23226)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
 
 <!--- ENGCOM-5344-->
-* The asterisk sign indicating a required field is now consistently positioned throughout the Admin. *Fix submitted by sanjaychouhan-webkul in pull request [22800](https://github.com/magento/magento2/pull/22800)*. [GitHub-22638](https://github.com/magento/magento2/issues/22638)
+*  The asterisk sign indicating a required field is now consistently positioned throughout the Admin. *Fix submitted by sanjaychouhan-webkul in pull request [22800](https://github.com/magento/magento2/pull/22800)*. [GitHub-22638](https://github.com/magento/magento2/issues/22638)
 
 <!--- ENGCOM-5326-->
-* Corrected misspelling in the `app/code/Magento/Ui/Block/Wrapper.php` file. *Fix submitted by Ravi Chandra in pull request [23335](https://github.com/magento/magento2/pull/23335)*.
+*  Corrected misspelling in the `app/code/Magento/Ui/Block/Wrapper.php` file. *Fix submitted by Ravi Chandra in pull request [23335](https://github.com/magento/magento2/pull/23335)*.
 
 <!--- ENGCOM-5287-->
-* Corrected typo in the tooltip toggle selector. *Fix submitted by Karla Saaremäe in pull request [23248](https://github.com/magento/magento2/pull/23248)*.
+*  Corrected typo in the tooltip toggle selector. *Fix submitted by Karla Saaremäe in pull request [23248](https://github.com/magento/magento2/pull/23248)*.
 
 <!--- ENGCOM-5068-->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by sanjaychouhan-webkul in pull request [22742](https://github.com/magento/magento2/pull/22742)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by sanjaychouhan-webkul in pull request [22742](https://github.com/magento/magento2/pull/22742)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!--- ENGCOM-5089-->
-* Corrected scrolling behavior on Product page. Previously, after you clicked on a product reviews count on a product page, you had to scroll in order to see customer reviews. *Fix submitted by sanjaychouhan-webkul in pull request [22794](https://github.com/magento/magento2/pull/22794)*. [GitHub-21558](https://github.com/magento/magento2/issues/21558)
+*  Corrected scrolling behavior on Product page. Previously, after you clicked on a product reviews count on a product page, you had to scroll in order to see customer reviews. *Fix submitted by sanjaychouhan-webkul in pull request [22794](https://github.com/magento/magento2/pull/22794)*. [GitHub-21558](https://github.com/magento/magento2/issues/21558)
 
 <!--- ENGCOM-5126-->
-* Magento now displays the  cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by sanjaychouhan-webkul in pull request [22795](https://github.com/magento/magento2/pull/22795)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the  cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by sanjaychouhan-webkul in pull request [22795](https://github.com/magento/magento2/pull/22795)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!--- ENGCOM-5125-->
-* Refactored the page title of the billing agreements page. *Fix submitted by Amit Vishvakarma in pull request [22876](https://github.com/magento/magento2/pull/22876)*. [GitHub-22875](https://github.com/magento/magento2/issues/22875)
+*  Refactored the page title of the billing agreements page. *Fix submitted by Amit Vishvakarma in pull request [22876](https://github.com/magento/magento2/pull/22876)*. [GitHub-22875](https://github.com/magento/magento2/issues/22875)
 
 <!--- ENGCOM-3817-->
-* The Shop By Menu no longer overlays the **Sort By** label on the product listing page. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
+*  The Shop By Menu no longer overlays the **Sort By** label on the product listing page. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
 
 <!--- ENGCOM-5124-->
-* Adjusted the position of the store-view label on **Admin** > **Content** > **Design** > **Configuration** > **Theme**. *Fix submitted by Kajal Solanki in pull request [22926](https://github.com/magento/magento2/pull/22926)*. [GitHub-22924](https://github.com/magento/magento2/issues/22924)
+*  Adjusted the position of the store-view label on **Admin** > **Content** > **Design** > **Configuration** > **Theme**. *Fix submitted by Kajal Solanki in pull request [22926](https://github.com/magento/magento2/pull/22926)*. [GitHub-22924](https://github.com/magento/magento2/issues/22924)
 
 <!--- ENGCOM-5376-->
-* Fixed spacing issue on **Admin** > **System** > **Import**. *Fix submitted by Kajal Solanki in pull request [21128](https://github.com/magento/magento2/pull/21128)*.
+*  Fixed spacing issue on **Admin** > **System** > **Import**. *Fix submitted by Kajal Solanki in pull request [21128](https://github.com/magento/magento2/pull/21128)*.
 
 <!--- ENGCOM-5340-->
-* Fixed misspelling in the `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` file. *Fix submitted by Ravi Chandra in pull request [23366](https://github.com/magento/magento2/pull/23366)*.
+*  Fixed misspelling in the `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` file. *Fix submitted by Ravi Chandra in pull request [23366](https://github.com/magento/magento2/pull/23366)*.
 
 <!--- ENGCOM-5342-->
-* Removed unnecessary `<span>` element from the **Test connection** button. *Fix submitted by Shankar Konar in pull request [23367](https://github.com/magento/magento2/pull/23367)*.
+*  Removed unnecessary `<span>` element from the **Test connection** button. *Fix submitted by Shankar Konar in pull request [23367](https://github.com/magento/magento2/pull/23367)*.
 
 <!--- ENGCOM-5291-->
-* The `lib/internal/Magento/Framework/Mview/View.php` file has been refactored to improve readability. *Fix submitted by Lukasz Bajsarowicz in pull request [23240](https://github.com/magento/magento2/pull/23240)*.
+*  The `lib/internal/Magento/Framework/Mview/View.php` file has been refactored to improve readability. *Fix submitted by Lukasz Bajsarowicz in pull request [23240](https://github.com/magento/magento2/pull/23240)*.
 
 ### CMS content
 
 <!--- MAGETWO-99695-->
-* Corrected alignment of the search suggestion panel with the **Advance reporting**  button. *Fix submitted by webkul-ajaysaini in pull request [22520](https://github.com/magento/magento2/pull/22520)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting**  button. *Fix submitted by webkul-ajaysaini in pull request [22520](https://github.com/magento/magento2/pull/22520)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!--- MC-5527-->
-* You can now remove text that is placed adjacent to a TinyMCE4 widget.
+*  You can now remove text that is placed adjacent to a TinyMCE4 widget.
 
 ### Configurable products
 
 <!--- MAGETWO-99443-->
-* Magento now validates the uniqueness of attribute option values during product creation. Previously, Magento did not save the product and displayed this error: `The value of Admin must be unique`.
+*  Magento now validates the uniqueness of attribute option values during product creation. Previously, Magento did not save the product and displayed this error: `The value of Admin must be unique`.
 
 <!--- MAGETWO-99550-->
-* The design of the tax rule form check box now matches the Admin checkbox design.
+*  The design of the tax rule form check box now matches the Admin checkbox design.
 
 <!--- ENGCOM-4844-->
-* The configurable product gallery now displays images in the correct order when the image list has more than 10 images. The correct order complies with the order assigned in the Admin. *Fix submitted by Mateusz Wira in pull request [22287](https://github.com/magento/magento2/pull/22287)*. [GitHub-22249](https://github.com/magento/magento2/issues/22249)
+*  The configurable product gallery now displays images in the correct order when the image list has more than 10 images. The correct order complies with the order assigned in the Admin. *Fix submitted by Mateusz Wira in pull request [22287](https://github.com/magento/magento2/pull/22287)*. [GitHub-22249](https://github.com/magento/magento2/issues/22249)
 
 <!--- MAGETWO-99500-->
-* You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
+*  You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
 
 <!--- ENGCOM-4825-->
-* Setting the **Update Product Preview Image** to **no**  now works as expected. Previously, when you clicked on a size or image that represented  another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [19184](https://github.com/magento/magento2/pull/19184)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
+*  Setting the **Update Product Preview Image** to **no**  now works as expected. Previously, when you clicked on a size or image that represented  another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [19184](https://github.com/magento/magento2/pull/19184)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
 
 <!--- ENGCOM-5385-->
-* The `POST V1/configurable-products/:sku/options` call now adds attribute options to a configurable product as expected. This resolves issues previously caused by the  MySQL table imposing a unique constraint on `product_id` and  `attribute_id` values. *Fix submitted by Lieven Pouwelse in pull request [23529](https://github.com/magento/magento2/pull/23529)*. [GitHub-9798](https://github.com/magento/magento2/issues/9798)
+*  The `POST V1/configurable-products/:sku/options` call now adds attribute options to a configurable product as expected. This resolves issues previously caused by the  MySQL table imposing a unique constraint on `product_id` and  `attribute_id` values. *Fix submitted by Lieven Pouwelse in pull request [23529](https://github.com/magento/magento2/pull/23529)*. [GitHub-9798](https://github.com/magento/magento2/issues/9798)
 
 ### Coupon
 
 <!--- ENGCOM-5292-->
-* The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Gaurav Agarwal in pull request [23250](https://github.com/magento/magento2/pull/23250)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
+*  The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Gaurav Agarwal in pull request [23250](https://github.com/magento/magento2/pull/23250)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
 
 ### Cron
 
 <!--- ENGCOM-5210-->
-* Runtime exception handling for cron jobs has been improved. Now, when an exception occurs, the current run is marked as **failed** in the `cron_schedule`  table. Then, when the next run completes correctly, Magento updates job status at the end of the `cron_schedule` table. Previously, when a job failed, the `cron_schedule`  table was filled with pending jobs; the `indexer_update_all_views` job was not run; no output was sent to the `var/log/cron.log` file, and no status updates were appended to the `cron_schedule` table.
+*  Runtime exception handling for cron jobs has been improved. Now, when an exception occurs, the current run is marked as **failed** in the `cron_schedule`  table. Then, when the next run completes correctly, Magento updates job status at the end of the `cron_schedule` table. Previously, when a job failed, the `cron_schedule`  table was filled with pending jobs; the `indexer_update_all_views` job was not run; no output was sent to the `var/log/cron.log` file, and no status updates were appended to the `cron_schedule` table.
 
 <!--- ENGCOM-5335-->
-* Cron jobs are no longer duplicated. Previously, after a cron job was run, Magento cleared the cache and processed the job again. *Fix submitted by Douglas Radburn in pull request [23312](https://github.com/magento/magento2/pull/23312)*.
+*  Cron jobs are no longer duplicated. Previously, after a cron job was run, Magento cleared the cache and processed the job again. *Fix submitted by Douglas Radburn in pull request [23312](https://github.com/magento/magento2/pull/23312)*.
 
 <!--- MC-18477-->
-* Consumers run from `cron` no longer create deadlocks in the database.
+*  Consumers run from `cron` no longer create deadlocks in the database.
 
 <!--- ENGCOM-5099-->
-* The `magento_newrelicreporting_cron` cron job now successfully completes as expected. Previously, `magento_newrelicreporting_cron` threw this error: `Warning: Invalid argument supplied for foreach() in /var/www/shop_test/src/www/vendor/magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php on line 83`.
+*  The `magento_newrelicreporting_cron` cron job now successfully completes as expected. Previously, `magento_newrelicreporting_cron` threw this error: `Warning: Invalid argument supplied for foreach() in /var/www/shop_test/src/www/vendor/magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php on line 83`.
 
 ### Customer
 
 <!--- MAGETWO-99647-->
-* Custom customer address attributes are populated with the * values that have been assigned for the selected  address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
+*  Custom customer address attributes are populated with the * values that have been assigned for the selected  address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
 
 <!--- MAGETWO-99493-->
-* The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
+*  The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
 
 <!--- MAGETWO-99496 -->
-* You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
+*  You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
 
 <!--- MAGETWO-99355 -->
-* You can now create a customer segment that exceeds 1,500,000 customers. Previously, Magento threw a 500 error when you tried to create a customer segment that large.
+*  You can now create a customer segment that exceeds 1,500,000 customers. Previously, Magento threw a 500 error when you tried to create a customer segment that large.
 
 <!--- MAGETWO-88905-->
-* Import checks now finish successfully when the csv file contains a customer `gender` field. Previously, Magento threw this error:  `Value for gender attribute contains incorrect value, see acceptable values on settings specified for Admin in row(s): 1`.
+*  Import checks now finish successfully when the csv file contains a customer `gender` field. Previously, Magento threw this error:  `Value for gender attribute contains incorrect value, see acceptable values on settings specified for Admin in row(s): 1`.
 
 <!--- MAGETWO-93522-->
-* Custom customer attributes are now always displayed in the Admin customer create and edit forms. Previously, the Admin did not display these attributes unless they were configured to show on either the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+*  Custom customer attributes are now always displayed in the Admin customer create and edit forms. Previously, the Admin did not display these attributes unless they were configured to show on either the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 <!--- MAGETWO-99584-->
-* You can now create an order from the Admin when  you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
+*  You can now create an order from the Admin when  you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
 
 <!--- MC-17769-->
-* You can now create an order from the Admin with a customer segment based on zero  or more orders and the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
+*  You can now create an order from the Admin with a customer segment based on zero  or more orders and the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
 
 <!--- MC-18250-->
-* The **Phone Number** field is now marked as required on the My account page.
+*  The **Phone Number** field is now marked as required on the My account page.
 
 <!--- ENGCOM-5378-->
-* Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Kazim Noorani in pull request [23494](https://github.com/magento/magento2/pull/23494)*.
+*  Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Kazim Noorani in pull request [23494](https://github.com/magento/magento2/pull/23494)*.
 
 <!--- ENGCOM-5048-->
-* Magento no longer duplicates the state/province fields of customer addresses in Admin forms. *Fix submitted by Shikha Mishra in pull request [22637](https://github.com/magento/magento2/pull/22637)*. [GitHub-22484](https://github.com/magento/magento2/issues/22484)
+*  Magento no longer duplicates the state/province fields of customer addresses in Admin forms. *Fix submitted by Shikha Mishra in pull request [22637](https://github.com/magento/magento2/pull/22637)*. [GitHub-22484](https://github.com/magento/magento2/issues/22484)
 
 <!--- ENGCOM-4581-->
-* Newly created customer accounts now require confirmation. Previously, Magento directly confirmed the new account even if the customer never logged in or confirmed the account. *Fix submitted by Maksym Novik in pull request [21394](https://github.com/magento/magento2/pull/21394)*. [GitHub-14492](https://github.com/magento/magento2/issues/14492)
+*  Newly created customer accounts now require confirmation. Previously, Magento directly confirmed the new account even if the customer never logged in or confirmed the account. *Fix submitted by Maksym Novik in pull request [21394](https://github.com/magento/magento2/pull/21394)*. [GitHub-14492](https://github.com/magento/magento2/issues/14492)
 
 ### Custom customer attributes
 
 <!--- MAGETWO-99451-->
-* Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
+*  Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
 
 <!--- MC-17928-->
-* You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
+*  You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
 
 ### Database media storage
 
 <!--- ENGCOM-5469-->
-* The PDF logo file is now database-aware. Consequently, logo images always appear on PDF invoices, even after the local `pub/media` directory is cleared. *Fix submitted by gwharton in pull request [23752](https://github.com/magento/magento2/pull/23752)*. [GitHub-23751](https://github.com/magento/magento2/issues/23751)
+*  The PDF logo file is now database-aware. Consequently, logo images always appear on PDF invoices, even after the local `pub/media` directory is cleared. *Fix submitted by gwharton in pull request [23752](https://github.com/magento/magento2/pull/23752)*. [GitHub-23751](https://github.com/magento/magento2/issues/23751)
 
 <!--- ENGCOM-5431-->
-* The `bin/magento catalog:images:resize` command is now database-media-storage-mode aware. As a result, resized images are now extracted from the database if they don’t exist locally prior to resizing, and are now stored back into the database once the resize operation completes. *Fix submitted by gwharton in pull request [23598](https://github.com/magento/magento2/pull/23598)*. [GitHub-23595](https://github.com/magento/magento2/issues/23595), [GitHub-23594](https://github.com/magento/magento2/issues/23594), [GitHub-23596](https://github.com/magento/magento2/issues/23596)
+*  The `bin/magento catalog:images:resize` command is now database-media-storage-mode aware. As a result, resized images are now extracted from the database if they don’t exist locally prior to resizing, and are now stored back into the database once the resize operation completes. *Fix submitted by gwharton in pull request [23598](https://github.com/magento/magento2/pull/23598)*. [GitHub-23595](https://github.com/magento/magento2/issues/23595), [GitHub-23594](https://github.com/magento/magento2/issues/23594), [GitHub-23596](https://github.com/magento/magento2/issues/23596)
 
 <!--- ENGCOM-5442-->
-* The  **use default value** checkbox on the Media Storage Location configuration setting has been removed. Previously, the JavaScript routines on the page interfered with that option, and consequently, the checkbox could be enabled but was still ignored. *Fix submitted by gwharton in pull request [23710](https://github.com/magento/magento2/pull/23710)*. [GitHub-23597](https://github.com/magento/magento2/issues/23597)
+*  The  **use default value** checkbox on the Media Storage Location configuration setting has been removed. Previously, the JavaScript routines on the page interfered with that option, and consequently, the checkbox could be enabled but was still ignored. *Fix submitted by gwharton in pull request [23710](https://github.com/magento/magento2/pull/23710)*. [GitHub-23597](https://github.com/magento/magento2/issues/23597)
 
 <!--- ENGCOM-4828 4802-->
-* Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously,  emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull requests [21675](https://github.com/magento/magento2/pull/21675) and [21674](https://github.com/magento/magento2/pull/21674)*. [GitHub-21672](https://github.com/magento/magento2/issues/21672)
+*  Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously,  emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull requests [21675](https://github.com/magento/magento2/pull/21675) and [21674](https://github.com/magento/magento2/pull/21674)*. [GitHub-21672](https://github.com/magento/magento2/issues/21672)
 
 <!--- ENGCOM-5198-->
-* Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21605](https://github.com/magento/magento2/pull/21605)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604), [GitHub-21546](https://github.com/magento/magento2/issues/21546)
+*  Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21605](https://github.com/magento/magento2/pull/21605)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604), [GitHub-21546](https://github.com/magento/magento2/issues/21546)
 
 ### Directory
 
 <!--- MAGETWO-99424-->
-* The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations. [GitHub-23141](https://github.com/magento/magento2/issues/23141)
+*  The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations. [GitHub-23141](https://github.com/magento/magento2/issues/23141)
 
 ### Downloadable products
 
 <!--- ENGCOM-5157-->
-* Downloadable products are now immediately accessible after they have been paid for. Previously, a downloadable product’s status remained in the pending state after payment for the product has been completed. *Fix submitted by Shikha Mishra in pull request [22658](https://github.com/magento/magento2/pull/22658)*. [GitHub-22545](https://github.com/magento/magento2/issues/22545)
+*  Downloadable products are now immediately accessible after they have been paid for. Previously, a downloadable product’s status remained in the pending state after payment for the product has been completed. *Fix submitted by Shikha Mishra in pull request [22658](https://github.com/magento/magento2/pull/22658)*. [GitHub-22545](https://github.com/magento/magento2/issues/22545)
 
 <!--- MAGETWO-98656-->
-* New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
+*  New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
 
 ### EAV
 
 <!--- MC-17505-->
-* Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
+*  Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
 
 <!--- MC-17623-->
-* You can now  save multiselect and select attribute options when swatches modules are disabled.
+*  You can now  save multiselect and select attribute options when swatches modules are disabled.
 [GitHub-23326](https://github.com/magento/magento2/issues/23326)
 
 ### Email
 
 <!--- ENGCOM-5433-->
-* Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message:  `Message too big`. *Fix submitted by gwharton in pull request [23649](https://github.com/magento/magento2/pull/23649)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
+*  Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message:  `Message too big`. *Fix submitted by gwharton in pull request [23649](https://github.com/magento/magento2/pull/23649)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
 
 <!--- ENGCOM-5090-->
-* The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview tab did not load the default content. *Fix submitted by Gaurav Agarwal in pull request [22791](https://github.com/magento/magento2/pull/22791)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
+*  The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview tab did not load the default content. *Fix submitted by Gaurav Agarwal in pull request [22791](https://github.com/magento/magento2/pull/22791)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
 
 <!--- ENGCOM-5393-->
-* All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23535](https://github.com/magento/magento2/pull/23535)*.
+*  All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23535](https://github.com/magento/magento2/pull/23535)*.
 
 ### Frameworks
 
 <!--- MC-14912-->
-* Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
+*  Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
 
 <!--- MAGETWO-99888-->
-* The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products  (for example, adding a product to category by SKU).
+*  The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products  (for example, adding a product to category by SKU).
 
 <!--- MC-17583-->
-* The performance of resize image operations has been improved. Previously, an SQL operation involved in the process returned redundant data, which resulted in images being saved multiple times.
+*  The performance of resize image operations has been improved. Previously, an SQL operation involved in the process returned redundant data, which resulted in images being saved multiple times.
 
 <!--- MAGETWO-99140-->
-* The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named  `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
+*  The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named  `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
 
 <!--- ENGCOM-3260-->
-* The Magento Framework API now has a module manager to detect module features and support enablement of third-party modules. *Fix submitted by Navarr Barnier in pull request [18748](https://github.com/magento/magento2/pull/18748)*.
+*  The Magento Framework API now has a module manager to detect module features and support enablement of third-party modules. *Fix submitted by Navarr Barnier in pull request [18748](https://github.com/magento/magento2/pull/18748)*.
 
 #### JavaScript framework
 
 <!--- MAGETWO-99535-->
-* The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
+*  The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
 
 <!--- ENGCOM-5118-->
-* Magento now displays previously missing validation messages on the storefront when JavaScript errors are caught by validation scripts in DatePicker form elements. *Fix submitted by Ravi Chandra in pull request [21397](https://github.com/magento/magento2/pull/21397)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795)
+*  Magento now displays previously missing validation messages on the storefront when JavaScript errors are caught by validation scripts in DatePicker form elements. *Fix submitted by Ravi Chandra in pull request [21397](https://github.com/magento/magento2/pull/21397)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795)
 
 ### General fixes
 
 <!--- MAGETWO-93061-->
-* Magento now displays the correct content for a selected store  in multi-site deployments where the websites have the same URL but the CMS pages have different content.
+*  Magento now displays the correct content for a selected store  in multi-site deployments where the websites have the same URL but the CMS pages have different content.
 
 <!--- MAGETWO-99677-->
-* Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
+*  Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
 
 <!--- MAGETWO-36337-->
-* The **Save in address book** checkbox on the Shipping Address section of the Admin Create Order page now behaves as expected. When this checkbox is enabled, the address in the Shipping Address field is saved, and merchants can disable or enable the checkbox
+*  The **Save in address book** checkbox on the Shipping Address section of the Admin Create Order page now behaves as expected. When this checkbox is enabled, the address in the Shipping Address field is saved, and merchants can disable or enable the checkbox
 
 <!--- MAGETWO-70681-->
-* Updated the length for the `store_name` field used in `sales_order` database table. The field length has been extended from 32 to 255 symbols.
+*  Updated the length for the `store_name` field used in `sales_order` database table. The field length has been extended from 32 to 255 symbols.
 
 <!--- MC-17511-->
-* Preloading of fonts has been moved from the Blank theme to the Luma theme.
+*  Preloading of fonts has been moved from the Blank theme to the Luma theme.
 
 <!--- ENGCOM-5171-->
-* Magento no longer includes canceled orders when calculating how many times a coupon code has been used. *Fix submitted by Pavel Bystritsky in pull request [20579](https://github.com/magento/magento2/pull/20579)*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
+*  Magento no longer includes canceled orders when calculating how many times a coupon code has been used. *Fix submitted by Pavel Bystritsky in pull request [20579](https://github.com/magento/magento2/pull/20579)*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
 
 <!--- ENGCOM-5022-->
-* Code Sniffer no longer marks correctly aligned DocBlock elements as code style violations. *Fix submitted by Pavel Bystritsky in pull request [22444](https://github.com/magento/magento2/pull/22444)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
+*  Code Sniffer no longer marks correctly aligned DocBlock elements as code style violations. *Fix submitted by Pavel Bystritsky in pull request [22444](https://github.com/magento/magento2/pull/22444)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
 
 <!--- ENGCOM-5066-->
-* Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [19584](https://github.com/magento/magento2/pull/19584)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
+*  Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [19584](https://github.com/magento/magento2/pull/19584)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
 
 <!--- MC-18094-->
-* Full page cache works as expected for non-default store views.
+*  Full page cache works as expected for non-default store views.
 
 <!--- MC-18270-->
-* Magento no longer creates a persistent cart session for logged-in users when the persistent cart feature has been disabled. Previously, Magento did not empty shopping carts for users when the user logged out.
+*  Magento no longer creates a persistent cart session for logged-in users when the persistent cart feature has been disabled. Previously, Magento did not empty shopping carts for users when the user logged out.
 
 <!--- ENGCOM-5375-->
-* The unused namespace import was removed from the  `CartTotalRepository.php` file. *Fix submitted by Ulyana Kiklevich in pull request [23457](https://github.com/magento/magento2/pull/23457)*.
+*  The unused namespace import was removed from the  `CartTotalRepository.php` file. *Fix submitted by Ulyana Kiklevich in pull request [23457](https://github.com/magento/magento2/pull/23457)*.
 
 <!--- MC-17934-->
-* The back-in-stock alert emails that Magento sends to both wholesale and general customers now include the appropriate  wholesale and general  product prices.
+*  The back-in-stock alert emails that Magento sends to both wholesale and general customers now include the appropriate  wholesale and general  product prices.
 
 <!--- MC-14837-->
-* The `MsrpSampleData` module installation script no longer generates incorrect data. Previously, this installation script did not set any data from fixtures due to incorrect dependencies between sample data modules.
+*  The `MsrpSampleData` module installation script no longer generates incorrect data. Previously, this installation script did not set any data from fixtures due to incorrect dependencies between sample data modules.
 
 <!--- ENGCOM-5377-->
-* Tooltips have been added to the store-view labels for CMS tables and blocks. *Fix submitted by Dipesh Rangani in pull request [23474](https://github.com/magento/magento2/pull/23474)*.
+*  Tooltips have been added to the store-view labels for CMS tables and blocks. *Fix submitted by Dipesh Rangani in pull request [23474](https://github.com/magento/magento2/pull/23474)*.
 
 <!--- ENGCOM-5390-->
-* Validation of `max-word` data now works as expected for forms. *Fix submitted by Sunil in pull request [23541](https://github.com/magento/magento2/pull/23541)*.
+*  Validation of `max-word` data now works as expected for forms. *Fix submitted by Sunil in pull request [23541](https://github.com/magento/magento2/pull/23541)*.
 
 <!--- ENGCOM-5267-->
-* Magento now subscribes a customer to a price or stock notification when they opt to subscribe to a  price or  stock alert on a product page without first logging in. Previously, Magento redirected the customer  to a 404 page. *Fix submitted by Arjen Miedema in pull request [23218](https://github.com/magento/magento2/pull/23218)*.
+*  Magento now subscribes a customer to a price or stock notification when they opt to subscribe to a  price or  stock alert on a product page without first logging in. Previously, Magento redirected the customer  to a 404 page. *Fix submitted by Arjen Miedema in pull request [23218](https://github.com/magento/magento2/pull/23218)*.
 
 <!--- ENGCOM-5228-->
-* The sendfriend feature now verifies product visibility as expected. Previously, this  feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23118](https://github.com/magento/magento2/pull/23118)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
+*  The sendfriend feature now verifies product visibility as expected. Previously, this  feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23118](https://github.com/magento/magento2/pull/23118)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
 
 <!--- ENGCOM-5135-->
-* Search input is no longer missing the `aria-expanded`  required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Geeta Modi in pull request [22942](https://github.com/magento/magento2/pull/22942)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
+*  Search input is no longer missing the `aria-expanded`  required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Geeta Modi in pull request [22942](https://github.com/magento/magento2/pull/22942)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
 
 <!--- ENGCOM-5129-->
-* The **Use Default Value** check boxes on the Advanced Pricing  pop-up window  now remain checked on both the **Special From** and **Special To** dates,  and display the values set in the All Store scope. *Fix submitted by Mahesh Singh in pull request [22521](https://github.com/magento/magento2/pull/22521)*. [GitHub-22511](https://github.com/magento/magento2/issues/22511)
+*  The **Use Default Value** check boxes on the Advanced Pricing  pop-up window  now remain checked on both the **Special From** and **Special To** dates,  and display the values set in the All Store scope. *Fix submitted by Mahesh Singh in pull request [22521](https://github.com/magento/magento2/pull/22521)*. [GitHub-22511](https://github.com/magento/magento2/issues/22511)
 
 <!--- ENGCOM-5300-->
-* The Recently Viewed feature now accurately lists the products and category paths that the user has recently visited. Previously, this list was inaccurate when the **Use Categories Path for Product URLs**  setting was disabled. *Fix submitted by Atish Goswami in pull request [22650](https://github.com/magento/magento2/pull/22650)*. [GitHub-13227](https://github.com/magento/magento2/issues/13227)
+*  The Recently Viewed feature now accurately lists the products and category paths that the user has recently visited. Previously, this list was inaccurate when the **Use Categories Path for Product URLs**  setting was disabled. *Fix submitted by Atish Goswami in pull request [22650](https://github.com/magento/magento2/pull/22650)*. [GitHub-13227](https://github.com/magento/magento2/issues/13227)
 
 <!--- MC-16233-->
-* The **Be the First to Review Product** link now directs the user to the product review form at the bottom of the product page as expected in deployments that include Page Builder.
+*  The **Be the First to Review Product** link now directs the user to the product review form at the bottom of the product page as expected in deployments that include Page Builder.
 
 <!--- MC-19684-->
-* You can now set the **minute** values for Analytics data collection (**Store** > **Configuration** > **General** > **Advanced Reporting**). Previously, due to an earlier fix that has now been reverted (see [GitHub-8258](https://github.com/magento/magento2/issues/8258)), validation failed when you set a value that exceeded 24.
+*  You can now set the **minute** values for Analytics data collection (**Store** > **Configuration** > **General** > **Advanced Reporting**). Previously, due to an earlier fix that has now been reverted (see [GitHub-8258](https://github.com/magento/magento2/issues/8258)), validation failed when you set a value that exceeded 24.
 
 <!--- ENGCOM-4843-->
-* The `getProductUrl()` method now returns the product URL for a specified website. Previously, this method did not let you retrieve the product URL for a specified website in multisite deployments. *Fix submitted by Nazar Klovanych in pull request [21876](https://github.com/magento/magento2/pull/21876)*. [GitHub-4247](https://github.com/magento/magento2/issues/4247)
+*  The `getProductUrl()` method now returns the product URL for a specified website. Previously, this method did not let you retrieve the product URL for a specified website in multisite deployments. *Fix submitted by Nazar Klovanych in pull request [21876](https://github.com/magento/magento2/pull/21876)*. [GitHub-4247](https://github.com/magento/magento2/issues/4247)
 
 ### Gift cards accounts
 
 <!--- MC-17124-->
-* Magento no longer creates a new gift card after issuing an online refund for another card. Previously, Magento created a new gift card account and sent the customer the previous gift card code and a new code.
+*  Magento no longer creates a new gift card after issuing an online refund for another card. Previously, Magento created a new gift card account and sent the customer the previous gift card code and a new code.
 
 <!--- MAGETWO-99367-->
-* All strings on storefront gift card messages can now be translated.
+*  All strings on storefront gift card messages can now be translated.
 
 <!--- MAGETWO-99425-->
-* Magento no longer closes an order that is paid for with the partial redemption of a gift card. Previously, if an order is paid partially using gift card, and a partial refund is issued for that order, the order becomes closed.
+*  Magento no longer closes an order that is paid for with the partial redemption of a gift card. Previously, if an order is paid partially using gift card, and a partial refund is issued for that order, the order becomes closed.
 
 ### Gift registry
 
 <!--- MC-18540-->
-* Magento no longer displays a console error during checkout when the cart contains a product from the gift registry. Previously, due to a missing function, Magento displayed this error: `checkout-data-resolver.js:248 Uncaught TypeError: addrs.isDefaultBilling is not a function`.
+*  Magento no longer displays a console error during checkout when the cart contains a product from the gift registry. Previously, due to a missing function, Magento displayed this error: `checkout-data-resolver.js:248 Uncaught TypeError: addrs.isDefaultBilling is not a function`.
 
 ### Google Tag Manager
 
 <!--- MAGETWO-99026-->
-* `getLoadedProductCollection()` has been refactored to support PHP 7.2.
+*  `getLoadedProductCollection()` has been refactored to support PHP 7.2.
 
 ### Image
 
 <!--- ENGCOM-4838-->
-* You can now programmatically  move an image to the gallery using the  `addImageToMediaGallery` method with `$move`. Previously, when you tried to move an image programmatically, Magento threw this exception: `[InvalidArgumentException] File 'pub/media/import/' doesn't exist`. *Fix submitted by dudzio12 in pull request [22020](https://github.com/magento/magento2/pull/22020)*. [GitHub-21978](https://github.com/magento/magento2/issues/21978)
+*  You can now programmatically  move an image to the gallery using the  `addImageToMediaGallery` method with `$move`. Previously, when you tried to move an image programmatically, Magento threw this exception: `[InvalidArgumentException] File 'pub/media/import/' doesn't exist`. *Fix submitted by dudzio12 in pull request [22020](https://github.com/magento/magento2/pull/22020)*. [GitHub-21978](https://github.com/magento/magento2/issues/21978)
 
 <!--- ENGCOM-5173-->
-* The performance of the `catalog:images:resize` command has been improved. This command now resizes only the images that are actually in use  and lists any  errors. *Fix submitted by Timon de Groot in pull request [23005](https://github.com/magento/magento2/pull/23005)*. [GitHub-22808](https://github.com/magento/magento2/issues/22808)
+*  The performance of the `catalog:images:resize` command has been improved. This command now resizes only the images that are actually in use  and lists any  errors. *Fix submitted by Timon de Groot in pull request [23005](https://github.com/magento/magento2/pull/23005)*. [GitHub-22808](https://github.com/magento/magento2/issues/22808)
 
 ### Import/export
 
 <!--- MAGETWO-99894-->
-* Import statistics now accurately reflect the results of import.
+*  Import statistics now accurately reflect the results of import.
 
 <!--- MAGETWO-98729-->
-* Magento now successfully saves product URL keys in Arabic.
+*  Magento now successfully saves product URL keys in Arabic.
 
 <!--- MAGETWO-98801-->
-* Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
+*  Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
 
 <!--- MAGETWO-99509-->
-* You can now successfully download a CSV file after export. Previously, Magento redirected you to the Admin dashboard when you tried to download the CSV file that was created during export.
+*  You can now successfully download a CSV file after export. Previously, Magento redirected you to the Admin dashboard when you tried to download the CSV file that was created during export.
 
 <!--- MAGETWO-99927-->
   Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously,  the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
 
 <!--- MAGETWO-60918-->
-* Magento no longer throws a fatal error during import or export if the category path contains deleted category IDs.
+*  Magento no longer throws a fatal error during import or export if the category path contains deleted category IDs.
 
 <!--- MC-18472-->
-* The import process maintain custom option prices that were assigned to different websites and scope before import. Previously, after import, these custom option prices were set to the default scope values.
+*  The import process maintain custom option prices that were assigned to different websites and scope before import. Previously, after import, these custom option prices were set to the default scope values.
 
 <!--- ENGCOM-5028-->
-* You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously,  when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22575](https://github.com/magento/magento2/pull/22575)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
+*  You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously,  when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22575](https://github.com/magento/magento2/pull/22575)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
 
 ### Index
 
 <!--- MAGETWO-99439-->
-* We have improved the processing of memory tables in the Galera Cluster.
+*  We have improved the processing of memory tables in the Galera Cluster.
 
 <!--- MC-17981-->
-* The pricing index can now be fully rebuilt and moved into the active price database table in a reasonable amount of time. Previously, this index ran without completing. [GitHub-22156](https://github.com/magento/magento2/issues/22156)
+*  The pricing index can now be fully rebuilt and moved into the active price database table in a reasonable amount of time. Previously, this index ran without completing. [GitHub-22156](https://github.com/magento/magento2/issues/22156)
 
 <!--- MC-17929-->
-* We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
+*  We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
 
 <!--- ENGCOM-5320-->
-* You can now filter administrative users by ID. Previously, when you tried to filter these users by ID, Magento threw a 500 error. *Fix submitted by Jeroen in pull request [23267](https://github.com/magento/magento2/pull/23267)*. [GitHub-23266](https://github.com/magento/magento2/issues/23266)
+*  You can now filter administrative users by ID. Previously, when you tried to filter these users by ID, Magento threw a 500 error. *Fix submitted by Jeroen in pull request [23267](https://github.com/magento/magento2/pull/23267)*. [GitHub-23266](https://github.com/magento/magento2/issues/23266)
 
 ### Infrastructure
 
 <!--- MC-14862-->
-* Magento 2.3.3 now supports PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21).
+*  Magento 2.3.3 now supports PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21).
 
 <!--- MC-14863-->
-* Varnish cache now supports version 6.2.0.
+*  Varnish cache now supports version 6.2.0.
 
 <!--- ENGCOM-5352-->
-* You can now use copy service on extension attributes for classes that extend Data Object. *Fix submitted by Oleksandr Kravchuk in pull request [23387](https://github.com/magento/magento2/pull/23387)*. [GitHub-23386](https://github.com/magento/magento2/issues/23386)
+*  You can now use copy service on extension attributes for classes that extend Data Object. *Fix submitted by Oleksandr Kravchuk in pull request [23387](https://github.com/magento/magento2/pull/23387)*. [GitHub-23386](https://github.com/magento/magento2/issues/23386)
 
 <!--- ENGCOM-5356-->
-* Removed an extraneous closing tag from the store-switcher template. *Fix submitted by Alastair Mucklow in pull request [23403](https://github.com/magento/magento2/pull/23403)*.
+*  Removed an extraneous closing tag from the store-switcher template. *Fix submitted by Alastair Mucklow in pull request [23403](https://github.com/magento/magento2/pull/23403)*.
 
 <!--- ENGCOM-5462-->
-* `\Magento\ConfigurableProduct\Pricing\Price\PriceResolverInterface` has been added to the `di.xml` file. *Fix submitted by Eden Duong in pull request [23753](https://github.com/magento/magento2/pull/23753)*. [GitHub-23717](https://github.com/magento/magento2/issues/23717)
+*  `\Magento\ConfigurableProduct\Pricing\Price\PriceResolverInterface` has been added to the `di.xml` file. *Fix submitted by Eden Duong in pull request [23753](https://github.com/magento/magento2/pull/23753)*. [GitHub-23717](https://github.com/magento/magento2/issues/23717)
 
 <!--- ENGCOM-5174-->
-* We improved validation of forms that contain multiple fields with identical names. Previously, Magento validated the first file in the form, but did not validate subsequent fields with that name. *Fix submitted by Jay Ghosh in pull request [15383](https://github.com/magento/magento2/pull/15383)*. [GitHub-8258](https://github.com/magento/magento2/issues/8258)
+*  We improved validation of forms that contain multiple fields with identical names. Previously, Magento validated the first file in the form, but did not validate subsequent fields with that name. *Fix submitted by Jay Ghosh in pull request [15383](https://github.com/magento/magento2/pull/15383)*. [GitHub-8258](https://github.com/magento/magento2/issues/8258)
 
 <!--- ENGCOM-5337-->
-* Magento now identifies review entity IDs programmatically instead of retrieving a hard-coded value. *Fix submitted by Danilo Argentiero in pull request [23353](https://github.com/magento/magento2/pull/23353)*.
+*  Magento now identifies review entity IDs programmatically instead of retrieving a hard-coded value. *Fix submitted by Danilo Argentiero in pull request [23353](https://github.com/magento/magento2/pull/23353)*.
 
 <!--- ENGCOM-5384-->
-* The array type hints in the Visibility model now correctly reference `string` instead of `int`. *Fix submitted by Patrick McLain in pull request [23532](https://github.com/magento/magento2/pull/23532)*.
+*  The array type hints in the Visibility model now correctly reference `string` instead of `int`. *Fix submitted by Patrick McLain in pull request [23532](https://github.com/magento/magento2/pull/23532)*.
 
 <!--- ENGCOM-5121-->
-* The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22914](https://github.com/magento/magento2/pull/22914)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
+*  The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22914](https://github.com/magento/magento2/pull/22914)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
 
 <!--- ENGCOM-5147-->
-* The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Mahesh Singh in pull request [22772](https://github.com/magento/magento2/pull/22772)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
+*  The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Mahesh Singh in pull request [22772](https://github.com/magento/magento2/pull/22772)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
 
 <!--- ENGCOM-5139-->
-* The `phpcs` script for PHP_CodeSniffer now displays all errors and warnings in the console. Previously, Magento threw a fatal error when it encountered an uncaught type error. *Fix submitted by Nazar Klovanych in pull request [22947](https://github.com/magento/magento2/pull/22947)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
+*  The `phpcs` script for PHP_CodeSniffer now displays all errors and warnings in the console. Previously, Magento threw a fatal error when it encountered an uncaught type error. *Fix submitted by Nazar Klovanych in pull request [22947](https://github.com/magento/magento2/pull/22947)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
 
 <!--- MC-15163-->
-* The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
+*  The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
 
 ### Newsletter
 
 <!--- MAGETWO-99636-->
-* Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
+*  Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
 
 <!--- MAGETWO-71785-->
-* You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`.
+*  You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`.
 
 ### Orders
 
 <!--- ENGCOM-5405-->
-* The creditmemo `getOrder()` method now returns the expected extension attributes for an order. Previously, this method did not load orders correctly. *Fix submitted by Pavel Bystritsky in pull request [23358](https://github.com/magento/magento2/pull/23358)*. [GitHub-23345](https://github.com/magento/magento2/issues/23345)
+*  The creditmemo `getOrder()` method now returns the expected extension attributes for an order. Previously, this method did not load orders correctly. *Fix submitted by Pavel Bystritsky in pull request [23358](https://github.com/magento/magento2/pull/23358)*. [GitHub-23345](https://github.com/magento/magento2/issues/23345)
 
 <!--- ENGCOM-5398-->
-* Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Shankar Konar in pull request [23360](https://github.com/magento/magento2/pull/23360)*.
+*  Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Shankar Konar in pull request [23360](https://github.com/magento/magento2/pull/23360)*.
 
 ### Payment methods
 
 This release includes the following changes to integrations for core payment methods to support compliance with PSD2 regulations:
 
 <!--- MAGEDTWO-99606 99867-->
-* The Braintree payment method now complies with PSD2 regulations. The core integration API for Braintree now supports the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
+*  The Braintree payment method now complies with PSD2 regulations. The core integration API for Braintree now supports the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
 
 <!--- MAGEDTWO-99736 -->
-* Authorize.net now provides 3D Secure verification through third-party services through the `cardholderAuthentication` request field. Starting from this release,the Authorize.Net `accept.js` integration will support 3DS 2.0 through CardinalCommerce.
+*  Authorize.net now provides 3D Secure verification through third-party services through the `cardholderAuthentication` request field. Starting from this release,the Authorize.Net `accept.js` integration will support 3DS 2.0 through CardinalCommerce.
 
 <!--- MAGEDTWO-99739 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
 
 #### Other payment issues
 
 <!--- MC-17337-->
-* Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
+*  Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
 
 <!--- MAGETWO-99035-->
-* Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
+*  Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
 
 <!--- MC-17462-->
-* When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
+*  When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
 
 <!--- MAGETWO-99383-->
-* Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
+*  Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
 
 <!--- MAGETWO-99624-->
-* Customers can now place an order for virtual products that have a zero subtotal  after they have entered address information. Previously, customers could not place an order for virtual products with a zero subtotal after they modified their address, and Magento displayed this message:  `The requested Payment Method is not available`.
+*  Customers can now place an order for virtual products that have a zero subtotal  after they have entered address information. Previously, customers could not place an order for virtual products with a zero subtotal after they modified their address, and Magento displayed this message:  `The requested Payment Method is not available`.
 
 <!--- MC-17236-->
-* Magento now displays Chinese locale text strings for PayPal buttons as expected.
+*  Magento now displays Chinese locale text strings for PayPal buttons as expected.
 
 <!--- MAGETWO-99586-->
-* You can now cancel orders placed with PayPal Express even after authorization has expired.
+*  You can now cancel orders placed with PayPal Express even after authorization has expired.
 
 <!--- MC-16769-->
-* The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `Accept.js` payment method.
+*  The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `Accept.js` payment method.
 
 <!--- MAGETWO-99112-->
-* The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
+*  The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
 
 <!--- ENGCOM-5105-->
-* Magento now displays stored payment methods and billing agreements if the related payment method is active. Previously, Magento displayed disabled payment methods in the customer dashboard. *Fix submitted by Torben Höhn in pull request [22850](https://github.com/magento/magento2/pull/22850)*. [GitHub-6659](https://github.com/magento/magento2/issues/6659)
+*  Magento now displays stored payment methods and billing agreements if the related payment method is active. Previously, Magento displayed disabled payment methods in the customer dashboard. *Fix submitted by Torben Höhn in pull request [22850](https://github.com/magento/magento2/pull/22850)*. [GitHub-6659](https://github.com/magento/magento2/issues/6659)
 
 <!--- ENGCOM-4839-->
-* Magento no longer saves credit card information when the  **Save for later use** checkbox on the payment page is not enabled during order creation. *Fix submitted by Patrick McLain in pull request [19767](https://github.com/magento/magento2/pull/19767)*. [GitHub-19515](https://github.com/magento/magento2/issues/19515)
+*  Magento no longer saves credit card information when the  **Save for later use** checkbox on the payment page is not enabled during order creation. *Fix submitted by Patrick McLain in pull request [19767](https://github.com/magento/magento2/pull/19767)*. [GitHub-19515](https://github.com/magento/magento2/issues/19515)
 
 <!--- ENGCOM-5451-->
-* When placing an order with Authorize.net, Magento now disables the Order page's **Place Order** button until billing information has been updated. Previously, this button remained enabled, no matter the status of the order in progress. *Fix submitted by Eden Duong in pull request [23718](https://github.com/magento/magento2/pull/23718)*. [GitHub-23624](https://github.com/magento/magento2/issues/23624)
+*  When placing an order with Authorize.net, Magento now disables the Order page's **Place Order** button until billing information has been updated. Previously, this button remained enabled, no matter the status of the order in progress. *Fix submitted by Eden Duong in pull request [23718](https://github.com/magento/magento2/pull/23718)*. [GitHub-23624](https://github.com/magento/magento2/issues/23624)
 
 <!--- MC-17753-->
-* Magento now displays an informative email message about invalid credentials when a user tries to pay for an order with the Authorize.net payment method that has an incompletely configured Authorize.net `accept.js` account.
+*  Magento now displays an informative email message about invalid credentials when a user tries to pay for an order with the Authorize.net payment method that has an incompletely configured Authorize.net `accept.js` account.
 
 <!--- MC-17984-->
-* You can now place an order from the Admin using Authorize.net as the payment method. Previously, Magento did not place the order and displayed this message: `Transaction has been declined. Please try again later`.
+*  You can now place an order from the Admin using Authorize.net as the payment method. Previously, Magento did not place the order and displayed this message: `Transaction has been declined. Please try again later`.
 
 <!--- MC-16289-->
-* The **Credentials** button on the Configure PayPal Express Checkout page (**Admin** > **Stores** > **Configuration**  > **Sales**  > **Payment Methods** > **PayPal Express Checkout**) is now displayed properly in modes.
+*  The **Credentials** button on the Configure PayPal Express Checkout page (**Admin** > **Stores** > **Configuration**  > **Sales**  > **Payment Methods** > **PayPal Express Checkout**) is now displayed properly in modes.
 
 <!--- MC-17576-->
-* Magento no longer throws an error when you place an order using a custom payment method in deployments running Signifyd. Previously, when you tried to place an order using a custom payment method, an error related to the merge of `signifyd_payment_mapping.xml` files occurred.
+*  Magento no longer throws an error when you place an order using a custom payment method in deployments running Signifyd. Previously, when you tried to place an order using a custom payment method, an error related to the merge of `signifyd_payment_mapping.xml` files occurred.
 
 <!--- ENGCOM-5504-->
-* Data type validation now occurs on data entered into the minimum and maximum order totals for all payment methods accessed under **Store** > **Configurations** > **Sales** > **Payment Method**. Previously, you could add values with invalid data types, and Magento saved these values with the wrong data type. *Fix submitted by Eden Duong in pull request [23917](https://github.com/magento/magento2/pull/23917)*. [GitHub-23916](https://github.com/magento/magento2/issues/23916)
+*  Data type validation now occurs on data entered into the minimum and maximum order totals for all payment methods accessed under **Store** > **Configurations** > **Sales** > **Payment Method**. Previously, you could add values with invalid data types, and Magento saved these values with the wrong data type. *Fix submitted by Eden Duong in pull request [23917](https://github.com/magento/magento2/pull/23917)*. [GitHub-23916](https://github.com/magento/magento2/issues/23916)
 
 <!--- ENGCOM-4752-->
-* The **PayPal Express Checkout** button now appears on the product details page only when the **Display on Product Details Page** and  **Enable Instant Purchase** configuration settings are enabled. *Fix submitted by Nazar Klovanych in pull request [22260](https://github.com/magento/magento2/pull/22260)*. [GitHub-22045](https://github.com/magento/magento2/issues/22045), [GitHub-22134](https://github.com/magento/magento2/issues/22134)
+*  The **PayPal Express Checkout** button now appears on the product details page only when the **Display on Product Details Page** and  **Enable Instant Purchase** configuration settings are enabled. *Fix submitted by Nazar Klovanych in pull request [22260](https://github.com/magento/magento2/pull/22260)*. [GitHub-22045](https://github.com/magento/magento2/issues/22045), [GitHub-22134](https://github.com/magento/magento2/issues/22134)
 
 <!--- ENGCOM-5452-->
-* The location of the Zero Subtotal Checkout payment settings has been changed to **Stores** > **Configuration** > **Sales** > **Payment Methods**. *Fix submitted by Andrea Parmeggiani in pull request [23679](https://github.com/magento/magento2/pull/23679)*. [GitHub-23678](https://github.com/magento/magento2/issues/23678)
+*  The location of the Zero Subtotal Checkout payment settings has been changed to **Stores** > **Configuration** > **Sales** > **Payment Methods**. *Fix submitted by Andrea Parmeggiani in pull request [23679](https://github.com/magento/magento2/pull/23679)*. [GitHub-23678](https://github.com/magento/magento2/issues/23678)
 
 <!--- ENGCOM-5324-->
-* Magento now displays the loading icon while processing a Braintree payment until the user is redirected to the new Order page. *Fix submitted by Kunal Soni in pull request [22675](https://github.com/magento/magento2/pull/22675)*. [GitHub-20038](https://github.com/magento/magento2/issues/20038)
+*  Magento now displays the loading icon while processing a Braintree payment until the user is redirected to the new Order page. *Fix submitted by Kunal Soni in pull request [22675](https://github.com/magento/magento2/pull/22675)*. [GitHub-20038](https://github.com/magento/magento2/issues/20038)
 
 ### Performance
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-* Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-16046-->
-* Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
+*  Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
 
 ### Pricing
 
 <!--- MAGETWO-99152-->
-* You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing  Yen.
+*  You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing  Yen.
 
 <!--- MAGETWO-98844-->
-* You can now set product price that exceeds 100,000,000.
+*  You can now set product price that exceeds 100,000,000.
 
 ### Reports
 
 <!--- ENGCOM-5413-->
-* The default date range for report filters is now set to the past month instead of the past 18 years. Previously, the default was set to 18 years, which resulted in errors in the filtered results. *Fix submitted by Yaroslav Rogoza in pull request [23607](https://github.com/magento/magento2/pull/23607)*. [GitHub-23606](https://github.com/magento/magento2/issues/23606)
+*  The default date range for report filters is now set to the past month instead of the past 18 years. Previously, the default was set to 18 years, which resulted in errors in the filtered results. *Fix submitted by Yaroslav Rogoza in pull request [23607](https://github.com/magento/magento2/pull/23607)*. [GitHub-23606](https://github.com/magento/magento2/issues/23606)
 
 <!--- MC-18195-->
-* The start and finish date in reports now correspond to the entered  values when you create a report from the Admin. Previously, the start and finish dates  in the displayed report was one day earlier than you entered.
+*  The start and finish date in reports now correspond to the entered  values when you create a report from the Admin. Previously, the start and finish dates  in the displayed report was one day earlier than you entered.
 
 <!--- ENGCOM-5505-->
-* The access controls on the **Reports** > **Product** > **Downloads** have been refactored to permit access to only administrators with the correct permissions. Previously, administrators with no access to this area could access the Downloads report. *Fix submitted by Eden Duong in pull request [23901](https://github.com/magento/magento2/pull/23901)*. [GitHub-23900](https://github.com/magento/magento2/issues/23900)
+*  The access controls on the **Reports** > **Product** > **Downloads** have been refactored to permit access to only administrators with the correct permissions. Previously, administrators with no access to this area could access the Downloads report. *Fix submitted by Eden Duong in pull request [23901](https://github.com/magento/magento2/pull/23901)*. [GitHub-23900](https://github.com/magento/magento2/issues/23900)
 
 <!--- ENGCOM-5052-->
-* Selecting **Show by year** when filtering  **Reports** > **Products**  > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per-order basis. *Fix submitted by Surabhi Srivastava in pull request [22087](https://github.com/magento/magento2/pull/22087)*. [GitHub-22646](https://github.com/magento/magento2/issues/22646), [GitHub-22087](https://github.com/magento/magento2/issues/22087)
+*  Selecting **Show by year** when filtering  **Reports** > **Products**  > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per-order basis. *Fix submitted by Surabhi Srivastava in pull request [22087](https://github.com/magento/magento2/pull/22087)*. [GitHub-22646](https://github.com/magento/magento2/issues/22646), [GitHub-22087](https://github.com/magento/magento2/issues/22087)
 
 ### Reviews
 
 <!--- MAGETWO-99591-->
-* Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
+*  Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
 
 ### Return Merchandise Authorizations (RMA)
 
 <!--- MAGETWO-98012-->
-* Magento now autopopulates fields as expected when you create a Return Merchandise Authorization (RMA) using REST. Previously, the following fields were null: `customer_id`, `rma_entity_id`, `created_at`, and `entity_id`.
+*  Magento now autopopulates fields as expected when you create a Return Merchandise Authorization (RMA) using REST. Previously, the following fields were null: `customer_id`, `rma_entity_id`, `created_at`, and `entity_id`.
 
 <!--- MC-17431-->
-* Magento now displays only enabled shipping methods on the Return details page. Previously, shipping methods that were disabled for RMA were displayed in the Carrier dropdown menu on the Return details page.
+*  Magento now displays only enabled shipping methods on the Return details page. Previously, shipping methods that were disabled for RMA were displayed in the Carrier dropdown menu on the Return details page.
 
 <!--- MAGETWO-60741-->
-* Clicking **Show Packages** on a Returns page (**My Account** > **My Returns**  > **Return**) now opens a new page about the selected package. Previously, clicking on this link resulted in a 404 error page.
+*  Clicking **Show Packages** on a Returns page (**My Account** > **My Returns**  > **Return**) now opens a new page about the selected package. Previously, clicking on this link resulted in a 404 error page.
 
 ### Reward
 
 <!--- MAGETWO-99901-->
-* Magento no longer sends reward point balance notification email to  clients  whose accounts have the **Subscribe for Balance Updates** setting disabled.
+*  Magento no longer sends reward point balance notification email to  clients  whose accounts have the **Subscribe for Balance Updates** setting disabled.
 
 <!--- MC-17798-->
-* Online refunds now work as expected  when the **Refund Reward Points Automatically** configuration setting is enabled. Previously, the Refund button was disabled under these conditions.
+*  Online refunds now work as expected  when the **Refund Reward Points Automatically** configuration setting is enabled. Previously, the Refund button was disabled under these conditions.
 
 ### Sales
 
 <!--- MAGETWO-99691-->
-* The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
+*  The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
 
 <!--- MAGETWO-99460-->
-* Custom order statuses no longer override default statuses in drop-down menus.
+*  Custom order statuses no longer override default statuses in drop-down menus.
 
 <!--- MAGETWO-99430-->
-* The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
+*  The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
 
 <!--- MAGETWO-99364-->
-* You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
+*  You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
 
 <!--- MAGETWO-99605-->
-* You can now use quotation marks  to create exact search terms in the Admin menu search grid  (**Customers** > **All Customers**).
+*  You can now use quotation marks  to create exact search terms in the Admin menu search grid  (**Customers** > **All Customers**).
 
 <!--- MC-17269-->
-* The date format used in tables throughout the product interface is now based on the Admin-defined locale.
+*  The date format used in tables throughout the product interface is now based on the Admin-defined locale.
 
 <!--- MAGETWO-72172-->
-* Magento no longer lets you add a disabled variation of configurable product to the shopping cart from the Admin.
+*  Magento no longer lets you add a disabled variation of configurable product to the shopping cart from the Admin.
 
 <!--- MAGETWO-99883-->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 <!--- MC-17860-->
-* Magento no longer adds to an order any selected products that have not been explicitly added to the cart when you create an order from the Admin.
+*  Magento no longer adds to an order any selected products that have not been explicitly added to the cart when you create an order from the Admin.
 
 <!--- MC-17797-->
-* Magento no longer throws a fatal error when you click **View Order** on an order that contains a product that was available when the order was created but which was subsequently  deleted from the storefront.
+*  Magento no longer throws a fatal error when you click **View Order** on an order that contains a product that was available when the order was created but which was subsequently  deleted from the storefront.
 
 <!--- MAGETWO-98832-->
-* The Allowed Countries drop-down list that is available in multisite deployments now reflects the settings that  are configured in **Stores**  > **Configuration**  > **General** >  **General**  > **Country Options**  >  **Allow Countries**.
+*  The Allowed Countries drop-down list that is available in multisite deployments now reflects the settings that  are configured in **Stores**  > **Configuration**  > **General** >  **General**  > **Country Options**  >  **Allow Countries**.
 
 ### SalesRule
 
 <!--- MAGETWO-99725-->
-* You can now update the conditions of an existing Scheduled update for a Cart Price Rule. Previously, when you tried to change the SKU condition for an update, Magento did not save or apply your changes.
+*  You can now update the conditions of an existing Scheduled update for a Cart Price Rule. Previously, when you tried to change the SKU condition for an update, Magento did not save or apply your changes.
 
 <!--- MC-18696-->
-* Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible.
+*  Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible.
 
 ### Search
 
 <!--- MAGETWO-99769-->
-* Search results now reflect the search weight that you assign to product attributes in attribute configuration.
+*  Search results now reflect the search weight that you assign to product attributes in attribute configuration.
 
 <!--- ENGCOM-5402-->
-* Search by keyword now supports searching on zero (0). *Fix submitted by jeysmook in pull request [23424](https://github.com/magento/magento2/pull/23424)*.
+*  Search by keyword now supports searching on zero (0). *Fix submitted by jeysmook in pull request [23424](https://github.com/magento/magento2/pull/23424)*.
 
 <!--- MAGETWO-99669-->
-* You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
+*  You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
 `{"0":"SQLSTATE[42000]: Syntax error or access violation: 1064 syntax error, unexpected $end, query was: SELECT`.
 
 <!--- MC-18009-->
-* Disabled products now appear in the list of available products in the search results of the Page Builder link attribute–on buttons, images, banners, sliders. Previously, these products did not appear in search results, which prevented users from creating content that went live with a schedule update.
+*  Disabled products now appear in the list of available products in the search results of the Page Builder link attribute–on buttons, images, banners, sliders. Previously, these products did not appear in search results, which prevented users from creating content that went live with a schedule update.
 
 ### Shipping
 
 <!--- MC-17502-->
-* You can now use Cybersource as a payment method when multishipping is enabled. Previously, when you tried to place an order, Magento threw this error: `Invalid Form Key. Please refresh the page`. This resulted from a problem with auto-attaching a form key on the submit event  when one form contained another form.
+*  You can now use Cybersource as a payment method when multishipping is enabled. Previously, when you tried to place an order, Magento threw this error: `Invalid Form Key. Please refresh the page`. This resulted from a problem with auto-attaching a form key on the submit event  when one form contained another form.
 
 <!--- ENGCOM-5110-->
-* The Order Tracking page now displays the Contact us link as expected  when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [22823](https://github.com/magento/magento2/pull/22823)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
+*  The Order Tracking page now displays the Contact us link as expected  when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [22823](https://github.com/magento/magento2/pull/22823)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
 
 <!--- ENGCOM-5109-->
-* Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields)  when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22787](https://github.com/magento/magento2/pull/22787)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
+*  Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields)  when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22787](https://github.com/magento/magento2/pull/22787)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
 
 <!--- ENGCOM-5379-->
-* You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23523](https://github.com/magento/magento2/pull/23523)*.
+*  You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23523](https://github.com/magento/magento2/pull/23523)*.
 
 <!--- MC-18004 -->
-* Merchants can now create shipping labels for return merchandise authorizations. Previously, when a merchant tried to create a shipping label, Magento displayed this error: `No authorized items or allowed shipping methods`.
+*  Merchants can now create shipping labels for return merchandise authorizations. Previously, when a merchant tried to create a shipping label, Magento displayed this error: `No authorized items or allowed shipping methods`.
 
 <!--- ENGCOM-5381-->
-* Magento now validates values entered into the **quantity** field on the Shipping to Multiple Addresses page. *Fix submitted by Nirmal Raval in pull request [23477](https://github.com/magento/magento2/pull/23477)*.
+*  Magento now validates values entered into the **quantity** field on the Shipping to Multiple Addresses page. *Fix submitted by Nirmal Raval in pull request [23477](https://github.com/magento/magento2/pull/23477)*.
 
 <!--- ENGCOM-5455-->
-* The updates that a customer makes to the shipping address during the checkout shipping step is maintained during the billing step. Previously, the information in the **Ship To** area was updated with empty values in the billing step when the **My billing and shipping address are the same** setting is set to **no**. *Fix submitted by rsimmons07 in pull request [23656](https://github.com/magento/magento2/pull/23656)*. [GitHub-22112](https://github.com/magento/magento2/issues/22112)
+*  The updates that a customer makes to the shipping address during the checkout shipping step is maintained during the billing step. Previously, the information in the **Ship To** area was updated with empty values in the billing step when the **My billing and shipping address are the same** setting is set to **no**. *Fix submitted by rsimmons07 in pull request [23656](https://github.com/magento/magento2/pull/23656)*. [GitHub-22112](https://github.com/magento/magento2/issues/22112)
 
 ### Sitemap
 
 <!--- MC-16312-->
-* Magento now generates all relevant product URLS when the **Use Categories Path for Product URLs** setting is enabled.
+*  Magento now generates all relevant product URLS when the **Use Categories Path for Product URLs** setting is enabled.
 
 <!--- ENGCOM-5240-->
-* The sitemap product generation for the **Use Categories Path for Product URLs** setting has been refactored. *Fix submitted by Sergiy Vasiutynskyi in pull request [23129](https://github.com/magento/magento2/pull/23129)*. [GitHub-22934](https://github.com/magento/magento2/issues/22934), [GitHub-4788](https://github.com/magento/magento2/issues/4788)
+*  The sitemap product generation for the **Use Categories Path for Product URLs** setting has been refactored. *Fix submitted by Sergiy Vasiutynskyi in pull request [23129](https://github.com/magento/magento2/pull/23129)*. [GitHub-22934](https://github.com/magento/magento2/issues/22934), [GitHub-4788](https://github.com/magento/magento2/issues/4788)
 
 ### Staging
 
 <!--- MAGETWO-98187-->
-* Magento no longer removes the child products of a grouped product after the group product’s schedule update has expired.
+*  Magento no longer removes the child products of a grouped product after the group product’s schedule update has expired.
 
 <!--- MAGETWO-99378-->
-* Magento now displays the correct product Short Description for the selected update in deployments where there are multiple schedule updates.
+*  Magento now displays the correct product Short Description for the selected update in deployments where there are multiple schedule updates.
 
 <!--- MC-15298-->
-* Magento is introducing the tracking of user actions and events on the Admin as part of our efforts to better understand the Admin user experience and improve product design.The first administrator who logs into the Admin after upgrading to Magento 2.3.3 will see the **Allow admin usage data collection** pop-up window, from which they can decline or agree to participate. Once data is captured, it is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See [Store Admin](https://docs.magento.com/m2/ce/user_guide/stores/admin.html) for more information.
+*  Magento is introducing the tracking of user actions and events on the Admin as part of our efforts to better understand the Admin user experience and improve product design.The first administrator who logs into the Admin after upgrading to Magento 2.3.3 will see the **Allow admin usage data collection** pop-up window, from which they can decline or agree to participate. Once data is captured, it is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See [Store Admin](https://docs.magento.com/m2/ce/user_guide/stores/admin.html) for more information.
 
 <!--- MC-15519-->
-* The database compare tool no longer shows the incorrect comparison results for these entities:
+*  The database compare tool no longer shows the incorrect comparison results for these entities:
 
     `sales_creditmemo`
     `sales_creditmemo_grid`
@@ -1199,28 +1199,28 @@ This release includes the following changes to integrations for core payment met
 ### Swatches
 
 <!--- ENGCOM-5020-->
-* You can update the dropdown attributes (**Admin** > **Stores** > **Attributes** > **Product**) when swatches have been disabled. Previously, when swatches were disabled, Magento displayed this error in the console: `Uncaught TypeError: panel.addClass is not a function`. *Fix submitted by Mark van der Sanden in pull request [22560](https://github.com/magento/magento2/pull/22560)*. [GitHub-20843](https://github.com/magento/magento2/issues/20843)
+*  You can update the dropdown attributes (**Admin** > **Stores** > **Attributes** > **Product**) when swatches have been disabled. Previously, when swatches were disabled, Magento displayed this error in the console: `Uncaught TypeError: panel.addClass is not a function`. *Fix submitted by Mark van der Sanden in pull request [22560](https://github.com/magento/magento2/pull/22560)*. [GitHub-20843](https://github.com/magento/magento2/issues/20843)
 
 <!--- ENGCOM-5175-->
-* The image gallery now correctly loads images for swatch colors. Previously, the gallery did not switch to the designated first image as expected. *Fix submitted by Milind Singh in pull request [23033](https://github.com/magento/magento2/pull/23033)*. [GitHub-23030](https://github.com/magento/magento2/issues/23030)
+*  The image gallery now correctly loads images for swatch colors. Previously, the gallery did not switch to the designated first image as expected. *Fix submitted by Milind Singh in pull request [23033](https://github.com/magento/magento2/pull/23033)*. [GitHub-23030](https://github.com/magento/magento2/issues/23030)
 
 ### Target Rule
 
 <!--- MAGETWO-99448-->
-* Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
+*  Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
 
 <!--- MC-18464-->
-* Magento now returns more informative error messages when a misconfigured target rule caused an error.
+*  Magento now returns more informative error messages when a misconfigured target rule caused an error.
 
 ### Templates
 
 <!--- ENGCOM-5440-->
-* The  Insert Variables popup window is now populated with template variables as expected. (This window is accessed from **Marketing** > **Email Templates** > **Add New Template**.) *Fix submitted by Mahesh Singh in pull request [23173](https://github.com/magento/magento2/pull/23173)*. [GitHub-23135](https://github.com/magento/magento2/issues/23135)
+*  The  Insert Variables popup window is now populated with template variables as expected. (This window is accessed from **Marketing** > **Email Templates** > **Add New Template**.) *Fix submitted by Mahesh Singh in pull request [23173](https://github.com/magento/magento2/pull/23173)*. [GitHub-23135](https://github.com/magento/magento2/issues/23135)
 
 ### Testing
 
 <!--- MC-16371 MC-18277 MC-18750 MC-11031 MC-15749-->
-* The following tests have been improved:
+*  The following tests have been improved:
 `CheckoutWithBraintreePaypalMinicartTest`
 `Magento\Catalog\Setup\Patch\Schema\ChangeTmpTablesEngine`
 `MAGETWO-69516: Cart Price Rule with related Banner for specific Customer Segment is persisted under long-term cookie`
@@ -1228,182 +1228,182 @@ This release includes the following changes to integrations for core payment met
 `Mftf Test: StorefrontApplyCategoryPermissionsToSecondWebsiteTest`
 
 <!--- MC-5806-->
-* The Dependency static test now detects URL dependencies as expected.
+*  The Dependency static test now detects URL dependencies as expected.
 
 <!--- MC-13909-->
-* `CreateCmsPageEntityMultipleStoreViewsTest` no longer fails on variation `CreateCmsPageEntityMultipleStoreViewsTestVariation1`.
+*  `CreateCmsPageEntityMultipleStoreViewsTest` no longer fails on variation `CreateCmsPageEntityMultipleStoreViewsTestVariation1`.
 
 <!--- ENGCOM-5470-->
-* `CommentLevelsSniff` now works correctly with the `@magento_import` statement. Previously, when you ran `Magento\Test\Less\LiveCodeTest`, Magento threw an error on lines that contained `@magento_import`. *Fix submitted by Pavel Bystritsky in pull request [23790](https://github.com/magento/magento2/pull/23790)*. [GitHub-23789](https://github.com/magento/magento2/issues/23789)
+*  `CommentLevelsSniff` now works correctly with the `@magento_import` statement. Previously, when you ran `Magento\Test\Less\LiveCodeTest`, Magento threw an error on lines that contained `@magento_import`. *Fix submitted by Pavel Bystritsky in pull request [23790](https://github.com/magento/magento2/pull/23790)*. [GitHub-23789](https://github.com/magento/magento2/issues/23789)
 
 <!--- ENGCOM-3132-->
-* Magento now deletes the stub modules that tests create. Previously, integration tests created stub modules in `app/code`, which could potentially affect production code. *Fix submitted by Andreas von Studnitz in pull request [18459](https://github.com/magento/magento2/pull/18459)*. [GitHub-12696](https://github.com/magento/magento2/issues/12696)
+*  Magento now deletes the stub modules that tests create. Previously, integration tests created stub modules in `app/code`, which could potentially affect production code. *Fix submitted by Andreas von Studnitz in pull request [18459](https://github.com/magento/magento2/pull/18459)*. [GitHub-12696](https://github.com/magento/magento2/issues/12696)
 
 ### Translation and locales
 
 <!--- ENGCOM-5196-->
-* White space between words now appears as expected in non-English websites. *Fix submitted by Alexey Arendarenko in pull request [23081](https://github.com/magento/magento2/pull/23081)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
+*  White space between words now appears as expected in non-English websites. *Fix submitted by Alexey Arendarenko in pull request [23081](https://github.com/magento/magento2/pull/23081)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
 
 <!--- ENGCOM-5334-->
-* The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Alexey Arendarenko in pull request [23338](https://github.com/magento/magento2/pull/23338)*.
+*  The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Alexey Arendarenko in pull request [23338](https://github.com/magento/magento2/pull/23338)*.
 
 ### UI
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-17922-->
-* The calendar date picker now updates values as expected when the linked input value is changed.
+*  The calendar date picker now updates values as expected when the linked input value is changed.
 
 <!--- MAGETWO-99361-->
-* The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **Url Rewrites**), Magento did not include most categories in the resulting view.
+*  The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **Url Rewrites**), Magento did not include most categories in the resulting view.
 
 <!--- MAGETWO-99832-->
-* Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
+*  Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
 
 <!--- ENGCOM-4923-->
-* Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Roman Kis in pull request [21992](https://github.com/magento/magento2/pull/21992)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
+*  Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Roman Kis in pull request [21992](https://github.com/magento/magento2/pull/21992)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
 
 <!--- ENGCOM-5067-->
-* The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Arvinda Kumar in pull request [22644](https://github.com/magento/magento2/pull/22644)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
+*  The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Arvinda Kumar in pull request [22644](https://github.com/magento/magento2/pull/22644)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
 
 <!--- ENGCOM-5083-->
-* The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22779](https://github.com/magento/magento2/pull/22779)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
+*  The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22779](https://github.com/magento/magento2/pull/22779)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
 
 <!--- ENGCOM-5148-->
-* Added appropriate white space between elements of product descriptions on the product list view. *Fix submitted by Hitesh in pull request [22931](https://github.com/magento/magento2/pull/22931)*. [GitHub-20788](https://github.com/magento/magento2/issues/20788)
+*  Added appropriate white space between elements of product descriptions on the product list view. *Fix submitted by Hitesh in pull request [22931](https://github.com/magento/magento2/pull/22931)*. [GitHub-20788](https://github.com/magento/magento2/issues/20788)
 
 <!--- ENGCOM-5176-->
-* Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23035](https://github.com/magento/magento2/pull/23035)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
+*  Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23035](https://github.com/magento/magento2/pull/23035)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
 
 <!--- MC-16334-->
-* Page element layout issues on  **Stores** > **Configuration** > **Advanced** > **Admin** have been resolved. Previously, when you expanded the security block on this page, the **Use system value** text appeared at the top of the page, not adjacent to the checkbox it applied to.
+*  Page element layout issues on  **Stores** > **Configuration** > **Advanced** > **Admin** have been resolved. Previously, when you expanded the security block on this page, the **Use system value** text appeared at the top of the page, not adjacent to the checkbox it applied to.
 
 <!--- MC-17003-->
-* The missing **Update Totals** button has been added to the Credit Memo page.
+*  The missing **Update Totals** button has been added to the Credit Memo page.
 
 <!--- ENGCOM-5512-->
-* Magento now displays an error message as needed when you click the  **Catalog** > **Products** > **Create Configurations** button and submit invalid data. Previously, Magento did not display the error message after validation due to lack of autofocus on the error field.
+*  Magento now displays an error message as needed when you click the  **Catalog** > **Products** > **Create Configurations** button and submit invalid data. Previously, Magento did not display the error message after validation due to lack of autofocus on the error field.
 *Fix submitted by Eden Duong in pull request [23905](https://github.com/magento/magento2/pull/23905)*. [GitHub-23904](https://github.com/magento/magento2/issues/23904)
 
 <!--- ENGCOM-5473-->
-* The toggle icon on the **Catalog** > **Products** > **New Product (Configurable)** > **Create Configuration** page now works as expected. *Fix submitted by Eden Duong in pull request [23803](https://github.com/magento/magento2/pull/23803)*. [GitHub-22702](https://github.com/magento/magento2/issues/22702)
+*  The toggle icon on the **Catalog** > **Products** > **New Product (Configurable)** > **Create Configuration** page now works as expected. *Fix submitted by Eden Duong in pull request [23803](https://github.com/magento/magento2/pull/23803)*. [GitHub-22702](https://github.com/magento/magento2/issues/22702)
 
 <!--- ENGCOM-5467-->
-* Magento no longer validates data in the **Discount Amount** field after page load until the user performs an action in the Create New Catalog Rule form. Previously, Magento ran validation checks on that field despite its inactivity, and threw an error. *Fix submitted by Eden Duong in pull request [23779](https://github.com/magento/magento2/pull/23779)*. [GitHub-23777](https://github.com/magento/magento2/issues/23777)
+*  Magento no longer validates data in the **Discount Amount** field after page load until the user performs an action in the Create New Catalog Rule form. Previously, Magento ran validation checks on that field despite its inactivity, and threw an error. *Fix submitted by Eden Duong in pull request [23779](https://github.com/magento/magento2/pull/23779)*. [GitHub-23777](https://github.com/magento/magento2/issues/23777)
 
 <!--- ENGCOM-5453-->
-* You can now edit the status label for the storefront from the Admin in single-store mode. Previously, there was no status field available from **Stores** > **Order Status** when single-store mode was enabled. *Fix submitted by Eden Duong in pull request [23681](https://github.com/magento/magento2/pull/23681)*. [GitHub-22654](https://github.com/magento/magento2/issues/22654)
+*  You can now edit the status label for the storefront from the Admin in single-store mode. Previously, there was no status field available from **Stores** > **Order Status** when single-store mode was enabled. *Fix submitted by Eden Duong in pull request [23681](https://github.com/magento/magento2/pull/23681)*. [GitHub-22654](https://github.com/magento/magento2/issues/22654)
 
 <!--- ENGCOM-5070-->
-* The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Abrar Pathan in pull request [21215](https://github.com/magento/magento2/pull/21215)*. [GitHub-21214](https://github.com/magento/magento2/issues/21214)
+*  The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Abrar Pathan in pull request [21215](https://github.com/magento/magento2/pull/21215)*. [GitHub-21214](https://github.com/magento/magento2/issues/21214)
 
 <!--- ENGCOM-5278-->
-* The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23234](https://github.com/magento/magento2/pull/23234)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
+*  The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23234](https://github.com/magento/magento2/pull/23234)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
 
 <!--- ENGCOM-4623-->
-* Magento now sets the `last` CSS class to the top menu when one or more parent items are not active. As a result, menu items will be filtered before they are processed for HTML output. *Fix submitted by Arnoud Beekman in pull request [22071](https://github.com/magento/magento2/pull/22071)*. [GitHub-13266](https://github.com/magento/magento2/issues/13266)
+*  Magento now sets the `last` CSS class to the top menu when one or more parent items are not active. As a result, menu items will be filtered before they are processed for HTML output. *Fix submitted by Arnoud Beekman in pull request [22071](https://github.com/magento/magento2/pull/22071)*. [GitHub-13266](https://github.com/magento/magento2/issues/13266)
 
 <!--- ENGCOM-5155-->
-* The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Nirav Patel in pull request [23007](https://github.com/magento/magento2/pull/23007)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
+*  The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Nirav Patel in pull request [23007](https://github.com/magento/magento2/pull/23007)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
 
 <!--- ENGCOM-5107-->
-* You can now specify custom fonts for use in your deployment. Previously, the `.lib-font-face()` mixin required that you include the font in all the formats listed (for example, `eot`, `woff2`, `woff`, `ttf`, and `svg`). If your font was not available in these formats, Magento displayed a 404 error. *Fix submitted by Karla Saaremäe in pull request [22854](https://github.com/magento/magento2/pull/22854)*. [GitHub-4628](https://github.com/magento/magento2/issues/4628)
+*  You can now specify custom fonts for use in your deployment. Previously, the `.lib-font-face()` mixin required that you include the font in all the formats listed (for example, `eot`, `woff2`, `woff`, `ttf`, and `svg`). If your font was not available in these formats, Magento displayed a 404 error. *Fix submitted by Karla Saaremäe in pull request [22854](https://github.com/magento/magento2/pull/22854)*. [GitHub-4628](https://github.com/magento/magento2/issues/4628)
 
 <!--- ENGCOM-5325-->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Nishant Jariwala in pull request [23286](https://github.com/magento/magento2/pull/23286)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Nishant Jariwala in pull request [23286](https://github.com/magento/magento2/pull/23286)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!--- ENGCOM-5386-->
-* The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23528](https://github.com/magento/magento2/pull/23528)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
+*  The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23528](https://github.com/magento/magento2/pull/23528)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
 
 <!--- ENGCOM-5358-->
-* The `font-size` setting for all `input-field` labels with a tooltip is no longer set to 0, and time fields are separated by colons (:) as expected. *Fix submitted by Geeta Modi in pull request [23393](https://github.com/magento/magento2/pull/23393)*. [GitHub-21974](https://github.com/magento/magento2/issues/21974)
+*  The `font-size` setting for all `input-field` labels with a tooltip is no longer set to 0, and time fields are separated by colons (:) as expected. *Fix submitted by Geeta Modi in pull request [23393](https://github.com/magento/magento2/pull/23393)*. [GitHub-21974](https://github.com/magento/magento2/issues/21974)
 
 <!--- ENGCOM-5321-->
-* Magento now displays the Admin grid header as expected when there are no buttons in the toolbar. *Fix submitted by Shankar Konar in pull request [23247](https://github.com/magento/magento2/pull/23247)*.
+*  Magento now displays the Admin grid header as expected when there are no buttons in the toolbar. *Fix submitted by Shankar Konar in pull request [23247](https://github.com/magento/magento2/pull/23247)*.
 
 ### URL rewrites
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MAGETWO-99830-->
-* Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
+*  Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
 
 <!--- MAGETWO-96663-->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!--- ENGCOM-5195-->
-* URL redirects now work as expected when you click **Save** after editing a product view from the Customer tab (**Customer** > **Product Reviews** > **Edit Review**). *Fix submitted by Ravi Chandra in pull request [22426](https://github.com/magento/magento2/pull/22426)*. [GitHub-22425](https://github.com/magento/magento2/issues/22425)
+*  URL redirects now work as expected when you click **Save** after editing a product view from the Customer tab (**Customer** > **Product Reviews** > **Edit Review**). *Fix submitted by Ravi Chandra in pull request [22426](https://github.com/magento/magento2/pull/22426)*. [GitHub-22425](https://github.com/magento/magento2/issues/22425)
 
 <!--- ENGCOM-5435-->
-* Magento now correctly renders the value of a product’s customizable option field of type `Area` when you enter a multi-line value from the Admin. Previously, a multi-line value was rendered with an HTML `<br>` tag as part of the value. *Fix submitted by Sunil in pull request [23524](https://github.com/magento/magento2/pull/23524)*. [GitHub-23510](https://github.com/magento/magento2/issues/23510)
+*  Magento now correctly renders the value of a product’s customizable option field of type `Area` when you enter a multi-line value from the Admin. Previously, a multi-line value was rendered with an HTML `<br>` tag as part of the value. *Fix submitted by Sunil in pull request [23524](https://github.com/magento/magento2/pull/23524)*. [GitHub-23510](https://github.com/magento/magento2/issues/23510)
 
 <!--- ENGCOM-5397-->
-* You can now use a plus sign (+) character in content contained within a widget on a CMS page. Previously, Magento did not render the character, although it appeared in the page content stored in the database and when editing the widget. *Fix submitted by Sarfaraz Bheda in pull request [23496](https://github.com/magento/magento2/pull/23496)*.
+*  You can now use a plus sign (+) character in content contained within a widget on a CMS page. Previously, Magento did not render the character, although it appeared in the page content stored in the database and when editing the widget. *Fix submitted by Sarfaraz Bheda in pull request [23496](https://github.com/magento/magento2/pull/23496)*.
 
 <!--- ENGCOM-5330-->
-* Product URLs are now updated as expected after Magento changes the URL key of the category in multi-site deployment. *Fix submitted by Alastair Mucklow in pull request [23309](https://github.com/magento/magento2/pull/23309)*. [GitHub-23074](https://github.com/magento/magento2/issues/23074)
+*  Product URLs are now updated as expected after Magento changes the URL key of the category in multi-site deployment. *Fix submitted by Alastair Mucklow in pull request [23309](https://github.com/magento/magento2/pull/23309)*. [GitHub-23074](https://github.com/magento/magento2/issues/23074)
 
 ### Vertex
 
-* Incorrect Customer Codes are no longer sent when Vertex invoices are set to send during an order status change.
+*  Incorrect Customer Codes are no longer sent when Vertex invoices are set to send during an order status change.
 
-* Resolved an issue where assisted parameters were not requested and logged during Invoice calls made during Order Status Change.
+*  Resolved an issue where assisted parameters were not requested and logged during Invoice calls made during Order Status Change.
 
-* Calls to Vertex are now made when string values exceed the maximum allowed length in the Vertex SDK.
+*  Calls to Vertex are now made when string values exceed the maximum allowed length in the Vertex SDK.
 
-* Tax code, vertex tax code, and invoice text codes are now saved for orders created during Guest Checkout.
+*  Tax code, vertex tax code, and invoice text codes are now saved for orders created during Guest Checkout.
 
-* Guest Orders are no longer invoiced twice if logging was enabled.
+*  Guest Orders are no longer invoiced twice if logging was enabled.
 
-* Shipping is now included on a Vertex invoice if that invoice was sent in the same request that its order was created in if that order was placed using guest checkout.
+*  Shipping is now included on a Vertex invoice if that invoice was sent in the same request that its order was created in if that order was placed using guest checkout.
 
-* Taxes for Magento Commerce gift wrap are now properly written to the Vertex tax journal.
+*  Taxes for Magento Commerce gift wrap are now properly written to the Vertex tax journal.
 
 ### Visual Merchandiser
 
 <!--- MAGETWO-96129-->
-* You can now add tier price conditions to smart categories.
+*  You can now add tier price conditions to smart categories.
 
 <!--- MAGETWO-98937-->
-* The Visual Merchandiser product list now renders properly when product names exceed 50 characters.
+*  The Visual Merchandiser product list now renders properly when product names exceed 50 characters.
 
 ### Web API framework
 
 <!--- ENGCOM-5162-->
-* Magento now renders shipment details for an order without a fatal error when you use REST to create a shipment. *Fix submitted by Milind Singh in pull request [22687](https://github.com/magento/magento2/pull/22687)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
+*  Magento now renders shipment details for an order without a fatal error when you use REST to create a shipment. *Fix submitted by Milind Singh in pull request [22687](https://github.com/magento/magento2/pull/22687)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
 
 <!--- ENGCOM-5116-->
-* You can now use REST to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22893](https://github.com/magento/magento2/pull/22893)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
+*  You can now use REST to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22893](https://github.com/magento/magento2/pull/22893)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
 
 <!--- ENGCOM-5192-->
-* Swagger now accepts requests in XML and can display results in the same format. *Fix submitted by Simon Schröer in pull request [23025](https://github.com/magento/magento2/pull/23025)*.
+*  Swagger now accepts requests in XML and can display results in the same format. *Fix submitted by Simon Schröer in pull request [23025](https://github.com/magento/magento2/pull/23025)*.
 
 <!--- ENGCOM-5312-->
-* The `POST` on `/orders` REST calls no longer fail when properties in the request body are out of order. Previously, when billing address data preceded customer data in the Order Create API JSON payload, the billing address email was not populated, so the order was empty. *Fix submitted by Mateusz Wira in pull request [23048](https://github.com/magento/magento2/pull/23048)*.
+*  The `POST` on `/orders` REST calls no longer fail when properties in the request body are out of order. Previously, when billing address data preceded customer data in the Order Create API JSON payload, the billing address email was not populated, so the order was empty. *Fix submitted by Mateusz Wira in pull request [23048](https://github.com/magento/magento2/pull/23048)*.
 
 ### Website restriction
 
 <!--- MAGETWO-99868-->
-* Administrators with appropriate permissions can now create a new customer account on the Admin when the **Website Restriction** setting is enabled. Previously, Magento threw this exception: `Can not register new customer due to restrictions are enabled`.
+*  Administrators with appropriate permissions can now create a new customer account on the Admin when the **Website Restriction** setting is enabled. Previously, Magento threw this exception: `Can not register new customer due to restrictions are enabled`.
 
 ### Wishlist
 
 <!--- MAGETWO-99228-->
-* Wishlists now accurately reflect product availability when a product has been added to a wishlist and then subsequently disabled. Previously, the wishlist displayed these contradictory messages: **You have no items in your wish list** and **1 item in wish list**.
+*  Wishlists now accurately reflect product availability when a product has been added to a wishlist and then subsequently disabled. Previously, the wishlist displayed these contradictory messages: **You have no items in your wish list** and **1 item in wish list**.
 
 <!--- MAGETWO-99312-->
-* Wishlist names can now be edited from the storefront.
+*  Wishlist names can now be edited from the storefront.
 
 <!--- MAGETWO-97216-->
-* The `Magento\FunctionalTestingFramework.functional.StorefrontAddMultipleStoreProductsToWishlistTest` test no longer fails randomly.
+*  The `Magento\FunctionalTestingFramework.functional.StorefrontAddMultipleStoreProductsToWishlistTest` test no longer fails randomly.
 
 <!--- MC-18800-->
-* The wishlist no longer shows an item that has been disabled on the Admin.
+*  The wishlist no longer shows an item that has been disabled on the Admin.
 
 <!--- ENGCOM-5514-->
-* Wishlist items now display decimal values as appropriate. Previously, Magento saved decimal quantities for wishlist items but did not display these values in the wishlist on the storefront. *Fix submitted by Max Fickers in pull request [23933](https://github.com/magento/magento2/pull/23933)*. [GitHub-23932](https://github.com/magento/magento2/issues/23932)
+*  Wishlist items now display decimal values as appropriate. Previously, Magento saved decimal quantities for wishlist items but did not display these values in the wishlist on the storefront. *Fix submitted by Max Fickers in pull request [23933](https://github.com/magento/magento2/pull/23933)*. [GitHub-23932](https://github.com/magento/magento2/issues/23932)
 
 ## Known issue
 
@@ -1418,9 +1418,9 @@ The  `Magento\Framework\Mail\Template\TransportBuilder` and `Magento\Newslet
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### Partner contributions
 

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -39,9 +39,9 @@ Look for the following highlights in this release:
 
 This release includes the following security enhancements:
 
-* PSD2 compliance to core payment methods
-* Fixes for 75 critical security issues
-* Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
+*  PSD2 compliance to core payment methods
+*  Fixes for 75 critical security issues
+*  Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
 
 #### Core payment methods integrations are now compliant with PSD2 regulations
 
@@ -49,16 +49,16 @@ The European Union recently revised the Payment Services Directive (PSD) regulat
 
 This release contains the following major PSD-related changes:
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**.
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**.
 
 <!--- MAGETWO-99739 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
 
 #### Security enhancements and fixes to core code
 
-* **75 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.3) have been ported to 2.2.10, 1.14.4.3, and 1.9.4.3, as appropriate.
+*  **75 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.3.3) have been ported to 2.2.10, 1.14.4.3, and 1.9.4.3, as appropriate.
 
 {:.bs-callout-info}
 Starting with the release of Magento Open Source 2.3.2, Magento will assign and publish indexed Common Vulnerabilities and Exposures (CVE) numbers with each security bug reported to us by external parties. This allows users of Magento Open Source to more easily identify unaddressed vulnerabilities in their deployment.
@@ -68,51 +68,51 @@ Starting with the release of Magento Open Source 2.3.2, Magento will assign and 
 The following upgrades to core platform components boost platform security and support PCI compliance:
 
 <!--- MC-14862-->
-* Magento 2.3.3 now supports **PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21)**.
+*  Magento 2.3.3 now supports **PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21)**.
 
 <!--- MC-14863-->
-* Magento now supports **Varnish 6.2.0**.
+*  Magento now supports **Varnish 6.2.0**.
 
 <!--- MC-14912-->
-* Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
+*  Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
 
 ### Performance boosts
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-* Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-16046-->
-* Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
+*  Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
 
 ### Infrastructure improvements
 
 This release contains  enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`,  `UrlRewrite`, `Customer`, and `Ui`. Here are some additional core enhancements:
 
-* The WYSIWYG editor has been upgraded to TinyMCE v. 4.9.5​.
+*  The WYSIWYG editor has been upgraded to TinyMCE v. 4.9.5​.
 
 ### Merchant tool enhancements
 
 <!--- MC-15298-->
-* As part of our efforts to better understand the Admin user experience and improve product design, Magento is introducing the tracking of user actions and events on the Admin. After you upgrade to Magento 2.3.3, the first administrative user who logs into the Admin will be prompted to **Allow admin usage data collection**. If the user agrees to data collection, the data captured from Admin activity is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See [Store Admin](https://docs.magento.com/m2/ce/user_guide/stores/admin.html) for more information.
+*  As part of our efforts to better understand the Admin user experience and improve product design, Magento is introducing the tracking of user actions and events on the Admin. After you upgrade to Magento 2.3.3, the first administrative user who logs into the Admin will be prompted to **Allow admin usage data collection**. If the user agrees to data collection, the data captured from Admin activity is sent to Adobe Analytics for analysis and reporting. Typical events include page views, save actions, and changes to Magento mode. See [Store Admin](https://docs.magento.com/m2/ce/user_guide/stores/admin.html) for more information.
 
 ### Inventory Management enhancements
 
-* Fixes to multiple  bugs. See [Inventory Management release notes](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html).
+*  Fixes to multiple  bugs. See [Inventory Management release notes](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html).
 
 ### GraphQL
 
 Expanded GraphQL functionality and improved coverage for PayPal payment integrations, gift cards, and store credit features. Added mutations and queries that support these tasks:
 
-* Process payments through PayPal Express checkout, Payflow Pro and Link Express Checkout, and other supported PayPal payment methods, Authorize.net, and Braintree
-* Redeem gift cards and convert to store credit balance for logged-in users
-* Update shopping carts for guest users to apply or remove gift cards and check card balance
-* Add configurable products to cart
+*  Process payments through PayPal Express checkout, Payflow Pro and Link Express Checkout, and other supported PayPal payment methods, Authorize.net, and Braintree
+*  Redeem gift cards and convert to store credit balance for logged-in users
+*  Update shopping carts for guest users to apply or remove gift cards and check card balance
+*  Add configurable products to cart
 
 See [Release notes](https://devdocs.magento.com/guides/v2.3/graphql/release-notes.html) for a more detailed discussion of recent GraphQL bug fixes.
 
@@ -128,9 +128,9 @@ The Google Shopping ads Channel Marketplace extension is now available as a bund
 
 This release of Magento Shipping includes:
 
-* Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
+*  Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
 
-* Support for bundled products and prepackage options.
+*  Support for bundled products and prepackage options.
 
 See [Magento Shipping](https://docs.magento.com/m2/ee/user_guide/shipping/magento-shipping.html).
 
@@ -144,28 +144,28 @@ Amazon Pay is now compliant with the PSD2 directive for UK and Germany. See [Pay
 
 #### dotdigital
 
-* Improved product catalog sync for bundled and custom products.
+*  Improved product catalog sync for bundled and custom products.
 
-* Enhanced communications for abandoned cart.
+*  Enhanced communications for abandoned cart.
 
 #### Klarna
 
-* Merchants can now disable the sending of customer information.
+*  Merchants can now disable the sending of customer information.
 
-* New options now support B2B transactions in select markets.
+*  New options now support B2B transactions in select markets.
 
-* PayBright, a Canadian payment coverage option, is now supported.
+*  PayBright, a Canadian payment coverage option, is now supported.
 
 See [Klarna](https://docs.magento.com/m2/ee/user_guide/payment/klarna.html).
 
 #### Vertex
 
-* Added support for Vertex Flexible Fields. Vertex flexible fields allow merchants to send additional information to the tax engine, which  can then be used in Tax Assist Rules to refine a product’s applicable tax.
+*  Added support for Vertex Flexible Fields. Vertex flexible fields allow merchants to send additional information to the tax engine, which  can then be used in Tax Assist Rules to refine a product’s applicable tax.
 
-* Several attributes are provided by default, including administrator-created Customer attributes, Address attributes, and Product attributes. Documentation is provided in the module’s README file on how integrators can add additional options to these attributes.
+*  Several attributes are provided by default, including administrator-created Customer attributes, Address attributes, and Product attributes. Documentation is provided in the module’s README file on how integrators can add additional options to these attributes.
 
 <!--- BUNDLE-2151-->
-* You can now add custom fields to the Vertex connector.
+*  You can now add custom fields to the Vertex connector.
 
 #### Yotpo
 
@@ -182,830 +182,830 @@ We've fixed hundreds of issues in the Magento 2.3.3 core code.
 ### Installation, upgrade, deployment
 
 <!--- MAGETWO-99616-->
-* Magento font icons now load as expected when deployment optimization is implemented.
+*  Magento font icons now load as expected when deployment optimization is implemented.
 
 <!--- ENGCOM-5056-->
-* The short form versions of the `—lock-env`  and  `—lock-config`  `bin/magento config:set` options now work as expected. *Fix submitted by Satya Prakash in pull request [22720](https://github.com/magento/magento2/pull/22720)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
+*  The short form versions of the `—lock-env`  and  `—lock-config`  `bin/magento config:set` options now work as expected. *Fix submitted by Satya Prakash in pull request [22720](https://github.com/magento/magento2/pull/22720)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
 
 <!--- ENGCOM-5184-->
-* Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [22884](https://github.com/magento/magento2/pull/22884)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
+*  Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [22884](https://github.com/magento/magento2/pull/22884)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
 
 <!--- ENGCOM-5002-->
-* You can now use JSON to  set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [22513](https://github.com/magento/magento2/pull/22513)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
+*  You can now use JSON to  set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [22513](https://github.com/magento/magento2/pull/22513)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
 
 <!--- MC-18697-->
-* PHP unit tests no longer fail by default when Magento is installed from Composer.
+*  PHP unit tests no longer fail by default when Magento is installed from Composer.
 
 <!--- ENGCOM-5241-->
-* Removed the  obsolete `system.xml` file from the `app/code/Magento/Theme/etc` directory. *Fix submitted by Alexander Taranovsky in pull request [23140](https://github.com/magento/magento2/pull/23140)*. [GitHub-23138](https://github.com/magento/magento2/issues/23138)
+*  Removed the  obsolete `system.xml` file from the `app/code/Magento/Theme/etc` directory. *Fix submitted by Alexander Taranovsky in pull request [23140](https://github.com/magento/magento2/pull/23140)*. [GitHub-23138](https://github.com/magento/magento2/issues/23138)
 
 <!--- ENGCOM-5187-->
-* Magento now displays a more informative message when a data patch cannot be applied due to an exception. *Fix submitted by Ash Smith in pull request [23046](https://github.com/magento/magento2/pull/23046)*. [GitHub-23045](https://github.com/magento/magento2/issues/23045)
+*  Magento now displays a more informative message when a data patch cannot be applied due to an exception. *Fix submitted by Ash Smith in pull request [23046](https://github.com/magento/magento2/pull/23046)*. [GitHub-23045](https://github.com/magento/magento2/issues/23045)
 
 <!--- ENGCOM-5264-->
-* The static content deployment progress bar now works as expected. *Fix submitted by Amit Vishvakarma in pull request [23216](https://github.com/magento/magento2/pull/23216)*. [GitHub-23213](https://github.com/magento/magento2/issues/23213)
+*  The static content deployment progress bar now works as expected. *Fix submitted by Amit Vishvakarma in pull request [23216](https://github.com/magento/magento2/pull/23216)*. [GitHub-23213](https://github.com/magento/magento2/issues/23213)
 
 <!--- ENGCOM-5395-->
-* The `setup:upgrade` command now throws an exception if the `app:config:import` command fails. *Fix submitted by Simon Frost in pull request [23310](https://github.com/magento/magento2/pull/23310)*.
+*  The `setup:upgrade` command now throws an exception if the `app:config:import` command fails. *Fix submitted by Simon Frost in pull request [23310](https://github.com/magento/magento2/pull/23310)*.
 
 <!--- ENGCOM-5441-->
-* Fields that have been disabled through configuration settings (**Admin** > **Stores** > **Configuration** > **General** > **General** > **Store Information**) can no longer be overwritten from the Admin. *Fix submitted by Rafael Kassner in pull request [22891](https://github.com/magento/magento2/pull/22891)*. [GitHub-22890](https://github.com/magento/magento2/issues/22890)
+*  Fields that have been disabled through configuration settings (**Admin** > **Stores** > **Configuration** > **General** > **General** > **Store Information**) can no longer be overwritten from the Admin. *Fix submitted by Rafael Kassner in pull request [22891](https://github.com/magento/magento2/pull/22891)*. [GitHub-22890](https://github.com/magento/magento2/issues/22890)
 
 <!--- ENGCOM-4644-->
-* The Magento installation process no longer checks for `dev php` extension dependencies from non-root `composer.json` files. *Fix submitted by Oleksii Lisovyi in pull request [22116](https://github.com/magento/magento2/pull/22116)*  [GitHub-21136](https://github.com/magento/magento2/issues/21136)
+*  The Magento installation process no longer checks for `dev php` extension dependencies from non-root `composer.json` files. *Fix submitted by Oleksii Lisovyi in pull request [22116](https://github.com/magento/magento2/pull/22116)*  [GitHub-21136](https://github.com/magento/magento2/issues/21136)
 
 <!--- ENGCOM-5098-->
-* Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22607](https://github.com/magento/magento2/pull/22607)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852)
+*  Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22607](https://github.com/magento/magento2/pull/22607)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852)
 
 <!--- ENGCOM-5500-->
-* Magento now runs an additional check when determining the password hashing algorithm to use for the libsodium library to see if it supports `argon2id`. The `bin/magento` command did not run successfully if the version of libsodium that you were running did not include `argon2id` support. *Fix submitted by Matei Stefanescu in pull request [23866](https://github.com/magento/magento2/pull/23866)*. [GitHub-23405](https://github.com/magento/magento2/issues/23405)
+*  Magento now runs an additional check when determining the password hashing algorithm to use for the libsodium library to see if it supports `argon2id`. The `bin/magento` command did not run successfully if the version of libsodium that you were running did not include `argon2id` support. *Fix submitted by Matei Stefanescu in pull request [23866](https://github.com/magento/magento2/pull/23866)*. [GitHub-23405](https://github.com/magento/magento2/issues/23405)
 
 ### Backend
 
 <!--- MC-17275-->
-* The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
+*  The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
 
 <!--- MC-17675-->
-* The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
+*  The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
 
 <!--- MC-17609-->
-* The store view drop-down menu no longer displays unnecessary symbols.
+*  The store view drop-down menu no longer displays unnecessary symbols.
 
 ### Bundle products
 
 <!--- MAGETWO-99371-->
-* You can now successfully check out bundle products using the Braintree payment method with the payment method set to **Authorize and Capture**.
+*  You can now successfully check out bundle products using the Braintree payment method with the payment method set to **Authorize and Capture**.
 
 <!--- ENGCOM-5360-->
-* Discount coupons now work as expected for bundle products that include both virtual and simple products when the **Ship Bundle Items** setting is set to **Separately**. *Fix submitted by Nikolay Sumrak in pull request [22987](https://github.com/magento/magento2/pull/22987)*.
+*  Discount coupons now work as expected for bundle products that include both virtual and simple products when the **Ship Bundle Items** setting is set to **Separately**. *Fix submitted by Nikolay Sumrak in pull request [22987](https://github.com/magento/magento2/pull/22987)*.
 
 ### Cache
 
 <!--- MC-14863-->
-* Varnish cache support has been upgraded for compatibility with version 6.2.0.
+*  Varnish cache support has been upgraded for compatibility with version 6.2.0.
 
 <!--- MAGETWO-98650-->
-* Full-page cache no longer clears out the checkout session data on uncached pages when the `Magento_Persistent` module is disabled. [GitHub-21614](https://github.com/magento/magento2/issues/21614)
+*  Full-page cache no longer clears out the checkout session data on uncached pages when the `Magento_Persistent` module is disabled. [GitHub-21614](https://github.com/magento/magento2/issues/21614)
 
 <!--- MAGETWO-54438-->
-* Magento now displays simple products on the storefront after the cancellation of an order that contains the bundled simple product. Previously, products did not appear on the storefront after an order containing the bundle product to which the simple product belongs was canceled.
+*  Magento now displays simple products on the storefront after the cancellation of an order that contains the bundled simple product. Previously, products did not appear on the storefront after an order containing the bundle product to which the simple product belongs was canceled.
 
 <!--- ENGCOM-5143-->
-* The Varnish health check no longer fails to the presence of `id_prefix` in `env.php`. Previously, Varnish returned a `503 Backend fetch failed` error. *Fix submitted by Nazar Klovanych in pull request [22307](https://github.com/magento/magento2/pull/22307)*. [GitHub-22143](https://github.com/magento/magento2/issues/22143)
+*  The Varnish health check no longer fails to the presence of `id_prefix` in `env.php`. Previously, Varnish returned a `503 Backend fetch failed` error. *Fix submitted by Nazar Klovanych in pull request [22307](https://github.com/magento/magento2/pull/22307)*. [GitHub-22143](https://github.com/magento/magento2/issues/22143)
 
 ### Cart and checkout
 
 <!--- MAGETWO-97317-->
-* The REST calls for adding an item to a cart (`POST V1/guest-carts/:cartId/items` and `POST V1/guest-carts/:cartId/items`) now include the product price when a call returns the product from an already populated cart. Previously, the item price was not returned if that cart had been emptied before the call was made.
+*  The REST calls for adding an item to a cart (`POST V1/guest-carts/:cartId/items` and `POST V1/guest-carts/:cartId/items`) now include the product price when a call returns the product from an already populated cart. Previously, the item price was not returned if that cart had been emptied before the call was made.
 
 <!--- MAGETWO-99075-->
-* Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
+*  Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
 
 <!--- MAGETWO-48570-->
-* Products added to a shopping cart through REST now display correct product prices. Previously, the shopping cart displayed product prices of zero. [GitHub-2991](https://github.com/magento/magento2/issues/2991)
+*  Products added to a shopping cart through REST now display correct product prices. Previously, the shopping cart displayed product prices of zero. [GitHub-2991](https://github.com/magento/magento2/issues/2991)
 
 <!--- MC-17755-->
-* Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order.
+*  Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order.
 
 <!--- MAGETWO-99370-->
-* You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
+*  You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
 
 <!--- ENGCOM-4126-->
-* Administrators with appropriate permissions can now view the contents of a cart for a registered customer from the Admin customer edit interface. *Fix submitted by Rav in pull request [20918](https://github.com/magento/magento2/pull/20918)*.
+*  Administrators with appropriate permissions can now view the contents of a cart for a registered customer from the Admin customer edit interface. *Fix submitted by Rav in pull request [20918](https://github.com/magento/magento2/pull/20918)*.
 
 <!--- ENGCOM-5071-->
-* Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Karan Shah in pull request [22387](https://github.com/magento/magento2/pull/22387)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
+*  Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Karan Shah in pull request [22387](https://github.com/magento/magento2/pull/22387)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
 
 <!--- MC-17808-->
-* The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
+*  The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
 
 <!--- MC-18281-->
-* The checkout order summary now displays the correct number of ordered items.
+*  The checkout order summary now displays the correct number of ordered items.
 
 <!--- ENGCOM-5357-->
-* The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Geeta Modi in pull request [23394](https://github.com/magento/magento2/pull/23394)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
+*  The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Geeta Modi in pull request [23394](https://github.com/magento/magento2/pull/23394)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
 
 <!--- ENGCOM-5026-->
-* Magento no longer throws an array-to-string conversion error when a customer changes the country setting from one-page checkout. Instead, shipping method, tax values, and payment providers now change according to country selection. Previously, Magento displayed an error about array-to-string conversion. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-12612](https://github.com/magento/magento2/issues/12612)
+*  Magento no longer throws an array-to-string conversion error when a customer changes the country setting from one-page checkout. Instead, shipping method, tax values, and payment providers now change according to country selection. Previously, Magento displayed an error about array-to-string conversion. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-12612](https://github.com/magento/magento2/issues/12612)
 
 <!--- ENGCOM-5026-->
-* Magento now validates the VAT number as expected during checkout when the customer address region field is empty. Previously, Magento threw an informative error: `Internal Error. Details are available in Magento log file` if the `regionId` was not set. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-22556](https://github.com/magento/magento2/issues/22556).
+*  Magento now validates the VAT number as expected during checkout when the customer address region field is empty. Previously, Magento threw an informative error: `Internal Error. Details are available in Magento log file` if the `regionId` was not set. *Fix submitted by Grzegorz Bogusz in pull request [22558](https://github.com/magento/magento2/pull/22558)*. [GitHub-22556](https://github.com/magento/magento2/issues/22556).
 
 <!--- ENGCOM-5443-->
-* Magento now creates an invoice for an order that has a zero subtotal when **Automatically Invoice All Items** is set to **yes**. *Fix submitted by Eden Duong in pull request [23688](https://github.com/magento/magento2/pull/23688)*. [GitHub-23211](https://github.com/magento/magento2/issues/23211)
+*  Magento now creates an invoice for an order that has a zero subtotal when **Automatically Invoice All Items** is set to **yes**. *Fix submitted by Eden Duong in pull request [23688](https://github.com/magento/magento2/pull/23688)*. [GitHub-23211](https://github.com/magento/magento2/issues/23211)
 
 ### Cart Price rules
 
 <!--- ENGCOM-5086-->
-* Coupon codes now work as expected. Previously, coupons sent for specific dates in a cart price rule were not applied. *Fix submitted by Adarsh Shukla in pull request [22718](https://github.com/magento/magento2/pull/22718)*. [GitHub-18183](https://github.com/magento/magento2/issues/18183)
+*  Coupon codes now work as expected. Previously, coupons sent for specific dates in a cart price rule were not applied. *Fix submitted by Adarsh Shukla in pull request [22718](https://github.com/magento/magento2/pull/22718)*. [GitHub-18183](https://github.com/magento/magento2/issues/18183)
 
 ### Catalog
 
 <!--- MAGETWO-99890-->
-* You can now use the Select all option when creating a mass-update action when the total number of products exceeds the number of displayed products per page. Previously, Magento only selected and applied mass-update actions to the number of products that were displayed per page. *Fix submitted by Shikha Mishra in pull request [22704](https://github.com/magento/magento2/pull/22704)*. [GitHub-22004](https://github.com/magento/magento2/issues/22004)
+*  You can now use the Select all option when creating a mass-update action when the total number of products exceeds the number of displayed products per page. Previously, Magento only selected and applied mass-update actions to the number of products that were displayed per page. *Fix submitted by Shikha Mishra in pull request [22704](https://github.com/magento/magento2/pull/22704)*. [GitHub-22004](https://github.com/magento/magento2/issues/22004)
 
 <!--- MAGETWO-63599-->
-* Magento no longer throws an error when you run the `php bin/magento catalog:images:resize` command on a  deployment that contains images with a zero byte size. Instead, the operation skips the offending file and updates the log file to indicate where the problematic file resides. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
+*  Magento no longer throws an error when you run the `php bin/magento catalog:images:resize` command on a  deployment that contains images with a zero byte size. Instead, the operation skips the offending file and updates the log file to indicate where the problematic file resides. [GitHub-8204](https://github.com/magento/magento2/issues/8204)
 
 <!--- MAGETWO-98708-->
-* You can now successfully clone a product with a linked product. Previously, cloning  failed and Magento displayed this error:  `The linked products data is invalid. Verify the data and try again`.
+*  You can now successfully clone a product with a linked product. Previously, cloning  failed and Magento displayed this error:  `The linked products data is invalid. Verify the data and try again`.
 
 <!--- MAGETWO-69893-->
-* Magento disables the **New Category** button on the Product page if the user is an administrator with restricted permissions for managing categories. Previously, the button was active, and Magento threw a 403 error if the restricted user clicked the button to create a category.
+*  Magento disables the **New Category** button on the Product page if the user is an administrator with restricted permissions for managing categories. Previously, the button was active, and Magento threw a 403 error if the restricted user clicked the button to create a category.
 
 <!--- MC-17640-->
-* The Items Ordered table (**Admin** > **Sales** > **Orders**) no longer displays bundle option discount amounts with tags.
+*  The Items Ordered table (**Admin** > **Sales** > **Orders**) no longer displays bundle option discount amounts with tags.
 
 <!--- MC-17218-->
-* Magento now creates resized images for all products for which images exist and lists the errors when you run the `php bin/catalog:image:resize` command. Previously, execution halted at the first missing image.
+*  Magento now creates resized images for all products for which images exist and lists the errors when you run the `php bin/catalog:image:resize` command. Previously, execution halted at the first missing image.
 
 <!--- MC-17387-->
-* You can now add a bundle product from a wishlist to your shopping cart. Previously, Magento threw a fatal error.
+*  You can now add a bundle product from a wishlist to your shopping cart. Previously, Magento threw a fatal error.
 
 <!--- MAGETWO-92712-->
-* The `\Magento\Catalog\Model\CategoryList::getList` operation now returns a sorted list of categories as expected.
+*  The `\Magento\Catalog\Model\CategoryList::getList` operation now returns a sorted list of categories as expected.
 
 <!--- MAGETWO-70599-->
-* The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
+*  The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
 
 <!--- MAGETWO-64923-->
-* A duplicated product that has been set to **Is in Stock** and **Enabled** now appears as expected on the storefront.
+*  A duplicated product that has been set to **Is in Stock** and **Enabled** now appears as expected on the storefront.
 
 <!--- MAGETWO-99587-->
-* Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
+*  Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
 
 <!--- MAGETWO-59978-->
-* Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
+*  Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
 
 <!--- MAGETWO-59431-->
-* Sample data now scales correctly when resized in mobile view.
+*  Sample data now scales correctly when resized in mobile view.
 
 <!--- ENGCOM-5371-->
-* Customers no longer receive product alerts after they have unsubscribed from product alerts. Previously, the product alert was not removed from the `product_alert_stock` table as expected, but Magento still displayed this message on the storefront: **You will no longer receive stock alerts for this product**. *Fix submitted by yuriichayka in pull request [23459](https://github.com/magento/magento2/pull/23459)*. [GitHub-22814](https://github.com/magento/magento2/issues/22814)
+*  Customers no longer receive product alerts after they have unsubscribed from product alerts. Previously, the product alert was not removed from the `product_alert_stock` table as expected, but Magento still displayed this message on the storefront: **You will no longer receive stock alerts for this product**. *Fix submitted by yuriichayka in pull request [23459](https://github.com/magento/magento2/pull/23459)*. [GitHub-22814](https://github.com/magento/magento2/issues/22814)
 
 <!--- ENGCOM-5387-->
-* Magento no longer automatically assigns a storeID to a saved product that is not assigned to a store. *Fix submitted by manishgoswamij in pull request [23500](https://github.com/magento/magento2/pull/23500)*. [GitHub-23383](https://github.com/magento/magento2/issues/23383), [GitHub-23500](https://github.com/magento/magento2/issues/23500)
+*  Magento no longer automatically assigns a storeID to a saved product that is not assigned to a store. *Fix submitted by manishgoswamij in pull request [23500](https://github.com/magento/magento2/pull/23500)*. [GitHub-23383](https://github.com/magento/magento2/issues/23383), [GitHub-23500](https://github.com/magento/magento2/issues/23500)
 
 <!--- ENGCOM-5410-->
-* Corrected misspellings in the `lib/web/css/docs/source/_actions-toolbar.less` and  `lib/web/css/docs/source/_layout.less` files. *Fix submitted by Prashant Sharma in pull request [22624](https://github.com/magento/magento2/pull/22624)*.
+*  Corrected misspellings in the `lib/web/css/docs/source/_actions-toolbar.less` and  `lib/web/css/docs/source/_layout.less` files. *Fix submitted by Prashant Sharma in pull request [22624](https://github.com/magento/magento2/pull/22624)*.
 
 <!--- ENGCOM-5067-->
-* Magento now displays the currency code as expected in the Cost column of the Admin catalog product list. *Fix submitted by Vlad Veselov in pull request [22739](https://github.com/magento/magento2/pull/22739)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+*  Magento now displays the currency code as expected in the Cost column of the Admin catalog product list. *Fix submitted by Vlad Veselov in pull request [22739](https://github.com/magento/magento2/pull/22739)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
 <!--- MAGETWO-99489-->
-* The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
+*  The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
 
 <!--- MC-17020-->
-* We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
+*  We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
 
 <!--- MC-10966-->
-* Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
+*  Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
 
 <!--- MC-17765-->
-* Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
+*  Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
 
 <!--- ENGCOM-5063-->
-* Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22724](https://github.com/magento/magento2/pull/22724)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
+*  Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22724](https://github.com/magento/magento2/pull/22724)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
 
 <!--- ENGCOM-5419-->
-* The catalog products filter now filters on enabled or disabled status as expected. Previously, the SQL generated by the `Magento\Catalog\Ui\DataProvider\Product\ProductCollection` class omitted the `attribute_id` condition, which resulted in any attribute of the same type (`int` or `varchar`, for example) matching the query if the values were the same. *Fix submitted by Matti Vapa in pull request [23444](https://github.com/magento/magento2/pull/23444)*. [GitHub-23435](https://github.com/magento/magento2/issues/23435)
+*  The catalog products filter now filters on enabled or disabled status as expected. Previously, the SQL generated by the `Magento\Catalog\Ui\DataProvider\Product\ProductCollection` class omitted the `attribute_id` condition, which resulted in any attribute of the same type (`int` or `varchar`, for example) matching the query if the values were the same. *Fix submitted by Matti Vapa in pull request [23444](https://github.com/magento/magento2/pull/23444)*. [GitHub-23435](https://github.com/magento/magento2/issues/23435)
 
 <!--- ENGCOM-5134-->
-* `ProductRepository` now updates and saves existing products with changed SKUs as expected. Previously, Magento threw an error, and you were not able to save the product. *Fix submitted by Pavel Bystritsky in pull request [22933](https://github.com/magento/magento2/pull/22933)*. [GitHub-22870](https://github.com/magento/magento2/issues/22870)
+*  `ProductRepository` now updates and saves existing products with changed SKUs as expected. Previously, Magento threw an error, and you were not able to save the product. *Fix submitted by Pavel Bystritsky in pull request [22933](https://github.com/magento/magento2/pull/22933)*. [GitHub-22870](https://github.com/magento/magento2/issues/22870)
 
 <!--- ENGCOM-5439-->
-* You can now change the position of the last two related products in a list of related products that spans multiple pages. Previously, drag and drop functionality allowed you to change only the position of products  on the current page. *Fix submitted by Maxim Tkachuk in pull request [22984](https://github.com/magento/magento2/pull/22984)*. [GitHub-14071](https://github.com/magento/magento2/issues/14071)
+*  You can now change the position of the last two related products in a list of related products that spans multiple pages. Previously, drag and drop functionality allowed you to change only the position of products  on the current page. *Fix submitted by Maxim Tkachuk in pull request [22984](https://github.com/magento/magento2/pull/22984)*. [GitHub-14071](https://github.com/magento/magento2/issues/14071)
 
 <!--- ENGCOM-4591-->
-* The **Select from gallery** button on the category edit page now works as expected. Previously, the image was not saved, and Magento did not display an image in the image preview. *Fix submitted by Bartłomiej Szubert in pull request [21131](https://github.com/magento/magento2/pull/21131)*. [GitHub-19872](https://github.com/magento/magento2/issues/19872), [GitHub-22092](https://github.com/magento/magento2/issues/22092)
+*  The **Select from gallery** button on the category edit page now works as expected. Previously, the image was not saved, and Magento did not display an image in the image preview. *Fix submitted by Bartłomiej Szubert in pull request [21131](https://github.com/magento/magento2/pull/21131)*. [GitHub-19872](https://github.com/magento/magento2/issues/19872), [GitHub-22092](https://github.com/magento/magento2/issues/22092)
 
 ### CatalogInventory
 
 <!--- MAGETWO-99941-->
-* The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
+*  The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
 
 <!--- MAGETWO-99585-->
-* Magento now correctly updates the `qty_backordered` value in the  `sales_order_item` table after you create an order that contains a backordered item.
+*  Magento now correctly updates the `qty_backordered` value in the  `sales_order_item` table after you create an order that contains a backordered item.
 
 <!--- MC-17513-->
-* Stock status records for all products are now added as expected  to the `cataloginventory_stock_status` table after a partial re-indexing.
+*  Stock status records for all products are now added as expected  to the `cataloginventory_stock_status` table after a partial re-indexing.
 
 ### Catalog rule
 
 <!--- MC-18254-->
-* The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how  catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento timezone.)
+*  The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how  catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento timezone.)
 
 ### Cleanup and simple code refactoring
 
 <!--- ENGCOM-3817-->
-* Corrected poor positioning  of the Shop By menu on product pages in mobile view on an iPhone 5. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
+*  Corrected poor positioning  of the Shop By menu on product pages in mobile view on an iPhone 5. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
 
 <!--- ENGCOM-4840-->
-* Corrected misalignment of Wishlist and Compare icons on the product page. *Fix submitted by sanjaychouhan-webkul in pull request [22532](https://github.com/magento/magento2/pull/22532)*. [GitHub-22527](https://github.com/magento/magento2/issues/22527)
+*  Corrected misalignment of Wishlist and Compare icons on the product page. *Fix submitted by sanjaychouhan-webkul in pull request [22532](https://github.com/magento/magento2/pull/22532)*. [GitHub-22527](https://github.com/magento/magento2/issues/22527)
 
 <!--- ENGCOM-4788-->
-* Store view-specific labels are no longer truncated in the left navigation menu of the Cart Price Rule Store View Specific Labels window (**Marketing** > **Cart Price rule** > **Labels** ). *Fix submitted by Sudhanshu Bajaj in pull request [22423](https://github.com/magento/magento2/pull/22423)*. [GitHub-22406](https://github.com/magento/magento2/issues/22406)
+*  Store view-specific labels are no longer truncated in the left navigation menu of the Cart Price Rule Store View Specific Labels window (**Marketing** > **Cart Price rule** > **Labels** ). *Fix submitted by Sudhanshu Bajaj in pull request [22423](https://github.com/magento/magento2/pull/22423)*. [GitHub-22406](https://github.com/magento/magento2/issues/22406)
 
 <!--- ENGCOM-5059-->
-* Added missing header to the Customer Sales Order table and corrected multiple typos. *Fix submitted by Vishal Sutariya in pull request [22643](https://github.com/magento/magento2/pull/22643)*. [GitHub-22641](https://github.com/magento/magento2/issues/22641)
+*  Added missing header to the Customer Sales Order table and corrected multiple typos. *Fix submitted by Vishal Sutariya in pull request [22643](https://github.com/magento/magento2/pull/22643)*. [GitHub-22641](https://github.com/magento/magento2/issues/22641)
 
 <!--- ENGCOM-5054-->
-* Improved awkward formatting of the customer account create page in mobile view. *Fix submitted by Arvinda Kumar in pull request [22656](https://github.com/magento/magento2/pull/22656)*. [GitHub-22647](https://github.com/magento/magento2/issues/22647)
+*  Improved awkward formatting of the customer account create page in mobile view. *Fix submitted by Arvinda Kumar in pull request [22656](https://github.com/magento/magento2/pull/22656)*. [GitHub-22647](https://github.com/magento/magento2/issues/22647)
 
 <!--- ENGCOM-5061-->
-* The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Surabhi Srivastava in pull request [22655](https://github.com/magento/magento2/pull/22655)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
+*  The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Surabhi Srivastava in pull request [22655](https://github.com/magento/magento2/pull/22655)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
 
 <!--- ENGCOM-5281-->
-* Corrected typo in CONTRIBUTING.md. *Fix submitted by Raul E Watson in pull request [23244](https://github.com/magento/magento2/pull/23244)*.
+*  Corrected typo in CONTRIBUTING.md. *Fix submitted by Raul E Watson in pull request [23244](https://github.com/magento/magento2/pull/23244)*.
 
 <!--- ENGCOM-5408-->
-* Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Amjad M in pull request [23226](https://github.com/magento/magento2/pull/23226)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
+*  Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Amjad M in pull request [23226](https://github.com/magento/magento2/pull/23226)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
 
 <!--- ENGCOM-5344-->
-* The asterisk sign indicating a required field is now consistently positioned throughout the Admin. *Fix submitted by sanjaychouhan-webkul in pull request [22800](https://github.com/magento/magento2/pull/22800)*. [GitHub-22638](https://github.com/magento/magento2/issues/22638)
+*  The asterisk sign indicating a required field is now consistently positioned throughout the Admin. *Fix submitted by sanjaychouhan-webkul in pull request [22800](https://github.com/magento/magento2/pull/22800)*. [GitHub-22638](https://github.com/magento/magento2/issues/22638)
 
 <!--- ENGCOM-5326-->
-* Corrected misspelling in the `app/code/Magento/Ui/Block/Wrapper.php` file. *Fix submitted by Ravi Chandra in pull request [23335](https://github.com/magento/magento2/pull/23335)*.
+*  Corrected misspelling in the `app/code/Magento/Ui/Block/Wrapper.php` file. *Fix submitted by Ravi Chandra in pull request [23335](https://github.com/magento/magento2/pull/23335)*.
 
 <!--- ENGCOM-5287-->
-* Corrected typo in the tooltip toggle selector. *Fix submitted by Karla Saaremäe in pull request [23248](https://github.com/magento/magento2/pull/23248)*.
+*  Corrected typo in the tooltip toggle selector. *Fix submitted by Karla Saaremäe in pull request [23248](https://github.com/magento/magento2/pull/23248)*.
 
 <!--- ENGCOM-5068-->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by sanjaychouhan-webkul in pull request [22742](https://github.com/magento/magento2/pull/22742)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by sanjaychouhan-webkul in pull request [22742](https://github.com/magento/magento2/pull/22742)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!--- ENGCOM-5089-->
-* Corrected scrolling behavior on Product page. Previously, after you clicked on a product reviews count on a product page, you had to scroll in order to see customer reviews. *Fix submitted by sanjaychouhan-webkul in pull request [22794](https://github.com/magento/magento2/pull/22794)*. [GitHub-21558](https://github.com/magento/magento2/issues/21558)
+*  Corrected scrolling behavior on Product page. Previously, after you clicked on a product reviews count on a product page, you had to scroll in order to see customer reviews. *Fix submitted by sanjaychouhan-webkul in pull request [22794](https://github.com/magento/magento2/pull/22794)*. [GitHub-21558](https://github.com/magento/magento2/issues/21558)
 
 <!--- ENGCOM-5126-->
-* Magento now displays the  cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by sanjaychouhan-webkul in pull request [22795](https://github.com/magento/magento2/pull/22795)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the  cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by sanjaychouhan-webkul in pull request [22795](https://github.com/magento/magento2/pull/22795)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!--- ENGCOM-5125-->
-* Refactored the page title of the billing agreements page. *Fix submitted by Amit Vishvakarma in pull request [22876](https://github.com/magento/magento2/pull/22876)*. [GitHub-22875](https://github.com/magento/magento2/issues/22875)
+*  Refactored the page title of the billing agreements page. *Fix submitted by Amit Vishvakarma in pull request [22876](https://github.com/magento/magento2/pull/22876)*. [GitHub-22875](https://github.com/magento/magento2/issues/22875)
 
 <!--- ENGCOM-3817-->
-* The Shop By Menu no longer overlays the **Sort By** label on the product listing page. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
+*  The Shop By Menu no longer overlays the **Sort By** label on the product listing page. *Fix submitted by Arvinda Kumar in pull request [20135](https://github.com/magento/magento2/pull/20135)*. [GitHub-20124](https://github.com/magento/magento2/issues/20124)
 
 <!--- ENGCOM-5124-->
-* Adjusted the position of the store-view label on **Admin** > **Content** > **Design** > **Configuration** > **Theme**. *Fix submitted by Kajal Solanki in pull request [22926](https://github.com/magento/magento2/pull/22926)*. [GitHub-22924](https://github.com/magento/magento2/issues/22924)
+*  Adjusted the position of the store-view label on **Admin** > **Content** > **Design** > **Configuration** > **Theme**. *Fix submitted by Kajal Solanki in pull request [22926](https://github.com/magento/magento2/pull/22926)*. [GitHub-22924](https://github.com/magento/magento2/issues/22924)
 
 <!--- ENGCOM-5376-->
-* Fixed spacing issue on **Admin** > **System** > **Import**. *Fix submitted by Kajal Solanki in pull request [21128](https://github.com/magento/magento2/pull/21128)*.
+*  Fixed spacing issue on **Admin** > **System** > **Import**. *Fix submitted by Kajal Solanki in pull request [21128](https://github.com/magento/magento2/pull/21128)*.
 
 <!--- ENGCOM-5340-->
-* Fixed misspelling in the `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` file. *Fix submitted by Ravi Chandra in pull request [23366](https://github.com/magento/magento2/pull/23366)*.
+*  Fixed misspelling in the `app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php` file. *Fix submitted by Ravi Chandra in pull request [23366](https://github.com/magento/magento2/pull/23366)*.
 
 <!--- ENGCOM-5342-->
-* Removed unnecessary `<span>` element from the **Test connection** button. *Fix submitted by Shankar Konar in pull request [23367](https://github.com/magento/magento2/pull/23367)*.
+*  Removed unnecessary `<span>` element from the **Test connection** button. *Fix submitted by Shankar Konar in pull request [23367](https://github.com/magento/magento2/pull/23367)*.
 
 <!--- ENGCOM-5291-->
-* The `lib/internal/Magento/Framework/Mview/View.php` file has been refactored to improve readability. *Fix submitted by Lukasz Bajsarowicz in pull request [23240](https://github.com/magento/magento2/pull/23240)*.
+*  The `lib/internal/Magento/Framework/Mview/View.php` file has been refactored to improve readability. *Fix submitted by Lukasz Bajsarowicz in pull request [23240](https://github.com/magento/magento2/pull/23240)*.
 
 ### CMS content
 
 <!--- MAGETWO-99695-->
-* Corrected alignment of the search suggestion panel with the **Advance reporting**  button. *Fix submitted by webkul-ajaysaini in pull request [22520](https://github.com/magento/magento2/pull/22520)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting**  button. *Fix submitted by webkul-ajaysaini in pull request [22520](https://github.com/magento/magento2/pull/22520)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!--- MC-5527-->
-* You can now remove text that is placed adjacent to a TinyMCE4 widget.
+*  You can now remove text that is placed adjacent to a TinyMCE4 widget.
 
 ### Configurable products
 
 <!--- MAGETWO-99443-->
-* Magento now validates the uniqueness of attribute option values during product creation. Previously, Magento did not save the product and displayed this error: `The value of Admin must be unique`.
+*  Magento now validates the uniqueness of attribute option values during product creation. Previously, Magento did not save the product and displayed this error: `The value of Admin must be unique`.
 
 <!--- MAGETWO-99550-->
-* The design of the tax rule form check box now matches the Admin checkbox design.
+*  The design of the tax rule form check box now matches the Admin checkbox design.
 
 <!--- ENGCOM-4844-->
-* The configurable product gallery now displays images in the correct order when the image list has more than 10 images. The correct order complies with the order assigned in the Admin. *Fix submitted by Mateusz Wira in pull request [22287](https://github.com/magento/magento2/pull/22287)*. [GitHub-22249](https://github.com/magento/magento2/issues/22249)
+*  The configurable product gallery now displays images in the correct order when the image list has more than 10 images. The correct order complies with the order assigned in the Admin. *Fix submitted by Mateusz Wira in pull request [22287](https://github.com/magento/magento2/pull/22287)*. [GitHub-22249](https://github.com/magento/magento2/issues/22249)
 
 <!--- MAGETWO-99500-->
-* You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
+*  You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
 
 <!--- ENGCOM-4825-->
-* Setting the **Update Product Preview Image** to **no**  now works as expected. Previously, when you clicked on a size or image that represented  another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [19184](https://github.com/magento/magento2/pull/19184)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
+*  Setting the **Update Product Preview Image** to **no**  now works as expected. Previously, when you clicked on a size or image that represented  another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [19184](https://github.com/magento/magento2/pull/19184)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
 
 <!--- ENGCOM-5385-->
-* The `POST V1/configurable-products/:sku/options` call now adds attribute options to a configurable product as expected. This resolves issues previously caused by the  MySQL table imposing a unique constraint on `product_id` and  `attribute_id` values. *Fix submitted by Lieven Pouwelse in pull request [23529](https://github.com/magento/magento2/pull/23529)*. [GitHub-9798](https://github.com/magento/magento2/issues/9798)
+*  The `POST V1/configurable-products/:sku/options` call now adds attribute options to a configurable product as expected. This resolves issues previously caused by the  MySQL table imposing a unique constraint on `product_id` and  `attribute_id` values. *Fix submitted by Lieven Pouwelse in pull request [23529](https://github.com/magento/magento2/pull/23529)*. [GitHub-9798](https://github.com/magento/magento2/issues/9798)
 
 ### Coupon
 
 <!--- ENGCOM-5292-->
-* The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Gaurav Agarwal in pull request [23250](https://github.com/magento/magento2/pull/23250)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
+*  The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Gaurav Agarwal in pull request [23250](https://github.com/magento/magento2/pull/23250)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
 
 ### Cron
 
 <!--- ENGCOM-5210-->
-* Runtime exception handling for cron jobs has been improved. Now, when an exception occurs, the current run is marked as **failed** in the `cron_schedule`  table. Then, when the next run completes correctly, Magento updates job status at the end of the `cron_schedule` table. Previously, when a job failed, the `cron_schedule`  table was filled with pending jobs; the `indexer_update_all_views` job was not run; no output was sent to the `var/log/cron.log` file, and no status updates were appended to the `cron_schedule` table.
+*  Runtime exception handling for cron jobs has been improved. Now, when an exception occurs, the current run is marked as **failed** in the `cron_schedule`  table. Then, when the next run completes correctly, Magento updates job status at the end of the `cron_schedule` table. Previously, when a job failed, the `cron_schedule`  table was filled with pending jobs; the `indexer_update_all_views` job was not run; no output was sent to the `var/log/cron.log` file, and no status updates were appended to the `cron_schedule` table.
 
 <!--- ENGCOM-5335-->
-* Cron jobs are no longer duplicated. Previously, after a cron job was run, Magento cleared the cache and processed the job again. *Fix submitted by Douglas Radburn in pull request [23312](https://github.com/magento/magento2/pull/23312)*.
+*  Cron jobs are no longer duplicated. Previously, after a cron job was run, Magento cleared the cache and processed the job again. *Fix submitted by Douglas Radburn in pull request [23312](https://github.com/magento/magento2/pull/23312)*.
 
 <!--- MC-18477-->
-* Consumers run from `cron` no longer create deadlocks in the database.
+*  Consumers run from `cron` no longer create deadlocks in the database.
 
 <!--- ENGCOM-5099-->
-* The `magento_newrelicreporting_cron` cron job now successfully completes as expected. Previously, `magento_newrelicreporting_cron` threw this error: `Warning: Invalid argument supplied for foreach() in /var/www/shop_test/src/www/vendor/magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php on line 83`.
+*  The `magento_newrelicreporting_cron` cron job now successfully completes as expected. Previously, `magento_newrelicreporting_cron` threw this error: `Warning: Invalid argument supplied for foreach() in /var/www/shop_test/src/www/vendor/magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php on line 83`.
 
 ### Customer
 
 <!--- MAGETWO-99647-->
-* Custom customer address attributes are populated with the values that have been assigned for the selected  address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
+*  Custom customer address attributes are populated with the values that have been assigned for the selected  address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
 
 <!--- MAGETWO-99493-->
-* The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
+*  The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
 
 <!--- MAGETWO-88905-->
-* Import checks now finish successfully when the csv file contains a customer `gender` field. Previously, Magento threw this error:  `Value for gender attribute contains incorrect value, see acceptable values on settings specified for Admin in row(s): 1`.
+*  Import checks now finish successfully when the csv file contains a customer `gender` field. Previously, Magento threw this error:  `Value for gender attribute contains incorrect value, see acceptable values on settings specified for Admin in row(s): 1`.
 
 <!--- MAGETWO-93522-->
-* Custom customer attributes are now always displayed in the Admin customer create and edit forms. Previously, the Admin did not display these attributes unless they were configured to show on either the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+*  Custom customer attributes are now always displayed in the Admin customer create and edit forms. Previously, the Admin did not display these attributes unless they were configured to show on either the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 <!--- MAGETWO-99584-->
-* You can now create an order from the Admin when  you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
+*  You can now create an order from the Admin when  you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
 
 <!--- MC-17769-->
-* You can now create an order from the Admin with a customer segment based on zero  or more orders and the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
+*  You can now create an order from the Admin with a customer segment based on zero  or more orders and the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
 
 <!--- MC-18250-->
-* The **Phone Number** field is now marked as required on the My account page.
+*  The **Phone Number** field is now marked as required on the My account page.
 
 <!--- ENGCOM-5378-->
-* Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Kazim Noorani in pull request [23494](https://github.com/magento/magento2/pull/23494)*.
+*  Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Kazim Noorani in pull request [23494](https://github.com/magento/magento2/pull/23494)*.
 
 <!--- ENGCOM-5048-->
-* Magento no longer duplicates the state/province fields of customer addresses in Admin forms. *Fix submitted by Shikha Mishra in pull request [22637](https://github.com/magento/magento2/pull/22637)*. [GitHub-22484](https://github.com/magento/magento2/issues/22484)
+*  Magento no longer duplicates the state/province fields of customer addresses in Admin forms. *Fix submitted by Shikha Mishra in pull request [22637](https://github.com/magento/magento2/pull/22637)*. [GitHub-22484](https://github.com/magento/magento2/issues/22484)
 
 <!--- ENGCOM-4581-->
-* Newly created customer accounts now require confirmation. Previously, Magento directly confirmed the new account even if the customer never logged in or confirmed the account. *Fix submitted by Maksym Novik in pull request [21394](https://github.com/magento/magento2/pull/21394)*. [GitHub-14492](https://github.com/magento/magento2/issues/14492)
+*  Newly created customer accounts now require confirmation. Previously, Magento directly confirmed the new account even if the customer never logged in or confirmed the account. *Fix submitted by Maksym Novik in pull request [21394](https://github.com/magento/magento2/pull/21394)*. [GitHub-14492](https://github.com/magento/magento2/issues/14492)
 
 ### Custom customer attributes
 
 <!--- MAGETWO-99451-->
-* Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
+*  Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
 
 <!--- MC-17928-->
-* You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
+*  You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
 
 ### Database media storage
 
 <!--- ENGCOM-5469-->
-* The PDF logo file is now database-aware. Consequently, logo images always appear on PDF invoices, even after the local `pub/media` directory is cleared. *Fix submitted by gwharton in pull request [23752](https://github.com/magento/magento2/pull/23752)*. [GitHub-23751](https://github.com/magento/magento2/issues/23751)
+*  The PDF logo file is now database-aware. Consequently, logo images always appear on PDF invoices, even after the local `pub/media` directory is cleared. *Fix submitted by gwharton in pull request [23752](https://github.com/magento/magento2/pull/23752)*. [GitHub-23751](https://github.com/magento/magento2/issues/23751)
 
 <!--- ENGCOM-5431-->
-* The `bin/magento catalog:images:resize` command is now database-media-storage-mode aware. As a result, resized images are now extracted from the database if they don’t exist locally prior to resizing, and are now stored back into the database once the resize operation completes. *Fix submitted by gwharton in pull request [23598](https://github.com/magento/magento2/pull/23598)*. [GitHub-23595](https://github.com/magento/magento2/issues/23595), [GitHub-23594](https://github.com/magento/magento2/issues/23594), [GitHub-23596](https://github.com/magento/magento2/issues/23596)
+*  The `bin/magento catalog:images:resize` command is now database-media-storage-mode aware. As a result, resized images are now extracted from the database if they don’t exist locally prior to resizing, and are now stored back into the database once the resize operation completes. *Fix submitted by gwharton in pull request [23598](https://github.com/magento/magento2/pull/23598)*. [GitHub-23595](https://github.com/magento/magento2/issues/23595), [GitHub-23594](https://github.com/magento/magento2/issues/23594), [GitHub-23596](https://github.com/magento/magento2/issues/23596)
 
 <!--- ENGCOM-5442-->
-* The  **use default value** checkbox on the Media Storage Location configuration setting has been removed. Previously, the JavaScript routines on the page interfered with that option, and consequently, the checkbox could be enabled but was still ignored. *Fix submitted by gwharton in pull request [23710](https://github.com/magento/magento2/pull/23710)*. [GitHub-23597](https://github.com/magento/magento2/issues/23597)
+*  The  **use default value** checkbox on the Media Storage Location configuration setting has been removed. Previously, the JavaScript routines on the page interfered with that option, and consequently, the checkbox could be enabled but was still ignored. *Fix submitted by gwharton in pull request [23710](https://github.com/magento/magento2/pull/23710)*. [GitHub-23597](https://github.com/magento/magento2/issues/23597)
 
 <!--- ENGCOM-4828 4802-->
-* Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously,  emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull requests [21675](https://github.com/magento/magento2/pull/21675) and [21674](https://github.com/magento/magento2/pull/21674)*. [GitHub-21672](https://github.com/magento/magento2/issues/21672)
+*  Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously,  emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull requests [21675](https://github.com/magento/magento2/pull/21675) and [21674](https://github.com/magento/magento2/pull/21674)*. [GitHub-21672](https://github.com/magento/magento2/issues/21672)
 
 <!--- ENGCOM-5198-->
-* Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21605](https://github.com/magento/magento2/pull/21605)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604), [GitHub-21546](https://github.com/magento/magento2/issues/21546)
+*  Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21605](https://github.com/magento/magento2/pull/21605)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604), [GitHub-21546](https://github.com/magento/magento2/issues/21546)
 
 ### Directory
 
 <!--- MAGETWO-99424-->
-* The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations. [GitHub-23141](https://github.com/magento/magento2/issues/23141)
+*  The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations. [GitHub-23141](https://github.com/magento/magento2/issues/23141)
 
 ### Downloadable products
 
 <!--- ENGCOM-5157-->
-* Downloadable products are now immediately accessible after they have been paid for. Previously, a downloadable product’s status remained in the pending state after payment for the product has been completed. *Fix submitted by Shikha Mishra in pull request [22658](https://github.com/magento/magento2/pull/22658)*. [GitHub-22545](https://github.com/magento/magento2/issues/22545)
+*  Downloadable products are now immediately accessible after they have been paid for. Previously, a downloadable product’s status remained in the pending state after payment for the product has been completed. *Fix submitted by Shikha Mishra in pull request [22658](https://github.com/magento/magento2/pull/22658)*. [GitHub-22545](https://github.com/magento/magento2/issues/22545)
 
 <!--- MAGETWO-98656-->
-* New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
+*  New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
 
 ### EAV
 
 <!--- MC-17505-->
-* Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
+*  Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
 
 <!--- MC-17623-->
-* You can now  save multiselect and select attribute options when swatches modules are disabled.
+*  You can now  save multiselect and select attribute options when swatches modules are disabled.
 [GitHub-23326](https://github.com/magento/magento2/issues/23326)
 
 ### Email
 
 <!--- ENGCOM-5433-->
-* Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message:  `Message too big`. *Fix submitted by gwharton in pull request [23649](https://github.com/magento/magento2/pull/23649)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
+*  Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message:  `Message too big`. *Fix submitted by gwharton in pull request [23649](https://github.com/magento/magento2/pull/23649)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
 
 <!--- ENGCOM-5090-->
-* The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview tab did not load the default content. *Fix submitted by Gaurav Agarwal in pull request [22791](https://github.com/magento/magento2/pull/22791)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
+*  The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview tab did not load the default content. *Fix submitted by Gaurav Agarwal in pull request [22791](https://github.com/magento/magento2/pull/22791)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
 
 <!--- ENGCOM-5393-->
-* All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23535](https://github.com/magento/magento2/pull/23535)*.
+*  All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23535](https://github.com/magento/magento2/pull/23535)*.
 
 ### Frameworks
 
 <!--- MC-14912-->
-* Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
+*  Zend Framework 2 Components have been upgraded to the Active/LTS versions. See [Support and Long Term Support Policies](https://framework.zend.com/long-term-support) for a discussion of Zend Framework long-term support policy.
 
 <!--- MAGETWO-99888-->
-* The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products  (for example, adding a product to category by SKU).
+*  The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products  (for example, adding a product to category by SKU).
 
 <!--- MC-17583-->
-* The performance of resize image operations has been improved. Previously, an SQL operation involved in the process returned redundant data, which resulted in images being saved multiple times.
+*  The performance of resize image operations has been improved. Previously, an SQL operation involved in the process returned redundant data, which resulted in images being saved multiple times.
 
 <!--- MAGETWO-99140-->
-* The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named  `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
+*  The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named  `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
 
 <!--- ENGCOM-3260-->
-* The Magento Framework API now has a module manager to detect module features and support enablement of third-party modules. *Fix submitted by Navarr Barnier in pull request [18748](https://github.com/magento/magento2/pull/18748)*.
+*  The Magento Framework API now has a module manager to detect module features and support enablement of third-party modules. *Fix submitted by Navarr Barnier in pull request [18748](https://github.com/magento/magento2/pull/18748)*.
 
 #### JavaScript framework
 
 <!--- MAGETWO-99535-->
-* The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
+*  The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
 
 <!--- ENGCOM-5118-->
-* Magento now displays previously missing validation messages on the storefront when JavaScript errors are caught by validation scripts in DatePicker form elements. *Fix submitted by Ravi Chandra in pull request [21397](https://github.com/magento/magento2/pull/21397)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795)
+*  Magento now displays previously missing validation messages on the storefront when JavaScript errors are caught by validation scripts in DatePicker form elements. *Fix submitted by Ravi Chandra in pull request [21397](https://github.com/magento/magento2/pull/21397)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795)
 
 ### General fixes
 
 <!--- MAGETWO-93061-->
-* Magento now displays the correct content for a selected store  in multi-site deployments where the websites have the same URL but the CMS pages have different content.
+*  Magento now displays the correct content for a selected store  in multi-site deployments where the websites have the same URL but the CMS pages have different content.
 
 <!--- MAGETWO-99677-->
-* Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
+*  Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
 
 <!--- MAGETWO-36337-->
-* The **Save in address book** checkbox on the Shipping Address section of the Admin Create Order page now behaves as expected. When this checkbox is enabled, the address in the Shipping Address field is saved, and merchants can disable or enable the checkbox
+*  The **Save in address book** checkbox on the Shipping Address section of the Admin Create Order page now behaves as expected. When this checkbox is enabled, the address in the Shipping Address field is saved, and merchants can disable or enable the checkbox
 
 <!--- MAGETWO-70681-->
-* Updated the type and format for all `store_name` fields used in Sales and Quote modules. All fields are now type `text` instead of type `varchar`, and the field length has been extended to 255 symbols.
+*  Updated the type and format for all `store_name` fields used in Sales and Quote modules. All fields are now type `text` instead of type `varchar`, and the field length has been extended to 255 symbols.
 
 <!--- MC-17511-->
-* Preloading of fonts has been moved from the Blank theme to the Luma theme.
+*  Preloading of fonts has been moved from the Blank theme to the Luma theme.
 
 <!--- ENGCOM-5171-->
-* Magento no longer includes canceled orders when calculating how many times a coupon code has been used. *Fix submitted by Pavel Bystritsky in pull request [20579](https://github.com/magento/magento2/pull/20579)*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
+*  Magento no longer includes canceled orders when calculating how many times a coupon code has been used. *Fix submitted by Pavel Bystritsky in pull request [20579](https://github.com/magento/magento2/pull/20579)*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
 
 <!--- ENGCOM-5022-->
-* Code Sniffer no longer marks correctly aligned DocBlock elements as code style violations. *Fix submitted by Pavel Bystritsky in pull request [22444](https://github.com/magento/magento2/pull/22444)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
+*  Code Sniffer no longer marks correctly aligned DocBlock elements as code style violations. *Fix submitted by Pavel Bystritsky in pull request [22444](https://github.com/magento/magento2/pull/22444)*. [GitHub-22317](https://github.com/magento/magento2/issues/22317)
 
 <!--- ENGCOM-5066-->
-* Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [19584](https://github.com/magento/magento2/pull/19584)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
+*  Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [19584](https://github.com/magento/magento2/pull/19584)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
 
 <!--- MC-18094-->
-* Full page cache works as expected for non-default store views.
+*  Full page cache works as expected for non-default store views.
 
 <!--- MC-18270-->
-* Magento no longer creates a persistent cart session for logged-in users when the persistent cart feature has been disabled. Previously, Magento did not empty shopping carts for users when the user logged out.
+*  Magento no longer creates a persistent cart session for logged-in users when the persistent cart feature has been disabled. Previously, Magento did not empty shopping carts for users when the user logged out.
 
 <!--- ENGCOM-5375-->
-* The unused namespace import was removed from the  `CartTotalRepository.php` file. *Fix submitted by Ulyana Kiklevich in pull request [23457](https://github.com/magento/magento2/pull/23457)*.
+*  The unused namespace import was removed from the  `CartTotalRepository.php` file. *Fix submitted by Ulyana Kiklevich in pull request [23457](https://github.com/magento/magento2/pull/23457)*.
 
 <!--- MC-17934-->
-* The back-in-stock alert emails that Magento sends to both wholesale and general customers now include the appropriate  wholesale and general  product prices.
+*  The back-in-stock alert emails that Magento sends to both wholesale and general customers now include the appropriate  wholesale and general  product prices.
 
 <!--- MC-14837-->
-* The `MsrpSampleData` module installation script no longer generates incorrect data. Previously, this installation script did not set any data from fixtures due to incorrect dependencies between sample data modules.
+*  The `MsrpSampleData` module installation script no longer generates incorrect data. Previously, this installation script did not set any data from fixtures due to incorrect dependencies between sample data modules.
 
 <!--- ENGCOM-5377-->
-* Tooltips have been added to the store-view labels for CMS tables and blocks. *Fix submitted by Dipesh Rangani in pull request [23474](https://github.com/magento/magento2/pull/23474)*.
+*  Tooltips have been added to the store-view labels for CMS tables and blocks. *Fix submitted by Dipesh Rangani in pull request [23474](https://github.com/magento/magento2/pull/23474)*.
 
 <!--- ENGCOM-5390-->
-* Validation of `max-word` data now works as expected for forms. *Fix submitted by Sunil in pull request [23541](https://github.com/magento/magento2/pull/23541)*.
+*  Validation of `max-word` data now works as expected for forms. *Fix submitted by Sunil in pull request [23541](https://github.com/magento/magento2/pull/23541)*.
 
 <!--- ENGCOM-5267-->
-* Magento now subscribes a customer to a price or stock notification when they opt to subscribe to a  price or  stock alert on a product page without first logging in. Previously, Magento redirected the customer  to a 404 page. *Fix submitted by Arjen Miedema in pull request [23218](https://github.com/magento/magento2/pull/23218)*.
+*  Magento now subscribes a customer to a price or stock notification when they opt to subscribe to a  price or  stock alert on a product page without first logging in. Previously, Magento redirected the customer  to a 404 page. *Fix submitted by Arjen Miedema in pull request [23218](https://github.com/magento/magento2/pull/23218)*.
 
 <!--- ENGCOM-5228-->
-* The sendfriend feature now verifies product visibility as expected. Previously, this  feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23118](https://github.com/magento/magento2/pull/23118)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
+*  The sendfriend feature now verifies product visibility as expected. Previously, this  feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23118](https://github.com/magento/magento2/pull/23118)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
 
 <!--- ENGCOM-5135-->
-* Search input is no longer missing the `aria-expanded`  required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Geeta Modi in pull request [22942](https://github.com/magento/magento2/pull/22942)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
+*  Search input is no longer missing the `aria-expanded`  required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Geeta Modi in pull request [22942](https://github.com/magento/magento2/pull/22942)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
 
 <!--- ENGCOM-5129-->
-* The **Use Default Value** check boxes on the Advanced Pricing  pop-up window  now remain checked on both the **Special From** and **Special To** dates,  and display the values set in the All Store scope. *Fix submitted by Mahesh Singh in pull request [22521](https://github.com/magento/magento2/pull/22521)*. [GitHub-22511](https://github.com/magento/magento2/issues/22511)
+*  The **Use Default Value** check boxes on the Advanced Pricing  pop-up window  now remain checked on both the **Special From** and **Special To** dates,  and display the values set in the All Store scope. *Fix submitted by Mahesh Singh in pull request [22521](https://github.com/magento/magento2/pull/22521)*. [GitHub-22511](https://github.com/magento/magento2/issues/22511)
 
 <!--- ENGCOM-5300-->
-* The Recently Viewed feature now accurately lists the products and category paths that the user has recently visited. Previously, this list was inaccurate when the **Use Categories Path for Product URLs**  setting was disabled. *Fix submitted by Atish Goswami in pull request [22650](https://github.com/magento/magento2/pull/22650)*. [GitHub-13227](https://github.com/magento/magento2/issues/13227)
+*  The Recently Viewed feature now accurately lists the products and category paths that the user has recently visited. Previously, this list was inaccurate when the **Use Categories Path for Product URLs**  setting was disabled. *Fix submitted by Atish Goswami in pull request [22650](https://github.com/magento/magento2/pull/22650)*. [GitHub-13227](https://github.com/magento/magento2/issues/13227)
 
 <!--- MC-16233-->
-* The **Be the First to Review Product** link now directs the user to the product review form at the bottom of the product page as expected in deployments that include PageBuilder.
+*  The **Be the First to Review Product** link now directs the user to the product review form at the bottom of the product page as expected in deployments that include PageBuilder.
 
 <!--- MC-19684-->
-* You can now set the **minute** values for Analytics data collection (**Store** > **Configuration** > **General** > **Advanced Reporting**). Previously, due to an earlier fix that has now been reverted (see [GitHub-8258](https://github.com/magento/magento2/issues/8258)), validation failed when you set a value that exceeded 24.
+*  You can now set the **minute** values for Analytics data collection (**Store** > **Configuration** > **General** > **Advanced Reporting**). Previously, due to an earlier fix that has now been reverted (see [GitHub-8258](https://github.com/magento/magento2/issues/8258)), validation failed when you set a value that exceeded 24.
 
 <!--- ENGCOM-4843-->
-* The `getProductUrl()` method now returns the product URL for a specified website. Previously, this method did not let you retrieve the product URL for a specified website in multisite deployments. *Fix submitted by Nazar Klovanych in pull request [21876](https://github.com/magento/magento2/pull/21876)*. [GitHub-4247](https://github.com/magento/magento2/issues/4247)
+*  The `getProductUrl()` method now returns the product URL for a specified website. Previously, this method did not let you retrieve the product URL for a specified website in multisite deployments. *Fix submitted by Nazar Klovanych in pull request [21876](https://github.com/magento/magento2/pull/21876)*. [GitHub-4247](https://github.com/magento/magento2/issues/4247)
 
 ### Image
 
 <!--- ENGCOM-4838-->
-* You can now programmatically  move an image to the gallery using the  `addImageToMediaGallery` method with `$move`. Previously, when you tried to move an image programmatically, Magento threw this exception: `[InvalidArgumentException] File 'pub/media/import/' doesn't exist`. *Fix submitted by dudzio12 in pull request [22020](https://github.com/magento/magento2/pull/22020)*. [GitHub-21978](https://github.com/magento/magento2/issues/21978)
+*  You can now programmatically  move an image to the gallery using the  `addImageToMediaGallery` method with `$move`. Previously, when you tried to move an image programmatically, Magento threw this exception: `[InvalidArgumentException] File 'pub/media/import/' doesn't exist`. *Fix submitted by dudzio12 in pull request [22020](https://github.com/magento/magento2/pull/22020)*. [GitHub-21978](https://github.com/magento/magento2/issues/21978)
 
 <!--- ENGCOM-5173-->
-* The performance of the `catalog:images:resize` command has been improved. This command now resizes only the images that are actually in use  and lists any  errors. *Fix submitted by Timon de Groot in pull request [23005](https://github.com/magento/magento2/pull/23005)*. [GitHub-22808](https://github.com/magento/magento2/issues/22808)
+*  The performance of the `catalog:images:resize` command has been improved. This command now resizes only the images that are actually in use  and lists any  errors. *Fix submitted by Timon de Groot in pull request [23005](https://github.com/magento/magento2/pull/23005)*. [GitHub-22808](https://github.com/magento/magento2/issues/22808)
 
 ### Import/export
 
 <!--- MAGETWO-99894-->
-* Import statistics now accurately reflect the results of import.
+*  Import statistics now accurately reflect the results of import.
 
 <!--- MAGETWO-98729-->
-* Magento now successfully saves product URL keys in Arabic.
+*  Magento now successfully saves product URL keys in Arabic.
 
 <!--- MAGETWO-98801-->
-* Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
+*  Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
 
 <!--- MAGETWO-99509-->
-* You can now successfully download a CSV file after export. Previously, Magento redirected you to the Admin dashboard when you tried to download the CSV file that was created during export.
+*  You can now successfully download a CSV file after export. Previously, Magento redirected you to the Admin dashboard when you tried to download the CSV file that was created during export.
 
 <!--- MAGETWO-99927-->
-* Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously,  the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
+*  Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously,  the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
 
 <!--- MAGETWO-60918-->
-* Magento no longer throws a fatal error during import or export if the category path contains deleted category IDs.
+*  Magento no longer throws a fatal error during import or export if the category path contains deleted category IDs.
 
 <!--- MC-18472-->
-* The import process maintain custom option prices that were assigned to different websites and scope before import. Previously, after import, these custom option prices were set to the default scope values.
+*  The import process maintain custom option prices that were assigned to different websites and scope before import. Previously, after import, these custom option prices were set to the default scope values.
 
 <!--- ENGCOM-5028-->
-* You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously,  when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22575](https://github.com/magento/magento2/pull/22575)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
+*  You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously,  when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22575](https://github.com/magento/magento2/pull/22575)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
 
 ### Index
 
 <!--- MAGETWO-99439-->
-* We have improved the processing of memory tables in the Galera Cluster.
+*  We have improved the processing of memory tables in the Galera Cluster.
 
 <!--- MC-17981-->
-* The pricing index can now be fully rebuilt and moved into the active price database table in a reasonable amount of time. Previously, this index ran without completing. [GitHub-22156](https://github.com/magento/magento2/issues/22156)
+*  The pricing index can now be fully rebuilt and moved into the active price database table in a reasonable amount of time. Previously, this index ran without completing. [GitHub-22156](https://github.com/magento/magento2/issues/22156)
 
 <!--- MC-17929-->
-* We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
+*  We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
 
 <!--- ENGCOM-5320-->
-* You can now filter administrative users by ID. Previously, when you tried to filter these users by ID, Magento threw a 500 error. *Fix submitted by Jeroen in pull request [23267](https://github.com/magento/magento2/pull/23267)*. [GitHub-23266](https://github.com/magento/magento2/issues/23266)
+*  You can now filter administrative users by ID. Previously, when you tried to filter these users by ID, Magento threw a 500 error. *Fix submitted by Jeroen in pull request [23267](https://github.com/magento/magento2/pull/23267)*. [GitHub-23266](https://github.com/magento/magento2/issues/23266)
 
 ### Infrastructure
 
 <!--- MC-14862-->
-* Magento 2.3.3 now supports PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21).
+*  Magento 2.3.3 now supports PHP 7.3.x (tested with PHP 7.3.8) and PHP 7.2.x (tested with 7.2.21).
 
 <!--- MC-14863-->
-* Varnish cache now supports version 6.2.0.
+*  Varnish cache now supports version 6.2.0.
 
 <!--- ENGCOM-5352-->
-* You can now use copy service on extension attributes for classes that extend Data Object. *Fix submitted by Oleksandr Kravchuk in pull request [23387](https://github.com/magento/magento2/pull/23387)*. [GitHub-23386](https://github.com/magento/magento2/issues/23386)
+*  You can now use copy service on extension attributes for classes that extend Data Object. *Fix submitted by Oleksandr Kravchuk in pull request [23387](https://github.com/magento/magento2/pull/23387)*. [GitHub-23386](https://github.com/magento/magento2/issues/23386)
 
 <!--- ENGCOM-5356-->
-* Removed an extraneous closing tag from the store-switcher template. *Fix submitted by Alastair Mucklow in pull request [23403](https://github.com/magento/magento2/pull/23403)*.
+*  Removed an extraneous closing tag from the store-switcher template. *Fix submitted by Alastair Mucklow in pull request [23403](https://github.com/magento/magento2/pull/23403)*.
 
 <!--- ENGCOM-5462-->
-* `\Magento\ConfigurableProduct\Pricing\Price\PriceResolverInterface` has been added to the `di.xml` file. *Fix submitted by Eden Duong in pull request [23753](https://github.com/magento/magento2/pull/23753)*. [GitHub-23717](https://github.com/magento/magento2/issues/23717)
+*  `\Magento\ConfigurableProduct\Pricing\Price\PriceResolverInterface` has been added to the `di.xml` file. *Fix submitted by Eden Duong in pull request [23753](https://github.com/magento/magento2/pull/23753)*. [GitHub-23717](https://github.com/magento/magento2/issues/23717)
 
 <!--- ENGCOM-5174-->
-* We improved validation of forms that contain multiple fields with identical names. Previously, Magento validated the first file in the form, but did not validate subsequent fields with that name. *Fix submitted by Jay Ghosh in pull request [15383](https://github.com/magento/magento2/pull/15383)*. [GitHub-8258](https://github.com/magento/magento2/issues/8258)
+*  We improved validation of forms that contain multiple fields with identical names. Previously, Magento validated the first file in the form, but did not validate subsequent fields with that name. *Fix submitted by Jay Ghosh in pull request [15383](https://github.com/magento/magento2/pull/15383)*. [GitHub-8258](https://github.com/magento/magento2/issues/8258)
 
 <!--- ENGCOM-5337-->
-* Magento now identifies review entity IDs programmatically instead of retrieving a hard-coded value. *Fix submitted by Danilo Argentiero in pull request [23353](https://github.com/magento/magento2/pull/23353)*.
+*  Magento now identifies review entity IDs programmatically instead of retrieving a hard-coded value. *Fix submitted by Danilo Argentiero in pull request [23353](https://github.com/magento/magento2/pull/23353)*.
 
 <!--- ENGCOM-5384-->
-* The array type hints in the Visibility model now correctly reference `string` instead of `int`. *Fix submitted by Patrick McLain in pull request [23532](https://github.com/magento/magento2/pull/23532)*.
+*  The array type hints in the Visibility model now correctly reference `string` instead of `int`. *Fix submitted by Patrick McLain in pull request [23532](https://github.com/magento/magento2/pull/23532)*.
 
 <!--- ENGCOM-5121-->
-* The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22914](https://github.com/magento/magento2/pull/22914)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
+*  The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22914](https://github.com/magento/magento2/pull/22914)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
 
 <!--- ENGCOM-5147-->
-* The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Mahesh Singh in pull request [22772](https://github.com/magento/magento2/pull/22772)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
+*  The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Mahesh Singh in pull request [22772](https://github.com/magento/magento2/pull/22772)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
 
 <!--- ENGCOM-5139-->
-* The `phpcs` script for PHP_CodeSniffer now displays all errors and warnings in the console. Previously, Magento threw a fatal error when it encountered an uncaught type error. *Fix submitted by Nazar Klovanych in pull request [22947](https://github.com/magento/magento2/pull/22947)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
+*  The `phpcs` script for PHP_CodeSniffer now displays all errors and warnings in the console. Previously, Magento threw a fatal error when it encountered an uncaught type error. *Fix submitted by Nazar Klovanych in pull request [22947](https://github.com/magento/magento2/pull/22947)*. [GitHub-20186](https://github.com/magento/magento2/issues/20186)
 
 <!--- MC-15163-->
-* The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
+*  The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
 
 ### Newsletter
 
 <!--- MAGETWO-99636-->
-* Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
+*  Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
 
 <!--- MAGETWO-71785-->
-* You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`.
+*  You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`.
 
 ### Orders
 
 <!--- ENGCOM-5405-->
-* The creditmemo `getOrder()` method now returns the expected extension attributes for an order. Previously, this method did not load orders correctly. *Fix submitted by Pavel Bystritsky in pull request [23358](https://github.com/magento/magento2/pull/23358)*. [GitHub-23345](https://github.com/magento/magento2/issues/23345)
+*  The creditmemo `getOrder()` method now returns the expected extension attributes for an order. Previously, this method did not load orders correctly. *Fix submitted by Pavel Bystritsky in pull request [23358](https://github.com/magento/magento2/pull/23358)*. [GitHub-23345](https://github.com/magento/magento2/issues/23345)
 
 <!--- ENGCOM-5398-->
-* Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Shankar Konar in pull request [23360](https://github.com/magento/magento2/pull/23360)*.
+*  Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Shankar Konar in pull request [23360](https://github.com/magento/magento2/pull/23360)*.
 
 ### Payment methods
 
 This release includes the following changes to integrations for core payment methods to support compliance with PSD2 regulations:
 
 <!--- MAGEDTWO-99606 99867-->
-* The Braintree payment method now complies with PSD2 regulations. The core integration API for Braintree now supports the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
+*  The Braintree payment method now complies with PSD2 regulations. The core integration API for Braintree now supports the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service.
 
 <!--- MAGEDTWO-99736 -->
-* Authorize.net now provides 3D Secure verification through third-party services through the `cardholderAuthentication` request field. Starting from this release,the Authorize.Net `accept.js` integration will support 3DS 2.0 through CardinalCommerce.
+*  Authorize.net now provides 3D Secure verification through third-party services through the `cardholderAuthentication` request field. Starting from this release,the Authorize.Net `accept.js` integration will support 3DS 2.0 through CardinalCommerce.
 
 <!--- MAGEDTWO-99739 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019. Use the official Marketplace extensions for these features instead.
 
 #### Other payment issues
 
 <!--- MC-17337-->
-* Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
+*  Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
 
 <!--- MAGETWO-99035-->
-* Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
+*  Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
 
 <!--- MC-17462-->
-* When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
+*  When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
 
 <!--- MAGETWO-99383-->
-* Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
+*  Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
 
 <!--- MAGETWO-99624-->
-* Customers can now place an order for virtual products that have a zero subtotal  after they have entered address information. Previously, customers could not place an order for virtual products with a zero subtotal if they had modified their address, and Magento displayed this message:  `The requested Payment Method is not available`.
+*  Customers can now place an order for virtual products that have a zero subtotal  after they have entered address information. Previously, customers could not place an order for virtual products with a zero subtotal if they had modified their address, and Magento displayed this message:  `The requested Payment Method is not available`.
 
 <!--- MC-17236-->
-* Magento now displays Chinese locale text strings for PayPal buttons as expected.
+*  Magento now displays Chinese locale text strings for PayPal buttons as expected.
 
 <!--- MAGETWO-99586-->
-* You can now cancel orders placed with PayPal Express even after authorization has expired.
+*  You can now cancel orders placed with PayPal Express even after authorization has expired.
 
 <!--- MC-16769-->
-* The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
+*  The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
 
 <!--- MAGETWO-99112-->
-* The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
+*  The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
 
 <!--- ENGCOM-5105-->
-* Magento now displays stored payment methods and billing agreements if the related payment method is active. Previously, Magento displayed disabled payment methods in the customer dashboard. *Fix submitted by Torben Höhn in pull request [22850](https://github.com/magento/magento2/pull/22850)*. [GitHub-6659](https://github.com/magento/magento2/issues/6659)
+*  Magento now displays stored payment methods and billing agreements if the related payment method is active. Previously, Magento displayed disabled payment methods in the customer dashboard. *Fix submitted by Torben Höhn in pull request [22850](https://github.com/magento/magento2/pull/22850)*. [GitHub-6659](https://github.com/magento/magento2/issues/6659)
 
 <!--- ENGCOM-4839-->
-* Magento no longer saves credit card information when the  **Save for later use** checkbox on the payment page is not enabled during order creation. *Fix submitted by Patrick McLain in pull request [19767](https://github.com/magento/magento2/pull/19767)*. [GitHub-19515](https://github.com/magento/magento2/issues/19515)
+*  Magento no longer saves credit card information when the  **Save for later use** checkbox on the payment page is not enabled during order creation. *Fix submitted by Patrick McLain in pull request [19767](https://github.com/magento/magento2/pull/19767)*. [GitHub-19515](https://github.com/magento/magento2/issues/19515)
 
 <!--- ENGCOM-5451-->
-* When placing an order with Authorize.net, Magento now disables the Order page's **Place Order** button until billing information has been updated. Previously, this button remained enabled, no matter the status of the order in progress. *Fix submitted by Eden Duong in pull request [23718](https://github.com/magento/magento2/pull/23718)*. [GitHub-23624](https://github.com/magento/magento2/issues/23624)
+*  When placing an order with Authorize.net, Magento now disables the Order page's **Place Order** button until billing information has been updated. Previously, this button remained enabled, no matter the status of the order in progress. *Fix submitted by Eden Duong in pull request [23718](https://github.com/magento/magento2/pull/23718)*. [GitHub-23624](https://github.com/magento/magento2/issues/23624)
 
 <!--- MC-17753-->
-* Magento now displays an informative email message about invalid credentials when a user tries to pay for an order with the Authorize.net payment method that has an incompletely configured Authorize.net `accept.js` account.
+*  Magento now displays an informative email message about invalid credentials when a user tries to pay for an order with the Authorize.net payment method that has an incompletely configured Authorize.net `accept.js` account.
 
 <!--- MC-17984-->
-* You can now place an order from the Admin using Authorize.net as the payment method. Previously, Magento did not place the order and displayed this message: `Transaction has been declined. Please try again later`.
+*  You can now place an order from the Admin using Authorize.net as the payment method. Previously, Magento did not place the order and displayed this message: `Transaction has been declined. Please try again later`.
 
 <!--- MC-16289-->
-* The **Credentials** button on the Configure PayPal Express Checkout page (**Admin** > **Stores** > **Configuration**  > **Sales**  > **Payment Methods** > **PayPal Express Checkout**) is now displayed properly in modes.
+*  The **Credentials** button on the Configure PayPal Express Checkout page (**Admin** > **Stores** > **Configuration**  > **Sales**  > **Payment Methods** > **PayPal Express Checkout**) is now displayed properly in modes.
 
 <!--- MC-17576-->
-* Magento no longer throws an error when you place an order using a custom payment method in deployments running Signifyd. Previously, when you tried to place an order using a custom payment method, an error related to the merge of `signifyd_payment_mapping.xml` files occurred.
+*  Magento no longer throws an error when you place an order using a custom payment method in deployments running Signifyd. Previously, when you tried to place an order using a custom payment method, an error related to the merge of `signifyd_payment_mapping.xml` files occurred.
 
 <!--- ENGCOM-5504-->
-* Data type validation now occurs on data entered into the minimum and maximum order totals for all payment methods accessed under **Store** > **Configurations** > **Sales** > **Payment Method**. Previously, you could add values with invalid data types, and Magento saved these values with the wrong data type. *Fix submitted by Eden Duong in pull request [23917](https://github.com/magento/magento2/pull/23917)*. [GitHub-23916](https://github.com/magento/magento2/issues/23916)
+*  Data type validation now occurs on data entered into the minimum and maximum order totals for all payment methods accessed under **Store** > **Configurations** > **Sales** > **Payment Method**. Previously, you could add values with invalid data types, and Magento saved these values with the wrong data type. *Fix submitted by Eden Duong in pull request [23917](https://github.com/magento/magento2/pull/23917)*. [GitHub-23916](https://github.com/magento/magento2/issues/23916)
 
 <!--- ENGCOM-4752-->
-* The **PayPal Express Checkout** button now appears on the product details page only when the **Display on Product Details Page** and  **Enable Instant Purchase** configuration settings are enabled. *Fix submitted by Nazar Klovanych in pull request [22260](https://github.com/magento/magento2/pull/22260)*. [GitHub-22045](https://github.com/magento/magento2/issues/22045), [GitHub-22134](https://github.com/magento/magento2/issues/22134)
+*  The **PayPal Express Checkout** button now appears on the product details page only when the **Display on Product Details Page** and  **Enable Instant Purchase** configuration settings are enabled. *Fix submitted by Nazar Klovanych in pull request [22260](https://github.com/magento/magento2/pull/22260)*. [GitHub-22045](https://github.com/magento/magento2/issues/22045), [GitHub-22134](https://github.com/magento/magento2/issues/22134)
 
 <!--- ENGCOM-5452-->
-* The location of the Zero Subtotal Checkout payment settings has been changed to **Stores** > **Configuration** > **Sales** > **Payment Methods**. *Fix submitted by Andrea Parmeggiani in pull request [23679](https://github.com/magento/magento2/pull/23679)*. [GitHub-23678](https://github.com/magento/magento2/issues/23678)
+*  The location of the Zero Subtotal Checkout payment settings has been changed to **Stores** > **Configuration** > **Sales** > **Payment Methods**. *Fix submitted by Andrea Parmeggiani in pull request [23679](https://github.com/magento/magento2/pull/23679)*. [GitHub-23678](https://github.com/magento/magento2/issues/23678)
 
 <!--- ENGCOM-5324-->
-* Magento now displays the loading icon while processing a Braintree payment until the user is redirected to the new Order page. *Fix submitted by Kunal Soni in pull request [22675](https://github.com/magento/magento2/pull/22675)*. [GitHub-20038](https://github.com/magento/magento2/issues/20038)
+*  Magento now displays the loading icon while processing a Braintree payment until the user is redirected to the new Order page. *Fix submitted by Kunal Soni in pull request [22675](https://github.com/magento/magento2/pull/22675)*. [GitHub-20038](https://github.com/magento/magento2/issues/20038)
 
 ### Performance
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MC-15763-->
-* Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
+*  Page load speeds have been improved by moving non-critical CSS elements to the bottom of the page. This enables the browser to render and display a storefront page more quickly. This setting is disabled by default, but you can enable it using **Stores** > **Configuration** > **Advanced** > **Developer** > **CSS Settings** > **Use CSS critical path**. For more information, see [CSS critical path documentation]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html).
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-16046-->
-* Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
+*  Store pages now display text in readable system fonts while loading custom fonts, which significantly increases page load speed. Merchants who deploy stores that implement large CSS files and many fonts will notice the greatest improvement.
 
 ### Pricing
 
 <!--- MAGETWO-99152-->
-* You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
+*  You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
 
 <!--- MAGETWO-98844-->
-* You can now set product price that exceeds 100,000,000.
+*  You can now set product price that exceeds 100,000,000.
 
 ### Reports
 
 <!--- ENGCOM-5413-->
-* The default date range for report filters is now set to the past month instead of the past 18 years. Previously, the default was set to 18 years, which resulted in errors in the filtered results. *Fix submitted by Yaroslav Rogoza in pull request [23607](https://github.com/magento/magento2/pull/23607)*. [GitHub-23606](https://github.com/magento/magento2/issues/23606)
+*  The default date range for report filters is now set to the past month instead of the past 18 years. Previously, the default was set to 18 years, which resulted in errors in the filtered results. *Fix submitted by Yaroslav Rogoza in pull request [23607](https://github.com/magento/magento2/pull/23607)*. [GitHub-23606](https://github.com/magento/magento2/issues/23606)
 
 <!--- MC-18195-->
-* The start and finish date in reports now correspond to the entered  values when you create a report from the Admin. Previously, the start and finish dates  in the displayed report was one day earlier than you entered.
+*  The start and finish date in reports now correspond to the entered  values when you create a report from the Admin. Previously, the start and finish dates  in the displayed report was one day earlier than you entered.
 
 <!--- ENGCOM-5505-->
-* The access controls on the **Reports** > **Product** > **Downloads** have been refactored to permit access to only administrators with the correct permissions. Previously, administrators with no access to this area could access the Downloads report. *Fix submitted by Eden Duong in pull request [23901](https://github.com/magento/magento2/pull/23901)*. [GitHub-23900](https://github.com/magento/magento2/issues/23900)
+*  The access controls on the **Reports** > **Product** > **Downloads** have been refactored to permit access to only administrators with the correct permissions. Previously, administrators with no access to this area could access the Downloads report. *Fix submitted by Eden Duong in pull request [23901](https://github.com/magento/magento2/pull/23901)*. [GitHub-23900](https://github.com/magento/magento2/issues/23900)
 
 <!--- ENGCOM-5052-->
-* Selecting **Show by year** when filtering  **Reports** > **Products**  > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per-order basis. *Fix submitted by Surabhi Srivastava in pull request [22087](https://github.com/magento/magento2/pull/22087)*. [GitHub-22646](https://github.com/magento/magento2/issues/22646), [GitHub-22087](https://github.com/magento/magento2/issues/22087)
+*  Selecting **Show by year** when filtering  **Reports** > **Products**  > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per-order basis. *Fix submitted by Surabhi Srivastava in pull request [22087](https://github.com/magento/magento2/pull/22087)*. [GitHub-22646](https://github.com/magento/magento2/issues/22646), [GitHub-22087](https://github.com/magento/magento2/issues/22087)
 
 ### Reviews
 
 <!--- MAGETWO-99591-->
-* Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
+*  Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
 
 ### Sales
 
 <!--- MAGETWO-99691-->
-* The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
+*  The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
 
 <!--- MAGETWO-99460-->
-* Custom order statuses no longer override default statuses in drop-down menus.
+*  Custom order statuses no longer override default statuses in drop-down menus.
 
 <!--- MAGETWO-99430-->
-* The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
+*  The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
 
 <!--- MAGETWO-99364-->
-* You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
+*  You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
 
 <!--- MAGETWO-99605-->
-* You can now use quotation marks  to create exact search terms in the Admin menu search grid  (**Customers** > **All Customers**).
+*  You can now use quotation marks  to create exact search terms in the Admin menu search grid  (**Customers** > **All Customers**).
 
 <!--- MC-17269-->
-* The date format used in tables throughout the product interface is now based on the Admin-defined locale.
+*  The date format used in tables throughout the product interface is now based on the Admin-defined locale.
 
 <!--- MAGETWO-72172-->
-* Magento no longer lets you add a disabled variation of configurable product to the shopping cart from the Admin.
+*  Magento no longer lets you add a disabled variation of configurable product to the shopping cart from the Admin.
 
 <!--- MAGETWO-99883-->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 <!--- MC-17860-->
-* Magento no longer adds to an order any selected products that have not been explicitly added to the cart when you create an order from the Admin.
+*  Magento no longer adds to an order any selected products that have not been explicitly added to the cart when you create an order from the Admin.
 
 <!--- MC-17797-->
-* Magento no longer throws a fatal error when you click **View Order**  on an order that contains a product that was available when the order was created but which was subsequently  deleted from the storefront.
+*  Magento no longer throws a fatal error when you click **View Order**  on an order that contains a product that was available when the order was created but which was subsequently  deleted from the storefront.
 
 <!--- MAGETWO-98832-->
-* The Allowed Countries drop-down list that is available in multisite deployments now reflects the settings that  are configured in **Stores** > **Configuration** > **General** > **General** > **Country Options** > **Allow Countries**.
+*  The Allowed Countries drop-down list that is available in multisite deployments now reflects the settings that  are configured in **Stores** > **Configuration** > **General** > **General** > **Country Options** > **Allow Countries**.
 
 ### Search
 
 <!--- MAGETWO-99769-->
-* Search results now reflect the search weight that you assign to product attributes in attribute configuration.
+*  Search results now reflect the search weight that you assign to product attributes in attribute configuration.
 
 <!--- ENGCOM-5402-->
-* Search by keyword now supports searching on zero (0). *Fix submitted by jeysmook in pull request [23424](https://github.com/magento/magento2/pull/23424)*.
+*  Search by keyword now supports searching on zero (0). *Fix submitted by jeysmook in pull request [23424](https://github.com/magento/magento2/pull/23424)*.
 
 <!--- MAGETWO-99669-->
-* You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
+*  You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
 `{"0":"SQLSTATE[42000]: Syntax error or access violation: 1064 syntax error, unexpected $end, query was: SELECT`.
 
 <!--- MC-18009-->
-* Disabled products now appear in the list of available products in the search results of the Page Builder link attribute–on buttons, images, banners, sliders. Previously, these products did not appear in search results, which prevented users from creating content that went live with a schedule update.
+*  Disabled products now appear in the list of available products in the search results of the Page Builder link attribute–on buttons, images, banners, sliders. Previously, these products did not appear in search results, which prevented users from creating content that went live with a schedule update.
 
 ### Shipping
 
 <!--- MC-17502-->
-* You can now use Cybersource as a payment method when multishipping is enabled. Previously, when you tried to place an order, Magento threw this error: `Invalid Form Key. Please refresh the page`. This resulted from a problem with auto-attaching a form key on the submit event  when one form contained another form.
+*  You can now use Cybersource as a payment method when multishipping is enabled. Previously, when you tried to place an order, Magento threw this error: `Invalid Form Key. Please refresh the page`. This resulted from a problem with auto-attaching a form key on the submit event  when one form contained another form.
 
 <!--- ENGCOM-5110-->
-* The Order Tracking page now displays the Contact us link as expected  when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [22823](https://github.com/magento/magento2/pull/22823)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
+*  The Order Tracking page now displays the Contact us link as expected  when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [22823](https://github.com/magento/magento2/pull/22823)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
 
 <!--- ENGCOM-5109-->
-* Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields)  when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22787](https://github.com/magento/magento2/pull/22787)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
+*  Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields)  when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22787](https://github.com/magento/magento2/pull/22787)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
 
 <!--- ENGCOM-5379-->
-* You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23523](https://github.com/magento/magento2/pull/23523)*.
+*  You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23523](https://github.com/magento/magento2/pull/23523)*.
 
 <!--- ENGCOM-5381-->
-* Magento now validates values entered into the **quantity** field on the Shipping to Multiple Addresses page. *Fix submitted by Nirmal Raval in pull request [23477](https://github.com/magento/magento2/pull/23477)*.
+*  Magento now validates values entered into the **quantity** field on the Shipping to Multiple Addresses page. *Fix submitted by Nirmal Raval in pull request [23477](https://github.com/magento/magento2/pull/23477)*.
 
 <!--- ENGCOM-5455-->
-* The updates that a customer makes to the shipping address during the checkout shipping step is maintained during the billing step. Previously, the information in the **Ship To** area was updated with empty values in the billing step when the **My billing and shipping address are the same** setting is set to **no**. *Fix submitted by rsimmons07 in pull request [23656](https://github.com/magento/magento2/pull/23656)*. [GitHub-22112](https://github.com/magento/magento2/issues/22112)
+*  The updates that a customer makes to the shipping address during the checkout shipping step is maintained during the billing step. Previously, the information in the **Ship To** area was updated with empty values in the billing step when the **My billing and shipping address are the same** setting is set to **no**. *Fix submitted by rsimmons07 in pull request [23656](https://github.com/magento/magento2/pull/23656)*. [GitHub-22112](https://github.com/magento/magento2/issues/22112)
 
 ### Sitemap
 
 <!--- MC-16312-->
-* Magento now generates all relevant product URLS when the **Use Categories Path for Product URLs** setting is enabled.
+*  Magento now generates all relevant product URLS when the **Use Categories Path for Product URLs** setting is enabled.
 
 <!--- ENGCOM-5240-->
-* The sitemap product generation for the **Use Categories Path for Product URLs** setting has been refactored. *Fix submitted by Sergiy Vasiutynskyi in pull request [23129](https://github.com/magento/magento2/pull/23129)*. [GitHub-22934](https://github.com/magento/magento2/issues/22934), [GitHub-4788](https://github.com/magento/magento2/issues/4788)
+*  The sitemap product generation for the **Use Categories Path for Product URLs** setting has been refactored. *Fix submitted by Sergiy Vasiutynskyi in pull request [23129](https://github.com/magento/magento2/pull/23129)*. [GitHub-22934](https://github.com/magento/magento2/issues/22934), [GitHub-4788](https://github.com/magento/magento2/issues/4788)
 
 ### Swatches
 
 <!--- ENGCOM-5020-->
-* You can update the dropdown attributes (**Admin** > **Stores** > **Attributes** > **Product**) when swatches have been disabled. Previously, when swatches were disabled, Magento displayed this error in the console: `Uncaught TypeError: panel.addClass is not a function`. *Fix submitted by Mark van der Sanden in pull request [22560](https://github.com/magento/magento2/pull/22560)*. [GitHub-20843](https://github.com/magento/magento2/issues/20843)
+*  You can update the dropdown attributes (**Admin** > **Stores** > **Attributes** > **Product**) when swatches have been disabled. Previously, when swatches were disabled, Magento displayed this error in the console: `Uncaught TypeError: panel.addClass is not a function`. *Fix submitted by Mark van der Sanden in pull request [22560](https://github.com/magento/magento2/pull/22560)*. [GitHub-20843](https://github.com/magento/magento2/issues/20843)
 
 <!--- ENGCOM-5175-->
-* The image gallery now correctly loads images for swatch colors. Previously, the gallery did not switch to the designated first image as expected. *Fix submitted by Milind Singh in pull request [23033](https://github.com/magento/magento2/pull/23033)*. [GitHub-23030](https://github.com/magento/magento2/issues/23030)
+*  The image gallery now correctly loads images for swatch colors. Previously, the gallery did not switch to the designated first image as expected. *Fix submitted by Milind Singh in pull request [23033](https://github.com/magento/magento2/pull/23033)*. [GitHub-23030](https://github.com/magento/magento2/issues/23030)
 
 ### Templates
 
 <!--- ENGCOM-5440-->
-* The Insert Variables popup window is now populated with template variables as expected. (This window is accessed from **Marketing** > **Email Templates** > **Add New Template**.) *Fix submitted by Mahesh Singh in pull request [23173](https://github.com/magento/magento2/pull/23173)*. [GitHub-23135](https://github.com/magento/magento2/issues/23135)
+*  The Insert Variables popup window is now populated with template variables as expected. (This window is accessed from **Marketing** > **Email Templates** > **Add New Template**.) *Fix submitted by Mahesh Singh in pull request [23173](https://github.com/magento/magento2/pull/23173)*. [GitHub-23135](https://github.com/magento/magento2/issues/23135)
 
 ### Testing
 
 <!--- MC-16371 MC-18277 MC-18750 MC-11031 MC-15749-->
-* The following tests have been improved:
+*  The following tests have been improved:
 `CheckoutWithBraintreePaypalMinicartTest`
 `Magento\Catalog\Setup\Patch\Schema\ChangeTmpTablesEngine`
 `MAGETWO-69516: Cart Price Rule with related Banner for specific Customer Segment is persisted under long-term cookie`
@@ -1013,167 +1013,167 @@ This release includes the following changes to integrations for core payment met
 `Mftf Test: StorefrontApplyCategoryPermissionsToSecondWebsiteTest`
 
 <!--- MC-5806-->
-* The Dependency static test now detects URL dependencies as expected.
+*  The Dependency static test now detects URL dependencies as expected.
 
 <!--- MC-18699-->
-* `Magento.Framework.Image.Adapter.InterfaceTest.testValidateUploadFileException` with data set `image_empty` no longer fails on 2.3.3-develop.
+*  `Magento.Framework.Image.Adapter.InterfaceTest.testValidateUploadFileException` with data set `image_empty` no longer fails on 2.3.3-develop.
 
 <!--- ENGCOM-5470-->
-* `CommentLevelsSniff` now works correctly with the `@magento_import` statement. Previously, when you ran `Magento\Test\Less\LiveCodeTest`, Magento threw an error on lines that contained `@magento_import`. *Fix submitted by Pavel Bystritsky in pull request [23790](https://github.com/magento/magento2/pull/23790)*. [GitHub-23789](https://github.com/magento/magento2/issues/23789)
+*  `CommentLevelsSniff` now works correctly with the `@magento_import` statement. Previously, when you ran `Magento\Test\Less\LiveCodeTest`, Magento threw an error on lines that contained `@magento_import`. *Fix submitted by Pavel Bystritsky in pull request [23790](https://github.com/magento/magento2/pull/23790)*. [GitHub-23789](https://github.com/magento/magento2/issues/23789)
 
 <!--- ENGCOM-3132-->
-* Magento now deletes the stub modules that tests create. Previously, integration tests created stub modules in `app/code`, which could potentially affect production code. *Fix submitted by Andreas von Studnitz in pull request [18459](https://github.com/magento/magento2/pull/18459)*. [GitHub-12696](https://github.com/magento/magento2/issues/12696)
+*  Magento now deletes the stub modules that tests create. Previously, integration tests created stub modules in `app/code`, which could potentially affect production code. *Fix submitted by Andreas von Studnitz in pull request [18459](https://github.com/magento/magento2/pull/18459)*. [GitHub-12696](https://github.com/magento/magento2/issues/12696)
 
 ### Translation and locales
 
 <!--- ENGCOM-5196-->
-* White space between words now appears as expected in non-English websites. *Fix submitted by Alexey Arendarenko in pull request [23081](https://github.com/magento/magento2/pull/23081)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
+*  White space between words now appears as expected in non-English websites. *Fix submitted by Alexey Arendarenko in pull request [23081](https://github.com/magento/magento2/pull/23081)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
 
 <!--- ENGCOM-5334-->
-* The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Alexey Arendarenko in pull request [23338](https://github.com/magento/magento2/pull/23338)*.
+*  The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Alexey Arendarenko in pull request [23338](https://github.com/magento/magento2/pull/23338)*.
 
 ### UI
 
 <!--- MC-16887-->
-* The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
+*  The `jQuery/ui` library has been refactored into separate widgets so that core modules load only the widgets they need. This update improves the performance of core storefront tasks including the loading of category, configurable product, home, and checkout pages.
 
 <!--- MC-17922-->
-* The calendar date picker now updates values as expected when the linked input value is changed.
+*  The calendar date picker now updates values as expected when the linked input value is changed.
 
 <!--- MAGETWO-99361-->
-* The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **Url Rewrites**), Magento did not include most categories in the resulting view.
+*  The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **Url Rewrites**), Magento did not include most categories in the resulting view.
 
 <!--- MAGETWO-99832-->
-* Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
+*  Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
 
 <!--- ENGCOM-4923-->
-* Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Roman Kis in pull request [21992](https://github.com/magento/magento2/pull/21992)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
+*  Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Roman Kis in pull request [21992](https://github.com/magento/magento2/pull/21992)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
 
 <!--- ENGCOM-5067-->
-* The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Arvinda Kumar in pull request [22644](https://github.com/magento/magento2/pull/22644)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
+*  The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Arvinda Kumar in pull request [22644](https://github.com/magento/magento2/pull/22644)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
 
 <!--- ENGCOM-5083-->
-* The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22779](https://github.com/magento/magento2/pull/22779)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
+*  The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22779](https://github.com/magento/magento2/pull/22779)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
 
 <!--- ENGCOM-5148-->
-* Added appropriate white space between elements of product descriptions on the product list view. *Fix submitted by Hitesh in pull request [22931](https://github.com/magento/magento2/pull/22931)*. [GitHub-20788](https://github.com/magento/magento2/issues/20788)
+*  Added appropriate white space between elements of product descriptions on the product list view. *Fix submitted by Hitesh in pull request [22931](https://github.com/magento/magento2/pull/22931)*. [GitHub-20788](https://github.com/magento/magento2/issues/20788)
 
 <!--- ENGCOM-5176-->
-* Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23035](https://github.com/magento/magento2/pull/23035)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
+*  Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23035](https://github.com/magento/magento2/pull/23035)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
 
 <!--- MC-16334-->
-* Page element layout issues on  **Stores** > **Configuration** > **Advanced** > **Admin** have been resolved. Previously, when you expanded the security block on this page, the **Use system value** text appeared at the top of the page, not adjacent to the checkbox it applied to.
+*  Page element layout issues on  **Stores** > **Configuration** > **Advanced** > **Admin** have been resolved. Previously, when you expanded the security block on this page, the **Use system value** text appeared at the top of the page, not adjacent to the checkbox it applied to.
 
 <!--- MC-17003-->
-* The missing **Update Totals**  button has been added to the Credit Memo page.
+*  The missing **Update Totals**  button has been added to the Credit Memo page.
 
 <!--- ENGCOM-5512-->
-* Magento now displays an error message as needed when you click the  **Catalog** > **Products** > **Create Configurations** button and submit invalid data. Previously, Magento did not display the error message after validation due to lack of autofocus on the error field.
+*  Magento now displays an error message as needed when you click the  **Catalog** > **Products** > **Create Configurations** button and submit invalid data. Previously, Magento did not display the error message after validation due to lack of autofocus on the error field.
 *Fix submitted by Eden Duong in pull request [23905](https://github.com/magento/magento2/pull/23905)*. [GitHub-23904](https://github.com/magento/magento2/issues/23904)
 
 <!--- ENGCOM-5473-->
-* The toggle icon on the **Catalog** > **Products** > **New Product (Configurable)** > **Create Configuration** page now works as expected. *Fix submitted by Eden Duong in pull request [23803](https://github.com/magento/magento2/pull/23803)*. [GitHub-22702](https://github.com/magento/magento2/issues/22702)
+*  The toggle icon on the **Catalog** > **Products** > **New Product (Configurable)** > **Create Configuration** page now works as expected. *Fix submitted by Eden Duong in pull request [23803](https://github.com/magento/magento2/pull/23803)*. [GitHub-22702](https://github.com/magento/magento2/issues/22702)
 
 <!--- ENGCOM-5467-->
-* Magento no longer validates data in the **Discount Amount** field after page load until the user performs an action in the Create New Catalog Rule form. Previously, Magento ran validation checks on that field despite its inactivity, and threw an error. *Fix submitted by Eden Duong in pull request [23779](https://github.com/magento/magento2/pull/23779)*. [GitHub-23777](https://github.com/magento/magento2/issues/23777)
+*  Magento no longer validates data in the **Discount Amount** field after page load until the user performs an action in the Create New Catalog Rule form. Previously, Magento ran validation checks on that field despite its inactivity, and threw an error. *Fix submitted by Eden Duong in pull request [23779](https://github.com/magento/magento2/pull/23779)*. [GitHub-23777](https://github.com/magento/magento2/issues/23777)
 
 <!--- ENGCOM-5453-->
-* You can now edit the status label for the storefront from the Admin in single-store mode. Previously, there was no status field available from **Stores** > **Order Status** when single-store mode was enabled. *Fix submitted by Eden Duong in pull request [23681](https://github.com/magento/magento2/pull/23681)*. [GitHub-22654](https://github.com/magento/magento2/issues/22654)
+*  You can now edit the status label for the storefront from the Admin in single-store mode. Previously, there was no status field available from **Stores** > **Order Status** when single-store mode was enabled. *Fix submitted by Eden Duong in pull request [23681](https://github.com/magento/magento2/pull/23681)*. [GitHub-22654](https://github.com/magento/magento2/issues/22654)
 
 <!--- ENGCOM-5070-->
-* The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Abrar Pathan in pull request [21215](https://github.com/magento/magento2/pull/21215)*. [GitHub-21214](https://github.com/magento/magento2/issues/21214)
+*  The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Abrar Pathan in pull request [21215](https://github.com/magento/magento2/pull/21215)*. [GitHub-21214](https://github.com/magento/magento2/issues/21214)
 
 <!--- ENGCOM-5278-->
-* The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23234](https://github.com/magento/magento2/pull/23234)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
+*  The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23234](https://github.com/magento/magento2/pull/23234)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
 
 <!--- ENGCOM-4623-->
-* Magento now sets the `last` CSS class to the top menu when one or more parent items are not active. As a result, menu items will be filtered before they are processed for HTML output. *Fix submitted by Arnoud Beekman in pull request [22071](https://github.com/magento/magento2/pull/22071)*. [GitHub-13266](https://github.com/magento/magento2/issues/13266)
+*  Magento now sets the `last` CSS class to the top menu when one or more parent items are not active. As a result, menu items will be filtered before they are processed for HTML output. *Fix submitted by Arnoud Beekman in pull request [22071](https://github.com/magento/magento2/pull/22071)*. [GitHub-13266](https://github.com/magento/magento2/issues/13266)
 
 <!--- ENGCOM-5155-->
-* The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Nirav Patel in pull request [23007](https://github.com/magento/magento2/pull/23007)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
+*  The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Nirav Patel in pull request [23007](https://github.com/magento/magento2/pull/23007)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
 
 <!--- ENGCOM-5107-->
-* You can now specify custom fonts for use in your deployment. Previously, the `.lib-font-face()` mixin required that you include the font in all the formats listed (for example, `eot`, `woff2`, `woff`, `ttf`, and `svg`). If your font was not available in these formats, Magento displayed a 404 error. *Fix submitted by Karla Saaremäe in pull request [22854](https://github.com/magento/magento2/pull/22854)*. [GitHub-4628](https://github.com/magento/magento2/issues/4628)
+*  You can now specify custom fonts for use in your deployment. Previously, the `.lib-font-face()` mixin required that you include the font in all the formats listed (for example, `eot`, `woff2`, `woff`, `ttf`, and `svg`). If your font was not available in these formats, Magento displayed a 404 error. *Fix submitted by Karla Saaremäe in pull request [22854](https://github.com/magento/magento2/pull/22854)*. [GitHub-4628](https://github.com/magento/magento2/issues/4628)
 
 <!--- ENGCOM-5325-->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Nishant Jariwala in pull request [23286](https://github.com/magento/magento2/pull/23286)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Nishant Jariwala in pull request [23286](https://github.com/magento/magento2/pull/23286)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!--- ENGCOM-5386-->
-* The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23528](https://github.com/magento/magento2/pull/23528)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
+*  The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23528](https://github.com/magento/magento2/pull/23528)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
 
 <!--- ENGCOM-5358-->
-* The `font-size` setting for all `input-field` labels with a tooltip is no longer set to 0, and time fields are separated by colons (:) as expected. *Fix submitted by Geeta Modi in pull request [23393](https://github.com/magento/magento2/pull/23393)*. [GitHub-21974](https://github.com/magento/magento2/issues/21974)
+*  The `font-size` setting for all `input-field` labels with a tooltip is no longer set to 0, and time fields are separated by colons (:) as expected. *Fix submitted by Geeta Modi in pull request [23393](https://github.com/magento/magento2/pull/23393)*. [GitHub-21974](https://github.com/magento/magento2/issues/21974)
 
 <!--- ENGCOM-5321-->
-* Magento now displays the Admin grid header as expected when there are no buttons in the toolbar. *Fix submitted by Shankar Konar in pull request [23247](https://github.com/magento/magento2/pull/23247)*.
+*  Magento now displays the Admin grid header as expected when there are no buttons in the toolbar. *Fix submitted by Shankar Konar in pull request [23247](https://github.com/magento/magento2/pull/23247)*.
 
 ### URL rewrites
 
 <!--- MC-4244-->
-* Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
+*  Merchants now have the ability to turn off the automatic URL rewrite generation that occurs by default on products when the category they belong to is saved. The new **Generate "category/product" URL Rewrites**  configuration option controls this behavior. When this feature is enabled, Magento will generate a lot of data when saving a category that contains many assigned products. This generated data is saved into rewrite tables that can degrade Magento performance.
 
 <!--- MAGETWO-99830-->
-* Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
+*  Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
 
 <!--- MAGETWO-96663-->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!--- ENGCOM-5195-->
-* URL redirects now work as expected when you click **Save** after editing a product view from the Customer tab (**Customer** > **Product Reviews** > **Edit Review**). *Fix submitted by Ravi Chandra in pull request [22426](https://github.com/magento/magento2/pull/22426)*. [GitHub-22425](https://github.com/magento/magento2/issues/22425)
+*  URL redirects now work as expected when you click **Save** after editing a product view from the Customer tab (**Customer** > **Product Reviews** > **Edit Review**). *Fix submitted by Ravi Chandra in pull request [22426](https://github.com/magento/magento2/pull/22426)*. [GitHub-22425](https://github.com/magento/magento2/issues/22425)
 
 <!--- ENGCOM-5435-->
-* Magento now correctly renders the value of a product’s customizable option field of type `Area` when you enter a multi-line value from the Admin. Previously, a multi-line value was rendered with an HTML `<br>` tag as part of the value. *Fix submitted by Sunil in pull request [23524](https://github.com/magento/magento2/pull/23524)*. [GitHub-23510](https://github.com/magento/magento2/issues/23510)
+*  Magento now correctly renders the value of a product’s customizable option field of type `Area` when you enter a multi-line value from the Admin. Previously, a multi-line value was rendered with an HTML `<br>` tag as part of the value. *Fix submitted by Sunil in pull request [23524](https://github.com/magento/magento2/pull/23524)*. [GitHub-23510](https://github.com/magento/magento2/issues/23510)
 
 <!--- ENGCOM-5397-->
-* You can now use a plus sign (+) character in content contained within a widget on a CMS page. Previously, Magento did not render the character, although it appeared in the page content stored in the database and when editing the widget. *Fix submitted by Sarfaraz Bheda in pull request [23496](https://github.com/magento/magento2/pull/23496)*.
+*  You can now use a plus sign (+) character in content contained within a widget on a CMS page. Previously, Magento did not render the character, although it appeared in the page content stored in the database and when editing the widget. *Fix submitted by Sarfaraz Bheda in pull request [23496](https://github.com/magento/magento2/pull/23496)*.
 
 <!--- ENGCOM-5330-->
-* Product URLs are now updated as expected after Magento changes the URL key of the category in multi-site deployment. *Fix submitted by Alastair Mucklow in pull request [23309](https://github.com/magento/magento2/pull/23309)*. [GitHub-23074](https://github.com/magento/magento2/issues/23074)
+*  Product URLs are now updated as expected after Magento changes the URL key of the category in multi-site deployment. *Fix submitted by Alastair Mucklow in pull request [23309](https://github.com/magento/magento2/pull/23309)*. [GitHub-23074](https://github.com/magento/magento2/issues/23074)
 
 ### Vertex
 
-* Incorrect Customer Codes are no longer sent when Vertex invoices are set to send during an order status change.
+*  Incorrect Customer Codes are no longer sent when Vertex invoices are set to send during an order status change.
 
-* Resolved an issue where assisted parameters were not requested and logged during Invoice calls made during Order Status Change.
+*  Resolved an issue where assisted parameters were not requested and logged during Invoice calls made during Order Status Change.
 
-* Calls to Vertex are now made when string values exceed the maximum allowed length in the Vertex SDK.
+*  Calls to Vertex are now made when string values exceed the maximum allowed length in the Vertex SDK.
 
-* Tax code, vertex tax code, and invoice text codes are now saved for orders created during Guest Checkout.
+*  Tax code, vertex tax code, and invoice text codes are now saved for orders created during Guest Checkout.
 
-* Guest Orders are no longer invoiced twice if logging was enabled.
+*  Guest Orders are no longer invoiced twice if logging was enabled.
 
-* Shipping is now included on a Vertex invoice if that invoice was sent in the same request that its order was created in if that order was placed using guest checkout.
+*  Shipping is now included on a Vertex invoice if that invoice was sent in the same request that its order was created in if that order was placed using guest checkout.
 
 ### Web API framework
 
 <!--- ENGCOM-5162-->
-* Magento now renders shipment details for an order without a fatal error when you use REST to create a shipment. *Fix submitted by Milind Singh in pull request [22687](https://github.com/magento/magento2/pull/22687)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
+*  Magento now renders shipment details for an order without a fatal error when you use REST to create a shipment. *Fix submitted by Milind Singh in pull request [22687](https://github.com/magento/magento2/pull/22687)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
 
 <!--- ENGCOM-5116-->
-* You can now use REST to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22893](https://github.com/magento/magento2/pull/22893)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
+*  You can now use REST to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22893](https://github.com/magento/magento2/pull/22893)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
 
 <!--- ENGCOM-5192-->
-* Swagger now accepts requests in XML and can display results in the same format. *Fix submitted by Simon Schröer in pull request [23025](https://github.com/magento/magento2/pull/23025)*.
+*  Swagger now accepts requests in XML and can display results in the same format. *Fix submitted by Simon Schröer in pull request [23025](https://github.com/magento/magento2/pull/23025)*.
 
 <!--- ENGCOM-5312-->
-* The `POST` on `/orders` REST calls no longer fail when properties in the request body are out of order. Previously, when billing address data preceded customer data in the Order Create API JSON payload, the billing address email was not populated, so the order was empty. *Fix submitted by Mateusz Wira in pull request [23048](https://github.com/magento/magento2/pull/23048)*.
+*  The `POST` on `/orders` REST calls no longer fail when properties in the request body are out of order. Previously, when billing address data preceded customer data in the Order Create API JSON payload, the billing address email was not populated, so the order was empty. *Fix submitted by Mateusz Wira in pull request [23048](https://github.com/magento/magento2/pull/23048)*.
 
 ### Wishlist
 
 <!--- MAGETWO-99228-->
-* Wishlists now accurately reflect product availability when a product has been added to a wishlist and then subsequently disabled. Previously, the wishlist displayed these contradictory messages: **You have no items in your wish list** and **1 item in wish list**.
+*  Wishlists now accurately reflect product availability when a product has been added to a wishlist and then subsequently disabled. Previously, the wishlist displayed these contradictory messages: **You have no items in your wish list** and **1 item in wish list**.
 
 <!--- MAGETWO-99312-->
-* Wishlist names can now be edited from the storefront.
+*  Wishlist names can now be edited from the storefront.
 
 <!--- MAGETWO-97216-->
-* The `Magento\FunctionalTestingFramework.functional.StorefrontAddMultipleStoreProductsToWishlistTest` test no longer fails randomly.
+*  The `Magento\FunctionalTestingFramework.functional.StorefrontAddMultipleStoreProductsToWishlistTest` test no longer fails randomly.
 
 <!--- MC-18800-->
-* The wishlist no longer shows an item that has been disabled on the Admin.
+*  The wishlist no longer shows an item that has been disabled on the Admin.
 
 <!--- ENGCOM-5514-->
-* Wishlist items now display decimal values as appropriate. Previously, Magento saved decimal quantities for wishlist items but did not display these values in the wishlist on the storefront. *Fix submitted by Max Fickers in pull request [23933](https://github.com/magento/magento2/pull/23933)*. [GitHub-23932](https://github.com/magento/magento2/issues/23932)
+*  Wishlist items now display decimal values as appropriate. Previously, Magento saved decimal quantities for wishlist items but did not display these values in the wishlist on the storefront. *Fix submitted by Max Fickers in pull request [23933](https://github.com/magento/magento2/pull/23933)*. [GitHub-23932](https://github.com/magento/magento2/issues/23932)
 
 ## Known issue
 
@@ -1188,9 +1188,9 @@ The  `Magento\Framework\Mail\Template\TransportBuilder` and `Magento\Newslet
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### Partner contributions
 

--- a/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -14,9 +14,9 @@ Use the `bin/magento queue:consumers:start async.operations.all` command to star
 
 Magento supports the following types of asynchronous requests:
 
-* POST
-* PUT
-* PATCH
+*  POST
+*  PUT
+*  PATCH
 
 {:.bs-callout .bs-callout-info}
 GET and DELETE requests are not supported. Although Magento does not currently implement any PATCH requests, they are supported in custom extensions.
@@ -101,7 +101,7 @@ PUT /all/async/V1/products/:sku
 
 The following rules apply when you create or update an object, such as a product.
 
-* If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
-* If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
-* If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
-* If `<store_code>` parameter is set, then values for only defined store will be updated.
+*  If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
+*  If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
+*  If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
+*  If `<store_code>` parameter is set, then values for only defined store will be updated.

--- a/guides/v2.3/rest/bulk-endpoints.md
+++ b/guides/v2.3/rest/bulk-endpoints.md
@@ -131,7 +131,7 @@ PUT /all/async/bulk/V1/products/:sku
 
 The following rules apply when you create or update an object, such as a product.
 
-* If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
-* If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
-* If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
-* If `<store_code>` parameter is set, then values for only defined store will be updated.
+*  If you do not set the store code while creating a new product, Magento creates a new object with all values set globally for each scope.
+*  If you do not set the store code while updating a product, then by fallback, Magento updates values for the default store only.
+*  If you include the `all` parameter, then Magento updates values for all store scopes (in case a particular store doesn't yet have its own value set).
+*  If `<store_code>` parameter is set, then values for only defined store will be updated.

--- a/guides/v2.3/rest/modules/inventory/bulk-inventory.md
+++ b/guides/v2.3/rest/modules/inventory/bulk-inventory.md
@@ -5,9 +5,9 @@ title: Inventory mass actions
 
 Magento provides several endpoints that allow Multi Source merchants to make quick updates across multiple products. This is helpful for transferring inventory between sources and removing a source without editing each product individually.
 
-* The bulk transfer endpoint moves all quantities of products from one source to another.
-* The bulk assign source endpoint adds sources to multiple products.
-* The bulk unassign source endpoint removes sources from the products. Any inventory quantity assigned to that source is no longer available.
+*  The bulk transfer endpoint moves all quantities of products from one source to another.
+*  The bulk assign source endpoint adds sources to multiple products.
+*  The bulk unassign source endpoint removes sources from the products. Any inventory quantity assigned to that source is no longer available.
 
 **Service names**
 

--- a/guides/v2.3/rest/modules/inventory/manage-low-quantity.md
+++ b/guides/v2.3/rest/modules/inventory/manage-low-quantity.md
@@ -5,9 +5,9 @@ title: Manage low-quantity notifications
 
 Low stock notification alert the merchant that the salable quantity of a stock has reached a critical threshold. The Admin allows the merchant to configure low-quantity notifications from several locations:
 
-* The **Notify for Quantity Below** field (**Stores** > **Settings** > **Configuration** > **Catalog** > **Inventory** > **Product Stock Options**) sets the default value globally for all products for the entire website/store.
-* The Advanced Inventory **Notify for Quantity Below** field (**Catalog** > **Products** > specific product > **Advanced Inventory**) overrides the value set at the website/store level. The value applies to all of the product's sources.
-* The **Notify Quantity** fields (**Catalog** > **Products** > specific product > **Assigned Sources** section) override all other settings. The merchant can assign a different threshold for each source for the specific product.
+*  The **Notify for Quantity Below** field (**Stores** > **Settings** > **Configuration** > **Catalog** > **Inventory** > **Product Stock Options**) sets the default value globally for all products for the entire website/store.
+*  The Advanced Inventory **Notify for Quantity Below** field (**Catalog** > **Products** > specific product > **Advanced Inventory**) overrides the value set at the website/store level. The value applies to all of the product's sources.
+*  The **Notify Quantity** fields (**Catalog** > **Products** > specific product > **Assigned Sources** section) override all other settings. The merchant can assign a different threshold for each source for the specific product.
 
 Magento deducts either the global or the overriding quantity from the total salable quantity for the stock.
 

--- a/guides/v2.3/rest/modules/inventory/manage-source-selection.md
+++ b/guides/v2.3/rest/modules/inventory/manage-source-selection.md
@@ -7,16 +7,16 @@ Inventory Management uses the Source Selection Algorithm (SSA) to track the sala
 
 The SSA uses stocks and sources to check the sales channel for incoming product requests and determines the available inventory. The algorithm:
 
-* Calculates the aggregated virtual salable quantity of all assigned sources per stock
-* Subtracts the Out-of-Stock Threshold amount from salable quantity to protect against overselling and support concurrent checkout
-* Reserves inventory quantities at checkout, deducting from in-stock inventory at order processing and shipment
-* Supports backorders with enhanced options for negative thresholds
+*  Calculates the aggregated virtual salable quantity of all assigned sources per stock
+*  Subtracts the Out-of-Stock Threshold amount from salable quantity to protect against overselling and support concurrent checkout
+*  Reserves inventory quantities at checkout, deducting from in-stock inventory at order processing and shipment
+*  Supports backorders with enhanced options for negative thresholds
 
 The SSA also manages shipments by providing recommendations for the best sources to ship partial or all products or override the selections to:
 
-* Ship partial shipments, sending only a few products from specific sources and completing the full order at a later date.
-* Ship the entire order from one source.
-* Break the order into partial shipments across multiple sources in different amounts to keep a balanced stock across all warehouses and stores.
+*  Ship partial shipments, sending only a few products from specific sources and completing the full order at a later date.
+*  Ship the entire order from one source.
+*  Break the order into partial shipments across multiple sources in different amounts to keep a balanced stock across all warehouses and stores.
 
 Third parties can also extend SSA to create customized algorithms for recommending cost-effective shipments.
 

--- a/guides/v2.3/rest/modules/inventory/manage-sources.md
+++ b/guides/v2.3/rest/modules/inventory/manage-sources.md
@@ -11,9 +11,9 @@ You cannot rename, delete, or disable the default source. You can create, modify
 
 Disabling a custom source has the following effects:
 
-* Magento ignores and does not list the source for shipment or order processing
-* Stocks do not access inventory quantities from the source for aggregated inventory totals
-* Order shipments cannot be assigned to disabled locations.
+*  Magento ignores and does not list the source for shipment or order processing
+*  Stocks do not access inventory quantities from the source for aggregated inventory totals
+*  Order shipments cannot be assigned to disabled locations.
 
 {:.bs-callout .bs-callout-info}
 Bundle and grouped products currently do not support multi-sourcing and must be assigned to the default source and default stock.

--- a/guides/v2.3/rest/operation-status-endpoints.md
+++ b/guides/v2.3/rest/operation-status-endpoints.md
@@ -9,8 +9,8 @@ functional_areas:
 
 Magento generates a `bulk_uuid` each time it executes an [asynchronous API request]({{ page.baseurl }}/rest/asynchronous-web-endpoints.html). You can track the status of an asynchronous operation with the following endpoints:
 
-* `GET /V1/bulk/:bulkUuid/status`
-* `GET /V1/bulk/:bulkUuid/detailed-status`
+*  `GET /V1/bulk/:bulkUuid/status`
+*  `GET /V1/bulk/:bulkUuid/detailed-status`
 
 ## Get the status summary
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.2/rest`
- `guides/v2.3/release-notes`