### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/mtf/mtf_entities/mtf_handler.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_handler.md
@@ -142,8 +142,8 @@ See the directory structure mentioned for the case with the Widget cURL handler:
 
 Let's create a cURL handler that creates a new widget.
 
-* Create a directory with the name `Widget` in the `Handler` directory of the Magento_Widget module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget`.
-* In the same directory, create [the interface](#mtf_handler_interface) for the cURL handler, and call the file `WidgetInterface.php`. Our new interface extends `HandlerInterface` class.
+*  Create a directory with the name `Widget` in the `Handler` directory of the Magento_Widget module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget`.
+*  In the same directory, create [the interface](#mtf_handler_interface) for the cURL handler, and call the file `WidgetInterface.php`. Our new interface extends `HandlerInterface` class.
 
   ```php
   <?php
@@ -161,7 +161,7 @@ Let's create a cURL handler that creates a new widget.
   }
   ```
 
-* Create `Curl.php` in the same directory. This file contains a [handler class](#mtf_handler_conf_hand), which defines preparation of a data to create a new widget.
+*  Create `Curl.php` in the same directory. This file contains a [handler class](#mtf_handler_conf_hand), which defines preparation of a data to create a new widget.
 
   The following code includes detailed comments for better understanding.
   {: #mtf_curl_script}
@@ -249,7 +249,7 @@ Let's create a cURL handler that creates a new widget.
   }
   ```
 
-* Create [`di.xml`](#mtf_handler_di) in the `etc/curl` directory of the Magento_Widget module.
+*  Create [`di.xml`](#mtf_handler_di) in the `etc/curl` directory of the Magento_Widget module.
 
 ```xml
 {% remote_markdown https://raw.githubusercontent.com/magento/magento2/2.2/dev/tests/functional/tests/app/Magento/Widget/Test/etc/curl/di.xml %}
@@ -291,8 +291,8 @@ $curl = new FrontendDecorator(new CurlTransport(), $this->customer);
 
 Let's create a UI handler that creates a new widget.
 
-* Create a directory with the name `Widget` in the `Handler` directory of the Magento_Widget module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget`.
-* In the same directory, create [interface](#mtf_handler_interface) for the UI handler, and call the file `WidgetInterface.php`. Our new interface extends `HandlerInterface` class.
+*  Create a directory with the name `Widget` in the `Handler` directory of the Magento_Widget module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget`.
+*  In the same directory, create [interface](#mtf_handler_interface) for the UI handler, and call the file `WidgetInterface.php`. Our new interface extends `HandlerInterface` class.
 
   ```php
   <?php
@@ -310,7 +310,7 @@ Let's create a UI handler that creates a new widget.
   }
   ```
 
-* Create `Ui.php` in the same directory. This file contains a [handler class](#mtf_handler_conf_hand), which defines preparation of a data to create a new widget.
+*  Create `Ui.php` in the same directory. This file contains a [handler class](#mtf_handler_conf_hand), which defines preparation of a data to create a new widget.
 
   The code has detailed comments for better understanding.
 
@@ -397,7 +397,7 @@ Let's create a UI handler that creates a new widget.
   }
   ```
 
-* Create [`di.xml`](#mtf_handler_di) in the `etc/ui` directory of the Magento_Widget [module](https://glossary.magento.com/module).
+*  Create [`di.xml`](#mtf_handler_di) in the `etc/ui` directory of the Magento_Widget [module](https://glossary.magento.com/module).
 
   ```xml
   <?xml version="1.0" ?>
@@ -413,8 +413,8 @@ Let's create a UI handler that creates a new widget.
 
 Let's create a WebAPI handler that creates a new [tax rule](https://glossary.magento.com/tax-rule).
 
-* Create a directory with the name `TaxRule` in the `Handler` directory of the Magento_Tax module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Tax/Test/Handler/TaxRule`.
-* In the same directory, create [interface](#mtf_handler_interface) for the WebAPI handler, and call the file `TaxRuleInterface.php`. Our new interface extends `HandlerInterface` class.
+*  Create a directory with the name `TaxRule` in the `Handler` directory of the Magento_Tax module - `<magento2_root_dir>/dev/tests/functional/tests/app/Magento/Tax/Test/Handler/TaxRule`.
+*  In the same directory, create [interface](#mtf_handler_interface) for the WebAPI handler, and call the file `TaxRuleInterface.php`. Our new interface extends `HandlerInterface` class.
 
   ```php
 
@@ -431,7 +431,7 @@ Let's create a WebAPI handler that creates a new [tax rule](https://glossary.mag
   }
   ```
 
-* Create `Webapi.php` in the same directory. The file contains a [handler class](#mtf_handler_conf_hand). In the following example WebAPI handler uses some cURL handler methods to prepare data.
+*  Create `Webapi.php` in the same directory. The file contains a [handler class](#mtf_handler_conf_hand). In the following example WebAPI handler uses some cURL handler methods to prepare data.
 
   ```php
   <?php
@@ -518,7 +518,7 @@ Let's create a WebAPI handler that creates a new [tax rule](https://glossary.mag
   }
   ```
 
-* Create [`di.xml`](#mtf_handler_di) in the `etc/webapi` directory of the Magento_Tax module.
+*  Create [`di.xml`](#mtf_handler_di) in the `etc/webapi` directory of the Magento_Tax module.
 
   ```xml
   <?xml version="1.0" ?>

--- a/guides/v2.2/mtf/mtf_entities/mtf_testcase.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_testcase.md
@@ -5,8 +5,8 @@ title: Test case
 
 The Magento Functional Testing Framework supports two types of functional tests:
 
-- Injectable test: the main type of the FTF test that uses [XML](https://glossary.magento.com/xml) [data set][] files as inputs
-- [Scenario test][]: supports a Magento modularity and enables you to inject one step into another test
+-  Injectable test: the main type of the FTF test that uses [XML](https://glossary.magento.com/xml) [data set][] files as inputs
+-  [Scenario test][]: supports a Magento modularity and enables you to inject one step into another test
 
 This topic discusses the injectable test only.
 
@@ -57,10 +57,10 @@ The `test()` method must contain the test steps described in a [docblock](#docbl
 
 In the following example, the test includes preconditions and test steps. Preconditions contain a logic of different scenarios about creating a product (depending on the [category](https://glossary.magento.com/category) state). Test steps are the following:
 
-- opening of the product creation grid page
-- searching by the `sku` parameter and opening of the product
-- editing of the found product
-- saving of the edited product
+-  opening of the product creation grid page
+-  searching by the `sku` parameter and opening of the product
+-  editing of the found product
+-  saving of the edited product
 
 ```php
 
@@ -142,8 +142,8 @@ __Step 3.__ Give it a name using the following format:
 
 For example:
 
-- <span style="color:blue">Create</span><span style="color:red">ConfigurableProduct</span>EntityTest
-- <span style="color:blue">Create</span><span style="color:red">CatalogEvent</span>Entity<span style="color:green">FromCategoryPage</span>Test
+-  <span style="color:blue">Create</span><span style="color:red">ConfigurableProduct</span>EntityTest
+-  <span style="color:blue">Create</span><span style="color:red">CatalogEvent</span>Entity<span style="color:green">FromCategoryPage</span>Test
 
 __Step 4.__ If you have preconditions, prepare the data using a [__prepare()](#prepare-method) method
 

--- a/guides/v2.2/mtf/mtf_introduction.md
+++ b/guides/v2.2/mtf/mtf_introduction.md
@@ -20,21 +20,21 @@ FTF does not contain tests. All functional tests are located in `<magento2 root 
 
 ### What tools should I use to run tests with FTF? {#mtf_intro_extratools}
 
--   [PHPUnit][] (downloaded via [composer](https://glossary.magento.com/composer) during installation)
+-  [PHPUnit][] (downloaded via [composer](https://glossary.magento.com/composer) during installation)
 
--   [Selenium Standalone Server][]
+-  [Selenium Standalone Server][]
 
--   Web browser
+-  Web browser
 
 ### What do I have as output after running tests with FTF? {#mtf_intro_mtf-output}
 
--   Tested application
+-  Tested application
 
--   Basic PHPUnit results
+-  Basic PHPUnit results
 
--   Screenshots of failures
+-  Screenshots of failures
 
--   Logs of failures
+-  Logs of failures
 
 ## Audience {#mtf_intro_audi}
 
@@ -58,15 +58,15 @@ can be tested using customized tests, created with FTF.
 
 Relative to your software development lifecycle, the FTF can help you:
 
-1.    During the development phase, test any changes of functionality (new modules, update modules, fix bugs).
+1. During the development phase, test any changes of functionality (new modules, update modules, fix bugs).
 
-1.    During the maintenance phase, for periodic automated regression testing.
+1. During the maintenance phase, for periodic automated regression testing.
 
 ### FTF use cases examples {#mtf_intro_scope_use-case-ex}
 
-1.    As Magento developer I want to cover implemented functionality with new tests (for example, added attribute on Customer Form, extended Search functionality, added tags for Products etc).
+1. As Magento developer I want to cover implemented functionality with new tests (for example, added attribute on Customer Form, extended Search functionality, added tags for Products etc).
 
-1.    As a software engineer I want to perform regression testing before release to be confident that Magento works as expected with new functionality.
+1. As a software engineer I want to perform regression testing before release to be confident that Magento works as expected with new functionality.
 
 ### Non-functional testing {#mtf_intro_scope_non-func-test}
 
@@ -74,13 +74,13 @@ FTF works with tests from `<magento2_root_dir>/dev/tests/functional` only.
 
 For other tests please see the following topics:
 
-- [How to run unit tests during development on the command line or PhpStorm.]({{ page.baseurl }}/test/unit/unit_test_execution.html)
+-  [How to run unit tests during development on the command line or PhpStorm.]({{ page.baseurl }}/test/unit/unit_test_execution.html)
 
-- [How to run unit and integration tests using `bin/magento` in continuous integration.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html)
+-  [How to run unit and integration tests using `bin/magento` in continuous integration.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-test.html)
 
-- [More information about JavaScript unit tests.]({{ page.baseurl }}/test/js/jasmine.html)
+-  [More information about JavaScript unit tests.]({{ page.baseurl }}/test/js/jasmine.html)
 
-- [More information about performance testing.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-perf-data.html)
+-  [More information about performance testing.]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-perf-data.html)
 
 ## FTF on GitHub {#mtf_intro_github-link}
 

--- a/guides/v2.2/mtf/mtf_quickstart/mtf_quickstart_runtest.md
+++ b/guides/v2.2/mtf/mtf_quickstart/mtf_quickstart_runtest.md
@@ -9,10 +9,10 @@ FTF uses PHPUnit, which is located in `<magento2_root_dir>/dev/tests/functional/
 
 Be sure that your system is ready for test run.
 
-- [Magento is ready for tests]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_pre)
-- [The Functional Testing Framework is installed]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_check)
-- [The Functional Testing Framework is configured]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
-- [Environment is ready to test run]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
+-  [Magento is ready for tests]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_pre)
+-  [The Functional Testing Framework is installed]({{ page.baseurl }}/mtf/mtf_installation.html#mtf_install_check)
+-  [The Functional Testing Framework is configured]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_config.html)
+-  [Environment is ready to test run]({{ page.baseurl }}/mtf/mtf_quickstart/mtf_quickstart_environment.html)
 
 ### Run all tests {#mtf_quickstart_testrun_all}
 

--- a/guides/v2.2/mtf/mtf_update.md
+++ b/guides/v2.2/mtf/mtf_update.md
@@ -9,12 +9,12 @@ While the MTF is still functional, all MTF tests are being ported over to the MF
 
 Two types of updates are available.
 
--     [Install a new version of the Functional Testing Framework](#mtf_update_install)
+-  [Install a new version of the Functional Testing Framework](#mtf_update_install)
 
 {: .bs-callout-info }
 Use this type of update if the version of the Functional Testing Framework in `<magento2>/dev/tests/functional/composer.json` and last version in `<magento2>/dev/tests/functional/vendor/magento/mtf/CHANGELOG.md` are different. For example, when you updated Magento.
 
--    [Update components from dependencies in `<magento2>/dev/tests/functional/composer.json`](#mtf_update_depend)
+-  [Update components from dependencies in `<magento2>/dev/tests/functional/composer.json`](#mtf_update_depend)
 
 {: .bs-callout-info }
 Use this type of update if you want to update dependent software from `composer.json`, or changed `composer.json` dependencies.

--- a/guides/v2.2/mtf/troubleshooting.md
+++ b/guides/v2.2/mtf/troubleshooting.md
@@ -11,5 +11,5 @@ Error message:
 
     PHPUnit_Extensions_Selenium2TestCase_WebDriverException: Unable to connect to host 127.0.0.1 on port 7055 after 45000 ms. Firefox console output: in selenium server console output
 
-* **Reason**: a Selenium server is [incompatible with your browser version](http://docs.seleniumhq.org/about/platforms.jsp#browsers)
-* **Solution**: [download the latest Selenium Standalone Server version](http://docs.seleniumhq.org/download/)
+*  **Reason**: a Selenium server is [incompatible with your browser version](http://docs.seleniumhq.org/about/platforms.jsp#browsers)
+*  **Solution**: [download the latest Selenium Standalone Server version](http://docs.seleniumhq.org/download/)

--- a/guides/v2.2/payments-integrations/bk-payments-integrations.md
+++ b/guides/v2.2/payments-integrations/bk-payments-integrations.md
@@ -15,6 +15,6 @@ This guide describes how the Magento payment provider gateway is implemented and
 
 The chapters of this guide are:
 
-* [Magento payment provider gateway]({{ page.baseurl }}/payments-integrations/payment-gateway/payment-gateway-intro.html)
-* [How to add a custom payment method using Magento payment provider gateway]({{ page.baseurl }}/payments-integrations/base-integration/integration-intro.html)
-* [How to add vault for the custom payment method]({{ page.baseurl }}/payments-integrations/vault/vault-intro.html)
+*  [Magento payment provider gateway]({{ page.baseurl }}/payments-integrations/payment-gateway/payment-gateway-intro.html)
+*  [How to add a custom payment method using Magento payment provider gateway]({{ page.baseurl }}/payments-integrations/base-integration/integration-intro.html)
+*  [How to add vault for the custom payment method]({{ page.baseurl }}/payments-integrations/vault/vault-intro.html)

--- a/guides/v2.2/payments-integrations/payment-gateway/gateway-client.md
+++ b/guides/v2.2/payments-integrations/payment-gateway/gateway-client.md
@@ -18,8 +18,8 @@ A gateway client receives a called [`Transfer`](#transfer_factory) object. The c
 
 The following gateway client implementations can be used out-of-the-box:
 
-* [\Magento\Payment\Gateway\Http\Client\Zend]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Gateway/Http/Client/Zend.php)
-* [\Magento\Payment\Gateway\Http\Client\Soap]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Gateway/Http/Client/Soap.php)
+*  [\Magento\Payment\Gateway\Http\Client\Zend]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Gateway/Http/Client/Zend.php)
+*  [\Magento\Payment\Gateway\Http\Client\Soap]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Gateway/Http/Client/Soap.php)
 
 ## Example
 

--- a/guides/v2.3/mtf/mtf_installation.md
+++ b/guides/v2.3/mtf/mtf_installation.md
@@ -11,11 +11,11 @@ Well, you are on the way to install the Functional Testing Framework!
 
 Follow the next three steps:
 
-- <a href="#mtf_install_pre">Check pre-installation conditions</a>
+-  <a href="#mtf_install_pre">Check pre-installation conditions</a>
 
-- <a href="#mtf_install_perform">Perform the installation</a>
+-  <a href="#mtf_install_perform">Perform the installation</a>
 
-- <a href="#mtf_install_check">Check the installation</a>
+-  <a href="#mtf_install_check">Check the installation</a>
 
 ## Check pre-installation conditions {#mtf_install_pre}
 

--- a/guides/v2.3/page-builder/index.md
+++ b/guides/v2.3/page-builder/index.md
@@ -9,37 +9,37 @@ The following links provide quick access to our [Page Builder GitHub code exampl
 
 ## Page Builder example modules
 
-- **[PageBuilderExtensionSlider](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderExtensionSlider)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to add `centerMode` and `centerPadding` settings from the [slick carousel](https://kenwheeler.github.io/slick/) used by the Slider.
+-  **[PageBuilderExtensionSlider](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderExtensionSlider)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to add `centerMode` and `centerPadding` settings from the [slick carousel](https://kenwheeler.github.io/slick/) used by the Slider.
 
-- **[PageBuilderExtensionBanner](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderExtensionBanner)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to customize an existing content type: the Banner. This is the completed module featured in the [Extend a content type tutorial](https://devdocs.magento.com/page-builder/docs/extend-existing-content-type/overview.html).
+-  **[PageBuilderExtensionBanner](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderExtensionBanner)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to customize an existing content type: the Banner. This is the completed module featured in the [Extend a content type tutorial](https://devdocs.magento.com/page-builder/docs/extend-existing-content-type/overview.html).
 
-- **[PageBuilderQuote](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderQuote)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to create a content type for a customer testimonial page. This is the completed Quote module featured in the [Create a content type tutorial](https://devdocs.magento.com/page-builder/docs/create-custom-content-type/overview.html).
+-  **[PageBuilderQuote](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderQuote)** — Created by [Bruce Denham](https://github.com/bdenham). This module shows you how to create a content type for a customer testimonial page. This is the completed Quote module featured in the [Create a content type tutorial](https://devdocs.magento.com/page-builder/docs/create-custom-content-type/overview.html).
 
-- **[PageBuilderGrid](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderGrid)** — Created by [Dave Macaulay](https://github.com/davemacaulay). This module shows you how to create a content type that recreates the layout of the Magento Luma-themed home page using a grid structure with grid items.
+-  **[PageBuilderGrid](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderGrid)** — Created by [Dave Macaulay](https://github.com/davemacaulay). This module shows you how to create a content type that recreates the layout of the Magento Luma-themed home page using a grid structure with grid items.
 
-- **[PageBuilderFaq](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderFaq)** — Created by [Igor Melnikov](https://github.com/melnikovi). This module shows you how to create a content type for an FAQ page that uses an accordion for the questions and answers.
+-  **[PageBuilderFaq](https://github.com/magento-devdocs/pagebuilder-examples/tree/master/Example/PageBuilderFaq)** — Created by [Igor Melnikov](https://github.com/melnikovi). This module shows you how to create a content type for an FAQ page that uses an accordion for the questions and answers.
 
 ## Tutorials
 
-- [Extend an existing content type]({{ site.baseurl }}/page-builder/docs/extend-existing-content-type/overview.html)
-- [Create a new content type]({{ site.baseurl }}/page-builder/docs/create-custom-content-type/overview.html)
+-  [Extend an existing content type]({{ site.baseurl }}/page-builder/docs/extend-existing-content-type/overview.html)
+-  [Create a new content type]({{ site.baseurl }}/page-builder/docs/create-custom-content-type/overview.html)
 
 ## How-Tos (just a few)
 
-- [How to customize the Page Builder panel]({{ site.baseurl }}/page-builder/docs/how-to/how-to-customize-panel.html)
-- [How to add an image uploader]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-image-uploader.html)
-- [How to add a storefront widget]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-storefront-widget.html)
-- [How to add a custom toolbar]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-custom-toolbar.html)
-- [How to add icons and images]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-icons-images.html)
-- [How to change breakpoints]({{ site.baseurl }}/page-builder/docs/how-to/how-to-change-breakpoints.html)
+-  [How to customize the Page Builder panel]({{ site.baseurl }}/page-builder/docs/how-to/how-to-customize-panel.html)
+-  [How to add an image uploader]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-image-uploader.html)
+-  [How to add a storefront widget]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-storefront-widget.html)
+-  [How to add a custom toolbar]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-custom-toolbar.html)
+-  [How to add icons and images]({{ site.baseurl }}/page-builder/docs/how-to/how-to-add-icons-images.html)
+-  [How to change breakpoints]({{ site.baseurl }}/page-builder/docs/how-to/how-to-change-breakpoints.html)
 
 ## Reference
 
-- [Page Builder configurations]({{ site.baseurl }}/page-builder/docs/reference/configurations.html)
-- [Page Builder Datastore]({{ site.baseurl }}/page-builder/docs/reference/data-store.html)
-- [Page Builder events]({{ site.baseurl }}/page-builder/docs/reference/events.html)
-- [Page Builder Knockout bindings]({{ site.baseurl }}/page-builder/docs/reference/knockout-bindings.html)
-- [Page Builder architecture]({{ site.baseurl }}/page-builder/docs/reference/architecture.html)
+-  [Page Builder configurations]({{ site.baseurl }}/page-builder/docs/reference/configurations.html)
+-  [Page Builder Datastore]({{ site.baseurl }}/page-builder/docs/reference/data-store.html)
+-  [Page Builder events]({{ site.baseurl }}/page-builder/docs/reference/events.html)
+-  [Page Builder Knockout bindings]({{ site.baseurl }}/page-builder/docs/reference/knockout-bindings.html)
+-  [Page Builder architecture]({{ site.baseurl }}/page-builder/docs/reference/architecture.html)
 
 ## Page Builder User Guide
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.3/payments-integrations`
- `guides/v2.3/page-builder`
- `guides/v2.3/mtf`