### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/bk-get-started-magento.md
+++ b/guides/v2.2/bk-get-started-magento.md
@@ -37,5 +37,5 @@ Feel free to contact the documentation team directly at
 {:.ref-header}
 Related topics
 
-*   [Release Notes]({{ page.baseurl }}/release-notes/bk-release-notes.html)
-*   [Architecture Guide]({{ page.baseurl }}/architecture/bk-architecture.html)
+*  [Release Notes]({{ page.baseurl }}/release-notes/bk-release-notes.html)
+*  [Architecture Guide]({{ page.baseurl }}/architecture/bk-architecture.html)

--- a/guides/v2.2/pattern-library/bk-pattern.md
+++ b/guides/v2.2/pattern-library/bk-pattern.md
@@ -19,44 +19,44 @@ Find more details about the [Admin](https://glossary.magento.com/admin) [Design 
 
 ### Container
 
-* [Static Content Container](containers/staticContentContainer/contentContainer.html)
-* [Slide-out Panels, Modal Windows, and Overlays](containers/slideouts-modals-overlays/slideouts-modals-overalys.html)
-* [Tabs](containers/tabs/tabs.html)
+*  [Static Content Container](containers/staticContentContainer/contentContainer.html)
+*  [Slide-out Panels, Modal Windows, and Overlays](containers/slideouts-modals-overlays/slideouts-modals-overalys.html)
+*  [Tabs](containers/tabs/tabs.html)
 
 ### Controls
 
-* [Buttons](controls/buttons/buttons.html)
-* [Button Bar](controls/button-bar/button-bar.html)
+*  [Buttons](controls/buttons/buttons.html)
+*  [Button Bar](controls/button-bar/button-bar.html)
 
 ### Displaying and Dealing with Data
 
-* [Tile](displaying-data/tile/tile.html)
-* [Filters](filters/data-table-filters/filtering.html)
-* [Data Table](displaying-data/datatable/datatable.html)
-* [Tree](displaying-data/tree/tree.html)
+*  [Tile](displaying-data/tile/tile.html)
+*  [Filters](filters/data-table-filters/filtering.html)
+*  [Data Table](displaying-data/datatable/datatable.html)
+*  [Tree](displaying-data/tree/tree.html)
 
 ### Feedback to User
 
-* [Progress Indicator](feedbackToUser/progressIndicator/progressIndicator.html)
+*  [Progress Indicator](feedbackToUser/progressIndicator/progressIndicator.html)
 
 ### Getting User Input
 
-* [Form Elements](getting-user-input/form_elements/form_elements.html)
-* [Image Uploader](getting-user-input/image_uploader/image_uploader.html)
-* [Date and Time Selector](getting-user-input/date_time_selector/date_time_selector.html)
-* [Use Default Config](getting-user-input/use_default_config/use_default_config.html)
-* [Select From List](getting-user-input/select_from_list/select_from_list.html)
+*  [Form Elements](getting-user-input/form_elements/form_elements.html)
+*  [Image Uploader](getting-user-input/image_uploader/image_uploader.html)
+*  [Date and Time Selector](getting-user-input/date_time_selector/date_time_selector.html)
+*  [Use Default Config](getting-user-input/use_default_config/use_default_config.html)
+*  [Select From List](getting-user-input/select_from_list/select_from_list.html)
 
 ### Navigation
 
-* [Links](navigation/links/links.html)
-* [Wizard](navigation/wizard/wizard.html)
+*  [Links](navigation/links/links.html)
+*  [Wizard](navigation/wizard/wizard.html)
 
 ### Templates
 
-* [Address Form](templates/address-form/address-form.html)
-* [Sign In Form](templates/sign-in-form/sign-in-form.html)
+*  [Address Form](templates/address-form/address-form.html)
+*  [Sign In Form](templates/sign-in-form/sign-in-form.html)
 
 ### General
 
-* [Accessibility Guidelines](general/accessibilityguideline/accessibilityGuideline.html)
+*  [Accessibility Guidelines](general/accessibilityguideline/accessibilityGuideline.html)

--- a/guides/v2.2/pattern-library/controls/buttons/buttons.md
+++ b/guides/v2.2/pattern-library/controls/buttons/buttons.md
@@ -257,13 +257,13 @@ The toggle button acts like a checkbox. When you touch/click on it, the state to
 
 Use toggle for:
 
-* Binary selection (true/false) when only a single option can be set
-* When multiple non-required selections can be set
-* In relation to other form elements when needed
+*  Binary selection (true/false) when only a single option can be set
+*  When multiple non-required selections can be set
+*  In relation to other form elements when needed
 
 Do not use checkboxes if:
 
-* Multiple options need visibility
+*  Multiple options need visibility
 
 #### Variations
 

--- a/guides/v2.2/pattern-library/controls/viewcontroller/viewcontroller.md
+++ b/guides/v2.2/pattern-library/controls/viewcontroller/viewcontroller.md
@@ -42,8 +42,8 @@ The view control should always be placed as the most right item on the same row 
 
 The controller should be accessible by keyboard and have a voice over for screen readers. Accessibility guideline follow buttons' guideline.
 
-* [Keyboard shortcuts in Windows](https://support.microsoft.com/en-us/help/12445/windows-keyboard-shortcuts)
-* [Mac keyboard shortcuts](http://support.apple.com/en-us/HT201236)
+*  [Keyboard shortcuts in Windows](https://support.microsoft.com/en-us/help/12445/windows-keyboard-shortcuts)
+*  [Mac keyboard shortcuts](http://support.apple.com/en-us/HT201236)
 
 (Keyboard shortcut same as checkbox)
 

--- a/guides/v2.2/pattern-library/displaying-data/datatable/datatable.md
+++ b/guides/v2.2/pattern-library/displaying-data/datatable/datatable.md
@@ -6,30 +6,30 @@ The data-table organizes [complex data](https://glossary.magento.com/complex-dat
 
 Data-table requirements for Magento 2 include:
 
-* Improved search and filters
-* Draggable columns
-* Sortable columns
-* Ability to add and remove columns
-* Inline editing
-* Support for thumbnails
-* Consistent case and naming format
-* Functional parity with the existing Magento application
+*  Improved search and filters
+*  Draggable columns
+*  Sortable columns
+*  Ability to add and remove columns
+*  Inline editing
+*  Support for thumbnails
+*  Consistent case and naming format
+*  Functional parity with the existing Magento application
 
 ## Data-table
 
 This specification defines the following features for the data-table:
 
-* Positioning of elements to allow for a more intuitive user experience
-* Pagination
-* Keyword Search
-* Allowing for user-defined number of items per page
-* Allowing users to go directly to a specific page
-* Filtering
-* Sortable columns
-* Ability to add and/or remove columns
-* Single item select and edit
-* Multiple item select and edit
-* Image/Thumbnail placement
+*  Positioning of elements to allow for a more intuitive user experience
+*  Pagination
+*  Keyword Search
+*  Allowing for user-defined number of items per page
+*  Allowing users to go directly to a specific page
+*  Filtering
+*  Sortable columns
+*  Ability to add and/or remove columns
+*  Single item select and edit
+*  Multiple item select and edit
+*  Image/Thumbnail placement
 
 ![](img/datatable01.jpg)
 
@@ -37,12 +37,12 @@ This specification defines the following features for the data-table:
 
 The data-table will contain the following elements where applicable and as needed:
 
-* Pagination controls
-* Actions
-* Settings, bookmarks and search
-* Filters
-* Column headers
-* Data
+*  Pagination controls
+*  Actions
+*  Settings, bookmarks and search
+*  Filters
+*  Column headers
+*  Data
 
 ## Modularity
 
@@ -71,7 +71,7 @@ Pagination controls allow the user to easily page through and organize data. Pag
 *  The ‘Previous’ button should be disabled when viewing the first page of results.
 *  The ‘Next’ button should be disabled when viewing the last page of results.
 *  The ‘Skip to’ field will allow only numeric values.
-* ‘Skip to’ will be instantiated once the value is changed and [Return] or [Tab] is clicked.
+*  ‘Skip to’ will be instantiated once the value is changed and [Return] or [Tab] is clicked.
 *  A custom number of items per page can be set by selecting the "Custom" link which will allow users to specify a number. This number can be edited.
 
 ![](img/datatable05.jpg)
@@ -183,7 +183,7 @@ When the user enters a keyword in the search field and submits the query (by cli
 
 As text is added to the search field, the system will suggest terms and phrases based on data contained in the table being searched against.
 
-* No more than 5 suggestions should be displayed at a time
+*  No more than 5 suggestions should be displayed at a time
 
 ![](img/datatable21.jpg)
 
@@ -364,10 +364,10 @@ content='Not all data-tables will allow for inline editing.'
 
 ### Single Item Select and Edit Interactions
 
-* Inline editing can be instantiated by single clicking on the field to be edited. Once inline editing is instantiated, all appropriate fields within a row will be editable.
-* Non-editable fields will require a disabled treatment.
-* Once a row becomes editable, action buttons will appear below the row allowing a user to commit or cancel the edit.
-* Editable fields will have a left-to-right tab order. [Tab] and [Enter] will set focus on the next editable field in the tab order, unless the focus is set to the last field in the tab order in which case [Enter] will commit the edit while [Tab] will set focus to the Save button.
+*  Inline editing can be instantiated by single clicking on the field to be edited. Once inline editing is instantiated, all appropriate fields within a row will be editable.
+*  Non-editable fields will require a disabled treatment.
+*  Once a row becomes editable, action buttons will appear below the row allowing a user to commit or cancel the edit.
+*  Editable fields will have a left-to-right tab order. [Tab] and [Enter] will set focus on the next editable field in the tab order, unless the focus is set to the last field in the tab order in which case [Enter] will commit the edit while [Tab] will set focus to the Save button.
 
 ![](img/datatable43.jpg)
 

--- a/guides/v2.2/pattern-library/displaying-data/tile/tile.md
+++ b/guides/v2.2/pattern-library/displaying-data/tile/tile.md
@@ -6,13 +6,13 @@ This topic contains examples of the Tile pattern used in the [Admin](https://glo
 
 ## Functional Behavior
 
-* Drag and Drop
-* Remove
-* Hero Product checkbox and link
-* Advance position left and right
-* Numerical input box
-* Multi selection
-* Hero Product Section
+*  Drag and Drop
+*  Remove
+*  Hero Product checkbox and link
+*  Advance position left and right
+*  Numerical input box
+*  Multi selection
+*  Hero Product Section
 
 ## Use of Tiles
 

--- a/guides/v2.2/pattern-library/getting-user-input/row_pattern/row_pattern.md
+++ b/guides/v2.2/pattern-library/getting-user-input/row_pattern/row_pattern.md
@@ -6,30 +6,30 @@ The "row pattern" (also referred to as _table light_ and _mini grid_) is used in
 
 The pattern supports following actions:
 
-* Add new row
-* Remove row
-* Rearrange/drag the rows
-* Edit fields in a row
-* Pagination (for 20 > more rows)
+*  Add new row
+*  Remove row
+*  Rearrange/drag the rows
+*  Edit fields in a row
+*  Pagination (for 20 > more rows)
 
 The pattern does _not_ support:
 
-* Filtering, sorting, searching the table
-* Adding, removing, rearranging of _columns_
+*  Filtering, sorting, searching the table
+*  Adding, removing, rearranging of _columns_
 
 ## Anatomy of a Row Pattern
 
 May include any of the following elements:
 
-* Table Body
-* Table heading
-* Row
-* Text in the row
-* Form elements inside the row
-* Drag handle
-* "Add row" button
-* "Remove row" icon
-* Pagination (for more than 20 rows)
+*  Table Body
+*  Table heading
+*  Row
+*  Text in the row
+*  Form elements inside the row
+*  Drag handle
+*  "Add row" button
+*  "Remove row" icon
+*  Pagination (for more than 20 rows)
 
 All these elements are optional, depending on the functions needed.
 

--- a/guides/v2.2/pattern-library/navigation/wizard/wizard.md
+++ b/guides/v2.2/pattern-library/navigation/wizard/wizard.md
@@ -12,17 +12,17 @@ Use this pattern when the user needs to go through a process to accomplish a tas
 
 ## When Not to Use
 
-* The wizard bar should not co-exist with a button bar. Only one can be present per page/modal.
-* Be careful when using this pattern. Wizard is a bad choice when users are experts and/or the task is done often, because Wizard has negative effect on efficiency and user control.
+*  The wizard bar should not co-exist with a button bar. Only one can be present per page/modal.
+*  Be careful when using this pattern. Wizard is a bad choice when users are experts and/or the task is done often, because Wizard has negative effect on efficiency and user control.
 
 ## How to Use
 
-* Break up a task into logical, titled steps.
-* Keep the number of steps at the minimum.
-* Remove or hide unnecessary interface elements that are not necessary for completing the task.
-* If possible, allow some freedom for the experts.
-* Show a sequence map of all the steps in the Wizard at the top of each page.
-* Show a summary on the last page (if necessary).
+*  Break up a task into logical, titled steps.
+*  Keep the number of steps at the minimum.
+*  Remove or hide unnecessary interface elements that are not necessary for completing the task.
+*  If possible, allow some freedom for the experts.
+*  Show a sequence map of all the steps in the Wizard at the top of each page.
+*  Show a summary on the last page (if necessary).
 
 ## Structure
 
@@ -127,10 +127,10 @@ It is not recommended to have too many steps for a wizard. But if a use case ari
 
 ## Assets
 
-* [Download Wizard Style - PSD source](src/wizard-pattern-styles.psd)
-* [Download Variation 1 - PSD source](src/Variation1.psd)
-* [Download Variation 2 - PSD source](src/Variation2.psd)
-* [Download Variation 3 - PSD source](src/Variation3.psd)
-* [Download Variation 4 - PSD source](src/Variation4.psd)
+*  [Download Wizard Style - PSD source](src/wizard-pattern-styles.psd)
+*  [Download Variation 1 - PSD source](src/Variation1.psd)
+*  [Download Variation 2 - PSD source](src/Variation2.psd)
+*  [Download Variation 3 - PSD source](src/Variation3.psd)
+*  [Download Variation 4 - PSD source](src/Variation4.psd)
 
 Please reach out to the Magento UX Design team if you need anything else.

--- a/guides/v2.2/payments-integrations/base-integration/admin-integration.md
+++ b/guides/v2.2/payments-integrations/base-integration/admin-integration.md
@@ -10,13 +10,13 @@ functional_areas:
 
 You can define whether the payment method is available for the [storefront](https://glossary.magento.com/storefront) and [checkout](https://glossary.magento.com/checkout) in the [payment method configuration in `config.xml`]({{ page.baseurl }}/payments-integrations/base-integration/payment-option-config.html):
 
-- `can_use_checkout`: whether [payment method](https://glossary.magento.com/payment-method) is available in storefront checkout
-- `can_use_internal`: whether payment method is available in [Admin](https://glossary.magento.com/admin) order creation
+-  `can_use_checkout`: whether [payment method](https://glossary.magento.com/payment-method) is available in storefront checkout
+-  `can_use_internal`: whether payment method is available in [Admin](https://glossary.magento.com/admin) order creation
 
 If your payment flow should be different for storefront and Admin panel, you can use a separate DI configuration for each [area]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_and_areas.html#magento-area-types):
 
-- `%Vendor_Module%/etc/adminhtml/di.xml`: DI configuration for the Admin panel
-- `%Vendor_Module%/etc/frontend/di.xml`: DI configuration for the storefront
+-  `%Vendor_Module%/etc/adminhtml/di.xml`: DI configuration for the Admin panel
+-  `%Vendor_Module%/etc/frontend/di.xml`: DI configuration for the storefront
 
 ## Example
 

--- a/guides/v2.2/payments-integrations/base-integration/formblocktype.md
+++ b/guides/v2.2/payments-integrations/base-integration/formblocktype.md
@@ -87,5 +87,5 @@ The following example adds the Braintree-specific template [`app/code/Magento/Pa
 
 ## What's next
 
-- [Payment method facade]({{ page.baseurl }}/payments-integrations/base-integration/facade-configuration.html)
-- [Add a gateway command]({{ page.baseurl }}/payments-integrations/base-integration/payment-action.html)
+-  [Payment method facade]({{ page.baseurl }}/payments-integrations/base-integration/facade-configuration.html)
+-  [Add a gateway command]({{ page.baseurl }}/payments-integrations/base-integration/payment-action.html)

--- a/guides/v2.2/payments-integrations/base-integration/module-configuration.md
+++ b/guides/v2.2/payments-integrations/base-integration/module-configuration.md
@@ -16,9 +16,9 @@ You can use the [sample Magento_SamplePaymentGateway module](https://github.com/
 
 Your custom payment integration module must have at least the following dependencies:
 
-- Magento_Sales module: to be able to get order details
-- Magento_Payment module: to use the Magento payment provider gateway infrastructure
-- Magento_Checkout module: to be able to add the new [payment method](https://glossary.magento.com/payment-method) to [checkout](https://glossary.magento.com/checkout). If you do not plan to use it on the [storefront](https://glossary.magento.com/storefront) checkout, this dependency is not required.
+-  Magento_Sales module: to be able to get order details
+-  Magento_Payment module: to use the Magento payment provider gateway infrastructure
+-  Magento_Checkout module: to be able to add the new [payment method](https://glossary.magento.com/payment-method) to [checkout](https://glossary.magento.com/checkout). If you do not plan to use it on the [storefront](https://glossary.magento.com/storefront) checkout, this dependency is not required.
 
 Specify these dependencies in your `composer.json` and `module.xml` files.
 

--- a/guides/v2.2/payments-integrations/base-integration/payment-action.md
+++ b/guides/v2.2/payments-integrations/base-integration/payment-action.md
@@ -10,10 +10,10 @@ functional_areas:
 
 For each payment action available for the payment method, you must implement the following:
 
-- Creating a request with payment details. Described in [Get payment information from frontend to backend]({{ page.baseurl }}/payments-integrations/base-integration/get-payment-info.html).
-- Request processing using [response handler]({{ page.baseurl }}/payments-integrations/payment-gateway/response-handler.html) and [response validator]({{ page.baseurl }}/payments-integrations/payment-gateway/response-validator.html).
-- Specify and configure the gateway command. Described in the [Gateway Command]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-command.html#adding-gateway-commands) topic.
-- Add the command to the commands pool, as described in [Command Pool]({{ page.baseurl }}/payments-integrations/payment-gateway/command-pool.html#command-pool-configuration-for-a-particular-provider).
+-  Creating a request with payment details. Described in [Get payment information from frontend to backend]({{ page.baseurl }}/payments-integrations/base-integration/get-payment-info.html).
+-  Request processing using [response handler]({{ page.baseurl }}/payments-integrations/payment-gateway/response-handler.html) and [response validator]({{ page.baseurl }}/payments-integrations/payment-gateway/response-validator.html).
+-  Specify and configure the gateway command. Described in the [Gateway Command]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-command.html#adding-gateway-commands) topic.
+-  Add the command to the commands pool, as described in [Command Pool]({{ page.baseurl }}/payments-integrations/payment-gateway/command-pool.html#command-pool-configuration-for-a-particular-provider).
 
 ## Configure the command
 
@@ -76,4 +76,4 @@ Please see the [Get payment information from frontend to backend]({{ page.baseur
 {:.ref-header}
 Related topics
 
-- [Add a custom payment method to checkout]({{ page.baseurl }}/howdoi/checkout/checkout_payment.html): how to add a custom payment integration to [checkout](https://glossary.magento.com/checkout) page.
+-  [Add a custom payment method to checkout]({{ page.baseurl }}/howdoi/checkout/checkout_payment.html): how to add a custom payment integration to [checkout](https://glossary.magento.com/checkout) page.

--- a/guides/v2.2/payments-integrations/base-integration/payment-option-config.md
+++ b/guides/v2.2/payments-integrations/base-integration/payment-option-config.md
@@ -84,5 +84,5 @@ Following is the illustration of such configuration (`config.xml` of the Braintr
 
 ## What's next
 
-- [Payment  method facade]({{ page.baseurl }}/payments-integrations/base-integration/facade-configuration.html)
-- [Payment info rendering in Admin checkout]({{ page.baseurl }}/payments-integrations/base-integration/formblocktype.html)
+-  [Payment  method facade]({{ page.baseurl }}/payments-integrations/base-integration/facade-configuration.html)
+-  [Payment info rendering in Admin checkout]({{ page.baseurl }}/payments-integrations/base-integration/formblocktype.html)

--- a/guides/v2.2/payments-integrations/cardinal/cardinal.md
+++ b/guides/v2.2/payments-integrations/cardinal/cardinal.md
@@ -17,8 +17,8 @@ The following diagram shows a simplified 3-D Secure verification flow using Card
 
 The *Magento_CardinalCommerce* [module][] allows you to:
 
-- Start `Cardinal Consumer Authentication` for enabling card network programs including Verified by Visa®, MasterCard SecureCode® and Identity Check®, American Express SafeKey®, Discover ProtectBuy® and Diners International® and JCB J-Secure®.
-- Handle specific return values for `Cardinal Consumer Authentication` on backend and storefront
+-  Start `Cardinal Consumer Authentication` for enabling card network programs including Verified by Visa®, MasterCard SecureCode® and Identity Check®, American Express SafeKey®, Discover ProtectBuy® and Diners International® and JCB J-Secure®.
+-  Handle specific return values for `Cardinal Consumer Authentication` on backend and storefront
 
 ## Payment method module integration with Magento_CardinalCommerce
 
@@ -28,7 +28,7 @@ CardinalCommerce maintains a [list of compatible payment gateways][].
 
 You need to add configuration parameter that will enable `Cardinal Consumer Authentication` in the `config.xml` and `system.xml` files  of your [payment method][] module:
 
-- `enabled_{payment_method_code}` - enables CCA for custom payment method.
+-  `enabled_{payment_method_code}` - enables CCA for custom payment method.
 
 The following example is the `config.xml` file of the AuthorizenetAcceptjs payment method:
 

--- a/guides/v2.2/payments-integrations/payment-gateway/gateway-command.md
+++ b/guides/v2.2/payments-integrations/payment-gateway/gateway-command.md
@@ -41,13 +41,13 @@ In the following example the `BraintreeAuthorizeCommand` gateway command is adde
 
 A gateway command must be configured with the following arguments:
 
-* `requestBuilder`: [request builder]({{ page.baseurl }}/payments-integrations/payment-gateway/request-builder.html), builds an array of provider-specific arguments using the order information.
+*  `requestBuilder`: [request builder]({{ page.baseurl }}/payments-integrations/payment-gateway/request-builder.html), builds an array of provider-specific arguments using the order information.
 
-* `transferFactory`: [transfer factory]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html#transfer_factory), creates transfer object from request data, which will be used by Gateway Client to process requests. For details see [Gateway Client #Transfer Factory]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html#transfer_factory)
+*  `transferFactory`: [transfer factory]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html#transfer_factory), creates transfer object from request data, which will be used by Gateway Client to process requests. For details see [Gateway Client #Transfer Factory]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html#transfer_factory)
 
-* `client`: [gateway client]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html), takes the provider-specific arguments and performs a low-level call to the provider.
+*  `client`: [gateway client]({{ page.baseurl }}/payments-integrations/payment-gateway/gateway-client.html), takes the provider-specific arguments and performs a low-level call to the provider.
 
 Optional arguments :
 
-* `handler`: [response handler]({{ page.baseurl }}/payments-integrations/payment-gateway/response-handler.html), changes the order and payment status depending on the payment provider response.
-* `validator`: [response validator]({{ page.baseurl }}/payments-integrations/payment-gateway/response-validator.html), validates the provider response.
+*  `handler`: [response handler]({{ page.baseurl }}/payments-integrations/payment-gateway/response-handler.html), changes the order and payment status depending on the payment provider response.
+*  `validator`: [response validator]({{ page.baseurl }}/payments-integrations/payment-gateway/response-validator.html), validates the provider response.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders/file:

- `guides/v2.3/payments-integrations`
- `guides/v2.3/pattern-library`
- ` guides/v2.2/bk-get-started-magento.md`