### PR TITLE
Markdown linting: Spaces after list markers (MD030)

### DIFF
--- a/guides/v2.2/javascript-dev-guide/widgets/widget_navigation.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_navigation.md
@@ -6,11 +6,11 @@ title: Navigation widget
 
 Magento navigation widget is a customized [jQuery UI Menu widget]. Magento navigation extends the default functionality with the following:
 
--    Expanding all layers of the menu tree past the second layer.
--    Limiting the maximum number of list items contained within the main
-     navigation (overflow items are placed into a secondary navigation
-     level).
--    Method for handling the responsive layout of the menu.
+-  Expanding all layers of the menu tree past the second layer.
+-  Limiting the maximum number of list items contained within the main
+   navigation (overflow items are placed into a secondary navigation
+   level).
+-  Method for handling the responsive layout of the menu.
 
 The navigation widget source is [lib/web/mage/menu.js].
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_password_strength_indicator.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_password_strength_indicator.md
@@ -13,9 +13,9 @@ The password strength indicator widget source is [`<Magento_Customer_module_dir>
 
 The widget is being used in the following templates:
 
-- [`<Magento_Customer_module_dir>/view/frontend/templates/form/register.phtml`] customer register template.
-- [`<Magento_Customer_module_dir>/view/frontend/templates/form/forgotpassword.phtml`] customer forgot password template.
-- [`<Magento_Customer_module_dir>/view/frontend/templates/form/edit.phtml`] customer account edit template.
+-  [`<Magento_Customer_module_dir>/view/frontend/templates/form/register.phtml`] customer register template.
+-  [`<Magento_Customer_module_dir>/view/frontend/templates/form/forgotpassword.phtml`] customer forgot password template.
+-  [`<Magento_Customer_module_dir>/view/frontend/templates/form/edit.phtml`] customer account edit template.
 
 ## Initialize the password_strength_indicator widget {#password_strength_indicator_initialize}
 
@@ -31,7 +31,7 @@ $('#password-input').passwordStrengthIndicator({
 
 Where:
 
-- `#password-input` is the selector of the element for which PasswordStrengthIndicator is initialized.
+-  `#password-input` is the selector of the element for which PasswordStrengthIndicator is initialized.
 
 The following example shows a PHTML file using the script:
 
@@ -57,11 +57,11 @@ For details about how to initialize the widget in a`.phtml` template, refer to t
 
 The password strength indicator widget has the following options:
 
--   [passwordSelector](#password_strength_indicator_password_selector)
--   [passwordStrengthMeterSelector](#password_strength_indicator_password_strength_meter_selector)
--   [passwordStrengthMeterLabelSelector](#password_strength_indicator_password_strength_meter_label_selector)
--   [formSelector](#password_strength_indicator_form_selector)
--   [emailSelector](#password_strength_indicator_email_selector)
+-  [passwordSelector](#password_strength_indicator_password_selector)
+-  [passwordStrengthMeterSelector](#password_strength_indicator_password_strength_meter_selector)
+-  [passwordStrengthMeterLabelSelector](#password_strength_indicator_password_strength_meter_label_selector)
+-  [formSelector](#password_strength_indicator_form_selector)
+-  [emailSelector](#password_strength_indicator_email_selector)
 
 ### passwordSelector {#password_strength_indicator_password_selector}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_prompt.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_prompt.md
@@ -53,20 +53,20 @@ For details about how to initialize a widget in a `.phtml` template, refer to th
 
 ## Options {#prompt_options}
 
-- [actions](#prompt_actions)
-- [autoOpen](#prompt_autoopen)
-- [clickableOverlay](#prompt_clickableOverlay)
-- [content](#prompt_content)
-- [focus](#prompt_focus)
-- [title](#prompt_title)
-- [modalClass](#prompt_modalClass)
-- [promptContentTmpl](#prompt_promptContentTmpl)
-- [value](#prompt_value)
-- [promptField](#prompt_promptField)
-- [attributesForm](#prompt_attributesForm)
-- [attributesField](#prompt_attributesField)
-- [validation](#prompt_validation)
-- [validationRules](#prompt_validationRules)
+-  [actions](#prompt_actions)
+-  [autoOpen](#prompt_autoopen)
+-  [clickableOverlay](#prompt_clickableOverlay)
+-  [content](#prompt_content)
+-  [focus](#prompt_focus)
+-  [title](#prompt_title)
+-  [modalClass](#prompt_modalClass)
+-  [promptContentTmpl](#prompt_promptContentTmpl)
+-  [value](#prompt_value)
+-  [promptField](#prompt_promptField)
+-  [attributesForm](#prompt_attributesForm)
+-  [attributesField](#prompt_attributesField)
+-  [validation](#prompt_validation)
+-  [validationRules](#prompt_validationRules)
 
 ### `actions` {#prompt_actions}
 Widget callbacks.
@@ -199,9 +199,9 @@ The array of validation classes which will be added to prompt field.
 
 The prompt widget implements the following events:
 
-- `confirm` callback: called when the confirmation button is clicked. The first argument is the value of the input field.
-- `cancel` callback: called when the cancel button is clicked.
-- `always` callback: called when the popup is closed.
+-  `confirm` callback: called when the confirmation button is clicked. The first argument is the value of the input field.
+-  `cancel` callback: called when the cancel button is clicked.
+-  `always` callback: called when the popup is closed.
 
 ## Keyboard navigation {#prompt_key_navigation}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_quickSearch.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_quickSearch.md
@@ -16,18 +16,18 @@ For information about how to initialize a widget in a JS component or `.phtml` t
 
 ## Options {#quicksearch_options}
 
--   [autocomplete](#q_autocomplete)
--   [destinationSelector](#q_destinationSelector)
--   [isExpandable](#q_isExpandable)
--   [formSelector](#q_formSelector)
--   [minSearchLength](#q_minSearchLength)
--   [responseFieldElements](#q_responseFieldElements)
--   [searchLabel](#q_searchLabel)
--   [selectClass](#q_selectClass)
--   [submitBtn](#q_submitBtn)
--   [suggestionDelay](#q_suggestionDelay)
--   [template](#q_template)
--   [url](#q_url)
+-  [autocomplete](#q_autocomplete)
+-  [destinationSelector](#q_destinationSelector)
+-  [isExpandable](#q_isExpandable)
+-  [formSelector](#q_formSelector)
+-  [minSearchLength](#q_minSearchLength)
+-  [responseFieldElements](#q_responseFieldElements)
+-  [searchLabel](#q_searchLabel)
+-  [selectClass](#q_selectClass)
+-  [submitBtn](#q_submitBtn)
+-  [suggestionDelay](#q_suggestionDelay)
+-  [template](#q_template)
+-  [url](#q_url)
 
 ### `autocomplete` {#q_autocomplete}
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_redirectUrl.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_redirectUrl.md
@@ -22,7 +22,7 @@ $("#element").redirectUrl({url: 'http://example.com'});
 
 Where:
 
-- `#element` is the selector of the element for which RedirectUrl is initialized.
+-  `#element` is the selector of the element for which RedirectUrl is initialized.
 
 The following example shows a PHTML file using the script:
 
@@ -43,8 +43,8 @@ The following example shows a PHTML file using the script:
 
 The RedirectUrl widget has the following options:
 
-- [event](#event)
-- [url](#url)
+-  [event](#event)
+-  [url](#url)
 
 ### `event`
 

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_tabs.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_tabs.md
@@ -19,7 +19,7 @@ $("#element").tabs();
 
 Where:
 
--   `#element` is the selector of the element for tabs is initialized.
+-  `#element` is the selector of the element for tabs is initialized.
 
 The following example shows a PHTML file using the script:
 
@@ -37,23 +37,23 @@ The following example shows a PHTML file using the script:
 
 The tabs widget has the following options:
 
-- [active](#fedg_tabs_options-active)
-- [ajaxUrlElement](#fedg_tabs_options-ajaxUrlElement)
-- [ajaxContent](#fedg_tabs_options-ajaxContent)
-- [animate](#fedg_tabs_options-animate)
-- [closedState](#fedg_tabs_options-closedState)
-- [collapsible](#fedg_tabs_options-collapsible)
-- [collapsibleElement](#fedg_tabs_options-collapsibleElement)
-- [content](#fedg_tabs_options-content)
-- [disabled](#fedg_tabs_options-disabled)
-- [disabledState](#fedg_tabs_options-disabledState)
-- [header](#fedg_tabs_options-header)
-- [icons](#fedg_tabs_options-icons)
-- [loadingClass](#fedg_tabs_options-loadingClass)
-- [openedState](#fedg_tabs_options-openedState)
-- [openOnFocus](#fedg_tabs_options-openOnFocus)
-- [saveState](#fedg_tabs_options-saveState)
-- [trigger](#fedg_tabs_options-trigger)
+-  [active](#fedg_tabs_options-active)
+-  [ajaxUrlElement](#fedg_tabs_options-ajaxUrlElement)
+-  [ajaxContent](#fedg_tabs_options-ajaxContent)
+-  [animate](#fedg_tabs_options-animate)
+-  [closedState](#fedg_tabs_options-closedState)
+-  [collapsible](#fedg_tabs_options-collapsible)
+-  [collapsibleElement](#fedg_tabs_options-collapsibleElement)
+-  [content](#fedg_tabs_options-content)
+-  [disabled](#fedg_tabs_options-disabled)
+-  [disabledState](#fedg_tabs_options-disabledState)
+-  [header](#fedg_tabs_options-header)
+-  [icons](#fedg_tabs_options-icons)
+-  [loadingClass](#fedg_tabs_options-loadingClass)
+-  [openedState](#fedg_tabs_options-openedState)
+-  [openOnFocus](#fedg_tabs_options-openOnFocus)
+-  [saveState](#fedg_tabs_options-saveState)
+-  [trigger](#fedg_tabs_options-trigger)
 
 ### `active` {#fedg_tabs_options-active}
 
@@ -85,18 +85,18 @@ Specifies if the collapse/expand actions are performed with animation. The optio
 **Type**:
 Multiple types are supported:
 
--   Boolean: the `false` value disables the animation
--   Number: duration in milliseconds
--   String: is parsed to an object as a json string
--   Object:
-    ```javascript
-    {
-        duration: <Number>,
-        easing: <String>,
-        <propToAnimate>: <howToAnimate>
-    }
-    ```
-    For details about the object passed, see [jQuery.animate()].
+-  Boolean: the `false` value disables the animation
+-  Number: duration in milliseconds
+-  String: is parsed to an object as a json string
+-  Object:
+   ```javascript
+   {
+       duration: <Number>,
+       easing: <String>,
+       <propToAnimate>: <howToAnimate>
+   }
+   ```
+   For details about the object passed, see [jQuery.animate()].
 
 **Default value**: `false`
 
@@ -200,8 +200,8 @@ The option of the [collapsible] widget used by tabs.
 
 **Type**:
 
-- String
-- jQuery object
+-  String
+-  jQuery object
 
 **Default value**: `[data-role=trigger]`
 
@@ -209,10 +209,10 @@ The option of the [collapsible] widget used by tabs.
 
 The tabs widget has the following methods:
 
--   [activate()](#fedg_tabs_methods-activate)
--   [enable()](#fedg_tabs_methods-enable)
--   [deactivate()](#fedg_tabs_methods-deactivate)
--   [disable()](#fedg_tabs_options-disable)
+-  [activate()](#fedg_tabs_methods-activate)
+-  [enable()](#fedg_tabs_methods-enable)
+-  [deactivate()](#fedg_tabs_methods-deactivate)
+-  [disable()](#fedg_tabs_options-disable)
 
 ### `activate()` {#fedg_tabs_methods-activate}
 
@@ -231,8 +231,8 @@ The tabs widget has the following methods:
 
 Tabs is subscribed to the same events as the [collapsible] widget:
 
--   [beforeOpen callback](#fedg_tabs_beforeOpen_callback)
--   [dimensionsChanged](#fedg_tabs_dimensionsChanged)
+-  [beforeOpen callback](#fedg_tabs_beforeOpen_callback)
+-  [dimensionsChanged](#fedg_tabs_dimensionsChanged)
 
 ### `beforeOpen callback` {#fedg_tabs_beforeOpen_callback}
 Called before the content is opened.

--- a/guides/v2.2/javascript-dev-guide/widgets/widget_toggle.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget_toggle.md
@@ -23,7 +23,7 @@ $("#element").toggleAdvanced();
 
 Where:
 
--   `#element` is the selector of the element for which ToggleAdvanced is initialized.
+-  `#element` is the selector of the element for which ToggleAdvanced is initialized.
 
 The following example shows a PHTML file using the script:
 
@@ -44,12 +44,12 @@ The following example shows a PHTML file using the script:
 
 The ToggleAdvanced widget has the following options:
 
-- [baseToggleClass](#basetoggleclass)
-- [selectorsToggleClass](#selectorstoggleclass)
-- [toggleContainers](#togglecontainers)
-- [newLabel](#newlabel)
-- [curLabel](#curlabel)
-- [currentLabelElement](#currentlabelelement)
+-  [baseToggleClass](#basetoggleclass)
+-  [selectorsToggleClass](#selectorstoggleclass)
+-  [toggleContainers](#togglecontainers)
+-  [newLabel](#newlabel)
+-  [curLabel](#curlabel)
+-  [currentLabelElement](#currentlabelelement)
 
 ### `baseToggleClass`
 
@@ -103,8 +103,8 @@ Container element of the current label.
 
 The ToggleAdvanced widget has the following methods:
 
-- [beforeCreate](#beforecreate)
-- [afterCreate](#aftercreate)
+-  [beforeCreate](#beforecreate)
+-  [afterCreate](#aftercreate)
 
 ### `beforeCreate`
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding Markdown linting: Spaces after list markers (MD030) rule in the following folders:

- `guides/v2.2/javascript-dev-guide`
- `guides/v2.3/javascript-dev-guide`

**Part 3**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
