### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/frontend-dev-guide/templates/template-override.md
+++ b/guides/v2.2/frontend-dev-guide/templates/template-override.md
@@ -30,22 +30,22 @@ The templates directory of `Magento_Catalog` is `app/code/Magento/Catalog/view/f
 
  Templates are stored in the following locations:
 
-* Module templates: `<module_dir>/view/frontend/templates/<path_to_templates>`
-* Theme templates: `<theme_dir>/<Namespace>_<Module>/templates/<path_to_templates>`
+*  Module templates: `<module_dir>/view/frontend/templates/<path_to_templates>`
+*  Theme templates: `<theme_dir>/<Namespace>_<Module>/templates/<path_to_templates>`
 
 `<path_to_templates>` indicates zero or more directory levels.
 
 Examples:
 
-* `app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml`
-* `app/code/Magento/Checkout/view/frontend/templates/cart.phtml`
+*  `app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml`
+*  `app/code/Magento/Checkout/view/frontend/templates/cart.phtml`
 
 ## Template overrides {#override}
 
 For template files with the same name, the following override rules apply:
 
-* Theme templates override module templates
-* [Child theme] templates override parent theme templates
+*  Theme templates override module templates
+*  [Child theme] templates override parent theme templates
 
 To change the output defined by an existing template, override the template in your custom theme.
 This concept is the basis of template customization in Magento.

--- a/guides/v2.2/frontend-dev-guide/theme-best-practice.md
+++ b/guides/v2.2/frontend-dev-guide/theme-best-practice.md
@@ -13,10 +13,10 @@ We recommend using the following best practices when developing themes:
 
 1. When [inheriting]({{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html) from a default Magento theme, extend the default styles instead of overriding them.  Whenever possible, put your customizations in the `_extend.less` or `_theme.less` file, instead of overriding a `.less` file from a parent theme.
 1. Customize, or create new, `.xml` layout files instead of customizing and overriding `.phtml` templates. For example, if you need to create a new container, it is better to add an `.xml` file than override an existing template. Some other customizations that can be performed using layout instructions include:
-    * Change the position of a block or container using `<move>`.
-    * Add or remove a block or container by setting the `remove` or `display` attribute to `true` or `false` within the `<referenceBlock>/<referenceContainer>`.
-    * Change the HTML tag or CSS class for the existing container using the `<referenceContainer>` element.
-    * Add fonts, images, and JavaScript files in the `<theme_dir>/web/` directory.
+    *  Change the position of a block or container using `<move>`.
+    *  Add or remove a block or container by setting the `remove` or `display` attribute to `true` or `false` within the `<referenceBlock>/<referenceContainer>`.
+    *  Change the HTML tag or CSS class for the existing container using the `<referenceContainer>` element.
+    *  Add fonts, images, and JavaScript files in the `<theme_dir>/web/` directory.
 
     See the [Layout chapter of this Guide]({{ page.baseurl }}/frontend-dev-guide/layouts/layout-overview.html) for more information on working with layouts.
 

--- a/guides/v2.2/frontend-dev-guide/themes/theme-images.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-images.md
@@ -116,8 +116,8 @@ All image properties used in `view.xml` should be listed in the order shown here
 
 Generally, product images are cached while saving the product. However, the `magento catalog:images:resize` command enables you to resize all images for display on your storefront. Situations where this could be necessary might be:
 
-* After you import products, which might have images of various sizes
-* If images were resized or deleted manually from [cache](https://glossary.magento.com/cache)
+*  After you import products, which might have images of various sizes
+*  If images were resized or deleted manually from [cache](https://glossary.magento.com/cache)
 
 Each image assigned to a product must be resized in accordance with image [metadata](https://glossary.magento.com/metadata) defined in a module's [`view.xml`]({{ page.baseurl }}/frontend-dev-guide/themes/theme-create.html#fedg_create_theme_how-to-images) configuration file. After resizing an image, its resized copy is stored in the cache (`/pub/media/catalog/product/cache` directory). Magento serves storefront images from cache.
 

--- a/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
@@ -258,8 +258,8 @@ The directories and files structure described below is the most extended one. It
 
 Apart from the configuration file and theme [metadata](https://glossary.magento.com/metadata) file, all theme files fall into the following two categories:
 
-* Static view files
-* Dynamic view files
+*  Static view files
+*  Dynamic view files
 
 ### Static view files {#theme-structure-pub}
 

--- a/guides/v2.2/frontend-dev-guide/tools/tools_overview.md
+++ b/guides/v2.2/frontend-dev-guide/tools/tools_overview.md
@@ -10,4 +10,4 @@ This chapter describes how to install and use additional tools that can make you
 
 **Chapter Contents**
 
-- [Using Grunt for Magento tasks]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html)
+-  [Using Grunt for Magento tasks]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html)

--- a/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
+++ b/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
@@ -72,8 +72,8 @@ You can translate the same element in different ways for different modules:
 
 ## Additional information
 
-- [Translations overview]
-- [Example theme translation dictionary]
+-  [Translations overview]
+-  [Example theme translation dictionary]
 
 [translation dictionaries]: {{page.baseurl}}/frontend-dev-guide/translations/xlate.html#translate_terms
 [`<Magento_Luma_theme_dir>/i18n/en_US.csv`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/design/frontend/Magento/luma/i18n/en_US.csv

--- a/guides/v2.2/frontend-dev-guide/translations/translate_practice.md
+++ b/guides/v2.2/frontend-dev-guide/translations/translate_practice.md
@@ -13,9 +13,9 @@ OrangeCo created a custom `orange` theme that inherits from the Magento Blank th
 
 Namely, they need the following changes:
 
--   Change **Add to Cart** label to **Purchase**
--   Change **Add to Compare** label to **Compare**
--   Change **Add to Wish List** label to **Wishlist**
+-  Change **Add to Cart** label to **Purchase**
+-  Change **Add to Compare** label to **Compare**
+-  Change **Add to Wish List** label to **Wishlist**
 
 The following image shows a page where the current strings are used:
 
@@ -51,9 +51,9 @@ For example:
 
 ## Additional information
 
--   [Translations overview]
--   [Translation dictionaries and language packages]
--   [Usetranslation dictionary to customize strings]
+-  [Translations overview]
+-  [Translation dictionaries and language packages]
+-  [Usetranslation dictionary to customize strings]
 
 [dictionary]: {{ page.baseurl }}/frontend-dev-guide/translations/xlate.html#translate_terms
 [Product page where the Add to Compare string is displayed]: {{site.baseurl}}/common/images/fdg_trans_bag.png

--- a/guides/v2.2/get-started/rest_front.md
+++ b/guides/v2.2/get-started/rest_front.md
@@ -10,10 +10,10 @@ The Magento REST [API](https://glossary.magento.com/api) defines a set of functi
 
 The caller issues an HTTP request, which contains the following elements:
 
-* An HTTP header that provides authentication and other instructions
-* A verb, which can be one of GET, POST, PUT, or DELETE.
-* An endpoint, which is a Uniform Resource Indicator (URI) that identifies the server, the web service, and the resource being acted on.
-* The call payload, which is set of input parameters and attributes that you supply with the request.
+*  An HTTP header that provides authentication and other instructions
+*  A verb, which can be one of GET, POST, PUT, or DELETE.
+*  An endpoint, which is a Uniform Resource Indicator (URI) that identifies the server, the web service, and the resource being acted on.
+*  The call payload, which is set of input parameters and attributes that you supply with the request.
 
 Magento returns a response payload as well as an HTTP status code.
 

--- a/guides/v2.2/get-started/soap/soap-web-api-calls.md
+++ b/guides/v2.2/get-started/soap/soap-web-api-calls.md
@@ -54,11 +54,11 @@ If you want an overview to all the available Web Services, use the following URL
 
 Service names use the following conventions:
 
-* CamelCase is used for service naming.
-* The string `Service` is omitted.
-* The `Magento` prefix is omitted.
-* The `Interface` suffix is omitted.
-* If the service name is the same as the [module](https://glossary.magento.com/module) name, the module name is omitted. For example, if there is a customer service interface in the customer module, the word `customer` will be used in the service name only once.
+*  CamelCase is used for service naming.
+*  The string `Service` is omitted.
+*  The `Magento` prefix is omitted.
+*  The `Interface` suffix is omitted.
+*  If the service name is the same as the [module](https://glossary.magento.com/module) name, the module name is omitted. For example, if there is a customer service interface in the customer module, the word `customer` will be used in the service name only once.
 
 | Original Service Interface Name | Service Name |
 |----------
@@ -91,6 +91,6 @@ $soapResponse = $soapClient->testModule1AllSoapAndRestV1Item($serviceArgs); ?>
 {:.ref-header}
 Related topics
 
-* [OAuth-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-oauth.html)
-* [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)
-* [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)
+*  [OAuth-based authentication]({{ page.baseurl }}/get-started/authentication/gs-authentication-oauth.html)
+*  [Service contracts]({{ page.baseurl }}/extension-dev-guide/service-contracts/service-contracts.html)
+*  [SOAP Reference]({{ page.baseurl }}/soap/bk-soap.html)

--- a/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.md
@@ -9,8 +9,8 @@ functional_areas:
 
 There are two possible ways to customize page layout in Magento:
 
-- Changing [layout](https://glossary.magento.com/layout) files.
-- Altering templates.
+-  Changing [layout](https://glossary.magento.com/layout) files.
+-  Altering templates.
 
 To change the page wireframe, modify the [page layout] files; all other customizations are performed in the [page configuration] or [generic layout] files.
 
@@ -23,10 +23,10 @@ For example, changes to the `app/code/Vendor/Module/view/frontend/layout/catalog
 
 Use these [layout instructions](https://glossary.magento.com/layout-instructions) to:
 
-- Move a page element to another parent element.
-- Add content.
-- Remove a page element.
-- Arrange the element position.
+-  Move a page element to another parent element.
+-  Add content.
+-  Remove a page element.
+-  Arrange the element position.
 
 The basic set of instructions is the same for all types of layout files. This topic describes these basic instructions. For details about how they are used in a particular layout file type, please refer to the [Layout file types] topic.
 
@@ -34,16 +34,16 @@ The basic set of instructions is the same for all types of layout files. This to
 
 Use the following layout instructions to customize your layout:
 
-- [`<block>`](#fedg_layout_xml-instruc_ex_block)
-- [`<container>`](#fedg_layout_xml-instruc_ex_cont)
-- [`before` and `after` attributes](#fedg_xml-instrux_before-after)
-- [`<action>`](#fedg_layout_xml-instruc_ex_act)
-- [`<referenceBlock>` and `<referenceContainer>`](#fedg_layout_xml-instruc_ex_ref)
-- [`<move>`](#fedg_layout_xml-instruc_ex_mv)
-- [`<remove>`](#fedg_layout_xml-instruc_ex_rmv)
-- [`<update>`](#fedg_layout_xml-instruc_ex_upd)
-- [`<argument>`](#argument)
-- [`<block> vs <container>`](#block_vs_container)
+-  [`<block>`](#fedg_layout_xml-instruc_ex_block)
+-  [`<container>`](#fedg_layout_xml-instruc_ex_cont)
+-  [`before` and `after` attributes](#fedg_xml-instrux_before-after)
+-  [`<action>`](#fedg_layout_xml-instruc_ex_act)
+-  [`<referenceBlock>` and `<referenceContainer>`](#fedg_layout_xml-instruc_ex_ref)
+-  [`<move>`](#fedg_layout_xml-instruc_ex_mv)
+-  [`<remove>`](#fedg_layout_xml-instruc_ex_rmv)
+-  [`<update>`](#fedg_layout_xml-instruc_ex_upd)
+-  [`<argument>`](#argument)
+-  [`<block> vs <container>`](#block_vs_container)
 
 ### block {#fedg_layout_xml-instruc_ex_block}
 
@@ -112,9 +112,9 @@ Use this feature to make temporary changes to a store, such as disabling a secti
 
 ### block vs. container {#block_vs_container}
 
-- Blocks represents the end of the chain in rendering HTML for Magento.
-- Containers contain blocks and can wrap them in an HTML tag.
-- Containers do not render any output if there are no children assigned to them.
+-  Blocks represents the end of the chain in rendering HTML for Magento.
+-  Containers contain blocks and can wrap them in an HTML tag.
+-  Containers do not render any output if there are no children assigned to them.
 
 ### before and after attributes {#fedg_xml-instrux_before-after}
 
@@ -182,7 +182,7 @@ To pass parameters to a block use the [`<argument></argument>`](#argument) instr
 | `remove` | Allows to remove or cancel the removal of the element. When a container is removed, its child elements are removed as well. | true/false | no |
 | `display` | Allows you to disable rendering of specific block or container with all its children (both set directly and by reference). The block's/container's and its children' respective PHP objects are still generated and available for manipulation. | true/false | no |
 
-- The `remove` attribute is optional and its default value is `false`.
+-  The `remove` attribute is optional and its default value is `false`.
 
     This implementation allows you to remove a block or container in your layout by setting the remove attribute value to `true`, or to cancel the removal of a block or container by setting the value to `false`.
 
@@ -190,7 +190,7 @@ To pass parameters to a block use the [`<argument></argument>`](#argument) instr
     <referenceBlock name="block.name" remove="true" />
     ```
 
-- The `display` attribute is optional and its default value is true.
+-  The `display` attribute is optional and its default value is true.
 
     You are always able to overwrite this value in your layout.
     In situation when remove value is true, the display attribute is ignored.
@@ -207,9 +207,9 @@ Sets the declared block or container element as a child of another element in th
 <move element="name.of.an.element" destination="name.of.destination.element" as="new_alias" after="name.of.element.after" before="name.of.element.before"/>
 ```
 
-- `<move>` is skipped if the element to be moved is not defined.
-- If the `as` attribute is not defined, the current value of the element alias is used. If that is not possible, the value of the `name` attribute is used instead.
-- During layout generation, the `<move>` instruction is processed before the removal (set using the `remove` attribute). This means if any elements are moved to the element scheduled for removal, they will be removed as well.
+-  `<move>` is skipped if the element to be moved is not defined.
+-  If the `as` attribute is not defined, the current value of the element alias is used. If that is not possible, the value of the `name` attribute is used instead.
+-  During layout generation, the `<move>` instruction is processed before the removal (set using the `remove` attribute). This means if any elements are moved to the element scheduled for removal, they will be removed as well.
 
 | Attribute | Description | Values | Required? |
 |:------- |:------ |:------ |:------ |
@@ -297,19 +297,19 @@ $cssClass = $this->hasCssClass() ? ' ' . $this->getCssClass() : '';
 As was described above the argument attribute can be added with different types.
 There are examples of all argument types.
 
-- The *string* type:
+-  The *string* type:
 
 ```xml
 <argument name="some_string" xsi:type="string" >Some String</argument>
 ```
 
-- The *boolean* type:
+-  The *boolean* type:
 
 ```xml
 <argument name="is_active" xsi:type="boolean" >true</argument>
 ```
 
-- The *object* type:
+-  The *object* type:
 
 ```xml
 <argument name="viewModel" xsi:type="object" >Vendor\CustomModule\ViewModel\Class</argument>
@@ -317,19 +317,19 @@ There are examples of all argument types.
 
 The `Vendor\CustomModule\ViewModel\Class` class should implement the `\Magento\Framework\View\Element\Block\ArgumentInterface` interface.
 
-- The *number* type:
+-  The *number* type:
 
 ```xml
 <argument name="some_number" xsi:type="number" >100</argument>
 ```
 
-- The *null* type:
+-  The *null* type:
 
 ```xml
 <argument name="null_value" xsi:type="null" />
 ```
 
-- The *array* type:
+-  The *array* type:
 
 ```xml
 <argument name="custom_array" xsi:type="array">
@@ -339,7 +339,7 @@ The `Vendor\CustomModule\ViewModel\Class` class should implement the `\Magento\F
 </argument>
 ```
 
-- The *options* type:
+-  The *options* type:
 
 ```xml
 <argument name="options" xsi:type="options" >Vendor\CustomModule\Source\Options\Class</argument>
@@ -347,13 +347,13 @@ The `Vendor\CustomModule\ViewModel\Class` class should implement the `\Magento\F
 
 The `Vendor\CustomModule\Source\Options\Class` class should implement the `\Magento\Framework\Data\OptionSourceInterface` interface.
 
-- The *url* type:
+-  The *url* type:
 
 ```xml
 <argument name="shopping_cart_url" xsi:type="url" path="checkout/cart/index" />
 ```
 
-- The *helper* type:
+-  The *helper* type:
 
 ```xml
 <argument name="helper_method_result" xsi:type="helper" helper="Vendor\CustomModule\Helper\Class::someMethod" >

--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -9,22 +9,22 @@ functional_areas:
 
 This article describes the following typical [layout](https://glossary.magento.com/layout) customization tasks:
 
-- [Set the page layout](#layout_markup_columns)
-- [Include static resources (JavaScript, CSS, fonts) in \<head\>](#layout_markup_css)
-- [Remove static resources (JavaScript, CSS, fonts) in \<head\>](#layout_markup_css_remove)
-- [Add meta tags to the head block](#layout_markup_meta)
-- [Create a container](#create_cont)
-- [Reference a container](#ref_container)
-- [Reference a CMS block](#ref_cms_block)
-- [Making the block visibility dynamic](#ref_config_block)
-- [Create a block](#xml-manage-block)
-- [Set the template used by a block](#set_template)
-- [Modify block arguments](#layout_markup_modify-block)
-- [Reference a block](#xml-manage-ref-block)
-- [Use block object methods to set block properties](#layout_markup_block-properties)
-- [Rearrange elements](#layout_markup_rearrange)
-- [Add functionality to existing elements](#layout_markup_add_to_elements)
-- [Modify functionality with plugins (interceptors)](#layout_markup_modify_with_plugins)
+-  [Set the page layout](#layout_markup_columns)
+-  [Include static resources (JavaScript, CSS, fonts) in \<head\>](#layout_markup_css)
+-  [Remove static resources (JavaScript, CSS, fonts) in \<head\>](#layout_markup_css_remove)
+-  [Add meta tags to the head block](#layout_markup_meta)
+-  [Create a container](#create_cont)
+-  [Reference a container](#ref_container)
+-  [Reference a CMS block](#ref_cms_block)
+-  [Making the block visibility dynamic](#ref_config_block)
+-  [Create a block](#xml-manage-block)
+-  [Set the template used by a block](#set_template)
+-  [Modify block arguments](#layout_markup_modify-block)
+-  [Reference a block](#xml-manage-ref-block)
+-  [Use block object methods to set block properties](#layout_markup_block-properties)
+-  [Rearrange elements](#layout_markup_rearrange)
+-  [Add functionality to existing elements](#layout_markup_add_to_elements)
+-  [Modify functionality with plugins (interceptors)](#layout_markup_modify_with_plugins)
 
 {:.bs-callout .bs-callout-info}
 To ensure stability and secure your customizations from being deleted during upgrade, do not change out-of-the-box Magento [module](https://glossary.magento.com/module) and [theme](https://glossary.magento.com/theme) layouts. To customize your layout, create extending and overriding layout files in your custom theme.
@@ -69,8 +69,8 @@ You can use either the `<link src="js/sample.js"/>` or `<script src="js/sample.j
 
 The path to assets is specified relatively to one the following locations:
 
-- `<theme_dir>/web`-
-- `<theme_dir>/<Namespace>_<Module>/web`-
+-  `<theme_dir>/web`-
+-  `<theme_dir>/<Namespace>_<Module>/web`-
 
 ### Adding conditional comments
 
@@ -251,8 +251,8 @@ Any block can be configured to show or not based on a [Magento/Config/Model/Conf
 
 There are two ways to set the template for a block:
 
-- using the `template` attribute
-- using the `<argument>` instruction
+-  using the `template` attribute
+-  using the `<argument>` instruction
 
 Both approaches are demonstrated in the following examples of changing the template of the page title block.
 
@@ -274,8 +274,8 @@ Both approaches are demonstrated in the following examples of changing the templ
 
 In both examples, the template is specified according to the following:
 
-- `Namespace_Module:` defines the module the template belongs to. For example, `Magento_Catalog`.
-- `new_template.phtml`: the path to the template relatively to the `templates` directory. It might be `<module_dir>/view/<area>/templates` or `<theme_dir>/<Namespace_Module>/templates`.
+-  `Namespace_Module:` defines the module the template belongs to. For example, `Magento_Catalog`.
+-  `new_template.phtml`: the path to the template relatively to the `templates` directory. It might be `<module_dir>/view/<area>/templates` or `<theme_dir>/<Namespace_Module>/templates`.
 
 {:.bs-callout .bs-callout-info}
 Template values specified as attributes have higher priority during layout generation, than the ones specified using `<argument>`. It means, that if for a certain block, a template is set as attribute, it will override the value you specify in `<argument>` for the same block.
@@ -316,8 +316,8 @@ Extending layout:
 
 There are two ways to access block object methods:
 
-- using the `<argument>` instruction for `<block>` or `<referenceBlock>`
-- using the `<action>` instruction. This way is not recommended, but can be used for calling those methods, which are not refactored yet to be accessed through `<argument>`.
+-  using the `<argument>` instruction for `<block>` or `<referenceBlock>`
+-  using the `<action>` instruction. This way is not recommended, but can be used for calling those methods, which are not refactored yet to be accessed through `<argument>`.
 
 **Example 1:** Set a CSS class and add an attribute for the product page using `<argument>`.
 
@@ -351,8 +351,8 @@ Extending layout:
 
 In layout files you can change the elements order on a page. This can be done using one of the following:
 
-- [`<move>` instruction]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv): allows changing elements' order and parent.
-- [`before` and `after` attributes of `<block>`]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_xml-instrux_before-after): allows changing elements' order within one parent.
+-  [`<move>` instruction]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_mv): allows changing elements' order and parent.
+-  [`before` and `after` attributes of `<block>`]({{page.baseurl}}/frontend-dev-guide/layouts/xml-instructions.html#fedg_xml-instrux_before-after): allows changing elements' order within one parent.
 
 **Example of `<move>` usage:**
 put the stock availability and SKU blocks next to the product price on a product page.
@@ -589,9 +589,9 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 {:.ref-header}
 Related topics
 
-- [Layout instructions]
-- [Extend a layout]
-- [Plugins (interceptors)]
+-  [Layout instructions]
+-  [Extend a layout]
+-  [Plugins (interceptors)]
 
 <!-- Link Definitions -->
 [page configuration]: {{page.baseurl}}/frontend-dev-guide/layouts/layout-types.html#layout-types-conf

--- a/guides/v2.3/inventory/architecture.md
+++ b/guides/v2.3/inventory/architecture.md
@@ -7,8 +7,8 @@ Magento 2 is a highly modular system that allows 3rd-party developers to extend 
 
 Module interchangeability was one of the main reasons behind introducing [Service Layer]({{ page.baseurl }}/architecture/archi_perspectives/service_layer.html) in Magento 2. By using service contracts and providing extensions over them, 3rd-party developers can:
 
-* Enhance out-of-the-box business logic
-* Replace a module without breaking the system or other extensions relying on these contracts
+*  Enhance out-of-the-box business logic
+*  Replace a module without breaking the system or other extensions relying on these contracts
 
 In Magento 2, a set of interfaces in a module's `/Api` directory typically define the service contracts, including the APIs and their implementations. A module interface expresses the elements (entity interfaces and services to manipulate them) that the module requires. These elements defined in the interface represent a gateway for communication between modules. The implementation contains the working business logic that corresponds to the elements declared in the interface.
 
@@ -20,10 +20,10 @@ Implementing a good modular architecture means maintaining a loose coupling betw
 
 As a result of applying SRP to module responsibilities (while taking into account the multi-layered architecture of Magento), Inventory Management is comprised of independent modules responsible for:
 
-* Service contract APIs
-* Implementation of the business logic for APIs
-* Admin UI
-* Frontend UI
+*  Service contract APIs
+*  Implementation of the business logic for APIs
+*  Admin UI
+*  Frontend UI
 
 The Admin and frontend UIs can be separated, because it's possible to have two different technology stacks. The Admin UI uses UI components, while the frontend UI can use the [PWA](https://magento.github.io/pwa-studio/) studio stack, consisting of technology such as webpack, React, Redux, and GraphQL.
 
@@ -31,9 +31,9 @@ Now, instead of creating one module that covers a specialized business domain, w
 
 This approach implies additional code limitations in the modules:
 
-* All modules should depend on the API module. Implementations can be swapped in `di.xml` files.
-* API modules should contain web API tests. These tests cover API endpoints agnostically to the implementation details. Example: `InventoryApi\Tests\Api\*`
-* Only UI modules should contain MFTF tests, because these tests cover the interaction between the user and the UI. Example: `InventoryCatalogAdminUi\Test\Mftf\*`.
+*  All modules should depend on the API module. Implementations can be swapped in `di.xml` files.
+*  API modules should contain web API tests. These tests cover API endpoints agnostically to the implementation details. Example: `InventoryApi\Tests\Api\*`
+*  Only UI modules should contain MFTF tests, because these tests cover the interaction between the user and the UI. Example: `InventoryCatalogAdminUi\Test\Mftf\*`.
 
 ## Module dependencies
 
@@ -43,31 +43,31 @@ The list of Inventory Management dependencies varies, depending on whether the m
 
 For non-headless installations, Magento Inventory Management has dependencies on the following Magento 2.3 modules:
 
-* Backend
-* BundleProduct
-* Catalog
-* CatalogInventory (legacy)
-* ConfigurableProduct
-* Directory
-* EAV
-* GroupedProduct
-* ImportExport
-* Reports
-* Sales
-* Shipping
-* Store
-* UI
+*  Backend
+*  BundleProduct
+*  Catalog
+*  CatalogInventory (legacy)
+*  ConfigurableProduct
+*  Directory
+*  EAV
+*  GroupedProduct
+*  ImportExport
+*  Reports
+*  Sales
+*  Shipping
+*  Store
+*  UI
 
 ### Dependencies in a headless installation
 
 In headless installations, Magento Inventory Management is dependent on the following Magento 2.3 modules:
 
-* BundleProduct
-* Catalog
-* CatalogInventory (legacy)
-* ConfigurableProduct
-* EAV
-* GroupedProduct
-* ImportExport
-* Sales
-* Store
+*  BundleProduct
+*  Catalog
+*  CatalogInventory (legacy)
+*  ConfigurableProduct
+*  EAV
+*  GroupedProduct
+*  ImportExport
+*  Sales
+*  Store

--- a/guides/v2.3/inventory/index.md
+++ b/guides/v2.3/inventory/index.md
@@ -8,10 +8,10 @@ landing-page: Inventory
 
 {{site.data.var.im}} features include
 
-* Different configurations for merchants whose inventory originates from a single source and from multiple sources
-* Stocks for tracking available aggregated quantities through assigned sources
-* Concurrent checkout protection
-* Shipment matching algorithms
+*  Different configurations for merchants whose inventory originates from a single source and from multiple sources
+*  Stocks for tracking available aggregated quantities through assigned sources
+*  Concurrent checkout protection
+*  Shipment matching algorithms
 
 Merchants install {{site.data.var.im}} as part of v2.3.x and upgrades with the name `magento/inventory-composer-metapackage`. For details, see [Install {{site.data.var.im}}]({{site.baseurl}}/extensions/inventory-management/).
 
@@ -21,13 +21,13 @@ Merchants install {{site.data.var.im}} as part of v2.3.x and upgrades with the n
 
 The following terms are important as you work with {{site.data.var.im}} APIs:
 
-* **Sources** represent physical locations that store and ship available products. These locations can include warehouses, brick-and-mortar stores, distribution centers, and drop shippers. (Any location can be designated as a source for virtual products.)
+*  **Sources** represent physical locations that store and ship available products. These locations can include warehouses, brick-and-mortar stores, distribution centers, and drop shippers. (Any location can be designated as a source for virtual products.)
 
-* **Stocks** map a sales channel (currently limited to websites) to source locations and on-hand inventory. A stock can map to multiple sales channels, but a sales channel can be assigned to only one stock.
+*  **Stocks** map a sales channel (currently limited to websites) to source locations and on-hand inventory. A stock can map to multiple sales channels, but a sales channel can be assigned to only one stock.
 
-* **Aggregate Salable Quantity** is the total virtual inventory that can be sold through a sales channel. The amount is calculated across all sources assigned to a stock.
+*  **Aggregate Salable Quantity** is the total virtual inventory that can be sold through a sales channel. The amount is calculated across all sources assigned to a stock.
 
-* **Reservations** track deductions from the salable quantity as customers add products to carts and complete checkout. When an order ships, the reservation clears and deducts the shipped amounts from specific source inventory quantities.
+*  **Reservations** track deductions from the salable quantity as customers add products to carts and complete checkout. When an order ships, the reservation clears and deducts the shipped amounts from specific source inventory quantities.
 
 ## A simple scenario
 
@@ -39,11 +39,11 @@ In this diagram, a bicycle merchant has inventory for a mountain bike in two war
 
 ## Important {{site.data.var.im}} objects
 
-* `Source` – Defines a physical stock.
+*  `Source` – Defines a physical stock.
 
-* `SourceItem` – A relation object that represents the amount of a specific product at a physical source. We use this entity for updating inventory on each source. Quantities might change as a result of synchronizing with an external Product Information Management (PIM) or Enterprise Resource Planning (ERP) system, or internally as a stock deduction during the checkout process. A `SourceItem` cannot be used for retrieving data that must be rendered on front-end, because only aggregated data should be used for all validations and UI representation.
+*  `SourceItem` – A relation object that represents the amount of a specific product at a physical source. We use this entity for updating inventory on each source. Quantities might change as a result of synchronizing with an external Product Information Management (PIM) or Enterprise Resource Planning (ERP) system, or internally as a stock deduction during the checkout process. A `SourceItem` cannot be used for retrieving data that must be rendered on front-end, because only aggregated data should be used for all validations and UI representation.
 
-* `StockItem` – Also known as Aggregated Virtual Stock. This is read-only data that the re-indexation process generates. Based on a pre-defined mapping, we define what sources are assigned to the current scope (sales channel) and aggregate quantities from all assigned sources. We also use `StockItem` to check if a product is in or out of stock.  Making this segregation by Read-Only interface (`StockItem`) and Write-Only interface (`SourceItem`), the Inventory architecture achieves Command Query Responsibility Segregation (CQRS). As a result, all `GET` HTTP requests should use `StockItem` entity, and all `POST/PUT` should use `SourceItem`.
+*  `StockItem` – Also known as Aggregated Virtual Stock. This is read-only data that the re-indexation process generates. Based on a pre-defined mapping, we define what sources are assigned to the current scope (sales channel) and aggregate quantities from all assigned sources. We also use `StockItem` to check if a product is in or out of stock.  Making this segregation by Read-Only interface (`StockItem`) and Write-Only interface (`SourceItem`), the Inventory architecture achieves Command Query Responsibility Segregation (CQRS). As a result, all `GET` HTTP requests should use `StockItem` entity, and all `POST/PUT` should use `SourceItem`.
 
 ## Shipping algorithms
 

--- a/guides/v2.3/inventory/inventory-api-reference.md
+++ b/guides/v2.3/inventory/inventory-api-reference.md
@@ -22,47 +22,47 @@ The following interfaces and classes have been deprecated. They cannot be mapped
 
 `ScalableInventory` interfaces:
 
-- `ItemInterface`
-- `ItemsInterface`
+-  `ItemInterface`
+-  `ItemsInterface`
 
 `CatalogInventory` interfaces:
 
-- `QueryProcessorInterface`
-- `RegisterProductSaleInterface`
-- `RevertProductSaleInterface`
-- `StockCollectionInterface`
-- `StockConfigurationInterface`
-- `StockCriteriaInterface`
-- `StockIndexInterface`
-- `StockInterface` (indexer)
-- `StockInterface`
-- `StockItemCollectionInterface`
-- `StockItemCriteriaInterface`
-- `StockItemInterface`
-- `StockItemRepositoryInterface`
-- `StockManagementInterface`
-- `StockRegistryInterface`
-- `StockRepositoryInterface`
-- `StockStateInterface`
-- `StockStatusCollectionInterface`
-- `StockStatusCriteriaInterface`
-- `StockStatusInterface`
-- `StockStatusRepositoryInterface`
+-  `QueryProcessorInterface`
+-  `RegisterProductSaleInterface`
+-  `RevertProductSaleInterface`
+-  `StockCollectionInterface`
+-  `StockConfigurationInterface`
+-  `StockCriteriaInterface`
+-  `StockIndexInterface`
+-  `StockInterface` (indexer)
+-  `StockInterface`
+-  `StockItemCollectionInterface`
+-  `StockItemCriteriaInterface`
+-  `StockItemInterface`
+-  `StockItemRepositoryInterface`
+-  `StockManagementInterface`
+-  `StockRegistryInterface`
+-  `StockRepositoryInterface`
+-  `StockStateInterface`
+-  `StockStatusCollectionInterface`
+-  `StockStatusCriteriaInterface`
+-  `StockStatusInterface`
+-  `StockStatusRepositoryInterface`
 
 `CatalogInventory` classes:
 
-- `Backorders`
-- `DefaultStock`
-- `DefaultStockqty`
-- `Item`
-- `Minsaleqty`
-- `Qtyincrements`
-- `QuantityValidator`
-- `Status`
-- `Stock` (Helper)
-- `Stock` (model/source)
-- `Stock`
-- `StockFactory`
+-  `Backorders`
+-  `DefaultStock`
+-  `DefaultStockqty`
+-  `Item`
+-  `Minsaleqty`
+-  `Qtyincrements`
+-  `QuantityValidator`
+-  `Status`
+-  `Stock` (Helper)
+-  `Stock` (model/source)
+-  `Stock`
+-  `StockFactory`
 
 ## {{site.data.var.im}} API
 

--- a/guides/v2.3/inventory/source-selection-algorithms.md
+++ b/guides/v2.3/inventory/source-selection-algorithms.md
@@ -5,15 +5,15 @@ title: Source selection algorithms
 
 The **Source Selection Algorithm (SSA)** recommends how to fulfill partial and full shipments. The merchant decides which business needs take precedence when deciding which shipping method to use:
 
-* Should the products be delivered from the sources designated as having the highest priority?
-* Should the total shipment cost be the primary factor in choosing a shipment method?
-* Should the shipments originate from the closest source?
-* Should the fastest shipping method with the shortest delivery time be used, even if it's not the cheapest?
+*  Should the products be delivered from the sources designated as having the highest priority?
+*  Should the total shipment cost be the primary factor in choosing a shipment method?
+*  Should the shipments originate from the closest source?
+*  Should the fastest shipping method with the shortest delivery time be used, even if it's not the cheapest?
 
 Magento provides the following algorithms:
 
-* Source priority
-* Distance priority
+*  Source priority
+*  Distance priority
 
 Third party developers can create additional algorithms to help merchants decide which shipping option best meets their needs.
 
@@ -25,10 +25,10 @@ Custom stocks include an assigned list of sources to sell and ship available pro
 
 When run, the algorithm:
 
-* Works through the configured order of sources at the stock level starting at the top
-* Skips any disabled sources
-* Continues down the list until the order shipment is filled
-* Recommends a quantity to ship and source per product based on the order in the list, available quantity, and quantity ordered
+*  Works through the configured order of sources at the stock level starting at the top
+*  Skips any disabled sources
+*  Continues down the list until the order shipment is filled
+*  Recommends a quantity to ship and source per product based on the order in the list, available quantity, and quantity ordered
 
 ## Distance Priority algorithm
 
@@ -58,21 +58,21 @@ Taking into account that there are at least two valid business cases when to lau
 
 Use these interfaces to create your own SSA:
 
-* [InventoryRequestInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/InventoryRequestInterface.php) requests products for a given quantity and stock ID
-* [ItemRequestInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/ItemRequestInterface.php) represents the requested quantity for a specific SKU
-* [SourceSelectionServiceInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/SourceSelectionServiceInterface.php) returns the source selection algorithm result for the specified `inventoryRequest`
-* [GetSourceSelectionAlgorithmListInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/GetSourceSelectionAlgorithmListInterface.php) returns the list of data interfaces that represent registered SSAs
-* [SourceSelectionAlgorithmInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/SourceSelectionAlgorithmInterface.php) represents a single SSA
-* [SourceSelectionInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Model/SourceSelectionInterface.php) returns the SSA result for the specified `inventoryRequest`
-* [GetDistanceInterface](https://github.com/magento-engcom/msi/blob/2.3-develop/app/code/Magento/InventoryDistanceBasedSourceSelectionApi/Api/GetDistanceInterface.php)  - returns the distance between the source and the shipping address in kilometers without specifying the units. To change this behavior, provide your own implementation for `\Magento\InventoryDistanceBasedSourceSelection\Model\DistanceProvider\GoogleMap\GetDistance`.
+*  [InventoryRequestInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/InventoryRequestInterface.php) requests products for a given quantity and stock ID
+*  [ItemRequestInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/ItemRequestInterface.php) represents the requested quantity for a specific SKU
+*  [SourceSelectionServiceInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/SourceSelectionServiceInterface.php) returns the source selection algorithm result for the specified `inventoryRequest`
+*  [GetSourceSelectionAlgorithmListInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/GetSourceSelectionAlgorithmListInterface.php) returns the list of data interfaces that represent registered SSAs
+*  [SourceSelectionAlgorithmInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Api/Data/SourceSelectionAlgorithmInterface.php) represents a single SSA
+*  [SourceSelectionInterface](https://github.com/magento-engcom/msi/blob/2.3.0-release/app/code/Magento/InventorySourceSelectionApi/Model/SourceSelectionInterface.php) returns the SSA result for the specified `inventoryRequest`
+*  [GetDistanceInterface](https://github.com/magento-engcom/msi/blob/2.3-develop/app/code/Magento/InventoryDistanceBasedSourceSelectionApi/Api/GetDistanceInterface.php)  - returns the distance between the source and the shipping address in kilometers without specifying the units. To change this behavior, provide your own implementation for `\Magento\InventoryDistanceBasedSourceSelection\Model\DistanceProvider\GoogleMap\GetDistance`.
 
 ## Develop a custom algorithm
 
 As you develop your custom Source Selection Algorithm, keep these design considerations in mind:
 
-* Implement `SourceSelectionInterface`
-* If your module provides an SSA on quotes, introduce your own `InventoryRequestFactory`
-* Register your SSA within a `di.xml` file
+*  Implement `SourceSelectionInterface`
+*  If your module provides an SSA on quotes, introduce your own `InventoryRequestFactory`
+*  Register your SSA within a `di.xml` file
 
 ### Implement  `SourceSelectionInterface`
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.3/get-started`
- `guides/v2.3/inventory`
- `guides/v2.3/frontend-dev-guide`