### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/marketplace/eqp/api.md
+++ b/guides/v2.2/marketplace/eqp/api.md
@@ -21,10 +21,10 @@ The APIs only accept encrypted communications using HTTPS at the following base 
 
 EQP APIs are based on REST concepts and use standard HTTP verbs:
 
-- GET
-- POST
-- PUT
-- DELETE
+-  GET
+-  POST
+-  PUT
+-  DELETE
 
 All endpoints start with **/rest/v1**, which supports API versioning. The initial release is version 1 (v1).
 

--- a/guides/v2.2/marketplace/eqp/files.md
+++ b/guides/v2.2/marketplace/eqp/files.md
@@ -5,11 +5,11 @@ title: Files
 
 Use `files` resources to manage all code artifacts and assets associated with an extension or a theme:
 
-* Magento 1 tarball (.tgz)
-* Magento 2 ZIP files
-* Image files for logos and galleries
-* Product Icons
-* PDF documents for User Guides, Installation Guides, and Reference Guides
+*  Magento 1 tarball (.tgz)
+*  Magento 2 ZIP files
+*  Image files for logos and galleries
+*  Product Icons
+*  PDF documents for User Guides, Installation Guides, and Reference Guides
 
 Each file upload receives a unique ID. You must associate these IDs with your submission later using the [packages API]({{ page.baseurl }}/marketplace/eqp/packages.html).
 
@@ -110,11 +110,11 @@ Content-Type: application/pdf
 ------------287032381131322--
 ```
 
-* Each part has a header and body with `Content-Disposition` header always set to `form-data`.
-* The `name` value must be set to `file[]` for all parts.
-* The original filename must be supplied in the `filename` parameter.
-* The `Content-Type` header must be set to the appropriate mime-type for the file.
-* The body of each part is the full contents of the raw file.
+*  Each part has a header and body with `Content-Disposition` header always set to `form-data`.
+*  The `name` value must be set to `file[]` for all parts.
+*  The original filename must be supplied in the `filename` parameter.
+*  The `Content-Type` header must be set to the appropriate mime-type for the file.
+*  The body of each part is the full contents of the raw file.
 
 For example, if you save the previous request body is saved to a temporary file at `/tmp/files-payload`, you can use it in your POST request to upload the file:
 
@@ -224,7 +224,7 @@ curl -X DELETE \
 ]
 ```
 
-* The API returns a batch response for each item, which includes a `code` and `message`.
-* A 200 OK HTTP response code indicates a successful upload.
-* Any non-200 HTTP response code indicates an error.
-* If no packages are associated with a file, the API returns an empty list and the file is removed.
+*  The API returns a batch response for each item, which includes a `code` and `message`.
+*  A 200 OK HTTP response code indicates a successful upload.
+*  Any non-200 HTTP response code indicates an error.
+*  If no packages are associated with a file, the API returns an empty list and the file is removed.

--- a/guides/v2.2/marketplace/eqp/users.md
+++ b/guides/v2.2/marketplace/eqp/users.md
@@ -178,8 +178,8 @@ The following example shows a request to update the personal profile bio field:
 
 The `action` field specifies which update operation to perform:
 
-* `publish`—The default if not specified. Publishes the profile to the relevant [Marketplace Store Partners page](https://marketplace.magento.com/partners.html).
-* `draft`—The update is saved on the Developer Portal, but not published.
+*  `publish`—The default if not specified. Publishes the profile to the relevant [Marketplace Store Partners page](https://marketplace.magento.com/partners.html).
+*  `draft`—The update is saved on the Developer Portal, but not published.
 
 **Request**
 
@@ -260,13 +260,13 @@ curl -X GET \
 
 #### Magento 2 keys
 
-* Each Composer key-pair has unique `label` and `is_enabled` flags to indicate whether the key is enabled.
-* A Composer key-pair is identified by `user_key` (username) and `password_key` (password) when prompted for Composer credentials.
+*  Each Composer key-pair has unique `label` and `is_enabled` flags to indicate whether the key is enabled.
+*  A Composer key-pair is identified by `user_key` (username) and `password_key` (password) when prompted for Composer credentials.
 
 #### Magento 1 keys
 
-* Provides a list of product names and associated product keys, which can be used in the Magento Connect Manager to install extensions.
-* You cannot create, update, or delete these keys.
+*  Provides a list of product names and associated product keys, which can be used in the Magento Connect Manager to install extensions.
+*  You cannot create, update, or delete these keys.
 
 ### Create keys
 
@@ -324,9 +324,9 @@ curl -X POST \
 }
 ```
 
-* The API returns a batch response for each label.
-* A 200 OK HTTP response code indicates a successful update.
-* Any non-200 HTTP response code indicates an error. See the `message` field for details.
+*  The API returns a batch response for each label.
+*  A 200 OK HTTP response code indicates a successful update.
+*  Any non-200 HTTP response code indicates an error. See the `message` field for details.
 
 ### Update keys
 

--- a/guides/v2.2/migration/migration-migrate-after.md
+++ b/guides/v2.2/migration/migration-migrate-after.md
@@ -11,12 +11,12 @@ functional_areas:
 
 After you have completed your migration and thoroughly tested your new Magento 2 site, perform the following tasks:
 
-* Put Magento 1 in maintenance mode and permanently stop all [Admin](https://glossary.magento.com/admin) activities
+*  Put Magento 1 in maintenance mode and permanently stop all [Admin](https://glossary.magento.com/admin) activities
 
-* Start Magento 2 cron jobs
+*  Start Magento 2 cron jobs
 
-* [Flush all Magento 2 cache types]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-clean){:target="_blank"}
+*  [Flush all Magento 2 cache types]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-clean){:target="_blank"}
 
-* [Reindex all Magento 2 indexers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#config-cli-subcommands-index-reindex){:target="_blank"}
+*  [Reindex all Magento 2 indexers]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-index.html#config-cli-subcommands-index-reindex){:target="_blank"}
 
-* Change DNS, load balancers, etc. to point to Magento 2 production hardware
+*  Change DNS, load balancers, etc. to point to Magento 2 production hardware

--- a/guides/v2.2/migration/migration-overview-practices.md
+++ b/guides/v2.2/migration/migration-overview-practices.md
@@ -15,15 +15,15 @@ This section provides our best information about how to speed up and simplify yo
 
 ## Best practices and recommendations
 
-* **Use a copy of the database from Magento 1 instance** when performing migration testing. Do not involve the main instance of your Magento 1 store database so that your production environment is not affected.
+*  **Use a copy of the database from Magento 1 instance** when performing migration testing. Do not involve the main instance of your Magento 1 store database so that your production environment is not affected.
 
-* **Remove outdated and redundant data** from your Magento 1 database before migration.
+*  **Remove outdated and redundant data** from your Magento 1 database before migration.
 
   Such data may include logs, order quotes, recently viewed or compared products, visitors, event-specific categories, promotional rules, etc.
 
-* **Follow our [General Rules for Successful Migration]({{ page.baseurl }}/migration/migration-migrate.html)** to avoid issues or conflicts.
+*  **Follow our [General Rules for Successful Migration]({{ page.baseurl }}/migration/migration-migrate.html)** to avoid issues or conflicts.
 
-* To boost performance, you may **enable the `direct_document_copy` option** in your `config.xml`:
+*  To boost performance, you may **enable the `direct_document_copy` option** in your `config.xml`:
 
         <direct_document_copy>1</direct_document_copy>
 
@@ -33,14 +33,14 @@ This section provides our best information about how to speed up and simplify yo
 
 We tested migration on the following system:
 
-* Environment: Virtual Box VM, CentOS 6, 2.5Gb RAM, CPU 1 core 2.6GHz
+*  Environment: Virtual Box VM, CentOS 6, 2.5Gb RAM, CPU 1 core 2.6GHz
 
-* Database had 177k products, 355k orders, 214k customers
+*  Database had 177k products, 355k orders, 214k customers
 
 ## Performance results
 
-* Settings migration time: ~10 mins
+*  Settings migration time: ~10 mins
 
-* Data migration time: ~9 hrs (all data except [URL](https://glossary.magento.com/url) Rewrites, ~85% of total data)
+*  Data migration time: ~9 hrs (all data except [URL](https://glossary.magento.com/url) Rewrites, ~85% of total data)
 
-* Site downtime estimate: a few minutes to reindex and change DNS settings. Additional time required to "warm up" the page [cache](https://glossary.magento.com/cache)
+*  Site downtime estimate: a few minutes to reindex and change DNS settings. Additional time required to "warm up" the page [cache](https://glossary.magento.com/cache)

--- a/guides/v2.2/migration/migration-troubleshooting.md
+++ b/guides/v2.2/migration/migration-troubleshooting.md
@@ -27,13 +27,13 @@ This message appears because the Data Migration Tool runs internal tests to veri
 
 #### Possible solutions
 
-* Install the corresponding Magento 2 extensions from [Magento Marketplace](https://marketplace.magento.com/){:target:"_blank"}
+*  Install the corresponding Magento 2 extensions from [Magento Marketplace](https://marketplace.magento.com/){:target:"_blank"}
 
     If the conflicting data originates from an extension which adds own database structure elements, then the Magento 2 version of the same extension may add such elements to the destination (Magento 2) database, thus fixing the issue.
 
-* Use the `-a` argument when executing the tool to auto resolve errors and prevent migration from stopping.
+*  Use the `-a` argument when executing the tool to auto resolve errors and prevent migration from stopping.
 
-* Configure the Tool to ignore the problematic data
+*  Configure the Tool to ignore the problematic data
 
 To ignore database entities, add the `<ignore>` tag to an entity in the `map.xml` file, like this:
 
@@ -72,13 +72,13 @@ A class from Magento 1 codebase could not be found in Magento 2 codebase during 
 
 #### Possible solutions
 
-* Install the corresponding Magento 2 extension
+*  Install the corresponding Magento 2 extension
 
-* Ignore the attribute that causes the issue
+*  Ignore the attribute that causes the issue
 
     For this, add the attribute to the `ignore` group in the `eav-attribute-groups.xml.dist` file.
 
-* Add class mapping using the `class-map.xml.dist` file
+*  Add class mapping using the `class-map.xml.dist` file
 
 ### Foreign key constraint fails
 

--- a/guides/v2.2/mtf/configuration.md
+++ b/guides/v2.2/mtf/configuration.md
@@ -5,8 +5,8 @@ title: Functional Testing Framework Configuration
 
 The Functional Testing Framework configuration settings are located in two [XML](https://glossary.magento.com/xml) files:
 
-- `phpunit.xml`
-- `config.xml`
+-  `phpunit.xml`
+-  `config.xml`
 
 ## `phpunit.xml` {#phpunit_xml}
 
@@ -68,16 +68,16 @@ Figure 2. - XML Schema for the `<magento2_root_dir>dev/tests/functional/vendor/m
 
 The FTF merges settings from both files with the following priority:
 
-- `config.xml` in Magento has higher priority then `config.xml` in the Framework
-- `config.xml.dist` is omitted if `config.xml` exists
+-  `config.xml` in Magento has higher priority then `config.xml` in the Framework
+-  `config.xml.dist` is omitted if `config.xml` exists
 
 Settings are grouped into the following blocks:
 
-- [`<application>`]
-- [`<isolation>`]
-- [`<server>`]
-- [`<handler>`]
-- [`<install>`] (set in Magento functional tests only)
+-  [`<application>`]
+-  [`<isolation>`]
+-  [`<server>`]
+-  [`<handler>`]
+-  [`<install>`] (set in Magento functional tests only)
 
 ### `<application>` {#application}
 
@@ -106,10 +106,10 @@ Settings are grouped into the following blocks:
 
 Values description:
 
-- `none` - never run
-- `before` - run before the entity to which it concerns
-- `after` - run after the entity to which it concerns
-- `both` - run before and after the entity to which it concerns
+-  `none` - never run
+-  `before` - run before the entity to which it concerns
+-  `after` - run after the entity to which it concerns
+-  `both` - run before and after the entity to which it concerns
 
 ### `<server>` {#server}
 

--- a/guides/v2.2/mtf/features.md
+++ b/guides/v2.2/mtf/features.md
@@ -5,11 +5,11 @@ title: Functional Testing Framework Features
 
 The Functional Testing Framework is:
 
-- Flexible, because of [modularity support].
-- Fast, because of [parallel execution].
-- Informative, because of the reporting tool.
-- Suitable, because of [test suites].
-- Compatible, because of [web driver selection].
+-  Flexible, because of [modularity support].
+-  Fast, because of [parallel execution].
+-  Informative, because of the reporting tool.
+-  Suitable, because of [test suites].
+-  Compatible, because of [web driver selection].
 
 Each feature will be described in a separate topic.
 

--- a/guides/v2.2/mtf/mtf_entities/mtf_constraint.md
+++ b/guides/v2.2/mtf/mtf_entities/mtf_constraint.md
@@ -26,7 +26,7 @@ The constraint [PHP](https://glossary.magento.com/php) class must:
    *  `AssertOrderPlaced` corresponds to `Assert{entityName}{action}`
    *  `AssertProductForm` corresponds to `Assert{entityName}{place}`
 
-* Extend the [Magento\Mtf\Constraint\AbstractConstraint](https://github.com/magento/mtf/blob/develop/Magento/Mtf/Constraint/AbstractConstraint.php) class.
+*  Extend the [Magento\Mtf\Constraint\AbstractConstraint](https://github.com/magento/mtf/blob/develop/Magento/Mtf/Constraint/AbstractConstraint.php) class.
 
 *  Contain the following methods:
 

--- a/guides/v2.3/mrg/intro.md
+++ b/guides/v2.3/mrg/intro.md
@@ -7,7 +7,7 @@ The [Module](https://glossary.magento.com/module) Reference Guide contains brief
 {:.ref-header}
 Related topics
 
-- [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
-- [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)
-- [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)
-- [REST Reference]({{ page.baseurl }}/rest/bk-rest.html)
+-  [Building a new Magento module]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html)
+-  [How to enable/disable a Magento module]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-enable.html)
+-  [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)
+-  [REST Reference]({{ page.baseurl }}/rest/bk-rest.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:
- `guides/v2.3/mtf`
- `guides/v2.3/mrg`
- `guides/v2.3/migration`
- `guides/v2.3/marketplace`