### PR TITLE
Refactored MD030 issues

### DIFF
--- a/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.md
@@ -12,17 +12,17 @@ We are pleased to present Magento Open Source 2.2.0 General Availability. This r
 
 Magento Open Source 2.2.0 includes a wealth of new, exciting features, and hundreds of enhancements and fixes. Look for the following highlights in this release:
 
-* **Bundled extensions**. This release of Magento includes the first third-party extension that we are bundling with Magento Commerce -- Magento Social. This extension establishes a connection between your store and your corporate Facebook account, and creates a page with products from your catalog. When shoppers click a product, they are redirected to the corresponding product page in your Magento store.
+*  **Bundled extensions**. This release of Magento includes the first third-party extension that we are bundling with Magento Commerce -- Magento Social. This extension establishes a connection between your store and your corporate Facebook account, and creates a page with products from your catalog. When shoppers click a product, they are redirected to the corresponding product page in your Magento store.
 
-* **Significant enhancements in platform security and developer experience**. Security improvements include the removal of unserialize calls and protection of this functionality to increase resilience against dangerous code execution attacks. We have also continued to review and improve our protection against Cross-Site Scripting (XSS) attacks.
+*  **Significant enhancements in platform security and developer experience**. Security improvements include the removal of unserialize calls and protection of this functionality to increase resilience against dangerous code execution attacks. We have also continued to review and improve our protection against Cross-Site Scripting (XSS) attacks.
 
-* **Upgraded technology stack.**  We've dropped support for PHP 5.6, and Varnish 3.  We now support PHP 7.1 Varnish 5, and MySQL 5.7. All third-party libraries have been upgraded to the latest stable version.
+*  **Upgraded technology stack.**  We've dropped support for PHP 5.6, and Varnish 3.  We now support PHP 7.1 Varnish 5, and MySQL 5.7. All third-party libraries have been upgraded to the latest stable version.
 
-* **Pipeline deployment**, a new deployment process, enables build and deployment stages to minimize production system downtime for site updates. Resource-intensive processes can run on the build server. Pipeline deployment supports easy management of configuration between environments, too. Read more about pipeline deployment [here]({{ page.baseurl }}/config-guide/deployment/pipeline/).
+*  **Pipeline deployment**, a new deployment process, enables build and deployment stages to minimize production system downtime for site updates. Resource-intensive processes can run on the build server. Pipeline deployment supports easy management of configuration between environments, too. Read more about pipeline deployment [here]({{ page.baseurl }}/config-guide/deployment/pipeline/).
 
-* **Performance gains from improvements in indexing, cart, and cache operations**. Customers can browse and shop on a storefront while indexers are running with no visible impact to their experience. Additionally, long-running indexers operate in batches to better manage memory and run times. Cart improvements enable a buyer to create a cart with more than 300 line items, and merchants can process a cart with at least 300 line items. Varnish cache configuration now includes saint and grace mode to ensure Varnish is always presenting a cached page to a shop’s customers.  Enhancements to cache invalidation logic and optimization of edge side include blocks for frequently changing data that significantly boost cache hit ratios.
+*  **Performance gains from improvements in indexing, cart, and cache operations**. Customers can browse and shop on a storefront while indexers are running with no visible impact to their experience. Additionally, long-running indexers operate in batches to better manage memory and run times. Cart improvements enable a buyer to create a cart with more than 300 line items, and merchants can process a cart with at least 300 line items. Varnish cache configuration now includes saint and grace mode to ensure Varnish is always presenting a cached page to a shop’s customers.  Enhancements to cache invalidation logic and optimization of edge side include blocks for frequently changing data that significantly boost cache hit ratios.
 
-* **Substantial contributions from our Community members**. Our Community Engineering Team has been working with skilled and enthusiastic community members, and together they've added hundreds of pull requests to the Magento code base. For more information about our Community Engineering Team. see [Magento Community Engineering](https://github.com/magento-engcom).
+*  **Substantial contributions from our Community members**. Our Community Engineering Team has been working with skilled and enthusiastic community members, and together they've added hundreds of pull requests to the Magento code base. For more information about our Community Engineering Team. see [Magento Community Engineering](https://github.com/magento-engcom).
 
 Looking for more information on these new features as well as many others? Check out  [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/).
 
@@ -40,9 +40,9 @@ Magento 2.2.0 GA includes the following known issues. Fixes for these issues are
 
 **Issue**:  This issue affects Magento installations that include multiple store views. If you delete a store view, any product grid filtered to that Store View does not load. If you've set your product filter to a store view you’ve deleted, when you open **Catalog > Products**, Magento displays the following behavior:
 
-* spinner widget spins indefinitely
+*  spinner widget spins indefinitely
 
-* error message: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem  persists, try again later.`
+*  error message: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem  persists, try again later.`
 
 **Issue**: Errors result when a deleted customer tries to log in or register for new account. When you delete a customer from the  Admin panel, a fatal error occurs if someone tries to log in or register using that deleted customer account.
 
@@ -69,7 +69,7 @@ This release contains hundreds of fixes and enhancements.
 *  We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
 
 <!---57343 -->
-*   You can now deploy build processes on a different staging machine than the one you're running your production environment on.
+*  You can now deploy build processes on a different staging machine than the one you're running your production environment on.
 
 <!---57943 -->
 *  Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
@@ -129,7 +129,7 @@ This release contains hundreds of fixes and enhancements.
 *  The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
 
 <!--- 56743  -->
-*   We've fixed issues with upgrading installations with split databases.
+*  We've fixed issues with upgrading installations with split databases.
 
 <!--- 57656  -->
 *  The import URL directive now contains base URL and locale placeholders instead of the real URL.
@@ -156,7 +156,7 @@ This release contains hundreds of fixes and enhancements.
 *  You can now use Component Manager to enable a previously disabled module. Previously, when you ran `bin/magento module:disable Magento_AnyModule`, then tried to re-enable  that module, Magento fails to enable it and any previously enabled cache types, and module installation fails. [GitHub-6078](https://github.com/magento/magento2/issues/6078)
 
 <!--- 58081 -->
-*   Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
+*  Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
 
 <!--- 58132 -->
 *  We’ve fixed problems with the uninstall process. Previously, when Magento tries to uninstall a module using composer, it simultaneously tried to update the `symfony/process` version. However,  because the `module:uninstall`  command uses   `symfony/process`, the command stopped running. [GitHub-5797](https://github.com/magento/magento2/issues/5797)
@@ -255,7 +255,7 @@ This release contains hundreds of fixes and enhancements.
 *  Magento now displays the correct error message when you enter an invalid discount code when making a payment. [GitHub-7230](https://github.com/magento/magento2/issues/7230)
 
 <!--- 56978 -->
-*   Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
+*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
 
 <!--- 47017 -->
 *  You can now directly add a configurable product to your shopping cart from category page. [GitHub-2574](https://github.com/magento/magento2/issues/2574), [GitHub-5850](https://github.com/magento/magento2/issues/5850), [GitHub-5882](https://github.com/magento/magento2/issues/5882), [GitHub-6572](https://github.com/magento/magento2/issues/6572), [GitHub-5558](https://github.com/magento/magento2/issues/5558), [GitHub-4184](https://github.com/magento/magento2/issues/4184)
@@ -278,7 +278,7 @@ This release contains hundreds of fixes and enhancements.
 ### Catalog
 
 <!--- 65324, 66829  -->
-*   Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
+*  Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
 
 <!--- 65251  -->
 *  The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
@@ -387,7 +387,7 @@ This release contains hundreds of fixes and enhancements.
 *  Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
 
 <!--- 65334 -->
-*   Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
+*  Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
 
 <!--- 69297 -->
 *  Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
@@ -405,25 +405,25 @@ This release contains hundreds of fixes and enhancements.
 *  The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
 
 <!--- 63601 -->
-*   The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
+*  The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
 
 <!--- 62426 -->
 *  Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
 
 <!--- 71445 -->
-*   Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
 <!--- 61826 -->
-*   Magento no longer throws an error when you try to save a product with imported custom options.
+*  Magento no longer throws an error when you try to save a product with imported custom options.
 
 <!--- 62468 -->
-*   Magento now displays the product price even when the product is out-of-stock.
+*  Magento now displays the product price even when the product is out-of-stock.
 
 <!--- 64710 -->
-*   `productWebsiteLink` no longer deletes a product’s custom origins.
+*  `productWebsiteLink` no longer deletes a product’s custom origins.
 
 <!--- 56943 -->
-*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
 <!--- 52577 -->
 *  Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
@@ -452,7 +452,7 @@ This release contains hundreds of fixes and enhancements.
 ### Configurable products
 
 <!---57055 -->
-*   You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
+*  You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
 
 <!---56998  -->
 *  Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
@@ -476,7 +476,7 @@ This release contains hundreds of fixes and enhancements.
 *  Query optimizations have improved the speed of configurable product price calculation.
 
 <!--- 65246  -->
-*   Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
+*  Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
 
 <!--- 56951 -->
 *  Magento now displays configurable products as expected after creation.
@@ -494,7 +494,7 @@ This release contains hundreds of fixes and enhancements.
 *  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
 <!---52717 -->
-*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
 <!---60483 -->
 *  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
@@ -530,7 +530,7 @@ This release contains hundreds of fixes and enhancements.
 *  Users no longer lose configurable product data when you change the interface locale to Chinese (China) or Arabic (Egypt).
 
 <!---59649 -->
-*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
 ### Email
 
@@ -605,7 +605,7 @@ This release contains hundreds of fixes and enhancements.
 #### JavaScript framework
 
 <!--- 71180  -->
-*   Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
+*  Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
 
 <!--- 58285  -->
 *  Magento now displays server-side Ajax error messages.
@@ -655,7 +655,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### General fixes
 
 <!--- 56892 -->
-*   You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
 <!--- 56126  -->
 *  You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
@@ -670,7 +670,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  We've removed the duplicated [PHP](https://glossary.magento.com/php) settings from the sample web server configuration files.
 
 <!---57187 -->
-*   When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
+*  When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
 
 <!---57351 -->
 *  We've removed the sample password from the Setup Wizard.
@@ -790,7 +790,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
 
 <!--- 59135 -->
-*   Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
+*  Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
 
 <!--- 63116 -->
 *  Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
@@ -827,7 +827,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### HTML
 
 <!--- 67487 -->
-*   The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
+*  The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
 
 ### Images
 
@@ -835,7 +835,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
 <!---56944 -->
-*   Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
 <!---58335, 42954 -->
 *  You can now preview uploaded images.
@@ -844,13 +844,13 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
 
 <!---55608 -->
-*   Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
+*  Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
 
 <!--- 55234 -->
 *  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
 <!--- 58031 -->
-*   Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
+*  Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
 
 #### Import/Export
 
@@ -879,7 +879,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
 
 <!--- 58316 -->
-*   Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
+*  Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
 
 <!--- 71013 -->
 *  The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
@@ -894,7 +894,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
 
 <!--- 65667 -->
-*   Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
+*  Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
 
 <!--- 67240 -->
 *  Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
@@ -1029,7 +1029,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
 
 <!---68795  -->
-*   Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
+*  Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
 
 <!--- 60587  -->
 *  We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
@@ -1053,7 +1053,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
 
 <!--- 60692 -->
-*   You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
+*  You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
 
 ### Payment methods
 
@@ -1084,7 +1084,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 <!--- 64413 -->
 *  The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
 
-* We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
+*  We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
 
 <!---56347  -->
 *  We’ve fixed an issue with the REST API that previously resulted in the PayPal gateway rejecting requests. [GitHub-10410](https://github.com/magento/magento2/issues/10410)
@@ -1132,7 +1132,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
 
 <!---59637 -->
-*   Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
 <!--- 56344 -->
@@ -1299,7 +1299,7 @@ This release includes substantial improvements to Magento caching, image process
 *  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
 
 <!---56936  -->
-*   The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
+*  The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
 
 <!---57001, 54460 -->
 *  A restricted user can now change storeview- or website- level attributes that are defined within his scope.
@@ -1316,13 +1316,13 @@ This release includes substantial improvements to Magento caching, image process
 ### Search
 
 <!---59088 -->
-*   Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
+*  Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
 
 <!---56356  -->
 *  Segmentation faults no longer occur when doing a `catalogsearch_fulltext` re-index, and indexing succeeds. Previously, in a large database (more than 70,000 products), the `catalogsearch_fulltext` (MySQL) re-index failed with a `Segmentation fault` message. [GitHub-7963](https://github.com/magento/magento2/issues/7963)
 
 <!---52905 -->
-*   Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
+*  Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
 
 <!---59477  -->
 *  Attribute weighting now works correctly for the MySQL adapter. [GitHub-9020](https://github.com/magento/magento2/issues/9020)
@@ -1456,10 +1456,10 @@ This release includes substantial improvements to Magento caching, image process
 *  Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
 
 <!---56922 -->
-*   Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
+*  Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
 
 <!---55055 -->
-*   Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
+*  Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
 
 ### Translation and locales
 
@@ -1503,7 +1503,7 @@ This release includes substantial improvements to Magento caching, image process
 <!--- 69372 -->
 *  Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member *Fix submitted by community member Bernhard in pull request 9711.*
 
-* Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
+*  Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
 
 <!--- 52923 -->
 *  Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
@@ -1553,9 +1553,9 @@ This release includes substantial improvements to Magento caching, image process
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of  top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of  top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### System requirements
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.md
@@ -12,25 +12,25 @@ We are pleased to present Magento Commerce 2.2.0 General Availability. This rele
 
 Magento Commerce 2.2.0 includes a wealth of new, exciting features, and hundreds of enhancements and fixes. Look for the following highlights in this release:
 
-* **B2B Commerce functionality** is designed to meet the needs of merchants whose primary customers are companies, rather than consumers. Companies can create and maintain their own accounts, each with teams of buyers with various roles and levels of permission. B2B Commerce functionality also includes a flexible API that integrates with a variety of ERP solutions from Magento partners. See [B2B Quick Start](http://docs.magento.com/m2/b2b/user_guide/quick-tour/b2b-quick-start.html) for an overview of the rich B2B feature set we're introducing in this release, and [Getting Started with Magento Commerce for B2B](http://docs.magento.com/m2/b2b/user_guide/getting-started.html) for a more complete exploration of these new features.
+*  **B2B Commerce functionality** is designed to meet the needs of merchants whose primary customers are companies, rather than consumers. Companies can create and maintain their own accounts, each with teams of buyers with various roles and levels of permission. B2B Commerce functionality also includes a flexible API that integrates with a variety of ERP solutions from Magento partners. See [B2B Quick Start](http://docs.magento.com/m2/b2b/user_guide/quick-tour/b2b-quick-start.html) for an overview of the rich B2B feature set we're introducing in this release, and [Getting Started with Magento Commerce for B2B](http://docs.magento.com/m2/b2b/user_guide/getting-started.html) for a more complete exploration of these new features.
 
-* **Magento Commerce Starter.** In addition to our Pro version, Magento Cloud (Commerce) now comes in a smaller, platform-as-a-service version — Magento Commerce Starter. This subscription plan differs from our Enterprise Cloud version in some key ways. For an overview of these versions, see [Welcome to Magento Commerce Cloud]({{ page.baseurl }}/cloud/bk-cloud.html).
+*  **Magento Commerce Starter.** In addition to our Pro version, Magento Cloud (Commerce) now comes in a smaller, platform-as-a-service version — Magento Commerce Starter. This subscription plan differs from our Enterprise Cloud version in some key ways. For an overview of these versions, see [Welcome to Magento Commerce Cloud]({{ page.baseurl }}/cloud/bk-cloud.html).
 
-* **Improvements to the Magento Commerce (Cloud) deployment process**. This release includes new build and deployment variables. Users of earlier versions of Magento Commerce (Cloud) will note that MCC has been replaced by ece-tools and ece-patches, which allows for patching your Magento Commerce (Cloud) without requiring a full installation of base code and the patch.
+*  **Improvements to the Magento Commerce (Cloud) deployment process**. This release includes new build and deployment variables. Users of earlier versions of Magento Commerce (Cloud) will note that MCC has been replaced by ece-tools and ece-patches, which allows for patching your Magento Commerce (Cloud) without requiring a full installation of base code and the patch.
 
-* **Bundled extensions**. This release of Magento includes the first third-party extension that we are bundling with Magento Commerce -- Magento Social. This extension establishes a connection between your store and your corporate Facebook account, and creates a page with products from your catalog. When shoppers click a product, they are redirected to the corresponding product page in your Magento store.
+*  **Bundled extensions**. This release of Magento includes the first third-party extension that we are bundling with Magento Commerce -- Magento Social. This extension establishes a connection between your store and your corporate Facebook account, and creates a page with products from your catalog. When shoppers click a product, they are redirected to the corresponding product page in your Magento store.
 
-* **Integrated Signifyd fraud protection**. You can learn more about this fraud protection service, which can help merchants eliminate liability for any losses or fees from fraudulent orders, in [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html).
+*  **Integrated Signifyd fraud protection**. You can learn more about this fraud protection service, which can help merchants eliminate liability for any losses or fees from fraudulent orders, in [Signifyd fraud protection]({{ site.baseurl }}/guides/v2.2/payments-integrations/signifyd/signifyd.html).
 
-* **Significant enhancements in platform security and developer experience**. Security improvements include the removal of unserialize calls and protection of this functionality to increase resilience against dangerous code execution attacks. We have also continued to review and improve our protection against Cross-Site Scripting (XSS) attacks.
+*  **Significant enhancements in platform security and developer experience**. Security improvements include the removal of unserialize calls and protection of this functionality to increase resilience against dangerous code execution attacks. We have also continued to review and improve our protection against Cross-Site Scripting (XSS) attacks.
 
-* **Upgraded technology stack.**  We've dropped support for PHP 5.6, Varnish 3, and Solr.  We now support PHP 7.1 and Varnish 5, along with Redis 3.2 and MySQL 5.7. All third-party libraries have been upgraded to the latest stable version. Note: Although we’ve dropped support for Solr with this release, Solr code will remain in the Magento code base until a later release.
+*  **Upgraded technology stack.**  We've dropped support for PHP 5.6, Varnish 3, and Solr.  We now support PHP 7.1 and Varnish 5, along with Redis 3.2 and MySQL 5.7. All third-party libraries have been upgraded to the latest stable version. Note: Although we’ve dropped support for Solr with this release, Solr code will remain in the Magento code base until a later release.
 
-* **Pipeline deployment**, a new deployment process, enables build and deployment stages to minimize production system downtime for site updates. Resource-intensive processes can run on the build server. Pipeline deployment supports easy management of configuration between environments, too. Read more about pipeline deployment [here]({{ page.baseurl }}/config-guide/deployment/pipeline/).
+*  **Pipeline deployment**, a new deployment process, enables build and deployment stages to minimize production system downtime for site updates. Resource-intensive processes can run on the build server. Pipeline deployment supports easy management of configuration between environments, too. Read more about pipeline deployment [here]({{ page.baseurl }}/config-guide/deployment/pipeline/).
 
-* **Performance gains from improvements in indexing, cart, and cache operations**. Customers can browse and shop on a storefront while indexers are running with no visible impact to their experience. Additionally, long-running indexers operate in batches to better manage memory and run times. Cart improvements enable a buyer to create a cart with more than 300 line items, and merchants can process a cart with at least 300 line items. Varnish cache configuration now includes saint and grace mode to ensure Varnish is always presenting a cached page to a shop’s customers.  Enhancements to cache invalidation logic and optimization of edge side include blocks for frequently changing data that significantly boost cache hit ratios.
+*  **Performance gains from improvements in indexing, cart, and cache operations**. Customers can browse and shop on a storefront while indexers are running with no visible impact to their experience. Additionally, long-running indexers operate in batches to better manage memory and run times. Cart improvements enable a buyer to create a cart with more than 300 line items, and merchants can process a cart with at least 300 line items. Varnish cache configuration now includes saint and grace mode to ensure Varnish is always presenting a cached page to a shop’s customers.  Enhancements to cache invalidation logic and optimization of edge side include blocks for frequently changing data that significantly boost cache hit ratios.
 
-* **Substantial contributions from our Community members**. Our Community Engineering Team has been working with skilled and enthusiastic community members, and together they've added hundreds of pull requests to the Magento code base. For more information about our Community Engineering Team. see [Magento Community Engineering](https://github.com/magento-engcom).
+*  **Substantial contributions from our Community members**. Our Community Engineering Team has been working with skilled and enthusiastic community members, and together they've added hundreds of pull requests to the Magento code base. For more information about our Community Engineering Team. see [Magento Community Engineering](https://github.com/magento-engcom).
 
 Looking for more information on these new features as well as many others? Check out  [Magento 2.2 Developer Documentation]({{ site.baseurl }}/guides/v2.2/).
 
@@ -52,9 +52,9 @@ The following issues affect all editions of Magento 2.2.0:
 
 **Issue**:  This issue affects Magento installations that include multiple store views. If you delete a store view, any product grid filtered to that Store View does not load. If you've set your product filter to a store view you’ve deleted, when you open **Catalog > Products**, Magento displays the following behavior:
 
-* spinner widget spins indefinitely
+*  spinner widget spins indefinitely
 
-* error message: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem  persists, try again later.`
+*  error message: `A technical problem with the server created an error. Try again to continue what you were doing. If the problem  persists, try again later.`
 
 **Issue**: Errors result when a deleted customer tries to log in or register for new account. When you delete a customer from the  Admin panel, a fatal error occurs if someone tries to log in or register using that deleted customer account.
 
@@ -106,7 +106,7 @@ This release contains hundreds of fixes and enhancements.
 *  We fixed an issue that blocked using the web installer to successfully set up Magento. Previously, if you tried to install Magento with the web installer, Magento would indicate that the readiness check failed, and installation would not complete.
 
 <!---57343 -->
-*   You can now deploy build processes on a different staging machine than the one you're running your production environment on.
+*  You can now deploy build processes on a different staging machine than the one you're running your production environment on.
 
 <!---57943 -->
 *  Magento 2.0.x and 2.1.x now support the use of table prefixing during installation. Previously, when you used table prefixing, your Magento installation failed with this error:   "Duplicate key on write or update". [GitHub-5688](https://github.com/magento/magento2/issues/5688)
@@ -169,7 +169,7 @@ This release contains hundreds of fixes and enhancements.
 *  The installation script no longer creates files in the root directory for missing modules when you install a community-created language pack. Translation packs created by the community often include translations for Magento Commerce modules. When you install these translation packs on an Open Source installation, the Commerce modules are missing. Previously, the installation script creates a file in the root directory for these Commerce modules instead of skipping them. [GitHub-6260](https://github.com/magento/magento2/issues/6260)
 
 <!--- 56743  -->
-*   We've fixed issues with upgrading installations with split databases.
+*  We've fixed issues with upgrading installations with split databases.
 
 <!--- 63022  -->
 *  Static content deployment (SCD) now works when multiple languages are specified. Previously, Magento displayed an error if you tried to deploy static content in more than one language (for example, `bin/magento setup:static-content:deploy en_CA fr_CA de_DE`).
@@ -223,7 +223,7 @@ This release contains hundreds of fixes and enhancements.
 *  Magento now re-processes queue messages if the consumer process is terminated.
 
 <!--- 58081 -->
-*   Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
+*  Magento no longer inserts HTTPSS:// for HTTPS in a store address when you install Magento using an HTTPS address over SSL. [GitHub-6262](https://github.com/magento/magento2/issues/6262)
 
 ### Cart and checkout
 
@@ -342,7 +342,7 @@ This release contains hundreds of fixes and enhancements.
 ### Catalog
 
 <!--- 65324, 66829  -->
-*   Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
+*  Magento no longer locks the `category_product_entity` table. Unlocking this table reduces the potential of lock-related timeouts that can occur when indexing and checkout operations run in parallel. Previously, Magento locked the `category_product_entity` table.
 
 <!--- 65251  -->
 *  The [storefront](https://glossary.magento.com/storefront) now displays images that Magento resizes during product save operations, rather than resizing the product on the storefront. Previously, the image path contained `store_id`,  and during save operations, Magento resized images for images the default store only.
@@ -451,7 +451,7 @@ This release contains hundreds of fixes and enhancements.
 *  Magento now displays the **Yes** or **No** attribute value on Product pages. *Fix submitted by community member Timo Klement in pull request [8623](https://github.com/magento/magento2/pull/8623){: target="_blank"}.*
 
 <!--- 65334 -->
-*   Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
+*  Setting the **show_out_of_stock** attribute to **No** now works as expected. *Fix submitted by community member Theis Corfixen in pull request [8736](https://github.com/magento/magento2/pull/8736){: target="_blank"}.*
 
 <!--- 69297 -->
 *  Magento now uses parent names (instead of SKU-based names) when creating configurable products. *Fix submitted by community member Pascal Brouwers in pull request [9681](https://github.com/magento/magento2/pull/9681){: target="_blank"}.*
@@ -469,31 +469,31 @@ This release contains hundreds of fixes and enhancements.
 *  The Magento WYSIWYG editor now handles special characters such as percent sign (%).  [GitHub-9452](https://github.com/magento/magento2/issues/9452)
 
 <!--- 63601 -->
-*   The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
+*  The `indexer:reindex catalog_category_product` process can now handle more than 500 products in a category.
 
 <!--- 62426 -->
 *  Magento now displays  the price set at store view-level for a product that has different prices set on the global and store view level.
 
 <!--- 71445 -->
-*   Out-of-stock options for configurable products no longer show up in search and layered navigation results.
+*  Out-of-stock options for configurable products no longer show up in search and layered navigation results.
 
 <!--- 67628 -->
-*   You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
+*  You can render the `tax_class_id` attribute nonsearchable. Previously, Magento displayed a 503 error under these circumstances.
 
 <!--- 63320 -->
 *  If you’ve enabled persistent shopping cart, you can now check out even after your session has expired.
 
 <!--- 61826 -->
-*   Magento no longer throws an error when you try to save a product with imported custom options.
+*  Magento no longer throws an error when you try to save a product with imported custom options.
 
 <!--- 62468 -->
-*   Magento now displays the product price even when the product is out-of-stock.
+*  Magento now displays the product price even when the product is out-of-stock.
 
 <!--- 64710 -->
-*   `productWebsiteLink` no longer deletes a product’s custom origins.
+*  `productWebsiteLink` no longer deletes a product’s custom origins.
 
 <!--- 56943 -->
-*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
 <!--- 52577 -->
 *  Magento no longer pre-fills the **Set Product as New From Date** field when you set a special price for a product. [GitHub-4387](https://github.com/magento/magento2/issues/4387)
@@ -502,7 +502,7 @@ This release contains hundreds of fixes and enhancements.
 *  When you edit a widget’s  existing condition, Magento now loads the SKU grid with all available SKUs. [GitHub-6985](https://github.com/magento/magento2/issues/6985)
 
 <!--- 56978 -->
-*   Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
+*  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the store view level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133), [GitHub-7251](https://github.com/magento/magento2/issues/7251)
 
 <!--- 60602 -->
 *  Combine rule conditions now work as expected for product list  widgets. [GitHub-7274](https://github.com/magento/magento2/issues/7274)
@@ -526,7 +526,7 @@ This release contains hundreds of fixes and enhancements.
 *  Product images in Magento installations with multiple store views are now assigned as expected to each store view. [GitHub-6259](https://github.com/magento/magento2/issues/6259)
 
 <!--- 56943 -->
-*   Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
+*  Magento now successfully handles purchases of product with minimum quantities of less than one. [GitHub-5570](https://github.com/magento/magento2/issues/5570)
 
 <!--- 58290  -->
 *  Magento no longer adds an empty product option to each PUT request. Previously, Magento added an empty option even when the options array was empty. [GitHub-5963](https://github.com/magento/magento2/issues/5963)
@@ -534,7 +534,7 @@ This release contains hundreds of fixes and enhancements.
 ### Configurable products
 
 <!---57055 -->
-*   You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
+*  You can now successfully disable the lowest price of a [configurable product](https://glossary.magento.com/configurable-product) and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled that price.
 
 <!---56998  -->
 *  Magento no longer applies one simple product's special price to another [simple product](https://glossary.magento.com/simple-product) of the same configurable product. Previously, when you set a regular and special price for a child product, all products associated with the same configurable product displayed a regular and special price, even when these amounts were the same. [GitHub-4442](https://github.com/magento/magento2/issues/4442), [GitHub-5097](https://github.com/magento/magento2/issues/5097), [GitHub-6645](https://github.com/magento/magento2/issues/6645)
@@ -558,7 +558,7 @@ This release contains hundreds of fixes and enhancements.
 *  Query optimizations have improved the speed of configurable product price calculation.
 
 <!--- 65246  -->
-*   Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
+*  Magento no longer calculates configurable product special prices on the category page. Previously, Magento calculated special prices on the category page, but did not display them.
 
 <!--- 56951 -->
 *  Magento now displays configurable products as expected after creation.
@@ -576,7 +576,7 @@ This release contains hundreds of fixes and enhancements.
 *  The price you set on the website scope no longer overrides any local settings you set on configurable products at the store view level.
 
 <!---52717, 59649 -->
-*   You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
+*  You can now successfully disable the lowest price of a configurable product and its associated simple products. Previously, Magento displayed a configurable product's lowest price even after you disabled the price. [GitHub-4419](https://github.com/magento/magento2/issues/4419)
 
 <!---60483 -->
 *  Magento now correctly displays a product as out-of-stock if its child products are disabled. Previously, the [category](https://glossary.magento.com/category) page failed to list the product at all, rather than listing it as out-of-stock.
@@ -684,7 +684,7 @@ This release contains hundreds of fixes and enhancements.
 #### JavaScript framework
 
 <!--- 71180  -->
-*   Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
+*  Customers can now place orders as expected when Magento is running a French locale in production mode. Previously, customers could not complete a transaction in a storefront running a French locale, although they could if they switched to the storefront running the English locale.
 
 <!--- 58285  -->
 *  Magento now displays server-side Ajax error messages.
@@ -734,7 +734,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### General fixes
 
 <!--- 56892 -->
-*   You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
+*  You can now save products using the multiple select attribute value. Previously, you could not save values if using this attribute.
 
 <!--- 56126  -->
 *  You can now log in successfully after creating a custom attribute. Previously, Magento would display an error message, and you could not log in, after first creating a custom attribute, then logging out.
@@ -752,7 +752,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now make Return Merchandise [Authorization](https://glossary.magento.com/authorization) (RMA) comments visible from the storefront by setting **Stores > Settings > Configuration > Sales > RMA Settings > Enable RMA on Storefront**.
 
 <!---57187 -->
-*   When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
+*  When creating a new page with the Add New Page feature, Magento no longer throws a JavaScript error when [Layout](https://glossary.magento.com/layout) is set to empty.
 
 <!---57351 -->
 *  We've removed the sample password from the Setup Wizard.
@@ -881,7 +881,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  The `Magento_Framework/View/Layout/etc/elements.xsd` file `blockReferenceType` definition now allows for the optional argument template. *Fix submitted by community member jissereitsma in pull request [9772](https://github.com/magento/magento2/pull/9772){: target="_blank"}.*
 
 <!--- 59135 -->
-*   Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
+*  Customer sessions for different customers are no longer shared on installations on multiple websites. [GitHub-4842](https://github.com/magento/magento2/issues/4842), [GitHub-6468](https://github.com/magento/magento2/issues/6468)
 
 <!--- 63116 -->
 *  Magento now handles quotation marks in product names. Previously,  quotation marks in product names caused a JSON error on the Product page.  [GitHub-8059](https://github.com/magento/magento2/issues/8059)
@@ -919,7 +919,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  The Checkout page no longer freezes when you order a virtual gift card using the Authorize.net Payment Action value set to **Authorize and Capture**.
 
 <!---57512 -->
-*   You can now complete the purchase of a gift card in environments where you have set the Braintree [payment method](https://glossary.magento.com/payment-method) Payment Action to **Authorize and Capture**. Previously, any order made under these conditions would remain indefinitely in the processing stage.
+*  You can now complete the purchase of a gift card in environments where you have set the Braintree [payment method](https://glossary.magento.com/payment-method) Payment Action to **Authorize and Capture**. Previously, any order made under these conditions would remain indefinitely in the processing stage.
 
 <!---57353 -->
 *  You can now add a gift card with an undefined amount to the Items Ordered table. Previously,  Magento did not permit you to add a gift card of an open value to this table.
@@ -944,7 +944,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### Gift wrapping
 
 <!--- 62721 -->
-*   The **Allow Gift Wrapping for Order Items** setting now works as expected. Previously, when **Stores > Settings > Configuration > Sales > Gift Options** was set to **No**, users  saw the Gift Option link under each product in their [shopping cart](https://glossary.magento.com/shopping-cart).
+*  The **Allow Gift Wrapping for Order Items** setting now works as expected. Previously, when **Stores > Settings > Configuration > Sales > Gift Options** was set to **No**, users  saw the Gift Option link under each product in their [shopping cart](https://glossary.magento.com/shopping-cart).
 
 <!--- 70603 -->
 *  You can now add gift options to an order if logged in using a secure URL
@@ -981,7 +981,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### HTML
 
 <!--- 67487 -->
-*   The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
+*  The CSS minify option no longer removes the whitespace around the minus (-) sign. Also, this option is now compatible with the `calc()` CSS function.  *Fix submitted by community member Petar Sambolek in pull request [9027](https://github.com/magento/magento2/pull/9027){: target="_blank"}.*
 
 ### Images
 
@@ -989,7 +989,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento no longer encounters an error when it cannot find a product image file. [GitHub-5184](https://github.com/magento/magento2/issues/5184), [GitHub-5497](https://github.com/magento/magento2/issues/5497), [GitHub-3545](https://github.com/magento/magento2/issues/3545), [GitHub-5871](https://github.com/magento/magento2/issues/5871)
 
 <!---56944 -->
-*   Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
+*  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
 <!---58335, 42954 -->
 *  You can now preview uploaded images.
@@ -998,13 +998,13 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now set an image size for product watermarks. [GitHub-5270](https://github.com/magento/magento2/issues/5270)
 
 <!---55608 -->
-*   Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
+*  Graphics now scroll as expected on mobile devices. [GitHub-5302](https://github.com/magento/magento2/issues/5302)
 
 <!--- 55234 -->
 *  Magento now successfully saves images that you edit in a [WYSIWYG](https://glossary.magento.com/wysiwyg) editor. Previously, when you tried to change an image by right-clicking it in a WYSIWYG editor and choosing Insert/Edit Image, Magento did not save your changes.
 
 <!--- 58031 -->
-*   Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
+*  Inserted images on the content block of Category no longer reference the Admin URL. Previously, when you used the Wysiwyg editor to insert an image into the Content block of a Category, the image URL on the frontend would reference the Admin location. When you subsequently logged out of the Admin panel, and refreshed the Category page, the image is no longer available.
 
 #### Import/Export
 
@@ -1033,7 +1033,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento now correctly displays both configurable and simple products, their attribute values, and visibility values after import if SKU is an integer. [GitHub-5547](https://github.com/magento/magento2/issues/5547)
 
 <!--- 58316 -->
-*   Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
+*  Magento now imports customer data as expected after the data passes the pre-import validation step. Previously, although data passed this validation step, an error would occur during import, and Magento displayed this message: `Invalid data for insert`. [GitHub-4921](https://github.com/magento/magento2/issues/4921), [GitHub-9469](https://github.com/magento/magento2/issues/9469)
 
 <!--- 71013 -->
 *  The export process now populates values in the configurable variations column for configurable products as expected. Previously, when exporting more than one product, the values for the configurable variations column for configurable products were not included.
@@ -1048,7 +1048,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  We've fixed an issue with the correct representation of date and time zones of items in a product [catalog](https://glossary.magento.com/catalog) during import or export. Previously, Magento exported all dates in the default format (UTC-8), including values that you set to be displayed using another standard.
 
 <!--- 65667 -->
-*   Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
+*  Magento now successfully imports customer multiselect attributes. Previously, when you imported a CSV file with either the option's ID numbers or the option's values, Magento returned an error.
 
 <!--- 67240 -->
 *  Magento now displays more verbose information about duplicated information with links to action for troubleshooting the import process. Previously, Magento displayed duplicated or incomplete information on the product page after import.
@@ -1147,7 +1147,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 ### Orders
 
 <!--- 61268, 59424, 56433, 59422-->
-* We’ve added PHP interfaces that add the ability to change the status of a [shipment](https://glossary.magento.com/shipment). The new Creditmemo interface supports tasks you can already do through the Magento Admin, including the ability to:
+*  We’ve added PHP interfaces that add the ability to change the status of a [shipment](https://glossary.magento.com/shipment). The new Creditmemo interface supports tasks you can already do through the Magento Admin, including the ability to:
 
    *  support returning multiple units of a configurable product. Previously, when you tried to refund an order, you could refund only one unit of a configurable product, not the amount in the original order.
 
@@ -1198,7 +1198,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  The Orders grid now displays correct order dates. *Fix submitted by community member  Anton Evers in pull request [9941](https://github.com/magento/magento2/pull/9941){: target="_blank"}.*
 
 <!---68795  -->
-*   Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
+*  Magento now displays the correct order time in the Sales Order grid in the Admin panel. [GitHub-9426](https://github.com/magento/magento2/issues/9426)
 
 <!--- 60587  -->
 *  We’ve increased the size of the `sales_order_payment.cc_number_enc` field. [GitHub-7334](https://github.com/magento/magento2/issues/7334)
@@ -1216,7 +1216,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  New orders no longer stay in the processing state after you click the Place Order button. Previously, new orders stayed in the processing state even after you clicked Place Order. [GitHub-5860](https://github.com/magento/magento2/issues/5860)
 
 <!--- 60692 -->
-*   You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
+*  You can now use either the parent order item ID or child product order item ID when using  the REST API (`/V1/order/:orderId/invoice : POST method API`)  to create an invoice for an order containing bundle products. [GitHub-6988](https://github.com/magento/magento2/issues/6988)
 
 <!--- 58722 -->
 *  We’ve increased the size of the `shipping_method` column in the `sales_order` and `quote_address` tables. [GitHub-6475](https://github.com/magento/magento2/issues/6475)
@@ -1228,7 +1228,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  Magento now displays all tax details as expected on the Admin order page. Previously, Magento did not save the order tax rate information, and the full tax summary was incomplete.
 
 <!--- 57880 -->
-*   You can now cancel an order of a bundle product. [GitHub-5194](https://github.com/magento/magento2/issues/5194)
+*  You can now cancel an order of a bundle product. [GitHub-5194](https://github.com/magento/magento2/issues/5194)
 
 <!--- 57312 -->
 *  We’ve fixed an issue with an undefined offset in the `order\config.php` file. [GitHub-6111](https://github.com/magento/magento2/issues/6111)
@@ -1268,7 +1268,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 <!--- 64413 -->
 *  The expiration year validator now works as expected. [GitHub-8482](https://github.com/magento/magento2/issues/8482)
 
-* We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
+*  We've introduced the `Magento\Vault\Block\TokenRendererInterface::getToken` method. This method provides details about payment tokens to renderer components, such as public hash and available card or account details. Third-party developers can use this method to implement this functionality in their payment integrations.
 
 <!--- 56345 -->
 *  Error messages associated with the `Authorize.net` payment method are now translated to fit the configured locale. [GitHub-5934](https://github.com/magento/magento2/issues/5934)
@@ -1285,7 +1285,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now place orders from the Admin using the Braintree payment method.
 
 <!---59578 -->
-* We've enhanced our PayPal and Braintree implementations so that merchants can now:
+*  We've enhanced our PayPal and Braintree implementations so that merchants can now:
 
    *  Save customer PayPal account information in the Braintree Vault when using Braintree as a service. This enhancement provides a secure method for charging my customers without prompting them to enter a payment information for multiple purchases or for purchases from multiple devices. We've also added support for Maestro and Discover BINs added to the credit card form both for Braintree and PayPal solutions.
 
@@ -1316,7 +1316,7 @@ Thanks to our hardworking Magento Open Source community members for the followin
 *  You can now successfully place orders with Braintree when using an alternative [merchant account](https://glossary.magento.com/merchant-account) ID. (The merchant account does not need to match the 3D Secure authorization merchant account.) [GitHub-5910](https://github.com/magento/magento2/issues/5910)
 
 <!---59637 -->
-*   Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
+*  Braintree no longer encounters an error during checkout when you apply a 100% discount coupon to a product and enable free shipping. Previously, Magento  displayed a spinning loader widget, and your screen froze. The Developer console displayed this error:
 `Uncaught Error: [paypal-container] is not a valid DOM Element`.
 
 <!--- 56344 -->
@@ -1492,7 +1492,7 @@ This release includes substantial improvements to Magento caching, image process
 *  Changing a product price under the website scope now updates the product price across all stores. Previously, any price you set on the [store view](https://glossary.magento.com/store-view) level overrode the price set in website scope. [GitHub-5133](https://github.com/magento/magento2/issues/5133)
 
 <!---56936  -->
-*   The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
+*  The list of allowed countries is now configured as part of website scope, not store view scope. [GitHub-2946](https://github.com/magento/magento2/issues/2946)
 
 <!---57001, 54460 -->
 *  A restricted user can now change storeview- or website- level attributes that are defined within his scope.
@@ -1509,10 +1509,10 @@ This release includes substantial improvements to Magento caching, image process
 ### Search
 
 <!---59088 -->
-*   Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
+*  Out-of-stock items no longer erroneously appear in results of layered navigation if that product option is out-of-stock.
 
 <!---52905 -->
-*   Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
+*  Magento now factors in the Weight attribute as expected when you use advanced search on grouped products.
 
 <!--- 71562  -->
 *  The Elasticsearch indexer search-by-attribute functionality now works as expected.
@@ -1596,7 +1596,7 @@ This release includes substantial improvements to Magento caching, image process
 ### Staging
 
 <!---57346, 53078 -->
-*   The [CMS](https://glossary.magento.com/cms) page now refreshes as expected after an update.
+*  The [CMS](https://glossary.magento.com/cms) page now refreshes as expected after an update.
 
 <!---71215 -->
 *  Magento no longer creates extraneous database values when you schedule new Staging updates.
@@ -1647,13 +1647,13 @@ This release includes substantial improvements to Magento caching, image process
 *  Content staging values for fields are now saved in database.
 
 <!--- 64461  -->
-*   When you import products  that exist in the CSV file, but not on the store (including categories), Magento now populates the categories as expected.
+*  When you import products  that exist in the CSV file, but not on the store (including categories), Magento now populates the categories as expected.
 
 <!--- 67754  -->
 *  Magento no longer deletes images associated with categories scheduled for update after you modify the image.
 
 <!--- 59687  -->
-*   Once the time frame for the scheduled update has passed, Magento removes the special price and displays the original price.
+*  Once the time frame for the scheduled update has passed, Magento removes the special price and displays the original price.
 
 <!--- 54512  -->
 *  You can now remove a product or category from a campaign.
@@ -1747,10 +1747,10 @@ This release includes substantial improvements to Magento caching, image process
 *  Magento no longer resets the tier price during [quote](https://glossary.magento.com/quote) recalculation. Previously, when you triggered an automatic quote recalculation (by changing the shipping address, for example), the tier price was lost. (This issue occurred only if the product record in the database had values for `row_id` and `entity_id` that didn't match.)
 
 <!---56922 -->
-*   Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
+*  Magento no longer adds a thousands separator ( , ) to representations of quantities that exceed 1000. [GitHub-5745](https://github.com/magento/magento2/issues/5745)
 
 <!---55055 -->
-*   Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
+*  Tier pricing now works correctly with full page cache. [GitHub-5364](https://github.com/magento/magento2/issues/5364)
 
 ### Translation and locales
 
@@ -1803,7 +1803,7 @@ This release includes substantial improvements to Magento caching, image process
 <!--- 69372 -->
 *  Varnish no longer caches Cookie Restriction Mode Overlay. *Fix submitted by community member Bernhard in pull request 9711.*
 
-* Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
+*  Varnish now supports `grace` and `saint` mode to ensure that customers always see cached pages.
 
 <!--- 52923 -->
 *  Viewing the page with HTTPS instead of HTTP no longer causes the Category menu to disappear in installations using Varnish cache.  [GitHub-4540](https://github.com/magento/magento2/issues/4540)
@@ -1867,9 +1867,9 @@ This release includes substantial improvements to Magento caching, image process
 
  We are grateful to the wider Magento community and would like to acknowledge their contributions to this release. Check out the following ways you can learn about the community contributions to our current releases:
 
-* If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
+*  If a community member has provided a fix for this release, we identify the fix in the Fixed Issue section of these notes with the phrase, "*Fix provided by community member @member_name*".
 
-* The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of  top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
+*  The Magento Community Engineering team [Magento Contributors](https://magento.com/magento-contributors) maintains a list of  top contributing individuals and partners by month, quarter, and year. From that Contributors page, you can follow links to their merged PRs on GitHub.
 
 ### System requirements
 

--- a/guides/v2.2/release-notes/ReleaseNotes2.2.4EE.md
+++ b/guides/v2.2/release-notes/ReleaseNotes2.2.4EE.md
@@ -20,9 +20,9 @@ Look for the following highlights in this release:
 
 *  **Numerous fixes and enhancements to the Magento Shipping and dotmailer** bundled extensions. Merchants can now use [dotmailer](http://docs.magento.com/m2/ee/user_guide/marketing/email-marketing-automation.html) to create their own transactional email templates. [Magento Shipping](http://docs.magento.com/m2/ee/user_guide/shipping/magento-shipping.html) capabilities have been expanded, too.
 
-* Fixes and enhancements to core features, including **performance improvements** that enable faster shopping with image loading and search performance enhancements.
+*  Fixes and enhancements to core features, including **performance improvements** that enable faster shopping with image loading and search performance enhancements.
 
-* Almost 200 **community contributions**. These community contributions include performance-tuning enhancements plus at least 80 engineering fixes.
+*  Almost 200 **community contributions**. These community contributions include performance-tuning enhancements plus at least 80 engineering fixes.
 
 Looking for more information on these new features as well as many others? Check out [Magento 2.2.x Developer Documentation]({{ site.baseurl }}/guides/v2.2/) and the [Magento Commerce User Guide](http://docs.magento.com/m2/ee/user_guide/getting-started.html).
 
@@ -43,7 +43,7 @@ This section describes changes in this release that are not full-fledged feature
 *  Magento now provides dedicated payment and shipping debug log files to store information specific to those functional areas.
 
 <!--- MAGETWO-87124  -->
-*   The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
+*  The Emogrifier dependency has been upgraded to 2.0.0 or later. *Fix submitted by Oliver Klee in pull request 13132*.
 
 <!--- MAGETWO-86744, MAGETWO-86743, MAGETWO-86746, MAGETWO-86742  -->
 *  We've replaced `is_null` with strict comparison only for models and block in the following modules: `Catalog`, `Tax`, `Sales`, and `EAV`. *Fixes submitted by Alexander Shkurko in pull requests 13171, 13170, 1163*.
@@ -52,15 +52,15 @@ This section describes changes in this release that are not full-fledged feature
 
 The dotmailer bundled extension features the following enhancements for this release:
 
-* The new Abandoned Cart report table
+*  The new Abandoned Cart report table
 
-* The ability for merchants to design their own transactional email template
+*  The ability for merchants to design their own transactional email template
 
-* Enhancement of syncs of subscriber's sales data. Sales data is now synced only if the sales data option is enabled in config.
+*  Enhancement of syncs of subscriber's sales data. Sales data is now synced only if the sales data option is enabled in config.
 
-* The ability to set transactional email at the Store level
+*  The ability to set transactional email at the Store level
 
-* Enhanced validation for deletion of cron job CSV files
+*  Enhanced validation for deletion of cron job CSV files
 
 ## Known issue
 
@@ -115,7 +115,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The `CrontabManager.php` file has been updated as follows: If `crontab` has already been populated, the `bin/magento cron:install` command adds `#~ MAGENTO START` and the rest of code directly to the last row of crontab without any spaces. *Fix submitted by Michele Fantetti in pull request*.
 
 <!--- MAGETWO-85744  -->
-*   The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
+*  The `ext-bcmath` PHP extension is now required in Open Source. Previously, it was required for Commerce only. *Fix submitted by Mobecls in pull request 12768*.
 
 <!--- MAGETWO-88149  -->
 *  The `cache_lifetime` default setting for the `Magento\Theme\Block\Html\Footer` block is no longer set to **false**, and the new default setting is **3600**. *Fix submitted by zolat in pull request 13762*.
@@ -124,13 +124,13 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The `bin/magento maintenance:allow-ips` command now has the `--add` flag, which appends a new IP address to the list of allowed IP addresses. Previously, when you added a new IP address, you had to copy the existing addresses. *Fix submitted by Barry vd. Heuvel in pull request 13586*.
 
 <!--- MAGETWO-87900  -->
-*   The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
+*  The `config:set` command now has a `lock-config` option, and configuration values are always stored in `app/etc/config.php` instead of `app/etc/env.php`. *Fix submitted by Andreas von Studnitz in pull request 13280*.
 
 <!--- MAGETWO-87859  -->
-*   In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
+*  In the `Backend/etc/adminhtml/system.xml` file, the `url` group and `redirect_to_base` field are now configured so that the `showInWebsite` and `showInStore` attributes are set to `1`. *Fix submitted by JeroenVanLeusden in pull request 13614*.
 
 <!--- MAGETWO-87856  -->
-*   You can now deploy static content on demand while in production mode.
+*  You can now deploy static content on demand while in production mode.
 
 <!--- MAGETWO-87838  -->
 *  The output of the `Magento maintenance:status` command no longer inserts a comma in between IP addresses, making it easier to copy and paste the values. *Fix submitted by Barry vd. Heuvel in pull request 13587*.
@@ -139,7 +139,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The `DeploymentConfig` reader now always returns an array. *Fix submitted by Barry vd. Heuvel in pull request 13584*.
 
 <!--- MAGETWO-83782  -->
-*   Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
+*  Magento has improved how it manages the size of the `cron_schedule` table. [GitHub-11002](https://github.com/magento/magento2/issues/11002)
 
 <!--- MAGETWO-82288  -->
 *  Magento now includes a helper object to facilitate access to styling objects in the Symfony console. *Fix submitted by Wesley Guthrie in pull request 11504*.
@@ -151,7 +151,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The `sampledata:deploy` and `remove` commands now have `no-update` options. *Fix submitted by Fabian Schmengler in pull request 12359*.
 
 <!--- MAGETWO-88155  -->
-*   The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
+*  The currencies dropdown menu that is available during the setup process (step 4 -- customize your store) no longer displays unallowed currencies. *Fix submitted by Ricardo Martins in pull request 13770*.
 
 ### Bundle products
 
@@ -164,13 +164,13 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 ### Catalog
 
 <!--- MAGETWO-87447  -->
-*   Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
+*  Magento now successfully updates a product's `stock_item` `extension_attribute` parameter for a product previously created using REST. *Fix submitted by nuzil in pull request 13494*.
 
 <!--- MAGETWO-73262  -->
-*   When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
+*  When two customers check out concurrently for the same product, one of the checkouts now succeeds. Previously, when two customers checked out concurrently for the same product, and the total quantity being ordered is greater than the quantity available, the stock could become negative. *Fix submitted by Myroslav Dobra in pull request 2133*.
 
 <!--- MAGETWO-87477  -->
-*   The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
+*  The `getUrl` method in `Magento\Catalog\Model\Product\Attribu…` no longer returns image URLs with unexpected double slashes. *Fix submitted by Igor Tregub in pull request 13498*.
 
 <!--- MAGETWO-73696  -->
 *  When sorting by price, Magento now displays the same number of products no matter how it sorts products in the Catalog Product list. Previously, Magento reduced the product count by the number of disabled products when sorting by price.
@@ -227,7 +227,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The `og:type` meta tag content value has been corrected from `<meta property="og:type" content="og:product" />` to `<meta property="og:type" content="product" />`. *Fix submitted by Atish Goswami in pull request 12530*.
 
 <!--- MAGETWO-85293  -->
-*   The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
+*  The Product Image Watermark Size Validation message has been revised for accuracy. *Fix submitted by Nickolas Malyovanets in pull request 985*. [GitHub-12613](https://github.com/magento/magento2/issues/12613)
 
 <!--- MAGETWO-85294  -->
 *  Magento no longer creates an extraneous new product when you save an existing product whose SKU you've changed.  *Fix submitted by Nickolas Malyovanets in pull request 984*. [GitHub-12535](https://github.com/magento/magento2/issues/12535)
@@ -282,7 +282,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Magento now loads type-dependent layout handles before more specific ID/SKU layout handles. Previously, when Magento updated a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml`, some changes were overwritten by a less specific `catalog_product_view_type_<product_type>.xml`. *Fix submitted by Andreas Schrammel in pull request 12807*.
 
 <!--- MAGETWO-87897  -->
-*   Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
+*  Unused temporary variables have been removed from `Adminhtml/Category/Save.html`. *Fix submitted by Pierre Martin in pull request 13663*.
 
 <!--- MAGETWO-87847  -->
 *  Language switching now works as expected on the Catalog and Product pages. Previously, language switching did not work on these pages in production mode. *Fix submitted by p-bystritsky in pull request 1143*. [GitHub-11963](https://github.com/magento/magento2/issues/11963)
@@ -294,7 +294,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  In cases where  `imagebuilder` makes multiple calls, it no longer re-uses attributes from the first call if attributes from a second call are empty. Previously, `imagebuilder` re-used the attributes from the first call, which lead to unexpected results in storefront image display. *Fix submitted by Ihor Sviziev in pull request 13438*.
 
 <!--- MAGETWO-87496  -->
-*   `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
+*  `updateCart.phtml` now uses dynamic rather than hardcoded validators. *Fix submitted by Gil Greenberg in pull request 13462*.
 
 <!--- MAGETWO-87294  -->
 *  An unused constructor dependency has been removed from the Product Link Save handler. *Fix submitted by Ihor Sviziev in pull request 13436*.
@@ -306,7 +306,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The Low Stock report now accurately lists all out-of-stock products. Previously, this report was not accurate when the All Websites view was selected. *Fix submitted by gwharton in pull request 13682*. [GitHub-10595](https://github.com/magento/magento2/issues/10595)
 
 <!--- MAGETWO-85163  -->
-*   We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
+*  We've improved the visibility of products when displayed by category, and you can now filter by status. *Fix submitted by Peter Jaap Blaakmeer in pull request 12564*.
 
 <!--- MAGETWO-85575  -->
 *  Magento now correctly sets a `product_links` position attribute even when the attribute value is not set in a GET request. Previously, only the first two of each link type was shown in the backend or in a GET request response, even though Magento correctly added the product links to the database. *Fix submitted by Mohammad Haj-Salem in pull request 12650*.
@@ -352,7 +352,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  You can now use custom price symbols when assigning prices to configurable prices. Previously, Magento did not properly display prices for configurable products when you used a custom price symbol when assigning prices. *Fix submitted by pradeep-wagento in pull request 13025*. [GitHub-12430](https://github.com/magento/magento2/issues/12430)
 
 <!--- MAGETWO-86311  -->
-*   Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
+*  Magento now reorders configurable attribute options as expected on the product page. *Fix submitted by wardcapp in pull request 12963*. [GitHub-7441](https://github.com/magento/magento2/issues/7441)
 
 <!--- MAGETWO-85782  -->
 *  Magento now displays elements of the **Catalog > Products > Create Configurations** page correctly. Previously, the currency symbol overlapped with the attribute option's price during the creation of a configurable product. *Fix submitted by Vasilina in a pull request*.
@@ -364,7 +364,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Magento now correctly runs a partial attribute (EAV) reindex of configurable products whose child products' visibility is set to **Not Visible Individually**. *Fix submitted by Roman K. in pull request 1023*. [GitHub-12667](https://github.com/magento/magento2/issues/12667)
 
 <!--- MAGETWO-85286  -->
-*   Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
+*  Magento now displays the ID and `Visibility` parameter of child products when you use the `LinkManagementInterface` service contract to retrieve the ID and visibility of these products. Previously, Magento displayed NULL. *Fix submitted by Nickolas Malyovanets in pull request 986*.
 
 <!--- MAGETWO-82888  -->
 *  The product price indexer (`catalog_product_price reindex`) no longer stalls during reindexing.
@@ -384,7 +384,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Magento now successfully sends an email (with content) even when you make a mistake in the email template file name. Previously, when the template name was incorrect, Magento sent the email with no content. *Fix submitted by Roman K. in pull request 970*. [GitHub-8437](https://github.com/magento/magento2/issues/8437)
 
 <!--- MAGETWO-85653  -->
-*   You can now import customer addresses from websites with country restrictions.
+*  You can now import customer addresses from websites with country restrictions.
 
 <!--- MAGETWO-84862  -->
 *  Magento no longer displays the `Too many passwords reset requests` error when the **max wait time between password resets** setting has been disabled. Previously, when you attempted to reset a customer's password through the Admin, Magento threw an error even when you disabled the `max wait time between password resets` setting in the store configuration settings. *Fix submitted by Cole Hafner in a pull request*. [GitHub-11409](https://github.com/magento/magento2/issues/11409)
@@ -411,7 +411,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  You can now create a custom attribute of type file for Customer objects as expected. Previously,  you could create the custom attribute, but the file would not upload. *Fix submitted by Mkennethsmith in pull request 13563*. [GitHub-11252](https://github.com/magento/magento2/issues/11252)
 
 <!--- MAGETWO-87950  -->
-*   The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file. *Fix submitted by Renon Stewart in pull request 13661*.
+*  The event `customer_address_after_save_viv_observer` is now spelled correctly in the Customer `events.xml` file. *Fix submitted by Renon Stewart in pull request 13661*.
 
 <!--- MAGETWO-71829  -->
 *  The `is_subscribed` extended parameter is now returned when a web API is used to modify or return information about a customer.
@@ -465,7 +465,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  `Magento\Eav\Model\Config::getAttribute` now stops the Profiler before it returns Profiler runtime. Previously, `Magento\Eav\Model\Config::getAttribute` did not stop the Profiler from returning early and consequently reported incorrect runtime. *Fix submitted by Nick Anstee in pull request 12810*.
 
 <!--- MAGETWO-87588  -->
-*   The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
+*  The `beforeSave` method encodes an attribute value only when it has not yet been encoded. Previously, the JSON-encoded attribute value was loaded  correctly, but when you saved a product multiple times,  the attribute value was also encoded multiple times. Consequently, Magento did save the product and  displayed this error, **Unable to unserialize value**. *Fix submitted by Tibor Kotosz in pull request 13551*.
 
 <!--- MAGETWO-87354  -->
 *  The deprecated `each()` function has been removed from the code. *Fix submitted by Ihor Sviziev in a pull request*.
@@ -514,7 +514,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  RewriteBase directive has been added to the `.htaccess` file in `pub/static` to support the potential installation of Magento code under a directory inside the web root. *Fix submitted by Cristiano Casciotti in pull request 13678*.
 
 <!--- MAGETWO-87261  -->
-*   The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
+*  The doc block of the `walk` method in a collection now correctly describes that the method accepts a string or array. *Fix submitted by ByteCreation in pull request 13373*.
 
 <!--- MAGETWO-82069  -->
 *  The report processor now returns an HTTP 500 status code (which better communicates the need for user action) instead of a 503 status code. *Fix submitted by Andrew Howden in pull request 11513*. [GitHub-11512](https://github.com/magento/magento2/issues/11512)
@@ -525,10 +525,10 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  The customer grid indexer now works as expected.  Previously, this indexer did not work when reindexing using the command-line interface during the upgrade. *Fix submitted by Leonid Poluyanov in pull request 10838*. [GitHub-10838](https://github.com/magento/magento2/issues/10838)
 
 <!--- MAGETWO-80223  -->
-*   `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
+*  `expectException()` calls now accept two parameters (instead of one). *Fix submitted by Fabian Schmengler in pull request 11099*. [GitHub-11059](https://github.com/magento/magento2/issues/11059)
 
 <!--- MAGETWO-84003  -->
-*   The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
+*  The `findAccessorMethodName()` method (`Magento\Framework\Reflection\NameFinder`) now provides a more helpful exception message. *Fix submitted by Roman K. in pull request 12303*. [GitHub-9764](https://github.com/magento/magento2/issues/9764)
 
 <!--- MAGETWO-84016  -->
 *  Customers with an empty **Date of Birth** field can now be saved even when the field is not marked (or checked on the JavaScript side) as mandatory. *Fix submitted by Vova Yatsyuk in pull request 12302*. [GitHub-12146](https://github.com/magento/magento2/issues/12146)
@@ -591,13 +591,13 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 ### General
 
 <!--- MAGETWO-86727  -->
-*   A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
+*  A customer can now successfully log out of a session and then immediately log back in. Previously, if a customer logged out and then attempted to log in without the logout success page first completing its timeout, Magento displayed the logout page. *Fix submitted by Vinay Shah in pull request 13040*.
 
 <!--- MAGETWO-87341  -->
 *  Magento now displays notification messages for only the expected duration. Previously, Magento displayed these messages indefinitely within a session. *Fix submitted by p-bystritsky in pull request 1111*. [GitHub-11527](https://github.com/magento/magento2/issues/11527)
 
 <!--- MAGETWO-87342  -->
-*   Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
+*  Sorting by product name now works as expected when filters are applied. *Fix submitted by p-bystritsky in pull request 1192*. [GitHub-12860](https://github.com/magento/magento2/issues/12860)
 
 <!--- MAGETWO-86748  -->
 *  We've removed the `Magento\ProductAlert\Controller\Add\TestObserver` class. *Fix submitted by Alexander Shkurko in pull request 13174*.
@@ -612,7 +612,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  A type error in `CartTotalRepository` has been resolved. Previously, `CartTotalRepository` could not handle extension attributes in quote addresses, and Magento threw a `PHP Fatal error:  Uncaught TypeError`. *Fix submitted by p-bystritsky in pull request 12993*. [GitHub-12993](https://github.com/magento/magento2/issues/12993), [GitHub-12819](https://github.com/magento/magento2/issues/12819)
 
 <!--- MAGETWO-86883  -->
-*   The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
+*  The WYSIWYG editor image insertion process now takes into account the static URLs configuration value (configuration setting `cms/wysiwyg/use_static_urls_in_catalog`). *Fix submitted by Nickolas Malyovanets in pull request 1215.* [GitHub-12147](https://github.com/magento/magento2/issues/12147)
 
 <!--- MAGETWO-86840  -->
 *  The `<![CDATA[]]>` statement in the `system.xml` file  now works as expected. Previously, when you entered an XML layout update with CDATA for the first time,  it worked as expected. After you saved the file, however, the `CDATA` tag disappeared. *Fix submitted by serhii-balko in pull request 1163*. [GitHub-12322](https://github.com/magento/magento2/issues/12322)
@@ -630,7 +630,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Minor display issues on the Magento home product page  have been resolved.  *Fix submitted by Punit Vaswani in pull request 13081*. [GitHub-11796](https://github.com/magento/magento2/issues/11796)
 
 <!--- MAGETWO-88145  -->
-*   We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
+*  We've removed a condition from the password reset strength meter that caused a JavaScript error. *Fix submitted by Alisson Oldoni in pull request 13429*.
 
 <!--- MAGETWO-86433  -->
 *  The copyright year has been updated to 2018. *Fix submitted by Bhargav Mehta in pull request 13027*.
@@ -687,13 +687,13 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Full Page Cache is no longer invalidated after you save a predictor category. Previously, all product-related cache data was invalidated, when only a narrow subset of cache tags associated with the `product_id` should have been.
 
 <!--- MAGETWO-88040  -->
-*   Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
+*  Magento now displays a more meaningful error message when a module name is misspelled in a unit test. *Fix submitted by Nickolas Malyovanets in pull request 13740*.
 
 <!--- MAGETWO-87908  -->
 *  Magento now displays a more meaningful error message when a module name is misspelled in `registration.php`. *Fix submitted by Jānis Elmeris in pull request 12843*.
 
 <!--- MAGETWO-87940  -->
-*   In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
+*  In the line `Perform login specific action` in  `StorageInterface.php`,  `login` has been replaced with  `logout`. *Fix submitted by David Angel in pull request 13679*.
 
 <!--- MAGETWO-87921  -->
 *  The incorrect field value in the joined `variable_value` table has been replaced with two values: `plain_value` and `html_value`. *Fix submitted by Maksymilian Szydło in pull request 13596*.
@@ -720,7 +720,7 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Customers can now successfully use RSS to share their wish lists. Previously, when a logged-in user added products to the wish list and then tried to share them using RSS, Magento threw this exception: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as a child to 'root', because the latter doesn't exist` *Fix submitted by mediactbv in a pull request*.
 
 <!--- MAGETWO-87242  -->
-*   When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
+*  When you select a new main menu option, the previously selected  menu item now loses the `ui-state-active` class as expected. *Fix submitted by Arnoud Beekman in pull request 13341*. [GitHub-13327](https://github.com/magento/magento2/issues/13327)
 
 <!--- MAGETWO-85311  -->
 *  Issues with displaying full-screen images and video on the configurable product page have been resolved. Previously, Magento displayed video associated with product options on this page as images, rather than video, and full-screen mode for images ignored the configurations settings in `view.xml`. *Fix submitted by Ievgen Shakhsuvarov in pull request 991*. [GitHub-12268](https://github.com/magento/magento2/issues/12268)
@@ -835,10 +835,10 @@ We do not recommend upgrading to Magento 2.2.4 if you deploy across multiple web
 *  Magento now shows all products as expected in the Recently Ordered list when a customer places an order that contains products from multiple stores. Previously, in installations with two storefronts, if a customer added products from both stores to the same shopping cart, and placed a single order, the recently ordered product list would not show all ordered products.
 
 <!--- MAGETWO-82577  -->
-*   The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
+*  The `getDefaultStoreLocale()` method has been added to allow for the fetching of scoped values. Use this method in `getCreatedAtFormatted()` to ensure that Magento translates the  `created_at` order date in emails for the locale being used in that store view. *Fix submitted by JeroenVanLeusden in pull request 11067*.
 
 <!--- MAGETWO-83410  -->
-*   You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
+*  You can now successfully open the Order edit page for orders that contain an address with extension attributes. Previously, when you tried to open this page, the page load failed with this error, `Recoverable Error: Object of class Magento\Sales\Api\Data\OrderAddressExtension could not be converted to string in .../module-sales/Model/AdminOrder/Create.php on line 503`.
 
 <!--- MAGETWO-83552  -->
 *  Magento now saves an invoice ID on the credit memo when you create a credit memo from the invoice in the Admin. Previously,
@@ -872,7 +872,7 @@ the invoice ID was not included.  *Fix submitted by Anton Evers in pull request 
 *  The cancel order and restore quote methods now accurately calculate the amount of stock to be returned to inventory when an order is canceled. Previously, when you canceled an order, some of these methods did not accurately calculate the amount of restored stock. *Fix submitted by Danny Verkade in pull request 12668*. [GitHub-9969](https://github.com/magento/magento2/issues/9969)
 
 <!--- MAGETWO-87292  -->
-*   Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
+*  Join extension attributes are now added as expected to order results when the order is created using REST. *Fix submitted by Nickolas Malyovanets in pull request 1168*.
 
 <!--- MAGETWO-87291  -->
 *  The Shipment Tracking REST API now throws an error as expected if the specified order doesn't exist. *Fix submitted by Roman K. in pull request 1162*.
@@ -900,7 +900,7 @@ Users of the CyberSource payment method should note that CyberSource uses the Ma
 *  You can now view order details for an order created with a custom offline payment method. Previously, Magento displayed  PHP warning (undefined index) instead of the order details. *Fix submitted by Alex in pull request 12296*. [GitHub-3596](https://github.com/magento/magento2/issues/3596)
 
 <!--- MAGETWO-86112  -->
-*   Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
+*  Magento no longer disables the BrainTree **Place Order** button after a failed payment validation. *Fix submitted by Ievgen Sentiabov in pull request 12902*.
 
 <!--- MAGETWO-86297  -->
 *  The  `is_active` and `is_visible` columns now default to true even when column default values are not set in the `vault_payment_token` installation script. *Fix submitted by helloitsluke in pull request 12965*.
@@ -979,7 +979,7 @@ Users of the CyberSource payment method should note that CyberSource uses the Ma
 *  Magento now displays the exact label value that was given in the Admin during the cart price rule creation. *Fix submitted by Ihor Sviziev in pull request 13141*. [GitHub-11428](https://github.com/magento/magento2/issues/11428), [GitHub-11497](https://github.com/magento/magento2/issues/11497)
 
 <!--- MAGETWO-87013 -->
-*   Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
+*  Magento now correctly displays in Cart Price rules the nesting levels for categories with nesting levels that exceed three levels.
 
 <!--- MAGETWO-85960 -->
 *  Coupon codes that a customer has applied to a subsequently canceled order are now available for re-use as expected. Previously, once a customer canceled this order, she could not apply the coupon code to another order. *Fix submitted by p-bystritsky in a pull request*. [GitHub-12817](https://github.com/magento/magento2/issues/12817)
@@ -1018,7 +1018,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 ### Sitemap
 
 <!--- MAGETWO-86349  -->
-*   `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
+*  `sitemap.xml` now displays URLs without `/home` appended. *Fix submitted by Oscar Recio in pull request 12649*. [GitHub-12446](https://github.com/magento/magento2/issues/12446)
 
 <!--- MAGETWO-85285  -->
 *  Sitemaps generated in a multi-store environment now include the correct URLs for each store (that is, `http://storename.com/` instead of `http://defaultstore.com/`). *Fix submitted by Roman K. in pull request 935*. [GitHub-12482](https://github.com/magento/magento2/issues/12482)
@@ -1050,7 +1050,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 ### Tax
 
 <!--- MAGETWO-87941  -->
-*   The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multi-select. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
+*  The default selector on the Admin's tax rule edit page now selects only the correct container (tax rate) following the Tax Rate multi-select. Previously, the default selector selected three elements, which resulted in inaccurate results. *Fix submitted by Pieter Hoste in pull request 13643*. [GitHub-12791](https://github.com/magento/magento2/issues/12791)
 
 <!--- MAGETWO-87352  -->
 *  We've removed the redundant default discount tax calculation (`tax/calculation/discount_tax`) from `Magento/Tax/etc/config.xml`. *Fix submitted by Vincent Marmiesse in pull request 13449*.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) refactors Markdown linting: spaces after list markers (MD030) rule in the folders:

- `guides/v2.2/release-notes`