### PR TITLE
Markdown linting: Spaces after list markers (MD030)

### DIFF
--- a/guides/v2.2/javascript-dev-guide/widgets/widget-row-builder.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget-row-builder.md
@@ -30,7 +30,7 @@ $("#row-builder").rowBuilder({
 
 Where:
 
-- `#row-builder` is the selector of the element which will be the RowBuilder.
+-  `#row-builder` is the selector of the element which will be the RowBuilder.
 
 The following example shows a PHTML file using the script:
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget-sortable.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget-sortable.md
@@ -23,7 +23,7 @@ $('#sortable').sortable();
 
 Where:
 
-- `#sortable` is the selector of the block element where Sortable is initialized.
+-  `#sortable` is the selector of the block element where Sortable is initialized.
 
 The following example shows a PHTML file using the script:
 
@@ -48,8 +48,8 @@ Most options, methods, and events for the Sortable widget correspond to the jQue
 
 The Sortable has only two custom options that are different from default [Sortable Widget] options.
 
-- [moveUpEvent](#moveupevent)
-- [moveDownEvent](#movedownevent)
+-  [moveUpEvent](#moveupevent)
+-  [moveDownEvent](#movedownevent)
 
 ### `moveUpEvent`
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget-trim-input.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget-trim-input.md
@@ -22,7 +22,7 @@ $('#element').trimInput();
 
 Where:
 
-- `#element` is the selector of the input element to be trimmed.
+-  `#element` is the selector of the input element to be trimmed.
 
 The following example shows a PHTML file using the script:
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_alert.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_alert.md
@@ -50,14 +50,14 @@ For details about how to initialize a widget in a`.phtml` template, refer to the
 
 The alert widget has the following options:
 
-- [actions]
-- [autoOpen]
-- [clickableOverlay]
-- [content]
-- [focus]
-- [title]
-- [modalClass]
-- [buttons]
+-  [actions]
+-  [autoOpen]
+-  [clickableOverlay]
+-  [content]
+-  [focus]
+-  [title]
+-  [modalClass]
+-  [buttons]
 
 ### `actions` {#alert_actions}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_collapsible.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_collapsible.md
@@ -45,22 +45,22 @@ The collapsible widget can be initialized using the `data-mage-init` attribute o
 
 The collapsible widget has the following options:
 
--   [active](#fedg_collaps_active)
--   [ajaxUrlElement](#fedg_collaps_ajaxUrlElement)
--   [ajaxContent](#fedg_collaps_ajaxContent)
--   [animate](#fedg_collaps_animate)
--   [collapsible](#fedg_collaps_collapsible)
--   [collateral](#fedg_collaps_collateral)
--   [content](#fedg_collaps_content)
--   [closedState](#fedg_collaps_closedState)
--   [disabled](#fedg_collaps_disabled)
--   [disabledState](#fedg_collaps_disabledState)
--   [header](#fedg_collaps_header)
--   [icons](#fedg_collaps_icons)
--   [loadingClass](#fedg_collaps_loadingClass)
--   [openedState](#fedg_collaps_openedState)
--   [saveState](#fedg_collaps_saveState)
--   [trigger](#fedg_collaps_trigger)
+-  [active](#fedg_collaps_active)
+-  [ajaxUrlElement](#fedg_collaps_ajaxUrlElement)
+-  [ajaxContent](#fedg_collaps_ajaxContent)
+-  [animate](#fedg_collaps_animate)
+-  [collapsible](#fedg_collaps_collapsible)
+-  [collateral](#fedg_collaps_collateral)
+-  [content](#fedg_collaps_content)
+-  [closedState](#fedg_collaps_closedState)
+-  [disabled](#fedg_collaps_disabled)
+-  [disabledState](#fedg_collaps_disabledState)
+-  [header](#fedg_collaps_header)
+-  [icons](#fedg_collaps_icons)
+-  [loadingClass](#fedg_collaps_loadingClass)
+-  [openedState](#fedg_collaps_openedState)
+-  [saveState](#fedg_collaps_saveState)
+-  [trigger](#fedg_collaps_trigger)
 
 ### `active` {#fedg_collaps_active}
 Specifies if the content should be expanded when the widget gets initialized.
@@ -103,10 +103,10 @@ Specifies if the collapse/expand actions are performed with animation.
 **Type**:
 Multiple types are supported:
 
--   Boolean: the `false` value disables the animation
--   Number: duration in milliseconds
--   String: is parsed to an object as a json string
--   Object: For details about the object passed, see [jQuery.animate()](http://api.jquery.com/animate/).
+-  Boolean: the `false` value disables the animation
+-  Number: duration in milliseconds
+-  String: is parsed to an object as a json string
+-  Object: For details about the object passed, see [jQuery.animate()](http://api.jquery.com/animate/).
 
     ```javascript
         {
@@ -164,8 +164,8 @@ Specifies the element, and the class which is assigned to this element, when the
 
 An object that contains the following:
 
-- `element`: an element, can be a selector or jQuery object.
-- `openedState`: the class name which is assigned to the element when the current element is in opened; removed when the current element is closed.
+-  `element`: an element, can be a selector or jQuery object.
+-  `openedState`: the class name which is assigned to the element when the current element is in opened; removed when the current element is closed.
 
 **Type**: String
 
@@ -183,8 +183,8 @@ Selector for the content element, searched for using `.find()` on the main colla
 
 **Type**:
 
--   String
--   jQuery Object
+-  String
+-  jQuery Object
 
 **Default value**: `[data-role=content]`
 
@@ -273,8 +273,8 @@ Selector for the header element, searched for using `.find()` on the main collap
 
 **Type**:
 
-- String
-- jQuery Object
+-  String
+-  jQuery Object
 
 **Default value**: `[data-role=title]`
 
@@ -413,8 +413,8 @@ Selector for the trigger element, applied using `.find()` on the main collapsibl
 
 **Type**:
 
--   String
--   jQuery Object
+-  String
+-  jQuery Object
 
 **Default value**: `[data-role=trigger]`
 
@@ -434,12 +434,12 @@ $("#element").collapsible("option","trigger",".trigger");
 
 ## Methods {#collaps_methods}
 
--   [activate()](#collaps_activate)
--   [deactivate()](#collaps_deactivate)
--   [disable()](#collaps_disable)
--   [enable()](#collaps_enable)
--   [forceActivate()](#collaps_forceActivate)
--   [forceDeactivate()](#collaps_forceDeactivate)
+-  [activate()](#collaps_activate)
+-  [deactivate()](#collaps_deactivate)
+-  [disable()](#collaps_disable)
+-  [enable()](#collaps_enable)
+-  [forceActivate()](#collaps_forceActivate)
+-  [forceDeactivate()](#collaps_forceDeactivate)
 
 ### `activate()` {#collaps_activate}
 Expand the content when this method is called.

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_confirm.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_confirm.md
@@ -52,14 +52,14 @@ For details about how to initialize a widget in a`.phtml` template, refer to the
 
 ## Options {#confirm_options}
 
--   [actions](#confirm_actions)
--   [autoOpen](#confirm_autoopen)
--   [clickableOverlay](#confirm_clickableOverlay)
--   [content](#confirm_content)
--   [focus](#confirm_focus)
--   [title](#confirm_title)
--   [modalClass](#confirm_modalClass)
--   [buttons](#confirm_buttons)
+-  [actions](#confirm_actions)
+-  [autoOpen](#confirm_autoopen)
+-  [clickableOverlay](#confirm_clickableOverlay)
+-  [content](#confirm_content)
+-  [focus](#confirm_focus)
+-  [title](#confirm_title)
+-  [modalClass](#confirm_modalClass)
+-  [buttons](#confirm_buttons)
 
 ### `actions` {#confirm_actions}
 Widget callbacks.
@@ -146,9 +146,9 @@ The CSS class of the confirm window.
 
 The confirmation widget implements the following events:
 
-- `confirm` callback: called when the confirmation button is clicked.
-- `cancel` callback: called when the cancel button is clicked.
-- `always` callback: called when the popup is closed.
+-  `confirm` callback: called when the confirmation button is clicked.
+-  `cancel` callback: called when the cancel button is clicked.
+-  `always` callback: called when the popup is closed.
 
 ## Keyboard navigation {#confirm_key_navigation}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_dialog.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_dialog.md
@@ -6,9 +6,9 @@ title: DropdownDialog widget
 
 Magento dropdownDialog [widget](https://glossary.magento.com/widget) is a customization of the standard [jQuery UI Dialog](http://api.jqueryui.com/dialog/){:target="_blank"}. As extra functionality it implements the following:
 
--   triggering [event](https://glossary.magento.com/event) for opening
--   delaying to automatically close the drop-down on mouse out
--   clicking outside the area closes the drop-down
+-  triggering [event](https://glossary.magento.com/event) for opening
+-  delaying to automatically close the drop-down on mouse out
+-  clicking outside the area closes the drop-down
 
 The dropdownDialog widget source is located in [lib/web/mage/dropdown.js].
 
@@ -20,19 +20,19 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 Magento customized Dialog widget has default [jQuery UI Dialog widget](http://api.jqueryui.com/dialog/){:target="_blank"} options, plus several custom options:
 
--   [autoPosition](#d_autoPosition)
--   [autoSize](#d_autoSize)
--   [autoOpen](#d_autoOpen)
--   [closeOnClickOutside](#d_closeOnClickOutside)
--   [closeOnMouseLeave](#d_closeOnMouseLeave)
--   [createTitleBar](#d_createTitleBar)
--   [defaultDialogClass](#d_defaultDialogClass)
--   [dialogContentClass](#d_dialogContentClass)
--   [parentClass](#d_parentClass)
--   [timeout](#d_timeout)
--   [triggerClass](#d_triggerClass)
--   [triggerEvent](#d_triggerEvent)
--   [triggerTarget](#d_triggerTarget)
+-  [autoPosition](#d_autoPosition)
+-  [autoSize](#d_autoSize)
+-  [autoOpen](#d_autoOpen)
+-  [closeOnClickOutside](#d_closeOnClickOutside)
+-  [closeOnMouseLeave](#d_closeOnMouseLeave)
+-  [createTitleBar](#d_createTitleBar)
+-  [defaultDialogClass](#d_defaultDialogClass)
+-  [dialogContentClass](#d_dialogContentClass)
+-  [parentClass](#d_parentClass)
+-  [timeout](#d_timeout)
+-  [triggerClass](#d_triggerClass)
+-  [triggerEvent](#d_triggerEvent)
+-  [triggerTarget](#d_triggerTarget)
 
 Description of each option as follows below location.
 
@@ -123,8 +123,8 @@ Element that triggers the drop-down.
 
 **Type**:
 
-- String
-- jQuery object
+-  String
+-  jQuery object
 
 **Default value**: `null`
 
@@ -141,8 +141,8 @@ Magento customized dropdownDialog widget has default [jQuery UI Dialog widget] m
 
 Customized public methods:
 
--   [open()](#d_open)
--   [close()](#d_close)
+-  [open()](#d_open)
+-  [close()](#d_close)
 
 ### `open()` {#d_open}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_dropdown.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_dropdown.md
@@ -13,9 +13,9 @@ Widget source file is [lib/web/mage/dropdowns.js].
 
 **Usages:**
 
-- [Shipping policy]
-- [Customer menu]
-- [UI tooltip]
+-  [Shipping policy]
+-  [Customer menu]
+-  [UI tooltip]
 
 [lib/web/mage/dropdowns.js]: {{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/mage/dropdowns.js
 [Shipping policy]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Shipping/view/frontend/web/template/checkout/shipping/shipping-policy.html
@@ -137,9 +137,9 @@ The parent element that initialized the widget. If not specified, the widget loc
 
 **Type**:
 
-- jQuery object
-- HTML
-- String
+-  jQuery object
+-  HTML
+-  String
 
 **Default value**: `null`
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -60,8 +60,8 @@ Action that activates zoom.
 
 Possible values:
 
-* `hover`
-* `click`
+*  `hover`
+*  `click`
 
 ### `fullscreenzoom` {#opt_fullscreenzoom}
 
@@ -93,8 +93,8 @@ Specifies whether to display magnified image inside / outside lens.
 
 Possible values:
 
-* `outside`
-* `inside`
+*  `outside`
+*  `inside`
 
 ## Configure magnifier options in `view.xml`
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_list.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_list.md
@@ -23,16 +23,16 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 The list widget has the following options:
 
--   [addButton](#l_addButton)
--   [destinationSelector](#l_destinationSelector)
--   [itemCount](#l_itemCount)
--   [itemIndex](#l_itemIndex)
--   [maxItems](#l_maxItems)
--   [maxItemsAlert](#l_maxItemsAlert)
--   [removeButton](#l_removeButton)
--   [template](#l_template)
--   [templateClass](#l_templateClass)
--   [templateWrapper](#l_templateWrapper)
+-  [addButton](#l_addButton)
+-  [destinationSelector](#l_destinationSelector)
+-  [itemCount](#l_itemCount)
+-  [itemIndex](#l_itemIndex)
+-  [maxItems](#l_maxItems)
+-  [maxItemsAlert](#l_maxItemsAlert)
+-  [removeButton](#l_removeButton)
+-  [template](#l_template)
+-  [templateClass](#l_templateClass)
+-  [templateWrapper](#l_templateWrapper)
 
 Detailed description of each option follows.
 
@@ -110,10 +110,10 @@ Element holding the template.
 
 The list widget has the following methods:
 
--   [addItem()](#list_addItem)
--   [checkLimit()](#list_checkLimit)
--   [handleAdd()](#list_handleAdd)
--   [removeItem()](#list_removeItem)
+-  [addItem()](#list_addItem)
+-  [checkLimit()](#list_checkLimit)
+-  [handleAdd()](#list_handleAdd)
+-  [removeItem()](#list_removeItem)
 
 ### `addItem()` {#list_addItem}
 Adds item to the list in the specified order (defined by the index parameter).

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_loader.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_loader.md
@@ -22,7 +22,7 @@ $('#example').loader({
 
 Where:
 
-- `#element` is the selector of the element for Loader is initialized.
+-  `#element` is the selector of the element for Loader is initialized.
 
 ```html
 <script>
@@ -40,9 +40,9 @@ require(['jquery', 'loader'], function ($) {
 
 The loader widget has the following options:
 
--   [icon](#l_icon)
--   [template](#l_template)
--   [texts](#l_texts)
+-  [icon](#l_icon)
+-  [template](#l_template)
+-  [texts](#l_texts)
 
 ### `icon` {#l_icon}
 
@@ -71,15 +71,15 @@ HTML wrapper for the output, or a DOM element selector.
 
 An object that contains translations for loader text:
 
--   `texts.loaderText`: The text that is displayed under the loader image.
-    **Default value**: *'Please wait...'*
--   `texts.imgAlt`: The text that is set as the `alt` attribute value of the loader image.
-    **Default value**: *'Loading...'*
+-  `texts.loaderText`: The text that is displayed under the loader image.
+   **Default value**: *'Please wait...'*
+-  `texts.imgAlt`: The text that is set as the `alt` attribute value of the loader image.
+   **Default value**: *'Loading...'*
 
 ## Methods {#loader_methods}
 
--   [show()](#method_show)
--   [hide()](#method_hide)
+-  [show()](#method_show)
+-  [hide()](#method_hide)
 
 ### `show()` {#method_show}
 
@@ -105,8 +105,8 @@ $("#element").loader("hide");
 
 Loader is subscribed to the following events:
 
--   [processStart](#l_processStart)
--   [processStop](#l_processStop)
+-  [processStart](#l_processStart)
+-  [processStop](#l_processStop)
 
 ### `processStart` {#l_processStart}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_menu.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_menu.md
@@ -6,9 +6,9 @@ title: Menu widget
 
 The Magento menu widget is a customized [jQuery UI Menu widget](http://api.jqueryui.com/menu/){:target="_blank"}. Magento menu extends the default functionality with the following:
 
--   expanding all layers of the menu tree past the second layer
--   declaring a responsive menu
--   setting hover delay
+-  expanding all layers of the menu tree past the second layer
+-  declaring a responsive menu
+-  setting hover delay
 
 The Magento menu [widget](https://glossary.magento.com/widget) source is [lib/web/mage/menu.js].
 
@@ -20,12 +20,12 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 Menu widget options mostly coincide with the options of the jQuery UI Menu widget, with addition of the following custom ones:
 
--   [delay](#m_delay)
--   [showDelay](#m_showDelay)
--   [hideDelay](#m_hideDelay)
--   [responsive](#m_responsive)
--   [expanded](#m_expanded)
--   [mediaBreakpoint](#m_mediaBreakpoint)
+-  [delay](#m_delay)
+-  [showDelay](#m_showDelay)
+-  [hideDelay](#m_hideDelay)
+-  [responsive](#m_responsive)
+-  [expanded](#m_expanded)
+-  [mediaBreakpoint](#m_mediaBreakpoint)
 
 ### `delay` {#m_delay}
 Set the delay length of opening submenu.
@@ -76,8 +76,8 @@ plus a couple more.
 
 ### Additional available methods
 
-- [toggle](#m_toggle)
-- [isExpanded](#m_isExpanded)
+-  [toggle](#m_toggle)
+-  [isExpanded](#m_isExpanded)
 
 ### `toggle()` {#m_toggle}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_modal.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_modal.md
@@ -6,9 +6,9 @@ title: Modal widget
 
 The Magento modal widget implements a secondary window that opens on top of the main window. It contains the overlay and modal content. The modal widget configuration enables the following:
 
--   Configuring as popup or slide
--   Controlling stack of modal widgets
--   Setting buttons for action bar
+-  Configuring as popup or slide
+-  Controlling stack of modal widgets
+-  Setting buttons for action bar
 
 The modal widget source is [`<Magento_Ui_module_dir>/view/base/web/js/modal/modal.js`].
 
@@ -37,21 +37,21 @@ For details about how to initialize the widget in a`.phtml` template, refer to t
 
 The modal widget has the following options:
 
--   [autoOpen](#modal_autoopen)
--   [buttons](#modal_buttons)
--   [closeText](#modal_closeText)
--   [clickableOverlay](#modal_clickableOverlay)
--   [focus](#modal_focus)
--   [innerScroll](#modal_innerScroll)
--   [modalAction](#modal_modalAction)
--   [modalClass](#modal_modalClass)
--   [modalCloseBtn](#modal_modalCloseBtn)
--   [modalContent](#modal_modalContent)
--   [modalLeftMargin](#modal_modalLeftMargin)
--   [responsive](#modal_responsive)
--   [title](#modal_title)
--   [trigger](#modal_trigger)
--   [type](#modal_type)
+-  [autoOpen](#modal_autoopen)
+-  [buttons](#modal_buttons)
+-  [closeText](#modal_closeText)
+-  [clickableOverlay](#modal_clickableOverlay)
+-  [focus](#modal_focus)
+-  [innerScroll](#modal_innerScroll)
+-  [modalAction](#modal_modalAction)
+-  [modalClass](#modal_modalClass)
+-  [modalCloseBtn](#modal_modalCloseBtn)
+-  [modalContent](#modal_modalContent)
+-  [modalLeftMargin](#modal_modalLeftMargin)
+-  [responsive](#modal_responsive)
+-  [title](#modal_title)
+-  [trigger](#modal_trigger)
+-  [type](#modal_type)
 
 ### autoOpen {#modal_autoopen}
 
@@ -186,10 +186,10 @@ The type of window: 'popup' or 'slide'.
 
 The modal widget has the following methods:
 
--   [closeModal()](#modal_close)
--   [keyEventSwitcher()](#modal_keyEventSwitcher)
--   [openModal()](#modal_open)
--   [toggleModal()](#modal_toggleModal)
+-  [closeModal()](#modal_close)
+-  [keyEventSwitcher()](#modal_keyEventSwitcher)
+-  [openModal()](#modal_open)
+-  [toggleModal()](#modal_toggleModal)
 
 ### `openModal()` {#modal_open}
 Open the modal window.
@@ -207,8 +207,8 @@ Toggles the modal window.
 
 The modal widget is subscribed to the following events:
 
--   [closed](#modal_closed)
--   [opened](#modal_opened)
+-  [closed](#modal_closed)
+-  [opened](#modal_opened)
 
 You can listen to these events in two ways:
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_navigation.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_navigation.md
@@ -6,11 +6,11 @@ title: Navigation widget
 
 Magento navigation widget is a customized [jQuery UI Menu widget]. Magento navigation extends the default functionality with the following:
 
--   Expanding all layers of the menu tree past the second layer.
--   Limiting the maximum number of list items contained within the main
-    navigation (overflow items are placed into a secondary navigation
-    level).
--   Method for handling the responsive layout of the menu.
+-    Expanding all layers of the menu tree past the second layer.
+-    Limiting the maximum number of list items contained within the main
+     navigation (overflow items are placed into a secondary navigation
+     level).
+-    Method for handling the responsive layout of the menu.
 
 The navigation widget source is [lib/web/mage/menu.js].
 
@@ -22,11 +22,11 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 The navigation widget has the following options:
 
--   [breakpoint](#n_breakpoint)
--   [container](#n_container)
--   [maxItems](#n_maxItems)
--   [moreText](#n_moreText)
--   [responsiveAction](#n_responsiveAction)
+-  [breakpoint](#n_breakpoint)
+-  [container](#n_container)
+-  [maxItems](#n_maxItems)
+-  [moreText](#n_moreText)
+-  [responsiveAction](#n_responsiveAction)
 
 ### `breakpoint` {#n_breakpoint}
 
@@ -72,8 +72,8 @@ The default responsive handler for the navigation widget.
 
 ## Methods {#navigation_methods}
 
--   [setMaxItems()](#nav_setMaxItems)
--   [setupMoreMenu()](#nav_setupMoreMenu)
+-  [setMaxItems()](#nav_setMaxItems)
+-  [setupMoreMenu()](#nav_setupMoreMenu)
 
 ### `setMaxItems()` {#nav_setMaxItems}
 Moves the list items that are more than the total max item number set by the user option.


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the following folders:

- `guides/v2.2/javascript-dev-guide`
- `guides/v2.3/javascript-dev-guide`

**Part 2**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
