### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.md
@@ -16,21 +16,21 @@ Look for the following highlights in this release:
 
 This release is focused on substantial security enhancements:
 
-* **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
+*  **75 security enhancements** that help close cross-site scripting (XSS), remote code execution (RCE), and sensitive data disclosure vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.9) have been ported to 2.3.2, 2.1.18, 1.14.4.2, and 1.9.4.2, as appropriate.
 
-* **Google reCAPTCHA module for PayPal Payflow checkout**. The new Paypal Recaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form. This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html). <!--- MC-15427-->
+*  **Google reCAPTCHA module for PayPal Payflow checkout**. The new Paypal Recaptcha module adds Google reCAPTCHA and CAPTCHA to the Payflow Pro checkout form. This enhanced functionality has been added in response to malicious targeting of Magento deployments that implement Payflow Pro. Configuration information can be found in [Google reCAPTCHA](https://docs.magento.com/m2/ee/user_guide/stores/security-google-recaptcha.html). <!--- MC-15427-->
 
 ### Infrastructure improvements
 
 This release contains 150 enhancements to core quality, which improve the quality of the Framework and these modules: `Catalog`, `Sales`, `Checkout/One Page Checkout`, `UrlRewrite`, `Customer/Customers`, and `UI`. Here are some additional core enhancements:
 
-* **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.
+*  **Braintree payment method is now supported for checkout with multiple addresses**. Previously, you could not use Braintree and Braintree PayPal when checking out an order that was being shipped to multiple addresses.
 
 <!--- MAGETWO-98424-->
 
-* **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98948-->
+*  **The CGI URL gateway in UPS module has been updated from HTTP to HTTPS**. The CGI URL gateway endpoint in the UPS module has been updated from HTTP to HTTPS in response to the disablement of the HTTP gateway by UPS in mid-2019. See [Magento User Guide](https://docs.magento.com/m2/ee/user_guide/shipping/ups.html) for a discussion of using the UPS shipment method. Shipping method configuration settings are described in the [Shipping methods](https://docs.magento.com/m2/ee/user_guide/configuration/sales/shipping-methods.html#UPS). <!--- MAGETWO-98948-->
 
-* **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
+*  **Google chart API updated to the Image-Charts**. Magento now uses the Image-Charts free service to render static charts in Admin dashboards. Earlier deployments used Google Image Charts, which was deprecated in 2012 and turned off on [March 18, 2019](https://developers.google.com/chart/image/docs/making_charts). <!--- MAGETWO-98833-->
 
 ## Functional fixes
 
@@ -40,387 +40,387 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- MAGETWO-76424 -->
 
-* Magento no longer displays an extraneous blank option in the country drop-down menu on the Country Options page for store configuration settings (**Stores** > **Settings** > **Configuration** > **General** > **Country Options**).
+*  Magento no longer displays an extraneous blank option in the country drop-down menu on the Country Options page for store configuration settings (**Stores** > **Settings** > **Configuration** > **General** > **Country Options**).
 
 <!-- ENGCOM-4741 -->
 
-* Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`. *Fix submitted by David Alger in pull request [22282](https://github.com/magento/magento2/pull/22282)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
+*  Magento no longer throws an error when executing `bin/magento setup:static-content:deploy` in parallel mode if theme or locale deployment takes more than 400 seconds. Previously, Magento threw the following error under these conditions: `2436; Status: 0`. *Fix submitted by David Alger in pull request [22282](https://github.com/magento/magento2/pull/22282)*. [GitHub-15090](https://github.com/magento/magento2/issues/15090)
 
 <!-- ENGCOM-4829 -->
 
-* All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by Keyur Kanani in pull request [22499](https://github.com/magento/magento2/pull/22499)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
+*  All fields are now hidden with appropriate dependencies as assigned in the backup configuration settings. *Fix submitted by Keyur Kanani in pull request [22499](https://github.com/magento/magento2/pull/22499)*. [GitHub-22474](https://github.com/magento/magento2/issues/22474)
 
 <!-- ENGCOM-4791 -->
 
-* Magento now sets the `id_prefix` option on prefix cache keys for the cache front end during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work. *Fix submitted by Cash and Carry Furniture in pull request [22439](https://github.com/magento/magento2/pull/22439)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
+*  Magento now sets the `id_prefix` option on prefix cache keys for the cache front end during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento `app/etc` directory. But if this value is not exactly the same on all web servers, cache invalidation will not work. *Fix submitted by Cash and Carry Furniture in pull request [22439](https://github.com/magento/magento2/pull/22439)*. [GitHub-15828](https://github.com/magento/magento2/issues/15828)
 
 ### AdminGWS
 
 <!-- MAGETWO-98053 -->
 
-* The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to.
+*  The total displayed on the widgets table (**Content** > **Elements** > **Widgets**) now reflects only the widgets for which the administrator has privilege. Previously, in a multi-site installation, the total displayed included widgets that the administrator did not have access to.
 
 <!-- MAGETWO-87222 -->
 
-* Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible.
+*  Magento now displays the Cart Price Rules list (**Marketing** > **Promotions** > **Cart Price Rules**) as expected when you add a new rule. Previously, the grid was not visible.
 
 ### Backend
 
 <!-- ENGCOM-4517 -->
 
-* The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by Ananth Iyer in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
+*  The JavaScript `minify` field on **Stores** > **Configuration** > **Advanced** > **Developer** is now disabled as expected. *Fix submitted by Ananth Iyer in pull request [21800](https://github.com/magento/magento2/pull/21800)*. [GitHub-21384](https://github.com/magento/magento2/issues/21384)
 
 <!-- ENGCOM-4435 -->
 
-* Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by Pratik Oza in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
+*  Magento now displays the correct date in the Admin for scheduled design changes. Previously, Magento displayed the current date instead of the scheduled date on **Content** > **Design** > **Schedule**. *Fix submitted by Pratik Oza in pull request [21568](https://github.com/magento/magento2/pull/21568)*. [GitHub-21425](https://github.com/magento/magento2/issues/21425)
 
 <!-- ENGCOM-4121 -->
 
-* Fixed the alignment of the time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Amol Chaudhari in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
+*  Fixed the alignment of the time fields in **Admin** > **Configuration** > **General** > **Advanced Reporting** in tablet landscape view. *Fix submitted by Amol Chaudhari in pull request [20602](https://github.com/magento/magento2/pull/20602)*. [GitHub-20580](https://github.com/magento/magento2/issues/20580)
 
 <!-- ENGCOM-4142 -->
 
-* Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Govind Sharma in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
+*  Magento now displays a success message when you create an order through the Admin and the **create shipment** and **Email copy of invoice** checkboxes are checked. *Fix submitted by Govind Sharma in pull request [20776](https://github.com/magento/magento2/pull/20776)*. [GitHub-19942](https://github.com/magento/magento2/issues/19942)
 
 <!-- ENGCOM-4229 -->
 
-* Fixed the alignment of the reload CAPTCHA icon on the Admin login page. *Fix submitted by Pratik Oza in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
+*  Fixed the alignment of the reload CAPTCHA icon on the Admin login page. *Fix submitted by Pratik Oza in pull request [21162](https://github.com/magento/magento2/pull/21162)*. [GitHub-20911](https://github.com/magento/magento2/issues/20911)
 
 <!-- ENGCOM-4768 -->
 
-* The Web Setup Wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by JeroenVanLeusden in pull request [22369](https://github.com/magento/magento2/pull/22369)*. [GitHub-11892](https://github.com/magento/magento2/issues/11892), [GitHub-7623](https://github.com/magento/magento2/issues/7623)
+*  The Web Setup Wizard now uses the correct base path to check if the setup folder exists. Previously, the wizard checked `base/data/web/magento2/pubsetup` instead of `/data/web/magento2/pub/setup`. *Fix submitted by JeroenVanLeusden in pull request [22369](https://github.com/magento/magento2/pull/22369)*. [GitHub-11892](https://github.com/magento/magento2/issues/11892), [GitHub-7623](https://github.com/magento/magento2/issues/7623)
 
 ### B2B
 
 <!-- MAGETWO-99000 -->
 
-* Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
+*  Store switcher now works as expected in deployments that use the shared catalog structure. Previously, the store switcher in the shared catalog structure configuration used the store's `group_id` instead of the `store_id` to filter product collection.
 
 <!-- MAGETWO-98553 -->
 
-* The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog.
+*  The `catalogpermissions_category` indexer in Update On Schedule mode now correctly picks up on the structure of a shared catalog.
 
 <!-- MAGETWO-98678 -->
 
-* You can now add backordered products to the cart when backorders are enabled.
+*  You can now add backordered products to the cart when backorders are enabled.
 
 <!-- MAGETWO-95281 -->
 
-* When you move a customer from one company to another, quotes now remain associated with the customer who generated the quotes. Previously, a quote did not appear in the customer’s account on the storefront after the move.
+*  When you move a customer from one company to another, quotes now remain associated with the customer who generated the quotes. Previously, a quote did not appear in the customer’s account on the storefront after the move.
 
 ### Bundle products
 
 <!-- ENGCOM-4041 -->
 
-* Fixed the alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by Amol Chaudhari in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
+*  Fixed the alignment of the bundle product radio button on the Product page when you click **Customize** and **Add to cart**. *Fix submitted by Amol Chaudhari in pull request [20743](https://github.com/magento/magento2/pull/20743)*. [GitHub-20518](https://github.com/magento/magento2/issues/20518)
 
 <!-- ENGCOM-4557 -->
 
-* Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by Amol Chaudhari in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
+*  Magento now calculates and displays the correct tier price for bundle products. *Fix submitted by Amol Chaudhari in pull request [21844](https://github.com/magento/magento2/pull/21844)*. [GitHub-21467](https://github.com/magento/magento2/issues/21467)
 
 <!-- ENGCOM-4143 -->
 
-* Fixed the alignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view. *Fix submitted by Amol Chaudhari in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
+*  Fixed the alignment of the **Add to cart** button on the bundle product page in portrait orientation in mobile view. *Fix submitted by Amol Chaudhari in pull request [20554](https://github.com/magento/magento2/pull/20554)*. [GitHub-20193](https://github.com/magento/magento2/issues/20193)
 
 <!-- MAGETWO-97226 -->
 
-* Magento now displays the correct price on the storefront for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
+*  Magento now displays the correct price on the storefront for products whose prices have been updated in a shared catalog. Previously, Magento did not update storefront prices when a price in the shared catalog was updated.
 
 ### Cache
 
 <!-- ENGCOM-4841 -->
 
-* CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by Amol Chaudhari in pull request [22534](https://github.com/magento/magento2/pull/22534)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
+*  CMS block cache keys now contain the appropriate store ID in deployments with multiple store views. Previously, Magento always loaded the cached version of the block for the first store view. *Fix submitted by Amol Chaudhari in pull request [22534](https://github.com/magento/magento2/pull/22534)*. [GitHub-22299](https://github.com/magento/magento2/issues/22299)
 
 ### Catalog
 
 <!-- MAGETWO-94426 -->
 
-* Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
+*  Dates in the Admin are now formatted correctly for French locales (dd/mm/yyyy).
 
 <!-- MAGETWO-74081 -->
 
-* You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
+*  You can now use the term _configurable_ as a group name in attribute sets. Previously, Magento threw an error when you used this term as a group name and subsequently tried to add or edit a product. [GitHub-6123](https://github.com/magento/magento2/issues/6123)
 
 <!-- MAGETWO-98626 -->
 
-* URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
+*  URLS in Arabic now resolve as expected. Previously, when you created a URL rewrite in Arabic, the browser returned a 404.
 
 <!-- MAGETWO-74455 -->
 
-* Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values.
+*  Magento now creates unique values for product attributes as expected when you duplicate a product. Previously, Magento duplicated a product, but both products had the same attribute values.
 
 <!-- MAGETWO-74037 -->
 
-* During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
+*  During product creation, Magento now displays default attribute values from the **Admin** column on the Manage Options (Values of Your Attribute) window when creating options. Previously, Magento displayed attribute options from the default storeview. [GitHub-6507](https://github.com/magento/magento2/issues/6507)
 
 <!-- MAGETWO-73157 -->
 
-* Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the configurabe options from the newly created product to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
+*  Magento now displays informative messages when you create a new product and try to set its SKU to one that is assigned to an existing product. Previously, under these circumstances, Magento displayed an informative message, but also imported the configurabe options from the newly created product to the older product. [GitHub-9457](https://github.com/magento/magento2/issues/9457)
 
 <!-- MAGETWO-72650 -->
 
-* Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
+*  Tax recalculation has been moved out of the transaction into the background for negotiable quotes running in an environment where B2B is deployed. This improves performance and helps avoid server timeouts.
 
 <!-- MAGETWO-97472 -->
 
-* Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level.
+*  Catalog Permission rules that are set for a category now remain applied when a new category is created at the same level.
 
 <!-- MAGETWO-97405 -->
 
-* You can now use storeview-level attributes to filter products on the products list.
+*  You can now use storeview-level attributes to filter products on the products list.
 
 <!-- MAGETWO-97400 -->
 
-* The selected store scope view now affects the categories displayed on the product edit page's category tree.
+*  The selected store scope view now affects the categories displayed on the product edit page's category tree.
 
 <!-- MAGETWO-97973 -->
 
-* Magento now calculates and displays the correct tier price for bundle products.
+*  Magento now calculates and displays the correct tier price for bundle products.
 
 <!-- MAGETWO-95616 -->
 
-* Magento no longer permits you to change an attribute set if the new set does not have the same attributes as the original set. Previously, Magento sometimes threw the following exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.`
+*  Magento no longer permits you to change an attribute set if the new set does not have the same attributes as the original set. Previously, Magento sometimes threw the following exception when you tried to change attribute sets: `Attempt to load value of nonexistent EAV attribute.`
 
 <!-- MAGETWO-97380 -->
 
-* You can now add grouped products to the shopping cart as expected when category permissions are enabled.
+*  You can now add grouped products to the shopping cart as expected when category permissions are enabled.
 
 <!-- MAGETWO-97425 -->
 
-* Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty.
+*  Magento does not display the **Country of Manufacture** field under the More Information tab of the product page when this value is empty.
 
 <!-- MAGETWO-98470 -->
 
-* Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave special prices empty.
+*  Scope assigned to prices in Catalog Price Scope (set in **Configuration** > **Price**) are now maintained when price is set to empty. Previously, you could not leave special prices empty.
 
 <!-- MAGETWO-95020 -->
 
-* Clicking on the root category for a store now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
+*  Clicking on the root category for a store now causes only that root category to expand. Previously, Magento expanded all other Root Categories into the top-level categories.
 
 <!-- ENGCOM-3697 -->
 
-* Magento now displays breadcrumbs in the proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
+*  Magento now displays breadcrumbs in the proper format. Previously, subcategories did not appear in breadcrumbs. *Fix submitted by Brandon Brown in pull request [19760](https://github.com/magento/magento2/pull/19760)*. [GitHub-7967](https://github.com/magento/magento2/issues/7967)
 
 <!-- ENGCOM-4245 -->
 
-* Fixed the alignment of the **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
+*  Fixed the alignment of the **Schedule Update From** field on the Admin category page when displayed in a browser set to 768 x 1147 resolution. *Fix submitted by Amol Chaudhari in pull request [20404](https://github.com/magento/magento2/pull/20404)*. [GitHub-20402](https://github.com/magento/magento2/issues/20402)
 
 <!-- ENGCOM-4030 -->
 
-* Fixed the alignment of product page tab content in mobile view. *Fix submitted by Amol Chaudhari in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
+*  Fixed the alignment of product page tab content in mobile view. *Fix submitted by Amol Chaudhari in pull request [20476](https://github.com/magento/magento2/pull/20476)*. [GitHub-20468](https://github.com/magento/magento2/issues/20468)
 
 <!-- ENGCOM-4254 -->
 
-* Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list. *Fix submitted by Pratik Oza in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
+*  Magento now displays currency symbols as expected for products in the Cost column of the Admin catalog list. *Fix submitted by Pratik Oza in pull request [21157](https://github.com/magento/magento2/pull/21157)*. [GitHub-20906](https://github.com/magento/magento2/issues/20906)
 
 <!-- ENGCOM-4236 -->
 
-* Corrected the behavior of the dropdown menu on the Option Type field in the New Option section of the Customizable Option page. *Fix submitted by Pratik Oza in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
+*  Corrected the behavior of the dropdown menu on the Option Type field in the New Option section of the Customizable Option page. *Fix submitted by Pratik Oza in pull request [21159](https://github.com/magento/magento2/pull/21159)*. [GitHub-20989](https://github.com/magento/magento2/issues/20989)
 
 <!-- ENGCOM-4292 -->
 
-* Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. *Fix submitted by Amol Chaudhari in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
+*  Magento now correctly calculates multi-currency custom option prices when the option price type is `percentage`. *Fix submitted by Amol Chaudhari in pull request [21263](https://github.com/magento/magento2/pull/21263)*. [GitHub-19561](https://github.com/magento/magento2/issues/19561)
 
 <!-- ENGCOM-4290 -->
 
-* You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw the following error: `Special price date from" Failed to parse time string`. *Fix submitted by Milan Osztromok in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
+*  You can now create a new product with a special price. Previously, when you saved the newly created product, Magento threw the following error: `Special price date from" Failed to parse time string`. *Fix submitted by Milan Osztromok in pull request [21273](https://github.com/magento/magento2/pull/21273)*. [GitHub-18158](https://github.com/magento/magento2/issues/18158)
 
 <!-- ENGCOM-4327 -->
 
-* The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by Amol Chaudhari in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
+*  The `product_type` attribute now contains the correct value in the CVS file that is created during export after you create a `custom type_id` attribute. *Fix submitted by Amol Chaudhari in pull request [21208](https://github.com/magento/magento2/pull/21208)*. [GitHub-19891](https://github.com/magento/magento2/issues/19891)
 
 <!-- ENGCOM-4340 -->
 
-* The `product:price:amount` metatag for a product now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by Pratik Oza in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
+*  The `product:price:amount` metatag for a product now contains the price converted to the appropriate base currency in multistore deployments with stores that use different base currencies. Previously, price in this metatag was always calculated in the base currency. *Fix submitted by Pratik Oza in pull request [21202](https://github.com/magento/magento2/pull/21202)*. [GitHub-20010](https://github.com/magento/magento2/issues/20010)
 
 <!-- ENGCOM-4429 -->
 
-* Magento no longer adds tax twice when adding a new product with tier pricing. Previously,the `MinimalTierPriceCalculator` function applied the tax twice when calculating the minimal price. *Fix submitted by Eduard Chitoraga in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
+*  Magento no longer adds tax twice when adding a new product with tier pricing. Previously,the `MinimalTierPriceCalculator` function applied the tax twice when calculating the minimal price. *Fix submitted by Eduard Chitoraga in pull request [21527](https://github.com/magento/magento2/pull/21527)*. [GitHub-21383](https://github.com/magento/magento2/issues/21383)
 
 <!-- ENGCOM-4447 -->
 
-* The `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files now allow modules with names that contain numbers. *Fix submitted by Lisovyi Yevhenii in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+*  The `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files now allow modules with names that contain numbers. *Fix submitted by Lisovyi Yevhenii in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
 <!-- ENGCOM-4182 -->
 
-* Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed the following warning: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by Nazar Klovanych in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
+*  Magento now correctly displays the mass product update attributes page when **Minimum Qty Allowed in Shopping Cart** is set. Previously, Magento displayed the following warning: `Exception #0 (Exception): Warning: A non-numeric value encountered in /var/www/html/vendor/magento/module-catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml on line 109 is present`. *Fix submitted by Nazar Klovanych in pull request [21080](https://github.com/magento/magento2/pull/21080)*. [GitHub-21073](https://github.com/magento/magento2/issues/21073)
 
 <!-- ENGCOM-4271 -->
 
-* You can now open the product details page from the compare products side bar. *Fix submitted by Eduard Chitoraga in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
+*  You can now open the product details page from the compare products side bar. *Fix submitted by Eduard Chitoraga in pull request [21238](https://github.com/magento/magento2/pull/21238)*. [GitHub-21101](https://github.com/magento/magento2/issues/21101)
 
 <!-- ENGCOM-4020 -->
 
-* Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Amol Chaudhari in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
+*  Magento no longer increments stock for products for which stock managing has been disabled. Previously, Magento increased the product quantity count when an order failed if **Manage Stock** was disabled. *Fix submitted by Amol Chaudhari in pull request [20644](https://github.com/magento/magento2/pull/20644)*. [GitHub-19482](https://github.com/magento/magento2/issues/19482)
 
 <!-- ENGCOM-4514 -->
 
-* We have replaced the incorrect proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
+*  We have replaced the incorrect proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver` in `di.xml`. (Specifically, `<argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
  has been replaced with the following argument:
   `<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`. ) *Fix submitted by VitaliyBoyko in pull request [21793](https://github.com/magento/magento2/pull/21793)*. [GitHub-167](https://github.com/magento/magento2/issues/167)
 
 <!-- MAGETWO-98794 -->
 
-* You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product using this method, Magento displayed the following message: `The SKU was not found in the catalog.`
+*  You can now add a product to an order by using the **Add products by SKU** button. Previously, when you tried to add a product using this method, Magento displayed the following message: `The SKU was not found in the catalog.`
 
 <!-- ENGCOM-4823 -->
 
-* Magento now increments product quantity correctly when a guest user adds products to the cart and later logs in. Previously, Magento added items separately instead. *Fix submitted by Amol Chaudhari in pull request [22378](https://github.com/magento/magento2/pull/22378)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
+*  Magento now increments product quantity correctly when a guest user adds products to the cart and later logs in. Previously, Magento added items separately instead. *Fix submitted by Amol Chaudhari in pull request [22378](https://github.com/magento/magento2/pull/22378)*. [GitHub-21375](https://github.com/magento/magento2/issues/21375)
 
 <!-- ENGCOM-4253 -->
 
-* **Meta Keywords** and **Meta Description** are now defined as `textarea` throughout product forms. Previously, they were defined as `input`. *Fix submitted by Amol Chaudhari in pull request [21199](https://github.com/magento/magento2/pull/21199)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
+*  **Meta Keywords** and **Meta Description** are now defined as `textarea` throughout product forms. Previously, they were defined as `input`. *Fix submitted by Amol Chaudhari in pull request [21199](https://github.com/magento/magento2/pull/21199)*. [GitHub-20555](https://github.com/magento/magento2/issues/20555)
 
 ### Catalog rule
 
 <!-- MAGETWO-98679 -->
 
-* Catalog rules are applied as expected after a customer uses Visual Merchandiser to drag and drop products in a category. Previously, discounts that were applied to products through a catalog rule were lost after the product was dragged and dropped.
+*  Catalog rules are applied as expected after a customer uses Visual Merchandiser to drag and drop products in a category. Previously, discounts that were applied to products through a catalog rule were lost after the product was dragged and dropped.
 
 ### Cart and checkout
 
 <!-- MAGETWO-98569 -->
 
-* Magento now persists the shipping quote in the shopping cart for guest customers when the **Persistent Shopping Cart** feature is enabled.
+*  Magento now persists the shipping quote in the shopping cart for guest customers when the **Persistent Shopping Cart** feature is enabled.
 
 <!-- MAGETWO-98365 -->
 
-* Magento now applies the correct tier price for a product based on the customer's assigned group when they log in, even if the item was added in a previous session when the customer was logged in as a guest. Previously, Magento did not apply the correct tier price to products added when the customer was still a guest.
+*  Magento now applies the correct tier price for a product based on the customer's assigned group when they log in, even if the item was added in a previous session when the customer was logged in as a guest. Previously, Magento did not apply the correct tier price to products added when the customer was still a guest.
 
 <!-- MAGETWO-97950 -->
 
-* Magento now correctly updates the minicart if a selected product is disabled during the shopping session.
+*  Magento now correctly updates the minicart if a selected product is disabled during the shopping session.
 
 <!-- ENGCOM-4013, 4283 -->
 
-* Corrected the alignment of the order item details label and subtotal label in mobile view. *Fix submitted by Rajneesh Gupta in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
+*  Corrected the alignment of the order item details label and subtotal label in mobile view. *Fix submitted by Rajneesh Gupta in pull request [21243](https://github.com/magento/magento2/pull/21243)*. [GitHub-20299](https://github.com/magento/magento2/issues/20299)
 
 <!-- ENGCOM-4127 -->
 
-* The title of the shipping method no longer overlaps with the **Edit** button on the checkout page. *Fix submitted by Amol Chaudhari in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
+*  The title of the shipping method no longer overlaps with the **Edit** button on the checkout page. *Fix submitted by Amol Chaudhari in pull request [20443](https://github.com/magento/magento2/pull/20443)*. [GitHub-20427](https://github.com/magento/magento2/issues/20427)
 
 <!-- ENGCOM-4043 -->
 
-* Fixed issue displaying numbers that exceed two digits in the **Qty:** field of the **Proceed to Checkout** pop- up. *Fix submitted by Amol Chaudhari in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
+*  Fixed issue displaying numbers that exceed two digits in the **Qty:** field of the **Proceed to Checkout** pop- up. *Fix submitted by Amol Chaudhari in pull request [20738](https://github.com/magento/magento2/pull/20738)*. [GitHub-20611](https://github.com/magento/magento2/issues/20611)
 
 <!-- ENGCOM- 4133-->
 
-* Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by Amol Chaudhari in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
+*  Fixed problems with the display of the tooltip drop-down pointer on the checkout page in tablet view. *Fix submitted by Amol Chaudhari in pull request [20490](https://github.com/magento/magento2/pull/20490)*. [GitHub-20487](https://github.com/magento/magento2/issues/20487)
 
 <!-- ENGCOM-4205 -->
 
-* Fixed the alignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
+*  Fixed the alignment of the **View and Edit Cart** link in the mini cart. *Fix submitted by Rajneesh Gupta in pull request [21124](https://github.com/magento/magento2/pull/21124)*. [GitHub-20382](https://github.com/magento/magento2/issues/20382)
 
 <!-- ENGCOM-4390 -->
 
-* Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null when an account was created after checkout. *Fix submitted by Nazar Klovanych in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
+*  Magento now persists customer-related values after a guest customer converts her account to a customer account after checkout. Previously, Magento saved these customer-related values as null when an account was created after checkout. *Fix submitted by Nazar Klovanych in pull request [21325](https://github.com/magento/magento2/pull/21325)*. [GitHub-19166](https://github.com/magento/magento2/issues/19166)
 
 <!-- ENGCOM-4421 -->
 
-* Magento now displays an error message as expected when a customer clicks on **Add to cart** without selecting at least one product from the recently ordered product list. *Fix submitted by Prince Patel in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
+*  Magento now displays an error message as expected when a customer clicks on **Add to cart** without selecting at least one product from the recently ordered product list. *Fix submitted by Prince Patel in pull request [21538](https://github.com/magento/magento2/pull/21538)*. [GitHub-21398](https://github.com/magento/magento2/issues/21398)
 
 <!-- ENGCOM-4436 -->
 
-* The **Cancel** button on the checkout page now works as expected. *Fix submitted by Pratik Oza in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
+*  The **Cancel** button on the checkout page now works as expected. *Fix submitted by Pratik Oza in pull request [21569](https://github.com/magento/magento2/pull/21569)*. [GitHub-21327](https://github.com/magento/magento2/issues/21327)
 
 <!-- ENGCOM-4479 -->
 
-* Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by Wojtek Naruniec in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
+*  Magento no longer runs `UpdateItemQty` validation before a Clear Shopping Cart action is triggered. Previously, due to the timing of this validation, you could not empty the shopping cart if any product in the cart was out-of-stock. *Fix submitted by Wojtek Naruniec in pull request [21528](https://github.com/magento/magento2/pull/21528)*. [GitHub-21294](https://github.com/magento/magento2/issues/21294)
 
 <!-- ENGCOM-4369 -->
 
-* Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by Amol Chaudhari in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
+*  Magento no longer displays the infinite loading indicator when you proceed to check out. Previously, Magento displayed the loading indicator, and threw the following JavaScript error: `Cannot read property 'quoteData' of undefined`. *Fix submitted by Amol Chaudhari in pull request [21432](https://github.com/magento/magento2/pull/21432)*. [GitHub-14412](https://github.com/magento/magento2/issues/14412)
 
 <!-- ENGCOM-4630 -->
 
-* Magento no longer empties the shopping cart when you click **Enter** after changing the product quantity. *Fix submitted by Leandro F. L. in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
+*  Magento no longer empties the shopping cart when you click **Enter** after changing the product quantity. *Fix submitted by Leandro F. L. in pull request [21512](https://github.com/magento/magento2/pull/21512)*. [GitHub-21499](https://github.com/magento/magento2/issues/21499)
 
 <!-- ENGCOM-4622 -->
 
-* Screen readers can now identify the `label` elements that are linked to `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated. *Fix submitted by Amol Chaudhari in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
+*  Screen readers can now identify the `label` elements that are linked to `input` fields for street address fields on the checkout page. Previously, screen readers could not identify these fields because the elements were not populated. *Fix submitted by Amol Chaudhari in pull request [22070](https://github.com/magento/magento2/pull/22070)*. [GitHub-10893](https://github.com/magento/magento2/issues/10893)
 
 <!-- MAGETWO-96375 -->
 
-* Magento now factors in cart price rule discounts before assessing whether free shipping order minimums have been reached for an order. Previously, Magento assessed free shipping before discounts were applied.
+*  Magento now factors in cart price rule discounts before assessing whether free shipping order minimums have been reached for an order. Previously, Magento assessed free shipping before discounts were applied.
 
 <!-- ENGCOM-4677 -->
 
-* The **Close** button on the mini cart no longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20844](https://github.com/magento/magento2/pull/20844)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
+*  The **Close** button on the mini cart no longer overlaps with the shipping section when the checkout page is opened on a mobile device. *Fix submitted by Pratik Oza in pull request [20844](https://github.com/magento/magento2/pull/20844)*. [GitHub-20614](https://github.com/magento/magento2/issues/20614)
 
 ### Cart Price rule
 
 <!-- ENGCOM-4540 -->
 
-* Added a new condition type Subtotal (Excl. Tax) to configure discounts that exclude the sales tax when calculating the subtotal on a Total Amount cart rule.  See [Price rules](https://docs.magento.com/m2/ee/user_guide/marketing/price-rule-discount-minimum-purchase.html). *Fix submitted by Eduard Chitoraga in pull request [21845](https://github.com/magento/magento2/pull/21845)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
+*  Added a new condition type Subtotal (Excl. Tax) to configure discounts that exclude the sales tax when calculating the subtotal on a Total Amount cart rule.  See [Price rules](https://docs.magento.com/m2/ee/user_guide/marketing/price-rule-discount-minimum-purchase.html). *Fix submitted by Eduard Chitoraga in pull request [21845](https://github.com/magento/magento2/pull/21845)*. [GitHub-12396](https://github.com/magento/magento2/issues/12396)
 
 ### Checkout agreements
 
 <!-- ENGCOM-3989 -->
 
-* Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Vishal Gelani in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
+*  Magento no longer throws SQL errors when table prefixes are used. *Fix submitted by Vishal Gelani in pull request [18866](https://github.com/magento/magento2/pull/18866)*. [GitHub-18357](https://github.com/magento/magento2/issues/18357), [GitHub-18954](https://github.com/magento/magento2/issues/18954)
 
 ### Clean up and minor refactoring
 
 <!-- ENGCOM-4304 -->
 
-* Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by Amol Chaudhari in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
+*  Removed excessive white space from the top of CMS pages when displayed in mobile view. *Fix submitted by Amol Chaudhari in pull request [20781](https://github.com/magento/magento2/pull/20781)*. [GitHub-20755](https://github.com/magento/magento2/issues/20755)
 
 <!-- ENGCOM- 4123-->
 
-* Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by Amol Chaudhari in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
+*  Corrected rendering of the apply discount code field in the Tab portrait view of the shopping cart. *Fix submitted by Amol Chaudhari in pull request [20586](https://github.com/magento/magento2/pull/20586)*. [GitHub-20278](https://github.com/magento/magento2/issues/20278)
 
 <!-- ENGCOM-4204 -->
 
-* Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
+*  Added missing bottom border to the list of customizable options on the Product page when accessed from the Admin. *Fix submitted by Eduard Chitoraga in pull request [20821](https://github.com/magento/magento2/pull/20821)*. [GitHub-20497](https://github.com/magento/magento2/issues/20497)
 
 <!-- ENGCOM-4230 -->
 
-* Fixed the alignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by Amol Chaudhari in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
+*  Fixed the alignment of the Orders and Returns section that is accessed from the footer of the orders page. *Fix submitted by Amol Chaudhari in pull request [21163](https://github.com/magento/magento2/pull/21163)*. [GitHub-20816](https://github.com/magento/magento2/issues/20816)
 
 <!-- ENGCOM-4239 -->
 
-* Fixed the alignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Amol Chaudhari in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
+*  Fixed the alignment of reviews under My Recent Reviews area of the My account dashboard. *Fix submitted by Amol Chaudhari in pull request [21172](https://github.com/magento/magento2/pull/21172)*. [GitHub-20800](https://github.com/magento/magento2/issues/20800)
 
 <!-- ENGCOM-4247 -->
 
-* The Widget Options left navigation block on the Add New Widget page now displays correctly in tablet view. *Fix submitted by Amol Chaudhari in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
+*  The Widget Options left navigation block on the Add New Widget page now displays correctly in tablet view. *Fix submitted by Amol Chaudhari in pull request [20529](https://github.com/magento/magento2/pull/20529)*. [GitHub-20492](https://github.com/magento/magento2/issues/20492)
 
 <!-- ENGCOM- 4535-->
 
-* Added a missing asterisk adjacent to the Checkout Agreements checkbox. *Fix submitted by Amol Chaudhari in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
+*  Added a missing asterisk adjacent to the Checkout Agreements checkbox. *Fix submitted by Amol Chaudhari in pull request [21838](https://github.com/magento/magento2/pull/21838)*. [GitHub-21648](https://github.com/magento/magento2/issues/21648)
 
 ### Company
 
 <!-- MAGETWO-98381 -->
 
-* Magento no longer throws an error when you try to export a customer report with a description filter.
+*  Magento no longer throws an error when you try to export a customer report with a description filter.
 
 ### Configurable products
 
 <!-- MAGETWO-97271 -->
 
-* Configurable products can no longer be added as a variation of another configurable product in the Admin.
+*  Configurable products can no longer be added as a variation of another configurable product in the Admin.
 
 <!-- MAGETWO-97332 -->
 
-* Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
+*  Magento no longer describes a configurable product as in-stock in the product list when the product is set to out-of-stock.
 
 <!-- ENGCOM-4308 -->
 
-* Fixed the alignment of fields on the Configure Product page that is accessed from the Wish List. *Fix submitted by Amol Chaudhari in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
+*  Fixed the alignment of fields on the Configure Product page that is accessed from the Wish List. *Fix submitted by Amol Chaudhari in pull request [21173](https://github.com/magento/magento2/pull/21173)*. [GitHub-20760](https://github.com/magento/magento2/issues/20760)
 
 <!-- ENGCOM-4092 -->
 
-* You can now successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed the following error: `Attribute with ID "Manufacturer" does not exist`. *Fix submitted by Suneet K. in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
+*  You can now successfully run `bin/magento setup:upgrade` to upgrade your Magento instance when your deployment lacks the `manufacturer` attribute. Previously, set up did not complete, and Magento displayed the following error: `Attribute with ID "Manufacturer" does not exist`. *Fix submitted by Suneet K. in pull request [19551](https://github.com/magento/magento2/pull/19551)*. [GitHub-18134](https://github.com/magento/magento2/issues/18134)
 
 <!-- ENGCOM-4470 -->
 
-* Corrected the position of the labels in the configurable product variations table. *Fix submitted by Eduard Chitoraga in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
+*  Corrected the position of the labels in the configurable product variations table. *Fix submitted by Eduard Chitoraga in pull request [21691](https://github.com/magento/magento2/pull/21691)*. [GitHub-20527](https://github.com/magento/magento2/issues/20527)
 
 <!-- ENGCOM-4754 -->
 
-* Configurable products can now be successfully updated through the bulk API using the following API endpoint: `POST rest/async/bulk/V1/configurable-products/bySku/child`).  *Fix submitted by Amol Chaudhari in pull request [22295](https://github.com/magento/magento2/pull/22295)*. [GitHub-20366](https://github.com/magento/magento2/issues/20366)
+*  Configurable products can now be successfully updated through the bulk API using the following API endpoint: `POST rest/async/bulk/V1/configurable-products/bySku/child`).  *Fix submitted by Amol Chaudhari in pull request [22295](https://github.com/magento/magento2/pull/22295)*. [GitHub-20366](https://github.com/magento/magento2/issues/20366)
 
 ### CMS
 
@@ -436,59 +436,59 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- MAGETWO-98990 -->
 
-* The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer 11.x.
+*  The HTML source editor **Update** and **Cancel** buttons now appear as expected in browsers running Internet Explorer 11.x.
 
 <!-- ENGCOM-4200 -->
 
-* Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
+*  Improved the display of images that are uploaded when you click the **Insert Image** button on a CMS page. *Fix submitted by Eduard Chitoraga in pull request [21110](https://github.com/magento/magento2/pull/21110)*. [GitHub-20786](https://github.com/magento/magento2/issues/20786)
 
 ### Customer
 
 <!-- MAGETWO-98334 -->
 
-* Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks.
+*  Customers who are not logged in can now see the dynamic blocks that have been created for guest accounts. Previously, only customers logged in to the registered guests segment could see these dynamic blocks.
 
 <!-- MAGETWO-72961 -->
 
-* Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
+*  Magento now uses the value of the default billing address attribute as expected during checkout. [GitHub-8777](https://github.com/magento/magento2/issues/8777)
 
 <!-- MAGETWO-93521 -->
 
-* Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
+*  Custom customer attributes now show as expected in the Admin customer create and edit forms. Previously, these attributes were not displayed unless configured for display on the Customer Registration or Customer Account Edit forms. [GitHub-14456](https://github.com/magento/magento2/issues/14456)
 
 <!-- ENGCOM-4132 -->
 
-* Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
+*  Removed an unneeded space from the title of the My Account page in mobile view. *Fix submitted by Amol Chaudhari in pull request [20782](https://github.com/magento/magento2/pull/20782)*. [GitHub-20723](https://github.com/magento/magento2/issues/20723)
 
 <!-- ENGCOM-4187 -->
 
-* Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
+*  Removed an empty block on the My Account page sidebar. *Fix submitted by Pratik Oza in pull request [20845](https://github.com/magento/magento2/pull/20845)*. [GitHub-19139](https://github.com/magento/magento2/issues/19139)
 
 <!-- ENGCOM-4284 -->
 
-* The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by Pratik Oza in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
+*  The Customer Name Prefix on the customer configuration page no longer displays extraneous white space when an extra separator is added. *Fix submitted by Pratik Oza in pull request [21245](https://github.com/magento/magento2/pull/21245)*. [GitHub-17861](https://github.com/magento/magento2/issues/17861)
 
 <!-- ENGCOM-4367 -->
 
-* The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by Amol Chaudhari in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
+*  The customer login block (defined as `Magento\Customer\Block\Form\Login`) no longer sets the page title. *Fix submitted by Amol Chaudhari in pull request [21434](https://github.com/magento/magento2/pull/21434)*. [GitHub-13982](https://github.com/magento/magento2/issues/13982)
 
 <!-- ENGCOM-4476 -->
 
-* The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by Pratik Oza in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
+*  The default sort order setting for the shopping cart and customer orders page is now `by create date in descending order`. *Fix submitted by Pratik Oza in pull request [21694](https://github.com/magento/magento2/pull/21694)*. [GitHub-21493](https://github.com/magento/magento2/issues/21493)
 
 <!-- ENGCOM-4213 -->
 
-* Magento now respects the number of lines permitted in a street address as set in **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
+*  Magento now respects the number of lines permitted in a street address as set in **Store** > **Configuration** > **Customer** > **Customer Configuration** > **Name and Address Options**. Previously, Magento displayed the last saved values instead of the default value. *Fix submitted by Ievgenii Gryshkun in pull request [20566](https://github.com/magento/magento2/pull/20566)*. [GitHub-13675](https://github.com/magento/magento2/issues/13675)
 
 <!-- MAGETWO-97684 -->
 
-* The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
+*  The **State/Province** field is no longer marked as mandatory in the Admin customer address form. Previously, this field was always marked by an asterisk, even when the field was not required.
 
 <!-- MAGETWO-98044 -->
 
-* Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
+*  Magento no longer applies the default customer group settings to customers that have already been assigned to another group.
 
-* Customer groups can now be reassigned successfully during order creation in the Admin.
+*  Customer groups can now be reassigned successfully during order creation in the Admin.
 
 ### cron
 
@@ -508,7 +508,7 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- ENGCOM-4660 -->
 
-* `crontab` now updates all currency rates daily as expected. Previously, `crontab` updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18980](https://github.com/magento/magento2/pull/18980)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
+*  `crontab` now updates all currency rates daily as expected. Previously, `crontab` updated only a subset of the enabled currencies. *Fix submitted by Denis Papec in pull request [18980](https://github.com/magento/magento2/pull/18980)*. [GitHub-18580](https://github.com/magento/magento2/issues/18580)
 
   See [Configure the lock provider]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html).
 
@@ -516,501 +516,501 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- MAGETWO-97528 -->
 
-* Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
+*  Magento now saves dates that are associated with custom customer attributes of type `date`. Previously, Magento did not save these dates, but displayed the following message: `Please enter a valid date`.
 
 <!-- MAGETWO-96265 -->
 
-* Magento now loads the customer attribute page as expected, and users can edit attributes when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
+*  Magento now loads the customer attribute page as expected, and users can edit attributes when attributes are set to default values. Previously, Magento did not completely load this page when attributes values were set to default.
 
 ### Directory
 
 <!-- ENGCOM-4234 -->
 
-* The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Pratik Oza in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
+*  The Swagger definition for `eav-data-attribute-option-interface` has been corrected. Previously, when you created a REST call to an endpoint that returns an object of `eav-data-attribute-option-interface` and `is_default` is set to `true`, `is_default` returns an object instead of the expected Boolean. *Fix submitted by Pratik Oza in pull request [21164](https://github.com/magento/magento2/pull/21164)*. [GitHub-18525](https://github.com/magento/magento2/issues/18525)
 
 ### Downloadable
 
 <!-- ENGCOM- 4297-->
 
-* You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by Amol Chaudhari in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
+*  You can now successfully download a downloadable product by clicking the link to the product in your downloadable products list. When you previously clicked this link. the page did not open correctly, and Magento threw the following error: `Something went wrong while getting the requested content`. *Fix submitted by Amol Chaudhari in pull request [21262](https://github.com/magento/magento2/pull/21262)*. [GitHub-18944](https://github.com/magento/magento2/issues/18944)
 
 <!-- ENGCOM-4466 -->
 
-* Added missing sort order to columns on Downloadable Product links page. *Fix submitted by Pratik Oza in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
+*  Added missing sort order to columns on Downloadable Product links page. *Fix submitted by Pratik Oza in pull request [21662](https://github.com/magento/magento2/pull/21662)*. [GitHub-21278](https://github.com/magento/magento2/issues/21278)
 
 <!-- ENGCOM-4816 -->
 
-* You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message.  *Fix submitted by Ravi Chandra in pull request [22471](https://github.com/magento/magento2/pull/22471)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
+*  You can now successfully change the sample file for an existing downloadable product. Previously, when you tried to change this sample file, Magento did not save the new file, and did not display an error message.  *Fix submitted by Ravi Chandra in pull request [22471](https://github.com/magento/magento2/pull/22471)*. [GitHub-6272](https://github.com/magento/magento2/issues/6272)
 
 <!-- ENGCOM-4777 -->
 
-* A logged-in user’s My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by James in pull request [22072](https://github.com/magento/magento2/pull/22072)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
+*  A logged-in user’s My Downloads page now displays links to the relevant downloadable products when **Order Item Status to Enable Downloads** is set to **Pending**. Previously, Magento displayed only the names of the pending products, and no links for downloadable products were displayed. *Fix submitted by James in pull request [22072](https://github.com/magento/magento2/pull/22072)*. [GitHub-21753](https://github.com/magento/magento2/issues/21753)
 
 ### EAV
 
 <!-- ENGCOM-4632 -->
 
-* Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw an `Invalid argument supplied for foreach()` warning. *Fix submitted by Wojtek Naruniec in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
+*  Initialization has been added to two class variables that can be returned by class methods as parameters of type `array`. Without this initialization, both variables are returned as null, which can cause Magento to throw an `Invalid argument supplied for foreach()` warning. *Fix submitted by Wojtek Naruniec in pull request [22086](https://github.com/magento/magento2/pull/22086)*. [GitHub-21134](https://github.com/magento/magento2/issues/21134)
 
 <!-- ENGCOM-4518 -->
 
-* Magento no longer throws an exception when the `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by Amol Chaudhari in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
+*  Magento no longer throws an exception when the `fixed-Quantity_and_stock_status` attribute has **Change Visible on Catalog Pages on Storefront** enabled. *Fix submitted by Amol Chaudhari in pull request [21802](https://github.com/magento/magento2/pull/21802)*. [GitHub-13612](https://github.com/magento/magento2/issues/13612)
 
 <!-- ENGCOM-4787 -->
 
-* The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by Lorenzo Stramaccia in pull request [22422](https://github.com/magento/magento2/pull/22422)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
+*  The `\Magento\Eav\Model\Entity\Collection\AbstractCollection::importFromArray()` method now returns a usable collection. Previously, the `_isCollectionLoaded` property was false, and every interaction threw an exception. *Fix submitted by Lorenzo Stramaccia in pull request [22422](https://github.com/magento/magento2/pull/22422)*. [GitHub-21868](https://github.com/magento/magento2/issues/21868)
 
 ### Email
 
 <!-- ENGCOM-4305 -->
 
-* Corrected problems with disabling and enabling order-related emails. *Fix submitted by Serhiy Zhovnir in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
+*  Corrected problems with disabling and enabling order-related emails. *Fix submitted by Serhiy Zhovnir in pull request [20954](https://github.com/magento/magento2/pull/20954)*. [GitHub-18698](https://github.com/magento/magento2/issues/18698)
 
 <!-- ENGCOM-4824 -->
 
-* Magento no longer sends via asynchronous email sending any sales-related emails that were created when email sending was disabled once email sending is enabled. *Fix submitted by Serhiy Zhovnir in pull request [22108](https://github.com/magento/magento2/pull/22108)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
+*  Magento no longer sends via asynchronous email sending any sales-related emails that were created when email sending was disabled once email sending is enabled. *Fix submitted by Serhiy Zhovnir in pull request [22108](https://github.com/magento/magento2/pull/22108)*. [GitHub-21786](https://github.com/magento/magento2/issues/21786)
 
 ### Frameworks
 
 <!-- MAGETWO-98554 -->
 
-* Magento now sorts media directories alphabetically during image upload.
+*  Magento now sorts media directories alphabetically during image upload.
 
 <!-- ENGCOM-4068 -->
 
-* Fixed the alignment of the _import successful_ message icon in the Admin. *Fix submitted by Kajal Solanki in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
+*  Fixed the alignment of the _import successful_ message icon in the Admin. *Fix submitted by Kajal Solanki in pull request [19333](https://github.com/magento/magento2/pull/19333)*. [GitHub-19328](https://github.com/magento/magento2/issues/19328)
 
 <!-- ENGCOM- 4286-->
 
-* Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by Amol Chaudhari in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
+*  Added the `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with three possible options: `style`, `script`, and `font`. *Fix submitted by Amol Chaudhari in pull request [21261](https://github.com/magento/magento2/pull/21261)*. [GitHub-18347](https://github.com/magento/magento2/issues/18347)
 
 <!-- ENGCOM-4354 -->
 
-* The use of the `SessionManagerInterface` class has replaced the direct use of `SessionManager`. *Fix submitted by Pratik Oza in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
+*  The use of the `SessionManagerInterface` class has replaced the direct use of `SessionManager`. *Fix submitted by Pratik Oza in pull request [21357](https://github.com/magento/magento2/pull/21357)*. [GitHub-19274](https://github.com/magento/magento2/issues/19274)
 
 <!-- ENGCOM-4395 -->
 
-* The module ranking in `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by Eduard Chitoraga in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
+*  The module ranking in `app/etc/config` now remains consistent when a new module is added but no other changes are made. Previously, a module addition affected the module ranking, which resulted in multiple unnecessary conflicts. *Fix submitted by Eduard Chitoraga in pull request [21423](https://github.com/magento/magento2/pull/21423)*. [GitHub-8479](https://github.com/magento/magento2/issues/8479),[GitHub-16116](https://github.com/magento/magento2/issues/16116)
 
 <!-- ENGCOM-4542 -->
 
-* Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines. *Fix submitted by Amol Chaudhari in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
+*  Magento now logs exceptions during autoloading instead of throwing exceptions. This conforms with PSR-4 guidelines. *Fix submitted by Amol Chaudhari in pull request [21435](https://github.com/magento/magento2/pull/21435)*. [GitHub-20773](https://github.com/magento/magento2/issues/20773)
 
 #### Cache framework
 
 <!-- ENGCOM-4183 -->
 
-* We corrected a syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php`. *Fix submitted by Nirav Kadiya in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
+*  We corrected a syntax error in `magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php`. *Fix submitted by Nirav Kadiya in pull request [21078](https://github.com/magento/magento2/pull/21078)*. [GitHub-13309](https://github.com/magento/magento2/issues/13309)
 
 #### JavaScript framework
 
 <!-- ENGCOM-4610 -->
 
-* JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by Roman Kis in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
+*  JavaScript validation on UI form components now works as expected. Previously, adding the `validate-per-page-value-list` validation rule resulted in a failure for every non-empty value in the field to which it as applied. *Fix submitted by Roman Kis in pull request [21813](https://github.com/magento/magento2/pull/21813)*. [GitHub-21734](https://github.com/magento/magento2/issues/21734)
 
 ### General
 
 <!-- ENGCOM-2667 -->
 
-* Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by afirlejczyk in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
+*  Sorting on stores from the Admin (**Stores** > **All Stores**) now works as expected. *Fix submitted by afirlejczyk in pull request [17371](https://github.com/magento/magento2/pull/17371)*. [GitHub-7283](https://github.com/magento/magento2/issues/7283)
 
 <!-- ENGCOM-4548 -->
 
-* Product attribute labels are no longer translated but maintain their store-specific values. *Fix submitted by Pratik Oza in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
+*  Product attribute labels are no longer translated but maintain their store-specific values. *Fix submitted by Pratik Oza in pull request [21864](https://github.com/magento/magento2/pull/21864)*. [GitHub-21750](https://github.com/magento/magento2/issues/21750)
 
 <!-- ENGCOM-4272 -->
 
-* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by Amol Chaudhari in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
+*  You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by Amol Chaudhari in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-7974](https://github.com/magento/magento2/issues/7974)
 
 <!-- MAGETWO-98000 -->
 
-* PayPal Express now creates a gift card as expected when payment for the card is captured. Previously, Magento did not create a gift card under these circumstances, even when payment action was set to **Authorize and Capture** and **Generate Gift Card Account when Order Item is** was set  to *Invoiced*.
+*  PayPal Express now creates a gift card as expected when payment for the card is captured. Previously, Magento did not create a gift card under these circumstances, even when payment action was set to **Authorize and Capture** and **Generate Gift Card Account when Order Item is** was set  to *Invoiced*.
 
 ### Gift card account
 
 <!-- MAGETWO-98000 -->
 
-* Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
+*  Gift card accounts are now created as expected when gift card orders are authorized and captured with PayPal Express.
 
 ### Import/export
 
 <!-- MAGETWO-96895 -->
 
-* The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
+*  The **Skip error entries** validation method for the import now works as expected. Previously, Magento did not let you skip an invalid entry and prevented import.
 
 <!-- MAGETWO-98694 -->
 
-* Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors.
+*  Magento now correctly saves product URL keys in Arabic. Previously, keys in Arabic returned 404 errors.
 
 ### Indexers
 
 <!-- ENGCOM-4555 -->
 
-* You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list, Magento threw a fatal error. *Fix submitted by Cristiano Casciotti in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
+*  You can now access a list of Admin indexers after creating a custom index. Previously, when you tried to access the Admin indexer list, Magento threw a fatal error. *Fix submitted by Cristiano Casciotti in pull request [21576](https://github.com/magento/magento2/pull/21576)*. [GitHub-21510](https://github.com/magento/magento2/issues/21510)
 
 ### Infrastructure
 
 <!-- ENGCOM-4570 -->
 
-* The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by Amol Chaudhari in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
+*  The `productAvailabilityChecks` argument has been added to `Magento\Sales\Model\Order\Reorder\OrderedProductAvailabilityChecker`. Previously, this required argument was missing. *Fix submitted by Amol Chaudhari in pull request [21920](https://github.com/magento/magento2/pull/21920)*. [GitHub-20825](https://github.com/magento/magento2/issues/20825)
 
 <!-- ENGCOM-4484 -->
 
-* Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic. *Fix submitted by Bartłomiej Szubert in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
+*  Logic has been removed from the constructor of `Magento\Sales\Model\Order\Address\Validator`. Previously, installation of the product could fail if this class was injected in the constructor through a command in a custom module when this class contained logic. *Fix submitted by Bartłomiej Szubert in pull request [21719](https://github.com/magento/magento2/pull/21719)*. [GitHub-21692](https://github.com/magento/magento2/issues/21692)
 
 <!-- ENGCOM-4587 -->
 
-* You can now use a period (`.`) for inline CMS content edits. Previously, if you included a period (`.`) in your edits, Magento displayed the following error: `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by Hiren Pandya in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
+*  You can now use a period (`.`) for inline CMS content edits. Previously, if you included a period (`.`) in your edits, Magento displayed the following error: `There are 1 messages requires your attention. Please make corrections to the errors in the table below and re-submit`. *Fix submitted by Hiren Pandya in pull request [21939](https://github.com/magento/magento2/pull/21939)*. [GitHub-21374](https://github.com/magento/magento2/issues/21374)
 
 <!-- ENGCOM-4626 -->
 
-* `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`. *Fix submitted by Lars Roettig in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
+*  `QuoteManagement::submitQuote` now logs all root exceptions. Previously, Magento logged only the second exception in `exception.log`. *Fix submitted by Lars Roettig in pull request [22037](https://github.com/magento/magento2/pull/22037)*. [GitHub-14926](https://github.com/magento/magento2/issues/14926), [GitHub-18752](https://github.com/magento/magento2/issues/18752)
 
 <!-- ENGCOM-4702 -->
 
-* Widget parameters can now contain multidimensional arrays. *Fix submitted by Stanislav Ilnytskyi in pull request [22214](https://github.com/magento/magento2/pull/22214)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
+*  Widget parameters can now contain multidimensional arrays. *Fix submitted by Stanislav Ilnytskyi in pull request [22214](https://github.com/magento/magento2/pull/22214)*. [GitHub-19909](https://github.com/magento/magento2/issues/19909)
 
 ### Layered navigation
 
 <!-- ENGCOM-4803 -->
 
-* Setting **Price Navigation Step Calculation** for layered navigation to **Automatic (equalize product counts)** now works as expected. Previously, results were not in the equals range, but omitted products. *Fix submitted by Nazar Klovanych in pull request [22453](https://github.com/magento/magento2/pull/22453)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715), [GitHub-21960](https://github.com/magento/magento2/issues/21960)
+*  Setting **Price Navigation Step Calculation** for layered navigation to **Automatic (equalize product counts)** now works as expected. Previously, results were not in the equals range, but omitted products. *Fix submitted by Nazar Klovanych in pull request [22453](https://github.com/magento/magento2/pull/22453)*. [GitHub-6715](https://github.com/magento/magento2/issues/6715), [GitHub-21960](https://github.com/magento/magento2/issues/21960)
 
 ### Logging
 
 <!-- MAGETWO-97595 -->
 
-* Editing a theme now creates an entry in the Admin action log as expected.
+*  Editing a theme now creates an entry in the Admin action log as expected.
 
 ### MSRP
 
 <!-- MAGETWO-73985 -->
 
-* MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed on the configurable product page and the category page display of the configurable product.
+*  MAP (minimum advertised price) prices for the simple products that belong to a configurable product are now supported. MAP prices for these products are now successfully handled and displayed on the configurable product page and the category page display of the configurable product.
 
 ### Newsletter
 
 <!-- ENGCOM-4303 -->
 
-* The newsletter subscription input box now displays all text in mobile view. *Fix submitted by dipti2jcommerce in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
+*  The newsletter subscription input box now displays all text in mobile view. *Fix submitted by dipti2jcommerce in pull request [20370](https://github.com/magento/magento2/pull/20370)*. [GitHub-20163](https://github.com/magento/magento2/issues/20163)
 
 <!-- MAGETWO-96957 -->
 
-* We fixed an issue that caused a long delay when you tried to navigate away from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Now, you can navigate away from this page as expected.
+*  We fixed an issue that caused a long delay when you tried to navigate away from the Admin newsletter subscribers page (**Marketing** > **Communications** > **Newsletter Subscribers**). Now, you can navigate away from this page as expected.
 
 ### Orders
 
 <!-- ENGCOM-4593 -->
 
-* Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Eduard Chitoraga in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
+*  Magento no longer displays a negative number in the dashboard to represent a canceled order. *Fix submitted by Eduard Chitoraga in pull request [21944](https://github.com/magento/magento2/pull/21944)*. [GitHub-18754](https://github.com/magento/magento2/issues/18754), [GitHub-21281](https://github.com/magento/magento2/issues/21281)
 
 ### Page Cache
 
 <!-- MAGETWO-90953 -->
 
-* Page caching is no longer active when maintenance mode is enabled. Previously, Magento cached pages from all IP addresses during maintenance mode.
+*  Page caching is no longer active when maintenance mode is enabled. Previously, Magento cached pages from all IP addresses during maintenance mode.
 
 ### Payment methods
 
 <!-- MAGETWO-98991 -->
 
-* Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even if a customer had entered all required credit card information.
+*  Magento creates an order using PayPal Payflow Pro as expected when a customer enters all the credit card information that PayPal needs to create the transaction. Previously, Magento did not create the order even if a customer had entered all required credit card information.
 
 <!-- MAGETWO-98670 -->
 
-* Magento now displays the account owner name that you have specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified.
+*  Magento now displays the account owner name that you have specified when you add a shipping address when using Braintree through PayPal and are redirected to Magento. Previously, Magento displayed the account owner's name, not the name you specified.
 
 <!-- MAGETWO-98431 -->
 
-* The PayPal `securetoken` and `securetokenid` are no longer vulnerable to compromise.
+*  The PayPal `securetoken` and `securetokenid` are no longer vulnerable to compromise.
 
 <!-- MAGETWO-96137 -->
 
-* The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
+*  The transfer cart line items and transfer shipping options in the the Shipping step of checkout now work for PayPal. [GitHub-19064](https://github.com/magento/magento2/issues/19064)
 
 <!-- ENGCOM-4328 -->
 
-* We improved accessibility by adding Alt attribute text that describes credit card type or stored payment methods during checkout. *Fix submitted by Amol Chaudhari in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+*  We improved accessibility by adding Alt attribute text that describes credit card type or stored payment methods during checkout. *Fix submitted by Amol Chaudhari in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
 <!-- MAGETWO-98111 -->
 
-* You can now place an order using Cybersource payment from the Admin.
+*  You can now place an order using Cybersource payment from the Admin.
 
 <!-- MAGETWO-97464 -->
 
-* Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
+*  Product search results now display the correct special price as set by a scheduled update. Previously, search results displayed the original special price, not the price set by the scheduled update.
 
 ### Pricing
 
 <!-- MAGETWO-99247 -->
 
-* Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**.
+*  Magento now saves customizable option price input on the store-view level when Catalog Price Scope is set to **Global**.
 
 <!-- MAGETWO-96062 -->
 
-* The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
+*  The quick order form now handles the SKUs that you enter for configurable products as expected. Previously, Magento threw an error when you tried to enter the SKU for a configurable product.
 
 <!-- MAGETWO-96898 -->
 
-* Tier pricing for bundle products now works as expected: Magento displays the correct price in the cart, and reminds customers that they can buy a specific quantity of the product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages.
+*  Tier pricing for bundle products now works as expected: Magento displays the correct price in the cart, and reminds customers that they can buy a specific quantity of the product for a discount. Previously, Magento did not calculate the price correctly, and did not display any informative messages about tier pricing on the category and product pages.
 
 ### Reports
 
 <!-- MAGETWO-96883 -->
 
-* Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.
+*  Reports now include orders from only the websites that the administrator has permissions for in multisite deployments. Previously, a report run by an administrator with access to one website only contained information about products and sales on other websites.
 
 <!-- ENGCOM-4445 -->
 
-* The date range in reports no longer displays the same start and end dates. *Fix submitted by Pratik Oza in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
+*  The date range in reports no longer displays the same start and end dates. *Fix submitted by Pratik Oza in pull request [21589](https://github.com/magento/magento2/pull/21589)*. [GitHub-20128](https://github.com/magento/magento2/issues/20128)
 
 <!-- ENGCOM-4834 -->
 
-* The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by Shikha Mishra in pull request [22523](https://github.com/magento/magento2/pull/22523)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
+*  The downloads report table (**Admin** > **Reports** > **Downloads**) now displays an accurate count of all downloadable products and the number of times they have been downloaded. *Fix submitted by Shikha Mishra in pull request [22523](https://github.com/magento/magento2/pull/22523)*. [GitHub-22223](https://github.com/magento/magento2/issues/22223)
 
 ### Review
 
 <!-- ENGCOM- 4006-->
 
-* Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Amol Chaudhari in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
+*  Fixed rendering of the **Add your text** link on the Product page. *Fix submitted by Amol Chaudhari in pull request [20257](https://github.com/magento/magento2/pull/20257)*. [GitHub-20221](https://github.com/magento/magento2/issues/20221)
 
 <!-- ENGCOM- 4539-->
 
-* Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by Eduard Chitoraga in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
+*  Pending Reviews are now correctly labeled under **System** > **User Roles** > **Add New Role** > **Role Resources**, and Magento now displays a new Pending reviews menu under **Marketing** > **User Content**. Previously, Magento displayed the Reviews menu twice. *Fix submitted by Eduard Chitoraga in pull request [21849](https://github.com/magento/magento2/pull/21849)*. [GitHub-20924](https://github.com/magento/magento2/issues/20924)
 
 ### RMA
 
 <!-- MAGETWO-93976 -->
 
-* Product-level RMA disabling now works as expected.
+*  Product-level RMA disabling now works as expected.
 
 ### Sales
 
 <!-- MAGETWO-97008 -->
 
-* When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
+*  When you place an Admin order for a product with a custom price, the `sales_order_item` table now behaves the same as it would for an order of a product with a regular price. Specifically, the price column contains the custom price excluding tax. Previously, the `sales_order_item` table's price column displayed the custom price including tax.
 
 <!-- MAGETWO-97096 -->
 
-* Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted.
+*  Magento now lets you enter new orders in the Admin on non-default websites in multisite deployments where some countries have been restricted.
 
 <!-- ENGCOM-4280 -->
 
-* Corrected the alignment of page elements on the Admin product reorder page. *Fix submitted by Amol Chaudhari in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
+*  Corrected the alignment of page elements on the Admin product reorder page. *Fix submitted by Amol Chaudhari in pull request [21241](https://github.com/magento/magento2/pull/21241)*. [GitHub-20919](https://github.com/magento/magento2/issues/20919)
 
 <!-- ENGCOM-3968 -->
 
-* The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
+*  The `transportBuilderByStore` class has been removed. Previously, this class was the cause of undesired repeat emails. *Fix submitted by gwharton in pull request [18472](https://github.com/magento/magento2/pull/18472)*. [GitHub-11740](https://github.com/magento/magento2/issues/11740), [GitHub-14945](https://github.com/magento/magento2/issues/14945), [GitHub-14952](https://github.com/magento/magento2/issues/14952), [GitHub-16355](https://github.com/magento/magento2/issues/16355)
 
 <!-- ENGCOM-4403 -->
 
-* You can now successfully re-order a virtual product. *Fix submitted by Shikha Mishra in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
+*  You can now successfully re-order a virtual product. *Fix submitted by Shikha Mishra in pull request [21513](https://github.com/magento/magento2/pull/21513)*. [GitHub-15059](https://github.com/magento/magento2/issues/15059)
 
 <!-- ENGCOM-4272 -->
 
-* You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by Amol Chaudhari in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
+*  You can now change customer groups when creating a new customer during order creation on the Admin. *Fix submitted by Amol Chaudhari in pull request [21239](https://github.com/magento/magento2/pull/21239)*. [GitHub-6162](https://github.com/magento/magento2/issues/6162)
 
 <!-- ENGCOM-4285 -->
 
-* Fixed display of the Luma theme *My Account Order* status tabs in mobile view. *Fix submitted by suryakant-krish in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
+*  Fixed display of the Luma theme *My Account Order* status tabs in mobile view. *Fix submitted by suryakant-krish in pull request [21250](https://github.com/magento/magento2/pull/21250)*. [GitHub-21070](https://github.com/magento/magento2/issues/21070)
 
 ### Sales rule
 
 <!-- MAGETWO-98568 -->
 
-* Magento now displays the Cart Price Rule code on the order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
+*  Magento now displays the Cart Price Rule code on the order details Admin page if free shipping applies. Previously, Magento did not display information about the Sales rule or why shipping was free.
 
 <!-- ENGCOM-4485 -->
 
-* Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by David Führ in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
+*  Sales rule validation has been refactored to eliminate a leak in the salesrule collection. Previously, a poorly constructed SQL query resulted in poor performance. *Fix submitted by David Führ in pull request [21699](https://github.com/magento/magento2/pull/21699)*. [GitHub-19117](https://github.com/magento/magento2/issues/19117)
 
 <!-- ENGCOM-4718 -->
 
-* We have fixed an error in discount calculations that prevented merchants from creating a rule that set a tax rate and 100% discount. Previously, when a tax rule was applied, and a 100% discount was also applied during check out, the shopping cart displayed a negative grand total. *Fix submitted by Stanislav Ilnytskyi in pull request [22227](https://github.com/magento/magento2/pull/22227)*. [GitHub-10790](https://github.com/magento/magento2/issues/10790)
+*  We have fixed an error in discount calculations that prevented merchants from creating a rule that set a tax rate and 100% discount. Previously, when a tax rule was applied, and a 100% discount was also applied during check out, the shopping cart displayed a negative grand total. *Fix submitted by Stanislav Ilnytskyi in pull request [22227](https://github.com/magento/magento2/pull/22227)*. [GitHub-10790](https://github.com/magento/magento2/issues/10790)
 
 ### Search
 
 <!-- MAGETWO-97374 -->
 
-* Layered navigation results no longer includes price ranges that contain no products.
+*  Layered navigation results no longer includes price ranges that contain no products.
 
 <!-- ENGCOM-4082 -->
 
-* Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar Klovanych in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
+*  Elasticsearch now correctly returns only products whose SKUs contain dashes when your search criteria specifies SKUs that contain dashes. Previously, search results contained unmatched products as well as products whose SKUs contained dashes. *Fix submitted by Nazar Klovanych in pull request [20876](https://github.com/magento/magento2/pull/20876)*. [GitHub-20716](https://github.com/magento/magento2/issues/20716)
 
 <!-- ENGCOM-4209 -->
 
-* Fixed the alignment of the advanced search page price field in mobile view. *Fix submitted by Amol Chaudhari in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
+*  Fixed the alignment of the advanced search page price field in mobile view. *Fix submitted by Amol Chaudhari in pull request [21114](https://github.com/magento/magento2/pull/21114)*. [GitHub-20157](https://github.com/magento/magento2/issues/20157)
 
 <!-- ENGCOM-4559 -->
 
-* Corrected formatting of the Advance Search link in page footers. *Fix submitted by Amol Chaudhari in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
+*  Corrected formatting of the Advance Search link in page footers. *Fix submitted by Amol Chaudhari in pull request [21892](https://github.com/magento/magento2/pull/21892)*. [GitHub-20809](https://github.com/magento/magento2/issues/20809)
 
 <!-- MAGETWO-97914 -->
 
-* The performance of the catalog search indexing that occurs after Elasticsearch upgrades has been improved substantially.
+*  The performance of the catalog search indexing that occurs after Elasticsearch upgrades has been improved substantially.
 
 <!-- ENGCOM-4793 -->
 
-* The search icon on Admin page headers now works as expected. *Fix submitted by Saphal Jha in pull request [22441](https://github.com/magento/magento2/pull/22441)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
+*  The search icon on Admin page headers now works as expected. *Fix submitted by Saphal Jha in pull request [22441](https://github.com/magento/magento2/pull/22441)*. [GitHub-22152](https://github.com/magento/magento2/issues/22152)
 
 ### Shipping
 
 <!-- MAGETWO-96001 -->
 
-* The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
+*  The tracking pop-up window now displays an accurate value for the delivery date for FedEx shipments in transit.
 
 <!-- ENGCOM-3602 -->
 
-* Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**.  *Fix submitted by gwharton in pull request [19488](https://github.com/magento/magento2/pull/19488)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
+*  Magento now provides quotes for DHL shipments when **DHL Content Type** is set to **Non Documents**.  *Fix submitted by gwharton in pull request [19488](https://github.com/magento/magento2/pull/19488)*. [GitHub-19485](https://github.com/magento/magento2/issues/19485)
 
 <!-- ENGCOM-4361 -->
 
-* If you retrieve an order, and then use the `getShippingMethod` as an object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  If you retrieve an order, and then use the `getShippingMethod` as an object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 ### Swatches
 
 <!-- MAGETWO-92495 -->
 
-* Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, the wrong colors were randomly displayed.
+*  Product images now display the color option you chose when you applied a color filter in layered navigation. Previously, the wrong colors were randomly displayed.
 
 <!-- ENGCOM-4120 -->
 
-* You can now change an attribute type from swatch to dropdown without losing data. Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by Amol Chaudhari in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
+*  You can now change an attribute type from swatch to dropdown without losing data. Previously, changing an attribute type from `swatch` to `dropdown` deleted swatch options for all attributes. *Fix submitted by Amol Chaudhari in pull request [20745](https://github.com/magento/magento2/pull/20745)*. [GitHub-20396](https://github.com/magento/magento2/issues/20396)
 
 <!-- ENGCOM-4477 -->
 
-* When you configure a price rule for configurable products with swatches, Magento now a shows the special price for products that match the price rule. Previously, Magento displayed both the old price and the special price for the matching configurable products. *Fix submitted by Pratik Oza in pull request [21695](https://github.com/magento/magento2/pull/21695)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
+*  When you configure a price rule for configurable products with swatches, Magento now a shows the special price for products that match the price rule. Previously, Magento displayed both the old price and the special price for the matching configurable products. *Fix submitted by Pratik Oza in pull request [21695](https://github.com/magento/magento2/pull/21695)*. [GitHub-19276](https://github.com/magento/magento2/issues/19276)
 
 ### Tax
 
 <!-- ENGCOM-4434 -->
 
-* You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw a MySQL error. *Fix submitted by Tuyen Nguyen in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
+*  You can now successfully search for a tax rule based on both the **Name** and **Tax Rate** fields. Previously, Magento threw a MySQL error. *Fix submitted by Tuyen Nguyen in pull request [21535](https://github.com/magento/magento2/pull/21535)*. [GitHub-21521](https://github.com/magento/magento2/issues/21521)
 
 <!-- ENGCOM-4439 -->
 
-* The value of `product_price_value` in the shopping cart data section now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by Pratik Oza in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
+*  The value of `product_price_value` in the shopping cart data section now includes taxes if the configuration settings are set accordingly (**Stores** > **Configuration** > **Sales** > **Tax** > **Shopping Cart Display Settings** > **Display Prices** > **Including Tax**). *Fix submitted by Pratik Oza in pull request [21570](https://github.com/magento/magento2/pull/21570)*. [GitHub-20310](https://github.com/magento/magento2/issues/20310)
 
 <!-- MAGETWO-96870 -->
 
-* The tax that is applied to a simple child product is now based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
+*  The tax that is applied to a simple child product is now based on the tax class of that product. Previously, Magento based the tax for a child product on the tax class of its parent product.
 
 <!-- MAGETWO-97975 -- FIX ME? Duplicate of MAGETWO-96870?-->
 
-* The tax that is applied to simple child product is now based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
+*  The tax that is applied to simple child product is now based on the tax Class of that product. Previously, the tax was based on the tax class of the parent product.
 
 <!-- ENGCOM-4625 -->
 
-* The shopping cart full tax summary now displays total tax as expected instead of individual tax values. *Fix submitted by Hiren Pandya in pull request [21961](https://github.com/magento/magento2/pull/21961)*. [GitHub-19701](https://github.com/magento/magento2/issues/19701), [GitHub-11358](https://github.com/magento/magento2/issues/11358)
+*  The shopping cart full tax summary now displays total tax as expected instead of individual tax values. *Fix submitted by Hiren Pandya in pull request [21961](https://github.com/magento/magento2/pull/21961)*. [GitHub-19701](https://github.com/magento/magento2/issues/19701), [GitHub-11358](https://github.com/magento/magento2/issues/11358)
 
 ### Testing
 
 <!-- ENGCOM-4415 -->
 
-* We added the `Squiz.Operators.ValidLogicalOperators` `phpcs` linter rule to the static test rules. *Fix submitted by Maksym Novik in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
+*  We added the `Squiz.Operators.ValidLogicalOperators` `phpcs` linter rule to the static test rules. *Fix submitted by Maksym Novik in pull request [21543](https://github.com/magento/magento2/pull/21543)*. [GitHub-21062](https://github.com/magento/magento2/issues/21062)
 
 <!-- ENGCOM-4814 -->
 
-* Integration and functional tests no longer fail when tests encounter filtered configuration values. Previously, Magento threw an error and tests failed if some configuration values were intentionally excluded. *Fix submitted by Bettina in pull request [22415](https://github.com/magento/magento2/pull/22415)*. [GitHub-22307](https://github.com/magento/magento2/issues/22307)
+*  Integration and functional tests no longer fail when tests encounter filtered configuration values. Previously, Magento threw an error and tests failed if some configuration values were intentionally excluded. *Fix submitted by Bettina in pull request [22415](https://github.com/magento/magento2/pull/22415)*. [GitHub-22307](https://github.com/magento/magento2/issues/22307)
 
 ### UI
 
 <!-- ENGCOM-4427 -->
 
-* Form fields of type multiline now work as expected on Admin forms. *Fix submitted by Vivek Kumar in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
+*  Form fields of type multiline now work as expected on Admin forms. *Fix submitted by Vivek Kumar in pull request [21561](https://github.com/magento/magento2/pull/21561)*. [GitHub-8086](https://github.com/magento/magento2/issues/8086), [GitHub-18115](https://github.com/magento/magento2/issues/18115)
 
 <!-- ENGCOM-4598 -->
 
-* The default design of the **Edit** and **Remove items** buttons on the Wish List page now match. *Fix submitted by Amol Chaudhari in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
+*  The default design of the **Edit** and **Remove items** buttons on the Wish List page now match. *Fix submitted by Amol Chaudhari in pull request [21118](https://github.com/magento/magento2/pull/21118)*. [GitHub-20790](https://github.com/magento/magento2/issues/20790)
 
 <!-- ENGCOM-4088 -->
 
-* Magento no longer throws a console error during a guest checkout when the list of allowed countries is modified from the Admin page. *Fix submitted by Amol Chaudhari in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
+*  Magento no longer throws a console error during a guest checkout when the list of allowed countries is modified from the Admin page. *Fix submitted by Amol Chaudhari in pull request [20885](https://github.com/magento/magento2/pull/20885)*. [GitHub-20631](https://github.com/magento/magento2/issues/20631)
 
 <!-- ENGCOM-4011 -->
 
-* The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Prince Patel in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
+*  The `ui-component` validation `error` event now bubbles upwards when an abstract element is nested in a field set. *Fix submitted by Prince Patel in pull request [20510](https://github.com/magento/magento2/pull/20510)*. [GitHub-17926](https://github.com/magento/magento2/issues/17926)
 
 <!-- ENGCOM-3974 -->
 
-* The drop-down toggle arrow on product pages now closes as closing as expected. *Fix submitted by Nirav Patel in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
+*  The drop-down toggle arrow on product pages now closes as closing as expected. *Fix submitted by Nirav Patel in pull request [20616](https://github.com/magento/magento2/pull/20616)*. [GitHub-20240](https://github.com/magento/magento2/issues/20240)
 
 <!-- ENGCOM-4311 -->
 
-* Fixed the alignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Pratik Oza in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
+*  Fixed the alignment of drop-down menus on the Advanced Pricing page. *Fix submitted by Pratik Oza in pull request [21229](https://github.com/magento/magento2/pull/21229)*. [GitHub-18775](https://github.com/magento/magento2/issues/18775)
 
 <!-- ENGCOM-4317 -->
 
-* The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu status (expanded or collapsed). *Fix submitted by Eduard Chitoraga in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
+*  The icon that identifies a drop-down menu throughout the product interface now reflects the changing state of the drop-down menu status (expanded or collapsed). *Fix submitted by Eduard Chitoraga in pull request [21320](https://github.com/magento/magento2/pull/21320)*. [GitHub-21196](https://github.com/magento/magento2/issues/21196)
 
 <!-- ENGCOM-4366 -->
 
-* You can now programmmatically upload an image for the customer attribute. Previously, Magento threw the following error: `error: Base64 is not defined`. *Fix submitted by Nazar Klovanych in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
+*  You can now programmmatically upload an image for the customer attribute. Previously, Magento threw the following error: `error: Base64 is not defined`. *Fix submitted by Nazar Klovanych in pull request [21437](https://github.com/magento/magento2/pull/21437)*. [GitHub-19983](https://github.com/magento/magento2/issues/19983)
 
 <!-- ENGCOM-4444 -->
 
-* Corrected tabbing issue on the product page. *Fix submitted by Amol Chaudhari in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
+*  Corrected tabbing issue on the product page. *Fix submitted by Amol Chaudhari in pull request [21588](https://github.com/magento/magento2/pull/21588)*. [GitHub-21077](https://github.com/magento/magento2/issues/21077)
 
 <!-- ENGCOM-4361 -->
 
-* If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
+*  If you retrieve an order, and then use the `getShippingMethod` as object function to retrieve the shipping method, Magento now returns `null` if no shipping method has been defined. Previously, this function returned an undefined index error if a shipping method was not available. *Fix submitted by Mahesh Singh in pull request [20866](https://github.com/magento/magento2/pull/20866)*. [GitHub-20380](https://github.com/magento/magento2/issues/20380)
 
 <!-- ENGCOM-4820 -->
 
-* Magento now cancels previous scrolling actions as expected when you click Add to cart on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked Add to cart. *Fix submitted by Amol Chaudhari in pull request [22358](https://github.com/magento/magento2/pull/22358)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
+*  Magento now cancels previous scrolling actions as expected when you click Add to cart on a product page. Previously, Magento scrolled back to the `qty` input box the same number of times as you clicked Add to cart. *Fix submitted by Amol Chaudhari in pull request [22358](https://github.com/magento/magento2/pull/22358)*. [GitHub-21715](https://github.com/magento/magento2/issues/21715)
 
 <!-- ENGCOM-4516 -->
 
-* Magento now properly renders double hyphens (--)  in attribute tags. Previously, Magento replaced the double hyphen (—-)  in classes with a single hyphen (-), which caused classes that contained the -- to be rewritten.  *Fix submitted by Amol Chaudhari in pull request [21804](https://github.com/magento/magento2/pull/21804)*. [GitHub-10645](https://github.com/magento/magento2/issues/10645)
+*  Magento now properly renders double hyphens (--)  in attribute tags. Previously, Magento replaced the double hyphen (—-)  in classes with a single hyphen (-), which caused classes that contained the -- to be rewritten.  *Fix submitted by Amol Chaudhari in pull request [21804](https://github.com/magento/magento2/pull/21804)*. [GitHub-10645](https://github.com/magento/magento2/issues/10645)
 
 ### URL rewrite
 
 <!-- ENGCOM-4621 -->
 
-* Magento now retains filter terms after you have applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by Amol Chaudhari in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
+*  Magento now retains filter terms after you have applied a filter to the Admin `url_rewrites` table, then click the back button. *Fix submitted by Amol Chaudhari in pull request [21805](https://github.com/magento/magento2/pull/21805)*. [GitHub-21805](https://github.com/magento/magento2/issues/21805)
 
 <!-- ENGCOM-4116 -->
 
-* The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key, Magento displayed a 404 page. *Fix submitted by Shikha Mishra in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
+*  The import process now retains permanent redirects for outdated product URLs as expected. Previously, the import process removed these redirects, and when you tried to open the changed product by the old URL key, Magento displayed a 404 page. *Fix submitted by Shikha Mishra in pull request [20737](https://github.com/magento/magento2/pull/20737)*. [GitHub-20282](https://github.com/magento/magento2/issues/20282)
 
 <!-- ENGCOM-4224 -->
 
-* The store switcher now works in multistore deployments. Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
+*  The store switcher now works in multistore deployments. Previously, the switcher redirected the user to the home page, not to the alternative store view as expected. *Fix submitted by Janak Bhimani in pull request [21140](https://github.com/magento/magento2/pull/21140)*. [GitHub-19714](https://github.com/magento/magento2/issues/19714)
 
 ### VAT ID
 
 <!-- ENGCOM-4232 -->
 
-* Magento can now validate Greek VAT numbers. *Fix submitted by Amol Chaudhari in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
+*  Magento can now validate Greek VAT numbers. *Fix submitted by Amol Chaudhari in pull request [21169](https://github.com/magento/magento2/pull/21169)*. [GitHub-6960](https://github.com/magento/magento2/issues/6960)
 
 ### Web API framework
 
 <!-- MAGETWO-73978 -->
 
-* Magento now throws an error as expected when you send an API request that specifies `pageSize` and `currentPage` values that exceed the number of products in the catalog that you are querying. Previously, when you queried a catalog and specified values that exceeded catalog size, the API would ignores the specified `currentPage` value, and return the same results as the highest valid `currentPage`.
+*  Magento now throws an error as expected when you send an API request that specifies `pageSize` and `currentPage` values that exceed the number of products in the catalog that you are querying. Previously, when you queried a catalog and specified values that exceeded catalog size, the API would ignores the specified `currentPage` value, and return the same results as the highest valid `currentPage`.
 
 <!-- ENGCOM-4792 -->
 
-* You can now use REST in scope `all` to save an existing category that does not have a name attribute. Previously, Magento threw the following exception: `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by Saphal Jha in pull request [22440](https://github.com/magento/magento2/pull/22440)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
+*  You can now use REST in scope `all` to save an existing category that does not have a name attribute. Previously, Magento threw the following exception: `Could not save category with message. The "Name" attribute value is empty. Set the attribute and try again`. *Fix submitted by Saphal Jha in pull request [22440](https://github.com/magento/magento2/pull/22440)*. [GitHub-22309](https://github.com/magento/magento2/issues/22309)
 
 <!-- ENGCOM-4837 -->
 
-* The `PUT /V1/products/:sku/media/:entryId` API operation now updates product images as expected. Previously, this operation updated the label, types, and disabled settings, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`. *Fix submitted by Nirav Patel in pull request [22533](https://github.com/magento/magento2/pull/22533)*. [GitHub-22402](https://github.com/magento/magento2/issues/22402)
+*  The `PUT /V1/products/:sku/media/:entryId` API operation now updates product images as expected. Previously, this operation updated the label, types, and disabled settings, but the actual `file-content` was not replaced with the values that were provided in `base64_encoded_data`. *Fix submitted by Nirav Patel in pull request [22533](https://github.com/magento/magento2/pull/22533)*. [GitHub-22402](https://github.com/magento/magento2/issues/22402)
 
 ### Wish List
 
 <!-- MAGETWO-73613 -->
 
-* The wish list quantity field now has limits on both the type and number of characters that you can enter. Previously, you could enter an extremely large quantity of both number and letters into this field, which resulted in undesirable, inaccurate quantity changes
+*  The wish list quantity field now has limits on both the type and number of characters that you can enter. Previously, you could enter an extremely large quantity of both number and letters into this field, which resulted in undesirable, inaccurate quantity changes
 
 <!-- ENGCOM-4513 -->
 
-* Customer wish lists now include review summaries for included products. *Fix submitted by Amol Chaudhari in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
+*  Customer wish lists now include review summaries for included products. *Fix submitted by Amol Chaudhari in pull request [21759](https://github.com/magento/magento2/pull/21759)*. [GitHub-21419](https://github.com/magento/magento2/issues/21419)
 
 ## Known issue
 
-* **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future.
+*  **Issue**: The Async/Bulk Web APIs support only the default store view. A hot fix for this issue will be available in the near future.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotesMagentoShipping2.2.x.md
+++ b/guides/v2.2/release-notes/ReleaseNotesMagentoShipping2.2.x.md
@@ -38,29 +38,29 @@ Here are the enhancements and  fixes available as of May 2, 2018:
 
 ### Enhancements
 
-* Provided validation to prevent merchants from indicating that the  package maximum weight greater that the actual package being shipped.
+*  Provided validation to prevent merchants from indicating that the  package maximum weight greater that the actual package being shipped.
 
-* Added international fields to shipment details.
+*  Added international fields to shipment details.
 
-* Added  tool-tips to inform users about the Locations, Carriers and Packages pages.
+*  Added  tool-tips to inform users about the Locations, Carriers and Packages pages.
 
-* Truncated long carrier nickname on Shipping Partners page.
+*  Truncated long carrier nickname on Shipping Partners page.
 
-* Improved appearance of  navigation buttons on carrier connection page.
+*  Improved appearance of  navigation buttons on carrier connection page.
 
-* Provided ad-hoc Return labels with return shipment tracking. This features builds on `Magento_Rma`.
+*  Provided ad-hoc Return labels with return shipment tracking. This features builds on `Magento_Rma`.
 
 ### Fixes
 
 Resolution of the following issues:
 
-* Incompatibility with Internet Explorer 11.x.
+*  Incompatibility with Internet Explorer 11.x.
 
-* Magento checkout price not respecting set currency in Portal.
+*  Magento checkout price not respecting set currency in Portal.
 
-* Currency conversion issues.
+*  Currency conversion issues.
 
-* Duplicated navigation menu during carrier connection.
+*  Duplicated navigation menu during carrier connection.
 
 ## Changes effective January 22, 2018
 
@@ -68,19 +68,19 @@ Here are the enhancements and fixes available as of January 22, 2018:
 
 ### Enhancements
 
-* Added a tutorial for activating Magento Shipping.
+*  Added a tutorial for activating Magento Shipping.
 
-* Redesigned the Shipping Experience Rules page so that it displays the rule execution sequence.
+*  Redesigned the Shipping Experience Rules page so that it displays the rule execution sequence.
 
-* Added alphanumeric validation to the Huxloe Hermes carrier tab. (Huxloe Hermes)
+*  Added alphanumeric validation to the Huxloe Hermes carrier tab. (Huxloe Hermes)
 
-* Improved the functionality of the label converter. (Huxloe Hermes)
+*  Improved the functionality of the label converter. (Huxloe Hermes)
 
-* Improved the error messages for the PickUpAvailability endpoint. (FedEx)
+*  Improved the error messages for the PickUpAvailability endpoint. (FedEx)
 
-* Improved the general quality of all error messages. (UPS)
+*  Improved the general quality of all error messages. (UPS)
 
-* Improved the validation of customer API keys during configuration.  (UK Mail)
+*  Improved the validation of customer API keys during configuration.  (UK Mail)
 
 ### Fixes
 
@@ -88,37 +88,37 @@ The fixes described here are categorized by shipping carrier.
 
 #### Australia Post
 
-* Fixed an issue with the error thrown if Export Category is **commercial** when the shipment isn't dutiable. Previously, the error thrown did not correctly address the issue.
+*  Fixed an issue with the error thrown if Export Category is **commercial** when the shipment isn't dutiable. Previously, the error thrown did not correctly address the issue.
 
 #### FedEx
 
-* Changed the default signature option to DIRECT for all services.
+*  Changed the default signature option to DIRECT for all services.
 
 #### UPS
 
-* Resolved a UI issue with validation so that users do not need to enter State or Province when connecting to UPS with a United Kingdom  address.
+*  Resolved a UI issue with validation so that users do not need to enter State or Province when connecting to UPS with a United Kingdom  address.
 
 #### DHL Express
 
-* Updated the pickup error response from DHL. Previously, this response was inaccurate.
+*  Updated the pickup error response from DHL. Previously, this response was inaccurate.
 
-* Updated the `getCompanyName` and `getOrganisationName` validation functions to check only for company name and organization name respectively.
+*  Updated the `getCompanyName` and `getOrganisationName` validation functions to check only for company name and organization name respectively.
 
-* Updated the validation process for company name and organization name used on the DHL Express Connect page.
+*  Updated the validation process for company name and organization name used on the DHL Express Connect page.
 
-* Updated the currency fields in the `cn23` template for customs declaration forms to match other documents and labels.
+*  Updated the currency fields in the `cn23` template for customs declaration forms to match other documents and labels.
 
-* Changed the default display of the `quantityUnit` field. The default value is now zero, and this field is left blank.
+*  Changed the default display of the `quantityUnit` field. The default value is now zero, and this field is left blank.
 
 #### Huxloe Hermes
 
-* Increased the duration of the response timeout from 10 to 20 seconds.
+*  Increased the duration of the response timeout from 10 to 20 seconds.
 
-* Fixed lint program.
+*  Fixed lint program.
 
-* Improved the functionality of the label converter.
+*  Improved the functionality of the label converter.
 
-* Upgraded to local time zones for booking, pickup, and tracking times.
+*  Upgraded to local time zones for booking, pickup, and tracking times.
 
 ## Changes effective January 5, 2018
 
@@ -126,48 +126,48 @@ Here are the enhancements and fixes available as of January 5, 2018:
 
 ### Enhancements
 
-* Added automated billing subscription redirection for billing
+*  Added automated billing subscription redirection for billing
 
-* Improved error handling for Australia Post
+*  Improved error handling for Australia Post
 
 ### Fixes
 
 #### Billing
 
-* Fixed issue with billing metric calculations and capture
+*  Fixed issue with billing metric calculations and capture
 
 #### Tracking
 
-* Fixed issue with tracking capture and display
+*  Fixed issue with tracking capture and display
 
 #### Portal
 
-* Fixed issue with redirection on log-out
+*  Fixed issue with redirection on log-out
 
-* Fixed issue that prevented the consistent saving of qualification rules
+*  Fixed issue that prevented the consistent saving of qualification rules
 
 #### Australia Post
 
-* Corrected incorrect service names
+*  Corrected incorrect service names
 
 #### UK Mail
 
-* Removed restrictions on mandatory county information
+*  Removed restrictions on mandatory county information
 
 #### FedEx
 
-* Removed unsupported freight services from list of available services
+*  Removed unsupported freight services from list of available services
 
-* Changed orientation of labels from landscape to portrait
+*  Changed orientation of labels from landscape to portrait
 
-* Corrected MPS handling in completion
+*  Corrected MPS handling in completion
 
-* Implemented sensible defaults for FedEx
+*  Implemented sensible defaults for FedEx
 
 #### Configuration
 
-* Set FedEx  to 'Upcoming' carrier.
+*  Set FedEx  to 'Upcoming' carrier.
 
 #### USPS
 
-* Updated label size to A6 default in PNG.
+*  Updated label size to A6 default in PNG.

--- a/guides/v2.2/release-notes/backward-incompatible-changes/index.md
+++ b/guides/v2.2/release-notes/backward-incompatible-changes/index.md
@@ -103,59 +103,59 @@ Deprecated method | Use instead | Subsequent calls
 **Class:** [`Magento\Paypal\Cron\FetchReports`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Paypal/Cron/FetchReports.php){:target="_blank"}<br/>
 **Action:**
 
-- Method `execute` has been reworked and now throws an `\Exception` instead of logging it
-- Method `__construction` no longer has the `\Psr\Log\LoggerInterface` dependency
-- The `report_date` column from the `paypal_settlement_report` table has been changed from `timestamp` format to `date`.
+-  Method `execute` has been reworked and now throws an `\Exception` instead of logging it
+-  Method `__construction` no longer has the `\Psr\Log\LoggerInterface` dependency
+-  The `report_date` column from the `paypal_settlement_report` table has been changed from `timestamp` format to `date`.
 
 ## Changes in repositories
 
 In Magento 2.2 the behavior of repositories regarding the Filters added to Search Criteria  was unified:
 
-- The boolean OR statement joins Filters inside a single Filter Group.
-- The boolean AND statement joins Filter Groups inside a Search Criteria.
+-  The boolean OR statement joins Filters inside a single Filter Group.
+-  The boolean AND statement joins Filter Groups inside a Search Criteria.
 
  In the scope of this work, the following repositories were affected.
 
 ### Affected {{site.data.var.ce}} repositories
 
-- `\Magento\Catalog\Api\AttributeSetRepositoryInterface`
-- `\Magento\Catalog\Api\CategoryAttributeRepositoryInterface`
-- `\Magento\Catalog\Api\ProductAttributeGroupRepositoryInterface`
-- `\Magento\Catalog\Api\ProductAttributeRepositoryInterface`
-- `\Magento\Cms\Api\BlockRepositoryInterface`
-- `\Magento\Cms\Api\PageRepositoryInterface`
-- `\Magento\Eav\Api\AttributeGroupRepositoryInterface`
-- `\Magento\Eav\Api\AttributeRepositoryInterface`
-- `\Magento\Eav\Api\AttributeSetRepositoryInterface`
-- `\Magento\Sales\Api\CreditmemoCommentRepositoryInterface`
-- `\Magento\Sales\Api\CreditmemoItemRepositoryInterface`
-- `\Magento\Sales\Api\CreditmemoRepositoryInterface`
-- `\Magento\Sales\Api\InvoiceCommentRepositoryInterface`
-- `\Magento\Sales\Api\InvoiceItemRepositoryInterface`
-- `\Magento\Sales\Api\InvoiceRepositoryInterface`
-- `\Magento\Sales\Api\OrderAddressRepositoryInterface`
-- `\Magento\Sales\Api\OrderItemRepositoryInterface`
-- `\Magento\Sales\Api\OrderPaymentRepositoryInterface`
-- `\Magento\Sales\Api\OrderStatusHistoryRepositoryInterface`
-- `\Magento\Sales\Api\ShipmentCommentRepositoryInterface`
-- `\Magento\Sales\Api\ShipmentItemRepositoryInterface`
-- `\Magento\Sales\Api\ShipmentRepositoryInterface`
-- `\Magento\Sales\Api\ShipmentTrackRepositoryInterface`
-- `\Magento\Sales\Api\TransactionRepositoryInterface`
-- `\Magento\Ui\Api\BookmarkRepositoryInterface`
-- `\Magento\Vault\Api\PaymentTokenRepositoryInterface`
+-  `\Magento\Catalog\Api\AttributeSetRepositoryInterface`
+-  `\Magento\Catalog\Api\CategoryAttributeRepositoryInterface`
+-  `\Magento\Catalog\Api\ProductAttributeGroupRepositoryInterface`
+-  `\Magento\Catalog\Api\ProductAttributeRepositoryInterface`
+-  `\Magento\Cms\Api\BlockRepositoryInterface`
+-  `\Magento\Cms\Api\PageRepositoryInterface`
+-  `\Magento\Eav\Api\AttributeGroupRepositoryInterface`
+-  `\Magento\Eav\Api\AttributeRepositoryInterface`
+-  `\Magento\Eav\Api\AttributeSetRepositoryInterface`
+-  `\Magento\Sales\Api\CreditmemoCommentRepositoryInterface`
+-  `\Magento\Sales\Api\CreditmemoItemRepositoryInterface`
+-  `\Magento\Sales\Api\CreditmemoRepositoryInterface`
+-  `\Magento\Sales\Api\InvoiceCommentRepositoryInterface`
+-  `\Magento\Sales\Api\InvoiceItemRepositoryInterface`
+-  `\Magento\Sales\Api\InvoiceRepositoryInterface`
+-  `\Magento\Sales\Api\OrderAddressRepositoryInterface`
+-  `\Magento\Sales\Api\OrderItemRepositoryInterface`
+-  `\Magento\Sales\Api\OrderPaymentRepositoryInterface`
+-  `\Magento\Sales\Api\OrderStatusHistoryRepositoryInterface`
+-  `\Magento\Sales\Api\ShipmentCommentRepositoryInterface`
+-  `\Magento\Sales\Api\ShipmentItemRepositoryInterface`
+-  `\Magento\Sales\Api\ShipmentRepositoryInterface`
+-  `\Magento\Sales\Api\ShipmentTrackRepositoryInterface`
+-  `\Magento\Sales\Api\TransactionRepositoryInterface`
+-  `\Magento\Ui\Api\BookmarkRepositoryInterface`
+-  `\Magento\Vault\Api\PaymentTokenRepositoryInterface`
 
 ### Affected {{site.data.var.ee}} repositories
 
-- `\Magento\GiftCardAccount\Api\GiftCardAccountRepositoryInterface`
-- `\Magento\GiftWrapping\Api\WrappingRepositoryInterface`
-- `\Magento\Rma\Api\CommentRepositoryInterface`
-- `\Magento\Rma\Model\RmaRepository`
-- `\Magento\Rma\Model\Service\RmaManagement`
-- `\Magento\Rma\Model\Rma\Status\HistoryRepository`
-- `\Magento\Rma\Api\RmaRepositoryInterface`
-- `\Magento\Staging\Api\UpdateRepositoryInterface`
-- `\Magento\VersionsCms\Api\HierarchyNodeRepositoryInterface`
+-  `\Magento\GiftCardAccount\Api\GiftCardAccountRepositoryInterface`
+-  `\Magento\GiftWrapping\Api\WrappingRepositoryInterface`
+-  `\Magento\Rma\Api\CommentRepositoryInterface`
+-  `\Magento\Rma\Model\RmaRepository`
+-  `\Magento\Rma\Model\Service\RmaManagement`
+-  `\Magento\Rma\Model\Rma\Status\HistoryRepository`
+-  `\Magento\Rma\Api\RmaRepositoryInterface`
+-  `\Magento\Staging\Api\UpdateRepositoryInterface`
+-  `\Magento\VersionsCms\Api\HierarchyNodeRepositoryInterface`
 
 For details about repositories see the [Searching with repositories]({{ page.baseurl }}/extension-dev-guide/searching-with-repositories.html) topic.
 
@@ -172,49 +172,49 @@ In order to adopt custom implementations of these interfaces, please, change met
 
 ### Affected {{site.data.var.ce}} repositories
 
-- `\Magento\Vault\Api\PaymentTokenRepositoryInterface::getList`
-- `\Magento\Tax\Api\TaxRuleRepositoryInterface::getList`
-- `\Magento\Sales\Api\CreditmemoCommentRepositoryInterface::getList`
-- `\Magento\Sales\Api\CreditmemoItemRepositoryInterface::getList`
-- `\Magento\Sales\Api\CreditmemoRepositoryInterface::getList`
-- `\Magento\Sales\Api\InvoiceCommentRepositoryInterface::getList`
-- `\Magento\Sales\Api\InvoiceItemRepositoryInterface::getList`
-- `\Magento\Sales\Api\InvoiceRepositoryInterface::getList`
-- `\Magento\Sales\Api\OrderAddressRepositoryInterface::getList`
-- `\Magento\Sales\Api\OrderItemRepositoryInterface::getList`
-- `\Magento\Sales\Api\OrderPaymentRepositoryInterface::getList`
-- `\Magento\Sales\Api\OrderRepositoryInterface::getList`
-- `\Magento\Sales\Api\OrderStatusHistoryRepositoryInterface::getList`
-- `\Magento\Sales\Api\ShipmentCommentRepositoryInterface::getList`
-- `\Magento\Sales\Api\ShipmentItemRepositoryInterface::getList`
-- `\Magento\Sales\Api\ShipmentRepositoryInterface::getList`
-- `\Magento\Sales\Api\ShipmentTrackRepositoryInterface::getList`
-- `\Magento\Sales\Api\TransactionRepositoryInterface::getList`
-- `\Magento\Quote\Api\CartRepositoryInterface::getList`
-- `\Magento\Vault\Model\PaymentTokenRepository::getList`
-- `\Magento\Tax\Model\TaxRuleRepository::getList`
-- `\Magento\Sales\Model\OrderRepository::getList`
-- `\Magento\Sales\Model\Order\AddressRepository::getList`
-- `\Magento\Sales\Model\Order\CreditmemoRepository::getList`
-- `\Magento\Sales\Model\Order\InvoiceRepository::getList`
-- `\Magento\Sales\Model\Order\ItemRepository::getList`
-- `\Magento\Sales\Model\Order\ShipmentRepository::getList`
-- `\Magento\Sales\Model\Order\Payment\Repository::getList`
-- `\Magento\Sales\Model\Order\Payment\Transaction\Repository::getList`
-- `\Magento\Quote\Model\QuoteRepository::getList`
+-  `\Magento\Vault\Api\PaymentTokenRepositoryInterface::getList`
+-  `\Magento\Tax\Api\TaxRuleRepositoryInterface::getList`
+-  `\Magento\Sales\Api\CreditmemoCommentRepositoryInterface::getList`
+-  `\Magento\Sales\Api\CreditmemoItemRepositoryInterface::getList`
+-  `\Magento\Sales\Api\CreditmemoRepositoryInterface::getList`
+-  `\Magento\Sales\Api\InvoiceCommentRepositoryInterface::getList`
+-  `\Magento\Sales\Api\InvoiceItemRepositoryInterface::getList`
+-  `\Magento\Sales\Api\InvoiceRepositoryInterface::getList`
+-  `\Magento\Sales\Api\OrderAddressRepositoryInterface::getList`
+-  `\Magento\Sales\Api\OrderItemRepositoryInterface::getList`
+-  `\Magento\Sales\Api\OrderPaymentRepositoryInterface::getList`
+-  `\Magento\Sales\Api\OrderRepositoryInterface::getList`
+-  `\Magento\Sales\Api\OrderStatusHistoryRepositoryInterface::getList`
+-  `\Magento\Sales\Api\ShipmentCommentRepositoryInterface::getList`
+-  `\Magento\Sales\Api\ShipmentItemRepositoryInterface::getList`
+-  `\Magento\Sales\Api\ShipmentRepositoryInterface::getList`
+-  `\Magento\Sales\Api\ShipmentTrackRepositoryInterface::getList`
+-  `\Magento\Sales\Api\TransactionRepositoryInterface::getList`
+-  `\Magento\Quote\Api\CartRepositoryInterface::getList`
+-  `\Magento\Vault\Model\PaymentTokenRepository::getList`
+-  `\Magento\Tax\Model\TaxRuleRepository::getList`
+-  `\Magento\Sales\Model\OrderRepository::getList`
+-  `\Magento\Sales\Model\Order\AddressRepository::getList`
+-  `\Magento\Sales\Model\Order\CreditmemoRepository::getList`
+-  `\Magento\Sales\Model\Order\InvoiceRepository::getList`
+-  `\Magento\Sales\Model\Order\ItemRepository::getList`
+-  `\Magento\Sales\Model\Order\ShipmentRepository::getList`
+-  `\Magento\Sales\Model\Order\Payment\Repository::getList`
+-  `\Magento\Sales\Model\Order\Payment\Transaction\Repository::getList`
+-  `\Magento\Quote\Model\QuoteRepository::getList`
 
 ### Affected {{site.data.var.ee}} repositories
 
-- `\Magento\Signifyd\Api\CaseRepositoryInterface::getList`
-- `\Magento\Rma\Api\CommentRepositoryInterface::getList`
-- `\Magento\Rma\Api\RmaManagementInterface::search`
-- `\Magento\Rma\Api\RmaRepositoryInterface::getList`
-- `\Magento\Rma\Api\TrackRepositoryInterface::getList`
-- `\Magento\GiftWrapping\Api\WrappingRepositoryInterface::getList`
-- `\Magento\GiftCardAccount\Api\GiftCardAccountRepositoryInterface::getList`
-- `\Magento\Signifyd\Model\CaseRepository::getList`
-- `\Magento\Rma\Model\Service\RmaManagement::search`
-- `\Magento\GiftWrapping\Model\WrappingRepository::getList`
+-  `\Magento\Signifyd\Api\CaseRepositoryInterface::getList`
+-  `\Magento\Rma\Api\CommentRepositoryInterface::getList`
+-  `\Magento\Rma\Api\RmaManagementInterface::search`
+-  `\Magento\Rma\Api\RmaRepositoryInterface::getList`
+-  `\Magento\Rma\Api\TrackRepositoryInterface::getList`
+-  `\Magento\GiftWrapping\Api\WrappingRepositoryInterface::getList`
+-  `\Magento\GiftCardAccount\Api\GiftCardAccountRepositoryInterface::getList`
+-  `\Magento\Signifyd\Model\CaseRepository::getList`
+-  `\Magento\Rma\Model\Service\RmaManagement::search`
+-  `\Magento\GiftWrapping\Model\WrappingRepository::getList`
 
 ## Compiler changes
 
@@ -222,11 +222,11 @@ This release removes the multi-tenant compiler option and support of the definit
 
 The following classes are no longer available:
 
-- `Magento\Setup\Console\Command\DiCompileMultiTenantCommand`
-- `Magento\Framework\ObjectManager\Relations\Compiled`
-- `Magento\Framework\ObjectManager\Definition\Compiled\Serialized`
-- `Magento\Framework\ObjectManager\Definition\Compiled\Binary`
-- `Magento\Framework\Interception\Definition\Compiled`
+-  `Magento\Setup\Console\Command\DiCompileMultiTenantCommand`
+-  `Magento\Framework\ObjectManager\Relations\Compiled`
+-  `Magento\Framework\ObjectManager\Definition\Compiled\Serialized`
+-  `Magento\Framework\ObjectManager\Definition\Compiled\Binary`
+-  `Magento\Framework\Interception\Definition\Compiled`
 
 The `bin/magento setup:config:set` command no longer has the `--definition-format` option.
 
@@ -277,11 +277,11 @@ You also need to write an upgrade script for the data in the database.
 **Case 5:**
 Your extension accesses values in the `core_config_data` table using the following paths:
 
-- `payment/braintree/countrycreditcard`
-- `design/theme/ua_regexp`
-- `cataloginventory/item_options/min_sale_qty`
-- `currency/options/customsymbol`
-- `admin/magento_logging/actions`
+-  `payment/braintree/countrycreditcard`
+-  `design/theme/ua_regexp`
+-  `cataloginventory/item_options/min_sale_qty`
+-  `currency/options/customsymbol`
+-  `admin/magento_logging/actions`
 
 **Solution:**
 Update your extension to use `\Magento\Framework\Serialize\Serializer\Json` for serializing/unserializing data instead of the native [PHP](https://glossary.magento.com/php) serialize/unserialize functions.
@@ -294,8 +294,8 @@ Write an [upgrade script]({{ page.baseurl }}/ext-best-practices/tutorials/serial
 
 **See:**
 
-- [Serialize to JSON data upgrade]({{ page.baseurl }}/ext-best-practices/tutorials/serialized-to-json-data-upgrade.html)
-- [Serialize Library]({{ page.baseurl }}/extension-dev-guide/framework/serializer.html)
+-  [Serialize to JSON data upgrade]({{ page.baseurl }}/ext-best-practices/tutorials/serialized-to-json-data-upgrade.html)
+-  [Serialize Library]({{ page.baseurl }}/extension-dev-guide/framework/serializer.html)
 
 ## Database field changes
 
@@ -362,12 +362,12 @@ It can be used to upgrade data in upgrade scripts.
 
 #### Features
 
-- Ability to process records in batches
-- Can use the `where` condition
-- Update multiple fields in a table at once
-- Update records in multiple threads
-- Convert nested serialized data
-- Update duplicate records at once
+-  Ability to process records in batches
+-  Can use the `where` condition
+-  Update multiple fields in a table at once
+-  Update records in multiple threads
+-  Convert nested serialized data
+-  Update duplicate records at once
 
 ## Input/Output format of methods
 

--- a/guides/v2.2/release-notes/bk-release-notes.md
+++ b/guides/v2.2/release-notes/bk-release-notes.md
@@ -16,40 +16,40 @@ Quarterly patch releases do not introduce backward-incompatible changes, archite
 
 ## Magento 2.2.x Release Notes
 
-* [{{site.data.var.ce}} 2.2.10 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-2-10-open-source.html)
-* [{{site.data.var.ee}} 2.2.10 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-2-10-commerce.html)
+*  [{{site.data.var.ce}} 2.2.10 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-2-10-open-source.html)
+*  [{{site.data.var.ee}} 2.2.10 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-2-10-commerce.html)
 
-* [{{site.data.var.ce}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9CE.html)
-* [{{site.data.var.ee}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9EE.html)
+*  [{{site.data.var.ce}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9CE.html)
+*  [{{site.data.var.ee}} 2.2.9 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.9EE.html)
 
-* [{{site.data.var.ce}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8CE.html)
-* [{{site.data.var.ee}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8EE.html)
+*  [{{site.data.var.ce}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8CE.html)
+*  [{{site.data.var.ee}} 2.2.8 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.8EE.html)
 
-* [{{site.data.var.ce}} 2.2.7 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.7CE.html)
-* [{{site.data.var.ee}} 2.2.7 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.7EE.html)
+*  [{{site.data.var.ce}} 2.2.7 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.7CE.html)
+*  [{{site.data.var.ee}} 2.2.7 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.7EE.html)
 
-* [{{site.data.var.ce}} 2.2.6 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.6CE.html)
-* [{{site.data.var.ee}} 2.2.6 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.6EE.html)
+*  [{{site.data.var.ce}} 2.2.6 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.6CE.html)
+*  [{{site.data.var.ee}} 2.2.6 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.6EE.html)
 
-* [{{site.data.var.ce}} 2.2.5 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.5CE.html)
-* [{{site.data.var.ee}} 2.2.5 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.5EE.html)
+*  [{{site.data.var.ce}} 2.2.5 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.5CE.html)
+*  [{{site.data.var.ee}} 2.2.5 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.5EE.html)
 
-* [{{site.data.var.ce}} 2.2.4 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.4CE.html)
-* [{{site.data.var.ee}} 2.2.4 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.4EE.html)
+*  [{{site.data.var.ce}} 2.2.4 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.4CE.html)
+*  [{{site.data.var.ee}} 2.2.4 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.4EE.html)
 
-* [{{site.data.var.ce}} 2.2.3 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.3CE.html)
-* [{{site.data.var.ee}} 2.2.3 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.3EE.html)
+*  [{{site.data.var.ce}} 2.2.3 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.3CE.html)
+*  [{{site.data.var.ee}} 2.2.3 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.3EE.html)
 
-* [{{site.data.var.ce}} 2.2.2 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.2CE.html)
-* [{{site.data.var.ee}} 2.2.2 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.2EE.html)
+*  [{{site.data.var.ce}} 2.2.2 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.2CE.html)
+*  [{{site.data.var.ee}} 2.2.2 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.2EE.html)
 
-* [{{site.data.var.ce}} 2.2.1 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.1CE.html)
-* [{{site.data.var.ee}} 2.2.1 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.1EE.html)
-* [{{site.data.var.ece}} 2.2.1 Release Notes]({{page.baseurl}}/cloud/release-notes/CloudReleaseNotes2.2.1.html)
+*  [{{site.data.var.ce}} 2.2.1 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.1CE.html)
+*  [{{site.data.var.ee}} 2.2.1 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.1EE.html)
+*  [{{site.data.var.ece}} 2.2.1 Release Notes]({{page.baseurl}}/cloud/release-notes/CloudReleaseNotes2.2.1.html)
 
-* [{{site.data.var.ce}} 2.2.0 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.0CE.html)
-* [{{site.data.var.ee}} 2.2.0 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.0EE.html)
-* [{{site.data.var.ece}} 2.2.0 Release Notes]({{page.baseurl}}/cloud/release-notes/CloudReleaseNotes2.2.html)
+*  [{{site.data.var.ce}} 2.2.0 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.0CE.html)
+*  [{{site.data.var.ee}} 2.2.0 Release Notes]({{page.baseurl}}/release-notes/ReleaseNotes2.2.0EE.html)
+*  [{{site.data.var.ece}} 2.2.0 Release Notes]({{page.baseurl}}/cloud/release-notes/CloudReleaseNotes2.2.html)
 
 ## Backward-incompatible changes
 

--- a/guides/v2.2/release-notes/release-candidate/component-status.md
+++ b/guides/v2.2/release-notes/release-candidate/component-status.md
@@ -12,9 +12,9 @@ This page shows the status of each component for the Magento 2.2.x release and i
 
 Each status color indicates the severity and amount of 2.2-related issues for a particular component.
 
-* <span class="status red">Red</span> - The module has critical and blocking issues that make this module unstable.
-* <span class="status yellow">Yellow</span> - The module has some issues that may cause problems, but it is still functional.
-* <span class="status green">Green</span> - The module has no significant or outstanding issues.
+*  <span class="status red">Red</span> - The module has critical and blocking issues that make this module unstable.
+*  <span class="status yellow">Yellow</span> - The module has some issues that may cause problems, but it is still functional.
+*  <span class="status green">Green</span> - The module has no significant or outstanding issues.
 
 The issues used to generate the status of these components come from verified internal and GitHub reports for Magento 2.2.
 Issues that are not related to the 2.2 release are not part of this report.

--- a/guides/v2.2/release-notes/release-notes-2-2-10-commerce.md
+++ b/guides/v2.2/release-notes/release-notes-2-2-10-commerce.md
@@ -18,16 +18,16 @@ Look for the following highlights in this release:
 
 The following upgrades to core platform components boost platform security and support PCI compliance:
 
-* Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
-* Magento 2.2.10 does not support PHP 7.0.x.<!--- MC-18521 -->
+*  Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
+*  Magento 2.2.10 does not support PHP 7.0.x.<!--- MC-18521 -->
 
 ### Substantial security enhancements
 
 This release includes the following security enhancements:
 
-* PSD2 compliance for core payment methods
-* Fixes for 75 critical security issues
-* Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
+*  PSD2 compliance for core payment methods
+*  Fixes for 75 critical security issues
+*  Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
 
 #### Core payment methods integrations are now compliant with PSD2 regulations
 
@@ -35,16 +35,16 @@ The European Union recently revised the Payment Services Directive (PSD) regulat
 
 This release contains the following major PSD-related changes:
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
 
 <!--- MC-18237 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which took effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which took effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
 
 #### Security enhancements and fixes to core code
 
-* **70 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.10) have been ported to 2.3.3, 1.14.4.3, and 1.9.4.3, as appropriate.
+*  **70 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.10) have been ported to 2.3.3, 1.14.4.3, and 1.9.4.3, as appropriate.
 
 ### Infrastructure improvements
 
@@ -57,708 +57,708 @@ In addition to security enhancements, this release contains the following functi
 ### Installation, setup, and deployment
 
 <!-- MAGETWO-18745 -->
-* PHP unit tests no longer fail by default when Magento is installed from Composer.
+*  PHP unit tests no longer fail by default when Magento is installed from Composer.
 
 <!-- MAGETWO-99617 -->
-* Magento font icons now load as expected when deployment optimization is implemented.
+*  Magento font icons now load as expected when deployment optimization is implemented.
 
 <!-- ENGCOM-5102 -->
-* The short form versions of the `—lock-env` and `—lock-config` `bin/magento config:set` options now work as expected. *Fix submitted by Shikha Mishra in pull request [22836](https://github.com/magento/magento2/pull/22836)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
+*  The short form versions of the `—lock-env` and `—lock-config` `bin/magento config:set` options now work as expected. *Fix submitted by Shikha Mishra in pull request [22836](https://github.com/magento/magento2/pull/22836)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
 
 <!-- ENGCOM-5150 -->
-* Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22610](https://github.com/magento/magento2/pull/22610)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852), [GitHub-22563](https://github.com/magento/magento2/issues/22563)
+*  Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22610](https://github.com/magento/magento2/pull/22610)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852), [GitHub-22563](https://github.com/magento/magento2/issues/22563)
 
 <!-- ENGCOM-5203 -->
-* Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [23114](https://github.com/magento/magento2/pull/23114)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
+*  Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [23114](https://github.com/magento/magento2/pull/23114)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
 
 <!-- ENGCOM-5306 -->
-* You can now use JSON to set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [23277](https://github.com/magento/magento2/pull/23277)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
+*  You can now use JSON to set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [23277](https://github.com/magento/magento2/pull/23277)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
 
 ### AdminGWS
 
 <!-- MAGETWO-99800 -->
-* An administrator with permission to a website now has access to the theme configuration for the website. Previously, administrators with website permission could update only the theme for the store view that is associated with a website, not the theme for the website itself.
+*  An administrator with permission to a website now has access to the theme configuration for the website. Previously, administrators with website permission could update only the theme for the store view that is associated with a website, not the theme for the website itself.
 
 <!-- MAGETWO-97421 -->
-* An administrator with restricted privileges can now successfully create a catalog price rule. Previously, a restricted administrator could create a catalog price rule, but when they saved it, Magento displayed an error and did not generate a scheduled update to set the new price rule to inactive.
+*  An administrator with restricted privileges can now successfully create a catalog price rule. Previously, a restricted administrator could create a catalog price rule, but when they saved it, Magento displayed an error and did not generate a scheduled update to set the new price rule to inactive.
 
 <!-- MAGETWO-97565 -->
-* We have improved the Admin login performance for users with limited permissions. Previously, the Admin login process for users with restricted access was significantly slower than it was for users with full administrative access.
+*  We have improved the Admin login performance for users with limited permissions. Previously, the Admin login process for users with restricted access was significantly slower than it was for users with full administrative access.
 
 <!-- MAGETWO-99149 -->
-* Magento now applies the correct role scope for administrators in multi-site deployments. (Post data is now saved in the session and re-rendered for a user only if the validation fails.) Previously, when you had two administrative roles with different website scopes, and you viewed one role before saving it and opening the second role, the website scope attributed to the second role was incorrectly taken from the first role.
+*  Magento now applies the correct role scope for administrators in multi-site deployments. (Post data is now saved in the session and re-rendered for a user only if the validation fails.) Previously, when you had two administrative roles with different website scopes, and you viewed one role before saving it and opening the second role, the website scope attributed to the second role was incorrectly taken from the first role.
 
 ### Backend
 
 <!-- MC-17292 -->
-* The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
+*  The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
 
 <!-- MC-99719 -->
-* The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
+*  The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
 
 ### Banner
 
 <!-- MC-17345 -->
-* Ajax requests are now cached as expected when the page they are associated with is cached. Previously, Ajax requests were still performed (not cached) even when a page was cached.
+*  Ajax requests are now cached as expected when the page they are associated with is cached. Previously, Ajax requests were still performed (not cached) even when a page was cached.
 
 ### B2B
 
 <!-- MAGETWO-96873 -->
-* The behavior of the Catalog page's Requisition list menu has been corrected.
+*  The behavior of the Catalog page's Requisition list menu has been corrected.
 
 <!-- MAGETWO-99542 -->
-* Non-administrative users who have been granted access privileges to catalogs and shared catalogs now also have access to the menu that permits them to manage these catalogs. Previously, these non-administrative users had permission to access the shared catalog, but not the menu that would permit them to manage the shared catalog.
+*  Non-administrative users who have been granted access privileges to catalogs and shared catalogs now also have access to the menu that permits them to manage these catalogs. Previously, these non-administrative users had permission to access the shared catalog, but not the menu that would permit them to manage the shared catalog.
 
 <!-- MAGETWO-94053 -->
-* A product that belongs to a category where the permissions do not allow adding it to cart can now be added to the cart from a different category. Previously, you could not add a product to the cart if one of the categories to which it belongs does not permit adding it the cart.
+*  A product that belongs to a category where the permissions do not allow adding it to cart can now be added to the cart from a different category. Previously, you could not add a product to the cart if one of the categories to which it belongs does not permit adding it the cart.
 
 <!-- MAGETWO-18557 -->
-* Magento now correctly calculates the total product quantity when you enter multiple SKU values in Quick Order.
+*  Magento now correctly calculates the total product quantity when you enter multiple SKU values in Quick Order.
 
 <!-- MAGETWO-18497 -->
-* Magento now correctly updates SKU quantities when you use Quick Order and manually enter a SKU in the **Enter Multiple SKUs** field when using Internet Explorer 11.x.
+*  Magento now correctly updates SKU quantities when you use Quick Order and manually enter a SKU in the **Enter Multiple SKUs** field when using Internet Explorer 11.x.
 
 <!-- MAGETWO-99842 -->
-* The `Magento_SharedCatalog::manage` role is now defined in the `acl.xml` file.
+*  The `Magento_SharedCatalog::manage` role is now defined in the `acl.xml` file.
 
 <!-- MAGETWO-99541 -->
-* Magento now displays the category tree as expected when you choose **Set Pricing and Structure** on a new shared catalog.
+*  Magento now displays the category tree as expected when you choose **Set Pricing and Structure** on a new shared catalog.
 
 <!-- MAGETWO-99447 -->
-* You can now create a new company account from the storefront in the same amount of time that it takes to create an account from the Admin. Previously, it took much longer to create a new company account on the storefront.
+*  You can now create a new company account from the storefront in the same amount of time that it takes to create an account from the Admin. Previously, it took much longer to create a new company account on the storefront.
 
 <!-- MC-17538 98817-->
-* Magento now correctly applies category permissions depending upon the scope values you set. Previously, when you enabled shared catalogs for only one website in a multi-site deployment, Magento applied catalog permissions globally instead of to the designated website only.
+*  Magento now correctly applies category permissions depending upon the scope values you set. Previously, when you enabled shared catalogs for only one website in a multi-site deployment, Magento applied catalog permissions globally instead of to the designated website only.
 
 <!-- MC-17296 -->
-* Magento now recalculates cart subtotals as expected when one of the ordered products that belongs to a shared catalog is disabled from the Admin. Previously, when you reloaded the cart after one of its products had been disabled, Magento reloaded the cart page with this exception: `Exception #0 (Magento\Framework\Exception\NoSuchEntityException): The product that was requested doesn't exist. Verify the product and try again`.
+*  Magento now recalculates cart subtotals as expected when one of the ordered products that belongs to a shared catalog is disabled from the Admin. Previously, when you reloaded the cart after one of its products had been disabled, Magento reloaded the cart page with this exception: `Exception #0 (Magento\Framework\Exception\NoSuchEntityException): The product that was requested doesn't exist. Verify the product and try again`.
 
 <!-- MAGETWO-98700 -->
-* Guests can now access available product options for a configurable product when one of its simple product options is out-of-stock but the configurable product is listed as in-stock in the shared catalog. Previously, under these circumstances, the options drop-down menu for the configurable product was empty, which prevented guests from ordering available options.
+*  Guests can now access available product options for a configurable product when one of its simple product options is out-of-stock but the configurable product is listed as in-stock in the shared catalog. Previously, under these circumstances, the options drop-down menu for the configurable product was empty, which prevented guests from ordering available options.
 
 <!-- MC-15402 -->
-* Export files now include all columns (including those not visible in the Company list) and their data. Previously, the `State/Province` columns of the exported CSV file were empty.
+*  Export files now include all columns (including those not visible in the Company list) and their data. Previously, the `State/Province` columns of the exported CSV file were empty.
 
 <!-- MC-17882 -->
-* Request a Quote functionality now works as expected on Internet Explorer 11.x.
+*  Request a Quote functionality now works as expected on Internet Explorer 11.x.
 
 <!-- MC-15671 -->
-* File links for customizable options on the Requisition list page now work as expected.
+*  File links for customizable options on the Requisition list page now work as expected.
 
 ### Bundle products
 
 <!-- MAGETWO-99952 -->
-* The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
+*  The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
 
 <!-- MAGETWO-99787 -->
-* Magento now issues a single request to the server when you change the shipping address for an order to a non-default address. Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
+*  Magento now issues a single request to the server when you change the shipping address for an order to a non-default address. Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
 
 ### Cache
 
 <!-- MAGETWO-99659 -->
-* Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
+*  Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
 
 ### Cart and checkout
 
 <!-- MC-17754 -->
-* Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order. [GitHub-23288](https://github.com/magento/magento2/issues/23288)
+*  Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order. [GitHub-23288](https://github.com/magento/magento2/issues/23288)
 
 <!-- MC-18286 -->
-* The checkout order summary now displays the correct number of ordered items.
+*  The checkout order summary now displays the correct number of ordered items.
 
 <!-- MAGETWO-93627 -->
-* Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
+*  Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
 
 <!-- MAGETWO-99251 -->
-* Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
+*  Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
 
 <!-- MC-17883 -->
-* The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
+*  The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
 
 <!-- MAGETWO-98462 -->
-* You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
+*  You can now add product quantities that require four digits to the shopping cart. Previously, Magento could not add four-digit product quantities to the cart.
 
 <!-- ENGCOM-5389 -->
-* The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Prakash Prajapati in pull request [23536](https://github.com/magento/magento2/pull/23536)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
+*  The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Prakash Prajapati in pull request [23536](https://github.com/magento/magento2/pull/23536)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
 
 <!-- ENGCOM-5400 -->
-* You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
+*  You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
 
 <!-- ENGCOM-5186 -->
-* Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Abrar Pathan in pull request [23058](https://github.com/magento/magento2/pull/23058)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
+*  Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Abrar Pathan in pull request [23058](https://github.com/magento/magento2/pull/23058)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
 
 <!-- MAGETWO-99709 -->
-* Magento no longer throws a custom address attribute multi-line error when a customer tries to place an order.
+*  Magento no longer throws a custom address attribute multi-line error when a customer tries to place an order.
 
 <!-- MC-16591 -->
-* Magento no longer indicates that your session has expired when you add a product to your shopping cart in deployments where the Scalable Checkout module is enabled.
+*  Magento no longer indicates that your session has expired when you add a product to your shopping cart in deployments where the Scalable Checkout module is enabled.
 
 <!-- MAGETWO-91328 -->
-* Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
+*  Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
 
 <!-- MAGETWO-99956 -->
-* The **Admin** > **Catalog** > **Categories** page now works as expected. Previously, Magento threw a fatal error when you tried to navigate to this page due to issues with the translation function.
+*  The **Admin** > **Catalog** > **Categories** page now works as expected. Previously, Magento threw a fatal error when you tried to navigate to this page due to issues with the translation function.
 
 <!-- ENGCOM-5400 -->
-* You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
+*  You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
 
 ### Catalog
 
 <!-- MAGETWO-17764 -->
-* Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
+*  Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
 
 <!-- MAGETWO-17622 -->
-* You can now save multi-select and select attribute options when swatches modules are disabled.
+*  You can now save multi-select and select attribute options when swatches modules are disabled.
 [GitHub-23326](https://github.com/magento/magento2/issues/23326)
 
 <!-- MAGETWO-98521 -->
-* You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
+*  You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
 
 <!-- MAGETWO-86335 -->
-* Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
+*  Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
 
 <!-- MAGETWO-93755 -->
-* Magento now maintains correct pagination when a Catalog list has multiple pages of products. Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
+*  Magento now maintains correct pagination when a Catalog list has multiple pages of products. Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
 
 <!-- MAGETWO-93316 -->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!-- MAGETWO-99319 -->
-* Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
+*  Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
 
 <!-- MAGETWO-73047 -->
-* The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
+*  The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
 
 <!-- MAGETWO-99722 -->
-* Magento now displays the correct currency in the Admin **Catalog** > **Products** list in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
+*  Magento now displays the correct currency in the Admin **Catalog** > **Products** list in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
 
 <!-- MAGETWO-73840 -->
-* Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
+*  Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
 
 <!-- MC-17021 -->
-* We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
+*  We’ve refined how Magento validates partial permissions. Design edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
 
 <!-- ENGCOM-5160 -->
-* The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Mahesh Singh in pull request [22581](https://github.com/magento/magento2/pull/22581)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
+*  The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Mahesh Singh in pull request [22581](https://github.com/magento/magento2/pull/22581)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
 
 <!-- ENGCOM-5149 -->
-* Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22991](https://github.com/magento/magento2/pull/22991)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
+*  Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22991](https://github.com/magento/magento2/pull/22991)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
 
 <!-- MAGETWO-97974 -->
-* You can now update product content descriptions on the store-view level when WYSIWYG is disabled.
+*  You can now update product content descriptions on the store-view level when WYSIWYG is disabled.
 
 ### Catalog rule
 
 <!-- MC-18038 -->
-* The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento time zone.)
+*  The CatalogRule module now handles discrepancies between the Magento time zone offset and the system time zone offset (which is in UTC). Previously, when the Magento time zone offset was greater than the system time zone offset, the active ranges set for special prices were inaccurate. This is a consequence of how catalog price rules special prices are stored and updated. (Catalog price rules special prices are stored in the `catalogrule_product_price` table. This table’s daily update is triggered by the `catalogrule_apply_all` cron job, which is scheduled at 01:00 every day. Cron schedule times are scheduled in Magento time zone.)
 
 <!-- MC-17459 -->
-* Coupon expiration dates and times now match the `end_date` value set in the staging update. Previously, coupon expiration dates could differ from the expiration date set by the sales rule.
+*  Coupon expiration dates and times now match the `end_date` value set in the staging update. Previously, coupon expiration dates could differ from the expiration date set by the sales rule.
 
 ### Clean up and minor refactoring
 
 <!-- ENGCOM-5428 -->
-* Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Prakash Prajapati in pull request [23657](https://github.com/magento/magento2/pull/23657)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
+*  Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Prakash Prajapati in pull request [23657](https://github.com/magento/magento2/pull/23657)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
 
 <!-- ENGCOM-5399 -->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!-- ENGCOM-5391 -->
-* Corrected capitalization of review text. *Fix submitted by Prakash Prajapati in pull request [23537](https://github.com/magento/magento2/pull/23537)*.
+*  Corrected capitalization of review text. *Fix submitted by Prakash Prajapati in pull request [23537](https://github.com/magento/magento2/pull/23537)*.
 
 <!-- ENGCOM-5399 -->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!-- ENGCOM-5366 -->
-* Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!-- ENGCOM-5229 -->
-* White space between words now appears as expected in non-English websites. *Fix submitted by Kajal Solanki in pull request [23164](https://github.com/magento/magento2/pull/23164)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
+*  White space between words now appears as expected in non-English websites. *Fix submitted by Kajal Solanki in pull request [23164](https://github.com/magento/magento2/pull/23164)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
 
 <!-- ENGCOM-5128 -->
-* The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Mahesh Singh in pull request [22908](https://github.com/magento/magento2/pull/22908)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
+*  The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Mahesh Singh in pull request [22908](https://github.com/magento/magento2/pull/22908)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
 
 <!-- ENGCOM-5214 -->
-* Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!-- ENGCOM-5213 -->
-* The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Prakash Prajapati in pull request [23150](https://github.com/magento/magento2/pull/23150)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
+*  The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Prakash Prajapati in pull request [23150](https://github.com/magento/magento2/pull/23150)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
 
 ### Configurable products
 
 <!-- MAGETWO-99930 -->
-* The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
+*  The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
 
 <!-- MAGETWO-99491 -->
-* You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
+*  You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
 
 ### Coupon
 
 <!-- ENGCOM-5355 -->
-* The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Prakash Prajapati in pull request [23332](https://github.com/magento/magento2/pull/23332)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
+*  The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Prakash Prajapati in pull request [23332](https://github.com/magento/magento2/pull/23332)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
 
 ### Cron
 
 <!-- ENGCOM-5365 -->
-* Cron jobs are no longer duplicated. Previously, after a `cron` job was run, Magento cleared the cache and processed the job again. *Fix submitted by Ihor Sviziev in pull request [23439](https://github.com/magento/magento2/pull/23439)*. [GitHub-21380](https://github.com/magento/magento2/issues/21380)
+*  Cron jobs are no longer duplicated. Previously, after a `cron` job was run, Magento cleared the cache and processed the job again. *Fix submitted by Ihor Sviziev in pull request [23439](https://github.com/magento/magento2/pull/23439)*. [GitHub-21380](https://github.com/magento/magento2/issues/21380)
 
 <!-- MAGETWO-18834 -->
-* Consumers run from `cron` no longer create deadlocks in the database.
+*  Consumers run from `cron` no longer create deadlocks in the database.
 
 ### Customer
 
 <!-- MAGETWO-86624 -->
-* An administrator with full permission for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an administrator with full permission could not see it.
+*  An administrator with full permission for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an administrator with full permission could not see it.
 
 <!-- MAGETWO-99492 -->
-* You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
+*  You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
 
 <!-- ENGCOM-5414 -->
-* Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Prakash Prajapati in pull request [23614](https://github.com/magento/magento2/pull/23614)*. [GitHub-23467](https://github.com/magento/magento2/issues/23467)
+*  Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Prakash Prajapati in pull request [23614](https://github.com/magento/magento2/pull/23614)*. [GitHub-23467](https://github.com/magento/magento2/issues/23467)
 
 <!-- MAGETWO-99516 -->
-* The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
+*  The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
 
 <!-- MC-17200 -->
-* You can now create an account as a guest when the address contains custom attributes. Previously, Magento threw a fatal error when you tried to create an account under these circumstances. [GitHub-22952](https://github.com/magento/magento2/issues/22952)
+*  You can now create an account as a guest when the address contains custom attributes. Previously, Magento threw a fatal error when you tried to create an account under these circumstances. [GitHub-22952](https://github.com/magento/magento2/issues/22952)
 
 ### Customer custom attributes
 
 <!-- MAGETWO-17930 -->
-* You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
+*  You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
 
 <!-- MAGETWO-99471 -->
-* Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
+*  Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
 
 ### Customer segment
 
 <!-- MAGETWO-99571 -->
-* You can now create an order from the Admin when you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
+*  You can now create an order from the Admin when you have a customer segment for customers with 0 or more orders. Previously, if you had a customer segment for customers with 0 or more orders, an SQL error occurred when you tried to create an order in the Admin.
 
 <!-- MC-17768 -->
-* You can now create an order from the Admin with a customer segment based on zero or more orders when the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
+*  You can now create an order from the Admin with a customer segment based on zero or more orders when the table prefix is specified. Previously, Magento threw an error when you tried to create an order from the Admin under these conditions.
 
 <!-- MAGETWO-97412 -->
-* You can now create a customer segment that exceeds 1,500,000 customers. Previously, Magento threw a 500 error when you tried to create a customer segment that large.
+*  You can now create a customer segment that exceeds 1,500,000 customers. Previously, Magento threw a 500 error when you tried to create a customer segment that large.
 
 ### Database media storage
 
 <!-- ENGCOM-5237 -->
-* Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21606](https://github.com/magento/magento2/pull/21606)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604)
+*  Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21606](https://github.com/magento/magento2/pull/21606)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604)
 
 <!-- ENGCOM-5302 4801-->
-* Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously, emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull request [21673](https://github.com/magento/magento2/pull/21673)*. [GitHub-21671](https://github.com/magento/magento2/issues/21671)
+*  Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directory. Previously, emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull request [21673](https://github.com/magento/magento2/pull/21673)*. [GitHub-21671](https://github.com/magento/magento2/issues/21671)
 
 ### Directory
 
 <!-- MAGETWO-99476 -->
-* The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations.
+*  The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations.
 
 ### Downloadable
 
 <!-- MAGETWO-98655 -->
-* New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
+*  New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
 
 ### EAV
 
 <!-- MC-17492 MC-17813-->
-* Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces, and displayed this error: `*Phone Number* contains non-numeric characters`.
+*  Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces, and displayed this error: `*Phone Number* contains non-numeric characters`.
 
 ### Email
 
 <!-- ENGCOM-5127 -->
-* The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview Tab did not load the default content. *Fix submitted by Mahesh Singh in pull request [22906](https://github.com/magento/magento2/pull/22906)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
+*  The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview Tab did not load the default content. *Fix submitted by Mahesh Singh in pull request [22906](https://github.com/magento/magento2/pull/22906)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
 
 <!-- ENGCOM-5392 -->
-* All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23537](https://github.com/magento/magento2/pull/23537)*. [GitHub-22103](https://github.com/magento/magento2/issues/22103), [GitHub-23199](https://github.com/magento/magento2/issues/23199)
+*  All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23537](https://github.com/magento/magento2/pull/23537)*. [GitHub-22103](https://github.com/magento/magento2/issues/22103), [GitHub-23199](https://github.com/magento/magento2/issues/23199)
 
 <!-- ENGCOM-5437 -->
-* Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message: `Message too big`. *Fix submitted by gwharton in pull request [23650](https://github.com/magento/magento2/pull/23650)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
+*  Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message: `Message too big`. *Fix submitted by gwharton in pull request [23650](https://github.com/magento/magento2/pull/23650)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
 
 ### Frameworks
 
 <!-- MAGETWO-99872 -->
-* The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on a large number of products (for example, adding a product to category by SKU).
+*  The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on a large number of products (for example, adding a product to category by SKU).
 
 <!-- MAGETWO-99622 -->
-* The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
+*  The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
 
 <!-- MAGETWO-94464 -->
-* A watermark with a white or transparent background is no longer converted to black when opacity is reduced below 100%.
+*  A watermark with a white or transparent background is no longer converted to black when opacity is reduced below 100%.
 
 <!-- MC-17940 -->
-* You can now successfully search for an order by email in the **Sales** > **Orders** list.
+*  You can now successfully search for an order by email in the **Sales** > **Orders** list.
 
 #### JavaScript framework
 
 <!-- MAGETWO-99562 -->
-* The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
+*  The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
 
 ### General
 
 <!-- MAGETWO-99372 -->
-* Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
+*  Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
 
 <!-- ENGCOM-5354 -->
-* Search input is no longer missing the `aria-expanded` required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Amol Chaudhari in pull request [23331](https://github.com/magento/magento2/pull/23331)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
+*  Search input is no longer missing the `aria-expanded` required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Amol Chaudhari in pull request [23331](https://github.com/magento/magento2/pull/23331)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
 
 <!-- ENGCOM-5253 -->
-* The sendfriend feature now verifies product visibility as expected. Previously, this feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23121](https://github.com/magento/magento2/pull/23121)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
+*  The sendfriend feature now verifies product visibility as expected. Previously, this feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23121](https://github.com/magento/magento2/pull/23121)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
 
 <!-- ENGCOM-5182 -->
-* The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22915](https://github.com/magento/magento2/pull/22915)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
+*  The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22915](https://github.com/magento/magento2/pull/22915)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
 
 <!-- ENGCOM-5132 -->
-* Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [22936](https://github.com/magento/magento2/pull/22936)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
+*  Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [22936](https://github.com/magento/magento2/pull/22936)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
 
 <!-- MAGETWO-73529 -->
-* We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
+*  We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
 
 <!-- MAGETWO-98485 -->
-* You can now successfully navigate to the Web Setup Wizard when `session.save_handler=db` is set in `app/env.php`. Previously, when you tried to navigate to the Web Setup Wizard, Magento threw a fatal error.
+*  You can now successfully navigate to the Web Setup Wizard when `session.save_handler=db` is set in `app/env.php`. Previously, when you tried to navigate to the Web Setup Wizard, Magento threw a fatal error.
 
 <!-- MC-18315 -->
-* Magento now sends sales-related email to the correct customer when `sales_emails` cron has an error.
+*  Magento now sends sales-related email to the correct customer when `sales_emails` cron has an error.
 
 ### Gift card account
 
 <!-- MC-17062 -->
-* Magento no longer creates a new gift card after issuing an online refund for another card. Previously, Magento created a new gift card account and sent the customer the previous gift card code and a new code.
+*  Magento no longer creates a new gift card after issuing an online refund for another card. Previously, Magento created a new gift card account and sent the customer the previous gift card code and a new code.
 
 <!-- MAGETWO-99537 -->
-* The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **URL Rewrites**), Magento did not include most categories in the resulting view.
+*  The URL rewrites category tree now includes all relevant categories. Previously, when you selected **For Category** after selecting **Create URL Rewrite** from (**Marketing** > **URL Rewrites**), Magento did not include most categories in the resulting view.
 
 <!-- MAGETWO-99357 -->
-* All strings on storefront gift card messages can now be translated.
+*  All strings on storefront gift card messages can now be translated.
 
 <!-- MAGETWO-99118 -->
-* Magento no longer closes an order that is paid for with the partial redemption of a gift card. Previously, if an order is paid partially using gift card, and a partial refund is issued for that order, the order becomes closed.
+*  Magento no longer closes an order that is paid for with the partial redemption of a gift card. Previously, if an order is paid partially using gift card, and a partial refund is issued for that order, the order becomes closed.
 
 ### Gift registry
 
 <!-- MAGETWO-18556 -->
-* Magento no longer displays a console error during checkout when the cart contains a product from the gift registry. Previously, due to a missing function, Magento displayed this error: `checkout-data-resolver.js:248 Uncaught TypeError: addrs.isDefaultBilling is not a function`.
+*  Magento no longer displays a console error during checkout when the cart contains a product from the gift registry. Previously, due to a missing function, Magento displayed this error: `checkout-data-resolver.js:248 Uncaught TypeError: addrs.isDefaultBilling is not a function`.
 
 ### Google Analytics
 
 <!-- MAGETWO-97851 -->
-* The Google Tag Manager snippet is now correctly placed in the HTML head section. Previously, this snippet was incorrectly positioned lower in the head section, which generated HTML validation errors.
+*  The Google Tag Manager snippet is now correctly placed in the HTML head section. Previously, this snippet was incorrectly positioned lower in the head section, which generated HTML validation errors.
 
 ### Google Tag Manager
 
 <!-- MAGETWO-99923 -->
-* `getLoadedProductCollection()` has been refactored to support PHP 7.2.
+*  `getLoadedProductCollection()` has been refactored to support PHP 7.2.
 
 ### Grouped products
 
 <!-- MAGETWO-97413 -->
-* Magento no longer removes the child products of a grouped product after the group product’s schedule update has expired.
+*  Magento no longer removes the child products of a grouped product after the group product’s schedule update has expired.
 
 <!-- MAGETWO-73529 -->
-* We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
+*  We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
 
 ### Import/export
 
 <!-- MAGETWO-99446 -->
-* Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
+*  Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
 
 <!-- ENGCOM-5165 -->
-* You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously, when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22902](https://github.com/magento/magento2/pull/22902)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
+*  You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously, when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22902](https://github.com/magento/magento2/pull/22902)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
 
 <!-- ENGCOM-5030 -->
-* Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Amol Chaudhari in pull request [22180](https://github.com/magento/magento2/pull/22180)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
+*  Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Amol Chaudhari in pull request [22180](https://github.com/magento/magento2/pull/22180)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 ### Indexers
 
 <!-- MC-18327 -->
-* We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
+*  We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
 
 ### Infrastructure
 
-* Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
+*  Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
 
-* Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
+*  Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
 
 <!-- ENGCOM-4855 -->
-* The `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by Bartłomiej Szubert in pull request [22549](https://github.com/magento/magento2/pull/22549)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
+*  The `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by Bartłomiej Szubert in pull request [22549](https://github.com/magento/magento2/pull/22549)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
 
 <!-- ENGCOM-5112 -->
-* Magento no longer caches absolute file paths in the validator factory (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by David Führ in pull request [22805](https://github.com/magento/magento2/pull/22805)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
+*  Magento no longer caches absolute file paths in the validator factory (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by David Führ in pull request [22805](https://github.com/magento/magento2/pull/22805)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
 
 <!-- ENGCOM-5217 -->
-* The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Prakash Prajapati in pull request [23149](https://github.com/magento/magento2/pull/23149)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
+*  The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Prakash Prajapati in pull request [23149](https://github.com/magento/magento2/pull/23149)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
 
 ### Media Storage
 
 <!-- MAGETWO-93497 -->
-* Media directives now work as expected when an administrator uses a custom domain (`admin/url/custom`) instead the default domain. Previously, the WYSIWYG `image-selector` returned malformed media directives, which resulted in broken links to images. [GitHub-16427](https://github.com/magento/magento2/issues/16427)
+*  Media directives now work as expected when an administrator uses a custom domain (`admin/url/custom`) instead the default domain. Previously, the WYSIWYG `image-selector` returned malformed media directives, which resulted in broken links to images. [GitHub-16427](https://github.com/magento/magento2/issues/16427)
 
 ### Newsletter
 
 <!-- MAGETWO-99642 -->
-* Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
+*  Magento now sends only a subscribe email when you create an account from an email invitation. Previously, you received two emails -- one that subscribed you to the newsletter, and another that unsubscribed you.
 
 ### Orders
 
 <!-- ENGCOM-5422 -->
-* Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Prakash Prajapati in pull request [23612](https://github.com/magento/magento2/pull/23612)*. [GitHub-23354](https://github.com/magento/magento2/issues/23354)
+*  Magento now displays an informative error message when you try to update the product quantity and shipping address for an order when the product quantity field is empty. *Fix submitted by Prakash Prajapati in pull request [23612](https://github.com/magento/magento2/pull/23612)*. [GitHub-23354](https://github.com/magento/magento2/issues/23354)
 
 <!-- MAGETWO-99660 -->
-* Custom customer address attributes are populated with the values that have been assigned for the selected address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
+*  Custom customer address attributes are populated with the values that have been assigned for the selected address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
 
 <!-- ENGCOM-5211 -->
-* You can now successfully view order information by selecting **Sales** > **Orders** > **View Order**. Previously, an issue with the `truncateString` method resulted in Magento throwing an error when you tried to view order information. *Fix submitted by emilie-blackbird in pull request [20849](https://github.com/magento/magento2/pull/20849)*. [GitHub-16958](https://github.com/magento/magento2/issues/16958)
+*  You can now successfully view order information by selecting **Sales** > **Orders** > **View Order**. Previously, an issue with the `truncateString` method resulted in Magento throwing an error when you tried to view order information. *Fix submitted by emilie-blackbird in pull request [20849](https://github.com/magento/magento2/pull/20849)*. [GitHub-16958](https://github.com/magento/magento2/issues/16958)
 
 ### Page Cache
 
 <!-- MC-18144 -->
-* Full page cache works as expected for non-default store views.
+*  Full page cache works as expected for non-default store views.
 
 ### Payment methods
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
 <!--- MC-18237 -->
 
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
 
 #### Other payment issues
 
 <!-- MAGETWO-16590 -->
-* The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
+*  The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
 
 <!-- MC-17358 -->
-* Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
+*  Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
 
 <!-- MC-19269 -->
-* You can now enter information into the **Credit Card Number** and **Expiration Date** fields on the Checkout page when the **CVV Verification** setting is disabled. Previously, you were not able to click on these fields to enter information.
+*  You can now enter information into the **Credit Card Number** and **Expiration Date** fields on the Checkout page when the **CVV Verification** setting is disabled. Previously, you were not able to click on these fields to enter information.
 
 <!-- MAGETWO-99416 -->
-* Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
+*  Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
 
 <!-- MAGETWO-98805 -->
-* Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
+*  Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
 
 <!-- MC-17551 -->
-* When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
+*  When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
 
 <!-- MC-99111 -->
-* The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
+*  The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
 
 <!-- MAGETWO-99581 -->
-* You can now cancel orders placed with PayPal Express even after authorization has expired.
+*  You can now cancel orders placed with PayPal Express even after authorization has expired.
 
 <!-- MAGETWO-99221 -->
-* Customers can now place the order for virtual products with a zero subtotal after entering address information. Previously, customers could not place an order for virtual products with a zero subtotal if they modified their address, and Magento displayed this message: `The requested Payment Method is not available`.
+*  Customers can now place the order for virtual products with a zero subtotal after entering address information. Previously, customers could not place an order for virtual products with a zero subtotal if they modified their address, and Magento displayed this message: `The requested Payment Method is not available`.
 
 <!-- MC-19610 -->
-* Magento no longer places an order if a JavaScript error occurs when a customer clicks **Place order** using Braintree as the payment method.
+*  Magento no longer places an order if a JavaScript error occurs when a customer clicks **Place order** using Braintree as the payment method.
 
 ### Pricing
 
 <!-- MC-98899 -->
-* You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
+*  You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
 
 ### Reports
 
 <!-- MC-18248 -->
-* The start and finish date in reports now correspond to the entered values when you create a report from the Admin. Previously, the start and finish dates in the displayed report was one day earlier than you entered.
+*  The start and finish date in reports now correspond to the entered values when you create a report from the Admin. Previously, the start and finish dates in the displayed report was one day earlier than you entered.
 
 <!-- ENGCOM-5298 -->
-* Selecting **Show by year** when filtering **Reports** > **Products** > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per order basis. *Fix submitted by Prakash Prajapati in pull request [23252](https://github.com/magento/magento2/pull/23252)*. [GitHub-22087](https://github.com/magento/magento2/issues/22087)
+*  Selecting **Show by year** when filtering **Reports** > **Products** > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending order. Previously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per order basis. *Fix submitted by Prakash Prajapati in pull request [23252](https://github.com/magento/magento2/pull/23252)*. [GitHub-22087](https://github.com/magento/magento2/issues/22087)
 
 ### Review
 
 <!-- MAGETWO-99864 -->
-* Magento no longer sends reward point balance notification email to clients whose accounts have the **Subscribe for Balance Updates** setting disabled.
+*  Magento no longer sends reward point balance notification email to clients whose accounts have the **Subscribe for Balance Updates** setting disabled.
 
 <!-- MAGETWO-99315 -->
-* Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
+*  Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
 
 ### Reward
 
 <!-- MAGETWO-99388 -->
-* Online refunds now work as expected when the **Refund Reward Points Automatically** configuration setting is enabled. Previously, the **Refund** button was disabled under these conditions.
+*  Online refunds now work as expected when the **Refund Reward Points Automatically** configuration setting is enabled. Previously, the **Refund** button was disabled under these conditions.
 
 ### RMA
 
 <!-- MAGETWO-73749 -->
-* Clicking **Show Packages** on a Returns page (**My Account** > **My Returns** > **Return**) now opens a new page about the selected package. Previously, clicking on this link resulted in a 404 error page.
+*  Clicking **Show Packages** on a Returns page (**My Account** > **My Returns** > **Return**) now opens a new page about the selected package. Previously, clicking on this link resulted in a 404 error page.
 
 <!-- MC-17452 -->
-* Magento now displays only enabled shipping methods on the Return details page. Previously, shipping methods that were disabled for RMA were displayed in the Carrier dropdown menu on the Return details page.
+*  Magento now displays only enabled shipping methods on the Return details page. Previously, shipping methods that were disabled for RMA were displayed in the Carrier dropdown menu on the Return details page.
 
 <!-- MC-18003 -->
-* Merchants can now create shipping labels for return merchandise authorizations. Previously, when a merchant tried to create a shipping label, Magento displayed this error: `No authorized items or allowed shipping methods`.
+*  Merchants can now create shipping labels for return merchandise authorizations. Previously, when a merchant tried to create a shipping label, Magento displayed this error: `No authorized items or allowed shipping methods`.
 
 <!-- MAGETWO-97371 -->
-* Magento now auto-populates all expected fields when an RMA is created via the REST API.
+*  Magento now auto-populates all expected fields when an RMA is created via the REST API.
 
 ### Sales
 
 <!-- MAGETWO-17268 -->
-* The date format used in tables throughout the product interface is now based on the Admin-defined locale.
+*  The date format used in tables throughout the product interface is now based on the Admin-defined locale.
 
 <!-- MAGETWO-99674 -->
-* The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
+*  The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
 
 <!-- MAGETWO-99358 99710 -->
-* You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
+*  You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
 
 <!-- MAGETWO-99462 -->
-* Custom order statuses no longer override default statuses in drop-down menus.
+*  Custom order statuses no longer override default statuses in drop-down menus.
 
 <!-- MAGETWO-99884 -->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 <!-- MC-17838 -->
-* Magento no longer adds a product that is selected but not explicitly added to the cart to an order when you create an order from the Admin.
+*  Magento no longer adds a product that is selected but not explicitly added to the cart to an order when you create an order from the Admin.
 
 <!-- MAGETWO-99569 -->
-* The Admin now returns exact matches for keyword searches.
+*  The Admin now returns exact matches for keyword searches.
 
 ### Sales rule
 
 <!-- MAGETWO-99724 -->
-* You can now update the conditions of an existing Scheduled update for a Cart Price Rule. Previously, when you tried to change the SKU condition for an update, Magento did not save or apply your changes.
+*  You can now update the conditions of an existing Scheduled update for a Cart Price Rule. Previously, when you tried to change the SKU condition for an update, Magento did not save or apply your changes.
 
 <!-- MAGETWO-99540 -->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 ### Search
 
 <!-- MAGETWO-92102 -->
-* Search results now reflect the search weight you assign to product attributes in attribute configuration.
+*  Search results now reflect the search weight you assign to product attributes in attribute configuration.
 
 <!-- MAGETWO-73989 -->
-* The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
+*  The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
 
 <!-- MAGETWO-99655 -->
-* You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
+*  You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
 `{"0":"SQLSTATE[42000]: Syntax error or access violation: 1064 syntax error, unexpected $end, query was: SELECT`.
 
 <!-- MAGETWO-99716 -->
-* You can now limit the number of search suggestions that the autocomplete feature provides by setting the **Autocomplete Limit** field.
+*  You can now limit the number of search suggestions that the autocomplete feature provides by setting the **Autocomplete Limit** field.
 
 ### Shipping
 
 <!-- ENGCOM-5423 -->
-* You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23603](https://github.com/magento/magento2/pull/23603)*. [GitHub-23522](https://github.com/magento/magento2/issues/23522)
+*  You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23603](https://github.com/magento/magento2/pull/23603)*. [GitHub-23522](https://github.com/magento/magento2/issues/23522)
 
 <!-- ENGCOM-5169 -->
-* The Order Tracking page now displays the Contact us link as expected when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [23019](https://github.com/magento/magento2/pull/23019)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
+*  The Order Tracking page now displays the Contact us link as expected when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [23019](https://github.com/magento/magento2/pull/23019)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
 
 <!-- ENGCOM-5136 -->
-* Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields) when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22873](https://github.com/magento/magento2/pull/22873)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
+*  Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields) when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22873](https://github.com/magento/magento2/pull/22873)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
 
 ### Staging
 
 <!-- MAGETWO-93728 -->
-* Coupon expiration dates now match the end date of the staging update the coupons are assigned to.
+*  Coupon expiration dates now match the end date of the staging update the coupons are assigned to.
 
 <!-- MAGETWO-98949 -->
-* Magento now displays the correct product Short Description for the selected update in deployments where there are multiple schedule updates.
+*  Magento now displays the correct product Short Description for the selected update in deployments where there are multiple schedule updates.
 
 ### Swatches
 
 <!-- ENGCOM-5427 -->
-* Setting the **Update Product Preview Image** to **no** now works as expected. Previously, when you clicked on a size or image that represented another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [22510](https://github.com/magento/magento2/pull/22510)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
+*  Setting the **Update Product Preview Image** to **no** now works as expected. Previously, when you clicked on a size or image that represented another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [22510](https://github.com/magento/magento2/pull/22510)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
 
 ### TargetRule
 
 <!-- MC-18285 -->
-* Magento now returns more informative error messages when a misconfigured target rule caused an error.
+*  Magento now returns more informative error messages when a misconfigured target rule caused an error.
 
 <!-- MAGETWO-99440 -->
-* Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
+*  Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
 
 ### Translation
 
 <!-- ENGCOM-5366 -->
-* The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Ihor Sviziev in pull request [23438](https://github.com/magento/magento2/pull/23438)*. [GitHub-23333](https://github.com/magento/magento2/issues/23333)
+*  The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Ihor Sviziev in pull request [23438](https://github.com/magento/magento2/pull/23438)*. [GitHub-23333](https://github.com/magento/magento2/issues/23333)
 
 ### UI
 
 <!-- MC-17512 -->
-* Pre-loading of fonts has been moved from the Blank theme to the Luma theme.
+*  Pre-loading of fonts has been moved from the Blank theme to the Luma theme.
 
 <!-- MAGETWO-99828 -->
-* Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
+*  Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
 
 <!-- MC-17295 -->
-* The calendar date picker now updates values as expected when the linked input value is changed.
+*  The calendar date picker now updates values as expected when the linked input value is changed.
 
 <!-- ENGCOM-5429 -->
-* The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Prakash Prajapati in pull request [23658](https://github.com/magento/magento2/pull/23658)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
+*  The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Prakash Prajapati in pull request [23658](https://github.com/magento/magento2/pull/23658)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
 
 <!-- ENGCOM-5401 -->
-* The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
+*  The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
 
 <!-- ENGCOM-5394 -->
-* The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23547](https://github.com/magento/magento2/pull/23547)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
+*  The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23547](https://github.com/magento/magento2/pull/23547)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
 
 <!-- ENGCOM-5396 -->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!-- ENGCOM-5336 -->
-* Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!-- ENGCOM-5396 -->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!-- ENGCOM-5084 -->
-* The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22783](https://github.com/magento/magento2/pull/22783)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
+*  The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22783](https://github.com/magento/magento2/pull/22783)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
 
 <!-- ENGCOM-5197 -->
-* Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23086](https://github.com/magento/magento2/pull/23086)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
+*  Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23086](https://github.com/magento/magento2/pull/23086)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
 
 <!-- ENGCOM-5156 5154-->
-* The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Ravi Chandra in pull request [23002](https://github.com/magento/magento2/pull/23002)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795),[GitHub-21214](https://github.com/magento/magento2/issues/21214)
+*  The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Ravi Chandra in pull request [23002](https://github.com/magento/magento2/pull/23002)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795),[GitHub-21214](https://github.com/magento/magento2/issues/21214)
 
 <!-- ENGCOM-5111 -->
-* Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Amol Chaudhari in pull request [22801](https://github.com/magento/magento2/pull/22801)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
+*  Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Amol Chaudhari in pull request [22801](https://github.com/magento/magento2/pull/22801)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
 
 ### URL rewrite
 
 <!-- MAGETWO-72788 -->
-* You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`
+*  You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`
 
 <!-- MAGETWO-96662 -->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!-- MAGETWO-99925 -->
-* Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously, the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
+*  Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously, the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
 
 <!-- MAGETWO-99813 -->
-* Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
+*  Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
 
 <!-- ENGCOM-3906 -->
-* During product URL rewrite generation, anchor categories are now loaded with the specified store ID as expected. Previously, Magento read the default URL key from the database.
+*  During product URL rewrite generation, anchor categories are now loaded with the specified store ID as expected. Previously, Magento read the default URL key from the database.
 
 ### Visual Merchandiser
 
 <!-- MAGETWO-93675 -->
-* You can now add tier price conditions to smart categories.
+*  You can now add tier price conditions to smart categories.
 
 <!-- MAGETWO-99869 -->
-* The Visual Merchandiser product list now renders properly when product names exceed 50 characters.
+*  The Visual Merchandiser product list now renders properly when product names exceed 50 characters.
 
 <!-- MC-19305 -->
-* Magento no longer displays products in the **Product in category** tab in both grid and tile mode simultaneously.
+*  Magento no longer displays products in the **Product in category** tab in both grid and tile mode simultaneously.
 
 ### Web API framework
 
 <!-- ENGCOM-5204 -->
-* Magento now renders shipment details for an order without a fatal error when you use `POST V1/shipment` to create a shipment. *Fix submitted by Milind Singh in pull request [23119](https://github.com/magento/magento2/pull/23119)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
+*  Magento now renders shipment details for an order without a fatal error when you use `POST V1/shipment` to create a shipment. *Fix submitted by Milind Singh in pull request [23119](https://github.com/magento/magento2/pull/23119)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
 
 <!-- ENGCOM-5188 -->
-* You can now use `POST V1/customers` to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22895](https://github.com/magento/magento2/pull/22895)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
+*  You can now use `POST V1/customers` to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22895](https://github.com/magento/magento2/pull/22895)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
 
 ### Website restriction
 
 <!-- MAGETWO-93052 -->
-* Administrators with appropriate permissions can now create a new customer account on the Admin when the **Website Restriction** setting is enabled. Previously, Magento threw this exception: `Can not register new customer due to restrictions are enabled`.
+*  Administrators with appropriate permissions can now create a new customer account on the Admin when the **Website Restriction** setting is enabled. Previously, Magento threw this exception: `Can not register new customer due to restrictions are enabled`.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/release-notes-2-2-10-open-source.md
+++ b/guides/v2.2/release-notes/release-notes-2-2-10-open-source.md
@@ -17,16 +17,16 @@ Look for the following highlights in this release:
 
 The following upgrades to core platform components boost platform security and support PCI compliance:
 
-* Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
-* Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
+*  Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
+*  Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
 
 ### Substantial security enhancements
 
 This release includes the following security enhancements:
 
-* PSD2 compliance for core payment methods
-* Fixes for 75 critical security issues
-* Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
+*  PSD2 compliance for core payment methods
+*  Fixes for 75 critical security issues
+*  Significant platform-security enhancements that boost XSS (cross-site scripting) protection against future exploits. This effort is the culmination of several months of concentrated effort on Magento's part to reduce our backlog of security enhancements.
 
 #### Core payment methods integrations are now compliant with PSD2 regulations
 
@@ -34,16 +34,16 @@ The European Union recently revised the Payment Services Directive (PSD) regulat
 
 This release contains the following major PSD-related changes:
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
 
 <!--- MC-18237 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which took effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which took effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
 
 #### Security enhancements and fixes to core code
 
-* **70 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.10) have been ported to 2.3.3, 1.14.4.3, and 1.9.4.3, as appropriate.
+*  **70 security enhancements** that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, [two-factor authentication](https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html), use of a VPN, the use of a unique location rather than `/admin`, and good password hygiene. See [Magento Security Center](https://magento.com/security/patches/magento-2.3.3-2.2.10-security-update) for a comprehensive discussion of these issues. All known exploitable security issues fixed in this release (2.2.10) have been ported to 2.3.3, 1.14.4.3, and 1.9.4.3, as appropriate.
 
 ### Infrastructure improvements
 
@@ -56,542 +56,542 @@ In addition to security enhancements, this release contains the following functi
 ### Installation, setup, and deployment
 
 <!-- MAGETWO-18745 -->
-* PHP unit tests no longer fail by default when Magento is installed from Composer.
+*  PHP unit tests no longer fail by default when Magento is installed from Composer.
 
 <!-- MAGETWO-99617 -->
-* Magento font icons now load as expected when deployment optimization is implemented.
+*  Magento font icons now load as expected when deployment optimization is implemented.
 
 <!-- ENGCOM-5102 -->
-* The short form versions of the `—lock-env` and `—lock-config` `bin/magento config:set` options now work as expected. *Fix submitted by Shikha Mishra in pull request [22836](https://github.com/magento/magento2/pull/22836)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
+*  The short form versions of the `—lock-env` and `—lock-config` `bin/magento config:set` options now work as expected. *Fix submitted by Shikha Mishra in pull request [22836](https://github.com/magento/magento2/pull/22836)*. [GitHub-22395](https://github.com/magento/magento2/issues/22395)
 
 <!-- ENGCOM-5150 -->
-* Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22610](https://github.com/magento/magento2/pull/22610)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852), [GitHub-22563](https://github.com/magento/magento2/issues/22563)
+*  Parallel execution of static content deployment has been improved to prevent errors and make it more stable. *Fix submitted by David Alger in pull request [22610](https://github.com/magento/magento2/pull/22610)*. [GitHub-21852](https://github.com/magento/magento2/issues/21852), [GitHub-22563](https://github.com/magento/magento2/issues/22563)
 
 <!-- ENGCOM-5203 -->
-* Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [23114](https://github.com/magento/magento2/pull/23114)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
+*  Magento now displays an exception message when an error occurs during static content deployment. Previously, if an error occurred, Magento showed the stack trace only. *Fix submitted by Ihor Sviziev in pull request [23114](https://github.com/magento/magento2/pull/23114)*. [GitHub-22882](https://github.com/magento/magento2/issues/22882)
 
 <!-- ENGCOM-5306 -->
-* You can now use JSON to set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [23277](https://github.com/magento/magento2/pull/23277)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
+*  You can now use JSON to set a configuration value for a configuration option through the command line. *Fix submitted by Shikha Mishra in pull request [23277](https://github.com/magento/magento2/pull/23277)*. [GitHub-22396](https://github.com/magento/magento2/issues/22396)
 
 <!-- MC-17292 -->
-* The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
+*  The Magento Admin now loads without issue after you change the store domain or set cookies to a different domain. Previously, the page did not redirect as expected.
 
 <!-- MC-99719 -->
-* The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
+*  The Admin no longer displays incorrect currency codes when the default base currency differs from the default website currency.
 
 ### Bundle products
 
 <!-- MAGETWO-99952 -->
-* The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
+*  The **Add to Cart** button is no longer visible to users who do not have Add to Cart category permissions. Previously, guest users could add items to the cart without being granted Add to Cart permission.
 
 <!-- MAGETWO-99787 -->
-* Magento now issues a single request to the server when you change the shipping address for an order to a non-default address.Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
+*  Magento now issues a single request to the server when you change the shipping address for an order to a non-default address.Previously, Magento issued multiple requests to the server when you changed the shipping address, which negatively affected performance.
 
 ### Cache
 
 <!-- MAGETWO-99659 -->
-* Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
+*  Enabling a product now clears the full-page cache for PDP if the product is not assigned to a category.
 
 ### Cart and checkout
 
 <!-- MC-17754 -->
-* Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order. [GitHub-23288](https://github.com/magento/magento2/issues/23288)
+*  Magento now displays an informative message when an error is thrown after the user Internet connection has been reset after placing an order. [GitHub-23288](https://github.com/magento/magento2/issues/23288)
 
 <!-- MC-18286 -->
-* The checkout order summary now displays the correct number of ordered items.
+*  The checkout order summary now displays the correct number of ordered items.
 
 <!-- MAGETWO-99709 -->
-* Magento no longer throws a custom address attribute multi-line error when a customer tries to place an order.
+*  Magento no longer throws a custom address attribute multi-line error when a customer tries to place an order.
 
 <!-- MAGETWO-99956 -->
-* The **Admin** > **Catalog** > **Categories** page now works as expected. Previously, Magento threw a fatal error when you tried to navigate to this page due to issues with the translation function.
+*  The **Admin** > **Catalog** > **Categories** page now works as expected. Previously, Magento threw a fatal error when you tried to navigate to this page due to issues with the translation function.
 
 <!-- MAGETWO-93627 -->
-* Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
+*  Magento no longer empties your shopping cart after you have reset your password. Previously, if you added items to your shopping cart using a guest account, then logged in and reset your password, Magento emptied your cart. [GitHub-14530](https://github.com/magento/magento2/issues/14530)
 
 <!-- MAGETWO-91328 -->
-* Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
+*  Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
 
 <!-- MAGETWO-99251 -->
-* Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
+*  Magento now submits an order only once when an order is submitted using **Enter**. Previously, Magento submitted several `payment-information` requests, and several orders with the same quote ID were placed.
 
 <!-- MC-17883 -->
-* The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
+*  The Review & Payment section of the One Page Checkout no longer displays custom customer attribute code when a guest checks out.
 
 <!-- MAGETWO-98462 -->
-* You can now add product quantities that require four digits to the shopping cart.Previously, Magento could not add four-digit product quantities to the cart.
+*  You can now add product quantities that require four digits to the shopping cart.Previously, Magento could not add four-digit product quantities to the cart.
 
 <!-- MC-16591 -->
-* Magento no longer indicates that your session has expired when you add a product to your shopping cart in deployments where the Scalable Checkout module is enabled.
+*  Magento no longer indicates that your session has expired when you add a product to your shopping cart in deployments where the Scalable Checkout module is enabled.
 
 <!-- ENGCOM-5389 -->
-* The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Prakash Prajapati in pull request [23536](https://github.com/magento/magento2/pull/23536)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
+*  The minicart loader is now visible when you add a product to the minicart. *Fix submitted by Prakash Prajapati in pull request [23536](https://github.com/magento/magento2/pull/23536)*. [GitHub-23377](https://github.com/magento/magento2/issues/23377)
 
 <!-- ENGCOM-5186 -->
-* Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Abrar Pathan in pull request [23058](https://github.com/magento/magento2/pull/23058)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
+*  Magento now applies the sort preferences that you set in website scope configuration for a particular website to the layout of the checkout page. Previously, sort order for elements of this page was derived from the default configuration, not website-specific values. *Fix submitted by Abrar Pathan in pull request [23058](https://github.com/magento/magento2/pull/23058)*. [GitHub-22380](https://github.com/magento/magento2/issues/22380)
 
 <!-- ENGCOM-5400 -->
-* You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
+*  You can now add any decimal quantity of a product to your shopping cart (even a quantity less than the quantity set in the **Minimum Qty** setting) when the **Qty Uses Decimals** setting is enabled. *Fix submitted by Prakash Prajapati in pull request [23574](https://github.com/magento/magento2/pull/23574)*. [GitHub-23038](https://github.com/magento/magento2/issues/23038)
 
 ### Catalog
 
 <!-- MAGETWO-17764 -->
-* Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
+*  Magento now renames images with the same name in the `pub/media/catalog/category` directory. Previously, images with the same name that belonged to different categories were not uploaded properly. [GitHub-23376](https://github.com/magento/magento2/issues/23376)
 
 <!-- MAGETWO-17622 -->
-* You can now save multi-select and select attribute options when swatches modules are disabled.
+*  You can now save multi-select and select attribute options when swatches modules are disabled.
 [GitHub-23326](https://github.com/magento/magento2/issues/23326)
 
 <!-- MAGETWO-98521 -->
-* You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
+*  You can now add an out-of-stock item to a product comparison. Previously, Magento displayed a success message, but did not add the item to the comparison. [GitHub-21518](https://github.com/magento/magento2/issues/21518)
 
 <!-- MAGETWO-86335 -->
-* Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
+*  Product availability is no longer tied to events associated with the categories to which they belong. Instead, Magento now uses the current category event for the page on which the product is displayed. Previously, products that were tied to categories with no events could be purchased, and products that were tied to expired events could not be purchased.
 
 <!-- MAGETWO-93755 -->
-* Magento now maintains correct pagination when a Catalog list has multiple pages of products. Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
+*  Magento now maintains correct pagination when a Catalog list has multiple pages of products. Previously, users were redirected to the first page (instead of the correct page) after navigating to a product from the list and saving it.
 
 <!-- MAGETWO-93316 -->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!-- MAGETWO-99319 -->
-* Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
+*  Custom options prices that are assigned to a website scope no longer rewrite prices on all scopes.
 
 <!-- MAGETWO-97974 -->
-* You can now update product content descriptions on the store-view level when WYSIWYG is disabled.
+*  You can now update product content descriptions on the store-view level when WYSIWYG is disabled.
 
 <!-- MAGETWO-73047 -->
-* The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
+*  The Admin Product Edit page and Customers page now load without JavaScript errors. [GitHub-5967](https://github.com/magento/magento2/issues/5967)
 
 <!-- MAGETWO-99722 -->
-* Magento now displays the correct currency in the Admin **Catalog** > **Products** list in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
+*  Magento now displays the correct currency in the Admin **Catalog** > **Products** list in deployments where websites are assigned different currencies. Previously, the products on the Admin Category page displayed the base currency even when **Product Price Scope** was set to **Per Website** and the website was assigned a different currency.
 
 <!-- MAGETWO-73840 -->
-* Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
+*  Videos in product descriptions now appear as they do in the Admin WYSIWYG editor. Previously, videos in the storefront product descriptions had the incorrect height.
 
 <!-- MC-17021 -->
-* We’ve refined how Magento validates partial permissionsDesign edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
+*  We’ve refined how Magento validates partial permissionsDesign edit permissions for categories, products, and CMS pages are now validated for each endpoint (web API and other) outside of the related model-layer classes. The web API now returns an error when design-related fields are being overridden. Previously, this behavior was ignored.
 
 <!-- ENGCOM-5160 -->
-* The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Mahesh Singh in pull request [22581](https://github.com/magento/magento2/pull/22581)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
+*  The catalog product flat data table for a store view is now populated with data from the specified store view as expected. Previously, this table was populated with data from the default store view. *Fix submitted by Mahesh Singh in pull request [22581](https://github.com/magento/magento2/pull/22581)*. [GitHub-21747](https://github.com/magento/magento2/issues/21747)
 
 <!-- ENGCOM-5149 -->
-* Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22991](https://github.com/magento/magento2/pull/22991)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
+*  Magento now displays a validation alert message when you click **Add Attribute**, and then click **Add selected** without first selecting an attribute. Previously, when you clicked **Add selected**, Magento selected all possible attributes. *Fix submitted by Mahesh Singh in pull request [22991](https://github.com/magento/magento2/pull/22991)*. [GitHub-22639](https://github.com/magento/magento2/issues/22639)
 
 ### Clean up and minor refactoring
 
 <!-- ENGCOM-5428 -->
-* Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Prakash Prajapati in pull request [23657](https://github.com/magento/magento2/pull/23657)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
+*  Corrected poor spacing in the Gift message section of the My Account page. *Fix submitted by Prakash Prajapati in pull request [23657](https://github.com/magento/magento2/pull/23657)*. [GitHub-22950](https://github.com/magento/magento2/issues/22950)
 
 <!-- ENGCOM-5399 -->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!-- ENGCOM-5391 -->
-* Corrected capitalization of review text. *Fix submitted by Prakash Prajapati in pull request [23537](https://github.com/magento/magento2/pull/23537)*.
+*  Corrected capitalization of review text. *Fix submitted by Prakash Prajapati in pull request [23537](https://github.com/magento/magento2/pull/23537)*.
 
 <!-- ENGCOM-5399 -->
-* Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
+*  Corrected misalignment of the Compare Products and My Wish List counters in the sidebar. *Fix submitted by Prakash Prajapati in pull request [23573](https://github.com/magento/magento2/pull/23573)*. [GitHub-22676](https://github.com/magento/magento2/issues/22676)
 
 <!-- ENGCOM-5366 -->
-* Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!-- ENGCOM-5229 -->
-* White space between words now appears as expected in non-English websites. *Fix submitted by Kajal Solanki in pull request [23164](https://github.com/magento/magento2/pull/23164)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
+*  White space between words now appears as expected in non-English websites. *Fix submitted by Kajal Solanki in pull request [23164](https://github.com/magento/magento2/pull/23164)*. [GitHub-23080](https://github.com/magento/magento2/issues/23080)
 
 <!-- ENGCOM-5214 -->
-* Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!-- ENGCOM-5128 -->
-* The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Mahesh Singh in pull request [22908](https://github.com/magento/magento2/pull/22908)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
+*  The checkbox on the Add New Tax Rule form has been redesigned to match the Admin checkbox. *Fix submitted by Mahesh Singh in pull request [22908](https://github.com/magento/magento2/pull/22908)*. [GitHub-22640](https://github.com/magento/magento2/issues/22640)
 
 <!-- ENGCOM-5214 -->
-* Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!-- ENGCOM-5213 -->
-* The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Prakash Prajapati in pull request [23150](https://github.com/magento/magento2/pull/23150)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
+*  The arrow toggle page element now works as expected throughout the Admin. *Fix submitted by Prakash Prajapati in pull request [23150](https://github.com/magento/magento2/pull/23150)*. [GitHub-22636](https://github.com/magento/magento2/issues/22636)
 
 ### Configurable products
 
 <!-- MAGETWO-99930 -->
-* The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
+*  The status (in stock or out of stock) of a configurable product in the Admin now matches the status displayed on the storefront.
 
 <!-- MAGETWO-99491 -->
-* You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
+*  You can now use the `POST V1/configurable-products/:sku/child` call to assign positions to configurable product attributes as expected. Previously, when you use REST to assign positions to configurable product attributes, the position value was overwritten after you linked simple products to the configurable product.
 
 ### Coupon
 
 <!-- ENGCOM-5355 -->
-* The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Prakash Prajapati in pull request [23332](https://github.com/magento/magento2/pull/23332)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
+*  The **Apply** button now functions as expected when you create a new order and apply a coupon from the Admin. Previously, clicking **Apply** removed the coupon instead of applying it. *Fix submitted by Prakash Prajapati in pull request [23332](https://github.com/magento/magento2/pull/23332)*. [GitHub-23238](https://github.com/magento/magento2/issues/23238)
 
 ### Cron
 
 <!-- ENGCOM-5365 -->
-* Cron jobs are no longer duplicated. Previously, after a `cron` job was run, Magento cleared the cache and processed the job again. *Fix submitted by Ihor Sviziev in pull request [23439](https://github.com/magento/magento2/pull/23439)*. [GitHub-21380](https://github.com/magento/magento2/issues/21380)
+*  Cron jobs are no longer duplicated. Previously, after a `cron` job was run, Magento cleared the cache and processed the job again. *Fix submitted by Ihor Sviziev in pull request [23439](https://github.com/magento/magento2/pull/23439)*. [GitHub-21380](https://github.com/magento/magento2/issues/21380)
 
 <!-- MAGETWO-18834 -->
-* Consumers run from `cron` no longer create deadlocks in the database.
+*  Consumers run from `cron` no longer create deadlocks in the database.
 
 ### Customer
 
 <!-- MAGETWO-86624 -->
-* An administrator with full permission for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an administrator with full permission could not see it.
+*  An administrator with full permission for all website scopes can now see any country listed in the Countries column or filter in the Customers list. Previously, if one of the website scopes did not allow a country, an administrator with full permission could not see it.
 
 <!-- MAGETWO-99516 -->
-* The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
+*  The account status list now updates as expected to correctly indicate the account lock status after `cron` is run. Previously, this list displayed status as unlocked only.
 
 <!-- MAGETWO-99492 -->
-* You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
+*  You can now create and successfully save a customer attribute when the **Use in Filter Options** and **Use in Search Options** settings are set to **no**. Previously, Magento did not display these attributes, and they could not be edited.
 
 <!-- MC-17200 -->
-* You can now create an account as a guest when the address contains custom attributes. Previously, Magento threw a fatal error when you tried to create an account under these circumstances. [GitHub-22952](https://github.com/magento/magento2/issues/22952)
+*  You can now create an account as a guest when the address contains custom attributes. Previously, Magento threw a fatal error when you tried to create an account under these circumstances. [GitHub-22952](https://github.com/magento/magento2/issues/22952)
 
 <!-- ENGCOM-5414 -->
-* Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Prakash Prajapati in pull request [23614](https://github.com/magento/magento2/pull/23614)*. [GitHub-23467](https://github.com/magento/magento2/issues/23467)
+*  Magento no longer displays editable text fields for customer phone numbers and zip codes if customers have not saved an address. *Fix submitted by Prakash Prajapati in pull request [23614](https://github.com/magento/magento2/pull/23614)*. [GitHub-23467](https://github.com/magento/magento2/issues/23467)
 
 ### Customer custom attributes
 
 <!-- MAGETWO-17930 -->
-* You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
+*  You can now edit a customer address from the Admin (**Admin** > **Customer** > **Address** > **Edit Address**) when the customer address attribute is of type `file` or `image`. Previously, Magento did not display the Edit Address form when you clicked on **Edit Address**.
 
 <!-- MAGETWO-99471 -->
-* Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
+*  Custom customer address attribute values are populated as expected when an administrator changes a customer address during order creation from the Admin. Previously, the custom attribute drop-down was empty.
 
 ### Database media storage
 
 <!-- ENGCOM-5237 -->
-* Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21606](https://github.com/magento/magento2/pull/21606)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604)
+*  Magento now copies any image needed for the Admin Product Edit page from the database to local storage as needed. Previously, if the image was not in local storage, Magento used a placeholder image. *Fix submitted by gwharton in pull request [21606](https://github.com/magento/magento2/pull/21606)*. [GitHub-21604](https://github.com/magento/magento2/issues/21604)
 
 <!-- ENGCOM-5302 4801-->
-* Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directoryPreviously, emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull request [21673](https://github.com/magento/magento2/pull/21673)*. [GitHub-21671](https://github.com/magento/magento2/issues/21671)
+*  Transactional email now copies the configured email logo image from the database when the logo file does not exist in the local `pub/media` directoryPreviously, emails used the default LUMA logo if it did not exist in the local directory. *Fix submitted by gwharton in pull request [21673](https://github.com/magento/magento2/pull/21673)*. [GitHub-21671](https://github.com/magento/magento2/issues/21671)
 
 ### Directory
 
 <!-- MAGETWO-99476 -->
-* The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations.
+*  The country drop-down list no longer includes an extraneous zero (0) when the allowed countries in the list differ from countries identified as top destinations.
 
 ### Downloadable
 
 <!-- MAGETWO-98655 -->
-* New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
+*  New downloadable products now appear in the downloadable products section after a customer checks out as a guest and then creates an account.
 
 ### EAV
 
 <!-- MAGETWO-99710 -->
-* You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
+*  You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
 
 <!-- MC-17492 17813-->
-* Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces, and displayed this error: `*Phone Number* contains non-numeric characters`.
+*  Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces, and displayed this error: `*Phone Number* contains non-numeric characters`.
 
 ### Email
 
 <!-- ENGCOM-5127 -->
-* The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview Tab did not load the default content. *Fix submitted by Mahesh Singh in pull request [22906](https://github.com/magento/magento2/pull/22906)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
+*  The Template Preview tab now loads with the default content that was assigned during the creation of a New Shipment email template as expected. Previously, the Template Preview Tab did not load the default content. *Fix submitted by Mahesh Singh in pull request [22906](https://github.com/magento/magento2/pull/22906)*. [GitHub-22788](https://github.com/magento/magento2/issues/22788)
 
 <!-- ENGCOM-5392 -->
-* All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23537](https://github.com/magento/magento2/pull/23537)*. [GitHub-22103](https://github.com/magento/magento2/issues/22103), [GitHub-23199](https://github.com/magento/magento2/issues/23199)
+*  All emails are now sent with correct MIME encoding. *Fix submitted by gwharton in pull request [23537](https://github.com/magento/magento2/pull/23537)*. [GitHub-22103](https://github.com/magento/magento2/issues/22103), [GitHub-23199](https://github.com/magento/magento2/issues/23199)
 
 <!-- ENGCOM-5437 -->
-* Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message: `Message too big`. *Fix submitted by gwharton in pull request [23650](https://github.com/magento/magento2/pull/23650)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
+*  Email created using a CSS-heavy template is now sent successfully. Previously, these emails were rejected by the server with this message: `Message too big`. *Fix submitted by gwharton in pull request [23650](https://github.com/magento/magento2/pull/23650)*. [GitHub-23643](https://github.com/magento/magento2/issues/23643)
 
 ### Frameworks
 
 <!-- MC-19307 -->
-* Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
+*  Starting and ending spaces are now trimmed from phone numbers before JavaScript validation. Previously, Magento did not trim these spaces and displayed this error: `*Phone Number* contains non-numeric characters`.
 
 <!-- MAGETWO-99872 -->
-* The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products (for example, adding a product to category by SKU).
+*  The `equalArrays` function in `lib/web/mage/utils/compare.js` file has been refactored to remove quadratic complexity. Previously, this feature significantly slowed Admin operations that were performed on large number of products (for example, adding a product to category by SKU).
 
 <!-- MC-17940 -->
-* You can now successfully search for an order by email in the **Sales** > **Orders** list.
+*  You can now successfully search for an order by email in the **Sales** > **Orders** list.
 
 <!-- MAGETWO-99622 -->
-* The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
+*  The error message that Magento displays when the user creates an attribute that starts with the reserved word `container` has been improved. For example, when a user created product attributes named `container_attributename` and `attributename`, Magento threw this error: `Exception in Magento/Framework/View/Element/UiComponentFactory.php` rather than stating which user behavior was causing the system problem.
 
 <!-- MAGETWO-94464 -->
-* A watermark with a white or transparent background is no longer converted to black when opacity is reduced below 100%.
+*  A watermark with a white or transparent background is no longer converted to black when opacity is reduced below 100%.
 
 #### JavaScript framework
 
 <!-- MAGETWO-99562 -->
-* The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
+*  The cursor on the email field of the login page now behaves as expected when running Magento on Safari. Previously, the cursor repeatedly moved to the end of the email address field when you tried to edit this field.
 
 <!-- MAGETWO-91328 -->
-* Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
+*  Customers can now successfully check out when the AdBlock extension and Google Analytics are enabled.
 
 ### General
 
 <!-- MAGETWO-73529 -->
-* We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
+*  We have improved the performance of the grouped product detail pages and category pages that contain a large number of grouped products.
 
 <!-- MAGETWO-98485 -->
-* You can now successfully navigate to the Web Setup Wizard when `session.save_handler=db` is set in `app/env.php`. Previously, when you tried to navigate to the Web Setup Wizard, Magento threw a fatal error.
+*  You can now successfully navigate to the Web Setup Wizard when `session.save_handler=db` is set in `app/env.php`. Previously, when you tried to navigate to the Web Setup Wizard, Magento threw a fatal error.
 
 <!-- MAGETWO-99372 -->
-* Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
+*  Magento now maintains custom prices for products in both the catalog and shopping cart after a quote is recalculated. Previously, the product price reverted to the default price after you recalculated the quote.
 
 <!-- MC-18315 -->
-* Magento now sends sales-related email to the correct customer when `sales_emails` cron has an error.
+*  Magento now sends sales-related email to the correct customer when `sales_emails` cron has an error.
 
 <!-- ENGCOM-5354 -->
-* Search input is no longer missing the `aria-expanded` required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Amol Chaudhari in pull request [23331](https://github.com/magento/magento2/pull/23331)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
+*  Search input is no longer missing the `aria-expanded` required attribute. Previously, the W3C HTML validator threw errors for the `#search` element. *Fix submitted by Amol Chaudhari in pull request [23331](https://github.com/magento/magento2/pull/23331)*. [GitHub-18337](https://github.com/magento/magento2/issues/18337)
 
 <!-- ENGCOM-5253 -->
-* The sendfriend feature now verifies product visibility as expected. Previously, this feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23121](https://github.com/magento/magento2/pull/23121)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
+*  The sendfriend feature now verifies product visibility as expected. Previously, this feature verified product status only. *Fix submitted by Mateusz Wira in pull request [23121](https://github.com/magento/magento2/pull/23121)*. [GitHub-23053](https://github.com/magento/magento2/issues/23053)
 
 <!-- ENGCOM-5182 -->
-* The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22915](https://github.com/magento/magento2/pull/22915)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
+*  The `getListByCustomerId` function in `PaymentTokenManagementInterface` now returns an array. *Fix submitted by Serhiy Zhovnir in pull request [22915](https://github.com/magento/magento2/pull/22915)*. [GitHub-22899](https://github.com/magento/magento2/issues/22899)
 
 <!-- ENGCOM-5132 -->
-* Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [22936](https://github.com/magento/magento2/pull/22936)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
+*  Tier prices can now be float values. Previously, Magento converted float percentage values to `int` before saving it. *Fix submitted by Maksym Novik in pull request [22936](https://github.com/magento/magento2/pull/22936)*. [GitHub-18651](https://github.com/magento/magento2/issues/18651)
 
 ### Import/export
 
 <!-- MAGETWO-99446 -->
-* Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
+*  Only modified or updated product records are flushed from the catalog cache after importing, re-indexing, and running `bin/magento cron:run --group index`. Previously, all products in the catalog were flushed.
 
 <!-- ENGCOM-5165 -->
-* You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously, when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22902](https://github.com/magento/magento2/pull/22902)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
+*  You can now update products through import of a CSV file when the updated products have `product_id` values that range widely (for example, a value 1 to a value 6000). Previously, when you initiated the import of the CSV file (**Admin** > **System** > **Import** > **Product** > **Add/Update**), Magento threw this error: `General error: 1114 The table 'catalog_product_index_price_temp' is full occurs`. *Fix submitted by Mateusz Wegrzycki in pull request [22902](https://github.com/magento/magento2/pull/22902)*. [GitHub-22028](https://github.com/magento/magento2/issues/22028)
 
 <!-- ENGCOM-5030 -->
-* Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Amol Chaudhari in pull request [22180](https://github.com/magento/magento2/pull/22180)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
+*  Custom import adapters now validate CSV files as expected if column and data are available. Previously, the CSV file was not validated, and Magento threw the following error: `Notice: Undefined index: sku in /var/www/html/hamtc/vendor/magento/module-import-export/Model/Import/Entity/AbstractEntity.php on line 411`. *Fix submitted by Amol Chaudhari in pull request [22180](https://github.com/magento/magento2/pull/22180)*. [GitHub-19761](https://github.com/magento/magento2/issues/19761)
 
 ### Indexers
 
 <!-- MC-18327 -->
-* We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
+*  We improved the performance of product flat data re-indexing. [GitHub-23462](https://github.com/magento/magento2/issues/23462)
 
 ### Infrastructure
 
-* Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
+*  Magento 2.2.10 now supports PHP 7.2.x (tested with 7.2.21). <!--- MC-16174 -->
 
-* Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
+*  Magento 2.2.10 does not support PHP 7.0.x. <!--- MC-18521 -->
 
 <!-- ENGCOM-4855 -->
-* The `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by Bartłomiej Szubert in pull request [22549](https://github.com/magento/magento2/pull/22549)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
+*  The `QuoteRepository` `get` methods now return an object of instance `Vendor\Module\Model\Quote`. *Fix submitted by Bartłomiej Szubert in pull request [22549](https://github.com/magento/magento2/pull/22549)*. [GitHub-12802](https://github.com/magento/magento2/issues/12802)
 
 <!-- ENGCOM-5112 -->
-* Magento no longer caches absolute file paths in the validator factory (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by David Führ in pull request [22805](https://github.com/magento/magento2/pull/22805)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
+*  Magento no longer caches absolute file paths in the validator factory (`Magento\Framework\Validator\Factory::_initializeConfigList`). Previously, caching absolute file paths resulted in problems during transactions when a customer, a `customer_address`, or quote for a registered customer was saved. *Fix submitted by David Führ in pull request [22805](https://github.com/magento/magento2/pull/22805)*. [GitHub-21842](https://github.com/magento/magento2/issues/21842)
 
 <!-- ENGCOM-5217 -->
-* The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Prakash Prajapati in pull request [23149](https://github.com/magento/magento2/pull/23149)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
+*  The description of the `setStoreId` function has been amended to more clearly explain how the function helps load CMS pages. *Fix submitted by Prakash Prajapati in pull request [23149](https://github.com/magento/magento2/pull/23149)*. [GitHub-22767](https://github.com/magento/magento2/issues/22767)
 
 ### Orders
 
 <!-- MAGETWO-99660 -->
-* Custom customer address attribute are populated with the values that have been assigned for the selected address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
+*  Custom customer address attribute are populated with the values that have been assigned for the selected address when the **Same As Billing Address** setting is disabled. Previously, when a merchant tried to change an address while creating an order from the Admin, the drop-down menu of available addresses was not populated.
 
 <!-- ENGCOM-5211 -->
-* You can now successfully view order information by selecting **Sales** > **Orders** > **View Order**. Previously, an issue with the `truncateString` method resulted in Magento throwing an error when you tried to view order information. *Fix submitted by emilie-blackbird in pull request [20849](https://github.com/magento/magento2/pull/20849)*. [GitHub-16958](https://github.com/magento/magento2/issues/16958)
+*  You can now successfully view order information by selecting **Sales** > **Orders** > **View Order**. Previously, an issue with the `truncateString` method resulted in Magento throwing an error when you tried to view order information. *Fix submitted by emilie-blackbird in pull request [20849](https://github.com/magento/magento2/pull/20849)*. [GitHub-16958](https://github.com/magento/magento2/issues/16958)
 
 ### Page Cache
 
 <!-- MC-18144 -->
-* Full page cache works as expected for non-default store views.
+*  Full page cache works as expected for non-default store views.
 
 ### Payment methods
 
-* The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
+*  The **Braintree payment method now complies with PSD2 regulations**. Its core integration API has been upgraded to the latest JavaScript SDK v3 API, which is a requirement for supporting native Braintree 3D Secure 2.0 adoption. Braintree transactions are now also verified by using the native Braintree 3D Secure 2.0 service. <!--- MAGETWO-99607 MC 17628 -->
 
-* Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
+*  Authorize.net now provides the ability, through the `cardholderAuthentication` request field, to make 3D Secure verification through third-party services such as CardinalCommerce. Starting with this release, **Authorize.net accept.js integration will support 3DS 2.0 through CardinalCommerce**. <!--- MAGETWO-99737 -->
 
 <!--- MC-18237 -->
-* The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
+*  The Cybersource and eWay payment modules have been deprecated in this release to comply with PSD2 SCA regulation, which takes effect on September 14, 2019, or shortly thereafter. Use the official Marketplace extensions for these features instead.
 
 #### Other payment issues
 
 <!-- MAGETWO-16590 -->
-* The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
+*  The Transactions tab now displays the correct status for a capture transaction for an order that was placed with the Authorize.net `accept.js` payment method.
 
 <!-- MC-17358 -->
-* Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
+*  Magento now displays a more informative error message (`CVV verification failed`) when you enter an invalid CVV code while using the Braintree payment method. Previously, Magento displayed a generic error message.
 
 <!-- MC-19269 -->
-* You can now enter information into the **Credit Card Number** and **Expiration Date** fields on the Checkout page when the **CVV Verification** setting is disabled. Previously, you were not able to click on these fields to enter information.
+*  You can now enter information into the **Credit Card Number** and **Expiration Date** fields on the Checkout page when the **CVV Verification** setting is disabled. Previously, you were not able to click on these fields to enter information.
 
 <!-- MAGETWO-99416 -->
-* Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
+*  Magento no longer processes payment for an order that has an empty email field in the quote. Previously, Braintree processed the payment, but displayed an error message on the storefront and did not create the order.
 
 <!-- MAGETWO-98805 -->
-* Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
+*  Customers can now successfully place an order when the order is partially paid for by gift card or when a discount is applied to the order. Previously, customers could not place an order, and Magento displayed this error: `error: Field format error: 10413-The totals of the cart item amounts do not match order amounts`.
 
 <!-- MC-17551 -->
-* When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
+*  When you create orders using Braintree, Magento now successfully creates the orders that contain both simple and virtual products with the **Checkout with Multiple Addresses** option enabled. Previously, Magento listed an order created with these features as an empty order with a grand total of zero on the Orders list.
 
 <!-- MC-99111 -->
-* The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
+*  The Admin sales list now displays the payment method for each order. [GitHub-22231](https://github.com/magento/magento2/issues/22231)
 
 <!-- MAGETWO-99581 -->
-* You can now cancel orders placed with PayPal Express even after authorization has expired.
+*  You can now cancel orders placed with PayPal Express even after authorization has expired.
 
 <!-- MAGETWO-99221 -->
-* Customers can now place the order for virtual products with a zero subtotal after entering address information. Previously, customers could not place an order for virtual products with a zero subtotal if they modified their address, and Magento displayed this message: `The requested Payment Method is not available`.
+*  Customers can now place the order for virtual products with a zero subtotal after entering address information. Previously, customers could not place an order for virtual products with a zero subtotal if they modified their address, and Magento displayed this message: `The requested Payment Method is not available`.
 
 <!-- MC-19610 -->
-* Magento no longer places an order if a JavaScript error occurs when a customer clicks **Place order** using Braintree as the payment method.
+*  Magento no longer places an order if a JavaScript error occurs when a customer clicks **Place order** using Braintree as the payment method.
 
 ### Pricing
 
 <!-- MC-98899 -->
-* You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
+*  You can now save a special price that exceeds three characters in Japanese Yen. Previously, you could not apply denominations that exceeded three characters with a comma separator when representing Yen.
 
 ### Reports
 
 <!-- MC-18248 -->
-* The start and finish date in reports now correspond to the entered values when you create a report from the Admin. Previously, the start and finish dates in the displayed report was one day earlier than you entered.
+*  The start and finish date in reports now correspond to the entered values when you create a report from the Admin. Previously, the start and finish dates in the displayed report was one day earlier than you entered.
 
 <!-- ENGCOM-5298 -->
-* Selecting **Show by year** when filtering **Reports** > **Products** > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending orderPreviously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per order basis. *Fix submitted by Prakash Prajapati in pull request [23252](https://github.com/magento/magento2/pull/23252)*. [GitHub-22087](https://github.com/magento/magento2/issues/22087)
+*  Selecting **Show by year** when filtering **Reports** > **Products** > **Ordered** now results in a list of products sold per year that is grouped by product quantity in descending orderPreviously, Magento displayed a list of products sold per year that contained multiple entries for a single product on a per order basis. *Fix submitted by Prakash Prajapati in pull request [23252](https://github.com/magento/magento2/pull/23252)*. [GitHub-22087](https://github.com/magento/magento2/issues/22087)
 
 ### Review
 
 <!-- MAGETWO-99315 -->
-* Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
+*  Administrators with restricted privileges to reviews can now edit review status from the pending reviews list.
 
 ### Sales
 
 <!-- MAGETWO-17268 -->
-* The date format used in tables throughout the product interface is now based on the Admin-defined locale.
+*  The date format used in tables throughout the product interface is now based on the Admin-defined locale.
 
 <!-- MAGETWO-99674 -->
-* The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
+*  The Orders Total now reflects relevant product discounts when you re-order a product. Previously, discounts were not included when you re-ordered.
 
 <!-- MAGETWO-99358 -->
-* You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
+*  You can now edit an order that contains a custom address attribute on its order form. Previously, Magento threw this error if you tried to edit an order with a custom address attribute: `We can't update the order address right now`.
 
 <!-- MAGETWO-99569 -->
-* The Admin now returns exact matches for keyword searches.
+*  The Admin now returns exact matches for keyword searches.
 
 <!-- MAGETWO-99462 -->
-* Custom order statuses no longer override default statuses in drop-down menus.
+*  Custom order statuses no longer override default statuses in drop-down menus.
 
 <!-- MAGETWO-99884 -->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 <!-- MC-17838 -->
-* Magento no longer adds a product that is selected but not explicitly added to the cart to an order when you create an order from the Admin.
+*  Magento no longer adds a product that is selected but not explicitly added to the cart to an order when you create an order from the Admin.
 
 ### Sales rule
 
 <!-- MAGETWO-99540 -->
-* Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
+*  Magento now includes the correct price for a discounted product when the Customer Group is not set to the default group. Previously, when you re-ordered a discounted product, the correct price was not displayed in the Items Ordered field.
 
 ### Search
 
 <!-- MAGETWO-92102 -->
-* Search results now reflect the search weight you assign to product attributes in attribute configuration.
+*  Search results now reflect the search weight you assign to product attributes in attribute configuration.
 
 <!-- MAGETWO-73989 -->
-* The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
+*  The Admin payment method validation now uses the updated billing address country for orders placed in the Admin. Previously, order creation failed when the **Payment from Applicable Countries** setting was set to **Specific Countries** and a non-US country was selected from the Payment from Specific Countries list.
 
 <!-- MAGETWO-99655 -->
-* You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
+*  You can now use Elasticsearch to run a query that includes the `<` character. Previously, when you used this symbol in a query, Magento threw this error:
 `{"0":"SQLSTATE[42000]: Syntax error or access violation: 1064 syntax error, unexpected $end, query was: SELECT`.
 
 <!-- MAGETWO-99716 -->
-* You can now limit the number of search suggestions that the autocomplete feature provides by setting the **Autocomplete Limit** field.
+*  You can now limit the number of search suggestions that the autocomplete feature provides by setting the **Autocomplete Limit** field.
 
 ### Shipping
 
 <!-- ENGCOM-5423 -->
-* You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23603](https://github.com/magento/magento2/pull/23603)*. [GitHub-23522](https://github.com/magento/magento2/issues/23522)
+*  You can now use more than 35 characters in the shipper’s address field when booking a UPS shipment or generating a UPS shipment label. Previously, if this address exceeded 35 characters, Magento threw an error. *Fix submitted by Ankur Raiyani in pull request [23603](https://github.com/magento/magento2/pull/23603)*. [GitHub-23522](https://github.com/magento/magento2/issues/23522)
 
 <!-- ENGCOM-5169 -->
-* The Order Tracking page now displays the Contact us link as expected when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [23019](https://github.com/magento/magento2/pull/23019)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
+*  The Order Tracking page now displays the Contact us link as expected when this feature is enabled and the designated shipping carrier is not available on the Order page. *Fix submitted by Eduard Chitoraga in pull request [23019](https://github.com/magento/magento2/pull/23019)*. [GitHub-22822](https://github.com/magento/magento2/issues/22822)
 
 <!-- ENGCOM-5136 -->
-* Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields) when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22873](https://github.com/magento/magento2/pull/22873)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
+*  Magento no longer tries to validate UPS required fields (UPS Access License Number, User ID, and Password fields) when UPS shipping is not active. *Fix submitted by Serhiy Zhovnir in pull request [22873](https://github.com/magento/magento2/pull/22873)*. [GitHub-22786](https://github.com/magento/magento2/issues/22786)
 
 ### Swatches
 
 <!-- ENGCOM-5427 -->
-* Setting the **Update Product Preview Image** to **no** now works as expected. Previously, when you clicked on a size or image that represented another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [22510](https://github.com/magento/magento2/pull/22510)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
+*  Setting the **Update Product Preview Image** to **no** now works as expected. Previously, when you clicked on a size or image that represented another variation for a configurable product, Magento displayed the image for one of the simple products associated with the configurable product. *Fix submitted by Ravi Chandra in pull request [22510](https://github.com/magento/magento2/pull/22510)*. [GitHub-16446](https://github.com/magento/magento2/issues/16446)
 
 ### TargetRule
 
 <!-- MC-18285 -->
-* Magento now returns more informative error messages when a misconfigured target rule caused an error.
+*  Magento now returns more informative error messages when a misconfigured target rule caused an error.
 
 <!-- MAGETWO-99440 -->
-* Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
+*  Deleting products no longer triggers exception errors. Previously, the target rule that was used to identify the product triggered an exception.
 
 ### Translation
 
 <!-- ENGCOM-5366 -->
-* The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Ihor Sviziev in pull request [23438](https://github.com/magento/magento2/pull/23438)*. [GitHub-23333](https://github.com/magento/magento2/issues/23333)
+*  The payment method area of the shipment and credit memo emails that are sent to customers now have correctly translated strings. *Fix submitted by Ihor Sviziev in pull request [23438](https://github.com/magento/magento2/pull/23438)*. [GitHub-23333](https://github.com/magento/magento2/issues/23333)
 
 ### UI
 
 <!-- MC-17512 -->
-* Pre-loading of fonts has been moved from the Blank theme to the Luma theme.
+*  Pre-loading of fonts has been moved from the Blank theme to the Luma theme.
 
 <!-- MAGETWO-99828 -->
-* Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
+*  Magento now saves order views with the date ranges you enter while creating the filter (**Sales** > **Orders**). Previously, when you opened a saved filtered order view, Magento indicated that the dates you entered were invalid.
 
 <!-- MC-17295 -->
-* The calendar date picker now updates values as expected when the linked input value is changed.
+*  The calendar date picker now updates values as expected when the linked input value is changed.
 
 <!-- ENGCOM-5429 -->
-* The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Prakash Prajapati in pull request [23658](https://github.com/magento/magento2/pull/23658)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
+*  The form reset feature now clears the **date** field in Admin forms as expected. *Fix submitted by Prakash Prajapati in pull request [23658](https://github.com/magento/magento2/pull/23658)*. [GitHub-22940](https://github.com/magento/magento2/issues/22940)
 
 <!-- ENGCOM-5401 -->
-* The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
+*  The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
 
 <!-- ENGCOM-5394 -->
-* The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23547](https://github.com/magento/magento2/pull/23547)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
+*  The behavior of the mobile menu JavaScript now triggers at the same breakpoint as the mobile menu styles. *Fix submitted by bobemoe in pull request [23547](https://github.com/magento/magento2/pull/23547)*. [GitHub-8298](https://github.com/magento/magento2/issues/8298)
 
 <!-- ENGCOM-5396 -->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!-- ENGCOM-5336 -->
-* Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
+*  Magento now displays the cursor to the right of the search keyword box as expected after multiple clicks on the search field in mobile view. *Fix submitted by Prakash Prajapati in pull request [23352](https://github.com/magento/magento2/pull/23352)*. [GitHub-22736](https://github.com/magento/magento2/issues/22736)
 
 <!-- ENGCOM-5401 -->
-* The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
+*  The `always` action that precedes the opening of the alert and confirm widgets is now called once. Previously, the `always triggering` text was logged twice after you clicked the **OK** button. *Fix submitted by Eduard Chitoraga in pull request [23579](https://github.com/magento/magento2/pull/23579)*. [GitHub-23233](https://github.com/magento/magento2/issues/23233)
 
 <!-- ENGCOM-5396 -->
-* The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
+*  The **Refund** button on the credit memo page now remains active after a merchant enters a value in the Refund Totals section. *Fix submitted by Prakash Prajapati in pull request [23566](https://github.com/magento/magento2/pull/23566)*. [GitHub-23285](https://github.com/magento/magento2/issues/23285)
 
 <!-- ENGCOM-5214 -->
-* Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
+*  Corrected alignment of the search suggestion panel with the **Advance reporting** button. *Fix submitted by Prakash Prajapati in pull request [23151](https://github.com/magento/magento2/pull/23151)*. [GitHub-22506](https://github.com/magento/magento2/issues/22506)
 
 <!-- ENGCOM-5084 -->
-* The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22783](https://github.com/magento/magento2/pull/22783)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
+*  The height setting in `.admin__control-textarea` component is no longer hard-coded. Previously, this hard-coded value prevented you from changing the height of this text field through the UI. *Fix submitted by Serhiy Zhovnir in pull request [22783](https://github.com/magento/magento2/pull/22783)*. [GitHub-22771](https://github.com/magento/magento2/issues/22771)
 
 <!-- ENGCOM-5197 -->
-* Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23086](https://github.com/magento/magento2/pull/23086)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
+*  Scrolling now behaves as expected on the create order page. *Fix submitted by Denis Kopylov in pull request [23086](https://github.com/magento/magento2/pull/23086)*. [GitHub-23034](https://github.com/magento/magento2/issues/23034)
 
 <!-- ENGCOM-5156 -->
-* The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Ravi Chandra in pull request [23002](https://github.com/magento/magento2/pull/23002)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795),[GitHub-21214](https://github.com/magento/magento2/issues/21214)
+*  The design of the Review & Payments **Apply Discount Coupon** box of the checkout page has been improved. *Fix submitted by Ravi Chandra in pull request [23002](https://github.com/magento/magento2/pull/23002)*. [GitHub-3795](https://github.com/magento/magento2/issues/3795),[GitHub-21214](https://github.com/magento/magento2/issues/21214)
 
 <!-- ENGCOM-5111 -->
-* Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Amol Chaudhari in pull request [22801](https://github.com/magento/magento2/pull/22801)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
+*  Form element validation is now triggered as expected when form validation rules change. Previously, when you changed form validation rules for a form element during runtime, the new validation rules were not applied. *Fix submitted by Amol Chaudhari in pull request [22801](https://github.com/magento/magento2/pull/22801)*. [GitHub-21473](https://github.com/magento/magento2/issues/21473)
 
 ### URL rewrite
 
 <!-- MAGETWO-72788 -->
-* You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`
+*  You can now export newsletter subscribers from the Admin. Previously, Magento displayed this error when you selected a subscriber name and clicked **Export**: `error: URI too long`
 
 <!-- MAGETWO-96662 -->
-* Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
+*  Magento no longer removes the query string from URLs when the query string is preceded by a slash. Previously, when a customer opened a URL that contained a trailing slash and query string (for example, `http://magento.host.com/sample-url-key/?cupcakes`), Magento redirected the user to a URL that omitted the slash (`http://magento.host.com/sample-url-key`).
 
 <!-- MAGETWO-99925 -->
-* Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously, the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
+*  Products are successfully updated through import of an CSV file in **Add/Update** mode. Previously, the import process failed, and Magento displayed this error: `The value specified in the URL Key field would generate a URL that already exists`.
 
 <!-- MAGETWO-99813 -->
-* Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
+*  Redundant URL rewrite operations that were triggered by category operations have been eliminated, and page load performance has been improved. Previously, updating a category to add or delete products triggered URL rewrite regeneration for all products with changed positions.
 
 ### Web API framework
 
 <!-- ENGCOM-5204 -->
-* Magento now renders shipment details for an order without a fatal error when you use `POST V1/shipment` to create a shipment. *Fix submitted by Milind Singh in pull request [23119](https://github.com/magento/magento2/pull/23119)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
+*  Magento now renders shipment details for an order without a fatal error when you use `POST V1/shipment` to create a shipment. *Fix submitted by Milind Singh in pull request [23119](https://github.com/magento/magento2/pull/23119)*. [GitHub-22686](https://github.com/magento/magento2/issues/22686)
 
 <!-- ENGCOM-5188 -->
-* You can now use `POST V1/customers` to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22895](https://github.com/magento/magento2/pull/22895)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
+*  You can now use `POST V1/customers` to update a customer that has no associated `store_id` without unintentionally changing other information. Previously, Magento changed the `store_id` to the default `store_id` if this field was left empty in the PUT request. *Fix submitted by Mateusz Wira in pull request [22895](https://github.com/magento/magento2/pull/22895)*. [GitHub-22869](https://github.com/magento/magento2/issues/22869)
 
 ### Wishlist
 
 <!-- MAGETWO-96873 -->
-* The behavior of the Catalog page Requisition list menu has been corrected.
+*  The behavior of the Catalog page Requisition list menu has been corrected.
 
 ## Community contributions
 

--- a/guides/v2.2/rest/asynchronous-web-endpoints.md
+++ b/guides/v2.2/rest/asynchronous-web-endpoints.md
@@ -15,9 +15,9 @@ Use the `bin/magento queue:consumers:start async.operations.all` command to star
 
 Magento supports the following types of asynchronous requests:
 
-* POST
-* PUT
-* PATCH
+*  POST
+*  PUT
+*  PATCH
 
 {:.bs-callout .bs-callout-info}
 GET and DELETE requests are not supported. Although Magento does not currently implement any PATCH requests, they are supported in custom extensions.

--- a/guides/v2.2/rest/operation-status-endpoints.md
+++ b/guides/v2.2/rest/operation-status-endpoints.md
@@ -10,8 +10,8 @@ functional_areas:
 
 Magento generates a `bulk_uuid` each time it executes an [asynchronous API request]({{ page.baseurl }}/rest/asynchronous-web-endpoints.html). You can track the status of an asynchronous operation with the following endpoints:
 
-* `GET /V1/bulk/:bulkUuid/status`
-* `GET /V1/bulk/:bulkUuid/detailed-status`
+*  `GET /V1/bulk/:bulkUuid/status`
+*  `GET /V1/bulk/:bulkUuid/detailed-status`
 
 ## Get the status summary
 

--- a/guides/v2.2/rest/retrieve-filtered-responses.md
+++ b/guides/v2.2/rest/retrieve-filtered-responses.md
@@ -10,10 +10,10 @@ This feature is not available for SOAP, because SOAP does not allow partial resp
 
 You can append `?fields=<field_or_object1>,<field_or_object2>,...` to any GET, POST, or PUT operation to filter unimportant information from the response. `<field_or_object>` can be any of the following:
 
-* Simple top-level field
-* Top-level object that includes all fields
-* Top-level object with selected fields
-* Nested objects
+*  Simple top-level field
+*  Top-level object that includes all fields
+*  Top-level object with selected fields
+*  Nested objects
 
 Separate each field or object with a comma.
 
@@ -88,9 +88,9 @@ The following example returns only the `name`, `qty`, and `sku` fields defined i
 
 This example returns only the following:
 
-* The product's `sku` and `name`
-* The entire `category_links` object, which is defined in `extension_attributes`
-* The `item_id` and `qty` fields of the `stock_item` object, which is also defined in `extension_attributes`
+*  The product's `sku` and `name`
+*  The entire `category_links` object, which is defined in `extension_attributes`
+*  The `item_id` and `qty` fields of the `stock_item` object, which is also defined in `extension_attributes`
 
 `GET <host>/rest/<store_code>/V1/products/MT12?fields=name,sku,extension_attributes[category_links,stock_item[item_id,qty]]`
 
@@ -191,4 +191,4 @@ The following query returns only the `sku` and `name` parameters for product ite
 {:.ref-header}
 Related topics
 
-* [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)
+*  [Search using REST APIs]({{ page.baseurl }}/rest/performing-searches.html)

--- a/guides/v2.2/rest/tutorials/index.md
+++ b/guides/v2.2/rest/tutorials/index.md
@@ -9,27 +9,27 @@ functional_areas:
 
 The REST tutorials provide an introduction to Magento web APIs. In general, the tutorials guide you through commonly-performed complex tasks:
 
-* The [**order processing** tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html) demonstrates the lifecycle of an order. Major steps include creating a quote, converting it to an order, issuing an invoice, and shipping the order.
+*  The [**order processing** tutorial]({{ page.baseurl }}/rest/tutorials/orders/order-intro.html) demonstrates the lifecycle of an order. Major steps include creating a quote, converting it to an order, issuing an invoice, and shipping the order.
 
-* The [**configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html) helps you plan then create a configurable product and its component simple products.
+*  The [**configurable product** tutorial]({{ page.baseurl }}/rest/tutorials/configurable-product/config-product-intro.html) helps you plan then create a configurable product and its component simple products.
 
-* The [**grouped products** tutorial]({{ page.baseurl }}/rest/tutorials/grouped-product/create-and-manage-grouped-products.html) demonstrates how to create and manage grouped products.
+*  The [**grouped products** tutorial]({{ page.baseurl }}/rest/tutorials/grouped-product/create-and-manage-grouped-products.html) demonstrates how to create and manage grouped products.
 
 ## Complete these prerequisites
 
 You will need
 
-* Install a Magento 2.2 (or later) instance with sample data.
+*  Install a Magento 2.2 (or later) instance with sample data.
 
   The sample data defines a functional store, called Luma, that sells fitness clothing and accessories. The store does not provide any sandbox accounts for testing credit card payments, so transactions will be simulated using an offline [payment method](https://glossary.magento.com/payment-method).
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
 
-* Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/swagger/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
+*  Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/swagger/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
 
-* Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}}](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
+*  Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}}](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
 
 ## Performing steps
 

--- a/guides/v2.2/rest/tutorials/orders/order-intro.md
+++ b/guides/v2.2/rest/tutorials/orders/order-intro.md
@@ -25,18 +25,18 @@ The **10-step tutorial** generally takes **30 minutes**.
 
 Complete the following prerequisites:
 
-* Install a Magento 2.1.3 (or later) instance with sample data.
+*  Install a Magento 2.1.3 (or later) instance with sample data.
 
   The sample data defines a functional store, called Luma, that sells fitness clothing and accessories. The store does not provide any sandbox accounts for testing credit card payments, so transactions will be simulated using an offline [payment method](https://glossary.magento.com/payment-method).
 
-* Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
 
-* Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
 
-* Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/swagger/){:target="_blank"} or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
+*  Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/swagger/){:target="_blank"} or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
 
-* Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}} 2.1](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
+*  Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}} 2.1](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
 
 ### Other resources
 
-* [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.

--- a/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
+++ b/guides/v2.2/rest/tutorials/orders/order-issue-refund.md
@@ -80,7 +80,7 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 {:.ref-header}
 Related topics
 
-* [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
-* [Create a configurable product Tutorial]({{ site.baseurl }}/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.html)
-* [REST API Reference Overview]({{ page.baseurl }}/rest/bk-rest.html)
-* [REST API documentation]({{ site.baseurl }}/swagger/){:target="_blank"}
+*  [Getting Started with Magento Web APIs]({{ page.baseurl }}/get-started/bk-get-started-api.html)
+*  [Create a configurable product Tutorial]({{ site.baseurl }}/guides/v2.2/rest/tutorials/configurable-product/config-product-intro.html)
+*  [REST API Reference Overview]({{ page.baseurl }}/rest/bk-rest.html)
+*  [REST API documentation]({{ site.baseurl }}/swagger/){:target="_blank"}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.2/release-notes`
- `guides/v2.2/rest`