### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.3/graphql/mutations/create-customer.md
+++ b/guides/v2.3/graphql/mutations/create-customer.md
@@ -71,8 +71,8 @@ The `createCustomer` mutation returns the `CustomerOutput` object.
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
-* [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
-* [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)
-* [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
+*  [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
+*  [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)
+*  [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)

--- a/guides/v2.3/graphql/mutations/create-paypal-express-token.md
+++ b/guides/v2.3/graphql/mutations/create-paypal-express-token.md
@@ -5,9 +5,9 @@ title: createPaypalExpressToken mutation
 
 The `createPaypalExpressToken` mutation begins the authorization process for the following payment methods:
 
-* PayPal Express Checkout
-* PayPal Payflow Pro with Express Checkout
-* PayPal Payflow Link with Express Checkout
+*  PayPal Express Checkout
+*  PayPal Payflow Pro with Express Checkout
+*  PayPal Payflow Link with Express Checkout
 
 The input includes the cart ID, the payment method code, and a set of URLs that PayPal uses to respond to the token request. If the request is successful, PayPal returns a token. The [`setPaymentMethodOnCart`]({{page.baseurl}}/graphql/mutations/set-payment-method.html) mutation uses this token later in the authorization process.
 

--- a/guides/v2.3/graphql/mutations/delete-customer-address.md
+++ b/guides/v2.3/graphql/mutations/delete-customer-address.md
@@ -47,8 +47,8 @@ The `deleteCustomerAddress` mutation returns a Boolean value that indicates whet
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
-* [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
-* [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
-* [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
+*  [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
+*  [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
+*  [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)

--- a/guides/v2.3/graphql/mutations/generate-customer-token.md
+++ b/guides/v2.3/graphql/mutations/generate-customer-token.md
@@ -59,5 +59,5 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [revokeCustomerToken mutation]({{page.baseurl}}/graphql/mutations/revoke-customer-token.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [revokeCustomerToken mutation]({{page.baseurl}}/graphql/mutations/revoke-customer-token.html)

--- a/guides/v2.3/graphql/mutations/index.md
+++ b/guides/v2.3/graphql/mutations/index.md
@@ -11,11 +11,11 @@ While GraphQL queries perform read operations, mutations change the data. A muta
 
 A mutation contains the following elements:
 
-* The keyword `mutation`
-* An operation name for your local implementation. This name is required if you include variables. Otherwise, it is optional.
-* The mutation name
-* The input object or attributes. Most mutations require an input object that contains data or individual attributes for the Magento server to process. However, some mutations, such as `createEmptyCart`, do not require an input object. In this particular case, the authorization token passed with the request provides the needed context.
-* The output object, which specifies which data the mutation returns.
+*  The keyword `mutation`
+*  An operation name for your local implementation. This name is required if you include variables. Otherwise, it is optional.
+*  The mutation name
+*  The input object or attributes. Most mutations require an input object that contains data or individual attributes for the Magento server to process. However, some mutations, such as `createEmptyCart`, do not require an input object. In this particular case, the authorization token passed with the request provides the needed context.
+*  The output object, which specifies which data the mutation returns.
 
 The following example shows the structure of the `createCustomer` mutation:
 
@@ -83,9 +83,9 @@ mutation myGenerateCustomerToken{
 
 Specifying variables in a mutation can help increase code re-use. Consider the following requirements when generating a mutation that contains one or more variables:
 
-* All variables must be declared up-front, immediately after the operation name.
-* Variables are typed: they can be scalar or an object.
-* You must use all declared variables. Object variables are defined in JSON.
+*  All variables must be declared up-front, immediately after the operation name.
+*  Variables are typed: they can be scalar or an object.
+*  You must use all declared variables. Object variables are defined in JSON.
 
 The following example declares the `$CustomerInput` variable. It is referenced in the `input` statement.
 

--- a/guides/v2.3/graphql/mutations/revoke-customer-token.md
+++ b/guides/v2.3/graphql/mutations/revoke-customer-token.md
@@ -45,5 +45,5 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [generateCustomerToken mutation]({{page.baseurl}}/graphql/mutations/generate-customer-token.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [generateCustomerToken mutation]({{page.baseurl}}/graphql/mutations/generate-customer-token.html)

--- a/guides/v2.3/graphql/mutations/set-shipping-address.md
+++ b/guides/v2.3/graphql/mutations/set-shipping-address.md
@@ -7,8 +7,8 @@ redirect from:
 
 The `setShippingAddressesOnCart` mutation sets one or more shipping addresses on a specific cart. The shipping address does not need to be specified in the following circumstances:
 
-* The cart contains only virtual items
-* When you defined the billing address, you set the `use_for_shipping` attribute to `true`. Magento assigns the same address as the shipping address.
+*  The cart contains only virtual items
+*  When you defined the billing address, you set the `use_for_shipping` attribute to `true`. Magento assigns the same address as the shipping address.
 
 ## Syntax
 

--- a/guides/v2.3/graphql/mutations/update-customer-address.md
+++ b/guides/v2.3/graphql/mutations/update-customer-address.md
@@ -63,8 +63,8 @@ The `updateCustomerAddress` mutation returns the `CustomerAddress` object.
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
-* [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
-* [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
-* [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
+*  [updateCustomer mutation]({{page.baseurl}}/graphql/mutations/update-customer.html)
+*  [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
+*  [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)

--- a/guides/v2.3/graphql/mutations/update-customer.md
+++ b/guides/v2.3/graphql/mutations/update-customer.md
@@ -62,8 +62,8 @@ The `updateCustomer` mutation returns the `CustomerOutput` object.
 
 ## Related topics
 
-* [customer query]({{page.baseurl}}/graphql/queries/customer.html)
-* [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
-* [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
-* [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)
-* [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)
+*  [customer query]({{page.baseurl}}/graphql/queries/customer.html)
+*  [createCustomer mutation]({{page.baseurl}}/graphql/mutations/create-customer.html)
+*  [createCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/create-customer-address.html)
+*  [updateCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/update-customer-address.html)
+*  [deleteCustomerAddress mutation]({{page.baseurl}}/graphql/mutations/delete-customer-address.html)

--- a/guides/v2.3/graphql/payment-methods/braintree-vault.md
+++ b/guides/v2.3/graphql/payment-methods/braintree-vault.md
@@ -30,7 +30,7 @@ The following diagram shows the workflow for placing an order when Braintree Vau
 
 1. The gateway sends the response to Magento.
 
-1.  Magento creates an order and sends an order ID in response to the `placeOrder` mutation.
+1. Magento creates an order and sends an order ID in response to the `placeOrder` mutation.
 
 ## `setPaymentMethodOnCart` mutation
 

--- a/guides/v2.3/graphql/payment-methods/payflow-express.md
+++ b/guides/v2.3/graphql/payment-methods/payflow-express.md
@@ -75,6 +75,6 @@ mutation {
 
 ## Related topics
 
-- [`createPaypalExpressToken` mutation]({{page.baseurl}}/graphql/mutations/create-paypal-express-token.html)
-- [`placeOrder` mutation]({{page.baseurl}}/graphql/mutations/place-order.html)
-- [`setPaymentMethodOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-payment-method.html)
+-  [`createPaypalExpressToken` mutation]({{page.baseurl}}/graphql/mutations/create-paypal-express-token.html)
+-  [`placeOrder` mutation]({{page.baseurl}}/graphql/mutations/place-order.html)
+-  [`setPaymentMethodOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-payment-method.html)

--- a/guides/v2.3/graphql/product/bundle-product.md
+++ b/guides/v2.3/graphql/product/bundle-product.md
@@ -7,9 +7,9 @@ redirect_from:
 
 The `BundleProduct` data type implements the following interfaces:
 
--   `ProductInterface`
--   `PhysicalProductInterface`
--   `CustomizableProductInterface`
+-  `ProductInterface`
+-  `PhysicalProductInterface`
+-  `CustomizableProductInterface`
 
 Attributes that are specific to bundle products can be used when performing a [`products`]({{page.baseurl}}/graphql/queries/products.html) query.
 

--- a/guides/v2.3/graphql/product/configurable-product.md
+++ b/guides/v2.3/graphql/product/configurable-product.md
@@ -7,9 +7,9 @@ redirect_from:
 
 The `ConfigurableProduct` data type implements the following interfaces:
 
--   `ProductInterface`
--   `PhysicalProductInterface`
--   `CustomizableProductInterface`
+-  `ProductInterface`
+-  `PhysicalProductInterface`
+-  `CustomizableProductInterface`
 
 Attributes that are specific to configurable products can be used when performing a [`products`]({{page.baseurl}}/graphql/queries/products.html) query.
 

--- a/guides/v2.3/graphql/product/customizable-option-interface.md
+++ b/guides/v2.3/graphql/product/customizable-option-interface.md
@@ -9,14 +9,14 @@ Customizable options for a product provide a way to offer customers a selection 
 
 `CustomizableOptionInterface` is defined in the `CatalogGraphQl` module, and its attributes can be used in any `products` query. This interface returns basic information about a customizable option and can be implemented by several types of configurable options:
 
-* Text area
-* Checkbox
-* Date picker
-* Drop-down menu
-* Text field
-* File picker
-* Multiple select box
-* Radio buttons
+*  Text area
+*  Checkbox
+*  Date picker
+*  Drop-down menu
+*  Text field
+*  File picker
+*  Multiple select box
+*  Radio buttons
 
 {: .bs-callout-info }
 Magento has not implemented all possible customizable product options for GraphQL.

--- a/guides/v2.3/graphql/product/gift-card-product.md
+++ b/guides/v2.3/graphql/product/gift-card-product.md
@@ -10,9 +10,9 @@ The `GiftCardProduct` data type defines properties of a gift card, including the
 
 It implements the following interfaces:
 
--   `ProductInterface`
--   `PhysicalProductInterface`
--   `CustomizableProductInterface`
+-  `ProductInterface`
+-  `PhysicalProductInterface`
+-  `CustomizableProductInterface`
 
 ## GiftCardProduct object
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.3/graphql`