### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.1CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.1CE.md
@@ -10,15 +10,15 @@ We are pleased to present Magento Open Source 2.2.1. This release includes numer
 
 Look for the following highlights in this release:
 
-* Integrated Signifyd Fraud Protection is now available in Magento Open Source. See [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html) for more information.
+*  Integrated Signifyd Fraud Protection is now available in Magento Open Source. See [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html) for more information.
 
-* Ability to implement translations from themes. We’ve also significantly reduced JavaScript-related translation issues.
+*  Ability to implement translations from themes. We’ve also significantly reduced JavaScript-related translation issues.
 
-* Improvements to how the PayPal Express Checkout payment method processes virtual products.
+*  Improvements to how the PayPal Express Checkout payment method processes virtual products.
 
-* Multiple enhancements to product security. See [Magento Security Center](https://magento.com/security/patches/magento-221-2110-and-2017-security-update) for more information.
+*  Multiple enhancements to product security. See [Magento Security Center](https://magento.com/security/patches/magento-221-2110-and-2017-security-update) for more information.
 
-* Twenty-two community-submitted bug fixes and multiple pull requests.
+*  Twenty-two community-submitted bug fixes and multiple pull requests.
 
 Looking for more information on these new features as well as many others? Check out  [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/).
 
@@ -39,7 +39,7 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 *  When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
 
 <!--- 80201  -->
-*   We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
+*  We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
 
 ### Catalog
 
@@ -53,7 +53,7 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 *  The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
 
 <!--- 75221  -->
-*   We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
+*  We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
 
 ### Configurable products
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.md
@@ -10,15 +10,15 @@ We are pleased to present Magento Commerce 2.2.1. This release includes numerous
 
 Look for the following highlights in this release:
 
-* Integrated Signifyd Fraud Protection is now available in Magento Open Source. See [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html) for more information.
+*  Integrated Signifyd Fraud Protection is now available in Magento Open Source. See [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html) for more information.
 
-* Ability to implement translations from themes. We’ve also significantly reduced JavaScript-related translation issues.
+*  Ability to implement translations from themes. We’ve also significantly reduced JavaScript-related translation issues.
 
-* Improvements to how the PayPal Express Checkout payment method processes virtual products.
+*  Improvements to how the PayPal Express Checkout payment method processes virtual products.
 
-* Multiple enhancements to product security. See [Magento Security Center](https://magento.com/security/patches/magento-221-2110-and-2017-security-update) for more information.
+*  Multiple enhancements to product security. See [Magento Security Center](https://magento.com/security/patches/magento-221-2110-and-2017-security-update) for more information.
 
-* Twenty-two community-submitted bug fixes and multiple pull requests.
+*  Twenty-two community-submitted bug fixes and multiple pull requests.
 
 Looking for more information on these new features as well as many others? Check out  [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/).
 
@@ -42,7 +42,7 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 *  When a callback during commit throws an exception, the calling plugin can now distinguish this exception from an unsuccessful commit and logs an exception. Previously, Magento threw an “Asymmetric transaction rollback error”. [GitHub-9955](https://github.com/magento/magento2/issues/9955)
 
 <!--- 80201  -->
-*   We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
+*  We’ve resolved a fatal error in the repository generator. Both `InputException` and `NoSuchEntityException` now require a Phrase object as their first constructor argument.  [GitHub-10601](https://github.com/magento/magento2/issues/10601)
 
 ### AMQP
 
@@ -55,10 +55,10 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 *  Magento now displays products that are filtered to a particular store view even when the corresponding store view has been deleted. Previously, Magento displayed a continuously spinning  spinner widget and this error message: **A technical problem with the server created an error. Try again to continue what you were doing. If the problem persists, try again later.**
 
 <!--- 72382  -->
-*   You can now save custom shared catalogs.
+*  You can now save custom shared catalogs.
 
 <!--- 78522  -->
-*   Magento no longer displays a 404 error when you change category permissions from Product Detail pages when multistore view is enabled.
+*  Magento no longer displays a 404 error when you change category permissions from Product Detail pages when multistore view is enabled.
 
 <!--- 75460  -->
 *  `LowestPriceOptionsProvider` now returns products with the `tax_class_id` attribute, which is used for price calculation operations such as  tax adjustment. [GitHub-6729](https://github.com/magento/magento2/issues/6729), [GitHub-6457](https://github.com/magento/magento2/issues/6457), [GitHub-7362](https://github.com/magento/magento2/issues/7362)
@@ -67,7 +67,7 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 *  The grouped product page now  shows the lowest price for a simple product.  [GitHub-9266](https://github.com/magento/magento2/issues/9266)
 
 <!--- 75221  -->
-*   We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
+*  We’ve fixed an issue with `priceScope` that had resulted in the storefront not displaying product prices that should be displayed.
 
 ### Cart and checkout
 
@@ -212,10 +212,10 @@ See [Magento Security Center](https://magento.com/security/patches/magento-221-2
 ### Visual Merchandiser
 
 <!--- 71554  -->
-*   We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
+*  We’ve improved the performance of editing or saving products in large categories (more than 18,000 products per category).
 
 <!--- 71986  -->
-*   Visual Merchandiser now retains page view options and position after you remove a product. Previously, when you removed a product from a category, and you weren't on the first page, Magento returned you to the first page.
+*  Visual Merchandiser now retains page view options and position after you remove a product. Previously, when you removed a product from a category, and you weren't on the first page, Magento returned you to the first page.
 
 ## Community contributions
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.md
@@ -12,37 +12,37 @@ We are pleased to present Magento Open Source 2.2.2. This release includes new t
 
 Look for the following highlights in this release:
 
-* Significant new features that streamline the customer experience and provide merchants with greater insight into their online business.
+*  Significant new features that streamline the customer experience and provide merchants with greater insight into their online business.
 
-* Numerous fixes and enhancements to core features, including significant improvements to the payment process.
+*  Numerous fixes and enhancements to core features, including significant improvements to the payment process.
 
-* Ninety-six community-submitted bug fixes and multiple pull requests.
+*  Ninety-six community-submitted bug fixes and multiple pull requests.
 
 ### New Features
 
-* **Advanced Reporting powered by Magento Business Intelligence**. Access easy-to-use order, product, and customer reports right from the Magento Admin to gain new insights and enable data-driven decision making. See [Advanced Reporting]({{ site.baseurl }}/guides/v2.2/advanced-reporting/overview.html) for more information.
+*  **Advanced Reporting powered by Magento Business Intelligence**. Access easy-to-use order, product, and customer reports right from the Magento Admin to gain new insights and enable data-driven decision making. See [Advanced Reporting]({{ site.baseurl }}/guides/v2.2/advanced-reporting/overview.html) for more information.
 
-* **Magento Shipping** (powered by Temando). This new feature provides integrated advanced multi-carrier shipping and fulfillment. (In addition to these release notes, you can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).)
+*  **Magento Shipping** (powered by Temando). This new feature provides integrated advanced multi-carrier shipping and fulfillment. (In addition to these release notes, you can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).)
 
-* **Streamlined Instant Purchase checkout** (contributed by Creatuity). Our new streamlined Instant Purchase option uses previously stored payment credentials and shipping information to bypass steps in the checkout process. See [Instant Purchase module]({{ site.baseurl }}/guides/v2.2/mrg/ce/instant-purchase/) for more information.
+*  **Streamlined Instant Purchase checkout** (contributed by Creatuity). Our new streamlined Instant Purchase option uses previously stored payment credentials and shipping information to bypass steps in the checkout process. See [Instant Purchase module]({{ site.baseurl }}/guides/v2.2/mrg/ce/instant-purchase/) for more information.
 
-* **Integrated dotmailer marketing automation software**. Magento is one of the first ecommerce solutions to include the dotmailer marketing automation with their core product. See [Email Marketing Automation](http://docs.magento.com/m2/ce/user_guide/marketing/email-marketing-automation.html).
+*  **Integrated dotmailer marketing automation software**. Magento is one of the first ecommerce solutions to include the dotmailer marketing automation with their core product. See [Email Marketing Automation](http://docs.magento.com/m2/ce/user_guide/marketing/email-marketing-automation.html).
 
-* **Magento Functional Testing Framework**.  The Magento Functional Testing Framework (MTFT) is our open-source, cross-platform testing solution. Its purpose is to facilitate functional testing and minimize efforts to perform regression testing. See [Introduction to Magento Functional Testing Framework]({{ site.baseurl }}/mftf/docs/introduction.html).
+*  **Magento Functional Testing Framework**.  The Magento Functional Testing Framework (MTFT) is our open-source, cross-platform testing solution. Its purpose is to facilitate functional testing and minimize efforts to perform regression testing. See [Introduction to Magento Functional Testing Framework]({{ site.baseurl }}/mftf/docs/introduction.html).
 
 Looking for more information on these new features as well as many others? Check out [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Open Source User Guide](http://docs.magento.com/m2/ce/user_guide/getting-started.html).
 
 ## Fixes and enhancements
 
-* **Significant enhancements for payment methods**. We've added support for the Indian Rupee (INR) to PayPal Express Checkout. We've also added  a fix for an issue where some Braintree refunds did not work.
+*  **Significant enhancements for payment methods**. We've added support for the Indian Rupee (INR) to PayPal Express Checkout. We've also added  a fix for an issue where some Braintree refunds did not work.
 
-* **Improvements to multi-storeview sites**. Switching store views multiple times no longer results in an error on the storefront.
+*  **Improvements to multi-storeview sites**. Switching store views multiple times no longer results in an error on the storefront.
 
-* **New functionality for the command-line interface**. We've added interactivity to the `admin:user:create` command and added the ability to handle CLI setup interactively (with prompts).
+*  **New functionality for the command-line interface**. We've added interactivity to the `admin:user:create` command and added the ability to handle CLI setup interactively (with prompts).
 
-* You can now use the **Enter** key (in addition to a mouse click) to  search tables in the Admin.
+*  You can now use the **Enter** key (in addition to a mouse click) to  search tables in the Admin.
 
-* Magento no longer creates duplicate shipments when merchants create shipments with bundled products via API.
+*  Magento no longer creates duplicate shipments when merchants create shipments with bundled products via API.
 
 ## Fixed issues
 ### Installation, setup, and deployment
@@ -293,7 +293,7 @@ Looking for more information on these new features as well as many others? Check
 *  The `customer_data_object` firstname is no longer equal to `orig_customer_data_object` after you save an existing user account with a new name or address. *Fix submitted by Roman K. in pull request 11676*. [GitHub-7915](https://github.com/magento/magento2/issues/7915)
 
 <!--- MAGETWO-82658  -->
-*   A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+*  A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
 <!--- MAGETWO-82761  -->
 *  We’ve fixed the dashboard graph’s y-axis range. *Fix submitted by Oscar Recio in pull request 11751*. [GitHub-7927](https://github.com/magento/magento2/issues/7927)
@@ -326,7 +326,7 @@ Looking for more information on these new features as well as many others? Check
 *  The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
 
 <!--- MAGETWO-83490  -->
-*   We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
+*  We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
 
 <!--- MAGETWO-83672  -->
 *  Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
@@ -364,7 +364,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
 
 <!--- MAGETWO-81594  -->
-*   Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
+*  Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
 
 <!--- MAGETWO-83310  -->
 *  Importing an import file to update customer data no longer results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
@@ -375,7 +375,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
 
 <!--- MAGETWO-80644  -->
-*   Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
+*  Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
 
 ### Infrastructure
 
@@ -386,13 +386,13 @@ Looking for more information on these new features as well as many others? Check
 *  We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
 
 <!--- MAGETWO-82003  -->
-*   Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
+*  Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
 
 <!--- MAGETWO-82658  -->
-*   We fixed a typo in the `Paypal/Test/TestCase/OnePageCheckoutTest.xml`. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+*  We fixed a typo in the `Paypal/Test/TestCase/OnePageCheckoutTest.xml`. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
 <!--- MAGETWO-83572  -->
-*   `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
+*  `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
 
 ### Newsletters
 
@@ -435,7 +435,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
 
 <!--- MAGETWO-81647  -->
-*   `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
+*  `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
 
 <!--- MAGETWO-81340  -->
 *  Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
@@ -555,15 +555,15 @@ We’ve identified the following unresolved issues with this version of Magento 
 
 **Workaround**: Ensure that the experience currency,  base currency, and display currency are the same. Additionally, incorporate these best practices into your shipping method configuration by ensuring that:
 
-* the Magento Core base currency is the same as the experience currency (**Store > Configuration > Currency Set Up > Base Current**).
-* the Magento Core base currency converter is the same as the experience and base currency (**Store > Currency Rates**)
+*  the Magento Core base currency is the same as the experience currency (**Store > Configuration > Currency Set Up > Base Current**).
+*  the Magento Core base currency converter is the same as the experience and base currency (**Store > Currency Rates**)
 
 **Issue**: Selecting a shipping method at checkout can sometimes result in two shipping methods being selected. This issue occurs during checkout. When a user selects a shipping method during checkout, Magento will select two shipping methods. <!--- BUNDLE-508-->
 
 **Workaround**:  Ensure that no two rules with a ‘Show Shipping Method’ outcome can both apply to the scenario. Consider these example rules:
 
-* Rule 1: Show ‘Free Shipping’ for Country is Canada and Cost is not greater than $99.99
-* Rule 2: Show ‘Free Shipping’ for Country is not Canada and Cost is greater than $100
+*  Rule 1: Show ‘Free Shipping’ for Country is Canada and Cost is not greater than $99.99
+*  Rule 2: Show ‘Free Shipping’ for Country is not Canada and Cost is greater than $100
 
 <!--- NOT NEEDED  MAGETWO-83834  MAGETWO-83755 MAGETWO-83740 MAGETWO-83682 MAGETWO-83672 MAGETWO-83632 MAGETWO-83600 MAGETWO-83572 MAGETWO-52974 MAGETWO-62981 MAGETWO-72138 MAGETWO-81987 MAGETWO-81886 MAGETWO-81830 MAGETWO-82003 MAGETWO-82117 MAGETWO-83184 MAGETWO-82126 MAGETWO-82125 MAGETWO-80479 MAGETWO-80480 MAGETWO-80481 MAGETWO-81786
 MAGETWO-80484 MAGETWO-80488 MAGETWO-80568

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
@@ -12,37 +12,37 @@ We are pleased to present Magento Commerce 2.2.2. This release includes new tool
 
 Look for the following highlights in this release:
 
-* Significant new features that streamline the customer experience and provide merchants with greater insight into their online business.
+*  Significant new features that streamline the customer experience and provide merchants with greater insight into their online business.
 
-* Numerous fixes and enhancements to core features, including significant improvements to the payment process.
+*  Numerous fixes and enhancements to core features, including significant improvements to the payment process.
 
-* Ninety-six community-submitted bug fixes and multiple pull requests.
+*  Ninety-six community-submitted bug fixes and multiple pull requests.
 
 ### New Features
 
-* **Advanced Reporting powered by Magento Business Intelligence**. Access easy-to-use order, product, and customer reports right from the Magento Admin to gain new insights and enable data-driven decision making. See [Advanced Reporting]({{ site.baseurl }}/guides/v2.2/advanced-reporting/overview.html) for more information.
+*  **Advanced Reporting powered by Magento Business Intelligence**. Access easy-to-use order, product, and customer reports right from the Magento Admin to gain new insights and enable data-driven decision making. See [Advanced Reporting]({{ site.baseurl }}/guides/v2.2/advanced-reporting/overview.html) for more information.
 
-* **Magento Shipping** (powered by Temando). This new feature provides integrated advanced multi-carrier shipping and fulfillment.  (In addition to these release notes, you can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).)
+*  **Magento Shipping** (powered by Temando). This new feature provides integrated advanced multi-carrier shipping and fulfillment.  (In addition to these release notes, you can find Magento Shipping-specific release notes in [Magento Shipping Release Notes]({{ page.baseurl }}/release-notes/ReleaseNotesMagentoShipping2.2.x.html).)
 
-* **Streamlined Instant Purchase checkout** (contributed by Creatuity). Our new streamlined Instant Purchase option uses previously stored payment credentials and shipping information to bypass steps in the checkout process. See [Instant Purchase module]({{ site.baseurl }}/guides/v2.2/mrg/ce/instant-purchase/) for more information.
+*  **Streamlined Instant Purchase checkout** (contributed by Creatuity). Our new streamlined Instant Purchase option uses previously stored payment credentials and shipping information to bypass steps in the checkout process. See [Instant Purchase module]({{ site.baseurl }}/guides/v2.2/mrg/ce/instant-purchase/) for more information.
 
-* **Integrated dotmailer marketing automation software**. Magento is one of the first ecommerce solutions to include the dotmailer marketing automation with their core product. See [Email Marketing Automation](http://docs.magento.com/m2/ce/user_guide/marketing/email-marketing-automation.html).
+*  **Integrated dotmailer marketing automation software**. Magento is one of the first ecommerce solutions to include the dotmailer marketing automation with their core product. See [Email Marketing Automation](http://docs.magento.com/m2/ce/user_guide/marketing/email-marketing-automation.html).
 
-* **Magento Functional Testing Framework**.  The Magento Functional Testing Framework (MFTF) is our open-source, cross-platform testing solution. Its purpose is to facilitate functional testing and minimize efforts to perform regression testing. See [Introduction to Magento Functional Testing Framework]({{ site.baseurl }}/mftf/docs/introduction.html).
+*  **Magento Functional Testing Framework**.  The Magento Functional Testing Framework (MFTF) is our open-source, cross-platform testing solution. Its purpose is to facilitate functional testing and minimize efforts to perform regression testing. See [Introduction to Magento Functional Testing Framework]({{ site.baseurl }}/mftf/docs/introduction.html).
 
 Looking for more information on these new features as well as many others? Check out [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Commerce User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html).
 
 ## Fixes and enhancements
 
-* **Significant enhancements for payment methods**. We've added support for the Indian Rupee (INR) to PayPal Express Checkout. We've also added a fix for an issue where some Braintree refunds did not work.
+*  **Significant enhancements for payment methods**. We've added support for the Indian Rupee (INR) to PayPal Express Checkout. We've also added a fix for an issue where some Braintree refunds did not work.
 
-* **Improvements to multi-storeview sites**. Switching store views multiple times no longer results in an error on the storefront.
+*  **Improvements to multi-storeview sites**. Switching store views multiple times no longer results in an error on the storefront.
 
-* **New functionality for the command-line interface**. We've added interactivity to the `admin:user:create` command and added the ability to handle CLI setup interactively (with prompts).
+*  **New functionality for the command-line interface**. We've added interactivity to the `admin:user:create` command and added the ability to handle CLI setup interactively (with prompts).
 
-* You can now use the **Enter** key (in addition to a mouse click) to  search tables in the Admin.
+*  You can now use the **Enter** key (in addition to a mouse click) to  search tables in the Admin.
 
-* Magento no longer creates duplicate shipments when merchants create shipments with bundled products via API.
+*  Magento no longer creates duplicate shipments when merchants create shipments with bundled products via API.
 
 ## Fixed issues
 
@@ -327,7 +327,7 @@ Looking for more information on these new features as well as many others? Check
 *  The Store View switcher now works as expected. *Fix submitted by thiagolima-bm in pull request 11337*. [GitHub-10908](https://github.com/magento/magento2/issues/10908), [GitHub-11211](https://github.com/magento/magento2/issues/11211)
 
 <!--- MAGETWO-83490  -->
-*   We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
+*  We've removed object manager references as well as deprecated calls to `$messageManager`. *Fix submitted by Atish Goswami in pull request 12061*.
 
 <!--- MAGETWO-83672  -->
 *  Magento now prepares street data to guarantee that the street array will be converted to a string. *Fix submitted by Vova Yatsyuk in pull request 12130*.
@@ -365,7 +365,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento now provides better error reporting when an error occurs during the import of a CSV file with a semicolon delimiter. Previously, Magento stopped import, but did not provide a link to the error report CSV file. [GitHub-5015](https://github.com/magento/magento2/issues/5015)
 
 <!--- MAGETWO-81594  -->
-*   Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
+*  Exception message was passed as a exception description argument instead of exception message. *Fix submitted by Tim Bezhashvyly in pull request 11363*. [GitHub-6924](https://github.com/magento/magento2/issues/6924)
 
 <!--- MAGETWO-83310  -->
 *  Importing an import file to update customer data no loner results in the `entity fields` being removed if the columns were not present on the imported file. *Fix submitted by Juan Alonso in pull request 11968*.
@@ -376,7 +376,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento no longer re-indexes entities if they are unchanged, which improves the performance of the refresh index cron job without any loss of functionality. [GitHub-4893](https://github.com/magento/magento2/issues/4893)
 
 <!--- MAGETWO-80644  -->
-*   Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
+*  Magento now correctly resets status to `StateInterface::STATUS_INVALID` if a fatal PHP error occurs during indexing. *Fix submitted by Lars Roettig in pull request 11183*. [GitHub-11166](https://github.com/magento/magento2/issues/11166)
 
 ### Infrastructure
 
@@ -387,13 +387,13 @@ Looking for more information on these new features as well as many others? Check
 *  We've ported a fix for the Travis CI builds for the  `2.2-develop` branch to the  `2.3-develop` branch. *Fix submitted by Ievgen Shakhsuvarov in pull request 11555*.
 
 <!--- MAGETWO-82003  -->
-*   Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
+*  Integration tests now reset the integration test database when `TESTS_CLEANUP` is set to enabled. *Fix submitted by Joshua Warren in pull request 11499*. [GitHub-10025](https://github.com/magento/magento2/issues/10025)
 
 <!--- MAGETWO-82658  -->
-*   A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
+*  A typo in  `Paypal/Test/TestCase/OnePageCheckoutTest.xml` has been fixed. *Fix submitted by Mr. Lewis in pull request 11673*. [GitHub-7591](https://github.com/magento/magento2/issues/7591)
 
 <!--- MAGETWO-83572  -->
-*   `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
+*  `FileClassScannerTest` no  longer has a dependency upon  `Magento_Catalog`. *Fix submitted by WEXO team in pull request 12144*. [GitHub-11230](https://github.com/magento/magento2/issues/11230)
 
 ### Newsletters
 
@@ -436,7 +436,7 @@ Looking for more information on these new features as well as many others? Check
 *  Magento no longer lets you cancel an invoice more than once.  *Fix submitted by Oscar Recio in pull request 11261*. [GitHub-9968](https://github.com/magento/magento2/issues/9968)
 
 <!--- MAGETWO-81647  -->
-*   `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
+*  `guest.php` now handles breadcrumb performance as expected. *Fix submitted by Juliano Vargas in pull request 11299*. [GitHub-11275](https://github.com/magento/magento2/issues/11275)
 
 <!--- MAGETWO-81340  -->
 *  Magento now sends confirmation emails to customers for orders containing a grouped product. Previously, when you tried to submit an invoice for an order containing a grouped product, Magento threw an error and did not send confirmation email to the customer. *Fix submitted by Michiel Gerritsen in pull request 11297*. [GitHub-5105](https://github.com/magento/magento2/issues/5105)
@@ -556,15 +556,15 @@ We’ve identified the following unresolved issues with this version of Magento 
 
 **Workaround**: Ensure that the experience currency,  base currency, and display currency are the same. Additionally, incorporate these best practices into your shipping method configuration by ensuring that:
 
-* the Magento Core base currency is the same as the experience currency (**Store > Configuration > Currency Set Up > Base Current**).
-* the Magento Core base currency converter is the same as the experience and base currency (**Store > Currency Rates**)
+*  the Magento Core base currency is the same as the experience currency (**Store > Configuration > Currency Set Up > Base Current**).
+*  the Magento Core base currency converter is the same as the experience and base currency (**Store > Currency Rates**)
 
 **Issue**: Selecting a shipping method at checkout can sometimes result in two shipping methods being selected. This issue occurs during checkout. When a user selects a shipping method during checkout, Magento will select two shipping methods. <!--- BUNDLE-508-->
 
 **Workaround**:  Ensure that no two rules with a ‘Show Shipping Method’ outcome can both apply to the scenario. Consider these example rules:
 
-* Rule 1: Show ‘Free Shipping’ for Country is Canada and Cost is not greater than $99.99
-* Rule 2: Show ‘Free Shipping’ for Country is not Canada and Cost is greater than $100
+*  Rule 1: Show ‘Free Shipping’ for Country is Canada and Cost is not greater than $99.99
+*  Rule 2: Show ‘Free Shipping’ for Country is not Canada and Cost is greater than $100
 
 <!--- NOT NEEDED  MAGETWO-83834 MAGETWO-83755 MAGETWO-83740 MAGETWO-83682 MAGETWO-83672 MAGETWO-83632 MAGETWO-83600  MAGETWO-52974 MAGETWO-62981   MAGETWO-72138  MAGETWO-81886 MAGETWO-81830 MAGETWO-82003 MAGETWO-82117 MAGETWO-84882  MAGETWO-84650 MAGETWO-84649 MAGETWO-84544 MAGETWO-84321 MAGETWO-84000 MAGETWO-83898 MAGETWO-83184 MAGETWO-80474 MAGETWO-80475 MAGETWO-80477 MAGETWO-80477 MAGETWO-80479 MAGETWO-80480 MAGETWO-80481 MAGETWO-80484 MAGETWO-80488 MAGETWO-80568
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.md
@@ -15,16 +15,16 @@ For security reasons, this release limits the ability to use symlinks for `/medi
 
 Look for the following highlights in this release:
 
-* **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
+*  **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
 
 <!--- MAGETWO-84775  -->
 *  **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
 
-* **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS  removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
+*  **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS  removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
 
-* **New layers of control for cache management tasks managed through the Magento Admin**. This release introduces finer permissions for cache management tasks such as flushing cache storage, flushing the Magento cache, and refreshing cache types. *Fix submitted by community member <a href="https://github.com/bartoszherba" target="_blank">Bartosz Herba</a>.*
+*  **New layers of control for cache management tasks managed through the Magento Admin**. This release introduces finer permissions for cache management tasks such as flushing cache storage, flushing the Magento cache, and refreshing cache types. *Fix submitted by community member <a href="https://github.com/bartoszherba" target="_blank">Bartosz Herba</a>.*
 
-* **Updated copyright to 2018**.
+*  **Updated copyright to 2018**.
 
 ## Security enhancements
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.md
@@ -15,16 +15,16 @@ For security reasons, this release limits the ability to use symlinks for `/medi
 
 Look for the following highlights in this release:
 
-* **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
+*  **Enhancements that help close cross-site request forgery (CSRF), unauthorized data leaks, and authenticated Admin user remote code execution vulnerabilities**. See [Magento Security Center](https://magento.com/security/patches/magento-223-2112-and-2018-security-update) for more information.
 
 <!--- MAGETWO-84775  -->
 *  **Support for Elasticsearch 5.x**. See [Install and configure Elasticsearch]({{ site.baseurl }}/guides/v2.2/config-guide/elasticsearch/es-overview.html) for more information about using Elasticsearch with Magento. *Fix submitted by community member <a href="https://github.com/afoucret" target="_blank">Aurélien Foucret</a>.*
 
-* **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
+*  **Change to Magento Admin to support recent USPS shipping changes**. On February 23, 2018, USPS removed APIs that support the creation of shipping labels without postage. In response, we’ve removed this functionality from the Magento Admin. Consequently, you cannot create and print shipping labels that do not have postage applied. If you require USPS postage printing capabilities, please visit [Magento Shipping](https://magento.com/products/shipping) to learn more, and explore various shipping extensions on Magento Marketplace.
 
-* **New layers of control for cache management tasks managed through the Magento Admin**. This release introduces finer permissions for cache management tasks such as flushing cache storage, flushing the Magento cache, and refreshing cache types. *Fix submitted by community member <a href="https://github.com/bartoszherba" target="_blank">Bartosz Herba</a>.*
+*  **New layers of control for cache management tasks managed through the Magento Admin**. This release introduces finer permissions for cache management tasks such as flushing cache storage, flushing the Magento cache, and refreshing cache types. *Fix submitted by community member <a href="https://github.com/bartoszherba" target="_blank">Bartosz Herba</a>.*
 
-* **Updated copyright to 2018**.
+*  **Updated copyright to 2018**.
 
 ## Security enhancements
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -42,7 +42,7 @@ Highlights of community contributions include  fixes that improve checkout flow 
 
 *  <!--- MAGETWO-87115 -->Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
-*  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+*  <!--- MAGETWO-73479 -->Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
 *  <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -40,7 +40,7 @@ This release includes significant performance improvements to the core Magento c
 
 Highlights of community contributions include  fixes that improve checkout flow and the sorting of simple products:
 
-*  <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
+*  <!--- MAGETWO-87115 -->Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
 *  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -34,7 +34,7 @@ This release includes significant performance improvements to the core Magento c
 
 *  <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
 
-*  <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
+*  <!--- MAGETWO-88775 -->Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
 
 ### Community contribution highlights
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -14,15 +14,15 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5
 
 Look for the following highlights in this release:
 
-* Enhancements that help close stored XSS, SQL injection, and cross-site request forgery (CSRF) vulnerabilities. See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5-and-2.1.14-security-update) for more information.
+*  Enhancements that help close stored XSS, SQL injection, and cross-site request forgery (CSRF) vulnerabilities. See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5-and-2.1.14-security-update) for more information.
 
-* Resolution of issues that customers were experiencing when upgrading to Magento 2.2.4 in deployments that span multiple websites. Magento multi-store installations were not using the store view-specific values from the store configuration settings if these settings differed from the global default configuration settings. Instead, Magento used the default configuration for all store views. See  [GitHub-15205](https://github.com/magento/magento2/issues/15205) and [GitHub-15245](https://github.com/magento/magento2/issues/15245) for more detailed discussions of the problems some customers encountered. *Fix submitted by Francesco Marangi in pull request 15929*.
+*  Resolution of issues that customers were experiencing when upgrading to Magento 2.2.4 in deployments that span multiple websites. Magento multi-store installations were not using the store view-specific values from the store configuration settings if these settings differed from the global default configuration settings. Instead, Magento used the default configuration for all store views. See  [GitHub-15205](https://github.com/magento/magento2/issues/15205) and [GitHub-15245](https://github.com/magento/magento2/issues/15245) for more detailed discussions of the problems some customers encountered. *Fix submitted by Francesco Marangi in pull request 15929*.
 
-* Substantial improvements to indexing performance.
+*  Substantial improvements to indexing performance.
 
-* Over 150 **community contributions**.
+*  Over 150 **community contributions**.
 
-* Improvements to our core bundled extensions.
+*  Improvements to our core bundled extensions.
 
 Looking for more information on these new features as well as many others? Check out [Magento 2.2.x Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Open Source User Guide](http://docs.magento.com/m2/ce/user_guide/getting-started.html).
 
@@ -30,33 +30,33 @@ Looking for more information on these new features as well as many others? Check
 
 This release includes significant performance improvements to the core Magento code:
 
-* <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->  Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
+*  <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->  Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
 
-* <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
+*  <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
 
-* <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
+*  <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
 
 ### Community contribution highlights
 
 Highlights of community contributions include  fixes that improve checkout flow and the sorting of simple products:
 
-* <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
+*  <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
-* <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+*  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
-* <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
-* <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
 ### Highlights (Magento Shipping)
 
 This release of Magento Shipping adds the following new capabilities:
 
-* With core returns, merchants can select carriers to use for returns and send a return label along with forward fulfillment.
+*  With core returns, merchants can select carriers to use for returns and send a return label along with forward fulfillment.
 
-* Batch processing increases automation and merchant efficiency by making it easier to process a large volume of shipments in batches.
+*  Batch processing increases automation and merchant efficiency by making it easier to process a large volume of shipments in batches.
 
-* Collection points provide the ability for customers to designate a drop point rather than residence for delivery by carrier.
+*  Collection points provide the ability for customers to designate a drop point rather than residence for delivery by carrier.
 
 This release of Magento Shipping also includes additional minor enhancements, such as pagination to improve the Admin experience and multiversion API.
 
@@ -190,7 +190,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 ### Swatches
 
 <!--- MAGETWO-86332  -->
-*   You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+*  You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### Testing
 
@@ -252,16 +252,16 @@ The Amazon Pay, Magento Shipping, and Vertex extensions have the following known
 
 ### Amazon Pay known issues
 
-* Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
+*  Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
 
 <!-- BUNDLE--1480  -->
-*   Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
+*  Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
 
 <!-- BUNDLE--15453  -->
-*   Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
+*  Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
 
 <!-- BUNDLE--1450  -->
-*   Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
+*  Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
 
 <!-- BUNDLE--1427  -->
 *  Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
@@ -297,7 +297,7 @@ The following Dotmailer behaviors have been observed when Magento Commerce for B
 ### Magento Shipping known issues
 
 <!-- BUNDLE--1448  -->
-*   A merchant can create multiple return shipments for an already shipped return.
+*  A merchant can create multiple return shipments for an already shipped return.
 
 ### Vertex known issues
 
@@ -311,13 +311,13 @@ The following Dotmailer behaviors have been observed when Magento Commerce for B
 *  Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
 
 <!-- BUNDLE--1399  -->
-*   The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
+*  The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
 
 <!-- BUNDLE--1405  -->
-*   The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
+*  The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
 
 <!-- BUNDLE--1410  -->
-*   When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
+*  When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
 
 <!-- BUNDLE--1457  -->
 *  Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.md
@@ -30,7 +30,7 @@ Looking for more information on these new features as well as many others? Check
 
 This release includes significant performance improvements to the core Magento code:
 
-*  <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->  Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
+*  <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
 
 *  <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -42,7 +42,7 @@ Highlights of community contributions include  fixes that improve checkout flow 
 
 *  <!--- MAGETWO-87115 -->Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
-*  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+*  <!--- MAGETWO-73479 -->Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
 *  <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -40,7 +40,7 @@ This release includes significant performance improvements to the core Magento c
 
 Highlights of community contributions include  fixes that improve checkout flow and the sorting of simple products:
 
-*  <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
+*  <!--- MAGETWO-87115 -->Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
 *  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -34,7 +34,7 @@ This release includes significant performance improvements to the core Magento c
 
 *  <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
 
-*  <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
+*  <!--- MAGETWO-88775 -->Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
 
 ### Community contribution highlights
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -46,7 +46,7 @@ Highlights of community contributions include  fixes that improve checkout flow 
 
 *  <!-- MAGETWO-86227 -->When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
-*  <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-73419 -->When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
 ### Highlights (Magento Shipping)
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -14,15 +14,15 @@ See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5
 
 Look for the following highlights in this release:
 
-* Enhancements that help close stored XSS, SQL injection, and cross-site request forgery (CSRF) vulnerabilities. See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5-and-2.1.14-security-update) for more information.
+*  Enhancements that help close stored XSS, SQL injection, and cross-site request forgery (CSRF) vulnerabilities. See [Magento Security Center](https://magento.com/security/patches/magento-2.2.5-and-2.1.14-security-update) for more information.
 
-* Resolution of issues that customers were experiencing when upgrading to Magento 2.2.4 in deployments that span multiple websites. Magento multi-store installations were not using the store view-specific values from the store configuration settings if these settings differed from the global default configuration settings. Instead, Magento used the default configuration for all store views. See  [GitHub-15205](https://github.com/magento/magento2/issues/15205) and [GitHub-15245](https://github.com/magento/magento2/issues/15245) for more detailed discussions of the problems some customers encountered. *Fix submitted by Francesco Marangi in pull request 15929*.
+*  Resolution of issues that customers were experiencing when upgrading to Magento 2.2.4 in deployments that span multiple websites. Magento multi-store installations were not using the store view-specific values from the store configuration settings if these settings differed from the global default configuration settings. Instead, Magento used the default configuration for all store views. See  [GitHub-15205](https://github.com/magento/magento2/issues/15205) and [GitHub-15245](https://github.com/magento/magento2/issues/15245) for more detailed discussions of the problems some customers encountered. *Fix submitted by Francesco Marangi in pull request 15929*.
 
-* Substantial improvements to indexing performance.
+*  Substantial improvements to indexing performance.
 
-* Over 150 **community contributions**.
+*  Over 150 **community contributions**.
 
-* Improvements to our core bundled extensions.
+*  Improvements to our core bundled extensions.
 
 Looking for more information on these new features as well as many others? Check out [Magento 2.2.x Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Commerce User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html).
 
@@ -30,23 +30,23 @@ Looking for more information on these new features as well as many others? Check
 
 This release includes significant performance improvements to the core Magento code:
 
-* <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->  Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
+*  <!--- MAGETWO-80789  MAGETWO-88808  MAGETWO-89545 -->  Merchants can now  run the catalog search full text indexer and category product indexer in parallel mode by store view, which can significantly decrease  `indexer:reindex` execution time when running Magento with multiple store views and shared catalogs.
 
-* <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
+*  <!--- MAGETWO-74154 --> Refactoring of the catalog full text indexer has improved indexing performance up to 15% for very large profiles (600,000 products) and product catalogs with many configurable options (5,000 configurable products and 500 options).
 
-* <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
+*  <!--- MAGETWO-88775 -->  Improving the behavior of swatch product attributes has improved search result page performance up to 31% for catalogs with many configurable product options (for example, 5,000 configurable products and 500 options).
 
 ### Community contribution highlights
 
 Highlights of community contributions include  fixes that improve checkout flow and the sorting of simple products:
 
-* <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
+*  <!--- MAGETWO-87115 --> Customers can now create an account from the Order Confirmation page. Previously, a customer could not populate the required fields to create an account from this page, and Magento displayed an error.
 
-* <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
+*  <!--- MAGETWO-73479 --> Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
-* <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
-* <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
 ### Highlights (Magento Shipping)
 
@@ -203,7 +203,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 ### Swatches
 
 <!--- MAGETWO-86332  -->
-*   You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
+*  You can now use JavaScript mixins to extend swatch functionality in all supported browsers. *Fix submitted by Renon Stewart in pull request 12929*. [GitHub-10559](https://github.com/magento/magento2/issues/10559)
 
 ### Testing
 
@@ -270,16 +270,16 @@ The Amazon Pay. dotmailer, Magento Shipping, and Vertex extensions have the foll
 
 ### Amazon Pay known issues
 
-* Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
+*  Clicking **Save Config** on the Payment Methods page while configuring your Amazon Pay settings can result in a JavaScript error. **Workaround**: Refresh the page.
 
 <!-- BUNDLE--1480  -->
-*   Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
+*  Magento throws the following exception during checkout if you disable Amazon Pay when installing Magento using the web wizard:  `Exception #0 (UnexpectedValueException): Payment model name is not provided in config!`.  Note that this error occurs only if one or two of the three Amazon modules shipped with Magento are disabled. If all three Amazon modules are disabled, this problem does not occur. [GitHub-16167](https://github.com/magento/magento2/issues/16167) <!--- BUNDLE-1480 -->
 
 <!-- BUNDLE--15453  -->
-*   Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
+*  Magento displays the Amazon Pay option during checkout with multiple addresses even though multi shipping is not supported with Amazon Pay.
 
 <!-- BUNDLE--1450  -->
-*   Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
+*  Magento does not display the Amazon Pay button during checkout when the customer selects Klarna or PayPal as a payment method for an order containing a virtual product.
 
 <!-- BUNDLE--1427  -->
 *  Magento does not display the Amazon Pay button on the Checkout page if an order contains a virtual product.
@@ -315,7 +315,7 @@ The following Dotmailer behaviors have been observed when Magento Commerce for B
 ### Magento Shipping known issues
 
 <!-- BUNDLE--1448  -->
-*   A merchant can create multiple return shipments for an already shipped return.
+*  A merchant can create multiple return shipments for an already shipped return.
 
 ### Vertex known issues
 
@@ -329,13 +329,13 @@ The following Dotmailer behaviors have been observed when Magento Commerce for B
 *  Magento displays an inaccurate Vertex API Status message when  the **Vertex Address Validation API Url** and **Vertex Validation Function** fields contain invalid values.
 
 <!-- BUNDLE--1399  -->
-*   The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
+*  The Transaction Details reports and Transaction Summary reports have slight irregularities.  Magento does not include product price and taxes in the Transaction Details Report "Gross Amount" and "Tax Amount" columns, and does not include product price in the Transaction Summary Report.
 
 <!-- BUNDLE--1405  -->
-*   The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
+*  The **Vertex invoice has been sent** message appears momentarily on the Review and Payments page, but not as expected on the Success page.
 
 <!-- BUNDLE--1410  -->
-*   When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
+*  When a customer places an order, Magento calculates the amount of tax and sends a Vertex invoice even when the Company Information tab is missing  the company street, company city, and company postal code.
 
 <!-- BUNDLE--1457  -->
 *  Magento does not display the Vertex invoice has been sent message as expected when the payment method is Authorize.net and  the order status is Suspect Fraud.

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.md
@@ -44,7 +44,7 @@ Highlights of community contributions include  fixes that improve checkout flow 
 
 *  <!--- MAGETWO-73479 -->Magento now correctly applies coupon codes that exclude bundle products. Previously, Magento applied these coupons but did not exclude bundle products as expected.
 
-*  <!-- MAGETWO-86227 --> When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
+*  <!-- MAGETWO-86227 -->When sorting simple products, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 
 *  <!-- MAGETWO-73419 --> When sorting simple products with a required custom option, which catalog promo price rule is applied for, these products are sorted by a regular price instead disregarding the applied promo price.
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.md
@@ -1029,7 +1029,7 @@ Our community contributors have made many helpful, minor corrections to spelling
 *  The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
 <!-- ENGCOM-1767  -->
-*   `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
+*  `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
 
 <!-- ENGCOM-1762  -->
 *  Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.6EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.6EE.md
@@ -1066,7 +1066,7 @@ Our community contributors have made many helpful, minor corrections to spelling
 *  The timestamp field now includes indexes, which reduces the chances of deadlocks that can occur while  erasing old records.  *Fix submitted by Carlos Lizaga in pull request [13328](https://github.com/magento/magento2/pull/13328)*. [GitHub-10346](https://github.com/magento/magento2/issues/10346)
 
 <!-- ENGCOM-1767  -->
-*   `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
+*  `setCateroryIds([])` has been corrected to `setCategoryIds([])` throughout the test suites. *Fix submitted by Neeta Kangiya in pull request [15621](https://github.com/magento/magento2/pull/15621)*. [GitHub-15590](https://github.com/magento/magento2/issues/15590)
 
 <!-- ENGCOM-1762  -->
 *  Menus with nested elements now align correctly. *Fix submitted by hitesh-wagento in pull request [15645](https://github.com/magento/magento2/pull/15645)*. [GitHub-7897](https://github.com/magento/magento2/issues/7897)

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.md
@@ -70,7 +70,7 @@ This release includes improvements to general usability of the core code plus en
 
 ### Magento Functional Test Framework (MFTF)
 
-* MTFT version 2.3.8 is now packaged with Magento 2.2.7.
+*  MTFT version 2.3.8 is now packaged with Magento 2.2.7.
 
 ### Community contribution highlights
 
@@ -199,7 +199,7 @@ In addition to security enhancements, this release contains the following functi
 *  You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
 
 <!-- ENGCOM-2758  -->
-*   You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
+*  You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
 
 <!-- MAGETWO-94080  -->
 *  The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
@@ -214,7 +214,7 @@ In addition to security enhancements, this release contains the following functi
 *  Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
 
 <!-- MAGETWO-73443  -->
-*   Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
+*  Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
 product, and hung indefinitely while trying to add the product.
 
 <!-- MAGETWO-73245  -->
@@ -310,7 +310,7 @@ product, and hung indefinitely while trying to add the product.
 ### EAV
 
 <!-- ENGCOM-2642  -->
-*   The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
+*  The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
 
 ### Email
 
@@ -372,7 +372,7 @@ product, and hung indefinitely while trying to add the product.
 *  The WYSIWYG editor now displays the backgrounds of .png thumbnail images as expected. Previously, transparent backgrounds were displayed as black.  *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
 
 <!-- ENGCOM-2860  -->
-*   Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
+*  Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
 
 <!-- ENGCOM-2322  -->
 *  Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
@@ -600,7 +600,7 @@ product, and hung indefinitely while trying to add the product.
 ### Wishlist
 
 <!-- MAGETWO-86609  -->
-*   Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
 <!-- MAGETWO-74289  -->
 *  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
@@ -617,7 +617,7 @@ product, and hung indefinitely while trying to add the product.
 *  The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
 
 <!-- BUNDLE-1835  -->
-*   Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
+*  Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
 
 <!-- not needed --  MAGETWO-93800 MAGETWO-94468 MAGETWO-94236 MAGETWO-94213 MAGETWO-94174 MAGETWO-94098 MAGETWO-93725 MAGETWO-93105 MAGETWO-92654 MAGETWO-92187 MAGETWO-92169 MAGETWO-91477 MAGETWO-91358 MAGETWO-91288 MAGETWO-89892 MAGETWO-89309 MAGETWO-88233 MAGETWO-86482 MAGETWO-85420 MAGETWO-82084 MAGETWO-73357 MAGETWO-72067 MAGETWO-71157 MAGETWO-95529 MAGETWO-95424 MAGETWO-94762 MAGETWO-94409 MAGETWO-94331 MAGETWO-94300 MAGETWO-94475 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.md
@@ -90,13 +90,13 @@ This release includes improvements to general usability of the core code plus en
 
 ### Magento Functional Test Framework (MFTF)
 
-* MTFT version 2.3.8 is now packaged with Magento 2.2.7.
+*  MTFT version 2.3.8 is now packaged with Magento 2.2.7.
 
 ### Community contribution highlights
 
 Highlights of community contributions include these fixes:
 
-* **Bulk Web APIs**  allow all existing REST APIs to accept payloads with multiple entities. These community-contributed bulk APIs support more efficient and scalable implementations that eliminate round-trip network overhead. Like asynchronous APIs, bulk web APIs can be used in conjunction with queues that have also been migrated to {{site.data.var.ce}}. [See Bulk endpoints]({{ page.baseurl }}/rest/bulk-endpoints.html) for more information.
+*  **Bulk Web APIs**  allow all existing REST APIs to accept payloads with multiple entities. These community-contributed bulk APIs support more efficient and scalable implementations that eliminate round-trip network overhead. Like asynchronous APIs, bulk web APIs can be used in conjunction with queues that have also been migrated to {{site.data.var.ce}}. [See Bulk endpoints]({{ page.baseurl }}/rest/bulk-endpoints.html) for more information.
 
 <!-- MAGETWO-86712  -->
 *  The email server no longer throws an exception when a customer places an order using a PayPal payment method. Previously, when a customer checked out using PayPal, Magento placed the order, but the email server threw an exception. Thanks to community member [Jason Woods](https://github.com/driskell)!
@@ -171,7 +171,7 @@ In addition to security enhancements, this release contains the following functi
 *  Administrators with appropriate permissions can now change the status of a company  to **Rejected**. Previously, Magento did not save the change in status, and threw an error.
 
 <!-- MAGETWO-93050  -->
-*   Magento now opens a new window for edit purposes when a merchant selects **Edit User in New Tab** from the company Users page. Previously, when a merchant tried to edit company users from the storefront by selecting  **Edit User in New Tab**, Magento threw a JSON error.
+*  Magento now opens a new window for edit purposes when a merchant selects **Edit User in New Tab** from the company Users page. Previously, when a merchant tried to edit company users from the storefront by selecting  **Edit User in New Tab**, Magento threw a JSON error.
 
 ### Bundle products
 
@@ -216,7 +216,7 @@ In addition to security enhancements, this release contains the following functi
 *  You can now save a title for a product from the **Product** > **Customizable Options** page. *Fix submitted by [Madhumala Krishnan](https://github.com/Madhumalak) in pull request [15357](https://github.com/magento/magento2/pull/15357)*. [GitHub-6305](https://github.com/magento/magento2/issues/6305)
 
 <!-- ENGCOM-2758  -->
-*   You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
+*  You can now add a custom fieldset  to the Admin category editor without changing the position of  the General section (that is, the section that contains the **Enable category**, **Include in Menu**, and **Category Name** fields). Previously, Magento moved the General section to the last position of the form. *Fix submitted by [Burlacu Vasilii](https://github.com/vasilii-b) in pull request [17540](https://github.com/magento/magento2/pull/17540)*. [GitHub-15041](https://github.com/magento/magento2/issues/15041)
 
 <!-- MAGETWO-94080  -->
 *  The Catalog Products List widget can now display products on the storefront that have specific attributes applied to the default Global scope.
@@ -234,7 +234,7 @@ In addition to security enhancements, this release contains the following functi
 *  Magento no longer switches from table to list view on the product page when you add a product from the wishlist to the shopping cart.
 
 <!-- MAGETWO-73443  -->
-*   Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
+*  Customers can now add a product to their shopping cart when their session has expired. Previously, Magento did not add the
 product, and hung indefinitely while trying to add the product.
 
 <!-- MAGETWO-73245  -->
@@ -373,7 +373,7 @@ product, and hung indefinitely while trying to add the product.
 ### EAV
 
 <!-- ENGCOM-2642  -->
-*   The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
+*  The Product Attribute Repository's incorrect return values have been replaced with values that now adhere to `Magento\Catalog\Api\ProductAttributeRepositoryInterface (extends Magento\Framework\Api\MetadataServiceInterface)` as expected. *Fix submitted by [julianvdrielen](https://github.com/julianvdrielen) in pull request [15691](https://github.com/magento/magento2/pull/15691)*. [GitHub-4803](https://github.com/magento/magento2/issues/4803)
 
 ### Email
 
@@ -435,7 +435,7 @@ product, and hung indefinitely while trying to add the product.
 *  `.png` images from the GD2 image library that have transparent backgrounds now retain their  transparent backgrounds after upload. Previously, these transparent backgrounds were rendered black when you displayed these images after upload. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [16733](https://github.com/magento/magento2/pull/16733)*. [GitHub-14248](https://github.com/magento/magento2/issues/14248)
 
 <!-- ENGCOM-2860  -->
-*   Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
+*  Magento no longer duplicates events during delete operations. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [17718](https://github.com/magento/magento2/pull/17718)*. [GitHub-17715](https://github.com/magento/magento2/issues/17715)
 
 <!-- ENGCOM-2322  -->
 *  Magento now correctly displays the Datepicker widget when a user scrolls a  page containing it. *Fix submitted by [Hitesh](https://github.com/hitesh-wagento) in pull request [16775](https://github.com/magento/magento2/pull/16775)*. [GitHub-7903](https://github.com/magento/magento2/issues/7903)
@@ -687,7 +687,7 @@ product, and hung indefinitely while trying to add the product.
 ### Wishlist
 
 <!-- MAGETWO-86609  -->
-*   Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
+*  Products disabled in the Admin  no longer appear in storefront wishlists. Previously, disabled products still appeared in the storefront wishlist, although when a customer clicked on a disabled product, Magento correctly returned “page not found”.
 
 <!-- MAGETWO-74289  -->
 *  Customers can now choose which wishlist to add a product to when adding products to the wishlist from the shopping cart.
@@ -704,7 +704,7 @@ product, and hung indefinitely while trying to add the product.
 *  The Vertex customer tax code that is defined on Vertex Cloud and specified in the **Customer Code** field ignores a new customer tax class if both are specified on the customer detail page in the Magento Admin.
 
 <!-- BUNDLE-1835  -->
-*   Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
+*  Customers will not be able to complete purchases  if  merchants configure Klarna payments to work in a different region than the store has been configured for.
 
 <!-- not needed --  MAGETWO-93800 MAGETWO-94468 MAGETWO-94236 MAGETWO-94213 MAGETWO-94174 MAGETWO-94098 MAGETWO-93725 MAGETWO-93105 MAGETWO-92654 MAGETWO-92187 MAGETWO-92169 MAGETWO-91477 MAGETWO-91358 MAGETWO-91288 MAGETWO-89892 MAGETWO-89309 MAGETWO-88233 MAGETWO-86482 MAGETWO-85420 MAGETWO-82084 MAGETWO-73357 MAGETWO-72067 MAGETWO-71157 MAGETWO-95529 MAGETWO-95424 MAGETWO-94762 MAGETWO-94409 MAGETWO-94331 MAGETWO-94300 MAGETWO-94475 -->
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.md
@@ -50,9 +50,9 @@ Look for the following highlights in this release:
 
 ### Merchant tool enhancements
 
-* **Improved order creation workflow in the Admin**. The Admin order creation workflow has been refactored to eliminate delays when editing billing and shipping addresses. Processing of these fields now happens only after they are populated. 96174
+*  **Improved order creation workflow in the Admin**. The Admin order creation workflow has been refactored to eliminate delays when editing billing and shipping addresses. Processing of these fields now happens only after they are populated. 96174
 
-* **Ability to upload PDP images without compression and downsizing**. Merchants can now upload PDP images larger than 1920 x 1200  without first compressing and downsizing the images. Previously, when a merchant uploaded a high quality product image (larger than 1920 x 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height. 95299
+*  **Ability to upload PDP images without compression and downsizing**. Merchants can now upload PDP images larger than 1920 x 1200  without first compressing and downsizing the images. Previously, when a merchant uploaded a high quality product image (larger than 1920 x 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height. 95299
 
 ### Substantial security enhancements
 
@@ -60,9 +60,9 @@ These releases include security enhancements that help close cross-site scriptin
 
 ### Infrastructure improvements
 
-* **Magento now supports Elasticsearch 6.x**. (Elasticsearch 5.x  reached end-of-life on March 11, 2019. For more information, see [Elastic Product End of Life Dates](https://www.elastic.co/support/eol). *Fix submitted by community member  [Romain Ruaud](https://github.com/romainruaud)*. Thank you, Romain!
+*  **Magento now supports Elasticsearch 6.x**. (Elasticsearch 5.x  reached end-of-life on March 11, 2019. For more information, see [Elastic Product End of Life Dates](https://www.elastic.co/support/eol). *Fix submitted by community member  [Romain Ruaud](https://github.com/romainruaud)*. Thank you, Romain!
 
-* Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5 based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5 based hash usage. See [Authorize.Net Direct Post](https://docs.magento.com/m2/2.2/ee/user_guide/payment/authorize-net-direct-post.html) for a discussion of this deprecation and the steps you need to take to add the new key you’ll need after deprecation.  <!-- MAGETWO-98129-->*
+*  Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5 based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5 based hash usage. See [Authorize.Net Direct Post](https://docs.magento.com/m2/2.2/ee/user_guide/payment/authorize-net-direct-post.html) for a discussion of this deprecation and the steps you need to take to add the new key you’ll need after deprecation.  <!-- MAGETWO-98129-->*
 
 ### Bundled extension enhancements
 
@@ -70,25 +70,25 @@ This release of Magento includes extensions developed by third-party vendors.
 
 #### dotdigital Engagement Cloud (formerly dotmailer)
 
-* dotmailer has been rebranded as dotdigital Engagement Cloud.
+*  dotmailer has been rebranded as dotdigital Engagement Cloud.
 
 #### Magento Shipping
 
-* Multiple improvements to the Shipment workflow user experience.
+*  Multiple improvements to the Shipment workflow user experience.
 
-* **Batch Processing**. Error messaging and field validation has been added to the batch processing workflow.
+*  **Batch Processing**. Error messaging and field validation has been added to the batch processing workflow.
 
-* **Carrier Specific Packaging**. Carrier-specific packaging has been added for FedEx. These packages will be available for selection during shipping if a FedEx carrier is configured.
+*  **Carrier Specific Packaging**. Carrier-specific packaging has been added for FedEx. These packages will be available for selection during shipping if a FedEx carrier is configured.
 
-* **Security**. We've closed scenarios that could allow for third-party code execution.
+*  **Security**. We've closed scenarios that could allow for third-party code execution.
 
-* **Magento Cart Price Rules**. Cart price rules can now be applied to Magento Shipping.
+*  **Magento Cart Price Rules**. Cart price rules can now be applied to Magento Shipping.
 
 #### Vertex
 
-* Added support for B2C VAT.
+*  Added support for B2C VAT.
 
-* Added support for configurable logging.
+*  Added support for configurable logging.
 
 ## Functional fixes
 
@@ -196,13 +196,13 @@ In addition to security enhancements, this release contains the following functi
 *  Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
 
 <!-- ENGCOM-4089  -->
-*   Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
 <!-- MAGETWO-73342  -->
 *  Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
 
 <!-- ENGCOM-2930  -->
-*   Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
 <!-- ENGCOM-2943  -->
 *  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
@@ -230,7 +230,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
 <!-- ENGCOM-3230  -->
-*   `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
 <!-- ENGCOM-3254  -->
 *  Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
@@ -245,10 +245,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
 <!-- MAGETWO-93673  -->
-*   You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
 <!-- MAGETWO-96258  -->
-*   **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
 <!-- MAGETWO-96374  -->
 *  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
@@ -269,13 +269,13 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
 
 <!-- ENGCOM-4004  -->
-*   The `bin/magento catalog:images:resize` command now processes all specified images.
+*  The `bin/magento catalog:images:resize` command now processes all specified images.
 
 <!-- ENGCOM-4003  -->
-*   The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
+*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
 
 <!-- ENGCOM-3859  -->
-*   `getProductUrl` no longer returns the wrong URL when the current category has no products.
+*  `getProductUrl` no longer returns the wrong URL when the current category has no products.
 
 <!-- ENGCOM-3978  -->
 *  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
@@ -318,7 +318,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
 <!-- MAGETWO-90056  -->
-*   Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
 <!-- MAGETWO-89397  -->
 *  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
@@ -336,7 +336,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
 <!-- MAGETWO-62841  -->
-*   Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
 <!-- MAGETWO-86477  -->
 *  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
@@ -366,7 +366,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
 <!-- MAGETWO-86120  -->
-*   You can now add gift wrapping to the shopping cart to an already added product without having to add to additional product.
+*  You can now add gift wrapping to the shopping cart to an already added product without having to add to additional product.
 
 ### Clean up and minor refactoring
 
@@ -389,10 +389,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
 <!-- ENGCOM-3853  -->
-*   Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+*  Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
 <!-- ENGCOM-3895  -->
-*   Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+*  Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
 <!-- ENGCOM-3970  -->
 *  The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
@@ -422,16 +422,16 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
 <!-- ENGCOM-4010  -->
-*   Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
 <!-- ENGCOM-4040  -->
-*   Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+*  Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
 <!-- ENGCOM-4058  -->
-*   Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
 <!-- ENGCOM-4090  -->
-*   Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
 <!-- ENGCOM-3935  -->
 *  Fixed checkbox alignment on the account information page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [19646](https://github.com/magento/magento2/pull/19646)*. [GitHub-19645](https://github.com/magento/magento2/issues/19645)
@@ -449,7 +449,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
 <!-- ENGCOM-4017  -->
-*   Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+*  Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
 ### Configurable products
 
@@ -485,7 +485,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
 <!-- MAGETWO-81818  -->
-*   Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
+*  Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
 
 <!-- ENGCOM-3052  -->
 *  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
@@ -509,7 +509,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
 <!-- MAGETWO-74169  -->
-*   Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
+*  Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
 
 ### Customer custom attributes
 
@@ -590,7 +590,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
 
 <!-- ENGCOM-3479  -->
-*   Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
 <!-- ENGCOM-3424  -->
 *  The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
@@ -730,7 +730,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
 
 <!-- ENGCOM-4075  -->
-*   The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+*  The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
 <!-- MAGETWO-74044  -->
 *  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
@@ -783,12 +783,12 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
 
 <!-- ENGCOM-3680  -->
-*   A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
 ### Offline shipping
 
 <!-- ENGCOM-3079  -->
-*   Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
 <!-- ENGCOM-3057  -->
 *  The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
@@ -805,10 +805,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
 
 <!-- ENGCOM-3997  -->
-*   Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+*  Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
 <!-- ENGCOM-3691  -->
-*   Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
 <!-- ENGCOM-3316  -->
 *  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
@@ -823,7 +823,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
 
 <!-- MAGETWO-94857  -->
-*   Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
+*  Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
 
 <!-- MAGETWO-95218  -->
 *  When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
@@ -891,7 +891,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 ### Sales
 
 <!-- ENGCOM-1429  -->
-*   The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+*  The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
 <!-- MAGETWO-93155  -->
 *  You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
@@ -921,7 +921,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
 <!-- MAGETWO-93393  -->
-*   Magento now uses  the correct table rate shipment when  a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
+*  Magento now uses  the correct table rate shipment when  a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
 
 <!-- MAGETWO-94458  -->
 *  You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
@@ -942,7 +942,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  You can now remove a custom price from a product during order creation from the Admin.
 
 <!-- ENGCOM-3998  -->
-*   The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+*  The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
 <!-- ENGCOM-3999  -->
 *  Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
@@ -1005,10 +1005,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
 
 <!-- ENGCOM-4042  -->
-*   Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
 <!-- ENGCOM-3008  -->
-*   Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+*  Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Store
 
@@ -1051,7 +1051,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
 
 <!-- ENGCOM-3021  -->
-*   Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
 ### Theme
 
@@ -1082,7 +1082,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
 <!-- ENGCOM-4012  -->
-*   Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+*  Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
 <!-- ENGCOM-3308  -->
 *  Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
@@ -1094,7 +1094,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
 <!-- ENGCOM-3177  -->
-*   Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
 <!-- ENGCOM-3313  -->
 *  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
@@ -1139,7 +1139,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
 <!-- ENGCOM-3929  -->
-*   `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
 ### Widget
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.md
@@ -53,9 +53,9 @@ Look for the following highlights in this release:
 
 ### Merchant tool enhancements
 
-* **Improved order creation workflow in the Admin**. The Admin order creation workflow has been refactored to eliminate delays when editing billing and shipping addresses. Processing of these fields now happens only after they are populated. <!-- MAGETWO-96174 -->
+*  **Improved order creation workflow in the Admin**. The Admin order creation workflow has been refactored to eliminate delays when editing billing and shipping addresses. Processing of these fields now happens only after they are populated. <!-- MAGETWO-96174 -->
 
-* **Ability to upload PDP images without compression and downsizing**. Merchants can now upload PDP images larger than 1920 x 1200  without first compressing and downsizing the images. Previously, when a merchant uploaded a high quality product image (larger than 1920 x 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height. <!-- MAGETWO-95299 -->
+*  **Ability to upload PDP images without compression and downsizing**. Merchants can now upload PDP images larger than 1920 x 1200  without first compressing and downsizing the images. Previously, when a merchant uploaded a high quality product image (larger than 1920 x 1200), Magento resized and compressed the image. Merchants can now set requirements for resizing and compression as well as compression quality and target width and height. <!-- MAGETWO-95299 -->
 
 ### Substantial security enhancements
 
@@ -63,11 +63,11 @@ These releases include security enhancements that help close cross-site scriptin
 
 ### Infrastructure improvements
 
-* **Magento now supports Elasticsearch 6.x**. (Elasticsearch 5.x  reached end-of-life on March 11, 2019. For more information, see [Elastic Product End of Life Dates](https://www.elastic.co/support/eol). *Fix submitted by community member  [Romain Ruaud](https://github.com/romainruaud)*. Thank you, Romain!
+*  **Magento now supports Elasticsearch 6.x**. (Elasticsearch 5.x  reached end-of-life on March 11, 2019. For more information, see [Elastic Product End of Life Dates](https://www.elastic.co/support/eol). *Fix submitted by community member  [Romain Ruaud](https://github.com/romainruaud)*. Thank you, Romain!
 
-* Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5 based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5 based hash usage. See [Authorize.Net Direct Post](https://docs.magento.com/m2/2.2/ee/user_guide/payment/authorize-net-direct-post.html) for a discussion of this deprecation and the steps you need to take to add the new key you’ll need after deprecation.  <!-- MAGETWO-98129-->*
+*  Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5 based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5 based hash usage. See [Authorize.Net Direct Post](https://docs.magento.com/m2/2.2/ee/user_guide/payment/authorize-net-direct-post.html) for a discussion of this deprecation and the steps you need to take to add the new key you’ll need after deprecation.  <!-- MAGETWO-98129-->*
 
-* The shipping and billing data that a user enters during checkout now persists if the user interrupts checkout to continue shopping. Previously, checkout data was deleted after a cart update. <!-- MAGETWO-95067 -->
+*  The shipping and billing data that a user enters during checkout now persists if the user interrupts checkout to continue shopping. Previously, checkout data was deleted after a cart update. <!-- MAGETWO-95067 -->
 
 ### Bundled extension enhancements
 
@@ -75,25 +75,25 @@ This release of Magento includes extensions developed by third-party vendors.
 
 #### dotdigital Engagement Cloud (formerly dotmailer)
 
-* dotmailer has been rebranded as dotdigital Engagement Cloud.
+*  dotmailer has been rebranded as dotdigital Engagement Cloud.
 
 #### Magento Shipping
 
-* Multiple improvements to the Shipment workflow user experience.
+*  Multiple improvements to the Shipment workflow user experience.
 
-* **Batch Processing**. Error messaging and field validation has been added to the batch processing workflow.
+*  **Batch Processing**. Error messaging and field validation has been added to the batch processing workflow.
 
-* **Carrier Specific Packaging**. Carrier-specific packaging has been added for FedEx. These packages will be available for selection during shipping if a FedEx carrier is configured.
+*  **Carrier Specific Packaging**. Carrier-specific packaging has been added for FedEx. These packages will be available for selection during shipping if a FedEx carrier is configured.
 
-* **Security**. We've closed scenarios that could allow for third-party code execution.
+*  **Security**. We've closed scenarios that could allow for third-party code execution.
 
-* **Magento Cart Price Rules**. Cart price rules can now be applied to Magento Shipping.
+*  **Magento Cart Price Rules**. Cart price rules can now be applied to Magento Shipping.
 
 #### Vertex
 
-* Added support for B2C VAT.
+*  Added support for B2C VAT.
 
-* Added support for configurable logging.
+*  Added support for configurable logging.
 
 ## Functional fixes
 
@@ -145,7 +145,7 @@ In addition to security enhancements, this release contains the following functi
 ### B2B
 
 <!-- MAGETWO-96442  -->
-*   Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
+*  Merchants can now add a product to the default public catalog,  and the product can be accessed by the product URL on the storefront. Previously, Magento did not add the product to the shared catalog and instead displayed this error, `Requested categories don't exist`.
 
 <!-- MAGETWO-94884  -->
 *  Magento no longer displays a duplicate **Add product** button when you change currency from the Order currency dropdown while creating an order from the Admin.
@@ -223,13 +223,13 @@ In addition to security enhancements, this release contains the following functi
 *  Category pages now display products  when swatch images are missing. Previously, Magento did not display these products, and the console displayed this error message, `Error: [object Object]`.
 
 <!-- ENGCOM-4089  -->
-*   Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
+*  Removed unnecessary slash from `app/code/Magento/CatalogInventory/etc/di.xml`. This extraneous slash had previously resulted in `Magento\Catalog\Api\ProductRenderListInterface` returning products regardless of visibility. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [20886](https://github.com/magento/magento2/pull/20886)*. [GitHub-20409](https://github.com/magento/magento2/issues/20409)
 
 <!-- MAGETWO-73342  -->
 *  Customers can change product status by clicking on the toggle element or by clicking on label text, but not by clicking the area around a toggle element. Previously, if a customer  clicked on the area around a toggle element, Magento changed the state of the element. Unintended results could occur if a customer mistakenly clicked on the area around the element and didn't realize that the status had  changed.
 
 <!-- ENGCOM-2930  -->
-*   Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
+*  Updates to related products now appear as expected in both the storefront product page and the Admin product edit page. Previously, the storefront displayed product updates, but not all related product updates showed up in the Admin. *Fix submitted by [Pieter Hoste](https://github.com/hostep) in pull request [17885](https://github.com/magento/magento2/pull/17885)*. [GitHub-14050](https://github.com/magento/magento2/issues/14050)
 
 <!-- ENGCOM-2943  -->
 *  You can now save a product on deployments in single-store mode when the default website has been removed and a new website has been added. *Fix submitted by [Eduard Chitoraga](https://github.com/eduard13) in pull request [18001](https://github.com/magento/magento2/pull/18001)*. [GitHub-13405](https://github.com/magento/magento2/issues/13405)
@@ -257,7 +257,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When a new customer is created, Magento sets a value of zero for any custom attribute if no other value is explicitly provided. Previously, if no value was explicitly assigned, Magento did not save the custom attribute with any value. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [16915](https://github.com/magento/magento2/pull/16915)*. [GitHub-14510](https://github.com/magento/magento2/issues/14510)
 
 <!-- ENGCOM-3230  -->
-*   `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
+*  `\Magento\Catalog\Model\Product::getQty()` now consistently returns float/double. *Fix submitted by [Mr. Lewis](https://github.com/lewisvoncken) in pull request [18424](https://github.com/magento/magento2/pull/18424)*. [GitHub-18094](https://github.com/magento/magento2/issues/18094)
 
 <!-- ENGCOM-3254  -->
 *  Magento no longer resets data entered from one WYSIWYG editor when you switch to a second editor when editing catalog categories. *Fix submitted by [m.matrafailo](https://github.com/k1las) in pull request [18535](https://github.com/magento/magento2/pull/18535)*. [GitHub-18534](https://github.com/magento/magento2/issues/18534)
@@ -272,10 +272,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now provides a white-space trimming function for SKUs on the Admin. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18862](https://github.com/magento/magento2/pull/18862)*. [GitHub-16572](https://github.com/magento/magento2/issues/16572), [GitHub-12300](https://github.com/magento/magento2/issues/12300)
 
 <!-- MAGETWO-93673  -->
-*   You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
+*  You can now use an attribute set on the product create page after moving the attributes from one attribute group to another.
 
 <!-- MAGETWO-96258  -->
-*   **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
+*  **Sorting by a price** for configurable products on category pages now works correctly when the **Display Out of Stock Products** setting is enabled.
 
 <!-- MAGETWO-96374  -->
 *  In a multi-website instance, with a category that contains products belonging to different websites, when the product sort order in a category is changed at the store-view level, the products that belong to a different website gets unassigned from the category.
@@ -296,13 +296,13 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento no longer throws an exception when a customer tries to place an order whose components will be shipped to different addresses.
 
 <!-- ENGCOM-4004  -->
-*   The `bin/magento catalog:images:resize` command now processes all specified images.
+*  The `bin/magento catalog:images:resize` command now processes all specified images.
 
 <!-- ENGCOM-4003  -->
-*   The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
+*  The message that Magento displays when you successfully add a product to your cart or shopping list is now available in the i18n translation file.
 
 <!-- ENGCOM-3859  -->
-*   `getProductUrl` no longer returns the wrong URL when the current category has no products.
+*  `getProductUrl` no longer returns the wrong URL when the current category has no products.
 
 <!-- ENGCOM-3978  -->
 *  Magento now correctly applies the **Set Items' Status to be In Stock When Order is Cancelled** attribute setting. Previously, after an order was canceled, Magento increased product stock even when **Set Items' Status to be In Stock When Order is Cancelled** is set to **no**.
@@ -345,7 +345,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  You can now update the quantity of grouped product  if the quantity field was left empty when initially added to an Admin order by SKU. Previously, under these circumstances, you could not update the quantity.
 
 <!-- MAGETWO-90056  -->
-*   Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
+*  Tooltips that are available from the checkout page on mobile devices are now displayed properly. Previously, customers had to scroll to access the tooltip.
 
 <!-- MAGETWO-89397  -->
 *  Magento now uses the configured default sort order  during checkout to calculate totals. Previously, Magento ignored the configured order and used **Sub Total** > **Shipping** > **Discount** > **Tax** > **Grand Total** to calculate order totals.
@@ -363,7 +363,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays the correct status for orders with zero subtotals. Previously, new order status appeared as pending when it was processing.
 
 <!-- MAGETWO-62841  -->
-*   Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
+*  Magento no longer permits you to use the up and down arrow keys to enter negative numbers when entering a credit card number on the payment information page during checkout.
 
 <!-- MAGETWO-86477  -->
 *  Magento now displays informative error messages when an order paid for with Authorize.Net fails.
@@ -393,7 +393,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays a product's special price on the storefront, product listings, and product detail page as expected when the special price is 0.00. Previously, Magento displayed the regular price, but used the special price for sorting and quote calculations. *Fix submitted by [Mahesh Singh](https://github.com/maheshWebkul721) in pull request [18604](https://github.com/magento/magento2/pull/18604)*. [GitHub-18268](https://github.com/magento/magento2/issues/18268)
 
 <!-- MAGETWO-86120  -->
-*   You can now add gift wrapping to the shopping cart to an already  added product without having to add to additional product.
+*  You can now add gift wrapping to the shopping cart to an already  added product without having to add to additional product.
 
 ### Clean up and minor refactoring
 
@@ -419,10 +419,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Fixed misalignment of logo on Admin home page. *Fix submitted by [suryakant-krish](https://github.com/suryakant-krish) in pull request [20456](https://github.com/magento/magento2/pull/20456)*. [GitHub-19791](https://github.com/magento/magento2/issues/19791)
 
 <!-- ENGCOM-3853  -->
-*   Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
+*  Magento no longer displays a hamburger menu on a page where no menus are present. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20219](https://github.com/magento/magento2/pull/20219)*. [GitHub-20210](https://github.com/magento/magento2/issues/20210)
 
 <!-- ENGCOM-3895  -->
-*   Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
+*  Fixed display issue with the customer login page input field length in tablet view. *Fix submitted by [Nainesh Waghale](https://github.com/nainesh2jcommerce) in pull request [20369](https://github.com/magento/magento2/pull/20369)*. [GitHub-20172](https://github.com/magento/magento2/issues/20172)
 
 <!-- ENGCOM-3970  -->
 *  The email confirmation popup's  **Close** button no longer overlaps with page content. *Fix submitted by [Arvinda Kumar](https://github.com/cedarvinda) in pull request [19986](https://github.com/magento/magento2/pull/19986)*. [GitHub-19985](https://github.com/magento/magento2/issues/19985)
@@ -452,16 +452,16 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Corrected typo in `SalesRule/Model/ResourceModel/Coupon/Usage.php`. *Fix submitted by [Milind Singh](https://github.com/milindsingh) in pull request [19968](https://github.com/magento/magento2/pull/19968)*. [GitHub-19721](https://github.com/magento/magento2/issues/19721)
 
 <!-- ENGCOM-4010  -->
-*   Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
+*  Added a missing space between the title of the workflow step and the saved address on the first page of the checkout process. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20418](https://github.com/magento/magento2/pull/20418)*. [GitHub-20304](https://github.com/magento/magento2/issues/20304)
 
 <!-- ENGCOM-4040  -->
-*   Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
+*  Fixed misalignment of the title of the order page accessed when you check a recent order in the sidebar of listing pages or account pages. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20744](https://github.com/magento/magento2/pull/20744)*. [GitHub-20500](https://github.com/magento/magento2/issues/20500)
 
 <!-- ENGCOM-4058  -->
-*   Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
+*  Fixed misalignment of the **Edit** and **Remove** buttons on the gift option popup that Magento displays when a customer adds a product to the shopping cart. *Fix submitted by [Ajay Ajabale](https://github.com/ajay2jcommerce) in pull request [20784](https://github.com/magento/magento2/pull/20784)*. [GitHub-20604](https://github.com/magento/magento2/issues/20604)
 
 <!-- ENGCOM-4090  -->
-*   Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
+*  Fixed the alignment of the **Apply discount** button  on the checkout page. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20837](https://github.com/magento/magento2/pull/20837)*. [GitHub-20137](https://github.com/magento/magento2/issues/20137)
 
 <!-- ENGCOM-3882  -->
 *  Corrected alignment of the store switcher in Tab view. *Fix submitted by [Shikha Mishra](https://github.com/shikhamis11) in pull request [20325](https://github.com/magento/magento2/pull/20325)*. [GitHub-20158](https://github.com/magento/magento2/issues/20158)
@@ -473,7 +473,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Fixed alignment of the **Update Qty** button on the sales order invoice. *Fix submitted by [Kajal Solanki](https://github.com/speedy008) in pull request [19804](https://github.com/magento/magento2/pull/19804)*. [GitHub-19796](https://github.com/magento/magento2/issues/19796)
 
 <!-- ENGCOM-4017  -->
-*   Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
+*  Fixed alignment of the currency value rate field on credit memos created from the Admin. *Fix submitted by [Dipti](https://github.com/dipti2jcommerce) in pull request [20613](https://github.com/magento/magento2/pull/20613)*. [GitHub-20609](https://github.com/magento/magento2/issues/20609)
 
 ### Configurable products
 
@@ -509,7 +509,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When a customer uses a gift card to make a purchase, Magento now applies only the applicable amount to the invoice. Previously, the total amount of the gift card was applied to a customer's store credit for a partial invoice.
 
 <!-- MAGETWO-81818  -->
-*   Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
+*  Magento now loads customer private data only once when system state changes. Previously, Directory Data and Cart were loaded twice after a user logged in to the system, which caused additional server load and traffic.
 
 <!-- ENGCOM-3052  -->
 *  Magento now maintains alphabetical order for customer groups when you filter customers by group in the Admin.  Previously, groups were sorted by ID. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18280](https://github.com/magento/magento2/pull/18280)*. [GitHub-18101](https://github.com/magento/magento2/issues/18101)
@@ -533,7 +533,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays the value of a custom customer address attribute  in the column for that attribute when you create a custom customer address attribute and set it to be displayed in the Columns list.  Previously, Magento added the customer code column to the Customer table, but left these columns blank.
 
 <!-- MAGETWO-74169  -->
-*   Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
+*  Magento displays no traces of the store credit functionality on the front end when you set **Store Credit Functionality** to **no** when installing Magento. [GitHub-5609](https://github.com/magento/magento2/issues/5609)
 
 ### Customer custom attributes
 
@@ -614,7 +614,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Interceptor class methods now support nullable return types. *Fix submitted by [Oleksandr Kravchuk](https://github.com/swnsma) in pull request [19398](https://github.com/magento/magento2/pull/19398)*. [GitHub-15505](https://github.com/magento/magento2/issues/15505)
 
 <!-- ENGCOM-3479  -->
-*   Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
+*  Magento can now read responses from third-party servers that use HTTP/2 if your server also uses HTTP/2. Previously, this inability to read requests from third-party servers that use HTTP/2 prevented access to Magento Marketplace. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [19239](https://github.com/magento/magento2/pull/19239)*. [GitHub-19127](https://github.com/magento/magento2/issues/19127)
 
 <!-- ENGCOM-3424  -->
 *  The node in `events.xml`  can now have child nodes. Previously, a cache flush triggered an exception. *Fix submitted by [Lisovyi Yevhenii](https://github.com/lisovyievhenii) in pull request [19145](https://github.com/magento/magento2/pull/19145)*. [GitHub-15931](https://github.com/magento/magento2/issues/15931)
@@ -759,7 +759,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Imported images that were removed through the Admin before import remain absent after import. Magento now displays an informative error message if images are not imported as expected.
 
 <!-- ENGCOM-4075  -->
-*   The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
+*  The `\Magento\ImportExport\Block\Adminhtml\Export\Filter::_getSelectHtmlWithValue()` method no longer overwrites `$value` arguments. Previously, Magento used the same name for different `$value` variables. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20863](https://github.com/magento/magento2/pull/20863)*. [GitHub-20624](https://github.com/magento/magento2/issues/20624)
 
 <!-- MAGETWO-74044  -->
 *  The import process now supports `add_update` along with the default behavior `append`.  [GitHub-6193](https://github.com/magento/magento2/issues/6193)
@@ -796,9 +796,9 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 
 ### Magento Shipping
 
-* Updating an order destination prior to creating a shipment  now results in the shipment being sent to the new destination.
+*  Updating an order destination prior to creating a shipment  now results in the shipment being sent to the new destination.
 
-* Shipments that contain the same item across multiple packages will now correctly update the shipped amount.
+*  Shipments that contain the same item across multiple packages will now correctly update the shipped amount.
 
 ### Newsletter
 
@@ -812,12 +812,12 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now displays an informative `You have unsubscribed` message when you click the unsubscribe link in the newsletter email.
 
 <!-- ENGCOM-3680  -->
-*   A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
+*  A logged-in user who already has an account can now use the footer to sign up for a newsletter subscription. Previously, this user received an error message, and Magento did not subscribed her to the newsletter. *Fix submitted by [Ravi chandra](https://github.com/ravi-chandra3197) in pull request [18912](https://github.com/magento/magento2/pull/18912)*. [GitHub-8952](https://github.com/magento/magento2/issues/8952)
 
 ### Offline shipping
 
 <!-- ENGCOM-3079  -->
-*   Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
+*  Magento now displays the appropriate error message when free shipping is not available for an order during check out. *Fix submitted by [vaibhavahalpara](https://github.com/vaibhavahalpara) in pull request [17982](https://github.com/magento/magento2/pull/17982)*. [GitHub-17977](https://github.com/magento/magento2/issues/17977)
 
 <!-- ENGCOM-3057  -->
 *  The table rate shipping method no longer fails to return a quote when a customer uses an American  post code in the form of *five-digit zip - four-digit* extension (for example, 44444-1234). *Fix submitted by [magently](https://github.com/magently) in pull request [18166](https://github.com/magento/magento2/pull/18166)*. [GitHub-17770](https://github.com/magento/magento2/issues/17770)
@@ -834,10 +834,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  When an order placed with PayPal fails during checkout, Magento no longer processes payment for the order. Previously, orders that failed during the checkout when being processed through PayPal were processed.
 
 <!-- ENGCOM-3997  -->
-*   Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
+*  Magento now identifies shipping method in the Shipping section of the order review page for orders that are paid with using PayPal Express. *Fix submitted by [Nirav Kadiya](https://github.com/ssp58bleuciel) in pull request [19655](https://github.com/magento/magento2/pull/19655)*. [GitHub-14712](https://github.com/magento/magento2/issues/14712)
 
 <!-- ENGCOM-3691  -->
-*   Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
+*  Magento now correctly handles attribute options that begin with zero. Previously, these attribute options  did not work if an option with the same number but lacking the zero already existed. *Fix submitted by [SikailoISM](https://github.com/SikailoISM) in pull request [19612](https://github.com/magento/magento2/pull/19612)*. [GitHub-19436](https://github.com/magento/magento2/issues/19436)
 
 <!-- ENGCOM-3316  -->
 *  Magento now populates the estimated billing address  field  on the checkout page with the default billing address as expected when the cart contains virtual products only. Previously, when a signed-in customer with different default shipping and billing addresses had a cart containing only virtual products, the cart estimation field was populated with the default shipping address information  instead of the default billing address information. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18863](https://github.com/magento/magento2/pull/18863)*. [GitHub-17744](https://github.com/magento/magento2/issues/17744)
@@ -852,7 +852,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Customers can now check out using PayPal when the **Request Billing Information** feature is not enabled. Previously, Magento threw this error when a customer tried to check out with Braintree through Paypal from the shopping cart,  `Undefined index: billingAddress in /app/aacdg4mgbgw24/vendor/magento/module-braintree/Model/PayPal/Helper/QuoteUpdater.php on line 138`.
 
 <!-- MAGETWO-94857  -->
-*   Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
+*  Magento now creates invoices as expected for orders created using Braintree PayPal. Previously, Magento threw an error when a merchant tried to create an invoice for an order from **Admin** > **Sales** > **Order**.
 
 <!-- MAGETWO-95218  -->
 *  When a customer selects PayPal as a payment method but then applies a gift card, Magento now reverts to zero subtotal checkout. Previously, the order failed at the review step if a gift card were applied.
@@ -920,7 +920,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 ### Sales
 
 <!-- ENGCOM-1429  -->
-*   The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
+*  The order status label on the  customer order status page  can now be translated. *Fix submitted by [Riccardo Tempesta](https://github.com/phoenix128) in pull request [14914](https://github.com/magento/magento2/pull/14914)*. [GitHub-14849](https://github.com/magento/magento2/issues/14849)
 
 <!-- MAGETWO-93155  -->
 *  You can now filter orders by customer email. Previously, Magento threw an error when you tried to filter orders by customer email from **Sales** > **Orders**.
@@ -950,7 +950,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Company logos are now displayed correctly in printed PDF versions of invoices and shipment statements.
 
 <!-- MAGETWO-93393  -->
-*   Magento now uses  the correct table rate shipment when a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
+*  Magento now uses  the correct table rate shipment when a merchant creates an order through the Admin. Previously, when a merchant  created an order through the Admin and selected the shipping method table rate, Magento took the shipping rate table from the wrong website ID.
 
 <!-- MAGETWO-94458  -->
 *  You can now create a credit memo for an order that contains taxes and discounts and is placed online.  Previously, when you tried to create this credit memo, Magento displayed an informative error.
@@ -971,7 +971,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  You can now remove a custom price from a product during order creation from the Admin.
 
 <!-- ENGCOM-3998  -->
-*   The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
+*  The order view invoice template is now displayed properly on the ipad. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20546](https://github.com/magento/magento2/pull/20546)*. [GitHub-20373](https://github.com/magento/magento2/issues/20373)
 
 <!-- ENGCOM-3999  -->
 *  Access restrictions on the order API are now enforced as expected. Previously, administrators with restricted privileges had complete access to orders. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20542](https://github.com/magento/magento2/pull/20542)*. [GitHub-20169](https://github.com/magento/magento2/issues/20169)
@@ -1034,10 +1034,10 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Magento now correctly handles U.K. shipping addresses in multisite deployments where the default store's  **Allowed Countries** setting is US only but the store from which the order is placed supports U. K. shipping. Previously, Magento did not complete the order set to ship to a U.K. address, and  displayed this error, `Please check the shipping address information. Invalid value of "GB" provided for the countryId field`.
 
 <!-- ENGCOM-4042  -->
-*   Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
+*  Fixed misalignment of elements on the shipping information page that Magento displays when you click **Check Out with Multiple Addresses** from the shopping cart. *Fix submitted by [Amol Chaudhari](https://github.com/amol2jcommerce) in pull request [20739](https://github.com/magento/magento2/pull/20739)*. [GitHub-20563](https://github.com/magento/magento2/issues/20563)
 
 <!-- ENGCOM-3008  -->
-*   Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
+*  Sitemaps now display correct base URLs for deployments with  multiple stores. *Fix submitted by [Toan Nguyen](https://github.com/nntoan) in pull request [18000](https://github.com/magento/magento2/pull/18000)*. [GitHub-17999](https://github.com/magento/magento2/issues/17999)
 
 ### Staging
 
@@ -1094,7 +1094,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  `magentoDataIsolation` has been replaced with `magentoDbIsolation` as needed in several integration tests. *Fix submitted by [p-bystritsky](https://github.com/p-bystritsky) in pull request [20298](https://github.com/magento/magento2/pull/20298)*. [GitHub-20296](https://github.com/magento/magento2/issues/20296)
 
 <!-- ENGCOM-3021  -->
-*   Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
+*  Integration tests now respect module status as defined in `config-global.php`.  This permits you to enable only the modules you typically keep enabled while still saving system resources. *Fix submitted by [Jisse Reitsma](https://github.com/jissereitsma) in pull request [16361](https://github.com/magento/magento2/pull/16361)*. [GitHub-15196](https://github.com/magento/magento2/issues/15196)
 
 ### Theme
 
@@ -1125,7 +1125,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Image files can no longer be uploaded to Admin category pages  by dragging when the upload field has been disabled. *Fix submitted by [Serhiy Zhovnir](https://github.com/serhiyzhovnir) in pull request [20636](https://github.com/magento/magento2/pull/20636)*. [GitHub-20376](https://github.com/magento/magento2/issues/20376)
 
 <!-- ENGCOM-4012  -->
-*   Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
+*  Store switcher now works correctly on mobile devices. *Fix submitted by [Rajneesh Gupta](https://github.com/irajneeshgupta) in pull request [20540](https://github.com/magento/magento2/pull/20540)*. [GitHub-20259](https://github.com/magento/magento2/issues/20259)
 
 <!-- ENGCOM-3308  -->
 *  Missing asterisks have been added where needed on the Admin. *Fix submitted by [Dmytro Cheshun](https://github.com/dmytro-ch) in pull request [18905](https://github.com/magento/magento2/pull/18905)*. [GitHub-18904](https://github.com/magento/magento2/issues/18904)
@@ -1137,7 +1137,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  Admin tables now work as expected when single store mode is set to **on**. Previously, column positioning in these tables was not preserved when the page was refreshed. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18561](https://github.com/magento/magento2/pull/18561)*. [GitHub-12070](https://github.com/magento/magento2/issues/12070)
 
 <!-- ENGCOM-3177  -->
-*   Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
+*  Magento now regenerates product URL rewrites as expected after an administrator changes a product URL key from the Admin and subsequently saves the product attribute URL path value. Previously, product URL rewrites could not be generated after this attribute value was changed. *Fix submitted by [Oleksii Lisovyi](https://github.com/oleksii-lisovyi) in pull request [18566](https://github.com/magento/magento2/pull/18566)*. [GitHub-5929](https://github.com/magento/magento2/issues/5929)
 
 <!-- ENGCOM-3313  -->
 *  You can now use the `OptionManagement.delete` method to programmatically delete a product attribute that converts to false. Previously, Magento threw an exception. *Fix submitted by [Vishal Gelani](https://github.com/gelanivishal) in pull request [18873](https://github.com/magento/magento2/pull/18873)*. [GitHub-13083](https://github.com/magento/magento2/issues/13083)
@@ -1182,7 +1182,7 @@ Previously, when you reopened these categories, no checkboxes were checked.  *Fi
 *  The response for `GET V1/orders/:orderId` now contains `bundle_option` and `product_option` information as expected.
 
 <!-- ENGCOM-3929  -->
-*   `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
+*  `Magento\Framework\Webapi\Rest\Response\Renderer` class's  `_formatValue` method has been refactored to handle ampersands correctly. Previously, an ampersand in any customer text field when using the WebApi doubled the encoding. [GitHub-18361](https://github.com/magento/magento2/issues/18361)
 
 ### Widget
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.md
@@ -212,7 +212,7 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- ENGCOM-4447 -->
 
-* The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by Lisovyi Yevhenii in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
+*  The  `product_types_base.xsd`, `product_options.xsd`, `import.xsd`, `export.xsd` files  now allow modules with names that contain  numbers. *Fix submitted by Lisovyi Yevhenii in pull request [21598](https://github.com/magento/magento2/pull/21598)*. [GitHub-14882](https://github.com/magento/magento2/issues/14882)
 
 <!-- ENGCOM-4182 -->
 
@@ -696,7 +696,7 @@ In addition to security enhancements, this release contains the following functi
 
 <!-- ENGCOM-4328 -->
 
-* Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by Amol Chaudhari in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
+*  Alt attribute text that describes  credit card type or stored payment methods during checkout has been added to support accessibility. *Fix submitted by Amol Chaudhari in pull request [21206](https://github.com/magento/magento2/pull/21206)*. [GitHub-21089](https://github.com/magento/magento2/issues/21089)
 
 <!-- MAGETWO-98111 -->
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.2/release-notes`